### PR TITLE
Remove explicit SearchResponse references from LegacyGeo, Aggregations and parent-join modules

### DIFF
--- a/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/bucket/AdjacencyMatrixIT.java
+++ b/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/bucket/AdjacencyMatrixIT.java
@@ -12,7 +12,7 @@ import org.apache.lucene.search.IndexSearcher;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
-import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.aggregations.AggregationIntegTestCase;
 import org.elasticsearch.aggregations.bucket.adjacency.AdjacencyMatrix;
 import org.elasticsearch.aggregations.bucket.adjacency.AdjacencyMatrix.Bucket;
@@ -35,7 +35,9 @@ import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.avg;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -98,181 +100,178 @@ public class AdjacencyMatrixIT extends AggregationIntegTestCase {
     }
 
     public void testSimple() throws Exception {
-        SearchResponse response = prepareSearch("idx").addAggregation(
+        SearchRequestBuilder builder = prepareSearch("idx").addAggregation(
             adjacencyMatrix("tags", newMap("tag1", termQuery("tag", "tag1")).add("tag2", termQuery("tag", "tag2")))
-        ).get();
+        );
 
-        assertNoFailures(response);
+        assertNoFailuresAndResponse(builder, response -> {
+            AdjacencyMatrix matrix = response.getAggregations().get("tags");
+            assertThat(matrix, notNullValue());
+            assertThat(matrix.getName(), equalTo("tags"));
 
-        AdjacencyMatrix matrix = response.getAggregations().get("tags");
-        assertThat(matrix, notNullValue());
-        assertThat(matrix.getName(), equalTo("tags"));
+            int expected = numMultiTagDocs > 0 ? 3 : 2;
+            assertThat(matrix.getBuckets().size(), equalTo(expected));
 
-        int expected = numMultiTagDocs > 0 ? 3 : 2;
-        assertThat(matrix.getBuckets().size(), equalTo(expected));
-
-        AdjacencyMatrix.Bucket bucket = matrix.getBucketByKey("tag1");
-        assertThat(bucket, Matchers.notNullValue());
-        assertThat(bucket.getDocCount(), equalTo((long) numTag1Docs));
-
-        bucket = matrix.getBucketByKey("tag2");
-        assertThat(bucket, Matchers.notNullValue());
-        assertThat(bucket.getDocCount(), equalTo((long) numTag2Docs));
-
-        bucket = matrix.getBucketByKey("tag1&tag2");
-        if (numMultiTagDocs == 0) {
-            assertThat(bucket, Matchers.nullValue());
-        } else {
+            AdjacencyMatrix.Bucket bucket = matrix.getBucketByKey("tag1");
             assertThat(bucket, Matchers.notNullValue());
-            assertThat(bucket.getDocCount(), equalTo((long) numMultiTagDocs));
-        }
+            assertThat(bucket.getDocCount(), equalTo((long) numTag1Docs));
 
+            bucket = matrix.getBucketByKey("tag2");
+            assertThat(bucket, Matchers.notNullValue());
+            assertThat(bucket.getDocCount(), equalTo((long) numTag2Docs));
+
+            bucket = matrix.getBucketByKey("tag1&tag2");
+            if (numMultiTagDocs == 0) {
+                assertThat(bucket, Matchers.nullValue());
+            } else {
+                assertThat(bucket, Matchers.notNullValue());
+                assertThat(bucket.getDocCount(), equalTo((long) numMultiTagDocs));
+            }
+        });
     }
 
     public void testCustomSeparator() throws Exception {
-        SearchResponse response = prepareSearch("idx").addAggregation(
+        SearchRequestBuilder builder = prepareSearch("idx").addAggregation(
             adjacencyMatrix("tags", "\t", newMap("tag1", termQuery("tag", "tag1")).add("tag2", termQuery("tag", "tag2")))
-        ).get();
+        );
 
-        assertNoFailures(response);
+        assertNoFailuresAndResponse(builder, response -> {
+            AdjacencyMatrix matrix = response.getAggregations().get("tags");
+            assertThat(matrix, notNullValue());
 
-        AdjacencyMatrix matrix = response.getAggregations().get("tags");
-        assertThat(matrix, notNullValue());
-
-        AdjacencyMatrix.Bucket bucket = matrix.getBucketByKey("tag1\ttag2");
-        if (numMultiTagDocs == 0) {
-            assertThat(bucket, Matchers.nullValue());
-        } else {
-            assertThat(bucket, Matchers.notNullValue());
-            assertThat(bucket.getDocCount(), equalTo((long) numMultiTagDocs));
-        }
-
+            AdjacencyMatrix.Bucket bucket = matrix.getBucketByKey("tag1\ttag2");
+            if (numMultiTagDocs == 0) {
+                assertThat(bucket, Matchers.nullValue());
+            } else {
+                assertThat(bucket, Matchers.notNullValue());
+                assertThat(bucket.getDocCount(), equalTo((long) numMultiTagDocs));
+            }
+        });
     }
 
     // See NullPointer issue when filters are empty:
     // https://github.com/elastic/elasticsearch/issues/8438
     public void testEmptyFilterDeclarations() throws Exception {
         QueryBuilder emptyFilter = new BoolQueryBuilder();
-        SearchResponse response = prepareSearch("idx").addAggregation(
+        SearchRequestBuilder builder = prepareSearch("idx").addAggregation(
             adjacencyMatrix("tags", newMap("all", emptyFilter).add("tag1", termQuery("tag", "tag1")))
-        ).get();
+        );
 
-        assertNoFailures(response);
+        assertNoFailuresAndResponse(builder, response -> {
+            AdjacencyMatrix filters = response.getAggregations().get("tags");
+            assertThat(filters, notNullValue());
+            AdjacencyMatrix.Bucket allBucket = filters.getBucketByKey("all");
+            assertThat(allBucket.getDocCount(), equalTo((long) numDocs));
 
-        AdjacencyMatrix filters = response.getAggregations().get("tags");
-        assertThat(filters, notNullValue());
-        AdjacencyMatrix.Bucket allBucket = filters.getBucketByKey("all");
-        assertThat(allBucket.getDocCount(), equalTo((long) numDocs));
-
-        AdjacencyMatrix.Bucket bucket = filters.getBucketByKey("tag1");
-        assertThat(bucket, Matchers.notNullValue());
-        assertThat(bucket.getDocCount(), equalTo((long) numTag1Docs));
+            AdjacencyMatrix.Bucket bucket = filters.getBucketByKey("tag1");
+            assertThat(bucket, Matchers.notNullValue());
+            assertThat(bucket.getDocCount(), equalTo((long) numTag1Docs));
+        });
     }
 
     public void testWithSubAggregation() throws Exception {
         BoolQueryBuilder boolQ = new BoolQueryBuilder();
         boolQ.must(termQuery("tag", "tag1"));
         boolQ.must(termQuery("tag", "tag2"));
-        SearchResponse response = prepareSearch("idx").addAggregation(
+        SearchRequestBuilder builder = prepareSearch("idx").addAggregation(
             adjacencyMatrix("tags", newMap("tag1", termQuery("tag", "tag1")).add("tag2", termQuery("tag", "tag2")).add("both", boolQ))
                 .subAggregation(avg("avg_value").field("value"))
-        ).get();
+        );
 
-        assertNoFailures(response);
+        assertNoFailuresAndResponse(builder, response -> {
+            AdjacencyMatrix matrix = response.getAggregations().get("tags");
+            assertThat(matrix, notNullValue());
+            assertThat(matrix.getName(), equalTo("tags"));
 
-        AdjacencyMatrix matrix = response.getAggregations().get("tags");
-        assertThat(matrix, notNullValue());
-        assertThat(matrix.getName(), equalTo("tags"));
+            int expectedBuckets = 0;
+            if (numTag1Docs > 0) {
+                expectedBuckets++;
+            }
+            if (numTag2Docs > 0) {
+                expectedBuckets++;
+            }
+            if (numMultiTagDocs > 0) {
+                // both, both&tag1, both&tag2, tag1&tag2
+                expectedBuckets += 4;
+            }
 
-        int expectedBuckets = 0;
-        if (numTag1Docs > 0) {
-            expectedBuckets++;
-        }
-        if (numTag2Docs > 0) {
-            expectedBuckets++;
-        }
-        if (numMultiTagDocs > 0) {
-            // both, both&tag1, both&tag2, tag1&tag2
-            expectedBuckets += 4;
-        }
+            assertThat(matrix.getBuckets().size(), equalTo(expectedBuckets));
+            assertThat(((InternalAggregation) matrix).getProperty("_bucket_count"), equalTo(expectedBuckets));
 
-        assertThat(matrix.getBuckets().size(), equalTo(expectedBuckets));
-        assertThat(((InternalAggregation) matrix).getProperty("_bucket_count"), equalTo(expectedBuckets));
+            Object[] propertiesKeys = (Object[]) ((InternalAggregation) matrix).getProperty("_key");
+            Object[] propertiesDocCounts = (Object[]) ((InternalAggregation) matrix).getProperty("_count");
+            Object[] propertiesCounts = (Object[]) ((InternalAggregation) matrix).getProperty("avg_value.value");
 
-        Object[] propertiesKeys = (Object[]) ((InternalAggregation) matrix).getProperty("_key");
-        Object[] propertiesDocCounts = (Object[]) ((InternalAggregation) matrix).getProperty("_count");
-        Object[] propertiesCounts = (Object[]) ((InternalAggregation) matrix).getProperty("avg_value.value");
+            assertEquals(expectedBuckets, propertiesKeys.length);
+            assertEquals(propertiesKeys.length, propertiesDocCounts.length);
+            assertEquals(propertiesKeys.length, propertiesCounts.length);
 
-        assertEquals(expectedBuckets, propertiesKeys.length);
-        assertEquals(propertiesKeys.length, propertiesDocCounts.length);
-        assertEquals(propertiesKeys.length, propertiesCounts.length);
+            for (int i = 0; i < propertiesCounts.length; i++) {
+                AdjacencyMatrix.Bucket bucket = matrix.getBucketByKey(propertiesKeys[i].toString());
+                assertThat(bucket, Matchers.notNullValue());
+                Avg avgValue = bucket.getAggregations().get("avg_value");
+                assertThat(avgValue, notNullValue());
+                assertThat((long) propertiesDocCounts[i], equalTo(bucket.getDocCount()));
+                assertThat((double) propertiesCounts[i], equalTo(avgValue.getValue()));
+            }
 
-        for (int i = 0; i < propertiesCounts.length; i++) {
-            AdjacencyMatrix.Bucket bucket = matrix.getBucketByKey(propertiesKeys[i].toString());
-            assertThat(bucket, Matchers.notNullValue());
-            Avg avgValue = bucket.getAggregations().get("avg_value");
-            assertThat(avgValue, notNullValue());
-            assertThat((long) propertiesDocCounts[i], equalTo(bucket.getDocCount()));
-            assertThat((double) propertiesCounts[i], equalTo(avgValue.getValue()));
-        }
+            AdjacencyMatrix.Bucket tag1Bucket = matrix.getBucketByKey("tag1");
+            assertThat(tag1Bucket, Matchers.notNullValue());
+            assertThat(tag1Bucket.getDocCount(), equalTo((long) numTag1Docs));
+            long sum = 0;
+            for (int i = 0; i < numSingleTag1Docs; i++) {
+                sum += i + 1;
+            }
+            for (int i = numSingleTag1Docs + numSingleTag2Docs; i < numDocs; i++) {
+                sum += i + 1;
+            }
+            assertThat(tag1Bucket.getAggregations().asList().isEmpty(), is(false));
+            Avg avgBucket1Value = tag1Bucket.getAggregations().get("avg_value");
+            assertThat(avgBucket1Value, notNullValue());
+            assertThat(avgBucket1Value.getName(), equalTo("avg_value"));
+            assertThat(avgBucket1Value.getValue(), equalTo((double) sum / numTag1Docs));
 
-        AdjacencyMatrix.Bucket tag1Bucket = matrix.getBucketByKey("tag1");
-        assertThat(tag1Bucket, Matchers.notNullValue());
-        assertThat(tag1Bucket.getDocCount(), equalTo((long) numTag1Docs));
-        long sum = 0;
-        for (int i = 0; i < numSingleTag1Docs; i++) {
-            sum += i + 1;
-        }
-        for (int i = numSingleTag1Docs + numSingleTag2Docs; i < numDocs; i++) {
-            sum += i + 1;
-        }
-        assertThat(tag1Bucket.getAggregations().asList().isEmpty(), is(false));
-        Avg avgBucket1Value = tag1Bucket.getAggregations().get("avg_value");
-        assertThat(avgBucket1Value, notNullValue());
-        assertThat(avgBucket1Value.getName(), equalTo("avg_value"));
-        assertThat(avgBucket1Value.getValue(), equalTo((double) sum / numTag1Docs));
+            Bucket tag2Bucket = matrix.getBucketByKey("tag2");
+            assertThat(tag2Bucket, Matchers.notNullValue());
+            assertThat(tag2Bucket.getDocCount(), equalTo((long) numTag2Docs));
+            sum = 0;
+            for (int i = numSingleTag1Docs; i < numDocs; i++) {
+                sum += i + 1;
+            }
+            assertThat(tag2Bucket.getAggregations().asList().isEmpty(), is(false));
+            Avg avgBucket2Value = tag2Bucket.getAggregations().get("avg_value");
+            assertThat(avgBucket2Value, notNullValue());
+            assertThat(avgBucket2Value.getName(), equalTo("avg_value"));
+            assertThat(avgBucket2Value.getValue(), equalTo((double) sum / numTag2Docs));
 
-        Bucket tag2Bucket = matrix.getBucketByKey("tag2");
-        assertThat(tag2Bucket, Matchers.notNullValue());
-        assertThat(tag2Bucket.getDocCount(), equalTo((long) numTag2Docs));
-        sum = 0;
-        for (int i = numSingleTag1Docs; i < numDocs; i++) {
-            sum += i + 1;
-        }
-        assertThat(tag2Bucket.getAggregations().asList().isEmpty(), is(false));
-        Avg avgBucket2Value = tag2Bucket.getAggregations().get("avg_value");
-        assertThat(avgBucket2Value, notNullValue());
-        assertThat(avgBucket2Value.getName(), equalTo("avg_value"));
-        assertThat(avgBucket2Value.getValue(), equalTo((double) sum / numTag2Docs));
+            // Check intersection buckets are computed correctly by comparing with
+            // ANDed query bucket results
+            Bucket bucketBothQ = matrix.getBucketByKey("both");
+            if (numMultiTagDocs == 0) {
+                // Empty intersections are not returned.
+                assertThat(bucketBothQ, Matchers.nullValue());
+                Bucket bucketIntersectQ = matrix.getBucketByKey("tag1&tag2");
+                assertThat(bucketIntersectQ, Matchers.nullValue());
+                Bucket tag1Both = matrix.getBucketByKey("both&tag1");
+                assertThat(tag1Both, Matchers.nullValue());
+            } else {
+                assertThat(bucketBothQ, Matchers.notNullValue());
+                assertThat(bucketBothQ.getDocCount(), equalTo((long) numMultiTagDocs));
+                Avg avgValueBothQ = bucketBothQ.getAggregations().get("avg_value");
 
-        // Check intersection buckets are computed correctly by comparing with
-        // ANDed query bucket results
-        Bucket bucketBothQ = matrix.getBucketByKey("both");
-        if (numMultiTagDocs == 0) {
-            // Empty intersections are not returned.
-            assertThat(bucketBothQ, Matchers.nullValue());
-            Bucket bucketIntersectQ = matrix.getBucketByKey("tag1&tag2");
-            assertThat(bucketIntersectQ, Matchers.nullValue());
-            Bucket tag1Both = matrix.getBucketByKey("both&tag1");
-            assertThat(tag1Both, Matchers.nullValue());
-        } else {
-            assertThat(bucketBothQ, Matchers.notNullValue());
-            assertThat(bucketBothQ.getDocCount(), equalTo((long) numMultiTagDocs));
-            Avg avgValueBothQ = bucketBothQ.getAggregations().get("avg_value");
+                Bucket bucketIntersectQ = matrix.getBucketByKey("tag1&tag2");
+                assertThat(bucketIntersectQ, Matchers.notNullValue());
+                assertThat(bucketIntersectQ.getDocCount(), equalTo((long) numMultiTagDocs));
+                Avg avgValueIntersectQ = bucketBothQ.getAggregations().get("avg_value");
+                assertThat(avgValueIntersectQ.getValue(), equalTo(avgValueBothQ.getValue()));
 
-            Bucket bucketIntersectQ = matrix.getBucketByKey("tag1&tag2");
-            assertThat(bucketIntersectQ, Matchers.notNullValue());
-            assertThat(bucketIntersectQ.getDocCount(), equalTo((long) numMultiTagDocs));
-            Avg avgValueIntersectQ = bucketBothQ.getAggregations().get("avg_value");
-            assertThat(avgValueIntersectQ.getValue(), equalTo(avgValueBothQ.getValue()));
-
-            Bucket tag1Both = matrix.getBucketByKey("both&tag1");
-            assertThat(tag1Both, Matchers.notNullValue());
-            assertThat(tag1Both.getDocCount(), equalTo((long) numMultiTagDocs));
-            Avg avgValueTag1BothIntersectQ = tag1Both.getAggregations().get("avg_value");
-            assertThat(avgValueTag1BothIntersectQ.getValue(), equalTo(avgValueBothQ.getValue()));
-        }
-
+                Bucket tag1Both = matrix.getBucketByKey("both&tag1");
+                assertThat(tag1Both, Matchers.notNullValue());
+                assertThat(tag1Both.getDocCount(), equalTo((long) numMultiTagDocs));
+                Avg avgValueTag1BothIntersectQ = tag1Both.getAggregations().get("avg_value");
+                assertThat(avgValueTag1BothIntersectQ.getValue(), equalTo(avgValueBothQ.getValue()));
+            }
+        });
     }
 
     public void testTooLargeMatrix() {
@@ -301,23 +300,22 @@ public class AdjacencyMatrixIT extends AggregationIntegTestCase {
     }
 
     public void testAsSubAggregation() {
-        SearchResponse response = prepareSearch("idx").addAggregation(
+        SearchRequestBuilder builder = prepareSearch("idx").addAggregation(
             histogram("histo").field("value").interval(2L).subAggregation(adjacencyMatrix("matrix", newMap("all", matchAllQuery())))
-        ).get();
+        );
+        assertNoFailuresAndResponse(builder, response -> {
+            Histogram histo = response.getAggregations().get("histo");
+            assertThat(histo, notNullValue());
+            assertThat(histo.getBuckets().size(), greaterThanOrEqualTo(1));
 
-        assertNoFailures(response);
-
-        Histogram histo = response.getAggregations().get("histo");
-        assertThat(histo, notNullValue());
-        assertThat(histo.getBuckets().size(), greaterThanOrEqualTo(1));
-
-        for (Histogram.Bucket bucket : histo.getBuckets()) {
-            AdjacencyMatrix matrix = bucket.getAggregations().get("matrix");
-            assertThat(matrix, notNullValue());
-            assertThat(matrix.getBuckets().size(), equalTo(1));
-            AdjacencyMatrix.Bucket filterBucket = matrix.getBuckets().get(0);
-            assertEquals(bucket.getDocCount(), filterBucket.getDocCount());
-        }
+            for (Histogram.Bucket bucket : histo.getBuckets()) {
+                AdjacencyMatrix matrix = bucket.getAggregations().get("matrix");
+                assertThat(matrix, notNullValue());
+                assertThat(matrix.getBuckets().size(), equalTo(1));
+                AdjacencyMatrix.Bucket filterBucket = matrix.getBuckets().get(0);
+                assertEquals(bucket.getDocCount(), filterBucket.getDocCount());
+            }
+        });
     }
 
     public void testWithContextBasedSubAggregation() throws Exception {
@@ -340,25 +338,26 @@ public class AdjacencyMatrixIT extends AggregationIntegTestCase {
     }
 
     public void testEmptyAggregation() throws Exception {
-        SearchResponse searchResponse = prepareSearch("empty_bucket_idx").setQuery(matchAllQuery())
+        SearchRequestBuilder builder = prepareSearch("empty_bucket_idx").setQuery(matchAllQuery())
             .addAggregation(
                 histogram("histo").field("value")
                     .interval(1L)
                     .minDocCount(0)
                     .subAggregation(adjacencyMatrix("matrix", newMap("all", matchAllQuery())))
-            )
-            .get();
+            );
 
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(2L));
-        Histogram histo = searchResponse.getAggregations().get("histo");
-        assertThat(histo, Matchers.notNullValue());
-        Histogram.Bucket bucket = histo.getBuckets().get(1);
-        assertThat(bucket, Matchers.notNullValue());
+        assertResponse(builder, response -> {
+            assertHitCount(response, 2L);
+            Histogram histo = response.getAggregations().get("histo");
+            assertThat(histo, Matchers.notNullValue());
+            Histogram.Bucket bucket = histo.getBuckets().get(1);
+            assertThat(bucket, Matchers.notNullValue());
 
-        AdjacencyMatrix matrix = bucket.getAggregations().get("matrix");
-        assertThat(matrix, notNullValue());
-        AdjacencyMatrix.Bucket all = matrix.getBucketByKey("all");
-        assertThat(all, Matchers.nullValue());
+            AdjacencyMatrix matrix = bucket.getAggregations().get("matrix");
+            assertThat(matrix, notNullValue());
+            AdjacencyMatrix.Bucket all = matrix.getBucketByKey("all");
+            assertThat(all, Matchers.nullValue());
+        });
     }
 
     // Helper methods for building maps of QueryBuilders

--- a/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/bucket/TimeSeriesAggregationsIT.java
+++ b/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/bucket/TimeSeriesAggregationsIT.java
@@ -13,7 +13,6 @@ import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.action.index.IndexRequestBuilder;
-import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.aggregations.AggregationIntegTestCase;
 import org.elasticsearch.aggregations.bucket.timeseries.InternalTimeSeries;
@@ -195,66 +194,74 @@ public class TimeSeriesAggregationsIT extends AggregationIntegTestCase {
 
     public void testTimeSeriesGroupedByADimension() {
         String groupBy = "dim_" + randomIntBetween(0, numberOfDimensions - 1);
-        SearchRequestBuilder builder = prepareSearch("index").setSize(0)
-            .addAggregation(
-                terms("by_dim").field(groupBy)
-                    .size(data.size())
-                    .collectMode(randomFrom(Aggregator.SubAggCollectionMode.values()))
-                    .subAggregation(timeSeries("by_ts"))
-            );
-        assertNoFailuresAndResponse(builder, response -> {
-            Aggregations aggregations = response.getAggregations();
-            assertNotNull(aggregations);
-            Terms terms = aggregations.get("by_dim");
-            Set<Map<String, String>> keys = new HashSet<>();
-            for (Terms.Bucket term : terms.getBuckets()) {
-                InternalTimeSeries timeSeries = term.getAggregations().get("by_ts");
-                for (InternalTimeSeries.Bucket bucket : timeSeries.getBuckets()) {
-                    @SuppressWarnings("unchecked")
-                    Map<String, String> key = (Map<String, String>) bucket.getKey();
-                    assertThat((long) data.get(key).size(), equalTo(bucket.getDocCount()));
-                    assertTrue("key is not unique", keys.add(key));
-                    assertThat("time series doesn't contain dimensions we grouped by", key.get(groupBy), equalTo(term.getKeyAsString()));
+        assertNoFailuresAndResponse(
+            prepareSearch("index").setSize(0)
+                .addAggregation(
+                    terms("by_dim").field(groupBy)
+                        .size(data.size())
+                        .collectMode(randomFrom(Aggregator.SubAggCollectionMode.values()))
+                        .subAggregation(timeSeries("by_ts"))
+                ),
+            response -> {
+                Aggregations aggregations = response.getAggregations();
+                assertNotNull(aggregations);
+                Terms terms = aggregations.get("by_dim");
+                Set<Map<String, String>> keys = new HashSet<>();
+                for (Terms.Bucket term : terms.getBuckets()) {
+                    InternalTimeSeries timeSeries = term.getAggregations().get("by_ts");
+                    for (InternalTimeSeries.Bucket bucket : timeSeries.getBuckets()) {
+                        @SuppressWarnings("unchecked")
+                        Map<String, String> key = (Map<String, String>) bucket.getKey();
+                        assertThat((long) data.get(key).size(), equalTo(bucket.getDocCount()));
+                        assertTrue("key is not unique", keys.add(key));
+                        assertThat(
+                            "time series doesn't contain dimensions we grouped by",
+                            key.get(groupBy),
+                            equalTo(term.getKeyAsString())
+                        );
+                    }
                 }
+                assertThat(keys, equalTo(data.keySet()));
             }
-            assertThat(keys, equalTo(data.keySet()));
-        });
+        );
     }
 
     public void testTimeSeriesGroupedByDateHistogram() {
         DateHistogramInterval fixedInterval = DateHistogramInterval.days(randomIntBetween(10, 100));
-        SearchRequestBuilder builder = prepareSearch("index").setSize(0)
-            .addAggregation(
-                dateHistogram("by_time").field("@timestamp")
-                    .fixedInterval(fixedInterval)
-                    .subAggregation(timeSeries("by_ts").subAggregation(stats("timestamp").field("@timestamp")))
-            );
-        assertNoFailuresAndResponse(builder, response -> {
-            Aggregations aggregations = response.getAggregations();
-            assertNotNull(aggregations);
-            Histogram histogram = aggregations.get("by_time");
-            Map<Map<String, String>, Long> keys = new HashMap<>();
-            for (Histogram.Bucket interval : histogram.getBuckets()) {
-                long intervalStart = ((ZonedDateTime) interval.getKey()).toEpochSecond() * 1000;
-                long intervalEnd = intervalStart + fixedInterval.estimateMillis();
-                InternalTimeSeries timeSeries = interval.getAggregations().get("by_ts");
-                for (InternalTimeSeries.Bucket bucket : timeSeries.getBuckets()) {
-                    @SuppressWarnings("unchecked")
-                    Map<String, String> key = (Map<String, String>) bucket.getKey();
-                    keys.compute(key, (k, v) -> (v == null ? 0 : v) + bucket.getDocCount());
-                    assertThat(bucket.getDocCount(), lessThanOrEqualTo((long) data.get(key).size()));
-                    Stats stats = bucket.getAggregations().get("timestamp");
-                    long minTimestamp = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parseMillis(stats.getMinAsString());
-                    long maxTimestamp = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parseMillis(stats.getMaxAsString());
-                    assertThat(minTimestamp, greaterThanOrEqualTo(intervalStart));
-                    assertThat(maxTimestamp, lessThan(intervalEnd));
+        assertNoFailuresAndResponse(
+            prepareSearch("index").setSize(0)
+                .addAggregation(
+                    dateHistogram("by_time").field("@timestamp")
+                        .fixedInterval(fixedInterval)
+                        .subAggregation(timeSeries("by_ts").subAggregation(stats("timestamp").field("@timestamp")))
+                ),
+            response -> {
+                Aggregations aggregations = response.getAggregations();
+                assertNotNull(aggregations);
+                Histogram histogram = aggregations.get("by_time");
+                Map<Map<String, String>, Long> keys = new HashMap<>();
+                for (Histogram.Bucket interval : histogram.getBuckets()) {
+                    long intervalStart = ((ZonedDateTime) interval.getKey()).toEpochSecond() * 1000;
+                    long intervalEnd = intervalStart + fixedInterval.estimateMillis();
+                    InternalTimeSeries timeSeries = interval.getAggregations().get("by_ts");
+                    for (InternalTimeSeries.Bucket bucket : timeSeries.getBuckets()) {
+                        @SuppressWarnings("unchecked")
+                        Map<String, String> key = (Map<String, String>) bucket.getKey();
+                        keys.compute(key, (k, v) -> (v == null ? 0 : v) + bucket.getDocCount());
+                        assertThat(bucket.getDocCount(), lessThanOrEqualTo((long) data.get(key).size()));
+                        Stats stats = bucket.getAggregations().get("timestamp");
+                        long minTimestamp = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parseMillis(stats.getMinAsString());
+                        long maxTimestamp = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parseMillis(stats.getMaxAsString());
+                        assertThat(minTimestamp, greaterThanOrEqualTo(intervalStart));
+                        assertThat(maxTimestamp, lessThan(intervalEnd));
+                    }
+                }
+                assertThat(keys.keySet(), equalTo(data.keySet()));
+                for (Map.Entry<Map<String, String>, Long> entry : keys.entrySet()) {
+                    assertThat(entry.getValue(), equalTo((long) data.get(entry.getKey()).size()));
                 }
             }
-            assertThat(keys.keySet(), equalTo(data.keySet()));
-            for (Map.Entry<Map<String, String>, Long> entry : keys.entrySet()) {
-                assertThat(entry.getValue(), equalTo((long) data.get(entry.getKey()).size()));
-            }
-        });
+        );
     }
 
     public void testStandAloneTimeSeriesAggWithDimFilter() {
@@ -294,32 +301,34 @@ public class TimeSeriesAggregationsIT extends AggregationIntegTestCase {
         if (include == false) {
             queryBuilder = QueryBuilders.boolQuery().mustNot(queryBuilder);
         }
-        SearchRequestBuilder builder = prepareSearch("index").setQuery(queryBuilder)
-            .setSize(0)
-            .addAggregation(timeSeries("by_ts").subAggregation(sum("filter_sum").field("metric_" + metric)))
-            .addAggregation(global("everything").subAggregation(sum("all_sum").field("metric_" + metric)))
-            .addAggregation(PipelineAggregatorBuilders.sumBucket("total_filter_sum", "by_ts>filter_sum"));
-        assertNoFailuresAndResponse(builder, response -> {
-            Aggregations aggregations = response.getAggregations();
-            assertNotNull(aggregations);
-            InternalTimeSeries timeSeries = aggregations.get("by_ts");
-            Map<Map<String, String>, Map<Long, Map<String, Double>>> filteredData = dataFilteredByDimension("dim_" + dim, val, include);
-            assertThat(
-                timeSeries.getBuckets().stream().map(MultiBucketsAggregation.Bucket::getKey).collect(Collectors.toSet()),
-                equalTo(filteredData.keySet())
-            );
-            for (InternalTimeSeries.Bucket bucket : timeSeries.getBuckets()) {
-                @SuppressWarnings("unchecked")
-                Map<String, String> key = (Map<String, String>) bucket.getKey();
-                assertThat(bucket.getDocCount(), equalTo((long) filteredData.get(key).size()));
-            }
-            SimpleValue obj = aggregations.get("total_filter_sum");
-            assertThat(obj.value(), closeTo(sumByMetric(filteredData, "metric_" + metric), obj.value() * 0.0001));
+        assertNoFailuresAndResponse(
+            prepareSearch("index").setQuery(queryBuilder)
+                .setSize(0)
+                .addAggregation(timeSeries("by_ts").subAggregation(sum("filter_sum").field("metric_" + metric)))
+                .addAggregation(global("everything").subAggregation(sum("all_sum").field("metric_" + metric)))
+                .addAggregation(PipelineAggregatorBuilders.sumBucket("total_filter_sum", "by_ts>filter_sum")),
+            response -> {
+                Aggregations aggregations = response.getAggregations();
+                assertNotNull(aggregations);
+                InternalTimeSeries timeSeries = aggregations.get("by_ts");
+                Map<Map<String, String>, Map<Long, Map<String, Double>>> filteredData = dataFilteredByDimension("dim_" + dim, val, include);
+                assertThat(
+                    timeSeries.getBuckets().stream().map(MultiBucketsAggregation.Bucket::getKey).collect(Collectors.toSet()),
+                    equalTo(filteredData.keySet())
+                );
+                for (InternalTimeSeries.Bucket bucket : timeSeries.getBuckets()) {
+                    @SuppressWarnings("unchecked")
+                    Map<String, String> key = (Map<String, String>) bucket.getKey();
+                    assertThat(bucket.getDocCount(), equalTo((long) filteredData.get(key).size()));
+                }
+                SimpleValue obj = aggregations.get("total_filter_sum");
+                assertThat(obj.value(), closeTo(sumByMetric(filteredData, "metric_" + metric), obj.value() * 0.0001));
 
-            Global global = aggregations.get("everything");
-            Sum allSum = global.getAggregations().get("all_sum");
-            assertThat(allSum.value(), closeTo(sumByMetric(data, "metric_" + metric), allSum.value() * 0.0001));
-        });
+                Global global = aggregations.get("everything");
+                Sum allSum = global.getAggregations().get("all_sum");
+                assertThat(allSum.value(), closeTo(sumByMetric(data, "metric_" + metric), allSum.value() * 0.0001));
+            }
+        );
 
         ElasticsearchException e = expectThrows(
             ElasticsearchException.class,

--- a/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/bucket/TimeSeriesAggregationsIT.java
+++ b/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/bucket/TimeSeriesAggregationsIT.java
@@ -13,7 +13,7 @@ import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.action.index.IndexRequestBuilder;
-import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.aggregations.AggregationIntegTestCase;
 import org.elasticsearch.aggregations.bucket.timeseries.InternalTimeSeries;
@@ -58,6 +58,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.topHits;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -176,84 +177,84 @@ public class TimeSeriesAggregationsIT extends AggregationIntegTestCase {
     }
 
     public void testStandAloneTimeSeriesAgg() {
-        SearchResponse response = prepareSearch("index").setSize(0).addAggregation(timeSeries("by_ts")).get();
-        assertNoFailures(response);
-        Aggregations aggregations = response.getAggregations();
-        assertNotNull(aggregations);
-        InternalTimeSeries timeSeries = aggregations.get("by_ts");
-        assertThat(
-            timeSeries.getBuckets().stream().map(MultiBucketsAggregation.Bucket::getKey).collect(Collectors.toSet()),
-            equalTo(data.keySet())
-        );
-        for (InternalTimeSeries.Bucket bucket : timeSeries.getBuckets()) {
-            @SuppressWarnings("unchecked")
-            Map<String, String> key = (Map<String, String>) bucket.getKey();
-            assertThat((long) data.get(key).size(), equalTo(bucket.getDocCount()));
-        }
+        assertNoFailuresAndResponse(prepareSearch("index").setSize(0).addAggregation(timeSeries("by_ts")), response -> {
+            Aggregations aggregations = response.getAggregations();
+            assertNotNull(aggregations);
+            InternalTimeSeries timeSeries = aggregations.get("by_ts");
+            assertThat(
+                timeSeries.getBuckets().stream().map(MultiBucketsAggregation.Bucket::getKey).collect(Collectors.toSet()),
+                equalTo(data.keySet())
+            );
+            for (InternalTimeSeries.Bucket bucket : timeSeries.getBuckets()) {
+                @SuppressWarnings("unchecked")
+                Map<String, String> key = (Map<String, String>) bucket.getKey();
+                assertThat((long) data.get(key).size(), equalTo(bucket.getDocCount()));
+            }
+        });
     }
 
     public void testTimeSeriesGroupedByADimension() {
         String groupBy = "dim_" + randomIntBetween(0, numberOfDimensions - 1);
-        SearchResponse response = prepareSearch("index").setSize(0)
+        SearchRequestBuilder builder = prepareSearch("index").setSize(0)
             .addAggregation(
                 terms("by_dim").field(groupBy)
                     .size(data.size())
                     .collectMode(randomFrom(Aggregator.SubAggCollectionMode.values()))
                     .subAggregation(timeSeries("by_ts"))
-            )
-            .get();
-        assertNoFailures(response);
-        Aggregations aggregations = response.getAggregations();
-        assertNotNull(aggregations);
-        Terms terms = aggregations.get("by_dim");
-        Set<Map<String, String>> keys = new HashSet<>();
-        for (Terms.Bucket term : terms.getBuckets()) {
-            InternalTimeSeries timeSeries = term.getAggregations().get("by_ts");
-            for (InternalTimeSeries.Bucket bucket : timeSeries.getBuckets()) {
-                @SuppressWarnings("unchecked")
-                Map<String, String> key = (Map<String, String>) bucket.getKey();
-                assertThat((long) data.get(key).size(), equalTo(bucket.getDocCount()));
-                assertTrue("key is not unique", keys.add(key));
-                assertThat("time series doesn't contain dimensions we grouped by", key.get(groupBy), equalTo(term.getKeyAsString()));
+            );
+        assertNoFailuresAndResponse(builder, response -> {
+            Aggregations aggregations = response.getAggregations();
+            assertNotNull(aggregations);
+            Terms terms = aggregations.get("by_dim");
+            Set<Map<String, String>> keys = new HashSet<>();
+            for (Terms.Bucket term : terms.getBuckets()) {
+                InternalTimeSeries timeSeries = term.getAggregations().get("by_ts");
+                for (InternalTimeSeries.Bucket bucket : timeSeries.getBuckets()) {
+                    @SuppressWarnings("unchecked")
+                    Map<String, String> key = (Map<String, String>) bucket.getKey();
+                    assertThat((long) data.get(key).size(), equalTo(bucket.getDocCount()));
+                    assertTrue("key is not unique", keys.add(key));
+                    assertThat("time series doesn't contain dimensions we grouped by", key.get(groupBy), equalTo(term.getKeyAsString()));
+                }
             }
-        }
-        assertThat(keys, equalTo(data.keySet()));
+            assertThat(keys, equalTo(data.keySet()));
+        });
     }
 
     public void testTimeSeriesGroupedByDateHistogram() {
         DateHistogramInterval fixedInterval = DateHistogramInterval.days(randomIntBetween(10, 100));
-        SearchResponse response = prepareSearch("index").setSize(0)
+        SearchRequestBuilder builder = prepareSearch("index").setSize(0)
             .addAggregation(
                 dateHistogram("by_time").field("@timestamp")
                     .fixedInterval(fixedInterval)
                     .subAggregation(timeSeries("by_ts").subAggregation(stats("timestamp").field("@timestamp")))
-            )
-            .get();
-        assertNoFailures(response);
-        Aggregations aggregations = response.getAggregations();
-        assertNotNull(aggregations);
-        Histogram histogram = aggregations.get("by_time");
-        Map<Map<String, String>, Long> keys = new HashMap<>();
-        for (Histogram.Bucket interval : histogram.getBuckets()) {
-            long intervalStart = ((ZonedDateTime) interval.getKey()).toEpochSecond() * 1000;
-            long intervalEnd = intervalStart + fixedInterval.estimateMillis();
-            InternalTimeSeries timeSeries = interval.getAggregations().get("by_ts");
-            for (InternalTimeSeries.Bucket bucket : timeSeries.getBuckets()) {
-                @SuppressWarnings("unchecked")
-                Map<String, String> key = (Map<String, String>) bucket.getKey();
-                keys.compute(key, (k, v) -> (v == null ? 0 : v) + bucket.getDocCount());
-                assertThat(bucket.getDocCount(), lessThanOrEqualTo((long) data.get(key).size()));
-                Stats stats = bucket.getAggregations().get("timestamp");
-                long minTimestamp = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parseMillis(stats.getMinAsString());
-                long maxTimestamp = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parseMillis(stats.getMaxAsString());
-                assertThat(minTimestamp, greaterThanOrEqualTo(intervalStart));
-                assertThat(maxTimestamp, lessThan(intervalEnd));
+            );
+        assertNoFailuresAndResponse(builder, response -> {
+            Aggregations aggregations = response.getAggregations();
+            assertNotNull(aggregations);
+            Histogram histogram = aggregations.get("by_time");
+            Map<Map<String, String>, Long> keys = new HashMap<>();
+            for (Histogram.Bucket interval : histogram.getBuckets()) {
+                long intervalStart = ((ZonedDateTime) interval.getKey()).toEpochSecond() * 1000;
+                long intervalEnd = intervalStart + fixedInterval.estimateMillis();
+                InternalTimeSeries timeSeries = interval.getAggregations().get("by_ts");
+                for (InternalTimeSeries.Bucket bucket : timeSeries.getBuckets()) {
+                    @SuppressWarnings("unchecked")
+                    Map<String, String> key = (Map<String, String>) bucket.getKey();
+                    keys.compute(key, (k, v) -> (v == null ? 0 : v) + bucket.getDocCount());
+                    assertThat(bucket.getDocCount(), lessThanOrEqualTo((long) data.get(key).size()));
+                    Stats stats = bucket.getAggregations().get("timestamp");
+                    long minTimestamp = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parseMillis(stats.getMinAsString());
+                    long maxTimestamp = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parseMillis(stats.getMaxAsString());
+                    assertThat(minTimestamp, greaterThanOrEqualTo(intervalStart));
+                    assertThat(maxTimestamp, lessThan(intervalEnd));
+                }
             }
-        }
-        assertThat(keys.keySet(), equalTo(data.keySet()));
-        for (Map.Entry<Map<String, String>, Long> entry : keys.entrySet()) {
-            assertThat(entry.getValue(), equalTo((long) data.get(entry.getKey()).size()));
-        }
+            assertThat(keys.keySet(), equalTo(data.keySet()));
+            for (Map.Entry<Map<String, String>, Long> entry : keys.entrySet()) {
+                assertThat(entry.getValue(), equalTo((long) data.get(entry.getKey()).size()));
+            }
+        });
     }
 
     public void testStandAloneTimeSeriesAggWithDimFilter() {
@@ -264,21 +265,24 @@ public class TimeSeriesAggregationsIT extends AggregationIntegTestCase {
         if (include == false) {
             queryBuilder = QueryBuilders.boolQuery().mustNot(queryBuilder);
         }
-        SearchResponse response = prepareSearch("index").setQuery(queryBuilder).setSize(0).addAggregation(timeSeries("by_ts")).get();
-        assertNoFailures(response);
-        Aggregations aggregations = response.getAggregations();
-        assertNotNull(aggregations);
-        InternalTimeSeries timeSeries = aggregations.get("by_ts");
-        Map<Map<String, String>, Map<Long, Map<String, Double>>> filteredData = dataFilteredByDimension("dim_" + dim, val, include);
-        assertThat(
-            timeSeries.getBuckets().stream().map(MultiBucketsAggregation.Bucket::getKey).collect(Collectors.toSet()),
-            equalTo(filteredData.keySet())
+        assertNoFailuresAndResponse(
+            prepareSearch("index").setQuery(queryBuilder).setSize(0).addAggregation(timeSeries("by_ts")),
+            response -> {
+                Aggregations aggregations = response.getAggregations();
+                assertNotNull(aggregations);
+                InternalTimeSeries timeSeries = aggregations.get("by_ts");
+                Map<Map<String, String>, Map<Long, Map<String, Double>>> filteredData = dataFilteredByDimension("dim_" + dim, val, include);
+                assertThat(
+                    timeSeries.getBuckets().stream().map(MultiBucketsAggregation.Bucket::getKey).collect(Collectors.toSet()),
+                    equalTo(filteredData.keySet())
+                );
+                for (InternalTimeSeries.Bucket bucket : timeSeries.getBuckets()) {
+                    @SuppressWarnings("unchecked")
+                    Map<String, String> key = (Map<String, String>) bucket.getKey();
+                    assertThat(bucket.getDocCount(), equalTo((long) filteredData.get(key).size()));
+                }
+            }
         );
-        for (InternalTimeSeries.Bucket bucket : timeSeries.getBuckets()) {
-            @SuppressWarnings("unchecked")
-            Map<String, String> key = (Map<String, String>) bucket.getKey();
-            assertThat(bucket.getDocCount(), equalTo((long) filteredData.get(key).size()));
-        }
     }
 
     public void testStandAloneTimeSeriesAggWithGlobalAggregation() {
@@ -290,32 +294,32 @@ public class TimeSeriesAggregationsIT extends AggregationIntegTestCase {
         if (include == false) {
             queryBuilder = QueryBuilders.boolQuery().mustNot(queryBuilder);
         }
-        SearchResponse response = prepareSearch("index").setQuery(queryBuilder)
+        SearchRequestBuilder builder = prepareSearch("index").setQuery(queryBuilder)
             .setSize(0)
             .addAggregation(timeSeries("by_ts").subAggregation(sum("filter_sum").field("metric_" + metric)))
             .addAggregation(global("everything").subAggregation(sum("all_sum").field("metric_" + metric)))
-            .addAggregation(PipelineAggregatorBuilders.sumBucket("total_filter_sum", "by_ts>filter_sum"))
-            .get();
-        assertNoFailures(response);
-        Aggregations aggregations = response.getAggregations();
-        assertNotNull(aggregations);
-        InternalTimeSeries timeSeries = aggregations.get("by_ts");
-        Map<Map<String, String>, Map<Long, Map<String, Double>>> filteredData = dataFilteredByDimension("dim_" + dim, val, include);
-        assertThat(
-            timeSeries.getBuckets().stream().map(MultiBucketsAggregation.Bucket::getKey).collect(Collectors.toSet()),
-            equalTo(filteredData.keySet())
-        );
-        for (InternalTimeSeries.Bucket bucket : timeSeries.getBuckets()) {
-            @SuppressWarnings("unchecked")
-            Map<String, String> key = (Map<String, String>) bucket.getKey();
-            assertThat(bucket.getDocCount(), equalTo((long) filteredData.get(key).size()));
-        }
-        SimpleValue obj = aggregations.get("total_filter_sum");
-        assertThat(obj.value(), closeTo(sumByMetric(filteredData, "metric_" + metric), obj.value() * 0.0001));
+            .addAggregation(PipelineAggregatorBuilders.sumBucket("total_filter_sum", "by_ts>filter_sum"));
+        assertNoFailuresAndResponse(builder, response -> {
+            Aggregations aggregations = response.getAggregations();
+            assertNotNull(aggregations);
+            InternalTimeSeries timeSeries = aggregations.get("by_ts");
+            Map<Map<String, String>, Map<Long, Map<String, Double>>> filteredData = dataFilteredByDimension("dim_" + dim, val, include);
+            assertThat(
+                timeSeries.getBuckets().stream().map(MultiBucketsAggregation.Bucket::getKey).collect(Collectors.toSet()),
+                equalTo(filteredData.keySet())
+            );
+            for (InternalTimeSeries.Bucket bucket : timeSeries.getBuckets()) {
+                @SuppressWarnings("unchecked")
+                Map<String, String> key = (Map<String, String>) bucket.getKey();
+                assertThat(bucket.getDocCount(), equalTo((long) filteredData.get(key).size()));
+            }
+            SimpleValue obj = aggregations.get("total_filter_sum");
+            assertThat(obj.value(), closeTo(sumByMetric(filteredData, "metric_" + metric), obj.value() * 0.0001));
 
-        Global global = aggregations.get("everything");
-        Sum allSum = global.getAggregations().get("all_sum");
-        assertThat(allSum.value(), closeTo(sumByMetric(data, "metric_" + metric), allSum.value() * 0.0001));
+            Global global = aggregations.get("everything");
+            Sum allSum = global.getAggregations().get("all_sum");
+            assertThat(allSum.value(), closeTo(sumByMetric(data, "metric_" + metric), allSum.value() * 0.0001));
+        });
 
         ElasticsearchException e = expectThrows(
             ElasticsearchException.class,
@@ -337,21 +341,29 @@ public class TimeSeriesAggregationsIT extends AggregationIntegTestCase {
         } else {
             queryBuilder.lte(val);
         }
-        SearchResponse response = prepareSearch("index").setQuery(queryBuilder).setSize(0).addAggregation(timeSeries("by_ts")).get();
-        assertNoFailures(response);
-        Aggregations aggregations = response.getAggregations();
-        assertNotNull(aggregations);
-        InternalTimeSeries timeSeries = aggregations.get("by_ts");
-        Map<Map<String, String>, Map<Long, Map<String, Double>>> filteredData = dataFilteredByMetric(data, "metric_" + metric, val, above);
-        assertThat(
-            timeSeries.getBuckets().stream().map(MultiBucketsAggregation.Bucket::getKey).collect(Collectors.toSet()),
-            equalTo(filteredData.keySet())
+        assertNoFailuresAndResponse(
+            prepareSearch("index").setQuery(queryBuilder).setSize(0).addAggregation(timeSeries("by_ts")),
+            response -> {
+                Aggregations aggregations = response.getAggregations();
+                assertNotNull(aggregations);
+                InternalTimeSeries timeSeries = aggregations.get("by_ts");
+                Map<Map<String, String>, Map<Long, Map<String, Double>>> filteredData = dataFilteredByMetric(
+                    data,
+                    "metric_" + metric,
+                    val,
+                    above
+                );
+                assertThat(
+                    timeSeries.getBuckets().stream().map(MultiBucketsAggregation.Bucket::getKey).collect(Collectors.toSet()),
+                    equalTo(filteredData.keySet())
+                );
+                for (InternalTimeSeries.Bucket bucket : timeSeries.getBuckets()) {
+                    @SuppressWarnings("unchecked")
+                    Map<String, String> key = (Map<String, String>) bucket.getKey();
+                    assertThat(bucket.getDocCount(), equalTo((long) filteredData.get(key).size()));
+                }
+            }
         );
-        for (InternalTimeSeries.Bucket bucket : timeSeries.getBuckets()) {
-            @SuppressWarnings("unchecked")
-            Map<String, String> key = (Map<String, String>) bucket.getKey();
-            assertThat(bucket.getDocCount(), equalTo((long) filteredData.get(key).size()));
-        }
     }
 
     public void testRetrievingHits() {

--- a/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/pipeline/DateDerivativeIT.java
+++ b/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/pipeline/DateDerivativeIT.java
@@ -9,7 +9,7 @@
 package org.elasticsearch.aggregations.pipeline;
 
 import org.elasticsearch.action.index.IndexRequestBuilder;
-import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.aggregations.AggregationsPlugin;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.time.DateFormatters;
@@ -39,7 +39,7 @@ import java.util.List;
 
 import static org.elasticsearch.search.aggregations.AggregationBuilders.dateHistogram;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
@@ -116,91 +116,91 @@ public class DateDerivativeIT extends ESIntegTestCase {
     }
 
     public void testSingleValuedField() throws Exception {
-        SearchResponse response = prepareSearch("idx").addAggregation(
+        SearchRequestBuilder builder = prepareSearch("idx").addAggregation(
             dateHistogram("histo").field("date")
                 .calendarInterval(DateHistogramInterval.MONTH)
                 .minDocCount(0)
                 .subAggregation(new DerivativePipelineAggregationBuilder("deriv", "_count"))
-        ).get();
+        );
 
-        assertNoFailures(response);
+        assertNoFailuresAndResponse(builder, response -> {
+            Histogram deriv = response.getAggregations().get("histo");
+            assertThat(deriv, notNullValue());
+            assertThat(deriv.getName(), equalTo("histo"));
+            List<? extends Bucket> buckets = deriv.getBuckets();
+            assertThat(buckets.size(), equalTo(3));
 
-        Histogram deriv = response.getAggregations().get("histo");
-        assertThat(deriv, notNullValue());
-        assertThat(deriv.getName(), equalTo("histo"));
-        List<? extends Bucket> buckets = deriv.getBuckets();
-        assertThat(buckets.size(), equalTo(3));
+            ZonedDateTime key = ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+            Histogram.Bucket bucket = buckets.get(0);
+            assertThat(bucket, notNullValue());
+            assertThat((ZonedDateTime) bucket.getKey(), equalTo(key));
+            assertThat(bucket.getDocCount(), equalTo(1L));
+            SimpleValue docCountDeriv = bucket.getAggregations().get("deriv");
+            assertThat(docCountDeriv, nullValue());
 
-        ZonedDateTime key = ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        Histogram.Bucket bucket = buckets.get(0);
-        assertThat(bucket, notNullValue());
-        assertThat((ZonedDateTime) bucket.getKey(), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(1L));
-        SimpleValue docCountDeriv = bucket.getAggregations().get("deriv");
-        assertThat(docCountDeriv, nullValue());
+            key = ZonedDateTime.of(2012, 2, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+            bucket = buckets.get(1);
+            assertThat(bucket, notNullValue());
+            assertThat((ZonedDateTime) bucket.getKey(), equalTo(key));
+            assertThat(bucket.getDocCount(), equalTo(2L));
+            docCountDeriv = bucket.getAggregations().get("deriv");
+            assertThat(docCountDeriv, notNullValue());
+            assertThat(docCountDeriv.value(), equalTo(1d));
 
-        key = ZonedDateTime.of(2012, 2, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        bucket = buckets.get(1);
-        assertThat(bucket, notNullValue());
-        assertThat((ZonedDateTime) bucket.getKey(), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(2L));
-        docCountDeriv = bucket.getAggregations().get("deriv");
-        assertThat(docCountDeriv, notNullValue());
-        assertThat(docCountDeriv.value(), equalTo(1d));
-
-        key = ZonedDateTime.of(2012, 3, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        bucket = buckets.get(2);
-        assertThat(bucket, notNullValue());
-        assertThat((ZonedDateTime) bucket.getKey(), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(3L));
-        docCountDeriv = bucket.getAggregations().get("deriv");
-        assertThat(docCountDeriv, notNullValue());
-        assertThat(docCountDeriv.value(), equalTo(1d));
+            key = ZonedDateTime.of(2012, 3, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+            bucket = buckets.get(2);
+            assertThat(bucket, notNullValue());
+            assertThat((ZonedDateTime) bucket.getKey(), equalTo(key));
+            assertThat(bucket.getDocCount(), equalTo(3L));
+            docCountDeriv = bucket.getAggregations().get("deriv");
+            assertThat(docCountDeriv, notNullValue());
+            assertThat(docCountDeriv.value(), equalTo(1d));
+        });
     }
 
     public void testSingleValuedFieldNormalised() throws Exception {
-        SearchResponse response = prepareSearch("idx").addAggregation(
+        SearchRequestBuilder builder = prepareSearch("idx").addAggregation(
             dateHistogram("histo").field("date")
                 .calendarInterval(DateHistogramInterval.MONTH)
                 .minDocCount(0)
                 .subAggregation(new DerivativePipelineAggregationBuilder("deriv", "_count").unit(DateHistogramInterval.DAY))
-        ).get();
+        );
 
-        assertNoFailures(response);
+        assertNoFailuresAndResponse(builder, response -> {
+            Histogram deriv = response.getAggregations().get("histo");
+            assertThat(deriv, notNullValue());
+            assertThat(deriv.getName(), equalTo("histo"));
+            List<? extends Bucket> buckets = deriv.getBuckets();
+            assertThat(buckets.size(), equalTo(3));
 
-        Histogram deriv = response.getAggregations().get("histo");
-        assertThat(deriv, notNullValue());
-        assertThat(deriv.getName(), equalTo("histo"));
-        List<? extends Bucket> buckets = deriv.getBuckets();
-        assertThat(buckets.size(), equalTo(3));
+            ZonedDateTime key = ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+            Histogram.Bucket bucket = buckets.get(0);
+            assertThat(bucket, notNullValue());
+            assertThat(bucket.getKey(), equalTo(key));
+            assertThat(bucket.getDocCount(), equalTo(1L));
+            Derivative docCountDeriv = bucket.getAggregations().get("deriv");
+            assertThat(docCountDeriv, nullValue());
 
-        ZonedDateTime key = ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        Histogram.Bucket bucket = buckets.get(0);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKey(), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(1L));
-        Derivative docCountDeriv = bucket.getAggregations().get("deriv");
-        assertThat(docCountDeriv, nullValue());
+            key = ZonedDateTime.of(2012, 2, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+            bucket = buckets.get(1);
+            assertThat(bucket, notNullValue());
+            assertThat(bucket.getKey(), equalTo(key));
+            assertThat(bucket.getDocCount(), equalTo(2L));
+            docCountDeriv = bucket.getAggregations().get("deriv");
+            assertThat(docCountDeriv, notNullValue());
+            assertThat(docCountDeriv.value(), closeTo(1d, 0.00001));
+            assertThat(docCountDeriv.normalizedValue(), closeTo(1d / 31d, 0.00001));
 
-        key = ZonedDateTime.of(2012, 2, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        bucket = buckets.get(1);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKey(), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(2L));
-        docCountDeriv = bucket.getAggregations().get("deriv");
-        assertThat(docCountDeriv, notNullValue());
-        assertThat(docCountDeriv.value(), closeTo(1d, 0.00001));
-        assertThat(docCountDeriv.normalizedValue(), closeTo(1d / 31d, 0.00001));
-
-        key = ZonedDateTime.of(2012, 3, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        bucket = buckets.get(2);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKey(), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(3L));
-        docCountDeriv = bucket.getAggregations().get("deriv");
-        assertThat(docCountDeriv, notNullValue());
-        assertThat(docCountDeriv.value(), closeTo(1d, 0.00001));
-        assertThat(docCountDeriv.normalizedValue(), closeTo(1d / 29d, 0.00001));
+            key = ZonedDateTime.of(2012, 3, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+            bucket = buckets.get(2);
+            assertThat(bucket, notNullValue());
+            assertThat(bucket.getKey(), equalTo(key));
+            assertThat(bucket.getDocCount(), equalTo(3L));
+            docCountDeriv = bucket.getAggregations().get("deriv");
+            assertThat(docCountDeriv, notNullValue());
+            assertThat(docCountDeriv.value(), closeTo(1d, 0.00001));
+            assertThat(docCountDeriv.normalizedValue(), closeTo(1d / 29d, 0.00001));
+        });
     }
 
     /**
@@ -221,43 +221,43 @@ public class DateDerivativeIT extends ESIntegTestCase {
         indexRandom(true, builders);
         ensureSearchable();
 
-        SearchResponse response = prepareSearch(IDX_DST_START).addAggregation(
+        SearchRequestBuilder builder = prepareSearch(IDX_DST_START).addAggregation(
             dateHistogram("histo").field("date")
                 .calendarInterval(DateHistogramInterval.DAY)
                 .timeZone(timezone)
                 .minDocCount(0)
                 .subAggregation(new DerivativePipelineAggregationBuilder("deriv", "_count").unit(DateHistogramInterval.HOUR))
-        ).get();
+        );
 
-        assertNoFailures(response);
+        assertNoFailuresAndResponse(builder, response -> {
+            Histogram deriv = response.getAggregations().get("histo");
+            assertThat(deriv, notNullValue());
+            assertThat(deriv.getName(), equalTo("histo"));
+            List<? extends Bucket> buckets = deriv.getBuckets();
+            assertThat(buckets.size(), equalTo(4));
 
-        Histogram deriv = response.getAggregations().get("histo");
-        assertThat(deriv, notNullValue());
-        assertThat(deriv.getName(), equalTo("histo"));
-        List<? extends Bucket> buckets = deriv.getBuckets();
-        assertThat(buckets.size(), equalTo(4));
+            DateFormatter dateFormatter = DateFormatter.forPattern("uuuu-MM-dd");
+            ZonedDateTime expectedKeyFirstBucket = LocalDate.from(dateFormatter.parse("2012-03-24"))
+                .atStartOfDay(timezone)
+                .withZoneSameInstant(ZoneOffset.UTC);
+            assertBucket(buckets.get(0), expectedKeyFirstBucket, 1L, nullValue(), null, null);
 
-        DateFormatter dateFormatter = DateFormatter.forPattern("uuuu-MM-dd");
-        ZonedDateTime expectedKeyFirstBucket = LocalDate.from(dateFormatter.parse("2012-03-24"))
-            .atStartOfDay(timezone)
-            .withZoneSameInstant(ZoneOffset.UTC);
-        assertBucket(buckets.get(0), expectedKeyFirstBucket, 1L, nullValue(), null, null);
+            ZonedDateTime expectedKeySecondBucket = LocalDate.from(dateFormatter.parse("2012-03-25"))
+                .atStartOfDay(timezone)
+                .withZoneSameInstant(ZoneOffset.UTC);
+            assertBucket(buckets.get(1), expectedKeySecondBucket, 2L, notNullValue(), 1d, 1d / 24d);
 
-        ZonedDateTime expectedKeySecondBucket = LocalDate.from(dateFormatter.parse("2012-03-25"))
-            .atStartOfDay(timezone)
-            .withZoneSameInstant(ZoneOffset.UTC);
-        assertBucket(buckets.get(1), expectedKeySecondBucket, 2L, notNullValue(), 1d, 1d / 24d);
+            // the following is normalized using a 23h bucket width
+            ZonedDateTime expectedKeyThirdBucket = LocalDate.from(dateFormatter.parse("2012-03-26"))
+                .atStartOfDay(timezone)
+                .withZoneSameInstant(ZoneOffset.UTC);
+            assertBucket(buckets.get(2), expectedKeyThirdBucket, 3L, notNullValue(), 1d, 1d / 23d);
 
-        // the following is normalized using a 23h bucket width
-        ZonedDateTime expectedKeyThirdBucket = LocalDate.from(dateFormatter.parse("2012-03-26"))
-            .atStartOfDay(timezone)
-            .withZoneSameInstant(ZoneOffset.UTC);
-        assertBucket(buckets.get(2), expectedKeyThirdBucket, 3L, notNullValue(), 1d, 1d / 23d);
-
-        ZonedDateTime expectedKeyFourthBucket = LocalDate.from(dateFormatter.parse("2012-03-27"))
-            .atStartOfDay(timezone)
-            .withZoneSameInstant(ZoneOffset.UTC);
-        assertBucket(buckets.get(3), expectedKeyFourthBucket, 4L, notNullValue(), 1d, 1d / 24d);
+            ZonedDateTime expectedKeyFourthBucket = LocalDate.from(dateFormatter.parse("2012-03-27"))
+                .atStartOfDay(timezone)
+                .withZoneSameInstant(ZoneOffset.UTC);
+            assertBucket(buckets.get(3), expectedKeyFourthBucket, 4L, notNullValue(), 1d, 1d / 24d);
+        });
     }
 
     /**
@@ -277,44 +277,44 @@ public class DateDerivativeIT extends ESIntegTestCase {
         indexRandom(true, builders);
         ensureSearchable();
 
-        SearchResponse response = prepareSearch(IDX_DST_END).addAggregation(
+        SearchRequestBuilder builder = prepareSearch(IDX_DST_END).addAggregation(
             dateHistogram("histo").field("date")
                 .calendarInterval(DateHistogramInterval.DAY)
                 .timeZone(timezone)
                 .minDocCount(0)
                 .subAggregation(new DerivativePipelineAggregationBuilder("deriv", "_count").unit(DateHistogramInterval.HOUR))
-        ).get();
+        );
 
-        assertNoFailures(response);
+        assertNoFailuresAndResponse(builder, response -> {
+            Histogram deriv = response.getAggregations().get("histo");
+            assertThat(deriv, notNullValue());
+            assertThat(deriv.getName(), equalTo("histo"));
+            List<? extends Bucket> buckets = deriv.getBuckets();
+            assertThat(buckets.size(), equalTo(4));
 
-        Histogram deriv = response.getAggregations().get("histo");
-        assertThat(deriv, notNullValue());
-        assertThat(deriv.getName(), equalTo("histo"));
-        List<? extends Bucket> buckets = deriv.getBuckets();
-        assertThat(buckets.size(), equalTo(4));
+            DateFormatter dateFormatter = DateFormatter.forPattern("uuuu-MM-dd").withZone(ZoneOffset.UTC);
 
-        DateFormatter dateFormatter = DateFormatter.forPattern("uuuu-MM-dd").withZone(ZoneOffset.UTC);
+            ZonedDateTime expectedKeyFirstBucket = LocalDate.from(dateFormatter.parse("2012-10-27"))
+                .atStartOfDay(timezone)
+                .withZoneSameInstant(ZoneOffset.UTC);
+            assertBucket(buckets.get(0), expectedKeyFirstBucket, 1L, nullValue(), null, null);
 
-        ZonedDateTime expectedKeyFirstBucket = LocalDate.from(dateFormatter.parse("2012-10-27"))
-            .atStartOfDay(timezone)
-            .withZoneSameInstant(ZoneOffset.UTC);
-        assertBucket(buckets.get(0), expectedKeyFirstBucket, 1L, nullValue(), null, null);
+            ZonedDateTime expectedKeySecondBucket = LocalDate.from(dateFormatter.parse("2012-10-28"))
+                .atStartOfDay(timezone)
+                .withZoneSameInstant(ZoneOffset.UTC);
+            assertBucket(buckets.get(1), expectedKeySecondBucket, 2L, notNullValue(), 1d, 1d / 24d);
 
-        ZonedDateTime expectedKeySecondBucket = LocalDate.from(dateFormatter.parse("2012-10-28"))
-            .atStartOfDay(timezone)
-            .withZoneSameInstant(ZoneOffset.UTC);
-        assertBucket(buckets.get(1), expectedKeySecondBucket, 2L, notNullValue(), 1d, 1d / 24d);
+            // the following is normalized using a 25h bucket width
+            ZonedDateTime expectedKeyThirdBucket = LocalDate.from(dateFormatter.parse("2012-10-29"))
+                .atStartOfDay(timezone)
+                .withZoneSameInstant(ZoneOffset.UTC);
+            assertBucket(buckets.get(2), expectedKeyThirdBucket, 3L, notNullValue(), 1d, 1d / 25d);
 
-        // the following is normalized using a 25h bucket width
-        ZonedDateTime expectedKeyThirdBucket = LocalDate.from(dateFormatter.parse("2012-10-29"))
-            .atStartOfDay(timezone)
-            .withZoneSameInstant(ZoneOffset.UTC);
-        assertBucket(buckets.get(2), expectedKeyThirdBucket, 3L, notNullValue(), 1d, 1d / 25d);
-
-        ZonedDateTime expectedKeyFourthBucket = LocalDate.from(dateFormatter.parse("2012-10-30"))
-            .atStartOfDay(timezone)
-            .withZoneSameInstant(ZoneOffset.UTC);
-        assertBucket(buckets.get(3), expectedKeyFourthBucket, 4L, notNullValue(), 1d, 1d / 24d);
+            ZonedDateTime expectedKeyFourthBucket = LocalDate.from(dateFormatter.parse("2012-10-30"))
+                .atStartOfDay(timezone)
+                .withZoneSameInstant(ZoneOffset.UTC);
+            assertBucket(buckets.get(3), expectedKeyFourthBucket, 4L, notNullValue(), 1d, 1d / 24d);
+        });
     }
 
     /**
@@ -335,44 +335,44 @@ public class DateDerivativeIT extends ESIntegTestCase {
         indexRandom(true, builders);
         ensureSearchable();
 
-        SearchResponse response = prepareSearch(IDX_DST_KATHMANDU).addAggregation(
+        SearchRequestBuilder builder = prepareSearch(IDX_DST_KATHMANDU).addAggregation(
             dateHistogram("histo").field("date")
                 .calendarInterval(DateHistogramInterval.HOUR)
                 .timeZone(timezone)
                 .minDocCount(0)
                 .subAggregation(new DerivativePipelineAggregationBuilder("deriv", "_count").unit(DateHistogramInterval.MINUTE))
-        ).get();
+        );
 
-        assertNoFailures(response);
+        assertNoFailuresAndResponse(builder, response -> {
+            Histogram deriv = response.getAggregations().get("histo");
+            assertThat(deriv, notNullValue());
+            assertThat(deriv.getName(), equalTo("histo"));
+            List<? extends Bucket> buckets = deriv.getBuckets();
+            assertThat(buckets.size(), equalTo(4));
 
-        Histogram deriv = response.getAggregations().get("histo");
-        assertThat(deriv, notNullValue());
-        assertThat(deriv.getName(), equalTo("histo"));
-        List<? extends Bucket> buckets = deriv.getBuckets();
-        assertThat(buckets.size(), equalTo(4));
+            DateFormatter dateFormatter = DateFormatter.forPattern("uuuu-MM-dd'T'HH:mm:ss").withZone(ZoneOffset.UTC);
 
-        DateFormatter dateFormatter = DateFormatter.forPattern("uuuu-MM-dd'T'HH:mm:ss").withZone(ZoneOffset.UTC);
+            ZonedDateTime expectedKeyFirstBucket = LocalDateTime.from(dateFormatter.parse("1985-12-31T22:00:00"))
+                .atZone(timezone)
+                .withZoneSameInstant(ZoneOffset.UTC);
+            assertBucket(buckets.get(0), expectedKeyFirstBucket, 1L, nullValue(), null, null);
 
-        ZonedDateTime expectedKeyFirstBucket = LocalDateTime.from(dateFormatter.parse("1985-12-31T22:00:00"))
-            .atZone(timezone)
-            .withZoneSameInstant(ZoneOffset.UTC);
-        assertBucket(buckets.get(0), expectedKeyFirstBucket, 1L, nullValue(), null, null);
+            ZonedDateTime expectedKeySecondBucket = LocalDateTime.from(dateFormatter.parse("1985-12-31T23:00:00"))
+                .atZone(timezone)
+                .withZoneSameInstant(ZoneOffset.UTC);
+            assertBucket(buckets.get(1), expectedKeySecondBucket, 2L, notNullValue(), 1d, 1d / 60d);
 
-        ZonedDateTime expectedKeySecondBucket = LocalDateTime.from(dateFormatter.parse("1985-12-31T23:00:00"))
-            .atZone(timezone)
-            .withZoneSameInstant(ZoneOffset.UTC);
-        assertBucket(buckets.get(1), expectedKeySecondBucket, 2L, notNullValue(), 1d, 1d / 60d);
+            // the following is normalized using a 105min bucket width
+            ZonedDateTime expectedKeyThirdBucket = LocalDateTime.from(dateFormatter.parse("1986-01-01T01:00:00"))
+                .atZone(timezone)
+                .withZoneSameInstant(ZoneOffset.UTC);
+            assertBucket(buckets.get(2), expectedKeyThirdBucket, 3L, notNullValue(), 1d, 1d / 105d);
 
-        // the following is normalized using a 105min bucket width
-        ZonedDateTime expectedKeyThirdBucket = LocalDateTime.from(dateFormatter.parse("1986-01-01T01:00:00"))
-            .atZone(timezone)
-            .withZoneSameInstant(ZoneOffset.UTC);
-        assertBucket(buckets.get(2), expectedKeyThirdBucket, 3L, notNullValue(), 1d, 1d / 105d);
-
-        ZonedDateTime expectedKeyFourthBucket = LocalDateTime.from(dateFormatter.parse("1986-01-01T02:00:00"))
-            .atZone(timezone)
-            .withZoneSameInstant(ZoneOffset.UTC);
-        assertBucket(buckets.get(3), expectedKeyFourthBucket, 4L, notNullValue(), 1d, 1d / 60d);
+            ZonedDateTime expectedKeyFourthBucket = LocalDateTime.from(dateFormatter.parse("1986-01-01T02:00:00"))
+                .atZone(timezone)
+                .withZoneSameInstant(ZoneOffset.UTC);
+            assertBucket(buckets.get(3), expectedKeyFourthBucket, 4L, notNullValue(), 1d, 1d / 60d);
+        });
     }
 
     private static void addNTimes(int amount, String index, ZonedDateTime dateTime, List<IndexRequestBuilder> builders) throws Exception {
@@ -401,203 +401,202 @@ public class DateDerivativeIT extends ESIntegTestCase {
     }
 
     public void testSingleValuedFieldWithSubAggregation() throws Exception {
-        SearchResponse response = prepareSearch("idx").addAggregation(
+        SearchRequestBuilder builder = prepareSearch("idx").addAggregation(
             dateHistogram("histo").field("date")
                 .calendarInterval(DateHistogramInterval.MONTH)
                 .minDocCount(0)
                 .subAggregation(sum("sum").field("value"))
                 .subAggregation(new DerivativePipelineAggregationBuilder("deriv", "sum"))
-        ).get();
-
-        assertNoFailures(response);
-
-        Histogram histo = response.getAggregations().get("histo");
-        assertThat(histo, notNullValue());
-        assertThat(histo.getName(), equalTo("histo"));
-        List<? extends Bucket> buckets = histo.getBuckets();
-        assertThat(buckets.size(), equalTo(3));
-        Object[] propertiesKeys = (Object[]) ((InternalAggregation) histo).getProperty("_key");
-        Object[] propertiesDocCounts = (Object[]) ((InternalAggregation) histo).getProperty("_count");
-        Object[] propertiesCounts = (Object[]) ((InternalAggregation) histo).getProperty("sum.value");
-
-        ZonedDateTime key = ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        Histogram.Bucket bucket = buckets.get(0);
-        assertThat(bucket, notNullValue());
-        assertThat((ZonedDateTime) bucket.getKey(), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(1L));
-        assertThat(bucket.getAggregations().asList().isEmpty(), is(false));
-        Sum sum = bucket.getAggregations().get("sum");
-        assertThat(sum, notNullValue());
-        assertThat(sum.value(), equalTo(1.0));
-        SimpleValue deriv = bucket.getAggregations().get("deriv");
-        assertThat(deriv, nullValue());
-        assertThat((ZonedDateTime) propertiesKeys[0], equalTo(key));
-        assertThat((long) propertiesDocCounts[0], equalTo(1L));
-        assertThat((double) propertiesCounts[0], equalTo(1.0));
-
-        key = ZonedDateTime.of(2012, 2, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        bucket = buckets.get(1);
-        assertThat(bucket, notNullValue());
-        assertThat((ZonedDateTime) bucket.getKey(), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(2L));
-        assertThat(bucket.getAggregations().asList().isEmpty(), is(false));
-        sum = bucket.getAggregations().get("sum");
-        assertThat(sum, notNullValue());
-        assertThat(sum.value(), equalTo(5.0));
-        deriv = bucket.getAggregations().get("deriv");
-        assertThat(deriv, notNullValue());
-        assertThat(deriv.value(), equalTo(4.0));
-        assertThat(
-            ((InternalMultiBucketAggregation.InternalBucket) bucket).getProperty(
-                "histo",
-                AggregationPath.parse("deriv.value").getPathElementsAsStringList()
-            ),
-            equalTo(4.0)
         );
-        assertThat((ZonedDateTime) propertiesKeys[1], equalTo(key));
-        assertThat((long) propertiesDocCounts[1], equalTo(2L));
-        assertThat((double) propertiesCounts[1], equalTo(5.0));
 
-        key = ZonedDateTime.of(2012, 3, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        bucket = buckets.get(2);
-        assertThat(bucket, notNullValue());
-        assertThat((ZonedDateTime) bucket.getKey(), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(3L));
-        assertThat(bucket.getAggregations().asList().isEmpty(), is(false));
-        sum = bucket.getAggregations().get("sum");
-        assertThat(sum, notNullValue());
-        assertThat(sum.value(), equalTo(15.0));
-        deriv = bucket.getAggregations().get("deriv");
-        assertThat(deriv, notNullValue());
-        assertThat(deriv.value(), equalTo(10.0));
-        assertThat(
-            ((InternalMultiBucketAggregation.InternalBucket) bucket).getProperty(
-                "histo",
-                AggregationPath.parse("deriv.value").getPathElementsAsStringList()
-            ),
-            equalTo(10.0)
-        );
-        assertThat((ZonedDateTime) propertiesKeys[2], equalTo(key));
-        assertThat((long) propertiesDocCounts[2], equalTo(3L));
-        assertThat((double) propertiesCounts[2], equalTo(15.0));
+        assertNoFailuresAndResponse(builder, response -> {
+            Histogram histo = response.getAggregations().get("histo");
+            assertThat(histo, notNullValue());
+            assertThat(histo.getName(), equalTo("histo"));
+            List<? extends Bucket> buckets = histo.getBuckets();
+            assertThat(buckets.size(), equalTo(3));
+            Object[] propertiesKeys = (Object[]) ((InternalAggregation) histo).getProperty("_key");
+            Object[] propertiesDocCounts = (Object[]) ((InternalAggregation) histo).getProperty("_count");
+            Object[] propertiesCounts = (Object[]) ((InternalAggregation) histo).getProperty("sum.value");
+
+            ZonedDateTime key = ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+            Histogram.Bucket bucket = buckets.get(0);
+            assertThat(bucket, notNullValue());
+            assertThat((ZonedDateTime) bucket.getKey(), equalTo(key));
+            assertThat(bucket.getDocCount(), equalTo(1L));
+            assertThat(bucket.getAggregations().asList().isEmpty(), is(false));
+            Sum sum = bucket.getAggregations().get("sum");
+            assertThat(sum, notNullValue());
+            assertThat(sum.value(), equalTo(1.0));
+            SimpleValue deriv = bucket.getAggregations().get("deriv");
+            assertThat(deriv, nullValue());
+            assertThat((ZonedDateTime) propertiesKeys[0], equalTo(key));
+            assertThat((long) propertiesDocCounts[0], equalTo(1L));
+            assertThat((double) propertiesCounts[0], equalTo(1.0));
+
+            key = ZonedDateTime.of(2012, 2, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+            bucket = buckets.get(1);
+            assertThat(bucket, notNullValue());
+            assertThat((ZonedDateTime) bucket.getKey(), equalTo(key));
+            assertThat(bucket.getDocCount(), equalTo(2L));
+            assertThat(bucket.getAggregations().asList().isEmpty(), is(false));
+            sum = bucket.getAggregations().get("sum");
+            assertThat(sum, notNullValue());
+            assertThat(sum.value(), equalTo(5.0));
+            deriv = bucket.getAggregations().get("deriv");
+            assertThat(deriv, notNullValue());
+            assertThat(deriv.value(), equalTo(4.0));
+            assertThat(
+                ((InternalMultiBucketAggregation.InternalBucket) bucket).getProperty(
+                    "histo",
+                    AggregationPath.parse("deriv.value").getPathElementsAsStringList()
+                ),
+                equalTo(4.0)
+            );
+            assertThat((ZonedDateTime) propertiesKeys[1], equalTo(key));
+            assertThat((long) propertiesDocCounts[1], equalTo(2L));
+            assertThat((double) propertiesCounts[1], equalTo(5.0));
+
+            key = ZonedDateTime.of(2012, 3, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+            bucket = buckets.get(2);
+            assertThat(bucket, notNullValue());
+            assertThat((ZonedDateTime) bucket.getKey(), equalTo(key));
+            assertThat(bucket.getDocCount(), equalTo(3L));
+            assertThat(bucket.getAggregations().asList().isEmpty(), is(false));
+            sum = bucket.getAggregations().get("sum");
+            assertThat(sum, notNullValue());
+            assertThat(sum.value(), equalTo(15.0));
+            deriv = bucket.getAggregations().get("deriv");
+            assertThat(deriv, notNullValue());
+            assertThat(deriv.value(), equalTo(10.0));
+            assertThat(
+                ((InternalMultiBucketAggregation.InternalBucket) bucket).getProperty(
+                    "histo",
+                    AggregationPath.parse("deriv.value").getPathElementsAsStringList()
+                ),
+                equalTo(10.0)
+            );
+            assertThat((ZonedDateTime) propertiesKeys[2], equalTo(key));
+            assertThat((long) propertiesDocCounts[2], equalTo(3L));
+            assertThat((double) propertiesCounts[2], equalTo(15.0));
+        });
     }
 
     public void testMultiValuedField() throws Exception {
-        SearchResponse response = prepareSearch("idx").addAggregation(
+        SearchRequestBuilder builder = prepareSearch("idx").addAggregation(
             dateHistogram("histo").field("dates")
                 .calendarInterval(DateHistogramInterval.MONTH)
                 .minDocCount(0)
                 .subAggregation(new DerivativePipelineAggregationBuilder("deriv", "_count"))
-        ).get();
+        );
 
-        assertNoFailures(response);
+        assertNoFailuresAndResponse(builder, response -> {
+            Histogram deriv = response.getAggregations().get("histo");
+            assertThat(deriv, notNullValue());
+            assertThat(deriv.getName(), equalTo("histo"));
+            List<? extends Bucket> buckets = deriv.getBuckets();
+            assertThat(buckets.size(), equalTo(4));
 
-        Histogram deriv = response.getAggregations().get("histo");
-        assertThat(deriv, notNullValue());
-        assertThat(deriv.getName(), equalTo("histo"));
-        List<? extends Bucket> buckets = deriv.getBuckets();
-        assertThat(buckets.size(), equalTo(4));
+            ZonedDateTime key = ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+            Histogram.Bucket bucket = buckets.get(0);
+            assertThat(bucket, notNullValue());
+            assertThat((ZonedDateTime) bucket.getKey(), equalTo(key));
+            assertThat(bucket.getDocCount(), equalTo(1L));
+            assertThat(bucket.getAggregations().asList().isEmpty(), is(true));
+            SimpleValue docCountDeriv = bucket.getAggregations().get("deriv");
+            assertThat(docCountDeriv, nullValue());
 
-        ZonedDateTime key = ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        Histogram.Bucket bucket = buckets.get(0);
-        assertThat(bucket, notNullValue());
-        assertThat((ZonedDateTime) bucket.getKey(), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(1L));
-        assertThat(bucket.getAggregations().asList().isEmpty(), is(true));
-        SimpleValue docCountDeriv = bucket.getAggregations().get("deriv");
-        assertThat(docCountDeriv, nullValue());
+            key = ZonedDateTime.of(2012, 2, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+            bucket = buckets.get(1);
+            assertThat(bucket, notNullValue());
+            assertThat((ZonedDateTime) bucket.getKey(), equalTo(key));
+            assertThat(bucket.getDocCount(), equalTo(3L));
+            assertThat(bucket.getAggregations().asList().isEmpty(), is(false));
+            docCountDeriv = bucket.getAggregations().get("deriv");
+            assertThat(docCountDeriv, notNullValue());
+            assertThat(docCountDeriv.value(), equalTo(2.0));
 
-        key = ZonedDateTime.of(2012, 2, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        bucket = buckets.get(1);
-        assertThat(bucket, notNullValue());
-        assertThat((ZonedDateTime) bucket.getKey(), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(3L));
-        assertThat(bucket.getAggregations().asList().isEmpty(), is(false));
-        docCountDeriv = bucket.getAggregations().get("deriv");
-        assertThat(docCountDeriv, notNullValue());
-        assertThat(docCountDeriv.value(), equalTo(2.0));
+            key = ZonedDateTime.of(2012, 3, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+            bucket = buckets.get(2);
+            assertThat(bucket, notNullValue());
+            assertThat((ZonedDateTime) bucket.getKey(), equalTo(key));
+            assertThat(bucket.getDocCount(), equalTo(5L));
+            assertThat(bucket.getAggregations().asList().isEmpty(), is(false));
+            docCountDeriv = bucket.getAggregations().get("deriv");
+            assertThat(docCountDeriv, notNullValue());
+            assertThat(docCountDeriv.value(), equalTo(2.0));
 
-        key = ZonedDateTime.of(2012, 3, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        bucket = buckets.get(2);
-        assertThat(bucket, notNullValue());
-        assertThat((ZonedDateTime) bucket.getKey(), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(5L));
-        assertThat(bucket.getAggregations().asList().isEmpty(), is(false));
-        docCountDeriv = bucket.getAggregations().get("deriv");
-        assertThat(docCountDeriv, notNullValue());
-        assertThat(docCountDeriv.value(), equalTo(2.0));
-
-        key = ZonedDateTime.of(2012, 4, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        bucket = buckets.get(3);
-        assertThat(bucket, notNullValue());
-        assertThat((ZonedDateTime) bucket.getKey(), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(3L));
-        assertThat(bucket.getAggregations().asList().isEmpty(), is(false));
-        docCountDeriv = bucket.getAggregations().get("deriv");
-        assertThat(docCountDeriv, notNullValue());
-        assertThat(docCountDeriv.value(), equalTo(-2.0));
+            key = ZonedDateTime.of(2012, 4, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+            bucket = buckets.get(3);
+            assertThat(bucket, notNullValue());
+            assertThat((ZonedDateTime) bucket.getKey(), equalTo(key));
+            assertThat(bucket.getDocCount(), equalTo(3L));
+            assertThat(bucket.getAggregations().asList().isEmpty(), is(false));
+            docCountDeriv = bucket.getAggregations().get("deriv");
+            assertThat(docCountDeriv, notNullValue());
+            assertThat(docCountDeriv.value(), equalTo(-2.0));
+        });
     }
 
     public void testUnmapped() throws Exception {
-        SearchResponse response = prepareSearch("idx_unmapped").addAggregation(
+        SearchRequestBuilder builder = prepareSearch("idx_unmapped").addAggregation(
             dateHistogram("histo").field("date")
                 .calendarInterval(DateHistogramInterval.MONTH)
                 .minDocCount(0)
                 .subAggregation(new DerivativePipelineAggregationBuilder("deriv", "_count"))
-        ).get();
+        );
 
-        assertNoFailures(response);
-
-        Histogram deriv = response.getAggregations().get("histo");
-        assertThat(deriv, notNullValue());
-        assertThat(deriv.getName(), equalTo("histo"));
-        assertThat(deriv.getBuckets().size(), equalTo(0));
+        assertNoFailuresAndResponse(builder, response -> {
+            Histogram deriv = response.getAggregations().get("histo");
+            assertThat(deriv, notNullValue());
+            assertThat(deriv.getName(), equalTo("histo"));
+            assertThat(deriv.getBuckets().size(), equalTo(0));
+        });
     }
 
     public void testPartiallyUnmapped() throws Exception {
-        SearchResponse response = prepareSearch("idx", "idx_unmapped").addAggregation(
+        SearchRequestBuilder builder = prepareSearch("idx", "idx_unmapped").addAggregation(
             dateHistogram("histo").field("date")
                 .calendarInterval(DateHistogramInterval.MONTH)
                 .minDocCount(0)
                 .subAggregation(new DerivativePipelineAggregationBuilder("deriv", "_count"))
-        ).get();
+        );
 
-        assertNoFailures(response);
+        assertNoFailuresAndResponse(builder, response -> {
+            Histogram deriv = response.getAggregations().get("histo");
+            assertThat(deriv, notNullValue());
+            assertThat(deriv.getName(), equalTo("histo"));
+            List<? extends Bucket> buckets = deriv.getBuckets();
+            assertThat(buckets.size(), equalTo(3));
 
-        Histogram deriv = response.getAggregations().get("histo");
-        assertThat(deriv, notNullValue());
-        assertThat(deriv.getName(), equalTo("histo"));
-        List<? extends Bucket> buckets = deriv.getBuckets();
-        assertThat(buckets.size(), equalTo(3));
+            ZonedDateTime key = ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+            Histogram.Bucket bucket = buckets.get(0);
+            assertThat(bucket, notNullValue());
+            assertThat((ZonedDateTime) bucket.getKey(), equalTo(key));
+            assertThat(bucket.getDocCount(), equalTo(1L));
+            assertThat(bucket.getAggregations().asList().isEmpty(), is(true));
+            SimpleValue docCountDeriv = bucket.getAggregations().get("deriv");
+            assertThat(docCountDeriv, nullValue());
 
-        ZonedDateTime key = ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        Histogram.Bucket bucket = buckets.get(0);
-        assertThat(bucket, notNullValue());
-        assertThat((ZonedDateTime) bucket.getKey(), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(1L));
-        assertThat(bucket.getAggregations().asList().isEmpty(), is(true));
-        SimpleValue docCountDeriv = bucket.getAggregations().get("deriv");
-        assertThat(docCountDeriv, nullValue());
+            key = ZonedDateTime.of(2012, 2, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+            bucket = buckets.get(1);
+            assertThat(bucket, notNullValue());
+            assertThat((ZonedDateTime) bucket.getKey(), equalTo(key));
+            assertThat(bucket.getDocCount(), equalTo(2L));
+            assertThat(bucket.getAggregations().asList().isEmpty(), is(false));
+            docCountDeriv = bucket.getAggregations().get("deriv");
+            assertThat(docCountDeriv, notNullValue());
+            assertThat(docCountDeriv.value(), equalTo(1.0));
 
-        key = ZonedDateTime.of(2012, 2, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        bucket = buckets.get(1);
-        assertThat(bucket, notNullValue());
-        assertThat((ZonedDateTime) bucket.getKey(), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(2L));
-        assertThat(bucket.getAggregations().asList().isEmpty(), is(false));
-        docCountDeriv = bucket.getAggregations().get("deriv");
-        assertThat(docCountDeriv, notNullValue());
-        assertThat(docCountDeriv.value(), equalTo(1.0));
-
-        key = ZonedDateTime.of(2012, 3, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        bucket = buckets.get(2);
-        assertThat(bucket, notNullValue());
-        assertThat((ZonedDateTime) bucket.getKey(), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(3L));
-        assertThat(bucket.getAggregations().asList().isEmpty(), is(false));
-        docCountDeriv = bucket.getAggregations().get("deriv");
-        assertThat(docCountDeriv, notNullValue());
-        assertThat(docCountDeriv.value(), equalTo(1.0));
+            key = ZonedDateTime.of(2012, 3, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+            bucket = buckets.get(2);
+            assertThat(bucket, notNullValue());
+            assertThat((ZonedDateTime) bucket.getKey(), equalTo(key));
+            assertThat(bucket.getDocCount(), equalTo(3L));
+            assertThat(bucket.getAggregations().asList().isEmpty(), is(false));
+            docCountDeriv = bucket.getAggregations().get("deriv");
+            assertThat(docCountDeriv, notNullValue());
+            assertThat(docCountDeriv.value(), equalTo(1.0));
+        });
     }
-
 }

--- a/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/pipeline/SerialDiffIT.java
+++ b/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/pipeline/SerialDiffIT.java
@@ -9,7 +9,7 @@
 package org.elasticsearch.aggregations.pipeline;
 
 import org.elasticsearch.action.index.IndexRequestBuilder;
-import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.aggregations.AggregationIntegTestCase;
 import org.elasticsearch.common.collect.EvictingQueue;
 import org.elasticsearch.common.util.Maps;
@@ -31,7 +31,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.histogra
 import static org.elasticsearch.search.aggregations.AggregationBuilders.max;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.min;
 import static org.elasticsearch.search.aggregations.PipelineAggregatorBuilders.diff;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
@@ -220,44 +220,43 @@ public class SerialDiffIT extends AggregationIntegTestCase {
     }
 
     public void testBasicDiff() {
-        SearchResponse response = prepareSearch("idx").addAggregation(
+        SearchRequestBuilder builder = prepareSearch("idx").addAggregation(
             histogram("histo").field(INTERVAL_FIELD)
                 .interval(interval)
                 .extendedBounds(0L, (long) (interval * (numBuckets - 1)))
                 .subAggregation(metric)
                 .subAggregation(diff("diff_counts", "_count").lag(lag).gapPolicy(gapPolicy))
                 .subAggregation(diff("diff_values", "the_metric").lag(lag).gapPolicy(gapPolicy))
-        ).get();
+        );
+        assertNoFailuresAndResponse(builder, response -> {
+            Histogram histo = response.getAggregations().get("histo");
+            assertThat(histo, notNullValue());
+            assertThat(histo.getName(), equalTo("histo"));
+            List<? extends Bucket> buckets = histo.getBuckets();
+            assertThat("Size of buckets array is not correct.", buckets.size(), equalTo(mockHisto.size()));
 
-        assertNoFailures(response);
+            List<Double> expectedCounts = testValues.get(MetricTarget.COUNT.toString());
+            List<Double> expectedValues = testValues.get(MetricTarget.VALUE.toString());
 
-        Histogram histo = response.getAggregations().get("histo");
-        assertThat(histo, notNullValue());
-        assertThat(histo.getName(), equalTo("histo"));
-        List<? extends Bucket> buckets = histo.getBuckets();
-        assertThat("Size of buckets array is not correct.", buckets.size(), equalTo(mockHisto.size()));
+            Iterator<? extends Histogram.Bucket> actualIter = buckets.iterator();
+            Iterator<PipelineAggregationHelperTests.MockBucket> expectedBucketIter = mockHisto.iterator();
+            Iterator<Double> expectedCountsIter = expectedCounts.iterator();
+            Iterator<Double> expectedValuesIter = expectedValues.iterator();
 
-        List<Double> expectedCounts = testValues.get(MetricTarget.COUNT.toString());
-        List<Double> expectedValues = testValues.get(MetricTarget.VALUE.toString());
+            while (actualIter.hasNext()) {
+                assertValidIterators(expectedBucketIter, expectedCountsIter, expectedValuesIter);
 
-        Iterator<? extends Histogram.Bucket> actualIter = buckets.iterator();
-        Iterator<PipelineAggregationHelperTests.MockBucket> expectedBucketIter = mockHisto.iterator();
-        Iterator<Double> expectedCountsIter = expectedCounts.iterator();
-        Iterator<Double> expectedValuesIter = expectedValues.iterator();
+                Histogram.Bucket actual = actualIter.next();
+                PipelineAggregationHelperTests.MockBucket expected = expectedBucketIter.next();
+                Double expectedCount = expectedCountsIter.next();
+                Double expectedValue = expectedValuesIter.next();
 
-        while (actualIter.hasNext()) {
-            assertValidIterators(expectedBucketIter, expectedCountsIter, expectedValuesIter);
+                assertThat("keys do not match", ((Number) actual.getKey()).longValue(), equalTo(expected.key));
+                assertThat("doc counts do not match", actual.getDocCount(), equalTo((long) expected.count));
 
-            Histogram.Bucket actual = actualIter.next();
-            PipelineAggregationHelperTests.MockBucket expected = expectedBucketIter.next();
-            Double expectedCount = expectedCountsIter.next();
-            Double expectedValue = expectedValuesIter.next();
-
-            assertThat("keys do not match", ((Number) actual.getKey()).longValue(), equalTo(expected.key));
-            assertThat("doc counts do not match", actual.getDocCount(), equalTo((long) expected.count));
-
-            assertBucketContents(actual, expectedCount, expectedValue);
-        }
+                assertBucketContents(actual, expectedCount, expectedValue);
+            }
+        });
     }
 
     public void testInvalidLagSize() {

--- a/modules/legacy-geo/src/internalClusterTest/java/org/elasticsearch/legacygeo/search/LegacyGeoShapeIT.java
+++ b/modules/legacy-geo/src/internalClusterTest/java/org/elasticsearch/legacygeo/search/LegacyGeoShapeIT.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.legacygeo.search;
 
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.geometry.Circle;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.legacygeo.test.TestLegacyGeoShapeFieldMapperPlugin;
@@ -24,7 +23,7 @@ import java.util.Collections;
 
 import static org.elasticsearch.index.query.QueryBuilders.geoShapeQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.hamcrest.Matchers.equalTo;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 
 public class LegacyGeoShapeIT extends GeoShapeIntegTestCase {
 
@@ -73,7 +72,6 @@ public class LegacyGeoShapeIT extends GeoShapeIntegTestCase {
         }));
 
         // test self crossing of circles
-        SearchResponse searchResponse = prepareSearch("test").setQuery(geoShapeQuery("shape", new Circle(30, 50, 77000))).get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
+        assertHitCount(prepareSearch("test").setQuery(geoShapeQuery("shape", new Circle(30, 50, 77000))), 1L);
     }
 }

--- a/modules/legacy-geo/src/test/java/org/elasticsearch/legacygeo/search/LegacyGeoShapeQueryTests.java
+++ b/modules/legacy-geo/src/test/java/org/elasticsearch/legacygeo/search/LegacyGeoShapeQueryTests.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.legacygeo.search;
 
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.geo.GeoJson;
 import org.elasticsearch.common.settings.Settings;
@@ -32,6 +31,7 @@ import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDI
 import static org.elasticsearch.index.query.QueryBuilders.geoIntersectionQuery;
 import static org.elasticsearch.index.query.QueryBuilders.geoShapeQuery;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
 
@@ -101,9 +101,7 @@ public class LegacyGeoShapeQueryTests extends GeoShapeQueryTestCase {
             .get();
 
         // test that point was inserted
-        SearchResponse response = client().prepareSearch("geo_points_only").setQuery(matchAllQuery()).get();
-
-        assertEquals(2, response.getHits().getTotalHits().value);
+        assertHitCount(client().prepareSearch("geo_points_only").setQuery(matchAllQuery()).get(), 2L);
     }
 
     public void testPointsOnly() throws Exception {
@@ -139,10 +137,7 @@ public class LegacyGeoShapeQueryTests extends GeoShapeQueryTestCase {
         }
 
         // test that point was inserted
-        SearchResponse response = client().prepareSearch("geo_points_only")
-            .setQuery(geoIntersectionQuery(defaultFieldName, geometry))
-            .get();
-        assertEquals(1, response.getHits().getTotalHits().value);
+        assertHitCount(client().prepareSearch("geo_points_only").setQuery(geoIntersectionQuery(defaultFieldName, geometry)), 1L);
     }
 
     public void testFieldAlias() throws IOException {
@@ -172,8 +167,7 @@ public class LegacyGeoShapeQueryTests extends GeoShapeQueryTestCase {
             .setRefreshPolicy(IMMEDIATE)
             .get();
 
-        SearchResponse response = client().prepareSearch(defaultIndexName).setQuery(geoShapeQuery("alias", multiPoint)).get();
-        assertEquals(1, response.getHits().getTotalHits().value);
+        assertHitCount(client().prepareSearch(defaultIndexName).setQuery(geoShapeQuery("alias", multiPoint)), 1L);
     }
 
     /**

--- a/modules/parent-join/src/internalClusterTest/java/org/elasticsearch/join/aggregations/ChildrenIT.java
+++ b/modules/parent-join/src/internalClusterTest/java/org/elasticsearch/join/aggregations/ChildrenIT.java
@@ -9,7 +9,6 @@ package org.elasticsearch.join.aggregations;
 
 import org.apache.lucene.search.join.ScoreMode;
 import org.elasticsearch.action.index.IndexRequestBuilder;
-import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.client.internal.Requests;
 import org.elasticsearch.search.SearchHit;
@@ -43,115 +42,119 @@ import static org.hamcrest.Matchers.sameInstance;
 public class ChildrenIT extends AbstractParentChildTestCase {
 
     public void testSimpleChildrenAgg() {
-        final SearchRequestBuilder searchRequest = prepareSearch("test").setQuery(matchQuery("randomized", true))
-            .addAggregation(children("to_comment", "comment"));
         long count = categoryToControl.values().stream().mapToLong(control -> control.commentIds.size()).sum();
-        assertNoFailuresAndResponse(searchRequest, response -> {
-            Children childrenAgg = response.getAggregations().get("to_comment");
-            assertThat("Request: " + searchRequest + "\nResponse: " + response + "\n", childrenAgg.getDocCount(), equalTo(count));
-        });
+        assertNoFailuresAndResponse(
+            prepareSearch("test").setQuery(matchQuery("randomized", true)).addAggregation(children("to_comment", "comment")),
+            response -> {
+                Children childrenAgg = response.getAggregations().get("to_comment");
+                assertThat("Response: " + response + "\n", childrenAgg.getDocCount(), equalTo(count));
+            }
+        );
     }
 
     public void testChildrenAggs() {
-        SearchRequestBuilder searchRequest = prepareSearch("test").setQuery(matchQuery("randomized", true))
-            .addAggregation(
-                terms("category").field("category")
-                    .size(10000)
-                    .subAggregation(
-                        children("to_comment", "comment").subAggregation(
-                            terms("commenters").field("commenter").size(10000).subAggregation(topHits("top_comments"))
+        assertNoFailuresAndResponse(
+            prepareSearch("test").setQuery(matchQuery("randomized", true))
+                .addAggregation(
+                    terms("category").field("category")
+                        .size(10000)
+                        .subAggregation(
+                            children("to_comment", "comment").subAggregation(
+                                terms("commenters").field("commenter").size(10000).subAggregation(topHits("top_comments"))
+                            )
                         )
-                    )
-            );
-        assertNoFailuresAndResponse(searchRequest, response -> {
-            Terms categoryTerms = response.getAggregations().get("category");
-            assertThat(categoryTerms.getBuckets().size(), equalTo(categoryToControl.size()));
-            for (Map.Entry<String, Control> entry1 : categoryToControl.entrySet()) {
-                Terms.Bucket categoryBucket = categoryTerms.getBucketByKey(entry1.getKey());
-                assertThat(categoryBucket.getKeyAsString(), equalTo(entry1.getKey()));
-                assertThat(categoryBucket.getDocCount(), equalTo((long) entry1.getValue().articleIds.size()));
+                ),
+            response -> {
+                Terms categoryTerms = response.getAggregations().get("category");
+                assertThat(categoryTerms.getBuckets().size(), equalTo(categoryToControl.size()));
+                for (Map.Entry<String, Control> entry1 : categoryToControl.entrySet()) {
+                    Terms.Bucket categoryBucket = categoryTerms.getBucketByKey(entry1.getKey());
+                    assertThat(categoryBucket.getKeyAsString(), equalTo(entry1.getKey()));
+                    assertThat(categoryBucket.getDocCount(), equalTo((long) entry1.getValue().articleIds.size()));
 
-                Children childrenBucket = categoryBucket.getAggregations().get("to_comment");
-                assertThat(childrenBucket.getName(), equalTo("to_comment"));
-                assertThat(childrenBucket.getDocCount(), equalTo((long) entry1.getValue().commentIds.size()));
-                assertThat(
-                    ((InternalAggregation) childrenBucket).getProperty("_count"),
-                    equalTo((long) entry1.getValue().commentIds.size())
-                );
+                    Children childrenBucket = categoryBucket.getAggregations().get("to_comment");
+                    assertThat(childrenBucket.getName(), equalTo("to_comment"));
+                    assertThat(childrenBucket.getDocCount(), equalTo((long) entry1.getValue().commentIds.size()));
+                    assertThat(
+                        ((InternalAggregation) childrenBucket).getProperty("_count"),
+                        equalTo((long) entry1.getValue().commentIds.size())
+                    );
 
-                Terms commentersTerms = childrenBucket.getAggregations().get("commenters");
-                assertThat(((InternalAggregation) childrenBucket).getProperty("commenters"), sameInstance(commentersTerms));
-                assertThat(commentersTerms.getBuckets().size(), equalTo(entry1.getValue().commenterToCommentId.size()));
-                for (Map.Entry<String, Set<String>> entry2 : entry1.getValue().commenterToCommentId.entrySet()) {
-                    Terms.Bucket commentBucket = commentersTerms.getBucketByKey(entry2.getKey());
-                    assertThat(commentBucket.getKeyAsString(), equalTo(entry2.getKey()));
-                    assertThat(commentBucket.getDocCount(), equalTo((long) entry2.getValue().size()));
+                    Terms commentersTerms = childrenBucket.getAggregations().get("commenters");
+                    assertThat(((InternalAggregation) childrenBucket).getProperty("commenters"), sameInstance(commentersTerms));
+                    assertThat(commentersTerms.getBuckets().size(), equalTo(entry1.getValue().commenterToCommentId.size()));
+                    for (Map.Entry<String, Set<String>> entry2 : entry1.getValue().commenterToCommentId.entrySet()) {
+                        Terms.Bucket commentBucket = commentersTerms.getBucketByKey(entry2.getKey());
+                        assertThat(commentBucket.getKeyAsString(), equalTo(entry2.getKey()));
+                        assertThat(commentBucket.getDocCount(), equalTo((long) entry2.getValue().size()));
 
-                    TopHits topHits = commentBucket.getAggregations().get("top_comments");
-                    for (SearchHit searchHit : topHits.getHits().getHits()) {
-                        assertThat(entry2.getValue().contains(searchHit.getId()), is(true));
+                        TopHits topHits = commentBucket.getAggregations().get("top_comments");
+                        for (SearchHit searchHit : topHits.getHits().getHits()) {
+                            assertThat(entry2.getValue().contains(searchHit.getId()), is(true));
+                        }
                     }
                 }
             }
-        });
+        );
     }
 
     public void testParentWithMultipleBuckets() {
-        SearchRequestBuilder searchRequest = prepareSearch("test").setQuery(matchQuery("randomized", false))
-            .addAggregation(
-                terms("category").field("category")
-                    .size(10000)
-                    .subAggregation(children("to_comment", "comment").subAggregation(topHits("top_comments").sort("id", SortOrder.ASC)))
-            );
+        assertNoFailuresAndResponse(
+            prepareSearch("test").setQuery(matchQuery("randomized", false))
+                .addAggregation(
+                    terms("category").field("category")
+                        .size(10000)
+                        .subAggregation(children("to_comment", "comment").subAggregation(topHits("top_comments").sort("id", SortOrder.ASC)))
+                ),
+            response -> {
+                Terms categoryTerms = response.getAggregations().get("category");
+                assertThat(categoryTerms.getBuckets().size(), equalTo(3));
 
-        assertNoFailuresAndResponse(searchRequest, response -> {
-            Terms categoryTerms = response.getAggregations().get("category");
-            assertThat(categoryTerms.getBuckets().size(), equalTo(3));
-
-            for (Terms.Bucket bucket : categoryTerms.getBuckets()) {
-                logger.info("bucket={}", bucket.getKey());
-                Children childrenBucket = bucket.getAggregations().get("to_comment");
-                TopHits topHits = childrenBucket.getAggregations().get("top_comments");
-                logger.info("total_hits={}", topHits.getHits().getTotalHits().value);
-                for (SearchHit searchHit : topHits.getHits()) {
-                    logger.info("hit= {} {}", searchHit.getSortValues()[0], searchHit.getId());
+                for (Terms.Bucket bucket : categoryTerms.getBuckets()) {
+                    logger.info("bucket={}", bucket.getKey());
+                    Children childrenBucket = bucket.getAggregations().get("to_comment");
+                    TopHits topHits = childrenBucket.getAggregations().get("top_comments");
+                    logger.info("total_hits={}", topHits.getHits().getTotalHits().value);
+                    for (SearchHit searchHit : topHits.getHits()) {
+                        logger.info("hit= {} {}", searchHit.getSortValues()[0], searchHit.getId());
+                    }
                 }
+
+                Terms.Bucket categoryBucket = categoryTerms.getBucketByKey("a");
+                assertThat(categoryBucket.getKeyAsString(), equalTo("a"));
+                assertThat(categoryBucket.getDocCount(), equalTo(3L));
+
+                Children childrenBucket = categoryBucket.getAggregations().get("to_comment");
+                assertThat(childrenBucket.getName(), equalTo("to_comment"));
+                assertThat(childrenBucket.getDocCount(), equalTo(2L));
+                TopHits topHits = childrenBucket.getAggregations().get("top_comments");
+                assertThat(topHits.getHits().getTotalHits().value, equalTo(2L));
+                assertThat(topHits.getHits().getAt(0).getId(), equalTo("e"));
+                assertThat(topHits.getHits().getAt(1).getId(), equalTo("f"));
+
+                categoryBucket = categoryTerms.getBucketByKey("b");
+                assertThat(categoryBucket.getKeyAsString(), equalTo("b"));
+                assertThat(categoryBucket.getDocCount(), equalTo(2L));
+
+                childrenBucket = categoryBucket.getAggregations().get("to_comment");
+                assertThat(childrenBucket.getName(), equalTo("to_comment"));
+                assertThat(childrenBucket.getDocCount(), equalTo(1L));
+                topHits = childrenBucket.getAggregations().get("top_comments");
+                assertThat(topHits.getHits().getTotalHits().value, equalTo(1L));
+                assertThat(topHits.getHits().getAt(0).getId(), equalTo("f"));
+
+                categoryBucket = categoryTerms.getBucketByKey("c");
+                assertThat(categoryBucket.getKeyAsString(), equalTo("c"));
+                assertThat(categoryBucket.getDocCount(), equalTo(2L));
+
+                childrenBucket = categoryBucket.getAggregations().get("to_comment");
+                assertThat(childrenBucket.getName(), equalTo("to_comment"));
+                assertThat(childrenBucket.getDocCount(), equalTo(1L));
+                topHits = childrenBucket.getAggregations().get("top_comments");
+                assertThat(topHits.getHits().getTotalHits().value, equalTo(1L));
+                assertThat(topHits.getHits().getAt(0).getId(), equalTo("f"));
             }
-
-            Terms.Bucket categoryBucket = categoryTerms.getBucketByKey("a");
-            assertThat(categoryBucket.getKeyAsString(), equalTo("a"));
-            assertThat(categoryBucket.getDocCount(), equalTo(3L));
-
-            Children childrenBucket = categoryBucket.getAggregations().get("to_comment");
-            assertThat(childrenBucket.getName(), equalTo("to_comment"));
-            assertThat(childrenBucket.getDocCount(), equalTo(2L));
-            TopHits topHits = childrenBucket.getAggregations().get("top_comments");
-            assertThat(topHits.getHits().getTotalHits().value, equalTo(2L));
-            assertThat(topHits.getHits().getAt(0).getId(), equalTo("e"));
-            assertThat(topHits.getHits().getAt(1).getId(), equalTo("f"));
-
-            categoryBucket = categoryTerms.getBucketByKey("b");
-            assertThat(categoryBucket.getKeyAsString(), equalTo("b"));
-            assertThat(categoryBucket.getDocCount(), equalTo(2L));
-
-            childrenBucket = categoryBucket.getAggregations().get("to_comment");
-            assertThat(childrenBucket.getName(), equalTo("to_comment"));
-            assertThat(childrenBucket.getDocCount(), equalTo(1L));
-            topHits = childrenBucket.getAggregations().get("top_comments");
-            assertThat(topHits.getHits().getTotalHits().value, equalTo(1L));
-            assertThat(topHits.getHits().getAt(0).getId(), equalTo("f"));
-
-            categoryBucket = categoryTerms.getBucketByKey("c");
-            assertThat(categoryBucket.getKeyAsString(), equalTo("c"));
-            assertThat(categoryBucket.getDocCount(), equalTo(2L));
-
-            childrenBucket = categoryBucket.getAggregations().get("to_comment");
-            assertThat(childrenBucket.getName(), equalTo("to_comment"));
-            assertThat(childrenBucket.getDocCount(), equalTo(1L));
-            topHits = childrenBucket.getAggregations().get("top_comments");
-            assertThat(topHits.getHits().getTotalHits().value, equalTo(1L));
-            assertThat(topHits.getHits().getAt(0).getId(), equalTo("f"));
-        });
+        );
     }
 
     public void testWithDeletes() throws Exception {
@@ -171,17 +174,16 @@ public class ChildrenIT extends AbstractParentChildTestCase {
         indexRandom(true, requests);
 
         for (int i = 0; i < 10; i++) {
-            SearchRequestBuilder searchRequest = prepareSearch(indexName).addAggregation(
-                children("children", "child").subAggregation(sum("counts").field("count"))
+            assertNoFailuresAndResponse(
+                prepareSearch(indexName).addAggregation(children("children", "child").subAggregation(sum("counts").field("count"))),
+                response -> {
+                    Children children = response.getAggregations().get("children");
+                    assertThat(children.getDocCount(), equalTo(4L));
+
+                    Sum count = children.getAggregations().get("counts");
+                    assertThat(count.value(), equalTo(4.));
+                }
             );
-
-            assertNoFailuresAndResponse(searchRequest, response -> {
-                Children children = response.getAggregations().get("children");
-                assertThat(children.getDocCount(), equalTo(4L));
-
-                Sum count = children.getAggregations().get("counts");
-                assertThat(count.value(), equalTo(4.));
-            });
 
             String idToUpdate = Integer.toString(2 + randomInt(3));
             /*
@@ -201,8 +203,7 @@ public class ChildrenIT extends AbstractParentChildTestCase {
     }
 
     public void testNonExistingChildType() throws Exception {
-        SearchRequestBuilder searchRequest = prepareSearch("test").addAggregation(children("non-existing", "xyz"));
-        assertNoFailuresAndResponse(searchRequest, response -> {
+        assertNoFailuresAndResponse(prepareSearch("test").addAggregation(children("non-existing", "xyz")), response -> {
             Children children = response.getAggregations().get("non-existing");
             assertThat(children.getName(), equalTo("non-existing"));
             assertThat(children.getDocCount(), equalTo(0L));
@@ -253,35 +254,35 @@ public class ChildrenIT extends AbstractParentChildTestCase {
         requests.add(createIndexRequest(indexName, childType, "16", "2", "color", "green", "size", "44"));
         indexRandom(true, requests);
 
-        SearchRequestBuilder searchRequest = prepareSearch(indexName).setQuery(
-            hasChildQuery(childType, termQuery("color", "orange"), ScoreMode.None)
-        )
-            .addAggregation(
-                children("my-refinements", childType).subAggregation(terms("my-colors").field("color"))
-                    .subAggregation(terms("my-sizes").field("size"))
-            );
-        assertNoFailuresAndResponse(searchRequest, response -> {
-            assertHitCount(response, 1L);
+        assertNoFailuresAndResponse(
+            prepareSearch(indexName).setQuery(hasChildQuery(childType, termQuery("color", "orange"), ScoreMode.None))
+                .addAggregation(
+                    children("my-refinements", childType).subAggregation(terms("my-colors").field("color"))
+                        .subAggregation(terms("my-sizes").field("size"))
+                ),
+            response -> {
+                assertHitCount(response, 1L);
 
-            Children childrenAgg = response.getAggregations().get("my-refinements");
-            assertThat(childrenAgg.getDocCount(), equalTo(7L));
+                Children childrenAgg = response.getAggregations().get("my-refinements");
+                assertThat(childrenAgg.getDocCount(), equalTo(7L));
 
-            Terms termsAgg = childrenAgg.getAggregations().get("my-colors");
-            assertThat(termsAgg.getBuckets().size(), equalTo(4));
-            assertThat(termsAgg.getBucketByKey("black").getDocCount(), equalTo(3L));
-            assertThat(termsAgg.getBucketByKey("blue").getDocCount(), equalTo(2L));
-            assertThat(termsAgg.getBucketByKey("green").getDocCount(), equalTo(1L));
-            assertThat(termsAgg.getBucketByKey("orange").getDocCount(), equalTo(1L));
+                Terms termsAgg = childrenAgg.getAggregations().get("my-colors");
+                assertThat(termsAgg.getBuckets().size(), equalTo(4));
+                assertThat(termsAgg.getBucketByKey("black").getDocCount(), equalTo(3L));
+                assertThat(termsAgg.getBucketByKey("blue").getDocCount(), equalTo(2L));
+                assertThat(termsAgg.getBucketByKey("green").getDocCount(), equalTo(1L));
+                assertThat(termsAgg.getBucketByKey("orange").getDocCount(), equalTo(1L));
 
-            termsAgg = childrenAgg.getAggregations().get("my-sizes");
-            assertThat(termsAgg.getBuckets().size(), equalTo(6));
-            assertThat(termsAgg.getBucketByKey("36").getDocCount(), equalTo(2L));
-            assertThat(termsAgg.getBucketByKey("32").getDocCount(), equalTo(1L));
-            assertThat(termsAgg.getBucketByKey("34").getDocCount(), equalTo(1L));
-            assertThat(termsAgg.getBucketByKey("38").getDocCount(), equalTo(1L));
-            assertThat(termsAgg.getBucketByKey("40").getDocCount(), equalTo(1L));
-            assertThat(termsAgg.getBucketByKey("44").getDocCount(), equalTo(1L));
-        });
+                termsAgg = childrenAgg.getAggregations().get("my-sizes");
+                assertThat(termsAgg.getBuckets().size(), equalTo(6));
+                assertThat(termsAgg.getBucketByKey("36").getDocCount(), equalTo(2L));
+                assertThat(termsAgg.getBucketByKey("32").getDocCount(), equalTo(1L));
+                assertThat(termsAgg.getBucketByKey("34").getDocCount(), equalTo(1L));
+                assertThat(termsAgg.getBucketByKey("38").getDocCount(), equalTo(1L));
+                assertThat(termsAgg.getBucketByKey("40").getDocCount(), equalTo(1L));
+                assertThat(termsAgg.getBucketByKey("44").getDocCount(), equalTo(1L));
+            }
+        );
     }
 
     public void testHierarchicalChildrenAggs() {
@@ -304,25 +305,28 @@ public class ChildrenIT extends AbstractParentChildTestCase {
         createIndexRequest(indexName, childType, "3", "2", "name", "brussels").setRouting("1").get();
         refresh();
 
-        SearchRequestBuilder searchRequest = prepareSearch(indexName).setQuery(matchQuery("name", "europe"))
-            .addAggregation(
-                children(parentType, parentType).subAggregation(children(childType, childType).subAggregation(terms("name").field("name")))
-            );
+        assertNoFailuresAndResponse(
+            prepareSearch(indexName).setQuery(matchQuery("name", "europe"))
+                .addAggregation(
+                    children(parentType, parentType).subAggregation(
+                        children(childType, childType).subAggregation(terms("name").field("name"))
+                    )
+                ),
+            response -> {
+                assertHitCount(response, 1L);
 
-        assertNoFailuresAndResponse(searchRequest, response -> {
-            assertHitCount(response, 1L);
-
-            Children children = response.getAggregations().get(parentType);
-            assertThat(children.getName(), equalTo(parentType));
-            assertThat(children.getDocCount(), equalTo(1L));
-            children = children.getAggregations().get(childType);
-            assertThat(children.getName(), equalTo(childType));
-            assertThat(children.getDocCount(), equalTo(1L));
-            Terms terms = children.getAggregations().get("name");
-            assertThat(terms.getBuckets().size(), equalTo(1));
-            assertThat(terms.getBuckets().get(0).getKey().toString(), equalTo("brussels"));
-            assertThat(terms.getBuckets().get(0).getDocCount(), equalTo(1L));
-        });
+                Children children = response.getAggregations().get(parentType);
+                assertThat(children.getName(), equalTo(parentType));
+                assertThat(children.getDocCount(), equalTo(1L));
+                children = children.getAggregations().get(childType);
+                assertThat(children.getName(), equalTo(childType));
+                assertThat(children.getDocCount(), equalTo(1L));
+                Terms terms = children.getAggregations().get("name");
+                assertThat(terms.getBuckets().size(), equalTo(1));
+                assertThat(terms.getBuckets().get(0).getKey().toString(), equalTo("brussels"));
+                assertThat(terms.getBuckets().get(0).getDocCount(), equalTo(1L));
+            }
+        );
     }
 
     public void testPostCollectAllLeafReaders() throws Exception {
@@ -355,41 +359,42 @@ public class ChildrenIT extends AbstractParentChildTestCase {
         requests.add(createIndexRequest("index", "childType", "8", "3", "name", "Dan", "age", 1));
         indexRandom(true, requests);
 
-        SearchRequestBuilder searchRequest = prepareSearch("index").setSize(0)
-            .addAggregation(
-                AggregationBuilders.terms("towns")
-                    .field("town")
-                    .subAggregation(
-                        AggregationBuilders.terms("parent_names").field("name").subAggregation(children("child_docs", "childType"))
-                    )
-            );
+        assertNoFailuresAndResponse(
+            prepareSearch("index").setSize(0)
+                .addAggregation(
+                    AggregationBuilders.terms("towns")
+                        .field("town")
+                        .subAggregation(
+                            AggregationBuilders.terms("parent_names").field("name").subAggregation(children("child_docs", "childType"))
+                        )
+                ),
+            response -> {
+                Terms towns = response.getAggregations().get("towns");
+                assertThat(towns.getBuckets().size(), equalTo(2));
+                assertThat(towns.getBuckets().get(0).getKeyAsString(), equalTo("Chicago"));
+                assertThat(towns.getBuckets().get(0).getDocCount(), equalTo(2L));
 
-        assertNoFailuresAndResponse(searchRequest, response -> {
-            Terms towns = response.getAggregations().get("towns");
-            assertThat(towns.getBuckets().size(), equalTo(2));
-            assertThat(towns.getBuckets().get(0).getKeyAsString(), equalTo("Chicago"));
-            assertThat(towns.getBuckets().get(0).getDocCount(), equalTo(2L));
+                Terms parents = towns.getBuckets().get(0).getAggregations().get("parent_names");
+                assertThat(parents.getBuckets().size(), equalTo(2));
+                assertThat(parents.getBuckets().get(0).getKeyAsString(), equalTo("Alice"));
+                assertThat(parents.getBuckets().get(0).getDocCount(), equalTo(1L));
+                Children children = parents.getBuckets().get(0).getAggregations().get("child_docs");
+                assertThat(children.getDocCount(), equalTo(1L));
 
-            Terms parents = towns.getBuckets().get(0).getAggregations().get("parent_names");
-            assertThat(parents.getBuckets().size(), equalTo(2));
-            assertThat(parents.getBuckets().get(0).getKeyAsString(), equalTo("Alice"));
-            assertThat(parents.getBuckets().get(0).getDocCount(), equalTo(1L));
-            Children children = parents.getBuckets().get(0).getAggregations().get("child_docs");
-            assertThat(children.getDocCount(), equalTo(1L));
+                assertThat(parents.getBuckets().get(1).getKeyAsString(), equalTo("Bill"));
+                assertThat(parents.getBuckets().get(1).getDocCount(), equalTo(1L));
+                children = parents.getBuckets().get(1).getAggregations().get("child_docs");
+                assertThat(children.getDocCount(), equalTo(2L));
 
-            assertThat(parents.getBuckets().get(1).getKeyAsString(), equalTo("Bill"));
-            assertThat(parents.getBuckets().get(1).getDocCount(), equalTo(1L));
-            children = parents.getBuckets().get(1).getAggregations().get("child_docs");
-            assertThat(children.getDocCount(), equalTo(2L));
-
-            assertThat(towns.getBuckets().get(1).getKeyAsString(), equalTo("Memphis"));
-            assertThat(towns.getBuckets().get(1).getDocCount(), equalTo(1L));
-            parents = towns.getBuckets().get(1).getAggregations().get("parent_names");
-            assertThat(parents.getBuckets().size(), equalTo(1));
-            assertThat(parents.getBuckets().get(0).getKeyAsString(), equalTo("Bob"));
-            assertThat(parents.getBuckets().get(0).getDocCount(), equalTo(1L));
-            children = parents.getBuckets().get(0).getAggregations().get("child_docs");
-            assertThat(children.getDocCount(), equalTo(2L));
-        });
+                assertThat(towns.getBuckets().get(1).getKeyAsString(), equalTo("Memphis"));
+                assertThat(towns.getBuckets().get(1).getDocCount(), equalTo(1L));
+                parents = towns.getBuckets().get(1).getAggregations().get("parent_names");
+                assertThat(parents.getBuckets().size(), equalTo(1));
+                assertThat(parents.getBuckets().get(0).getKeyAsString(), equalTo("Bob"));
+                assertThat(parents.getBuckets().get(0).getDocCount(), equalTo(1L));
+                children = parents.getBuckets().get(0).getAggregations().get("child_docs");
+                assertThat(children.getDocCount(), equalTo(2L));
+            }
+        );
     }
 }

--- a/modules/parent-join/src/internalClusterTest/java/org/elasticsearch/join/aggregations/ChildrenIT.java
+++ b/modules/parent-join/src/internalClusterTest/java/org/elasticsearch/join/aggregations/ChildrenIT.java
@@ -10,7 +10,6 @@ package org.elasticsearch.join.aggregations;
 import org.apache.lucene.search.join.ScoreMode;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchRequestBuilder;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.client.internal.Requests;
 import org.elasticsearch.search.SearchHit;
@@ -35,7 +34,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.topHits;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
@@ -46,15 +45,15 @@ public class ChildrenIT extends AbstractParentChildTestCase {
     public void testSimpleChildrenAgg() {
         final SearchRequestBuilder searchRequest = prepareSearch("test").setQuery(matchQuery("randomized", true))
             .addAggregation(children("to_comment", "comment"));
-        final SearchResponse searchResponse = searchRequest.get();
         long count = categoryToControl.values().stream().mapToLong(control -> control.commentIds.size()).sum();
-        assertNoFailures(searchResponse);
-        Children childrenAgg = searchResponse.getAggregations().get("to_comment");
-        assertThat("Request: " + searchRequest + "\nResponse: " + searchResponse + "\n", childrenAgg.getDocCount(), equalTo(count));
+        assertNoFailuresAndResponse(searchRequest, response -> {
+            Children childrenAgg = response.getAggregations().get("to_comment");
+            assertThat("Request: " + searchRequest + "\nResponse: " + response + "\n", childrenAgg.getDocCount(), equalTo(count));
+        });
     }
 
     public void testChildrenAggs() {
-        SearchResponse searchResponse = prepareSearch("test").setQuery(matchQuery("randomized", true))
+        SearchRequestBuilder searchRequest = prepareSearch("test").setQuery(matchQuery("randomized", true))
             .addAggregation(
                 terms("category").field("category")
                     .size(10000)
@@ -63,94 +62,96 @@ public class ChildrenIT extends AbstractParentChildTestCase {
                             terms("commenters").field("commenter").size(10000).subAggregation(topHits("top_comments"))
                         )
                     )
-            )
-            .get();
-        assertNoFailures(searchResponse);
+            );
+        assertNoFailuresAndResponse(searchRequest, response -> {
+            Terms categoryTerms = response.getAggregations().get("category");
+            assertThat(categoryTerms.getBuckets().size(), equalTo(categoryToControl.size()));
+            for (Map.Entry<String, Control> entry1 : categoryToControl.entrySet()) {
+                Terms.Bucket categoryBucket = categoryTerms.getBucketByKey(entry1.getKey());
+                assertThat(categoryBucket.getKeyAsString(), equalTo(entry1.getKey()));
+                assertThat(categoryBucket.getDocCount(), equalTo((long) entry1.getValue().articleIds.size()));
 
-        Terms categoryTerms = searchResponse.getAggregations().get("category");
-        assertThat(categoryTerms.getBuckets().size(), equalTo(categoryToControl.size()));
-        for (Map.Entry<String, Control> entry1 : categoryToControl.entrySet()) {
-            Terms.Bucket categoryBucket = categoryTerms.getBucketByKey(entry1.getKey());
-            assertThat(categoryBucket.getKeyAsString(), equalTo(entry1.getKey()));
-            assertThat(categoryBucket.getDocCount(), equalTo((long) entry1.getValue().articleIds.size()));
+                Children childrenBucket = categoryBucket.getAggregations().get("to_comment");
+                assertThat(childrenBucket.getName(), equalTo("to_comment"));
+                assertThat(childrenBucket.getDocCount(), equalTo((long) entry1.getValue().commentIds.size()));
+                assertThat(
+                    ((InternalAggregation) childrenBucket).getProperty("_count"),
+                    equalTo((long) entry1.getValue().commentIds.size())
+                );
 
-            Children childrenBucket = categoryBucket.getAggregations().get("to_comment");
-            assertThat(childrenBucket.getName(), equalTo("to_comment"));
-            assertThat(childrenBucket.getDocCount(), equalTo((long) entry1.getValue().commentIds.size()));
-            assertThat(((InternalAggregation) childrenBucket).getProperty("_count"), equalTo((long) entry1.getValue().commentIds.size()));
+                Terms commentersTerms = childrenBucket.getAggregations().get("commenters");
+                assertThat(((InternalAggregation) childrenBucket).getProperty("commenters"), sameInstance(commentersTerms));
+                assertThat(commentersTerms.getBuckets().size(), equalTo(entry1.getValue().commenterToCommentId.size()));
+                for (Map.Entry<String, Set<String>> entry2 : entry1.getValue().commenterToCommentId.entrySet()) {
+                    Terms.Bucket commentBucket = commentersTerms.getBucketByKey(entry2.getKey());
+                    assertThat(commentBucket.getKeyAsString(), equalTo(entry2.getKey()));
+                    assertThat(commentBucket.getDocCount(), equalTo((long) entry2.getValue().size()));
 
-            Terms commentersTerms = childrenBucket.getAggregations().get("commenters");
-            assertThat(((InternalAggregation) childrenBucket).getProperty("commenters"), sameInstance(commentersTerms));
-            assertThat(commentersTerms.getBuckets().size(), equalTo(entry1.getValue().commenterToCommentId.size()));
-            for (Map.Entry<String, Set<String>> entry2 : entry1.getValue().commenterToCommentId.entrySet()) {
-                Terms.Bucket commentBucket = commentersTerms.getBucketByKey(entry2.getKey());
-                assertThat(commentBucket.getKeyAsString(), equalTo(entry2.getKey()));
-                assertThat(commentBucket.getDocCount(), equalTo((long) entry2.getValue().size()));
-
-                TopHits topHits = commentBucket.getAggregations().get("top_comments");
-                for (SearchHit searchHit : topHits.getHits().getHits()) {
-                    assertThat(entry2.getValue().contains(searchHit.getId()), is(true));
+                    TopHits topHits = commentBucket.getAggregations().get("top_comments");
+                    for (SearchHit searchHit : topHits.getHits().getHits()) {
+                        assertThat(entry2.getValue().contains(searchHit.getId()), is(true));
+                    }
                 }
             }
-        }
+        });
     }
 
     public void testParentWithMultipleBuckets() {
-        SearchResponse searchResponse = prepareSearch("test").setQuery(matchQuery("randomized", false))
+        SearchRequestBuilder searchRequest = prepareSearch("test").setQuery(matchQuery("randomized", false))
             .addAggregation(
                 terms("category").field("category")
                     .size(10000)
                     .subAggregation(children("to_comment", "comment").subAggregation(topHits("top_comments").sort("id", SortOrder.ASC)))
-            )
-            .get();
-        assertNoFailures(searchResponse);
+            );
 
-        Terms categoryTerms = searchResponse.getAggregations().get("category");
-        assertThat(categoryTerms.getBuckets().size(), equalTo(3));
+        assertNoFailuresAndResponse(searchRequest, response -> {
+            Terms categoryTerms = response.getAggregations().get("category");
+            assertThat(categoryTerms.getBuckets().size(), equalTo(3));
 
-        for (Terms.Bucket bucket : categoryTerms.getBuckets()) {
-            logger.info("bucket={}", bucket.getKey());
-            Children childrenBucket = bucket.getAggregations().get("to_comment");
-            TopHits topHits = childrenBucket.getAggregations().get("top_comments");
-            logger.info("total_hits={}", topHits.getHits().getTotalHits().value);
-            for (SearchHit searchHit : topHits.getHits()) {
-                logger.info("hit= {} {}", searchHit.getSortValues()[0], searchHit.getId());
+            for (Terms.Bucket bucket : categoryTerms.getBuckets()) {
+                logger.info("bucket={}", bucket.getKey());
+                Children childrenBucket = bucket.getAggregations().get("to_comment");
+                TopHits topHits = childrenBucket.getAggregations().get("top_comments");
+                logger.info("total_hits={}", topHits.getHits().getTotalHits().value);
+                for (SearchHit searchHit : topHits.getHits()) {
+                    logger.info("hit= {} {}", searchHit.getSortValues()[0], searchHit.getId());
+                }
             }
-        }
 
-        Terms.Bucket categoryBucket = categoryTerms.getBucketByKey("a");
-        assertThat(categoryBucket.getKeyAsString(), equalTo("a"));
-        assertThat(categoryBucket.getDocCount(), equalTo(3L));
+            Terms.Bucket categoryBucket = categoryTerms.getBucketByKey("a");
+            assertThat(categoryBucket.getKeyAsString(), equalTo("a"));
+            assertThat(categoryBucket.getDocCount(), equalTo(3L));
 
-        Children childrenBucket = categoryBucket.getAggregations().get("to_comment");
-        assertThat(childrenBucket.getName(), equalTo("to_comment"));
-        assertThat(childrenBucket.getDocCount(), equalTo(2L));
-        TopHits topHits = childrenBucket.getAggregations().get("top_comments");
-        assertThat(topHits.getHits().getTotalHits().value, equalTo(2L));
-        assertThat(topHits.getHits().getAt(0).getId(), equalTo("e"));
-        assertThat(topHits.getHits().getAt(1).getId(), equalTo("f"));
+            Children childrenBucket = categoryBucket.getAggregations().get("to_comment");
+            assertThat(childrenBucket.getName(), equalTo("to_comment"));
+            assertThat(childrenBucket.getDocCount(), equalTo(2L));
+            TopHits topHits = childrenBucket.getAggregations().get("top_comments");
+            assertThat(topHits.getHits().getTotalHits().value, equalTo(2L));
+            assertThat(topHits.getHits().getAt(0).getId(), equalTo("e"));
+            assertThat(topHits.getHits().getAt(1).getId(), equalTo("f"));
 
-        categoryBucket = categoryTerms.getBucketByKey("b");
-        assertThat(categoryBucket.getKeyAsString(), equalTo("b"));
-        assertThat(categoryBucket.getDocCount(), equalTo(2L));
+            categoryBucket = categoryTerms.getBucketByKey("b");
+            assertThat(categoryBucket.getKeyAsString(), equalTo("b"));
+            assertThat(categoryBucket.getDocCount(), equalTo(2L));
 
-        childrenBucket = categoryBucket.getAggregations().get("to_comment");
-        assertThat(childrenBucket.getName(), equalTo("to_comment"));
-        assertThat(childrenBucket.getDocCount(), equalTo(1L));
-        topHits = childrenBucket.getAggregations().get("top_comments");
-        assertThat(topHits.getHits().getTotalHits().value, equalTo(1L));
-        assertThat(topHits.getHits().getAt(0).getId(), equalTo("f"));
+            childrenBucket = categoryBucket.getAggregations().get("to_comment");
+            assertThat(childrenBucket.getName(), equalTo("to_comment"));
+            assertThat(childrenBucket.getDocCount(), equalTo(1L));
+            topHits = childrenBucket.getAggregations().get("top_comments");
+            assertThat(topHits.getHits().getTotalHits().value, equalTo(1L));
+            assertThat(topHits.getHits().getAt(0).getId(), equalTo("f"));
 
-        categoryBucket = categoryTerms.getBucketByKey("c");
-        assertThat(categoryBucket.getKeyAsString(), equalTo("c"));
-        assertThat(categoryBucket.getDocCount(), equalTo(2L));
+            categoryBucket = categoryTerms.getBucketByKey("c");
+            assertThat(categoryBucket.getKeyAsString(), equalTo("c"));
+            assertThat(categoryBucket.getDocCount(), equalTo(2L));
 
-        childrenBucket = categoryBucket.getAggregations().get("to_comment");
-        assertThat(childrenBucket.getName(), equalTo("to_comment"));
-        assertThat(childrenBucket.getDocCount(), equalTo(1L));
-        topHits = childrenBucket.getAggregations().get("top_comments");
-        assertThat(topHits.getHits().getTotalHits().value, equalTo(1L));
-        assertThat(topHits.getHits().getAt(0).getId(), equalTo("f"));
+            childrenBucket = categoryBucket.getAggregations().get("to_comment");
+            assertThat(childrenBucket.getName(), equalTo("to_comment"));
+            assertThat(childrenBucket.getDocCount(), equalTo(1L));
+            topHits = childrenBucket.getAggregations().get("top_comments");
+            assertThat(topHits.getHits().getTotalHits().value, equalTo(1L));
+            assertThat(topHits.getHits().getAt(0).getId(), equalTo("f"));
+        });
     }
 
     public void testWithDeletes() throws Exception {
@@ -170,16 +171,17 @@ public class ChildrenIT extends AbstractParentChildTestCase {
         indexRandom(true, requests);
 
         for (int i = 0; i < 10; i++) {
-            SearchResponse searchResponse = prepareSearch(indexName).addAggregation(
+            SearchRequestBuilder searchRequest = prepareSearch(indexName).addAggregation(
                 children("children", "child").subAggregation(sum("counts").field("count"))
-            ).get();
+            );
 
-            assertNoFailures(searchResponse);
-            Children children = searchResponse.getAggregations().get("children");
-            assertThat(children.getDocCount(), equalTo(4L));
+            assertNoFailuresAndResponse(searchRequest, response -> {
+                Children children = response.getAggregations().get("children");
+                assertThat(children.getDocCount(), equalTo(4L));
 
-            Sum count = children.getAggregations().get("counts");
-            assertThat(count.value(), equalTo(4.));
+                Sum count = children.getAggregations().get("counts");
+                assertThat(count.value(), equalTo(4.));
+            });
 
             String idToUpdate = Integer.toString(2 + randomInt(3));
             /*
@@ -199,12 +201,12 @@ public class ChildrenIT extends AbstractParentChildTestCase {
     }
 
     public void testNonExistingChildType() throws Exception {
-        SearchResponse searchResponse = prepareSearch("test").addAggregation(children("non-existing", "xyz")).get();
-        assertNoFailures(searchResponse);
-
-        Children children = searchResponse.getAggregations().get("non-existing");
-        assertThat(children.getName(), equalTo("non-existing"));
-        assertThat(children.getDocCount(), equalTo(0L));
+        SearchRequestBuilder searchRequest = prepareSearch("test").addAggregation(children("non-existing", "xyz"));
+        assertNoFailuresAndResponse(searchRequest, response -> {
+            Children children = response.getAggregations().get("non-existing");
+            assertThat(children.getName(), equalTo("non-existing"));
+            assertThat(children.getDocCount(), equalTo(0L));
+        });
     }
 
     public void testPostCollection() throws Exception {
@@ -251,33 +253,35 @@ public class ChildrenIT extends AbstractParentChildTestCase {
         requests.add(createIndexRequest(indexName, childType, "16", "2", "color", "green", "size", "44"));
         indexRandom(true, requests);
 
-        SearchResponse response = prepareSearch(indexName).setQuery(hasChildQuery(childType, termQuery("color", "orange"), ScoreMode.None))
+        SearchRequestBuilder searchRequest = prepareSearch(indexName).setQuery(
+            hasChildQuery(childType, termQuery("color", "orange"), ScoreMode.None)
+        )
             .addAggregation(
                 children("my-refinements", childType).subAggregation(terms("my-colors").field("color"))
                     .subAggregation(terms("my-sizes").field("size"))
-            )
-            .get();
-        assertNoFailures(response);
-        assertHitCount(response, 1);
+            );
+        assertNoFailuresAndResponse(searchRequest, response -> {
+            assertHitCount(response, 1L);
 
-        Children childrenAgg = response.getAggregations().get("my-refinements");
-        assertThat(childrenAgg.getDocCount(), equalTo(7L));
+            Children childrenAgg = response.getAggregations().get("my-refinements");
+            assertThat(childrenAgg.getDocCount(), equalTo(7L));
 
-        Terms termsAgg = childrenAgg.getAggregations().get("my-colors");
-        assertThat(termsAgg.getBuckets().size(), equalTo(4));
-        assertThat(termsAgg.getBucketByKey("black").getDocCount(), equalTo(3L));
-        assertThat(termsAgg.getBucketByKey("blue").getDocCount(), equalTo(2L));
-        assertThat(termsAgg.getBucketByKey("green").getDocCount(), equalTo(1L));
-        assertThat(termsAgg.getBucketByKey("orange").getDocCount(), equalTo(1L));
+            Terms termsAgg = childrenAgg.getAggregations().get("my-colors");
+            assertThat(termsAgg.getBuckets().size(), equalTo(4));
+            assertThat(termsAgg.getBucketByKey("black").getDocCount(), equalTo(3L));
+            assertThat(termsAgg.getBucketByKey("blue").getDocCount(), equalTo(2L));
+            assertThat(termsAgg.getBucketByKey("green").getDocCount(), equalTo(1L));
+            assertThat(termsAgg.getBucketByKey("orange").getDocCount(), equalTo(1L));
 
-        termsAgg = childrenAgg.getAggregations().get("my-sizes");
-        assertThat(termsAgg.getBuckets().size(), equalTo(6));
-        assertThat(termsAgg.getBucketByKey("36").getDocCount(), equalTo(2L));
-        assertThat(termsAgg.getBucketByKey("32").getDocCount(), equalTo(1L));
-        assertThat(termsAgg.getBucketByKey("34").getDocCount(), equalTo(1L));
-        assertThat(termsAgg.getBucketByKey("38").getDocCount(), equalTo(1L));
-        assertThat(termsAgg.getBucketByKey("40").getDocCount(), equalTo(1L));
-        assertThat(termsAgg.getBucketByKey("44").getDocCount(), equalTo(1L));
+            termsAgg = childrenAgg.getAggregations().get("my-sizes");
+            assertThat(termsAgg.getBuckets().size(), equalTo(6));
+            assertThat(termsAgg.getBucketByKey("36").getDocCount(), equalTo(2L));
+            assertThat(termsAgg.getBucketByKey("32").getDocCount(), equalTo(1L));
+            assertThat(termsAgg.getBucketByKey("34").getDocCount(), equalTo(1L));
+            assertThat(termsAgg.getBucketByKey("38").getDocCount(), equalTo(1L));
+            assertThat(termsAgg.getBucketByKey("40").getDocCount(), equalTo(1L));
+            assertThat(termsAgg.getBucketByKey("44").getDocCount(), equalTo(1L));
+        });
     }
 
     public void testHierarchicalChildrenAggs() {
@@ -300,24 +304,25 @@ public class ChildrenIT extends AbstractParentChildTestCase {
         createIndexRequest(indexName, childType, "3", "2", "name", "brussels").setRouting("1").get();
         refresh();
 
-        SearchResponse response = prepareSearch(indexName).setQuery(matchQuery("name", "europe"))
+        SearchRequestBuilder searchRequest = prepareSearch(indexName).setQuery(matchQuery("name", "europe"))
             .addAggregation(
                 children(parentType, parentType).subAggregation(children(childType, childType).subAggregation(terms("name").field("name")))
-            )
-            .get();
-        assertNoFailures(response);
-        assertHitCount(response, 1);
+            );
 
-        Children children = response.getAggregations().get(parentType);
-        assertThat(children.getName(), equalTo(parentType));
-        assertThat(children.getDocCount(), equalTo(1L));
-        children = children.getAggregations().get(childType);
-        assertThat(children.getName(), equalTo(childType));
-        assertThat(children.getDocCount(), equalTo(1L));
-        Terms terms = children.getAggregations().get("name");
-        assertThat(terms.getBuckets().size(), equalTo(1));
-        assertThat(terms.getBuckets().get(0).getKey().toString(), equalTo("brussels"));
-        assertThat(terms.getBuckets().get(0).getDocCount(), equalTo(1L));
+        assertNoFailuresAndResponse(searchRequest, response -> {
+            assertHitCount(response, 1L);
+
+            Children children = response.getAggregations().get(parentType);
+            assertThat(children.getName(), equalTo(parentType));
+            assertThat(children.getDocCount(), equalTo(1L));
+            children = children.getAggregations().get(childType);
+            assertThat(children.getName(), equalTo(childType));
+            assertThat(children.getDocCount(), equalTo(1L));
+            Terms terms = children.getAggregations().get("name");
+            assertThat(terms.getBuckets().size(), equalTo(1));
+            assertThat(terms.getBuckets().get(0).getKey().toString(), equalTo("brussels"));
+            assertThat(terms.getBuckets().get(0).getDocCount(), equalTo(1L));
+        });
     }
 
     public void testPostCollectAllLeafReaders() throws Exception {
@@ -350,40 +355,41 @@ public class ChildrenIT extends AbstractParentChildTestCase {
         requests.add(createIndexRequest("index", "childType", "8", "3", "name", "Dan", "age", 1));
         indexRandom(true, requests);
 
-        SearchResponse response = prepareSearch("index").setSize(0)
+        SearchRequestBuilder searchRequest = prepareSearch("index").setSize(0)
             .addAggregation(
                 AggregationBuilders.terms("towns")
                     .field("town")
                     .subAggregation(
                         AggregationBuilders.terms("parent_names").field("name").subAggregation(children("child_docs", "childType"))
                     )
-            )
-            .get();
+            );
 
-        Terms towns = response.getAggregations().get("towns");
-        assertThat(towns.getBuckets().size(), equalTo(2));
-        assertThat(towns.getBuckets().get(0).getKeyAsString(), equalTo("Chicago"));
-        assertThat(towns.getBuckets().get(0).getDocCount(), equalTo(2L));
+        assertNoFailuresAndResponse(searchRequest, response -> {
+            Terms towns = response.getAggregations().get("towns");
+            assertThat(towns.getBuckets().size(), equalTo(2));
+            assertThat(towns.getBuckets().get(0).getKeyAsString(), equalTo("Chicago"));
+            assertThat(towns.getBuckets().get(0).getDocCount(), equalTo(2L));
 
-        Terms parents = towns.getBuckets().get(0).getAggregations().get("parent_names");
-        assertThat(parents.getBuckets().size(), equalTo(2));
-        assertThat(parents.getBuckets().get(0).getKeyAsString(), equalTo("Alice"));
-        assertThat(parents.getBuckets().get(0).getDocCount(), equalTo(1L));
-        Children children = parents.getBuckets().get(0).getAggregations().get("child_docs");
-        assertThat(children.getDocCount(), equalTo(1L));
+            Terms parents = towns.getBuckets().get(0).getAggregations().get("parent_names");
+            assertThat(parents.getBuckets().size(), equalTo(2));
+            assertThat(parents.getBuckets().get(0).getKeyAsString(), equalTo("Alice"));
+            assertThat(parents.getBuckets().get(0).getDocCount(), equalTo(1L));
+            Children children = parents.getBuckets().get(0).getAggregations().get("child_docs");
+            assertThat(children.getDocCount(), equalTo(1L));
 
-        assertThat(parents.getBuckets().get(1).getKeyAsString(), equalTo("Bill"));
-        assertThat(parents.getBuckets().get(1).getDocCount(), equalTo(1L));
-        children = parents.getBuckets().get(1).getAggregations().get("child_docs");
-        assertThat(children.getDocCount(), equalTo(2L));
+            assertThat(parents.getBuckets().get(1).getKeyAsString(), equalTo("Bill"));
+            assertThat(parents.getBuckets().get(1).getDocCount(), equalTo(1L));
+            children = parents.getBuckets().get(1).getAggregations().get("child_docs");
+            assertThat(children.getDocCount(), equalTo(2L));
 
-        assertThat(towns.getBuckets().get(1).getKeyAsString(), equalTo("Memphis"));
-        assertThat(towns.getBuckets().get(1).getDocCount(), equalTo(1L));
-        parents = towns.getBuckets().get(1).getAggregations().get("parent_names");
-        assertThat(parents.getBuckets().size(), equalTo(1));
-        assertThat(parents.getBuckets().get(0).getKeyAsString(), equalTo("Bob"));
-        assertThat(parents.getBuckets().get(0).getDocCount(), equalTo(1L));
-        children = parents.getBuckets().get(0).getAggregations().get("child_docs");
-        assertThat(children.getDocCount(), equalTo(2L));
+            assertThat(towns.getBuckets().get(1).getKeyAsString(), equalTo("Memphis"));
+            assertThat(towns.getBuckets().get(1).getDocCount(), equalTo(1L));
+            parents = towns.getBuckets().get(1).getAggregations().get("parent_names");
+            assertThat(parents.getBuckets().size(), equalTo(1));
+            assertThat(parents.getBuckets().get(0).getKeyAsString(), equalTo("Bob"));
+            assertThat(parents.getBuckets().get(0).getDocCount(), equalTo(1L));
+            children = parents.getBuckets().get(0).getAggregations().get("child_docs");
+            assertThat(children.getDocCount(), equalTo(2L));
+        });
     }
 }

--- a/modules/parent-join/src/internalClusterTest/java/org/elasticsearch/join/aggregations/ParentIT.java
+++ b/modules/parent-join/src/internalClusterTest/java/org/elasticsearch/join/aggregations/ParentIT.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.join.aggregations;
 
 import org.elasticsearch.action.search.SearchRequestBuilder;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
@@ -27,7 +26,7 @@ import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
 import static org.elasticsearch.join.aggregations.JoinAggregationBuilders.parent;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.topHits;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
 import static org.hamcrest.Matchers.equalTo;
 
 public class ParentIT extends AbstractParentChildTestCase {
@@ -36,73 +35,70 @@ public class ParentIT extends AbstractParentChildTestCase {
         final SearchRequestBuilder searchRequest = prepareSearch("test").setSize(0)
             .setQuery(matchQuery("randomized", true))
             .addAggregation(parent("to_article", "comment"));
-        SearchResponse searchResponse = searchRequest.get();
-
-        assertNoFailures(searchResponse);
         long articlesWithComment = articleToControl.values()
             .stream()
             .filter(parentControl -> parentControl.commentIds.isEmpty() == false)
             .count();
-        Parent parentAgg = searchResponse.getAggregations().get("to_article");
-        assertThat(
-            "Request: " + searchRequest + "\nResponse: " + searchResponse + "\n",
-            parentAgg.getDocCount(),
-            equalTo(articlesWithComment)
-        );
+        assertNoFailuresAndResponse(searchRequest, response -> {
+            Parent parentAgg = response.getAggregations().get("to_article");
+            assertThat(
+                "Request: " + searchRequest + "\nResponse: " + response + "\n",
+                parentAgg.getDocCount(),
+                equalTo(articlesWithComment)
+            );
+        });
     }
 
     public void testSimpleParentAggWithSubAgg() {
         final SearchRequestBuilder searchRequest = prepareSearch("test").setSize(10000)
             .setQuery(matchQuery("randomized", true))
             .addAggregation(parent("to_article", "comment").subAggregation(terms("category").field("category").size(10000)));
-        SearchResponse searchResponse = searchRequest.get();
-        assertNoFailures(searchResponse);
-
         long articlesWithComment = articleToControl.values()
             .stream()
             .filter(parentControl -> parentControl.commentIds.isEmpty() == false)
             .count();
-
-        Parent parentAgg = searchResponse.getAggregations().get("to_article");
-        assertThat(
-            "Request: " + searchRequest + "\nResponse: " + searchResponse + "\n",
-            parentAgg.getDocCount(),
-            equalTo(articlesWithComment)
-        );
-        Terms categoryTerms = parentAgg.getAggregations().get("category");
         long categoriesWithComments = categoryToControl.values().stream().filter(control -> control.commentIds.isEmpty() == false).count();
-        assertThat(
-            "Buckets: "
-                + categoryTerms.getBuckets()
+        assertNoFailuresAndResponse(searchRequest, response -> {
+            Parent parentAgg = response.getAggregations().get("to_article");
+            assertThat(
+                "Request: " + searchRequest + "\nResponse: " + response + "\n",
+                parentAgg.getDocCount(),
+                equalTo(articlesWithComment)
+            );
+            Terms categoryTerms = parentAgg.getAggregations().get("category");
+            assertThat(
+                "Buckets: "
+                    + categoryTerms.getBuckets()
+                        .stream()
+                        .map((Function<Terms.Bucket, String>) MultiBucketsAggregation.Bucket::getKeyAsString)
+                        .collect(Collectors.toList())
+                    + "\nCategories: "
+                    + categoryToControl.keySet(),
+                (long) categoryTerms.getBuckets().size(),
+                equalTo(categoriesWithComments)
+            );
+            for (Map.Entry<String, Control> entry : categoryToControl.entrySet()) {
+                // no children for this category -> no entry in the child to parent-aggregation
+                if (entry.getValue().commentIds.isEmpty()) {
+                    assertNull(categoryTerms.getBucketByKey(entry.getKey()));
+                    continue;
+                }
+
+                final Terms.Bucket categoryBucket = categoryTerms.getBucketByKey(entry.getKey());
+                assertNotNull("Failed for category " + entry.getKey(), categoryBucket);
+                assertThat("Failed for category " + entry.getKey(), categoryBucket.getKeyAsString(), equalTo(entry.getKey()));
+
+                // count all articles in this category which have at least one comment
+                long articlesForCategory = articleToControl.values()
                     .stream()
-                    .map((Function<Terms.Bucket, String>) MultiBucketsAggregation.Bucket::getKeyAsString)
-                    .collect(Collectors.toList())
-                + "\nCategories: "
-                + categoryToControl.keySet(),
-            (long) categoryTerms.getBuckets().size(),
-            equalTo(categoriesWithComments)
-        );
-        for (Map.Entry<String, Control> entry : categoryToControl.entrySet()) {
-            // no children for this category -> no entry in the child to parent-aggregation
-            if (entry.getValue().commentIds.isEmpty()) {
-                assertNull(categoryTerms.getBucketByKey(entry.getKey()));
-                continue;
+                    // only articles with this category
+                    .filter(parentControl -> parentControl.category.equals(entry.getKey()))
+                    // only articles which have comments
+                    .filter(parentControl -> parentControl.commentIds.isEmpty() == false)
+                    .count();
+                assertThat("Failed for category " + entry.getKey(), categoryBucket.getDocCount(), equalTo(articlesForCategory));
             }
-
-            final Terms.Bucket categoryBucket = categoryTerms.getBucketByKey(entry.getKey());
-            assertNotNull("Failed for category " + entry.getKey(), categoryBucket);
-            assertThat("Failed for category " + entry.getKey(), categoryBucket.getKeyAsString(), equalTo(entry.getKey()));
-
-            // count all articles in this category which have at least one comment
-            long articlesForCategory = articleToControl.values()
-                .stream()
-                // only articles with this category
-                .filter(parentControl -> parentControl.category.equals(entry.getKey()))
-                // only articles which have comments
-                .filter(parentControl -> parentControl.commentIds.isEmpty() == false)
-                .count();
-            assertThat("Failed for category " + entry.getKey(), categoryBucket.getDocCount(), equalTo(articlesForCategory));
-        }
+        });
     }
 
     public void testParentAggs() throws Exception {
@@ -117,65 +113,65 @@ public class ParentIT extends AbstractParentChildTestCase {
                         )
                     )
             );
-        SearchResponse searchResponse = searchRequest.get();
-        assertNoFailures(searchResponse);
+        assertNoFailuresAndResponse(searchRequest, response -> {
+            final Set<String> commenters = getCommenters();
+            final Map<String, Set<String>> commenterToComments = getCommenterToComments();
 
-        final Set<String> commenters = getCommenters();
-        final Map<String, Set<String>> commenterToComments = getCommenterToComments();
-
-        Terms categoryTerms = searchResponse.getAggregations().get("to_commenter");
-        assertThat(
-            "Request: " + searchRequest + "\nResponse: " + searchResponse + "\n",
-            categoryTerms.getBuckets().size(),
-            equalTo(commenters.size())
-        );
-        for (Terms.Bucket commenterBucket : categoryTerms.getBuckets()) {
-            Set<String> comments = commenterToComments.get(commenterBucket.getKeyAsString());
-            assertNotNull(comments);
+            Terms categoryTerms = response.getAggregations().get("to_commenter");
             assertThat(
-                "Failed for commenter " + commenterBucket.getKeyAsString(),
-                commenterBucket.getDocCount(),
-                equalTo((long) comments.size())
+                "Request: " + searchRequest + "\nResponse: " + response + "\n",
+                categoryTerms.getBuckets().size(),
+                equalTo(commenters.size())
             );
+            for (Terms.Bucket commenterBucket : categoryTerms.getBuckets()) {
+                Set<String> comments = commenterToComments.get(commenterBucket.getKeyAsString());
+                assertNotNull(comments);
+                assertThat(
+                    "Failed for commenter " + commenterBucket.getKeyAsString(),
+                    commenterBucket.getDocCount(),
+                    equalTo((long) comments.size())
+                );
 
-            Parent articleAgg = commenterBucket.getAggregations().get("to_article");
-            assertThat(articleAgg.getName(), equalTo("to_article"));
-            // find all articles for the comments for the current commenter
-            Set<String> articles = articleToControl.values()
-                .stream()
-                .flatMap(
-                    (Function<ParentControl, Stream<String>>) parentControl -> parentControl.commentIds.stream().filter(comments::contains)
-                )
-                .collect(Collectors.toSet());
+                Parent articleAgg = commenterBucket.getAggregations().get("to_article");
+                assertThat(articleAgg.getName(), equalTo("to_article"));
+                // find all articles for the comments for the current commenter
+                Set<String> articles = articleToControl.values()
+                    .stream()
+                    .flatMap(
+                        (Function<ParentControl, Stream<String>>) parentControl -> parentControl.commentIds.stream()
+                            .filter(comments::contains)
+                    )
+                    .collect(Collectors.toSet());
 
-            assertThat(articleAgg.getDocCount(), equalTo((long) articles.size()));
+                assertThat(articleAgg.getDocCount(), equalTo((long) articles.size()));
 
-            Terms categoryAgg = articleAgg.getAggregations().get("to_category");
-            assertNotNull(categoryAgg);
+                Terms categoryAgg = articleAgg.getAggregations().get("to_category");
+                assertNotNull(categoryAgg);
 
-            List<String> categories = categoryToControl.entrySet()
-                .stream()
-                .filter(entry -> entry.getValue().commenterToCommentId.containsKey(commenterBucket.getKeyAsString()))
-                .map(Map.Entry::getKey)
-                .collect(Collectors.toList());
+                List<String> categories = categoryToControl.entrySet()
+                    .stream()
+                    .filter(entry -> entry.getValue().commenterToCommentId.containsKey(commenterBucket.getKeyAsString()))
+                    .map(Map.Entry::getKey)
+                    .collect(Collectors.toList());
 
-            for (String category : categories) {
-                Terms.Bucket categoryBucket = categoryAgg.getBucketByKey(category);
-                assertNotNull(categoryBucket);
+                for (String category : categories) {
+                    Terms.Bucket categoryBucket = categoryAgg.getBucketByKey(category);
+                    assertNotNull(categoryBucket);
 
-                Aggregation topCategory = categoryBucket.getAggregations().get("top_category");
-                assertNotNull(topCategory);
+                    Aggregation topCategory = categoryBucket.getAggregations().get("top_category");
+                    assertNotNull(topCategory);
+                }
             }
-        }
 
-        for (String commenter : commenters) {
-            Terms.Bucket categoryBucket = categoryTerms.getBucketByKey(commenter);
-            assertThat(categoryBucket.getKeyAsString(), equalTo(commenter));
-            assertThat(categoryBucket.getDocCount(), equalTo((long) commenterToComments.get(commenter).size()));
+            for (String commenter : commenters) {
+                Terms.Bucket categoryBucket = categoryTerms.getBucketByKey(commenter);
+                assertThat(categoryBucket.getKeyAsString(), equalTo(commenter));
+                assertThat(categoryBucket.getDocCount(), equalTo((long) commenterToComments.get(commenter).size()));
 
-            Parent childrenBucket = categoryBucket.getAggregations().get("to_article");
-            assertThat(childrenBucket.getName(), equalTo("to_article"));
-        }
+                Parent childrenBucket = categoryBucket.getAggregations().get("to_article");
+                assertThat(childrenBucket.getName(), equalTo("to_article"));
+            }
+        });
     }
 
     private Set<String> getCommenters() {
@@ -197,12 +193,11 @@ public class ParentIT extends AbstractParentChildTestCase {
     }
 
     public void testNonExistingParentType() throws Exception {
-        SearchResponse searchResponse = prepareSearch("test").addAggregation(parent("non-existing", "xyz")).get();
-        assertNoFailures(searchResponse);
-
-        Parent parent = searchResponse.getAggregations().get("non-existing");
-        assertThat(parent.getName(), equalTo("non-existing"));
-        assertThat(parent.getDocCount(), equalTo(0L));
+        assertNoFailuresAndResponse(prepareSearch("test").addAggregation(parent("non-existing", "xyz")), response -> {
+            Parent parent = response.getAggregations().get("non-existing");
+            assertThat(parent.getName(), equalTo("non-existing"));
+            assertThat(parent.getDocCount(), equalTo(0L));
+        });
     }
 
     public void testTermsParentAggTerms() throws Exception {
@@ -213,52 +208,52 @@ public class ParentIT extends AbstractParentChildTestCase {
                     .size(10000)
                     .subAggregation(parent("to_article", "comment").subAggregation(terms("to_category").field("category").size(10000)))
             );
-        SearchResponse searchResponse = searchRequest.get();
-        assertNoFailures(searchResponse);
+        assertNoFailuresAndResponse(searchRequest, response -> {
+            final Set<String> commenters = getCommenters();
+            final Map<String, Set<String>> commenterToComments = getCommenterToComments();
 
-        final Set<String> commenters = getCommenters();
-        final Map<String, Set<String>> commenterToComments = getCommenterToComments();
-
-        Terms commentersAgg = searchResponse.getAggregations().get("to_commenter");
-        assertThat(
-            "Request: " + searchRequest + "\nResponse: " + searchResponse + "\n",
-            commentersAgg.getBuckets().size(),
-            equalTo(commenters.size())
-        );
-        for (Terms.Bucket commenterBucket : commentersAgg.getBuckets()) {
-            Set<String> comments = commenterToComments.get(commenterBucket.getKeyAsString());
-            assertNotNull(comments);
+            Terms commentersAgg = response.getAggregations().get("to_commenter");
             assertThat(
-                "Failed for commenter " + commenterBucket.getKeyAsString(),
-                commenterBucket.getDocCount(),
-                equalTo((long) comments.size())
+                "Request: " + searchRequest + "\nResponse: " + response + "\n",
+                commentersAgg.getBuckets().size(),
+                equalTo(commenters.size())
             );
+            for (Terms.Bucket commenterBucket : commentersAgg.getBuckets()) {
+                Set<String> comments = commenterToComments.get(commenterBucket.getKeyAsString());
+                assertNotNull(comments);
+                assertThat(
+                    "Failed for commenter " + commenterBucket.getKeyAsString(),
+                    commenterBucket.getDocCount(),
+                    equalTo((long) comments.size())
+                );
 
-            Parent articleAgg = commenterBucket.getAggregations().get("to_article");
-            assertThat(articleAgg.getName(), equalTo("to_article"));
-            // find all articles for the comments for the current commenter
-            Set<String> articles = articleToControl.values()
-                .stream()
-                .flatMap(
-                    (Function<ParentControl, Stream<String>>) parentControl -> parentControl.commentIds.stream().filter(comments::contains)
-                )
-                .collect(Collectors.toSet());
+                Parent articleAgg = commenterBucket.getAggregations().get("to_article");
+                assertThat(articleAgg.getName(), equalTo("to_article"));
+                // find all articles for the comments for the current commenter
+                Set<String> articles = articleToControl.values()
+                    .stream()
+                    .flatMap(
+                        (Function<ParentControl, Stream<String>>) parentControl -> parentControl.commentIds.stream()
+                            .filter(comments::contains)
+                    )
+                    .collect(Collectors.toSet());
 
-            assertThat(articleAgg.getDocCount(), equalTo((long) articles.size()));
+                assertThat(articleAgg.getDocCount(), equalTo((long) articles.size()));
 
-            Terms categoryAgg = articleAgg.getAggregations().get("to_category");
-            assertNotNull(categoryAgg);
+                Terms categoryAgg = articleAgg.getAggregations().get("to_category");
+                assertNotNull(categoryAgg);
 
-            List<String> categories = categoryToControl.entrySet()
-                .stream()
-                .filter(entry -> entry.getValue().commenterToCommentId.containsKey(commenterBucket.getKeyAsString()))
-                .map(Map.Entry::getKey)
-                .collect(Collectors.toList());
+                List<String> categories = categoryToControl.entrySet()
+                    .stream()
+                    .filter(entry -> entry.getValue().commenterToCommentId.containsKey(commenterBucket.getKeyAsString()))
+                    .map(Map.Entry::getKey)
+                    .collect(Collectors.toList());
 
-            for (String category : categories) {
-                Terms.Bucket categoryBucket = categoryAgg.getBucketByKey(category);
-                assertNotNull(categoryBucket);
+                for (String category : categories) {
+                    Terms.Bucket categoryBucket = categoryAgg.getBucketByKey(category);
+                    assertNotNull(categoryBucket);
+                }
             }
-        }
+        });
     }
 }

--- a/modules/parent-join/src/internalClusterTest/java/org/elasticsearch/join/aggregations/ParentIT.java
+++ b/modules/parent-join/src/internalClusterTest/java/org/elasticsearch/join/aggregations/ParentIT.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.join.aggregations;
 
-import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
@@ -32,146 +31,138 @@ import static org.hamcrest.Matchers.equalTo;
 public class ParentIT extends AbstractParentChildTestCase {
 
     public void testSimpleParentAgg() {
-        final SearchRequestBuilder searchRequest = prepareSearch("test").setSize(0)
-            .setQuery(matchQuery("randomized", true))
-            .addAggregation(parent("to_article", "comment"));
         long articlesWithComment = articleToControl.values()
             .stream()
             .filter(parentControl -> parentControl.commentIds.isEmpty() == false)
             .count();
-        assertNoFailuresAndResponse(searchRequest, response -> {
-            Parent parentAgg = response.getAggregations().get("to_article");
-            assertThat(
-                "Request: " + searchRequest + "\nResponse: " + response + "\n",
-                parentAgg.getDocCount(),
-                equalTo(articlesWithComment)
-            );
-        });
+        assertNoFailuresAndResponse(
+            prepareSearch("test").setSize(0).setQuery(matchQuery("randomized", true)).addAggregation(parent("to_article", "comment")),
+            response -> {
+                Parent parentAgg = response.getAggregations().get("to_article");
+                assertThat("\nResponse: " + response + "\n", parentAgg.getDocCount(), equalTo(articlesWithComment));
+            }
+        );
     }
 
     public void testSimpleParentAggWithSubAgg() {
-        final SearchRequestBuilder searchRequest = prepareSearch("test").setSize(10000)
-            .setQuery(matchQuery("randomized", true))
-            .addAggregation(parent("to_article", "comment").subAggregation(terms("category").field("category").size(10000)));
         long articlesWithComment = articleToControl.values()
             .stream()
             .filter(parentControl -> parentControl.commentIds.isEmpty() == false)
             .count();
         long categoriesWithComments = categoryToControl.values().stream().filter(control -> control.commentIds.isEmpty() == false).count();
-        assertNoFailuresAndResponse(searchRequest, response -> {
-            Parent parentAgg = response.getAggregations().get("to_article");
-            assertThat(
-                "Request: " + searchRequest + "\nResponse: " + response + "\n",
-                parentAgg.getDocCount(),
-                equalTo(articlesWithComment)
-            );
-            Terms categoryTerms = parentAgg.getAggregations().get("category");
-            assertThat(
-                "Buckets: "
-                    + categoryTerms.getBuckets()
+        assertNoFailuresAndResponse(
+            prepareSearch("test").setSize(10000)
+                .setQuery(matchQuery("randomized", true))
+                .addAggregation(parent("to_article", "comment").subAggregation(terms("category").field("category").size(10000))),
+            response -> {
+                Parent parentAgg = response.getAggregations().get("to_article");
+                assertThat("Response: " + response + "\n", parentAgg.getDocCount(), equalTo(articlesWithComment));
+                Terms categoryTerms = parentAgg.getAggregations().get("category");
+                assertThat(
+                    "Buckets: "
+                        + categoryTerms.getBuckets()
+                            .stream()
+                            .map((Function<Terms.Bucket, String>) MultiBucketsAggregation.Bucket::getKeyAsString)
+                            .collect(Collectors.toList())
+                        + "\nCategories: "
+                        + categoryToControl.keySet(),
+                    (long) categoryTerms.getBuckets().size(),
+                    equalTo(categoriesWithComments)
+                );
+                for (Map.Entry<String, Control> entry : categoryToControl.entrySet()) {
+                    // no children for this category -> no entry in the child to parent-aggregation
+                    if (entry.getValue().commentIds.isEmpty()) {
+                        assertNull(categoryTerms.getBucketByKey(entry.getKey()));
+                        continue;
+                    }
+
+                    final Terms.Bucket categoryBucket = categoryTerms.getBucketByKey(entry.getKey());
+                    assertNotNull("Failed for category " + entry.getKey(), categoryBucket);
+                    assertThat("Failed for category " + entry.getKey(), categoryBucket.getKeyAsString(), equalTo(entry.getKey()));
+
+                    // count all articles in this category which have at least one comment
+                    long articlesForCategory = articleToControl.values()
                         .stream()
-                        .map((Function<Terms.Bucket, String>) MultiBucketsAggregation.Bucket::getKeyAsString)
-                        .collect(Collectors.toList())
-                    + "\nCategories: "
-                    + categoryToControl.keySet(),
-                (long) categoryTerms.getBuckets().size(),
-                equalTo(categoriesWithComments)
-            );
-            for (Map.Entry<String, Control> entry : categoryToControl.entrySet()) {
-                // no children for this category -> no entry in the child to parent-aggregation
-                if (entry.getValue().commentIds.isEmpty()) {
-                    assertNull(categoryTerms.getBucketByKey(entry.getKey()));
-                    continue;
+                        // only articles with this category
+                        .filter(parentControl -> parentControl.category.equals(entry.getKey()))
+                        // only articles which have comments
+                        .filter(parentControl -> parentControl.commentIds.isEmpty() == false)
+                        .count();
+                    assertThat("Failed for category " + entry.getKey(), categoryBucket.getDocCount(), equalTo(articlesForCategory));
                 }
-
-                final Terms.Bucket categoryBucket = categoryTerms.getBucketByKey(entry.getKey());
-                assertNotNull("Failed for category " + entry.getKey(), categoryBucket);
-                assertThat("Failed for category " + entry.getKey(), categoryBucket.getKeyAsString(), equalTo(entry.getKey()));
-
-                // count all articles in this category which have at least one comment
-                long articlesForCategory = articleToControl.values()
-                    .stream()
-                    // only articles with this category
-                    .filter(parentControl -> parentControl.category.equals(entry.getKey()))
-                    // only articles which have comments
-                    .filter(parentControl -> parentControl.commentIds.isEmpty() == false)
-                    .count();
-                assertThat("Failed for category " + entry.getKey(), categoryBucket.getDocCount(), equalTo(articlesForCategory));
             }
-        });
+        );
     }
 
     public void testParentAggs() throws Exception {
-        final SearchRequestBuilder searchRequest = prepareSearch("test").setSize(10000)
-            .setQuery(matchQuery("randomized", true))
-            .addAggregation(
-                terms("to_commenter").field("commenter")
-                    .size(10000)
-                    .subAggregation(
-                        parent("to_article", "comment").subAggregation(
-                            terms("to_category").field("category").size(10000).subAggregation(topHits("top_category"))
+        assertNoFailuresAndResponse(
+            prepareSearch("test").setSize(10000)
+                .setQuery(matchQuery("randomized", true))
+                .addAggregation(
+                    terms("to_commenter").field("commenter")
+                        .size(10000)
+                        .subAggregation(
+                            parent("to_article", "comment").subAggregation(
+                                terms("to_category").field("category").size(10000).subAggregation(topHits("top_category"))
+                            )
                         )
-                    )
-            );
-        assertNoFailuresAndResponse(searchRequest, response -> {
-            final Set<String> commenters = getCommenters();
-            final Map<String, Set<String>> commenterToComments = getCommenterToComments();
+                ),
+            response -> {
+                final Set<String> commenters = getCommenters();
+                final Map<String, Set<String>> commenterToComments = getCommenterToComments();
 
-            Terms categoryTerms = response.getAggregations().get("to_commenter");
-            assertThat(
-                "Request: " + searchRequest + "\nResponse: " + response + "\n",
-                categoryTerms.getBuckets().size(),
-                equalTo(commenters.size())
-            );
-            for (Terms.Bucket commenterBucket : categoryTerms.getBuckets()) {
-                Set<String> comments = commenterToComments.get(commenterBucket.getKeyAsString());
-                assertNotNull(comments);
-                assertThat(
-                    "Failed for commenter " + commenterBucket.getKeyAsString(),
-                    commenterBucket.getDocCount(),
-                    equalTo((long) comments.size())
-                );
+                Terms categoryTerms = response.getAggregations().get("to_commenter");
+                assertThat("Response: " + response + "\n", categoryTerms.getBuckets().size(), equalTo(commenters.size()));
+                for (Terms.Bucket commenterBucket : categoryTerms.getBuckets()) {
+                    Set<String> comments = commenterToComments.get(commenterBucket.getKeyAsString());
+                    assertNotNull(comments);
+                    assertThat(
+                        "Failed for commenter " + commenterBucket.getKeyAsString(),
+                        commenterBucket.getDocCount(),
+                        equalTo((long) comments.size())
+                    );
 
-                Parent articleAgg = commenterBucket.getAggregations().get("to_article");
-                assertThat(articleAgg.getName(), equalTo("to_article"));
-                // find all articles for the comments for the current commenter
-                Set<String> articles = articleToControl.values()
-                    .stream()
-                    .flatMap(
-                        (Function<ParentControl, Stream<String>>) parentControl -> parentControl.commentIds.stream()
-                            .filter(comments::contains)
-                    )
-                    .collect(Collectors.toSet());
+                    Parent articleAgg = commenterBucket.getAggregations().get("to_article");
+                    assertThat(articleAgg.getName(), equalTo("to_article"));
+                    // find all articles for the comments for the current commenter
+                    Set<String> articles = articleToControl.values()
+                        .stream()
+                        .flatMap(
+                            (Function<ParentControl, Stream<String>>) parentControl -> parentControl.commentIds.stream()
+                                .filter(comments::contains)
+                        )
+                        .collect(Collectors.toSet());
 
-                assertThat(articleAgg.getDocCount(), equalTo((long) articles.size()));
+                    assertThat(articleAgg.getDocCount(), equalTo((long) articles.size()));
 
-                Terms categoryAgg = articleAgg.getAggregations().get("to_category");
-                assertNotNull(categoryAgg);
+                    Terms categoryAgg = articleAgg.getAggregations().get("to_category");
+                    assertNotNull(categoryAgg);
 
-                List<String> categories = categoryToControl.entrySet()
-                    .stream()
-                    .filter(entry -> entry.getValue().commenterToCommentId.containsKey(commenterBucket.getKeyAsString()))
-                    .map(Map.Entry::getKey)
-                    .collect(Collectors.toList());
+                    List<String> categories = categoryToControl.entrySet()
+                        .stream()
+                        .filter(entry -> entry.getValue().commenterToCommentId.containsKey(commenterBucket.getKeyAsString()))
+                        .map(Map.Entry::getKey)
+                        .collect(Collectors.toList());
 
-                for (String category : categories) {
-                    Terms.Bucket categoryBucket = categoryAgg.getBucketByKey(category);
-                    assertNotNull(categoryBucket);
+                    for (String category : categories) {
+                        Terms.Bucket categoryBucket = categoryAgg.getBucketByKey(category);
+                        assertNotNull(categoryBucket);
 
-                    Aggregation topCategory = categoryBucket.getAggregations().get("top_category");
-                    assertNotNull(topCategory);
+                        Aggregation topCategory = categoryBucket.getAggregations().get("top_category");
+                        assertNotNull(topCategory);
+                    }
+                }
+
+                for (String commenter : commenters) {
+                    Terms.Bucket categoryBucket = categoryTerms.getBucketByKey(commenter);
+                    assertThat(categoryBucket.getKeyAsString(), equalTo(commenter));
+                    assertThat(categoryBucket.getDocCount(), equalTo((long) commenterToComments.get(commenter).size()));
+
+                    Parent childrenBucket = categoryBucket.getAggregations().get("to_article");
+                    assertThat(childrenBucket.getName(), equalTo("to_article"));
                 }
             }
-
-            for (String commenter : commenters) {
-                Terms.Bucket categoryBucket = categoryTerms.getBucketByKey(commenter);
-                assertThat(categoryBucket.getKeyAsString(), equalTo(commenter));
-                assertThat(categoryBucket.getDocCount(), equalTo((long) commenterToComments.get(commenter).size()));
-
-                Parent childrenBucket = categoryBucket.getAggregations().get("to_article");
-                assertThat(childrenBucket.getName(), equalTo("to_article"));
-            }
-        });
+        );
     }
 
     private Set<String> getCommenters() {
@@ -201,59 +192,57 @@ public class ParentIT extends AbstractParentChildTestCase {
     }
 
     public void testTermsParentAggTerms() throws Exception {
-        final SearchRequestBuilder searchRequest = prepareSearch("test").setSize(10000)
-            .setQuery(matchQuery("randomized", true))
-            .addAggregation(
-                terms("to_commenter").field("commenter")
-                    .size(10000)
-                    .subAggregation(parent("to_article", "comment").subAggregation(terms("to_category").field("category").size(10000)))
-            );
-        assertNoFailuresAndResponse(searchRequest, response -> {
-            final Set<String> commenters = getCommenters();
-            final Map<String, Set<String>> commenterToComments = getCommenterToComments();
+        assertNoFailuresAndResponse(
+            prepareSearch("test").setSize(10000)
+                .setQuery(matchQuery("randomized", true))
+                .addAggregation(
+                    terms("to_commenter").field("commenter")
+                        .size(10000)
+                        .subAggregation(parent("to_article", "comment").subAggregation(terms("to_category").field("category").size(10000)))
+                ),
+            response -> {
+                final Set<String> commenters = getCommenters();
+                final Map<String, Set<String>> commenterToComments = getCommenterToComments();
 
-            Terms commentersAgg = response.getAggregations().get("to_commenter");
-            assertThat(
-                "Request: " + searchRequest + "\nResponse: " + response + "\n",
-                commentersAgg.getBuckets().size(),
-                equalTo(commenters.size())
-            );
-            for (Terms.Bucket commenterBucket : commentersAgg.getBuckets()) {
-                Set<String> comments = commenterToComments.get(commenterBucket.getKeyAsString());
-                assertNotNull(comments);
-                assertThat(
-                    "Failed for commenter " + commenterBucket.getKeyAsString(),
-                    commenterBucket.getDocCount(),
-                    equalTo((long) comments.size())
-                );
+                Terms commentersAgg = response.getAggregations().get("to_commenter");
+                assertThat("Response: " + response + "\n", commentersAgg.getBuckets().size(), equalTo(commenters.size()));
+                for (Terms.Bucket commenterBucket : commentersAgg.getBuckets()) {
+                    Set<String> comments = commenterToComments.get(commenterBucket.getKeyAsString());
+                    assertNotNull(comments);
+                    assertThat(
+                        "Failed for commenter " + commenterBucket.getKeyAsString(),
+                        commenterBucket.getDocCount(),
+                        equalTo((long) comments.size())
+                    );
 
-                Parent articleAgg = commenterBucket.getAggregations().get("to_article");
-                assertThat(articleAgg.getName(), equalTo("to_article"));
-                // find all articles for the comments for the current commenter
-                Set<String> articles = articleToControl.values()
-                    .stream()
-                    .flatMap(
-                        (Function<ParentControl, Stream<String>>) parentControl -> parentControl.commentIds.stream()
-                            .filter(comments::contains)
-                    )
-                    .collect(Collectors.toSet());
+                    Parent articleAgg = commenterBucket.getAggregations().get("to_article");
+                    assertThat(articleAgg.getName(), equalTo("to_article"));
+                    // find all articles for the comments for the current commenter
+                    Set<String> articles = articleToControl.values()
+                        .stream()
+                        .flatMap(
+                            (Function<ParentControl, Stream<String>>) parentControl -> parentControl.commentIds.stream()
+                                .filter(comments::contains)
+                        )
+                        .collect(Collectors.toSet());
 
-                assertThat(articleAgg.getDocCount(), equalTo((long) articles.size()));
+                    assertThat(articleAgg.getDocCount(), equalTo((long) articles.size()));
 
-                Terms categoryAgg = articleAgg.getAggregations().get("to_category");
-                assertNotNull(categoryAgg);
+                    Terms categoryAgg = articleAgg.getAggregations().get("to_category");
+                    assertNotNull(categoryAgg);
 
-                List<String> categories = categoryToControl.entrySet()
-                    .stream()
-                    .filter(entry -> entry.getValue().commenterToCommentId.containsKey(commenterBucket.getKeyAsString()))
-                    .map(Map.Entry::getKey)
-                    .collect(Collectors.toList());
+                    List<String> categories = categoryToControl.entrySet()
+                        .stream()
+                        .filter(entry -> entry.getValue().commenterToCommentId.containsKey(commenterBucket.getKeyAsString()))
+                        .map(Map.Entry::getKey)
+                        .collect(Collectors.toList());
 
-                for (String category : categories) {
-                    Terms.Bucket categoryBucket = categoryAgg.getBucketByKey(category);
-                    assertNotNull(categoryBucket);
+                    for (String category : categories) {
+                        Terms.Bucket categoryBucket = categoryAgg.getBucketByKey(category);
+                        assertNotNull(categoryBucket);
+                    }
                 }
             }
-        });
+        );
     }
 }

--- a/modules/parent-join/src/internalClusterTest/java/org/elasticsearch/join/query/InnerHitsIT.java
+++ b/modules/parent-join/src/internalClusterTest/java/org/elasticsearch/join/query/InnerHitsIT.java
@@ -12,7 +12,7 @@ import org.apache.lucene.search.join.ScoreMode;
 import org.apache.lucene.util.ArrayUtil;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
-import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.index.IndexSettings;
@@ -54,6 +54,8 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCountAndNoFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHit;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHitsWithoutFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.hasId;
@@ -114,56 +116,58 @@ public class InnerHitsIT extends ParentChildTestCase {
         requests.add(createIndexRequest("articles", "comment", "c6", "p2", "message", "elephant scared by mice x y"));
         indexRandom(true, requests);
 
-        SearchResponse response = prepareSearch("articles").setQuery(
+        SearchRequestBuilder searchRequest = prepareSearch("articles").setQuery(
             hasChildQuery("comment", matchQuery("message", "fox"), ScoreMode.None).innerHit(new InnerHitBuilder())
-        ).get();
-        assertNoFailures(response);
-        assertHitCount(response, 1);
-        assertSearchHit(response, 1, hasId("p1"));
-        assertThat(response.getHits().getAt(0).getShard(), notNullValue());
+        );
+        assertNoFailuresAndResponse(searchRequest, response -> {
+            assertHitCount(response, 1);
+            assertSearchHit(response, 1, hasId("p1"));
+            assertThat(response.getHits().getAt(0).getShard(), notNullValue());
 
-        assertThat(response.getHits().getAt(0).getInnerHits().size(), equalTo(1));
-        SearchHits innerHits = response.getHits().getAt(0).getInnerHits().get("comment");
-        assertThat(innerHits.getTotalHits().value, equalTo(2L));
+            assertThat(response.getHits().getAt(0).getInnerHits().size(), equalTo(1));
+            SearchHits innerHits = response.getHits().getAt(0).getInnerHits().get("comment");
+            assertThat(innerHits.getTotalHits().value, equalTo(2L));
 
-        assertThat(innerHits.getAt(0).getId(), equalTo("c1"));
-        assertThat(innerHits.getAt(1).getId(), equalTo("c2"));
+            assertThat(innerHits.getAt(0).getId(), equalTo("c1"));
+            assertThat(innerHits.getAt(1).getId(), equalTo("c2"));
+        });
 
         final boolean seqNoAndTerm = randomBoolean();
-        response = prepareSearch("articles").setQuery(
+        searchRequest = prepareSearch("articles").setQuery(
             hasChildQuery("comment", matchQuery("message", "elephant"), ScoreMode.None).innerHit(
                 new InnerHitBuilder().setSeqNoAndPrimaryTerm(seqNoAndTerm)
             )
-        ).get();
-        assertNoFailures(response);
-        assertHitCount(response, 1);
-        assertSearchHit(response, 1, hasId("p2"));
+        );
+        assertNoFailuresAndResponse(searchRequest, response -> {
+            assertHitCount(response, 1);
+            assertSearchHit(response, 1, hasId("p2"));
 
-        assertThat(response.getHits().getAt(0).getInnerHits().size(), equalTo(1));
-        innerHits = response.getHits().getAt(0).getInnerHits().get("comment");
-        assertThat(innerHits.getTotalHits().value, equalTo(3L));
+            assertThat(response.getHits().getAt(0).getInnerHits().size(), equalTo(1));
+            SearchHits innerHits = response.getHits().getAt(0).getInnerHits().get("comment");
+            assertThat(innerHits.getTotalHits().value, equalTo(3L));
 
-        assertThat(innerHits.getAt(0).getId(), equalTo("c4"));
-        assertThat(innerHits.getAt(1).getId(), equalTo("c5"));
-        assertThat(innerHits.getAt(2).getId(), equalTo("c6"));
+            assertThat(innerHits.getAt(0).getId(), equalTo("c4"));
+            assertThat(innerHits.getAt(1).getId(), equalTo("c5"));
+            assertThat(innerHits.getAt(2).getId(), equalTo("c6"));
 
-        if (seqNoAndTerm) {
-            assertThat(innerHits.getAt(0).getPrimaryTerm(), equalTo(1L));
-            assertThat(innerHits.getAt(1).getPrimaryTerm(), equalTo(1L));
-            assertThat(innerHits.getAt(2).getPrimaryTerm(), equalTo(1L));
-            assertThat(innerHits.getAt(0).getSeqNo(), greaterThanOrEqualTo(0L));
-            assertThat(innerHits.getAt(1).getSeqNo(), greaterThanOrEqualTo(0L));
-            assertThat(innerHits.getAt(2).getSeqNo(), greaterThanOrEqualTo(0L));
-        } else {
-            assertThat(innerHits.getAt(0).getPrimaryTerm(), equalTo(UNASSIGNED_PRIMARY_TERM));
-            assertThat(innerHits.getAt(1).getPrimaryTerm(), equalTo(UNASSIGNED_PRIMARY_TERM));
-            assertThat(innerHits.getAt(2).getPrimaryTerm(), equalTo(UNASSIGNED_PRIMARY_TERM));
-            assertThat(innerHits.getAt(0).getSeqNo(), equalTo(UNASSIGNED_SEQ_NO));
-            assertThat(innerHits.getAt(1).getSeqNo(), equalTo(UNASSIGNED_SEQ_NO));
-            assertThat(innerHits.getAt(2).getSeqNo(), equalTo(UNASSIGNED_SEQ_NO));
-        }
+            if (seqNoAndTerm) {
+                assertThat(innerHits.getAt(0).getPrimaryTerm(), equalTo(1L));
+                assertThat(innerHits.getAt(1).getPrimaryTerm(), equalTo(1L));
+                assertThat(innerHits.getAt(2).getPrimaryTerm(), equalTo(1L));
+                assertThat(innerHits.getAt(0).getSeqNo(), greaterThanOrEqualTo(0L));
+                assertThat(innerHits.getAt(1).getSeqNo(), greaterThanOrEqualTo(0L));
+                assertThat(innerHits.getAt(2).getSeqNo(), greaterThanOrEqualTo(0L));
+            } else {
+                assertThat(innerHits.getAt(0).getPrimaryTerm(), equalTo(UNASSIGNED_PRIMARY_TERM));
+                assertThat(innerHits.getAt(1).getPrimaryTerm(), equalTo(UNASSIGNED_PRIMARY_TERM));
+                assertThat(innerHits.getAt(2).getPrimaryTerm(), equalTo(UNASSIGNED_PRIMARY_TERM));
+                assertThat(innerHits.getAt(0).getSeqNo(), equalTo(UNASSIGNED_SEQ_NO));
+                assertThat(innerHits.getAt(1).getSeqNo(), equalTo(UNASSIGNED_SEQ_NO));
+                assertThat(innerHits.getAt(2).getSeqNo(), equalTo(UNASSIGNED_SEQ_NO));
+            }
+        });
 
-        response = prepareSearch("articles").setQuery(
+        searchRequest = prepareSearch("articles").setQuery(
             hasChildQuery("comment", matchQuery("message", "fox"), ScoreMode.None).innerHit(
                 new InnerHitBuilder().addFetchField("message")
                     .setHighlightBuilder(new HighlightBuilder().field("message"))
@@ -171,24 +175,28 @@ public class InnerHitsIT extends ParentChildTestCase {
                     .setSize(1)
                     .addScriptField("script", new Script(ScriptType.INLINE, MockScriptEngine.NAME, "5", Collections.emptyMap()))
             )
-        ).get();
-        assertNoFailures(response);
-        innerHits = response.getHits().getAt(0).getInnerHits().get("comment");
-        assertThat(innerHits.getHits().length, equalTo(1));
-        assertThat(innerHits.getAt(0).getHighlightFields().get("message").getFragments()[0].string(), equalTo("<em>fox</em> eat quick"));
-        assertThat(innerHits.getAt(0).getExplanation().toString(), containsString("weight(message:fox"));
-        assertThat(innerHits.getAt(0).getFields().get("message").getValue().toString(), equalTo("fox eat quick"));
-        assertThat(innerHits.getAt(0).getFields().get("script").getValue().toString(), equalTo("5"));
-
-        response = prepareSearch("articles").setQuery(
+        );
+        assertNoFailuresAndResponse(searchRequest, response -> {
+            SearchHits innerHits = response.getHits().getAt(0).getInnerHits().get("comment");
+            assertThat(innerHits.getHits().length, equalTo(1));
+            assertThat(
+                innerHits.getAt(0).getHighlightFields().get("message").getFragments()[0].string(),
+                equalTo("<em>fox</em> eat quick")
+            );
+            assertThat(innerHits.getAt(0).getExplanation().toString(), containsString("weight(message:fox"));
+            assertThat(innerHits.getAt(0).getFields().get("message").getValue().toString(), equalTo("fox eat quick"));
+            assertThat(innerHits.getAt(0).getFields().get("script").getValue().toString(), equalTo("5"));
+        });
+        searchRequest = prepareSearch("articles").setQuery(
             hasChildQuery("comment", matchQuery("message", "fox"), ScoreMode.None).innerHit(
                 new InnerHitBuilder().addDocValueField("message").setSize(1)
             )
-        ).get();
-        assertNoFailures(response);
-        innerHits = response.getHits().getAt(0).getInnerHits().get("comment");
-        assertThat(innerHits.getHits().length, equalTo(1));
-        assertThat(innerHits.getAt(0).getFields().get("message").getValue().toString(), equalTo("eat"));
+        );
+        assertNoFailuresAndResponse(searchRequest, response -> {
+            SearchHits innerHits = response.getHits().getAt(0).getInnerHits().get("comment");
+            assertThat(innerHits.getHits().length, equalTo(1));
+            assertThat(innerHits.getAt(0).getFields().get("message").getValue().toString(), equalTo("eat"));
+        });
     }
 
     public void testRandomParentChild() throws Exception {
@@ -251,39 +259,39 @@ public class InnerHitsIT extends ParentChildTestCase {
                 )
             )
         );
-        SearchResponse searchResponse = prepareSearch("idx").setSize(numDocs).addSort("id", SortOrder.ASC).setQuery(boolQuery).get();
+        SearchRequestBuilder searchRequest = prepareSearch("idx").setSize(numDocs).addSort("id", SortOrder.ASC).setQuery(boolQuery);
+        assertNoFailuresAndResponse(searchRequest, response -> {
+            assertHitCount(response, numDocs);
+            assertThat(response.getHits().getHits().length, equalTo(numDocs));
 
-        assertNoFailures(searchResponse);
-        assertHitCount(searchResponse, numDocs);
-        assertThat(searchResponse.getHits().getHits().length, equalTo(numDocs));
+            int offset1 = 0;
+            int offset2 = 0;
+            for (int parent = 0; parent < numDocs; parent++) {
+                SearchHit searchHit = response.getHits().getAt(parent);
+                assertThat(searchHit.getId(), equalTo(String.format(Locale.ENGLISH, "p_%03d", parent)));
+                assertThat(searchHit.getShard(), notNullValue());
 
-        int offset1 = 0;
-        int offset2 = 0;
-        for (int parent = 0; parent < numDocs; parent++) {
-            SearchHit searchHit = searchResponse.getHits().getAt(parent);
-            assertThat(searchHit.getId(), equalTo(String.format(Locale.ENGLISH, "p_%03d", parent)));
-            assertThat(searchHit.getShard(), notNullValue());
+                SearchHits inner = searchHit.getInnerHits().get("a");
+                assertThat(inner.getTotalHits().value, equalTo((long) child1InnerObjects[parent]));
+                for (int child = 0; child < child1InnerObjects[parent] && child < size; child++) {
+                    SearchHit innerHit = inner.getAt(child);
+                    String childId = String.format(Locale.ENGLISH, "c1_%04d", offset1 + child);
+                    assertThat(innerHit.getId(), equalTo(childId));
+                    assertThat(innerHit.getNestedIdentity(), nullValue());
+                }
+                offset1 += child1InnerObjects[parent];
 
-            SearchHits inner = searchHit.getInnerHits().get("a");
-            assertThat(inner.getTotalHits().value, equalTo((long) child1InnerObjects[parent]));
-            for (int child = 0; child < child1InnerObjects[parent] && child < size; child++) {
-                SearchHit innerHit = inner.getAt(child);
-                String childId = String.format(Locale.ENGLISH, "c1_%04d", offset1 + child);
-                assertThat(innerHit.getId(), equalTo(childId));
-                assertThat(innerHit.getNestedIdentity(), nullValue());
+                inner = searchHit.getInnerHits().get("b");
+                assertThat(inner.getTotalHits().value, equalTo((long) child2InnerObjects[parent]));
+                for (int child = 0; child < child2InnerObjects[parent] && child < size; child++) {
+                    SearchHit innerHit = inner.getAt(child);
+                    String childId = String.format(Locale.ENGLISH, "c2_%04d", offset2 + child);
+                    assertThat(innerHit.getId(), equalTo(childId));
+                    assertThat(innerHit.getNestedIdentity(), nullValue());
+                }
+                offset2 += child2InnerObjects[parent];
             }
-            offset1 += child1InnerObjects[parent];
-
-            inner = searchHit.getInnerHits().get("b");
-            assertThat(inner.getTotalHits().value, equalTo((long) child2InnerObjects[parent]));
-            for (int child = 0; child < child2InnerObjects[parent] && child < size; child++) {
-                SearchHit innerHit = inner.getAt(child);
-                String childId = String.format(Locale.ENGLISH, "c2_%04d", offset2 + child);
-                assertThat(innerHit.getId(), equalTo(childId));
-                assertThat(innerHit.getNestedIdentity(), nullValue());
-            }
-            offset2 += child2InnerObjects[parent];
-        }
+        });
     }
 
     public void testInnerHitsOnHasParent() throws Exception {
@@ -320,24 +328,24 @@ public class InnerHitsIT extends ParentChildTestCase {
         );
         indexRandom(true, requests);
 
-        SearchResponse response = prepareSearch("stack").addSort("id", SortOrder.ASC)
+        SearchRequestBuilder searchRequest = prepareSearch("stack").addSort("id", SortOrder.ASC)
             .setQuery(
                 boolQuery().must(matchQuery("body", "fail2ban"))
                     .must(hasParentQuery("question", matchAllQuery(), false).innerHit(new InnerHitBuilder()))
-            )
-            .get();
-        assertNoFailures(response);
-        assertHitCount(response, 2);
+            );
+        assertNoFailuresAndResponse(searchRequest, response -> {
+            assertHitCount(response, 2);
 
-        SearchHit searchHit = response.getHits().getAt(0);
-        assertThat(searchHit.getId(), equalTo("3"));
-        assertThat(searchHit.getInnerHits().get("question").getTotalHits().value, equalTo(1L));
-        assertThat(searchHit.getInnerHits().get("question").getAt(0).getId(), equalTo("1"));
+            SearchHit searchHit = response.getHits().getAt(0);
+            assertThat(searchHit.getId(), equalTo("3"));
+            assertThat(searchHit.getInnerHits().get("question").getTotalHits().value, equalTo(1L));
+            assertThat(searchHit.getInnerHits().get("question").getAt(0).getId(), equalTo("1"));
 
-        searchHit = response.getHits().getAt(1);
-        assertThat(searchHit.getId(), equalTo("4"));
-        assertThat(searchHit.getInnerHits().get("question").getTotalHits().value, equalTo(1L));
-        assertThat(searchHit.getInnerHits().get("question").getAt(0).getId(), equalTo("2"));
+            searchHit = response.getHits().getAt(1);
+            assertThat(searchHit.getId(), equalTo("4"));
+            assertThat(searchHit.getInnerHits().get("question").getTotalHits().value, equalTo(1L));
+            assertThat(searchHit.getInnerHits().get("question").getAt(0).getId(), equalTo("2"));
+        });
     }
 
     public void testParentChildMultipleLayers() throws Exception {
@@ -362,47 +370,49 @@ public class InnerHitsIT extends ParentChildTestCase {
         requests.add(createIndexRequest("articles", "remark", "6", "4", "message", "bad").setRouting("2"));
         indexRandom(true, requests);
 
-        SearchResponse response = prepareSearch("articles").setQuery(
+        SearchRequestBuilder searchRequest = prepareSearch("articles").setQuery(
             hasChildQuery(
                 "comment",
                 hasChildQuery("remark", matchQuery("message", "good"), ScoreMode.None).innerHit(new InnerHitBuilder()),
                 ScoreMode.None
             ).innerHit(new InnerHitBuilder())
-        ).get();
+        );
 
-        assertNoFailures(response);
-        assertHitCount(response, 1);
-        assertSearchHit(response, 1, hasId("1"));
+        assertNoFailuresAndResponse(searchRequest, response -> {
+            assertHitCount(response, 1);
+            assertSearchHit(response, 1, hasId("1"));
 
-        assertThat(response.getHits().getAt(0).getInnerHits().size(), equalTo(1));
-        SearchHits innerHits = response.getHits().getAt(0).getInnerHits().get("comment");
-        assertThat(innerHits.getTotalHits().value, equalTo(1L));
-        assertThat(innerHits.getAt(0).getId(), equalTo("3"));
+            assertThat(response.getHits().getAt(0).getInnerHits().size(), equalTo(1));
+            SearchHits innerHits = response.getHits().getAt(0).getInnerHits().get("comment");
+            assertThat(innerHits.getTotalHits().value, equalTo(1L));
+            assertThat(innerHits.getAt(0).getId(), equalTo("3"));
 
-        innerHits = innerHits.getAt(0).getInnerHits().get("remark");
-        assertThat(innerHits.getTotalHits().value, equalTo(1L));
-        assertThat(innerHits.getAt(0).getId(), equalTo("5"));
+            innerHits = innerHits.getAt(0).getInnerHits().get("remark");
+            assertThat(innerHits.getTotalHits().value, equalTo(1L));
+            assertThat(innerHits.getAt(0).getId(), equalTo("5"));
+        });
 
-        response = prepareSearch("articles").setQuery(
+        searchRequest = prepareSearch("articles").setQuery(
             hasChildQuery(
                 "comment",
                 hasChildQuery("remark", matchQuery("message", "bad"), ScoreMode.None).innerHit(new InnerHitBuilder()),
                 ScoreMode.None
             ).innerHit(new InnerHitBuilder())
-        ).get();
+        );
 
-        assertNoFailures(response);
-        assertHitCount(response, 1);
-        assertSearchHit(response, 1, hasId("2"));
+        assertNoFailuresAndResponse(searchRequest, response -> {
+            assertHitCount(response, 1);
+            assertSearchHit(response, 1, hasId("2"));
 
-        assertThat(response.getHits().getAt(0).getInnerHits().size(), equalTo(1));
-        innerHits = response.getHits().getAt(0).getInnerHits().get("comment");
-        assertThat(innerHits.getTotalHits().value, equalTo(1L));
-        assertThat(innerHits.getAt(0).getId(), equalTo("4"));
+            assertThat(response.getHits().getAt(0).getInnerHits().size(), equalTo(1));
+            SearchHits innerHits = response.getHits().getAt(0).getInnerHits().get("comment");
+            assertThat(innerHits.getTotalHits().value, equalTo(1L));
+            assertThat(innerHits.getAt(0).getId(), equalTo("4"));
 
-        innerHits = innerHits.getAt(0).getInnerHits().get("remark");
-        assertThat(innerHits.getTotalHits().value, equalTo(1L));
-        assertThat(innerHits.getAt(0).getId(), equalTo("6"));
+            innerHits = innerHits.getAt(0).getInnerHits().get("remark");
+            assertThat(innerHits.getTotalHits().value, equalTo(1L));
+            assertThat(innerHits.getAt(0).getId(), equalTo("6"));
+        });
     }
 
     public void testRoyals() throws Exception {
@@ -437,7 +447,7 @@ public class InnerHitsIT extends ParentChildTestCase {
         requests.add(createIndexRequest("royals", "baron", "baron4", "earl4").setRouting("king"));
         indexRandom(true, requests);
 
-        SearchResponse response = prepareSearch("royals").setQuery(
+        SearchRequestBuilder searchRequest = prepareSearch("royals").setQuery(
             boolQuery().filter(
                 hasParentQuery(
                     "prince",
@@ -452,40 +462,42 @@ public class InnerHitsIT extends ParentChildTestCase {
                         ScoreMode.None
                     ).innerHit(new InnerHitBuilder().addSort(SortBuilders.fieldSort("id").order(SortOrder.ASC)).setName("earls").setSize(4))
                 )
-        ).get();
-        assertHitCount(response, 1);
-        assertThat(response.getHits().getAt(0).getId(), equalTo("duke"));
+        );
+        assertResponse(searchRequest, response -> {
+            assertHitCount(response, 1);
+            assertThat(response.getHits().getAt(0).getId(), equalTo("duke"));
 
-        SearchHits innerHits = response.getHits().getAt(0).getInnerHits().get("earls");
-        assertThat(innerHits.getTotalHits().value, equalTo(4L));
-        assertThat(innerHits.getAt(0).getId(), equalTo("earl1"));
-        assertThat(innerHits.getAt(1).getId(), equalTo("earl2"));
-        assertThat(innerHits.getAt(2).getId(), equalTo("earl3"));
-        assertThat(innerHits.getAt(3).getId(), equalTo("earl4"));
+            SearchHits innerHits = response.getHits().getAt(0).getInnerHits().get("earls");
+            assertThat(innerHits.getTotalHits().value, equalTo(4L));
+            assertThat(innerHits.getAt(0).getId(), equalTo("earl1"));
+            assertThat(innerHits.getAt(1).getId(), equalTo("earl2"));
+            assertThat(innerHits.getAt(2).getId(), equalTo("earl3"));
+            assertThat(innerHits.getAt(3).getId(), equalTo("earl4"));
 
-        SearchHits innerInnerHits = innerHits.getAt(0).getInnerHits().get("barons");
-        assertThat(innerInnerHits.getTotalHits().value, equalTo(1L));
-        assertThat(innerInnerHits.getAt(0).getId(), equalTo("baron1"));
+            SearchHits innerInnerHits = innerHits.getAt(0).getInnerHits().get("barons");
+            assertThat(innerInnerHits.getTotalHits().value, equalTo(1L));
+            assertThat(innerInnerHits.getAt(0).getId(), equalTo("baron1"));
 
-        innerInnerHits = innerHits.getAt(1).getInnerHits().get("barons");
-        assertThat(innerInnerHits.getTotalHits().value, equalTo(1L));
-        assertThat(innerInnerHits.getAt(0).getId(), equalTo("baron2"));
+            innerInnerHits = innerHits.getAt(1).getInnerHits().get("barons");
+            assertThat(innerInnerHits.getTotalHits().value, equalTo(1L));
+            assertThat(innerInnerHits.getAt(0).getId(), equalTo("baron2"));
 
-        innerInnerHits = innerHits.getAt(2).getInnerHits().get("barons");
-        assertThat(innerInnerHits.getTotalHits().value, equalTo(1L));
-        assertThat(innerInnerHits.getAt(0).getId(), equalTo("baron3"));
+            innerInnerHits = innerHits.getAt(2).getInnerHits().get("barons");
+            assertThat(innerInnerHits.getTotalHits().value, equalTo(1L));
+            assertThat(innerInnerHits.getAt(0).getId(), equalTo("baron3"));
 
-        innerInnerHits = innerHits.getAt(3).getInnerHits().get("barons");
-        assertThat(innerInnerHits.getTotalHits().value, equalTo(1L));
-        assertThat(innerInnerHits.getAt(0).getId(), equalTo("baron4"));
+            innerInnerHits = innerHits.getAt(3).getInnerHits().get("barons");
+            assertThat(innerInnerHits.getTotalHits().value, equalTo(1L));
+            assertThat(innerInnerHits.getAt(0).getId(), equalTo("baron4"));
 
-        innerHits = response.getHits().getAt(0).getInnerHits().get("princes");
-        assertThat(innerHits.getTotalHits().value, equalTo(1L));
-        assertThat(innerHits.getAt(0).getId(), equalTo("prince"));
+            innerHits = response.getHits().getAt(0).getInnerHits().get("princes");
+            assertThat(innerHits.getTotalHits().value, equalTo(1L));
+            assertThat(innerHits.getAt(0).getId(), equalTo("prince"));
 
-        innerInnerHits = innerHits.getAt(0).getInnerHits().get("kings");
-        assertThat(innerInnerHits.getTotalHits().value, equalTo(1L));
-        assertThat(innerInnerHits.getAt(0).getId(), equalTo("king"));
+            innerInnerHits = innerHits.getAt(0).getInnerHits().get("kings");
+            assertThat(innerInnerHits.getTotalHits().value, equalTo(1L));
+            assertThat(innerInnerHits.getAt(0).getId(), equalTo("king"));
+        });
     }
 
     public void testMatchesQueriesParentChildInnerHits() throws Exception {
@@ -498,29 +510,33 @@ public class InnerHitsIT extends ParentChildTestCase {
         requests.add(createIndexRequest("index", "child", "5", "2", "field", "value1"));
         indexRandom(true, requests);
 
-        SearchResponse response = prepareSearch("index").setQuery(
+        SearchRequestBuilder searchRequest = prepareSearch("index").setQuery(
             hasChildQuery("child", matchQuery("field", "value1").queryName("_name1"), ScoreMode.None).innerHit(new InnerHitBuilder())
-        ).addSort("id", SortOrder.ASC).get();
-        assertHitCount(response, 2);
-        assertThat(response.getHits().getAt(0).getId(), equalTo("1"));
-        assertThat(response.getHits().getAt(0).getInnerHits().get("child").getTotalHits().value, equalTo(1L));
-        assertThat(response.getHits().getAt(0).getInnerHits().get("child").getAt(0).getMatchedQueries().length, equalTo(1));
-        assertThat(response.getHits().getAt(0).getInnerHits().get("child").getAt(0).getMatchedQueries()[0], equalTo("_name1"));
+        ).addSort("id", SortOrder.ASC);
+        assertResponse(searchRequest, response -> {
+            assertHitCount(response, 2);
+            assertThat(response.getHits().getAt(0).getId(), equalTo("1"));
+            assertThat(response.getHits().getAt(0).getInnerHits().get("child").getTotalHits().value, equalTo(1L));
+            assertThat(response.getHits().getAt(0).getInnerHits().get("child").getAt(0).getMatchedQueries().length, equalTo(1));
+            assertThat(response.getHits().getAt(0).getInnerHits().get("child").getAt(0).getMatchedQueries()[0], equalTo("_name1"));
 
-        assertThat(response.getHits().getAt(1).getId(), equalTo("2"));
-        assertThat(response.getHits().getAt(1).getInnerHits().get("child").getTotalHits().value, equalTo(1L));
-        assertThat(response.getHits().getAt(1).getInnerHits().get("child").getAt(0).getMatchedQueries().length, equalTo(1));
-        assertThat(response.getHits().getAt(1).getInnerHits().get("child").getAt(0).getMatchedQueries()[0], equalTo("_name1"));
+            assertThat(response.getHits().getAt(1).getId(), equalTo("2"));
+            assertThat(response.getHits().getAt(1).getInnerHits().get("child").getTotalHits().value, equalTo(1L));
+            assertThat(response.getHits().getAt(1).getInnerHits().get("child").getAt(0).getMatchedQueries().length, equalTo(1));
+            assertThat(response.getHits().getAt(1).getInnerHits().get("child").getAt(0).getMatchedQueries()[0], equalTo("_name1"));
+        });
 
         QueryBuilder query = hasChildQuery("child", matchQuery("field", "value2").queryName("_name2"), ScoreMode.None).innerHit(
             new InnerHitBuilder()
         );
-        response = prepareSearch("index").setQuery(query).addSort("id", SortOrder.ASC).get();
-        assertHitCount(response, 1);
-        assertThat(response.getHits().getAt(0).getId(), equalTo("1"));
-        assertThat(response.getHits().getAt(0).getInnerHits().get("child").getTotalHits().value, equalTo(1L));
-        assertThat(response.getHits().getAt(0).getInnerHits().get("child").getAt(0).getMatchedQueries().length, equalTo(1));
-        assertThat(response.getHits().getAt(0).getInnerHits().get("child").getAt(0).getMatchedQueries()[0], equalTo("_name2"));
+        searchRequest = prepareSearch("index").setQuery(query).addSort("id", SortOrder.ASC);
+        assertResponse(searchRequest, response -> {
+            assertHitCount(response, 1);
+            assertThat(response.getHits().getAt(0).getId(), equalTo("1"));
+            assertThat(response.getHits().getAt(0).getInnerHits().get("child").getTotalHits().value, equalTo(1L));
+            assertThat(response.getHits().getAt(0).getInnerHits().get("child").getAt(0).getMatchedQueries().length, equalTo(1));
+            assertThat(response.getHits().getAt(0).getInnerHits().get("child").getAt(0).getMatchedQueries()[0], equalTo("_name2"));
+        });
     }
 
     public void testUseMaxDocInsteadOfSize() throws Exception {
@@ -539,9 +555,7 @@ public class InnerHitsIT extends ParentChildTestCase {
         QueryBuilder query = hasChildQuery("child", matchQuery("field", "value1"), ScoreMode.None).innerHit(
             new InnerHitBuilder().setSize(ArrayUtil.MAX_ARRAY_LENGTH - 1)
         );
-        SearchResponse response = prepareSearch("index1").setQuery(query).get();
-        assertNoFailures(response);
-        assertHitCount(response, 1);
+        assertHitCountAndNoFailures(prepareSearch("index1").setQuery(query), 1L);
     }
 
     public void testNestedInnerHitWrappedInParentChildInnerhit() {
@@ -557,7 +571,7 @@ public class InnerHitsIT extends ParentChildTestCase {
         createIndexRequest("test", "parent_type", "1", null, "key", "value").get();
         createIndexRequest("test", "child_type", "2", "1", "nested_type", Collections.singletonMap("key", "value")).get();
         refresh();
-        SearchResponse response = prepareSearch("test").setQuery(
+        SearchRequestBuilder searchRequest = prepareSearch("test").setQuery(
             boolQuery().must(matchQuery("key", "value"))
                 .should(
                     hasChildQuery(
@@ -566,12 +580,17 @@ public class InnerHitsIT extends ParentChildTestCase {
                         ScoreMode.None
                     ).innerHit(new InnerHitBuilder())
                 )
-        ).get();
-        assertHitCount(response, 1);
-        SearchHit hit = response.getHits().getAt(0);
-        String parentId = (String) extractValue("join_field.parent", hit.getInnerHits().get("child_type").getAt(0).getSourceAsMap());
-        assertThat(parentId, equalTo("1"));
-        assertThat(hit.getInnerHits().get("child_type").getAt(0).getInnerHits().get("nested_type").getAt(0).field("_parent"), nullValue());
+        );
+        assertResponse(searchRequest, response -> {
+            assertHitCount(response, 1);
+            SearchHit hit = response.getHits().getAt(0);
+            String parentId = (String) extractValue("join_field.parent", hit.getInnerHits().get("child_type").getAt(0).getSourceAsMap());
+            assertThat(parentId, equalTo("1"));
+            assertThat(
+                hit.getInnerHits().get("child_type").getAt(0).getInnerHits().get("nested_type").getAt(0).field("_parent"),
+                nullValue()
+            );
+        });
     }
 
     public void testInnerHitsWithIgnoreUnmapped() {

--- a/modules/parent-join/src/internalClusterTest/java/org/elasticsearch/join/query/InnerHitsIT.java
+++ b/modules/parent-join/src/internalClusterTest/java/org/elasticsearch/join/query/InnerHitsIT.java
@@ -12,7 +12,6 @@ import org.apache.lucene.search.join.ScoreMode;
 import org.apache.lucene.util.ArrayUtil;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
-import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.index.IndexSettings;
@@ -116,87 +115,96 @@ public class InnerHitsIT extends ParentChildTestCase {
         requests.add(createIndexRequest("articles", "comment", "c6", "p2", "message", "elephant scared by mice x y"));
         indexRandom(true, requests);
 
-        SearchRequestBuilder searchRequest = prepareSearch("articles").setQuery(
-            hasChildQuery("comment", matchQuery("message", "fox"), ScoreMode.None).innerHit(new InnerHitBuilder())
+        assertNoFailuresAndResponse(
+            prepareSearch("articles").setQuery(
+                hasChildQuery("comment", matchQuery("message", "fox"), ScoreMode.None).innerHit(new InnerHitBuilder())
+            ),
+            response -> {
+                assertHitCount(response, 1);
+                assertSearchHit(response, 1, hasId("p1"));
+                assertThat(response.getHits().getAt(0).getShard(), notNullValue());
+
+                assertThat(response.getHits().getAt(0).getInnerHits().size(), equalTo(1));
+                SearchHits innerHits = response.getHits().getAt(0).getInnerHits().get("comment");
+                assertThat(innerHits.getTotalHits().value, equalTo(2L));
+
+                assertThat(innerHits.getAt(0).getId(), equalTo("c1"));
+                assertThat(innerHits.getAt(1).getId(), equalTo("c2"));
+            }
         );
-        assertNoFailuresAndResponse(searchRequest, response -> {
-            assertHitCount(response, 1);
-            assertSearchHit(response, 1, hasId("p1"));
-            assertThat(response.getHits().getAt(0).getShard(), notNullValue());
-
-            assertThat(response.getHits().getAt(0).getInnerHits().size(), equalTo(1));
-            SearchHits innerHits = response.getHits().getAt(0).getInnerHits().get("comment");
-            assertThat(innerHits.getTotalHits().value, equalTo(2L));
-
-            assertThat(innerHits.getAt(0).getId(), equalTo("c1"));
-            assertThat(innerHits.getAt(1).getId(), equalTo("c2"));
-        });
 
         final boolean seqNoAndTerm = randomBoolean();
-        searchRequest = prepareSearch("articles").setQuery(
-            hasChildQuery("comment", matchQuery("message", "elephant"), ScoreMode.None).innerHit(
-                new InnerHitBuilder().setSeqNoAndPrimaryTerm(seqNoAndTerm)
-            )
-        );
-        assertNoFailuresAndResponse(searchRequest, response -> {
-            assertHitCount(response, 1);
-            assertSearchHit(response, 1, hasId("p2"));
+        assertNoFailuresAndResponse(
+            prepareSearch("articles").setQuery(
+                hasChildQuery("comment", matchQuery("message", "elephant"), ScoreMode.None).innerHit(
+                    new InnerHitBuilder().setSeqNoAndPrimaryTerm(seqNoAndTerm)
+                )
+            ),
+            response -> {
+                assertHitCount(response, 1);
+                assertSearchHit(response, 1, hasId("p2"));
 
-            assertThat(response.getHits().getAt(0).getInnerHits().size(), equalTo(1));
-            SearchHits innerHits = response.getHits().getAt(0).getInnerHits().get("comment");
-            assertThat(innerHits.getTotalHits().value, equalTo(3L));
+                assertThat(response.getHits().getAt(0).getInnerHits().size(), equalTo(1));
+                SearchHits innerHits = response.getHits().getAt(0).getInnerHits().get("comment");
+                assertThat(innerHits.getTotalHits().value, equalTo(3L));
 
-            assertThat(innerHits.getAt(0).getId(), equalTo("c4"));
-            assertThat(innerHits.getAt(1).getId(), equalTo("c5"));
-            assertThat(innerHits.getAt(2).getId(), equalTo("c6"));
+                assertThat(innerHits.getAt(0).getId(), equalTo("c4"));
+                assertThat(innerHits.getAt(1).getId(), equalTo("c5"));
+                assertThat(innerHits.getAt(2).getId(), equalTo("c6"));
 
-            if (seqNoAndTerm) {
-                assertThat(innerHits.getAt(0).getPrimaryTerm(), equalTo(1L));
-                assertThat(innerHits.getAt(1).getPrimaryTerm(), equalTo(1L));
-                assertThat(innerHits.getAt(2).getPrimaryTerm(), equalTo(1L));
-                assertThat(innerHits.getAt(0).getSeqNo(), greaterThanOrEqualTo(0L));
-                assertThat(innerHits.getAt(1).getSeqNo(), greaterThanOrEqualTo(0L));
-                assertThat(innerHits.getAt(2).getSeqNo(), greaterThanOrEqualTo(0L));
-            } else {
-                assertThat(innerHits.getAt(0).getPrimaryTerm(), equalTo(UNASSIGNED_PRIMARY_TERM));
-                assertThat(innerHits.getAt(1).getPrimaryTerm(), equalTo(UNASSIGNED_PRIMARY_TERM));
-                assertThat(innerHits.getAt(2).getPrimaryTerm(), equalTo(UNASSIGNED_PRIMARY_TERM));
-                assertThat(innerHits.getAt(0).getSeqNo(), equalTo(UNASSIGNED_SEQ_NO));
-                assertThat(innerHits.getAt(1).getSeqNo(), equalTo(UNASSIGNED_SEQ_NO));
-                assertThat(innerHits.getAt(2).getSeqNo(), equalTo(UNASSIGNED_SEQ_NO));
+                if (seqNoAndTerm) {
+                    assertThat(innerHits.getAt(0).getPrimaryTerm(), equalTo(1L));
+                    assertThat(innerHits.getAt(1).getPrimaryTerm(), equalTo(1L));
+                    assertThat(innerHits.getAt(2).getPrimaryTerm(), equalTo(1L));
+                    assertThat(innerHits.getAt(0).getSeqNo(), greaterThanOrEqualTo(0L));
+                    assertThat(innerHits.getAt(1).getSeqNo(), greaterThanOrEqualTo(0L));
+                    assertThat(innerHits.getAt(2).getSeqNo(), greaterThanOrEqualTo(0L));
+                } else {
+                    assertThat(innerHits.getAt(0).getPrimaryTerm(), equalTo(UNASSIGNED_PRIMARY_TERM));
+                    assertThat(innerHits.getAt(1).getPrimaryTerm(), equalTo(UNASSIGNED_PRIMARY_TERM));
+                    assertThat(innerHits.getAt(2).getPrimaryTerm(), equalTo(UNASSIGNED_PRIMARY_TERM));
+                    assertThat(innerHits.getAt(0).getSeqNo(), equalTo(UNASSIGNED_SEQ_NO));
+                    assertThat(innerHits.getAt(1).getSeqNo(), equalTo(UNASSIGNED_SEQ_NO));
+                    assertThat(innerHits.getAt(2).getSeqNo(), equalTo(UNASSIGNED_SEQ_NO));
+                }
             }
-        });
+        );
 
-        searchRequest = prepareSearch("articles").setQuery(
-            hasChildQuery("comment", matchQuery("message", "fox"), ScoreMode.None).innerHit(
-                new InnerHitBuilder().addFetchField("message")
-                    .setHighlightBuilder(new HighlightBuilder().field("message"))
-                    .setExplain(true)
-                    .setSize(1)
-                    .addScriptField("script", new Script(ScriptType.INLINE, MockScriptEngine.NAME, "5", Collections.emptyMap()))
-            )
+        assertNoFailuresAndResponse(
+            prepareSearch("articles").setQuery(
+                hasChildQuery("comment", matchQuery("message", "fox"), ScoreMode.None).innerHit(
+                    new InnerHitBuilder().addFetchField("message")
+                        .setHighlightBuilder(new HighlightBuilder().field("message"))
+                        .setExplain(true)
+                        .setSize(1)
+                        .addScriptField("script", new Script(ScriptType.INLINE, MockScriptEngine.NAME, "5", Collections.emptyMap()))
+                )
+            ),
+            response -> {
+                SearchHits innerHits = response.getHits().getAt(0).getInnerHits().get("comment");
+                assertThat(innerHits.getHits().length, equalTo(1));
+                assertThat(
+                    innerHits.getAt(0).getHighlightFields().get("message").getFragments()[0].string(),
+                    equalTo("<em>fox</em> eat quick")
+                );
+                assertThat(innerHits.getAt(0).getExplanation().toString(), containsString("weight(message:fox"));
+                assertThat(innerHits.getAt(0).getFields().get("message").getValue().toString(), equalTo("fox eat quick"));
+                assertThat(innerHits.getAt(0).getFields().get("script").getValue().toString(), equalTo("5"));
+            }
         );
-        assertNoFailuresAndResponse(searchRequest, response -> {
-            SearchHits innerHits = response.getHits().getAt(0).getInnerHits().get("comment");
-            assertThat(innerHits.getHits().length, equalTo(1));
-            assertThat(
-                innerHits.getAt(0).getHighlightFields().get("message").getFragments()[0].string(),
-                equalTo("<em>fox</em> eat quick")
-            );
-            assertThat(innerHits.getAt(0).getExplanation().toString(), containsString("weight(message:fox"));
-            assertThat(innerHits.getAt(0).getFields().get("message").getValue().toString(), equalTo("fox eat quick"));
-            assertThat(innerHits.getAt(0).getFields().get("script").getValue().toString(), equalTo("5"));
-        });
-        searchRequest = prepareSearch("articles").setQuery(
-            hasChildQuery("comment", matchQuery("message", "fox"), ScoreMode.None).innerHit(
-                new InnerHitBuilder().addDocValueField("message").setSize(1)
-            )
+
+        assertNoFailuresAndResponse(
+            prepareSearch("articles").setQuery(
+                hasChildQuery("comment", matchQuery("message", "fox"), ScoreMode.None).innerHit(
+                    new InnerHitBuilder().addDocValueField("message").setSize(1)
+                )
+            ),
+            response -> {
+                SearchHits innerHits = response.getHits().getAt(0).getInnerHits().get("comment");
+                assertThat(innerHits.getHits().length, equalTo(1));
+                assertThat(innerHits.getAt(0).getFields().get("message").getValue().toString(), equalTo("eat"));
+            }
         );
-        assertNoFailuresAndResponse(searchRequest, response -> {
-            SearchHits innerHits = response.getHits().getAt(0).getInnerHits().get("comment");
-            assertThat(innerHits.getHits().length, equalTo(1));
-            assertThat(innerHits.getAt(0).getFields().get("message").getValue().toString(), equalTo("eat"));
-        });
     }
 
     public void testRandomParentChild() throws Exception {
@@ -259,8 +267,8 @@ public class InnerHitsIT extends ParentChildTestCase {
                 )
             )
         );
-        SearchRequestBuilder searchRequest = prepareSearch("idx").setSize(numDocs).addSort("id", SortOrder.ASC).setQuery(boolQuery);
-        assertNoFailuresAndResponse(searchRequest, response -> {
+
+        assertNoFailuresAndResponse(prepareSearch("idx").setSize(numDocs).addSort("id", SortOrder.ASC).setQuery(boolQuery), response -> {
             assertHitCount(response, numDocs);
             assertThat(response.getHits().getHits().length, equalTo(numDocs));
 
@@ -328,24 +336,26 @@ public class InnerHitsIT extends ParentChildTestCase {
         );
         indexRandom(true, requests);
 
-        SearchRequestBuilder searchRequest = prepareSearch("stack").addSort("id", SortOrder.ASC)
-            .setQuery(
-                boolQuery().must(matchQuery("body", "fail2ban"))
-                    .must(hasParentQuery("question", matchAllQuery(), false).innerHit(new InnerHitBuilder()))
-            );
-        assertNoFailuresAndResponse(searchRequest, response -> {
-            assertHitCount(response, 2);
+        assertNoFailuresAndResponse(
+            prepareSearch("stack").addSort("id", SortOrder.ASC)
+                .setQuery(
+                    boolQuery().must(matchQuery("body", "fail2ban"))
+                        .must(hasParentQuery("question", matchAllQuery(), false).innerHit(new InnerHitBuilder()))
+                ),
+            response -> {
+                assertHitCount(response, 2);
 
-            SearchHit searchHit = response.getHits().getAt(0);
-            assertThat(searchHit.getId(), equalTo("3"));
-            assertThat(searchHit.getInnerHits().get("question").getTotalHits().value, equalTo(1L));
-            assertThat(searchHit.getInnerHits().get("question").getAt(0).getId(), equalTo("1"));
+                SearchHit searchHit = response.getHits().getAt(0);
+                assertThat(searchHit.getId(), equalTo("3"));
+                assertThat(searchHit.getInnerHits().get("question").getTotalHits().value, equalTo(1L));
+                assertThat(searchHit.getInnerHits().get("question").getAt(0).getId(), equalTo("1"));
 
-            searchHit = response.getHits().getAt(1);
-            assertThat(searchHit.getId(), equalTo("4"));
-            assertThat(searchHit.getInnerHits().get("question").getTotalHits().value, equalTo(1L));
-            assertThat(searchHit.getInnerHits().get("question").getAt(0).getId(), equalTo("2"));
-        });
+                searchHit = response.getHits().getAt(1);
+                assertThat(searchHit.getId(), equalTo("4"));
+                assertThat(searchHit.getInnerHits().get("question").getTotalHits().value, equalTo(1L));
+                assertThat(searchHit.getInnerHits().get("question").getAt(0).getId(), equalTo("2"));
+            }
+        );
     }
 
     public void testParentChildMultipleLayers() throws Exception {
@@ -370,49 +380,51 @@ public class InnerHitsIT extends ParentChildTestCase {
         requests.add(createIndexRequest("articles", "remark", "6", "4", "message", "bad").setRouting("2"));
         indexRandom(true, requests);
 
-        SearchRequestBuilder searchRequest = prepareSearch("articles").setQuery(
-            hasChildQuery(
-                "comment",
-                hasChildQuery("remark", matchQuery("message", "good"), ScoreMode.None).innerHit(new InnerHitBuilder()),
-                ScoreMode.None
-            ).innerHit(new InnerHitBuilder())
+        assertNoFailuresAndResponse(
+            prepareSearch("articles").setQuery(
+                hasChildQuery(
+                    "comment",
+                    hasChildQuery("remark", matchQuery("message", "good"), ScoreMode.None).innerHit(new InnerHitBuilder()),
+                    ScoreMode.None
+                ).innerHit(new InnerHitBuilder())
+            ),
+            response -> {
+                assertHitCount(response, 1);
+                assertSearchHit(response, 1, hasId("1"));
+
+                assertThat(response.getHits().getAt(0).getInnerHits().size(), equalTo(1));
+                SearchHits innerHits = response.getHits().getAt(0).getInnerHits().get("comment");
+                assertThat(innerHits.getTotalHits().value, equalTo(1L));
+                assertThat(innerHits.getAt(0).getId(), equalTo("3"));
+
+                innerHits = innerHits.getAt(0).getInnerHits().get("remark");
+                assertThat(innerHits.getTotalHits().value, equalTo(1L));
+                assertThat(innerHits.getAt(0).getId(), equalTo("5"));
+            }
         );
 
-        assertNoFailuresAndResponse(searchRequest, response -> {
-            assertHitCount(response, 1);
-            assertSearchHit(response, 1, hasId("1"));
+        assertNoFailuresAndResponse(
+            prepareSearch("articles").setQuery(
+                hasChildQuery(
+                    "comment",
+                    hasChildQuery("remark", matchQuery("message", "bad"), ScoreMode.None).innerHit(new InnerHitBuilder()),
+                    ScoreMode.None
+                ).innerHit(new InnerHitBuilder())
+            ),
+            response -> {
+                assertHitCount(response, 1);
+                assertSearchHit(response, 1, hasId("2"));
 
-            assertThat(response.getHits().getAt(0).getInnerHits().size(), equalTo(1));
-            SearchHits innerHits = response.getHits().getAt(0).getInnerHits().get("comment");
-            assertThat(innerHits.getTotalHits().value, equalTo(1L));
-            assertThat(innerHits.getAt(0).getId(), equalTo("3"));
+                assertThat(response.getHits().getAt(0).getInnerHits().size(), equalTo(1));
+                SearchHits innerHits = response.getHits().getAt(0).getInnerHits().get("comment");
+                assertThat(innerHits.getTotalHits().value, equalTo(1L));
+                assertThat(innerHits.getAt(0).getId(), equalTo("4"));
 
-            innerHits = innerHits.getAt(0).getInnerHits().get("remark");
-            assertThat(innerHits.getTotalHits().value, equalTo(1L));
-            assertThat(innerHits.getAt(0).getId(), equalTo("5"));
-        });
-
-        searchRequest = prepareSearch("articles").setQuery(
-            hasChildQuery(
-                "comment",
-                hasChildQuery("remark", matchQuery("message", "bad"), ScoreMode.None).innerHit(new InnerHitBuilder()),
-                ScoreMode.None
-            ).innerHit(new InnerHitBuilder())
+                innerHits = innerHits.getAt(0).getInnerHits().get("remark");
+                assertThat(innerHits.getTotalHits().value, equalTo(1L));
+                assertThat(innerHits.getAt(0).getId(), equalTo("6"));
+            }
         );
-
-        assertNoFailuresAndResponse(searchRequest, response -> {
-            assertHitCount(response, 1);
-            assertSearchHit(response, 1, hasId("2"));
-
-            assertThat(response.getHits().getAt(0).getInnerHits().size(), equalTo(1));
-            SearchHits innerHits = response.getHits().getAt(0).getInnerHits().get("comment");
-            assertThat(innerHits.getTotalHits().value, equalTo(1L));
-            assertThat(innerHits.getAt(0).getId(), equalTo("4"));
-
-            innerHits = innerHits.getAt(0).getInnerHits().get("remark");
-            assertThat(innerHits.getTotalHits().value, equalTo(1L));
-            assertThat(innerHits.getAt(0).getId(), equalTo("6"));
-        });
     }
 
     public void testRoyals() throws Exception {
@@ -446,58 +458,61 @@ public class InnerHitsIT extends ParentChildTestCase {
         requests.add(createIndexRequest("royals", "baron", "baron3", "earl3").setRouting("king"));
         requests.add(createIndexRequest("royals", "baron", "baron4", "earl4").setRouting("king"));
         indexRandom(true, requests);
-
-        SearchRequestBuilder searchRequest = prepareSearch("royals").setQuery(
-            boolQuery().filter(
-                hasParentQuery(
-                    "prince",
-                    hasParentQuery("king", matchAllQuery(), false).innerHit(new InnerHitBuilder().setName("kings")),
-                    false
-                ).innerHit(new InnerHitBuilder().setName("princes"))
-            )
-                .filter(
-                    hasChildQuery(
-                        "earl",
-                        hasChildQuery("baron", matchAllQuery(), ScoreMode.None).innerHit(new InnerHitBuilder().setName("barons")),
-                        ScoreMode.None
-                    ).innerHit(new InnerHitBuilder().addSort(SortBuilders.fieldSort("id").order(SortOrder.ASC)).setName("earls").setSize(4))
+        assertResponse(
+            prepareSearch("royals").setQuery(
+                boolQuery().filter(
+                    hasParentQuery(
+                        "prince",
+                        hasParentQuery("king", matchAllQuery(), false).innerHit(new InnerHitBuilder().setName("kings")),
+                        false
+                    ).innerHit(new InnerHitBuilder().setName("princes"))
                 )
+                    .filter(
+                        hasChildQuery(
+                            "earl",
+                            hasChildQuery("baron", matchAllQuery(), ScoreMode.None).innerHit(new InnerHitBuilder().setName("barons")),
+                            ScoreMode.None
+                        ).innerHit(
+                            new InnerHitBuilder().addSort(SortBuilders.fieldSort("id").order(SortOrder.ASC)).setName("earls").setSize(4)
+                        )
+                    )
+            ),
+            response -> {
+                assertHitCount(response, 1);
+                assertThat(response.getHits().getAt(0).getId(), equalTo("duke"));
+
+                SearchHits innerHits = response.getHits().getAt(0).getInnerHits().get("earls");
+                assertThat(innerHits.getTotalHits().value, equalTo(4L));
+                assertThat(innerHits.getAt(0).getId(), equalTo("earl1"));
+                assertThat(innerHits.getAt(1).getId(), equalTo("earl2"));
+                assertThat(innerHits.getAt(2).getId(), equalTo("earl3"));
+                assertThat(innerHits.getAt(3).getId(), equalTo("earl4"));
+
+                SearchHits innerInnerHits = innerHits.getAt(0).getInnerHits().get("barons");
+                assertThat(innerInnerHits.getTotalHits().value, equalTo(1L));
+                assertThat(innerInnerHits.getAt(0).getId(), equalTo("baron1"));
+
+                innerInnerHits = innerHits.getAt(1).getInnerHits().get("barons");
+                assertThat(innerInnerHits.getTotalHits().value, equalTo(1L));
+                assertThat(innerInnerHits.getAt(0).getId(), equalTo("baron2"));
+
+                innerInnerHits = innerHits.getAt(2).getInnerHits().get("barons");
+                assertThat(innerInnerHits.getTotalHits().value, equalTo(1L));
+                assertThat(innerInnerHits.getAt(0).getId(), equalTo("baron3"));
+
+                innerInnerHits = innerHits.getAt(3).getInnerHits().get("barons");
+                assertThat(innerInnerHits.getTotalHits().value, equalTo(1L));
+                assertThat(innerInnerHits.getAt(0).getId(), equalTo("baron4"));
+
+                innerHits = response.getHits().getAt(0).getInnerHits().get("princes");
+                assertThat(innerHits.getTotalHits().value, equalTo(1L));
+                assertThat(innerHits.getAt(0).getId(), equalTo("prince"));
+
+                innerInnerHits = innerHits.getAt(0).getInnerHits().get("kings");
+                assertThat(innerInnerHits.getTotalHits().value, equalTo(1L));
+                assertThat(innerInnerHits.getAt(0).getId(), equalTo("king"));
+            }
         );
-        assertResponse(searchRequest, response -> {
-            assertHitCount(response, 1);
-            assertThat(response.getHits().getAt(0).getId(), equalTo("duke"));
-
-            SearchHits innerHits = response.getHits().getAt(0).getInnerHits().get("earls");
-            assertThat(innerHits.getTotalHits().value, equalTo(4L));
-            assertThat(innerHits.getAt(0).getId(), equalTo("earl1"));
-            assertThat(innerHits.getAt(1).getId(), equalTo("earl2"));
-            assertThat(innerHits.getAt(2).getId(), equalTo("earl3"));
-            assertThat(innerHits.getAt(3).getId(), equalTo("earl4"));
-
-            SearchHits innerInnerHits = innerHits.getAt(0).getInnerHits().get("barons");
-            assertThat(innerInnerHits.getTotalHits().value, equalTo(1L));
-            assertThat(innerInnerHits.getAt(0).getId(), equalTo("baron1"));
-
-            innerInnerHits = innerHits.getAt(1).getInnerHits().get("barons");
-            assertThat(innerInnerHits.getTotalHits().value, equalTo(1L));
-            assertThat(innerInnerHits.getAt(0).getId(), equalTo("baron2"));
-
-            innerInnerHits = innerHits.getAt(2).getInnerHits().get("barons");
-            assertThat(innerInnerHits.getTotalHits().value, equalTo(1L));
-            assertThat(innerInnerHits.getAt(0).getId(), equalTo("baron3"));
-
-            innerInnerHits = innerHits.getAt(3).getInnerHits().get("barons");
-            assertThat(innerInnerHits.getTotalHits().value, equalTo(1L));
-            assertThat(innerInnerHits.getAt(0).getId(), equalTo("baron4"));
-
-            innerHits = response.getHits().getAt(0).getInnerHits().get("princes");
-            assertThat(innerHits.getTotalHits().value, equalTo(1L));
-            assertThat(innerHits.getAt(0).getId(), equalTo("prince"));
-
-            innerInnerHits = innerHits.getAt(0).getInnerHits().get("kings");
-            assertThat(innerInnerHits.getTotalHits().value, equalTo(1L));
-            assertThat(innerInnerHits.getAt(0).getId(), equalTo("king"));
-        });
     }
 
     public void testMatchesQueriesParentChildInnerHits() throws Exception {
@@ -510,27 +525,28 @@ public class InnerHitsIT extends ParentChildTestCase {
         requests.add(createIndexRequest("index", "child", "5", "2", "field", "value1"));
         indexRandom(true, requests);
 
-        SearchRequestBuilder searchRequest = prepareSearch("index").setQuery(
-            hasChildQuery("child", matchQuery("field", "value1").queryName("_name1"), ScoreMode.None).innerHit(new InnerHitBuilder())
-        ).addSort("id", SortOrder.ASC);
-        assertResponse(searchRequest, response -> {
-            assertHitCount(response, 2);
-            assertThat(response.getHits().getAt(0).getId(), equalTo("1"));
-            assertThat(response.getHits().getAt(0).getInnerHits().get("child").getTotalHits().value, equalTo(1L));
-            assertThat(response.getHits().getAt(0).getInnerHits().get("child").getAt(0).getMatchedQueries().length, equalTo(1));
-            assertThat(response.getHits().getAt(0).getInnerHits().get("child").getAt(0).getMatchedQueries()[0], equalTo("_name1"));
+        assertResponse(
+            prepareSearch("index").setQuery(
+                hasChildQuery("child", matchQuery("field", "value1").queryName("_name1"), ScoreMode.None).innerHit(new InnerHitBuilder())
+            ).addSort("id", SortOrder.ASC),
+            response -> {
+                assertHitCount(response, 2);
+                assertThat(response.getHits().getAt(0).getId(), equalTo("1"));
+                assertThat(response.getHits().getAt(0).getInnerHits().get("child").getTotalHits().value, equalTo(1L));
+                assertThat(response.getHits().getAt(0).getInnerHits().get("child").getAt(0).getMatchedQueries().length, equalTo(1));
+                assertThat(response.getHits().getAt(0).getInnerHits().get("child").getAt(0).getMatchedQueries()[0], equalTo("_name1"));
 
-            assertThat(response.getHits().getAt(1).getId(), equalTo("2"));
-            assertThat(response.getHits().getAt(1).getInnerHits().get("child").getTotalHits().value, equalTo(1L));
-            assertThat(response.getHits().getAt(1).getInnerHits().get("child").getAt(0).getMatchedQueries().length, equalTo(1));
-            assertThat(response.getHits().getAt(1).getInnerHits().get("child").getAt(0).getMatchedQueries()[0], equalTo("_name1"));
-        });
+                assertThat(response.getHits().getAt(1).getId(), equalTo("2"));
+                assertThat(response.getHits().getAt(1).getInnerHits().get("child").getTotalHits().value, equalTo(1L));
+                assertThat(response.getHits().getAt(1).getInnerHits().get("child").getAt(0).getMatchedQueries().length, equalTo(1));
+                assertThat(response.getHits().getAt(1).getInnerHits().get("child").getAt(0).getMatchedQueries()[0], equalTo("_name1"));
+            }
+        );
 
         QueryBuilder query = hasChildQuery("child", matchQuery("field", "value2").queryName("_name2"), ScoreMode.None).innerHit(
             new InnerHitBuilder()
         );
-        searchRequest = prepareSearch("index").setQuery(query).addSort("id", SortOrder.ASC);
-        assertResponse(searchRequest, response -> {
+        assertResponse(prepareSearch("index").setQuery(query).addSort("id", SortOrder.ASC), response -> {
             assertHitCount(response, 1);
             assertThat(response.getHits().getAt(0).getId(), equalTo("1"));
             assertThat(response.getHits().getAt(0).getInnerHits().get("child").getTotalHits().value, equalTo(1L));
@@ -571,26 +587,31 @@ public class InnerHitsIT extends ParentChildTestCase {
         createIndexRequest("test", "parent_type", "1", null, "key", "value").get();
         createIndexRequest("test", "child_type", "2", "1", "nested_type", Collections.singletonMap("key", "value")).get();
         refresh();
-        SearchRequestBuilder searchRequest = prepareSearch("test").setQuery(
-            boolQuery().must(matchQuery("key", "value"))
-                .should(
-                    hasChildQuery(
-                        "child_type",
-                        nestedQuery("nested_type", matchAllQuery(), ScoreMode.None).innerHit(new InnerHitBuilder()),
-                        ScoreMode.None
-                    ).innerHit(new InnerHitBuilder())
-                )
+        assertResponse(
+            prepareSearch("test").setQuery(
+                boolQuery().must(matchQuery("key", "value"))
+                    .should(
+                        hasChildQuery(
+                            "child_type",
+                            nestedQuery("nested_type", matchAllQuery(), ScoreMode.None).innerHit(new InnerHitBuilder()),
+                            ScoreMode.None
+                        ).innerHit(new InnerHitBuilder())
+                    )
+            ),
+            response -> {
+                assertHitCount(response, 1);
+                SearchHit hit = response.getHits().getAt(0);
+                String parentId = (String) extractValue(
+                    "join_field.parent",
+                    hit.getInnerHits().get("child_type").getAt(0).getSourceAsMap()
+                );
+                assertThat(parentId, equalTo("1"));
+                assertThat(
+                    hit.getInnerHits().get("child_type").getAt(0).getInnerHits().get("nested_type").getAt(0).field("_parent"),
+                    nullValue()
+                );
+            }
         );
-        assertResponse(searchRequest, response -> {
-            assertHitCount(response, 1);
-            SearchHit hit = response.getHits().getAt(0);
-            String parentId = (String) extractValue("join_field.parent", hit.getInnerHits().get("child_type").getAt(0).getSourceAsMap());
-            assertThat(parentId, equalTo("1"));
-            assertThat(
-                hit.getInnerHits().get("child_type").getAt(0).getInnerHits().get("nested_type").getAt(0).field("_parent"),
-                nullValue()
-            );
-        });
     }
 
     public void testInnerHitsWithIgnoreUnmapped() {

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/LegacyGeoShapeWithDocValuesQueryTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/LegacyGeoShapeWithDocValuesQueryTests.java
@@ -225,11 +225,13 @@ public class LegacyGeoShapeWithDocValuesQueryTests extends GeoShapeQueryTestCase
         assertHitCount(client().prepareSearch(defaultIndexName).setQuery(geoShapeQuery("alias", multiPoint)), 1L);
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/86118")
     @Override
     public void testIndexPointsFromLine() throws Exception {
         super.testIndexPointsFromLine();
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/86118")
     @Override
     public void testIndexPointsFromPolygon() throws Exception {
         super.testIndexPointsFromPolygon();

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/LegacyGeoShapeWithDocValuesQueryTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/LegacyGeoShapeWithDocValuesQueryTests.java
@@ -225,13 +225,11 @@ public class LegacyGeoShapeWithDocValuesQueryTests extends GeoShapeQueryTestCase
         assertHitCount(client().prepareSearch(defaultIndexName).setQuery(geoShapeQuery("alias", multiPoint)), 1L);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/86118")
     @Override
     public void testIndexPointsFromLine() throws Exception {
         super.testIndexPointsFromLine();
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/86118")
     @Override
     public void testIndexPointsFromPolygon() throws Exception {
         super.testIndexPointsFromPolygon();


### PR DESCRIPTION
Another iteration to remove SearchResponse references from integration test.