### PR TITLE
[8.11] ESQL small doc improvement (#101226)

### DIFF
--- a/docs/reference/esql/esql-commands.asciidoc
+++ b/docs/reference/esql/esql-commands.asciidoc
@@ -8,7 +8,7 @@
 // tag::source_commands[]
 ==== Source commands
 
-An {esql} source command produces a table, typically with data from {es}.
+An {esql} source command produces a table, typically with data from {es}. An {esql} query must start with a source command.
 
 image::images/esql/source-command.svg[A source command producing a table from {es},align="center"]
 
@@ -17,10 +17,6 @@ image::images/esql/source-command.svg[A source command producing a table from {e
 * <<esql-from>>
 * <<esql-row>>
 * <<esql-show>>
-
-include::source-commands/from.asciidoc[]
-include::source-commands/row.asciidoc[]
-include::source-commands/show.asciidoc[]
 
 // end::source_command[]
 
@@ -47,6 +43,12 @@ image::images/esql/processing-command.svg[A processing command changing an input
 * <<esql-stats-by>>
 * <<esql-where>>
 
+// end::proc_command[]
+
+include::source-commands/from.asciidoc[]
+include::source-commands/row.asciidoc[]
+include::source-commands/show.asciidoc[]
+
 include::processing-commands/dissect.asciidoc[]
 include::processing-commands/drop.asciidoc[]
 include::processing-commands/enrich.asciidoc[]
@@ -59,5 +61,3 @@ include::processing-commands/rename.asciidoc[]
 include::processing-commands/sort.asciidoc[]
 include::processing-commands/stats.asciidoc[]
 include::processing-commands/where.asciidoc[]
-
-// end::proc_command[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.11`:
 - [ESQL small doc improvement (#101226)](https://github.com/elastic/elasticsearch/pull/101226)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)