### PR TITLE
S3 CAS operation should respect abortMutipartUpload failure

### DIFF
--- a/docs/changelog/101253.yaml
+++ b/docs/changelog/101253.yaml
@@ -1,5 +1,0 @@
-pr: 101253
-summary: S3 CAS operation should respect `abortMutipartUpload` failure
-area: Snapshot/Restore
-type: bug
-issues: []

--- a/docs/changelog/101253.yaml
+++ b/docs/changelog/101253.yaml
@@ -1,0 +1,5 @@
+pr: 101253
+summary: S3 CAS operation should respect `abortMutipartUpload` failure
+area: Snapshot/Restore
+type: bug
+issues: []

--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobContainer.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobContainer.java
@@ -744,7 +744,7 @@ class S3BlobContainer extends AbstractBlobContainer {
                                 final var currentUploadId = currentUpload.getUploadId();
                                 if (uploadId.equals(currentUploadId) == false) {
                                     blobStore.getSnapshotExecutor()
-                                        .execute(ActionRunnable.run(listeners.acquire(), () -> safeAbortMultipartUpload(currentUploadId)));
+                                        .execute(ActionRunnable.run(listeners.acquire(), () -> abortMultipartUploadIfExists(currentUploadId)));
                                 }
                             }
                         } finally {

--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobContainer.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobContainer.java
@@ -744,7 +744,9 @@ class S3BlobContainer extends AbstractBlobContainer {
                                 final var currentUploadId = currentUpload.getUploadId();
                                 if (uploadId.equals(currentUploadId) == false) {
                                     blobStore.getSnapshotExecutor()
-                                        .execute(ActionRunnable.run(listeners.acquire(), () -> abortMultipartUploadIfExists(currentUploadId)));
+                                        .execute(
+                                            ActionRunnable.run(listeners.acquire(), () -> abortMultipartUploadIfExists(currentUploadId))
+                                        );
                                 }
                             }
                         } finally {


### PR DESCRIPTION
We inadvertently made s3 CAS operation to ignore abortMutipartUpload failures in #98664. This PR fixes it.
