### PR TITLE
Provide stable resampling

### DIFF
--- a/docs/changelog/101255.yaml
+++ b/docs/changelog/101255.yaml
@@ -1,0 +1,5 @@
+pr: 101255
+summary: Provide stable resampling
+area: Application
+type: bug
+issues: []

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetStackTracesRequest.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetStackTracesRequest.java
@@ -173,7 +173,13 @@ public class GetStackTracesRequest extends ActionRequest implements IndicesReque
 
     @Override
     public int hashCode() {
-        return Objects.hash(query, sampleSize);
+        // The object representation of `query` may use Lucene's ByteRef to represent values. This class' hashCode implementation
+        // uses StringUtils.GOOD_FAST_HASH_SEED which is reinitialized for each JVM. This means that hashcode is consistent *within*
+        // a JVM but will not be consistent across the cluster. As we use hashCode e.g. to initialize the random number generator in
+        // Resampler to produce a consistent downsampling results, relying on the default hashCode implementation of `query` will
+        // produce consistent results per node but not across the cluster. To avoid this, we produce the hashCode based on the
+        // string representation instead, which will produce consistent results for the entire cluster and across node restarts.
+        return Objects.hash(Objects.toString(query, "null"), sampleSize);
     }
 
     @Override


### PR DESCRIPTION
We resample data randomly if required. So far we have initialized the random number generator based on the hash code of the request with the intent of providing a random resampling that is still stable if the same request is issued multiple times. However, the hash code was not stable in a cluster because a query may use Lucene's `ByteRef` class to store values (such as the upper and lower bound of a date range). That class uses a murmur hash for its hash code. The murmur hash is initialized from `org.apache.lucene.util.StringHelper#GOOD_FAST_HASH_SEED` which intentionally varies across JVM instances. Consequently, the hash code of `ByteRef` (and ultimately the request's hash code) varies depending on which node in the cluster handles a request.

With this commit we instead rely on the string representation of a query, which is stable across instances and node restarts to initialize the random number generator. This provides randomness across requests but also a consistent result for identical requests. Converting the query builder to its string representation adds around 1ms of overhead. Given that typical response times are in the range of single digit seconds, we deem this overhead acceptable.
