### PR TITLE
[8.11] Provide stable resampling (#101255)

### DIFF
--- a/docs/changelog/101255.yaml
+++ b/docs/changelog/101255.yaml
@@ -1,0 +1,5 @@
+pr: 101255
+summary: Provide stable resampling
+area: Application
+type: bug
+issues: []

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetStackTracesRequest.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetStackTracesRequest.java
@@ -173,7 +173,13 @@ public class GetStackTracesRequest extends ActionRequest implements IndicesReque
 
     @Override
     public int hashCode() {
-        return Objects.hash(query, sampleSize);
+        // The object representation of `query` may use Lucene's ByteRef to represent values. This class' hashCode implementation
+        // uses StringUtils.GOOD_FAST_HASH_SEED which is reinitialized for each JVM. This means that hashcode is consistent *within*
+        // a JVM but will not be consistent across the cluster. As we use hashCode e.g. to initialize the random number generator in
+        // Resampler to produce a consistent downsampling results, relying on the default hashCode implementation of `query` will
+        // produce consistent results per node but not across the cluster. To avoid this, we produce the hashCode based on the
+        // string representation instead, which will produce consistent results for the entire cluster and across node restarts.
+        return Objects.hash(Objects.toString(query, "null"), sampleSize);
     }
 
     @Override


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Provide stable resampling (#101255)