### PR TITLE
[8.11] S3 CAS operation should respect abortMutipartUpload failure (#101253)

### DIFF
--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobContainer.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobContainer.java
@@ -741,7 +741,9 @@ class S3BlobContainer extends AbstractBlobContainer {
                                 final var currentUploadId = currentUpload.getUploadId();
                                 if (uploadId.equals(currentUploadId) == false) {
                                     blobStore.getSnapshotExecutor()
-                                        .execute(ActionRunnable.run(listeners.acquire(), () -> safeAbortMultipartUpload(currentUploadId)));
+                                        .execute(
+                                            ActionRunnable.run(listeners.acquire(), () -> abortMultipartUploadIfExists(currentUploadId))
+                                        );
                                 }
                             }
                         } finally {


### PR DESCRIPTION
Backports the following commits to 8.11:
 - S3 CAS operation should respect abortMutipartUpload failure (#101253)