### PR TITLE
[8.11] Percolator to support parsing script score query with params (#101051)

### DIFF
--- a/docs/changelog/101051.yaml
+++ b/docs/changelog/101051.yaml
@@ -1,0 +1,6 @@
+pr: 101051
+summary: Percolator to support parsing script score query with params
+area: Mapping
+type: bug
+issues:
+ - 97377

--- a/server/src/main/java/org/elasticsearch/index/mapper/DotExpandingXContentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DotExpandingXContentParser.java
@@ -172,34 +172,60 @@ class DotExpandingXContentParser extends FilterXContentParserWrapper {
             return parsers.peek();
         }
 
+        /*
+        The following methods (map* and list*) are known not be called by DocumentParser when parsing documents, but we support indexing
+        percolator queries which are also parsed through DocumentParser, and their parsing code is completely up to each query, which are
+        also pluggable. That means that this parser needs to fully support parsing arbitrary content, when dots expansion is turned off.
+        We do throw UnsupportedOperationException when dots expansion is enabled as we don't expect such methods to be ever called in
+        those circumstances.
+         */
+
         @Override
         public Map<String, Object> map() throws IOException {
+            if (contentPath.isWithinLeafObject()) {
+                return super.map();
+            }
             throw new UnsupportedOperationException();
         }
 
         @Override
         public Map<String, Object> mapOrdered() throws IOException {
+            if (contentPath.isWithinLeafObject()) {
+                return super.mapOrdered();
+            }
             throw new UnsupportedOperationException();
         }
 
         @Override
         public Map<String, String> mapStrings() throws IOException {
+            if (contentPath.isWithinLeafObject()) {
+                return super.mapStrings();
+            }
             throw new UnsupportedOperationException();
         }
 
         @Override
         public <T> Map<String, T> map(Supplier<Map<String, T>> mapFactory, CheckedFunction<XContentParser, T, IOException> mapValueParser)
             throws IOException {
+            if (contentPath.isWithinLeafObject()) {
+                return super.map(mapFactory, mapValueParser);
+            }
             throw new UnsupportedOperationException();
         }
 
         @Override
         public List<Object> list() throws IOException {
+            if (contentPath.isWithinLeafObject()) {
+                return super.list();
+            }
             throw new UnsupportedOperationException();
         }
 
         @Override
         public List<Object> listOrderedMap() throws IOException {
+            if (contentPath.isWithinLeafObject()) {
+                return super.listOrderedMap();
+            }
             throw new UnsupportedOperationException();
         }
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/DotExpandingXContentParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DotExpandingXContentParserTests.java
@@ -15,6 +15,9 @@ import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.json.JsonXContent;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class DotExpandingXContentParserTests extends ESTestCase {
 
@@ -347,5 +350,95 @@ public class DotExpandingXContentParserTests extends ESTestCase {
         assertEquals(expectedParser.getTokenLocation(), dotExpandedParser.getTokenLocation());
         assertNull(dotExpandedParser.nextToken());
         assertNull(expectedParser.nextToken());
+    }
+
+    public void testParseMapUOE() throws Exception {
+        XContentParser dotExpandedParser = DotExpandingXContentParser.expandDots(
+            createParser(JsonXContent.jsonXContent, ""),
+            new ContentPath()
+        );
+        expectThrows(UnsupportedOperationException.class, dotExpandedParser::map);
+    }
+
+    public void testParseMapOrderedUOE() throws Exception {
+        XContentParser dotExpandedParser = DotExpandingXContentParser.expandDots(
+            createParser(JsonXContent.jsonXContent, ""),
+            new ContentPath()
+        );
+        expectThrows(UnsupportedOperationException.class, dotExpandedParser::mapOrdered);
+    }
+
+    public void testParseMapStringsUOE() throws Exception {
+        XContentParser dotExpandedParser = DotExpandingXContentParser.expandDots(
+            createParser(JsonXContent.jsonXContent, ""),
+            new ContentPath()
+        );
+        expectThrows(UnsupportedOperationException.class, dotExpandedParser::mapStrings);
+    }
+
+    public void testParseMapSupplierUOE() throws Exception {
+        XContentParser dotExpandedParser = DotExpandingXContentParser.expandDots(
+            createParser(JsonXContent.jsonXContent, ""),
+            new ContentPath()
+        );
+        expectThrows(UnsupportedOperationException.class, () -> dotExpandedParser.map(HashMap::new, XContentParser::text));
+    }
+
+    public void testParseMap() throws Exception {
+        String jsonInput = """
+            {"params":{"one":"one",
+            "two":"two"}}\
+            """;
+
+        ContentPath contentPath = new ContentPath();
+        contentPath.setWithinLeafObject(true);
+        XContentParser dotExpandedParser = DotExpandingXContentParser.expandDots(
+            createParser(JsonXContent.jsonXContent, jsonInput),
+            contentPath
+        );
+        assertEquals(XContentParser.Token.START_OBJECT, dotExpandedParser.nextToken());
+        assertEquals(XContentParser.Token.FIELD_NAME, dotExpandedParser.nextToken());
+        assertEquals("params", dotExpandedParser.currentName());
+        assertEquals(XContentParser.Token.START_OBJECT, dotExpandedParser.nextToken());
+        Map<String, Object> map = dotExpandedParser.map();
+        assertEquals(2, map.size());
+        assertEquals("one", map.get("one"));
+        assertEquals("two", map.get("two"));
+    }
+
+    public void testParseListUOE() throws Exception {
+        XContentParser dotExpandedParser = DotExpandingXContentParser.expandDots(
+            createParser(JsonXContent.jsonXContent, ""),
+            new ContentPath()
+        );
+        expectThrows(UnsupportedOperationException.class, dotExpandedParser::list);
+    }
+
+    public void testParseListOrderedUOE() throws Exception {
+        XContentParser dotExpandedParser = DotExpandingXContentParser.expandDots(
+            createParser(JsonXContent.jsonXContent, ""),
+            new ContentPath()
+        );
+        expectThrows(UnsupportedOperationException.class, dotExpandedParser::listOrderedMap);
+    }
+
+    public void testParseList() throws Exception {
+        String jsonInput = """
+            {"params":["one","two"]}\
+            """;
+
+        ContentPath contentPath = new ContentPath();
+        contentPath.setWithinLeafObject(true);
+        XContentParser dotExpandedParser = DotExpandingXContentParser.expandDots(
+            createParser(JsonXContent.jsonXContent, jsonInput),
+            contentPath
+        );
+        assertEquals(XContentParser.Token.START_OBJECT, dotExpandedParser.nextToken());
+        assertEquals(XContentParser.Token.FIELD_NAME, dotExpandedParser.nextToken());
+        assertEquals("params", dotExpandedParser.currentName());
+        List<Object> list = dotExpandedParser.list();
+        assertEquals(2, list.size());
+        assertEquals("one", list.get(0));
+        assertEquals("two", list.get(1));
     }
 }


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Percolator to support parsing script score query with params (#101051)