### PR TITLE
[DOCS] Deprecate rollups

### DIFF
--- a/build-tools-internal/src/main/resources/changelog-schema.json
+++ b/build-tools-internal/src/main/resources/changelog-schema.json
@@ -75,6 +75,7 @@
             "Ranking",
             "Recovery",
             "Reindex",
+            "Rollup",
             "SQL",
             "Search",
             "Security",
@@ -277,6 +278,7 @@
         "Packaging",
         "Painless",
         "REST API",
+        "Rollup",
         "System requirement",
         "Transform"
       ]

--- a/docs/changelog/101265.yaml
+++ b/docs/changelog/101265.yaml
@@ -1,0 +1,13 @@
+pr: 101265
+summary: Rollup functionality is now deprecated
+area: Rollup
+type: deprecation
+issues: []
+deprecation:
+  title: >-
+    Rollup functionality is now deprecated
+  area: Rollup
+  details: |-
+    {ref}/xpack-rollup[Rollup functionality] has been deprecated and will be removed in a future release. Previously, rollups were available in technical preview.
+  impact: |-
+    Use {ref}/downsampling.html[downsampling] to reduce storage costs for time series data by by storing it at reduced granularity.

--- a/docs/reference/data-rollup-transform.asciidoc
+++ b/docs/reference/data-rollup-transform.asciidoc
@@ -8,6 +8,8 @@
 
 * <<xpack-rollup,Rolling up your historical data>>
 +
+deprecated::[8.11.0,"Rollups will be removed in a future version. Use <<downsampling,downsampling>> instead."]
++
 include::rollup/index.asciidoc[tag=rollup-intro]
 
 * <<transforms,Transforming your data>>

--- a/docs/reference/how-to/disk-usage.asciidoc
+++ b/docs/reference/how-to/disk-usage.asciidoc
@@ -137,5 +137,5 @@ if fields always occur in the same order.
 === Roll up historical data
 
 Keeping older data can be useful for later analysis but is often avoided due to
-storage costs. You can use data rollups to summarize and store historical data
-at a fraction of the raw data's storage cost. See <<xpack-rollup>>.
+storage costs. You can use downsampling to summarize and store historical data
+at a fraction of the raw data's storage cost. See <<downsampling>>.

--- a/docs/reference/intro.asciidoc
+++ b/docs/reference/intro.asciidoc
@@ -261,6 +261,6 @@ secondary clusters are read-only followers.
 As with any enterprise system, you need tools to secure, manage, and
 monitor your {es} clusters. Security, monitoring, and administrative features
 that are integrated into {es} enable you to use {kibana-ref}/introduction.html[{kib}]
-as a control center for managing a cluster. Features like <<xpack-rollup,
-data rollups>> and <<index-lifecycle-management, index lifecycle management>>
+as a control center for managing a cluster. Features like <<downsampling,
+downsampling>> and <<index-lifecycle-management, index lifecycle management>>
 help you intelligently manage your data over time.

--- a/docs/reference/landing-page.asciidoc
+++ b/docs/reference/landing-page.asciidoc
@@ -172,7 +172,7 @@
       <a href="data-management.html">Data management</a>
     </li>
     <li>
-      <a href="data-rollup-transform.html">Roll up or transform your data</a>
+      <a href="downsampling.html">Downsampling</a>
     </li>
     <li>
       <a href="snapshot-restore.html">Snapshot and restore</a>

--- a/docs/reference/rollup/api-quickref.asciidoc
+++ b/docs/reference/rollup/api-quickref.asciidoc
@@ -5,10 +5,7 @@
 <titleabbrev>API quick reference</titleabbrev>
 ++++
 
-experimental[]
-
-NOTE: For version 8.5 and above we recommend <<downsampling,downsampling>> over
-rollups as a way to reduce your storage costs for time series data.
+deprecated::[8.11.0,"Rollups will be removed in a future version. Use <<downsampling,downsampling>> instead."]
 
 Most rollup endpoints have the following base:
 

--- a/docs/reference/rollup/apis/delete-job.asciidoc
+++ b/docs/reference/rollup/apis/delete-job.asciidoc
@@ -6,12 +6,9 @@
 <titleabbrev>Delete {rollup-jobs}</titleabbrev>
 ++++
 
-Deletes an existing {rollup-job}. 
+deprecated::[8.11.0,"Rollups will be removed in a future version. Use <<downsampling,downsampling>> instead."]
 
-experimental[]
-
-NOTE: For version 8.5 and above we recommend <<downsampling,downsampling>> over
-rollups as a way to reduce your storage costs for time series data.
+Deletes an existing {rollup-job}.
 
 [[rollup-delete-job-request]]
 ==== {api-request-title}

--- a/docs/reference/rollup/apis/get-job.asciidoc
+++ b/docs/reference/rollup/apis/get-job.asciidoc
@@ -5,12 +5,9 @@
 <titleabbrev>Get job</titleabbrev>
 ++++
 
+deprecated::[8.11.0,"Rollups will be removed in a future version. Use <<downsampling,downsampling>> instead."]
+
 Retrieves the configuration, stats, and status of {rollup-jobs}.
-
-experimental[]
-
-NOTE: For version 8.5 and above we recommend <<downsampling,downsampling>> over
-rollups as a way to reduce your storage costs for time series data.
 
 [[rollup-get-job-request]]
 ==== {api-request-title}
@@ -48,7 +45,7 @@ For details about a historical {rollup-job}, the
 ==== {api-response-body-title}
 
 `jobs`::
-(array) An array of {rollup-job} resources. 
+(array) An array of {rollup-job} resources.
 +
 .Properties of {rollup-job} resources
 [%collapsible%open]

--- a/docs/reference/rollup/apis/put-job.asciidoc
+++ b/docs/reference/rollup/apis/put-job.asciidoc
@@ -6,12 +6,9 @@
 <titleabbrev>Create {rollup-jobs}</titleabbrev>
 ++++
 
+deprecated::[8.11.0,"Rollups will be removed in a future version. Use <<downsampling,downsampling>> instead."]
+
 Creates a {rollup-job}.
-
-experimental[]
-
-NOTE: For version 8.5 and above we recommend <<downsampling,downsampling>> over
-rollups as a way to reduce your storage costs for time series data.
 
 [[rollup-put-job-api-request]]
 ==== {api-request-title}
@@ -93,7 +90,7 @@ documents without a timestamp and a `date_histogram` group. The
 +
 .Properties of `date_histogram`
 [%collapsible%open]
-===== 
+=====
 `calendar_interval` or `fixed_interval`::::
 (Required, <<time-units,time units>>) The interval of time buckets to be
 generated when rolling up. For example, `60m` produces 60 minute (hourly)
@@ -139,11 +136,11 @@ in `UTC`.
 //Begin histogram
 `histogram`:::
 (Optional, object) The histogram group aggregates one or more numeric fields
-into numeric histogram intervals. 
+into numeric histogram intervals.
 +
 .Properties of `histogram`
 [%collapsible%open]
-===== 
+=====
 `fields`::::
 (Required, array) The set of fields that you wish to build histograms for. All
 fields specified must be some kind of numeric. Order does not matter.
@@ -175,7 +172,7 @@ judicious which high-cardinality fields are included for that reason.
 +
 .Properties of `terms`
 [%collapsible%open]
-===== 
+=====
 
 `fields`::::
 (Required, string) The set of fields that you wish to collect terms for. This

--- a/docs/reference/rollup/apis/rollup-caps.asciidoc
+++ b/docs/reference/rollup/apis/rollup-caps.asciidoc
@@ -5,13 +5,10 @@
 <titleabbrev>Get rollup caps</titleabbrev>
 ++++
 
+deprecated::[8.11.0,"Rollups will be removed in a future version. Use <<downsampling,downsampling>> instead."]
+
 Returns the capabilities of any {rollup-jobs} that have been configured for a
 specific index or index pattern.
-
-experimental[]
-
-NOTE: For version 8.5 and above we recommend <<downsampling,downsampling>> over
-rollups as a way to reduce your storage costs for time series data.
 
 [[rollup-get-rollup-caps-request]]
 ==== {api-request-title}
@@ -43,7 +40,7 @@ can be performed, and where does the data live?
 ==== {api-path-parms-title}
 
 `<index>`::
-  (string) Index, indices or index-pattern to return rollup capabilities for. 
+  (string) Index, indices or index-pattern to return rollup capabilities for.
   `_all` may be used to fetch rollup capabilities from all jobs.
 
 

--- a/docs/reference/rollup/apis/rollup-index-caps.asciidoc
+++ b/docs/reference/rollup/apis/rollup-index-caps.asciidoc
@@ -5,13 +5,10 @@
 <titleabbrev>Get rollup index caps</titleabbrev>
 ++++
 
+deprecated::[8.11.0,"Rollups will be removed in a future version. Use <<downsampling,downsampling>> instead."]
+
 Returns the rollup capabilities of all jobs inside of a rollup index (e.g. the
 index where rollup data is stored).
-
-experimental[]
-
-NOTE: For version 8.5 and above we recommend <<downsampling,downsampling>> over
-rollups as a way to reduce your storage costs for time series data.
 
 [[rollup-get-rollup-index-caps-request]]
 ==== {api-request-title}

--- a/docs/reference/rollup/apis/rollup-search.asciidoc
+++ b/docs/reference/rollup/apis/rollup-search.asciidoc
@@ -5,12 +5,9 @@
 <titleabbrev>Rollup search</titleabbrev>
 ++++
 
+deprecated::[8.11.0,"Rollups will be removed in a future version. Use <<downsampling,downsampling>> instead."]
+
 Enables searching rolled-up data using the standard Query DSL.
-
-experimental[]
-
-NOTE: For version 8.5 and above we recommend <<downsampling,downsampling>> over
-rollups as a way to reduce your storage costs for time series data.
 
 [[rollup-search-request]]
 ==== {api-request-title}

--- a/docs/reference/rollup/apis/start-job.asciidoc
+++ b/docs/reference/rollup/apis/start-job.asciidoc
@@ -6,12 +6,9 @@
 <titleabbrev>Start {rollup-jobs}</titleabbrev>
 ++++
 
+deprecated::[8.11.0,"Rollups will be removed in a future version. Use <<downsampling,downsampling>> instead."]
+
 Starts an existing, stopped {rollup-job}.
-
-experimental[]
-
-NOTE: For version 8.5 and above we recommend <<downsampling,downsampling>> over
-rollups as a way to reduce your storage costs for time series data.
 
 [[rollup-start-job-request]]
 ==== {api-request-title}
@@ -36,7 +33,7 @@ to start a job that is already started, nothing happens.
 
 `<job_id>`::
   (Required, string) Identifier for the {rollup-job}.
-  
+
 [[rollup-start-job-response-codes]]
 ==== {api-response-codes-title}
 

--- a/docs/reference/rollup/apis/stop-job.asciidoc
+++ b/docs/reference/rollup/apis/stop-job.asciidoc
@@ -6,12 +6,9 @@
 <titleabbrev>Stop {rollup-jobs}</titleabbrev>
 ++++
 
+deprecated::[8.11.0,"Rollups will be removed in a future version. Use <<downsampling,downsampling>> instead."]
+
 Stops an existing, started {rollup-job}.
-
-experimental[]
-
-NOTE: For version 8.5 and above we recommend <<downsampling,downsampling>> over
-rollups as a way to reduce your storage costs for time series data.
 
 [[rollup-stop-job-request]]
 ==== {api-request-title}
@@ -52,7 +49,7 @@ processing and eventually moves the job to `STOPPED`. The timeout simply means
 the API call itself timed out while waiting for the status change.
 
 --
-  
+
 `wait_for_completion`::
   (Optional, Boolean) If set to `true`, causes the API to block until the
   indexer state completely stops. If set to `false`, the API returns immediately

--- a/docs/reference/rollup/index.asciidoc
+++ b/docs/reference/rollup/index.asciidoc
@@ -2,10 +2,7 @@
 [[xpack-rollup]]
 == Rolling up historical data
 
-experimental[]
-
-NOTE: For version 8.5 and above we recommend <<downsampling,downsampling>> over
-rollups as a way to reduce your storage costs for time series data.
+deprecated::[8.11.0,"Rollups will be removed in a future version. Use <<downsampling,downsampling>> instead."]
 
 Keeping historical data around for analysis is extremely useful but often avoided due to the financial cost of
 archiving massive amounts of data. Retention periods are thus driven by financial realities rather than by the

--- a/docs/reference/rollup/overview.asciidoc
+++ b/docs/reference/rollup/overview.asciidoc
@@ -5,10 +5,7 @@
 <titleabbrev>Overview</titleabbrev>
 ++++
 
-experimental[]
-
-NOTE: For version 8.5 and above we recommend <<downsampling,downsampling>> over
-rollups as a way to reduce your storage costs for time series data.
+deprecated::[8.11.0,"Rollups will be removed in a future version. Use <<downsampling,downsampling>> instead."]
 
 Time-based data (documents that are predominantly identified by their timestamp) often have associated retention policies
 to manage data growth. For example, your system may be generating 500 documents every second. That will generate

--- a/docs/reference/rollup/rollup-agg-limitations.asciidoc
+++ b/docs/reference/rollup/rollup-agg-limitations.asciidoc
@@ -2,10 +2,7 @@
 [[rollup-agg-limitations]]
 === {rollup-cap} aggregation limitations
 
-experimental[]
-
-NOTE: For version 8.5 and above we recommend <<downsampling,downsampling>> over
-rollups as a way to reduce your storage costs for time series data.
+deprecated::[8.11.0,"Rollups will be removed in a future version. Use <<downsampling,downsampling>> instead."]
 
 There are some limitations to how fields can be rolled up / aggregated. This page highlights the major limitations so that
 you are aware of them.

--- a/docs/reference/rollup/rollup-apis.asciidoc
+++ b/docs/reference/rollup/rollup-apis.asciidoc
@@ -2,6 +2,8 @@
 [[rollup-apis]]
 == Rollup APIs
 
+deprecated::[8.11.0,"Rollups will be removed in a future version. Use <<downsampling,downsampling>> instead."]
+
 [discrete]
 [[rollup-jobs-endpoint]]
 === Jobs

--- a/docs/reference/rollup/rollup-getting-started.asciidoc
+++ b/docs/reference/rollup/rollup-getting-started.asciidoc
@@ -5,10 +5,7 @@
 <titleabbrev>Getting started</titleabbrev>
 ++++
 
-experimental[]
-
-NOTE: For version 8.5 and above we recommend <<downsampling,downsampling>> over
-rollups as a way to reduce your storage costs for time series data.
+deprecated::[8.11.0,"Rollups will be removed in a future version. Use <<downsampling,downsampling>> instead."]
 
 To use the Rollup feature, you need to create one or more "Rollup Jobs". These jobs run continuously in the background
 and rollup the index or indices that you specify, placing the rolled documents in a secondary index (also of your choosing).

--- a/docs/reference/rollup/rollup-search-limitations.asciidoc
+++ b/docs/reference/rollup/rollup-search-limitations.asciidoc
@@ -2,10 +2,7 @@
 [[rollup-search-limitations]]
 === {rollup-cap} search limitations
 
-experimental[]
-
-NOTE: For version 8.5 and above we recommend <<downsampling,downsampling>> over
-rollups as a way to reduce your storage costs for time series data.
+deprecated::[8.11.0,"Rollups will be removed in a future version. Use <<downsampling,downsampling>> instead."]
 
 While we feel the Rollup function is extremely flexible, the nature of summarizing data means there will be some limitations. Once
 live data is thrown away, you will always lose some flexibility.

--- a/docs/reference/rollup/understanding-groups.asciidoc
+++ b/docs/reference/rollup/understanding-groups.asciidoc
@@ -2,10 +2,7 @@
 [[rollup-understanding-groups]]
 === Understanding groups
 
-experimental[]
-
-NOTE: For version 8.5 and above we recommend <<downsampling,downsampling>> over
-rollups as a way to reduce your storage costs for time series data.
+deprecated::[8.11.0,"Rollups will be removed in a future version. Use <<downsampling,downsampling>> instead."]
 
 To preserve flexibility, Rollup Jobs are defined based on how future queries may need to use the data. Traditionally, systems force
 the admin to make decisions about what metrics to rollup and on what interval. E.g. The average of `cpu_time` on an hourly basis. This


### PR DESCRIPTION
In 8.11, we're deprecating rollup functionality which is still in tech preview. Instead, users should use downsampling to reduce the footprint of their data by using a smaller granularity.