### PR TITLE
[8.11] Align look-back with client-side cache (#101264)

### DIFF
--- a/docs/changelog/101264.yaml
+++ b/docs/changelog/101264.yaml
@@ -1,0 +1,5 @@
+pr: 101264
+summary: Align look-back with client-side cache
+area: Application
+type: bug
+issues: []

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStackTracesAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStackTracesAction.java
@@ -79,12 +79,13 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
      * K/V indices (such as profiling-stacktraces) are assumed to contain data from their creation date until the creation date
      * of the next index that is created by rollover. Due to client-side caching of K/V data we need to extend the validity period
      * of the prior index by this time. This means that for queries that cover a time period around the time when a new index has
-     * been created we will query not only the new index but also the prior one (for up to four hours by default). The default value
-     * on the client is three hours but to ensure we won't miss anything due to unlucky timing, we add a bit more slack (1 hour).
+     * been created we will query not only the new index but also the prior one. The client-side parameters that influence cache duration
+     * are <code>elfInfoCacheTTL</code> for executables (default: 6 hours) and <code>traceExpirationTimeout</code> for stack
+     * traces (default: 3 hours).
      */
     public static final Setting<TimeValue> PROFILING_KV_INDEX_OVERLAP = Setting.positiveTimeSetting(
         "xpack.profiling.kv_index.overlap",
-        TimeValue.timeValueHours(4),
+        TimeValue.timeValueHours(6),
         Setting.Property.NodeScope
     );
 


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Align look-back with client-side cache (#101264)