### PR TITLE
Add an extra check to DeprecationHttpIT that the index is actually deleted

### DIFF
--- a/x-pack/plugin/deprecation/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/deprecation/DeprecationHttpIT.java
+++ b/x-pack/plugin/deprecation/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/deprecation/DeprecationHttpIT.java
@@ -36,6 +36,7 @@ import org.junit.Before;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -48,6 +49,7 @@ import static org.elasticsearch.test.hamcrest.RegexMatcher.matches;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.hasEntry;
@@ -108,8 +110,13 @@ public class DeprecationHttpIT extends ESRestTestCase {
             } catch (Exception e) {
                 throw new AssertionError(e);
             }
-
         }, 30, TimeUnit.SECONDS);
+
+        assertBusy(() -> {
+            // wait for the data stream to really be deleted
+            var response = ESRestTestCase.entityAsMap(client().performRequest(new Request("GET", "/_data_stream")));
+            assertThat((Collection<?>) response.get("data_streams"), empty());
+        });
     }
 
     /**


### PR DESCRIPTION
This is to try and fix the various failures of DeprecationHttpIT around tests affecting each other - #96141, #96723, #100849, #101257, #101263