### PR TITLE
Remove index.codec setting from setting up tsdb docs.

### DIFF
--- a/docs/reference/data-streams/set-up-tsds.asciidoc
+++ b/docs/reference/data-streams/set-up-tsds.asciidoc
@@ -192,8 +192,7 @@ PUT _component_template/my-weather-sensor-settings
   "template": {
     "settings": {
       "index.lifecycle.name": "my-lifecycle-policy",
-      "index.look_ahead_time": "3h",
-      "index.codec": "best_compression"
+      "index.look_ahead_time": "3h"
     }
   },
   "_meta": {


### PR DESCRIPTION
This is not needed for tsdb, because of synthetic source and slows down indexing / refreshes.
