### PR TITLE
Unmute DeprecationHttpIT.testCompatibleMessagesCanBeIndexed

### DIFF
--- a/x-pack/plugin/deprecation/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/deprecation/DeprecationHttpIT.java
+++ b/x-pack/plugin/deprecation/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/deprecation/DeprecationHttpIT.java
@@ -569,7 +569,6 @@ public class DeprecationHttpIT extends ESRestTestCase {
     /**
      * Check that log messages about REST API compatibility are recorded to an index
      */
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/96723")
     public void testCompatibleMessagesCanBeIndexed() throws Exception {
 
         final Request compatibleRequest = new Request("GET", "/_test_cluster/compat_only");


### PR DESCRIPTION
Unmutes test muted for #96723, hopefully fixed by #101273