### PR TITLE
Remove explicit SearchResponse references from test framework module

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/bucket/AbstractTermsTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/bucket/AbstractTermsTestCase.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.search.aggregations.bucket;
 
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.search.aggregations.Aggregator.SubAggCollectionMode;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
@@ -16,6 +15,7 @@ import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregatorFactory
 import org.elasticsearch.test.ESIntegTestCase;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 
 public abstract class AbstractTermsTestCase extends ESIntegTestCase {
 
@@ -33,34 +33,37 @@ public abstract class AbstractTermsTestCase extends ESIntegTestCase {
 
     public void testOtherDocCount(String... fieldNames) {
         for (String fieldName : fieldNames) {
-            SearchResponse allTerms = prepareSearch("idx").addAggregation(
+            assertResponse(prepareSearch("idx").addAggregation(
                 new TermsAggregationBuilder("terms").executionHint(randomExecutionHint())
                     .field(fieldName)
                     .size(10000)
                     .collectMode(randomFrom(SubAggCollectionMode.values()))
-            ).get();
-            assertNoFailures(allTerms);
+            ), allTerms -> {
+                assertNoFailures(allTerms);
 
-            Terms terms = allTerms.getAggregations().get("terms");
-            assertEquals(0, terms.getSumOfOtherDocCounts()); // size is 0
-            final long sumOfDocCounts = sumOfDocCounts(terms);
-            final int totalNumTerms = terms.getBuckets().size();
+                Terms terms = allTerms.getAggregations().get("terms");
+                assertEquals(0, terms.getSumOfOtherDocCounts()); // size is 0
+                final long sumOfDocCounts = sumOfDocCounts(terms);
+                final int totalNumTerms = terms.getBuckets().size();
 
-            for (int size = 1; size < totalNumTerms + 2; size += randomIntBetween(1, 5)) {
-                for (int shardSize = size; shardSize <= totalNumTerms + 2; shardSize += randomIntBetween(1, 5)) {
-                    SearchResponse resp = prepareSearch("idx").addAggregation(
-                        new TermsAggregationBuilder("terms").executionHint(randomExecutionHint())
-                            .field(fieldName)
-                            .size(size)
-                            .shardSize(shardSize)
-                            .collectMode(randomFrom(SubAggCollectionMode.values()))
-                    ).get();
-                    assertNoFailures(resp);
-                    terms = resp.getAggregations().get("terms");
-                    assertEquals(Math.min(size, totalNumTerms), terms.getBuckets().size());
-                    assertEquals(sumOfDocCounts, sumOfDocCounts(terms));
+                for (int size = 1; size < totalNumTerms + 2; size += randomIntBetween(1, 5)) {
+                    for (int shardSize = size; shardSize <= totalNumTerms + 2; shardSize += randomIntBetween(1, 5)) {
+                        final int finalSize = size;
+                        assertResponse(prepareSearch("idx").addAggregation(
+                            new TermsAggregationBuilder("terms").executionHint(randomExecutionHint())
+                                .field(fieldName)
+                                .size(size)
+                                .shardSize(shardSize)
+                                .collectMode(randomFrom(SubAggCollectionMode.values()))
+                        ), response -> {
+                            assertNoFailures(response);
+                            Terms innerTerms = response.getAggregations().get("terms");
+                            assertEquals(Math.min(finalSize, totalNumTerms), innerTerms.getBuckets().size());
+                            assertEquals(sumOfDocCounts, sumOfDocCounts(innerTerms));
+                        });
+                    }
                 }
-            }
+            });
         }
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/bucket/AbstractTermsTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/bucket/AbstractTermsTestCase.java
@@ -33,37 +33,43 @@ public abstract class AbstractTermsTestCase extends ESIntegTestCase {
 
     public void testOtherDocCount(String... fieldNames) {
         for (String fieldName : fieldNames) {
-            assertResponse(prepareSearch("idx").addAggregation(
-                new TermsAggregationBuilder("terms").executionHint(randomExecutionHint())
-                    .field(fieldName)
-                    .size(10000)
-                    .collectMode(randomFrom(SubAggCollectionMode.values()))
-            ), allTerms -> {
-                assertNoFailures(allTerms);
+            assertResponse(
+                prepareSearch("idx").addAggregation(
+                    new TermsAggregationBuilder("terms").executionHint(randomExecutionHint())
+                        .field(fieldName)
+                        .size(10000)
+                        .collectMode(randomFrom(SubAggCollectionMode.values()))
+                ),
+                allTerms -> {
+                    assertNoFailures(allTerms);
 
-                Terms terms = allTerms.getAggregations().get("terms");
-                assertEquals(0, terms.getSumOfOtherDocCounts()); // size is 0
-                final long sumOfDocCounts = sumOfDocCounts(terms);
-                final int totalNumTerms = terms.getBuckets().size();
+                    Terms terms = allTerms.getAggregations().get("terms");
+                    assertEquals(0, terms.getSumOfOtherDocCounts()); // size is 0
+                    final long sumOfDocCounts = sumOfDocCounts(terms);
+                    final int totalNumTerms = terms.getBuckets().size();
 
-                for (int size = 1; size < totalNumTerms + 2; size += randomIntBetween(1, 5)) {
-                    for (int shardSize = size; shardSize <= totalNumTerms + 2; shardSize += randomIntBetween(1, 5)) {
-                        final int finalSize = size;
-                        assertResponse(prepareSearch("idx").addAggregation(
-                            new TermsAggregationBuilder("terms").executionHint(randomExecutionHint())
-                                .field(fieldName)
-                                .size(size)
-                                .shardSize(shardSize)
-                                .collectMode(randomFrom(SubAggCollectionMode.values()))
-                        ), response -> {
-                            assertNoFailures(response);
-                            Terms innerTerms = response.getAggregations().get("terms");
-                            assertEquals(Math.min(finalSize, totalNumTerms), innerTerms.getBuckets().size());
-                            assertEquals(sumOfDocCounts, sumOfDocCounts(innerTerms));
-                        });
+                    for (int size = 1; size < totalNumTerms + 2; size += randomIntBetween(1, 5)) {
+                        for (int shardSize = size; shardSize <= totalNumTerms + 2; shardSize += randomIntBetween(1, 5)) {
+                            final int finalSize = size;
+                            assertResponse(
+                                prepareSearch("idx").addAggregation(
+                                    new TermsAggregationBuilder("terms").executionHint(randomExecutionHint())
+                                        .field(fieldName)
+                                        .size(size)
+                                        .shardSize(shardSize)
+                                        .collectMode(randomFrom(SubAggCollectionMode.values()))
+                                ),
+                                response -> {
+                                    assertNoFailures(response);
+                                    Terms innerTerms = response.getAggregations().get("terms");
+                                    assertEquals(Math.min(finalSize, totalNumTerms), innerTerms.getBuckets().size());
+                                    assertEquals(sumOfDocCounts, sumOfDocCounts(innerTerms));
+                                }
+                            );
+                        }
                     }
                 }
-            });
+            );
         }
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractGeoTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractGeoTestCase.java
@@ -229,25 +229,28 @@ public abstract class AbstractGeoTestCase extends ESIntegTestCase {
         // value for NUMBER_FIELD_NAME. This will check that after random indexing each document only has 1 value for
         // NUMBER_FIELD_NAME and it is the correct value. Following this initial change its seems that this call was getting
         // more that 2000 hits (actual value was 2059) so now it will also check to ensure all hits have the correct index and type.
-        assertCheckedResponse(prepareSearch(HIGH_CARD_IDX_NAME).addStoredField(NUMBER_FIELD_NAME)
-            .addSort(SortBuilders.fieldSort(NUMBER_FIELD_NAME).order(SortOrder.ASC))
-            .setSize(5000), response -> {
-            assertNoFailures(response);
-            long totalHits = response.getHits().getTotalHits().value;
-            XContentBuilder builder = XContentFactory.jsonBuilder();
-            ChunkedToXContent.wrapAsToXContent(response).toXContent(builder, ToXContent.EMPTY_PARAMS);
-            logger.info("Full high_card_idx Response Content:\n{ {} }", Strings.toString(builder));
-            for (int i = 0; i < totalHits; i++) {
-                SearchHit searchHit = response.getHits().getAt(i);
-                assertThat("Hit " + i + " with id: " + searchHit.getId(), searchHit.getIndex(), equalTo("high_card_idx"));
-                DocumentField hitField = searchHit.field(NUMBER_FIELD_NAME);
+        assertCheckedResponse(
+            prepareSearch(HIGH_CARD_IDX_NAME).addStoredField(NUMBER_FIELD_NAME)
+                .addSort(SortBuilders.fieldSort(NUMBER_FIELD_NAME).order(SortOrder.ASC))
+                .setSize(5000),
+            response -> {
+                assertNoFailures(response);
+                long totalHits = response.getHits().getTotalHits().value;
+                XContentBuilder builder = XContentFactory.jsonBuilder();
+                ChunkedToXContent.wrapAsToXContent(response).toXContent(builder, ToXContent.EMPTY_PARAMS);
+                logger.info("Full high_card_idx Response Content:\n{ {} }", Strings.toString(builder));
+                for (int i = 0; i < totalHits; i++) {
+                    SearchHit searchHit = response.getHits().getAt(i);
+                    assertThat("Hit " + i + " with id: " + searchHit.getId(), searchHit.getIndex(), equalTo("high_card_idx"));
+                    DocumentField hitField = searchHit.field(NUMBER_FIELD_NAME);
 
-                assertThat("Hit " + i + " has wrong number of values", hitField.getValues().size(), equalTo(1));
-                Long value = hitField.getValue();
-                assertThat("Hit " + i + " has wrong value", value.intValue(), equalTo(i));
+                    assertThat("Hit " + i + " has wrong number of values", hitField.getValues().size(), equalTo(1));
+                    Long value = hitField.getValue();
+                    assertThat("Hit " + i + " has wrong value", value.intValue(), equalTo(i));
+                }
+                assertThat(totalHits, equalTo(2000L));
             }
-            assertThat(totalHits, equalTo(2000L));
-        });
+        );
     }
 
     private SpatialPoint computeCentroid(SpatialPoint[] points) {

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractGeoTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractGeoTestCase.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.action.index.IndexRequestBuilder;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.document.DocumentField;
 import org.elasticsearch.common.geo.SpatialPoint;
@@ -30,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertCheckedResponse;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
@@ -229,25 +229,25 @@ public abstract class AbstractGeoTestCase extends ESIntegTestCase {
         // value for NUMBER_FIELD_NAME. This will check that after random indexing each document only has 1 value for
         // NUMBER_FIELD_NAME and it is the correct value. Following this initial change its seems that this call was getting
         // more that 2000 hits (actual value was 2059) so now it will also check to ensure all hits have the correct index and type.
-        SearchResponse response = prepareSearch(HIGH_CARD_IDX_NAME).addStoredField(NUMBER_FIELD_NAME)
+        assertCheckedResponse(prepareSearch(HIGH_CARD_IDX_NAME).addStoredField(NUMBER_FIELD_NAME)
             .addSort(SortBuilders.fieldSort(NUMBER_FIELD_NAME).order(SortOrder.ASC))
-            .setSize(5000)
-            .get();
-        assertNoFailures(response);
-        long totalHits = response.getHits().getTotalHits().value;
-        XContentBuilder builder = XContentFactory.jsonBuilder();
-        ChunkedToXContent.wrapAsToXContent(response).toXContent(builder, ToXContent.EMPTY_PARAMS);
-        logger.info("Full high_card_idx Response Content:\n{ {} }", Strings.toString(builder));
-        for (int i = 0; i < totalHits; i++) {
-            SearchHit searchHit = response.getHits().getAt(i);
-            assertThat("Hit " + i + " with id: " + searchHit.getId(), searchHit.getIndex(), equalTo("high_card_idx"));
-            DocumentField hitField = searchHit.field(NUMBER_FIELD_NAME);
+            .setSize(5000), response -> {
+            assertNoFailures(response);
+            long totalHits = response.getHits().getTotalHits().value;
+            XContentBuilder builder = XContentFactory.jsonBuilder();
+            ChunkedToXContent.wrapAsToXContent(response).toXContent(builder, ToXContent.EMPTY_PARAMS);
+            logger.info("Full high_card_idx Response Content:\n{ {} }", Strings.toString(builder));
+            for (int i = 0; i < totalHits; i++) {
+                SearchHit searchHit = response.getHits().getAt(i);
+                assertThat("Hit " + i + " with id: " + searchHit.getId(), searchHit.getIndex(), equalTo("high_card_idx"));
+                DocumentField hitField = searchHit.field(NUMBER_FIELD_NAME);
 
-            assertThat("Hit " + i + " has wrong number of values", hitField.getValues().size(), equalTo(1));
-            Long value = hitField.getValue();
-            assertThat("Hit " + i + " has wrong value", value.intValue(), equalTo(i));
-        }
-        assertThat(totalHits, equalTo(2000L));
+                assertThat("Hit " + i + " has wrong number of values", hitField.getValues().size(), equalTo(1));
+                Long value = hitField.getValue();
+                assertThat("Hit " + i + " has wrong value", value.intValue(), equalTo(i));
+            }
+            assertThat(totalHits, equalTo(2000L));
+        });
     }
 
     private SpatialPoint computeCentroid(SpatialPoint[] points) {

--- a/test/framework/src/main/java/org/elasticsearch/search/geo/BasePointShapeQueryTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/geo/BasePointShapeQueryTestCase.java
@@ -111,19 +111,24 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
             .get();
 
         Geometry geometry = new Rectangle(-45, 45, 45, -45);
-        assertNoFailuresAndResponse(client().prepareSearch(defaultIndexName)
-            .setQuery(queryBuilder().shapeQuery(defaultFieldName, geometry).relation(ShapeRelation.INTERSECTS)), response -> {
-            assertThat(response.getHits().getTotalHits().value, equalTo(1L));
-            assertThat(response.getHits().getHits().length, equalTo(1));
-            assertThat(response.getHits().getAt(0).getId(), equalTo("1"));
-        });
+        assertNoFailuresAndResponse(
+            client().prepareSearch(defaultIndexName)
+                .setQuery(queryBuilder().shapeQuery(defaultFieldName, geometry).relation(ShapeRelation.INTERSECTS)),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(1L));
+                assertThat(response.getHits().getHits().length, equalTo(1));
+                assertThat(response.getHits().getAt(0).getId(), equalTo("1"));
+            }
+        );
         // default query, without specifying relation (expect intersects)
-        assertNoFailuresAndResponse(client().prepareSearch(defaultIndexName)
-                .setQuery(queryBuilder().shapeQuery(defaultFieldName, geometry)), response -> {
-            assertThat(response.getHits().getTotalHits().value, equalTo(1L));
-            assertThat(response.getHits().getHits().length, equalTo(1));
-            assertThat(response.getHits().getAt(0).getId(), equalTo("1"));
-        });
+        assertNoFailuresAndResponse(
+            client().prepareSearch(defaultIndexName).setQuery(queryBuilder().shapeQuery(defaultFieldName, geometry)),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(1L));
+                assertThat(response.getHits().getHits().length, equalTo(1));
+                assertThat(response.getHits().getAt(0).getId(), equalTo("1"));
+            }
+        );
     }
 
     public void testIndexPointsCircle() throws Exception {
@@ -174,12 +179,15 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
 
         Polygon polygon = new Polygon(new LinearRing(new double[] { -35, -35, -25, -25, -35 }, new double[] { -35, -25, -25, -35, -35 }));
 
-        assertNoFailuresAndResponse(client().prepareSearch(defaultIndexName)
-            .setQuery(queryBuilder().shapeQuery(defaultFieldName, polygon).relation(ShapeRelation.INTERSECTS)), response -> {
-            SearchHits searchHits = response.getHits();
-            assertThat(searchHits.getTotalHits().value, equalTo(1L));
-            assertThat(searchHits.getAt(0).getId(), equalTo("1"));
-        });
+        assertNoFailuresAndResponse(
+            client().prepareSearch(defaultIndexName)
+                .setQuery(queryBuilder().shapeQuery(defaultFieldName, polygon).relation(ShapeRelation.INTERSECTS)),
+            response -> {
+                SearchHits searchHits = response.getHits();
+                assertThat(searchHits.getTotalHits().value, equalTo(1L));
+                assertThat(searchHits.getAt(0).getId(), equalTo("1"));
+            }
+        );
     }
 
     public void testIndexPointsMultiPolygon() throws Exception {
@@ -214,31 +222,43 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
 
         MultiPolygon multiPolygon = new MultiPolygon(List.of(encloseDocument1Cb, encloseDocument2Cb));
 
-        assertNoFailuresAndResponse(client().prepareSearch(defaultIndexName)
-            .setQuery(queryBuilder().shapeQuery(defaultFieldName, multiPolygon).relation(ShapeRelation.INTERSECTS)), response -> {
-            assertThat(response.getHits().getTotalHits().value, equalTo(2L));
-            assertThat(response.getHits().getHits().length, equalTo(2));
-            assertThat(response.getHits().getAt(0).getId(), not(equalTo("2")));
-            assertThat(response.getHits().getAt(1).getId(), not(equalTo("2")));
-        });
-        assertNoFailuresAndResponse(client().prepareSearch(defaultIndexName)
-            .setQuery(queryBuilder().shapeQuery(defaultFieldName, multiPolygon).relation(ShapeRelation.WITHIN)), response -> {
-            assertThat(response.getHits().getTotalHits().value, equalTo(2L));
-            assertThat(response.getHits().getHits().length, equalTo(2));
-            assertThat(response.getHits().getAt(0).getId(), not(equalTo("2")));
-            assertThat(response.getHits().getAt(1).getId(), not(equalTo("2")));
-        });
-        assertNoFailuresAndResponse(client().prepareSearch(defaultIndexName)
-            .setQuery(queryBuilder().shapeQuery(defaultFieldName, multiPolygon).relation(ShapeRelation.DISJOINT)), response -> {
-            assertThat(response.getHits().getTotalHits().value, equalTo(1L));
-            assertThat(response.getHits().getHits().length, equalTo(1));
-            assertThat(response.getHits().getAt(0).getId(), equalTo("2"));
-        });
-        assertNoFailuresAndResponse(client().prepareSearch(defaultIndexName)
-            .setQuery(queryBuilder().shapeQuery(defaultFieldName, multiPolygon).relation(ShapeRelation.CONTAINS)), response -> {
-            assertThat(response.getHits().getTotalHits().value, equalTo(0L));
-            assertThat(response.getHits().getHits().length, equalTo(0));
-        });
+        assertNoFailuresAndResponse(
+            client().prepareSearch(defaultIndexName)
+                .setQuery(queryBuilder().shapeQuery(defaultFieldName, multiPolygon).relation(ShapeRelation.INTERSECTS)),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(2L));
+                assertThat(response.getHits().getHits().length, equalTo(2));
+                assertThat(response.getHits().getAt(0).getId(), not(equalTo("2")));
+                assertThat(response.getHits().getAt(1).getId(), not(equalTo("2")));
+            }
+        );
+        assertNoFailuresAndResponse(
+            client().prepareSearch(defaultIndexName)
+                .setQuery(queryBuilder().shapeQuery(defaultFieldName, multiPolygon).relation(ShapeRelation.WITHIN)),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(2L));
+                assertThat(response.getHits().getHits().length, equalTo(2));
+                assertThat(response.getHits().getAt(0).getId(), not(equalTo("2")));
+                assertThat(response.getHits().getAt(1).getId(), not(equalTo("2")));
+            }
+        );
+        assertNoFailuresAndResponse(
+            client().prepareSearch(defaultIndexName)
+                .setQuery(queryBuilder().shapeQuery(defaultFieldName, multiPolygon).relation(ShapeRelation.DISJOINT)),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(1L));
+                assertThat(response.getHits().getHits().length, equalTo(1));
+                assertThat(response.getHits().getAt(0).getId(), equalTo("2"));
+            }
+        );
+        assertNoFailuresAndResponse(
+            client().prepareSearch(defaultIndexName)
+                .setQuery(queryBuilder().shapeQuery(defaultFieldName, multiPolygon).relation(ShapeRelation.CONTAINS)),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(0L));
+                assertThat(response.getHits().getHits().length, equalTo(0));
+            }
+        );
     }
 
     public void testIndexPointsRectangle() throws Exception {
@@ -259,12 +279,15 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
 
         Rectangle rectangle = new Rectangle(-50, -40, -45, -55);
 
-        assertNoFailuresAndResponse(client().prepareSearch(defaultIndexName)
-            .setQuery(queryBuilder().shapeQuery(defaultFieldName, rectangle).relation(ShapeRelation.INTERSECTS)), response -> {
-            assertThat(response.getHits().getTotalHits().value, equalTo(1L));
-            assertThat(response.getHits().getHits().length, equalTo(1));
-            assertThat(response.getHits().getAt(0).getId(), equalTo("2"));
-        });
+        assertNoFailuresAndResponse(
+            client().prepareSearch(defaultIndexName)
+                .setQuery(queryBuilder().shapeQuery(defaultFieldName, rectangle).relation(ShapeRelation.INTERSECTS)),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(1L));
+                assertThat(response.getHits().getHits().length, equalTo(1));
+                assertThat(response.getHits().getAt(0).getId(), equalTo("2"));
+            }
+        );
     }
 
     public void testIndexPointsIndexedRectangle() throws Exception {
@@ -310,25 +333,31 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
             .setRefreshPolicy(IMMEDIATE)
             .get();
 
-        assertNoFailuresAndResponse(client().prepareSearch(defaultIndexName)
-            .setQuery(
-                queryBuilder().shapeQuery(defaultFieldName, "shape1")
-                    .relation(ShapeRelation.INTERSECTS)
-                    .indexedShapeIndex(indexedShapeIndex)
-                    .indexedShapePath(indexedShapePath)
-            ), response -> {
-            assertThat(response.getHits().getTotalHits().value, equalTo(1L));
-            assertThat(response.getHits().getHits().length, equalTo(1));
-            assertThat(response.getHits().getAt(0).getId(), equalTo("point2"));
-        });
+        assertNoFailuresAndResponse(
+            client().prepareSearch(defaultIndexName)
+                .setQuery(
+                    queryBuilder().shapeQuery(defaultFieldName, "shape1")
+                        .relation(ShapeRelation.INTERSECTS)
+                        .indexedShapeIndex(indexedShapeIndex)
+                        .indexedShapePath(indexedShapePath)
+                ),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(1L));
+                assertThat(response.getHits().getHits().length, equalTo(1));
+                assertThat(response.getHits().getAt(0).getId(), equalTo("point2"));
+            }
+        );
 
-        assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName)
-            .setQuery(
-                queryBuilder().shapeQuery(defaultFieldName, "shape2")
-                    .relation(ShapeRelation.INTERSECTS)
-                    .indexedShapeIndex(indexedShapeIndex)
-                    .indexedShapePath(indexedShapePath)
-            ), 0L);
+        assertHitCountAndNoFailures(
+            client().prepareSearch(defaultIndexName)
+                .setQuery(
+                    queryBuilder().shapeQuery(defaultFieldName, "shape2")
+                        .relation(ShapeRelation.INTERSECTS)
+                        .indexedShapeIndex(indexedShapeIndex)
+                        .indexedShapePath(indexedShapePath)
+                ),
+            0L
+        );
     }
 
     public void testWithInQueryLine() throws Exception {
@@ -395,17 +424,28 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
 
         Point point = new Point(-35, -25);
 
-        assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName)
-            .setQuery(queryBuilder().shapeQuery(defaultFieldName, point)), 1L);
+        assertHitCountAndNoFailures(
+            client().prepareSearch(defaultIndexName).setQuery(queryBuilder().shapeQuery(defaultFieldName, point)),
+            1L
+        );
 
-        assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName)
-            .setQuery(queryBuilder().shapeQuery(defaultFieldName, point).relation(ShapeRelation.WITHIN)), 1L);
+        assertHitCountAndNoFailures(
+            client().prepareSearch(defaultIndexName)
+                .setQuery(queryBuilder().shapeQuery(defaultFieldName, point).relation(ShapeRelation.WITHIN)),
+            1L
+        );
 
-        assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName)
-            .setQuery(queryBuilder().shapeQuery(defaultFieldName, point).relation(ShapeRelation.CONTAINS)), 1L);
+        assertHitCountAndNoFailures(
+            client().prepareSearch(defaultIndexName)
+                .setQuery(queryBuilder().shapeQuery(defaultFieldName, point).relation(ShapeRelation.CONTAINS)),
+            1L
+        );
 
-        assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName)
-            .setQuery(queryBuilder().shapeQuery(defaultFieldName, point).relation(ShapeRelation.DISJOINT)), 0L);
+        assertHitCountAndNoFailures(
+            client().prepareSearch(defaultIndexName)
+                .setQuery(queryBuilder().shapeQuery(defaultFieldName, point).relation(ShapeRelation.DISJOINT)),
+            0L
+        );
     }
 
     public void testQueryMultiPoint() throws Exception {
@@ -420,17 +460,28 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
 
         MultiPoint multiPoint = new MultiPoint(List.of(new Point(-35, -25), new Point(-15, -5)));
 
-        assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName)
-            .setQuery(queryBuilder().shapeQuery(defaultFieldName, multiPoint)), 1L);
+        assertHitCountAndNoFailures(
+            client().prepareSearch(defaultIndexName).setQuery(queryBuilder().shapeQuery(defaultFieldName, multiPoint)),
+            1L
+        );
 
-        assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName)
-            .setQuery(queryBuilder().shapeQuery(defaultFieldName, multiPoint).relation(ShapeRelation.WITHIN)), 1L);
+        assertHitCountAndNoFailures(
+            client().prepareSearch(defaultIndexName)
+                .setQuery(queryBuilder().shapeQuery(defaultFieldName, multiPoint).relation(ShapeRelation.WITHIN)),
+            1L
+        );
 
-        assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName)
-            .setQuery(queryBuilder().shapeQuery(defaultFieldName, multiPoint).relation(ShapeRelation.CONTAINS)), 0L);
+        assertHitCountAndNoFailures(
+            client().prepareSearch(defaultIndexName)
+                .setQuery(queryBuilder().shapeQuery(defaultFieldName, multiPoint).relation(ShapeRelation.CONTAINS)),
+            0L
+        );
 
-        assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName)
-            .setQuery(queryBuilder().shapeQuery(defaultFieldName, multiPoint).relation(ShapeRelation.DISJOINT)), 0L);
+        assertHitCountAndNoFailures(
+            client().prepareSearch(defaultIndexName)
+                .setQuery(queryBuilder().shapeQuery(defaultFieldName, multiPoint).relation(ShapeRelation.DISJOINT)),
+            0L
+        );
     }
 
     public void testQueryPointFromGeoJSON() throws Exception {
@@ -448,17 +499,28 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
 
         Point point = new Point(-35, -25);
 
-        assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName)
-            .setQuery(queryBuilder().shapeQuery(defaultFieldName, point)), 1L);
+        assertHitCountAndNoFailures(
+            client().prepareSearch(defaultIndexName).setQuery(queryBuilder().shapeQuery(defaultFieldName, point)),
+            1L
+        );
 
-        assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName)
-            .setQuery(queryBuilder().shapeQuery(defaultFieldName, point).relation(ShapeRelation.WITHIN)), 1L);
+        assertHitCountAndNoFailures(
+            client().prepareSearch(defaultIndexName)
+                .setQuery(queryBuilder().shapeQuery(defaultFieldName, point).relation(ShapeRelation.WITHIN)),
+            1L
+        );
 
-        assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName)
-            .setQuery(queryBuilder().shapeQuery(defaultFieldName, point).relation(ShapeRelation.CONTAINS)), 1L);
+        assertHitCountAndNoFailures(
+            client().prepareSearch(defaultIndexName)
+                .setQuery(queryBuilder().shapeQuery(defaultFieldName, point).relation(ShapeRelation.CONTAINS)),
+            1L
+        );
 
-        assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName)
-            .setQuery(queryBuilder().shapeQuery(defaultFieldName, point).relation(ShapeRelation.DISJOINT)), 0L);
+        assertHitCountAndNoFailures(
+            client().prepareSearch(defaultIndexName)
+                .setQuery(queryBuilder().shapeQuery(defaultFieldName, point).relation(ShapeRelation.DISJOINT)),
+            0L
+        );
 
     }
 
@@ -496,21 +558,33 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
             int expectedDocs = point.equals(pointInvalid) ? 0 : 1;
             int disjointDocs = point.equals(pointInvalid) ? 1 : 0;
 
-            assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName)
-                .setTrackTotalHits(true)
-                .setQuery(queryBuilder().shapeQuery(defaultFieldName, point)), expectedDocs);
+            assertHitCountAndNoFailures(
+                client().prepareSearch(defaultIndexName)
+                    .setTrackTotalHits(true)
+                    .setQuery(queryBuilder().shapeQuery(defaultFieldName, point)),
+                expectedDocs
+            );
 
-            assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName)
-                .setTrackTotalHits(true)
-                .setQuery(queryBuilder().shapeQuery(defaultFieldName, point).relation(ShapeRelation.WITHIN)), 0L);
+            assertHitCountAndNoFailures(
+                client().prepareSearch(defaultIndexName)
+                    .setTrackTotalHits(true)
+                    .setQuery(queryBuilder().shapeQuery(defaultFieldName, point).relation(ShapeRelation.WITHIN)),
+                0L
+            );
 
-            assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName)
-                .setTrackTotalHits(true)
-                .setQuery(queryBuilder().shapeQuery(defaultFieldName, point).relation(ShapeRelation.CONTAINS)), expectedDocs);
+            assertHitCountAndNoFailures(
+                client().prepareSearch(defaultIndexName)
+                    .setTrackTotalHits(true)
+                    .setQuery(queryBuilder().shapeQuery(defaultFieldName, point).relation(ShapeRelation.CONTAINS)),
+                expectedDocs
+            );
 
-            assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName)
-                .setTrackTotalHits(true)
-                .setQuery(queryBuilder().shapeQuery(defaultFieldName, point).relation(ShapeRelation.DISJOINT)), disjointDocs);
+            assertHitCountAndNoFailures(
+                client().prepareSearch(defaultIndexName)
+                    .setTrackTotalHits(true)
+                    .setQuery(queryBuilder().shapeQuery(defaultFieldName, point).relation(ShapeRelation.DISJOINT)),
+                disjointDocs
+            );
         }
     }
 
@@ -530,9 +604,12 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
         }
         client().admin().indices().prepareRefresh(defaultIndexName).get();
         // all points from a line intersect with the line
-        assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName)
-            .setTrackTotalHits(true)
-            .setQuery(queryBuilder().shapeQuery(defaultFieldName, line).relation(ShapeRelation.INTERSECTS)), line.length());
+        assertHitCountAndNoFailures(
+            client().prepareSearch(defaultIndexName)
+                .setTrackTotalHits(true)
+                .setQuery(queryBuilder().shapeQuery(defaultFieldName, line).relation(ShapeRelation.INTERSECTS)),
+            line.length()
+        );
     }
 
     public void testIndexPointsFromPolygon() throws Exception {
@@ -552,9 +629,12 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
         }
         client().admin().indices().prepareRefresh(defaultIndexName).get();
         // all points from a polygon intersect with the polygon
-        assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName)
-            .setTrackTotalHits(true)
-            .setQuery(queryBuilder().shapeQuery(defaultFieldName, polygon).relation(ShapeRelation.INTERSECTS)), linearRing.length());
+        assertHitCountAndNoFailures(
+            client().prepareSearch(defaultIndexName)
+                .setTrackTotalHits(true)
+                .setQuery(queryBuilder().shapeQuery(defaultFieldName, polygon).relation(ShapeRelation.INTERSECTS)),
+            linearRing.length()
+        );
     }
 
     /** Only LegacyGeoShape has limited support, so other tests will ignore nothing */

--- a/test/framework/src/main/java/org/elasticsearch/search/geo/BasePointShapeQueryTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/geo/BasePointShapeQueryTestCase.java
@@ -11,7 +11,6 @@ package org.elasticsearch.search.geo;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.geo.GeoJson;
 import org.elasticsearch.common.geo.GeometryNormalizer;
@@ -47,7 +46,8 @@ import java.util.List;
 import java.util.Map;
 
 import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCountAndNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -111,22 +111,19 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
             .get();
 
         Geometry geometry = new Rectangle(-45, 45, 45, -45);
-        SearchResponse searchResponse = client().prepareSearch(defaultIndexName)
-            .setQuery(queryBuilder().shapeQuery(defaultFieldName, geometry).relation(ShapeRelation.INTERSECTS))
-            .get();
-
-        assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
-        assertThat(searchResponse.getHits().getHits().length, equalTo(1));
-        assertThat(searchResponse.getHits().getAt(0).getId(), equalTo("1"));
-
+        assertNoFailuresAndResponse(client().prepareSearch(defaultIndexName)
+            .setQuery(queryBuilder().shapeQuery(defaultFieldName, geometry).relation(ShapeRelation.INTERSECTS)), response -> {
+            assertThat(response.getHits().getTotalHits().value, equalTo(1L));
+            assertThat(response.getHits().getHits().length, equalTo(1));
+            assertThat(response.getHits().getAt(0).getId(), equalTo("1"));
+        });
         // default query, without specifying relation (expect intersects)
-        searchResponse = client().prepareSearch(defaultIndexName).setQuery(queryBuilder().shapeQuery(defaultFieldName, geometry)).get();
-
-        assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
-        assertThat(searchResponse.getHits().getHits().length, equalTo(1));
-        assertThat(searchResponse.getHits().getAt(0).getId(), equalTo("1"));
+        assertNoFailuresAndResponse(client().prepareSearch(defaultIndexName)
+                .setQuery(queryBuilder().shapeQuery(defaultFieldName, geometry)), response -> {
+            assertThat(response.getHits().getTotalHits().value, equalTo(1L));
+            assertThat(response.getHits().getHits().length, equalTo(1));
+            assertThat(response.getHits().getAt(0).getId(), equalTo("1"));
+        });
     }
 
     public void testIndexPointsCircle() throws Exception {
@@ -177,14 +174,12 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
 
         Polygon polygon = new Polygon(new LinearRing(new double[] { -35, -35, -25, -25, -35 }, new double[] { -35, -25, -25, -35, -35 }));
 
-        SearchResponse searchResponse = client().prepareSearch(defaultIndexName)
-            .setQuery(queryBuilder().shapeQuery(defaultFieldName, polygon).relation(ShapeRelation.INTERSECTS))
-            .get();
-
-        assertNoFailures(searchResponse);
-        SearchHits searchHits = searchResponse.getHits();
-        assertThat(searchHits.getTotalHits().value, equalTo(1L));
-        assertThat(searchHits.getAt(0).getId(), equalTo("1"));
+        assertNoFailuresAndResponse(client().prepareSearch(defaultIndexName)
+            .setQuery(queryBuilder().shapeQuery(defaultFieldName, polygon).relation(ShapeRelation.INTERSECTS)), response -> {
+            SearchHits searchHits = response.getHits();
+            assertThat(searchHits.getTotalHits().value, equalTo(1L));
+            assertThat(searchHits.getAt(0).getId(), equalTo("1"));
+        });
     }
 
     public void testIndexPointsMultiPolygon() throws Exception {
@@ -218,47 +213,32 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
         );
 
         MultiPolygon multiPolygon = new MultiPolygon(List.of(encloseDocument1Cb, encloseDocument2Cb));
-        {
-            SearchResponse searchResponse = client().prepareSearch(defaultIndexName)
-                .setQuery(queryBuilder().shapeQuery(defaultFieldName, multiPolygon).relation(ShapeRelation.INTERSECTS))
-                .get();
 
-            assertNoFailures(searchResponse);
-            assertThat(searchResponse.getHits().getTotalHits().value, equalTo(2L));
-            assertThat(searchResponse.getHits().getHits().length, equalTo(2));
-            assertThat(searchResponse.getHits().getAt(0).getId(), not(equalTo("2")));
-            assertThat(searchResponse.getHits().getAt(1).getId(), not(equalTo("2")));
-        }
-        {
-            SearchResponse searchResponse = client().prepareSearch(defaultIndexName)
-                .setQuery(queryBuilder().shapeQuery(defaultFieldName, multiPolygon).relation(ShapeRelation.WITHIN))
-                .get();
-
-            assertNoFailures(searchResponse);
-            assertThat(searchResponse.getHits().getTotalHits().value, equalTo(2L));
-            assertThat(searchResponse.getHits().getHits().length, equalTo(2));
-            assertThat(searchResponse.getHits().getAt(0).getId(), not(equalTo("2")));
-            assertThat(searchResponse.getHits().getAt(1).getId(), not(equalTo("2")));
-        }
-        {
-            SearchResponse searchResponse = client().prepareSearch(defaultIndexName)
-                .setQuery(queryBuilder().shapeQuery(defaultFieldName, multiPolygon).relation(ShapeRelation.DISJOINT))
-                .get();
-
-            assertNoFailures(searchResponse);
-            assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
-            assertThat(searchResponse.getHits().getHits().length, equalTo(1));
-            assertThat(searchResponse.getHits().getAt(0).getId(), equalTo("2"));
-        }
-        {
-            SearchResponse searchResponse = client().prepareSearch(defaultIndexName)
-                .setQuery(queryBuilder().shapeQuery(defaultFieldName, multiPolygon).relation(ShapeRelation.CONTAINS))
-                .get();
-
-            assertNoFailures(searchResponse);
-            assertThat(searchResponse.getHits().getTotalHits().value, equalTo(0L));
-            assertThat(searchResponse.getHits().getHits().length, equalTo(0));
-        }
+        assertNoFailuresAndResponse(client().prepareSearch(defaultIndexName)
+            .setQuery(queryBuilder().shapeQuery(defaultFieldName, multiPolygon).relation(ShapeRelation.INTERSECTS)), response -> {
+            assertThat(response.getHits().getTotalHits().value, equalTo(2L));
+            assertThat(response.getHits().getHits().length, equalTo(2));
+            assertThat(response.getHits().getAt(0).getId(), not(equalTo("2")));
+            assertThat(response.getHits().getAt(1).getId(), not(equalTo("2")));
+        });
+        assertNoFailuresAndResponse(client().prepareSearch(defaultIndexName)
+            .setQuery(queryBuilder().shapeQuery(defaultFieldName, multiPolygon).relation(ShapeRelation.WITHIN)), response -> {
+            assertThat(response.getHits().getTotalHits().value, equalTo(2L));
+            assertThat(response.getHits().getHits().length, equalTo(2));
+            assertThat(response.getHits().getAt(0).getId(), not(equalTo("2")));
+            assertThat(response.getHits().getAt(1).getId(), not(equalTo("2")));
+        });
+        assertNoFailuresAndResponse(client().prepareSearch(defaultIndexName)
+            .setQuery(queryBuilder().shapeQuery(defaultFieldName, multiPolygon).relation(ShapeRelation.DISJOINT)), response -> {
+            assertThat(response.getHits().getTotalHits().value, equalTo(1L));
+            assertThat(response.getHits().getHits().length, equalTo(1));
+            assertThat(response.getHits().getAt(0).getId(), equalTo("2"));
+        });
+        assertNoFailuresAndResponse(client().prepareSearch(defaultIndexName)
+            .setQuery(queryBuilder().shapeQuery(defaultFieldName, multiPolygon).relation(ShapeRelation.CONTAINS)), response -> {
+            assertThat(response.getHits().getTotalHits().value, equalTo(0L));
+            assertThat(response.getHits().getHits().length, equalTo(0));
+        });
     }
 
     public void testIndexPointsRectangle() throws Exception {
@@ -279,14 +259,12 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
 
         Rectangle rectangle = new Rectangle(-50, -40, -45, -55);
 
-        SearchResponse searchResponse = client().prepareSearch(defaultIndexName)
-            .setQuery(queryBuilder().shapeQuery(defaultFieldName, rectangle).relation(ShapeRelation.INTERSECTS))
-            .get();
-
-        assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
-        assertThat(searchResponse.getHits().getHits().length, equalTo(1));
-        assertThat(searchResponse.getHits().getAt(0).getId(), equalTo("2"));
+        assertNoFailuresAndResponse(client().prepareSearch(defaultIndexName)
+            .setQuery(queryBuilder().shapeQuery(defaultFieldName, rectangle).relation(ShapeRelation.INTERSECTS)), response -> {
+            assertThat(response.getHits().getTotalHits().value, equalTo(1L));
+            assertThat(response.getHits().getHits().length, equalTo(1));
+            assertThat(response.getHits().getAt(0).getId(), equalTo("2"));
+        });
     }
 
     public void testIndexPointsIndexedRectangle() throws Exception {
@@ -332,30 +310,25 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
             .setRefreshPolicy(IMMEDIATE)
             .get();
 
-        SearchResponse searchResponse = client().prepareSearch(defaultIndexName)
+        assertNoFailuresAndResponse(client().prepareSearch(defaultIndexName)
             .setQuery(
                 queryBuilder().shapeQuery(defaultFieldName, "shape1")
                     .relation(ShapeRelation.INTERSECTS)
                     .indexedShapeIndex(indexedShapeIndex)
                     .indexedShapePath(indexedShapePath)
-            )
-            .get();
+            ), response -> {
+            assertThat(response.getHits().getTotalHits().value, equalTo(1L));
+            assertThat(response.getHits().getHits().length, equalTo(1));
+            assertThat(response.getHits().getAt(0).getId(), equalTo("point2"));
+        });
 
-        assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
-        assertThat(searchResponse.getHits().getHits().length, equalTo(1));
-        assertThat(searchResponse.getHits().getAt(0).getId(), equalTo("point2"));
-
-        searchResponse = client().prepareSearch(defaultIndexName)
+        assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName)
             .setQuery(
                 queryBuilder().shapeQuery(defaultFieldName, "shape2")
                     .relation(ShapeRelation.INTERSECTS)
                     .indexedShapeIndex(indexedShapeIndex)
                     .indexedShapePath(indexedShapePath)
-            )
-            .get();
-        assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(0L));
+            ), 0L);
     }
 
     public void testWithInQueryLine() throws Exception {
@@ -421,34 +394,18 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
             .get();
 
         Point point = new Point(-35, -25);
-        {
-            SearchResponse response = client().prepareSearch(defaultIndexName)
-                .setQuery(queryBuilder().shapeQuery(defaultFieldName, point))
-                .get();
-            SearchHits searchHits = response.getHits();
-            assertEquals(1, searchHits.getTotalHits().value);
-        }
-        {
-            SearchResponse response = client().prepareSearch(defaultIndexName)
-                .setQuery(queryBuilder().shapeQuery(defaultFieldName, point).relation(ShapeRelation.WITHIN))
-                .get();
-            SearchHits searchHits = response.getHits();
-            assertEquals(1, searchHits.getTotalHits().value);
-        }
-        {
-            SearchResponse response = client().prepareSearch(defaultIndexName)
-                .setQuery(queryBuilder().shapeQuery(defaultFieldName, point).relation(ShapeRelation.CONTAINS))
-                .get();
-            SearchHits searchHits = response.getHits();
-            assertEquals(1, searchHits.getTotalHits().value);
-        }
-        {
-            SearchResponse response = client().prepareSearch(defaultIndexName)
-                .setQuery(queryBuilder().shapeQuery(defaultFieldName, point).relation(ShapeRelation.DISJOINT))
-                .get();
-            SearchHits searchHits = response.getHits();
-            assertEquals(0, searchHits.getTotalHits().value);
-        }
+
+        assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName)
+            .setQuery(queryBuilder().shapeQuery(defaultFieldName, point)), 1L);
+
+        assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName)
+            .setQuery(queryBuilder().shapeQuery(defaultFieldName, point).relation(ShapeRelation.WITHIN)), 1L);
+
+        assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName)
+            .setQuery(queryBuilder().shapeQuery(defaultFieldName, point).relation(ShapeRelation.CONTAINS)), 1L);
+
+        assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName)
+            .setQuery(queryBuilder().shapeQuery(defaultFieldName, point).relation(ShapeRelation.DISJOINT)), 0L);
     }
 
     public void testQueryMultiPoint() throws Exception {
@@ -463,34 +420,17 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
 
         MultiPoint multiPoint = new MultiPoint(List.of(new Point(-35, -25), new Point(-15, -5)));
 
-        {
-            SearchResponse response = client().prepareSearch(defaultIndexName)
-                .setQuery(queryBuilder().shapeQuery(defaultFieldName, multiPoint))
-                .get();
-            SearchHits searchHits = response.getHits();
-            assertEquals(1, searchHits.getTotalHits().value);
-        }
-        {
-            SearchResponse response = client().prepareSearch(defaultIndexName)
-                .setQuery(queryBuilder().shapeQuery(defaultFieldName, multiPoint).relation(ShapeRelation.WITHIN))
-                .get();
-            SearchHits searchHits = response.getHits();
-            assertEquals(1, searchHits.getTotalHits().value);
-        }
-        {
-            SearchResponse response = client().prepareSearch(defaultIndexName)
-                .setQuery(queryBuilder().shapeQuery(defaultFieldName, multiPoint).relation(ShapeRelation.CONTAINS))
-                .get();
-            SearchHits searchHits = response.getHits();
-            assertEquals(0, searchHits.getTotalHits().value);
-        }
-        {
-            SearchResponse response = client().prepareSearch(defaultIndexName)
-                .setQuery(queryBuilder().shapeQuery(defaultFieldName, multiPoint).relation(ShapeRelation.DISJOINT))
-                .get();
-            SearchHits searchHits = response.getHits();
-            assertEquals(0, searchHits.getTotalHits().value);
-        }
+        assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName)
+            .setQuery(queryBuilder().shapeQuery(defaultFieldName, multiPoint)), 1L);
+
+        assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName)
+            .setQuery(queryBuilder().shapeQuery(defaultFieldName, multiPoint).relation(ShapeRelation.WITHIN)), 1L);
+
+        assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName)
+            .setQuery(queryBuilder().shapeQuery(defaultFieldName, multiPoint).relation(ShapeRelation.CONTAINS)), 0L);
+
+        assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName)
+            .setQuery(queryBuilder().shapeQuery(defaultFieldName, multiPoint).relation(ShapeRelation.DISJOINT)), 0L);
     }
 
     public void testQueryPointFromGeoJSON() throws Exception {
@@ -507,34 +447,19 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
         client().index(new IndexRequest(defaultIndexName).id("1").source(doc1, XContentType.JSON).setRefreshPolicy(IMMEDIATE)).actionGet();
 
         Point point = new Point(-35, -25);
-        {
-            SearchResponse response = client().prepareSearch(defaultIndexName)
-                .setQuery(queryBuilder().shapeQuery(defaultFieldName, point))
-                .get();
-            SearchHits searchHits = response.getHits();
-            assertEquals(1, searchHits.getTotalHits().value);
-        }
-        {
-            SearchResponse response = client().prepareSearch(defaultIndexName)
-                .setQuery(queryBuilder().shapeQuery(defaultFieldName, point).relation(ShapeRelation.WITHIN))
-                .get();
-            SearchHits searchHits = response.getHits();
-            assertEquals(1, searchHits.getTotalHits().value);
-        }
-        {
-            SearchResponse response = client().prepareSearch(defaultIndexName)
-                .setQuery(queryBuilder().shapeQuery(defaultFieldName, point).relation(ShapeRelation.CONTAINS))
-                .get();
-            SearchHits searchHits = response.getHits();
-            assertEquals(1, searchHits.getTotalHits().value);
-        }
-        {
-            SearchResponse response = client().prepareSearch(defaultIndexName)
-                .setQuery(queryBuilder().shapeQuery(defaultFieldName, point).relation(ShapeRelation.DISJOINT))
-                .get();
-            SearchHits searchHits = response.getHits();
-            assertEquals(0, searchHits.getTotalHits().value);
-        }
+
+        assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName)
+            .setQuery(queryBuilder().shapeQuery(defaultFieldName, point)), 1L);
+
+        assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName)
+            .setQuery(queryBuilder().shapeQuery(defaultFieldName, point).relation(ShapeRelation.WITHIN)), 1L);
+
+        assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName)
+            .setQuery(queryBuilder().shapeQuery(defaultFieldName, point).relation(ShapeRelation.CONTAINS)), 1L);
+
+        assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName)
+            .setQuery(queryBuilder().shapeQuery(defaultFieldName, point).relation(ShapeRelation.DISJOINT)), 0L);
+
     }
 
     /**
@@ -570,34 +495,22 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
         for (Point point : new Point[] { pointA, pointB, pointC, pointD, pointInvalid }) {
             int expectedDocs = point.equals(pointInvalid) ? 0 : 1;
             int disjointDocs = point.equals(pointInvalid) ? 1 : 0;
-            {
-                SearchResponse response = client().prepareSearch(defaultIndexName)
-                    .setQuery(queryBuilder().shapeQuery(defaultFieldName, point))
-                    .get();
-                SearchHits searchHits = response.getHits();
-                assertEquals("Doc matches %s" + point, expectedDocs, searchHits.getTotalHits().value);
-            }
-            {
-                SearchResponse response = client().prepareSearch(defaultIndexName)
-                    .setQuery(queryBuilder().shapeQuery(defaultFieldName, point).relation(ShapeRelation.WITHIN))
-                    .get();
-                SearchHits searchHits = response.getHits();
-                assertEquals("Doc WITHIN %s" + point, 0, searchHits.getTotalHits().value);
-            }
-            {
-                SearchResponse response = client().prepareSearch(defaultIndexName)
-                    .setQuery(queryBuilder().shapeQuery(defaultFieldName, point).relation(ShapeRelation.CONTAINS))
-                    .get();
-                SearchHits searchHits = response.getHits();
-                assertEquals("Doc CONTAINS %s" + point, expectedDocs, searchHits.getTotalHits().value);
-            }
-            {
-                SearchResponse response = client().prepareSearch(defaultIndexName)
-                    .setQuery(queryBuilder().shapeQuery(defaultFieldName, point).relation(ShapeRelation.DISJOINT))
-                    .get();
-                SearchHits searchHits = response.getHits();
-                assertEquals("Doc DISJOINT with %s" + point, disjointDocs, searchHits.getTotalHits().value);
-            }
+
+            assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName)
+                .setTrackTotalHits(true)
+                .setQuery(queryBuilder().shapeQuery(defaultFieldName, point)), expectedDocs);
+
+            assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName)
+                .setTrackTotalHits(true)
+                .setQuery(queryBuilder().shapeQuery(defaultFieldName, point).relation(ShapeRelation.WITHIN)), 0L);
+
+            assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName)
+                .setTrackTotalHits(true)
+                .setQuery(queryBuilder().shapeQuery(defaultFieldName, point).relation(ShapeRelation.CONTAINS)), expectedDocs);
+
+            assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName)
+                .setTrackTotalHits(true)
+                .setQuery(queryBuilder().shapeQuery(defaultFieldName, point).relation(ShapeRelation.DISJOINT)), disjointDocs);
         }
     }
 
@@ -617,13 +530,9 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
         }
         client().admin().indices().prepareRefresh(defaultIndexName).get();
         // all points from a line intersect with the line
-        SearchResponse searchResponse = client().prepareSearch(defaultIndexName)
+        assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName)
             .setTrackTotalHits(true)
-            .setQuery(queryBuilder().shapeQuery(defaultFieldName, line).relation(ShapeRelation.INTERSECTS))
-            .get();
-        assertNoFailures(searchResponse);
-        SearchHits searchHits = searchResponse.getHits();
-        assertThat(searchHits.getTotalHits().value, equalTo((long) line.length()));
+            .setQuery(queryBuilder().shapeQuery(defaultFieldName, line).relation(ShapeRelation.INTERSECTS)), line.length());
     }
 
     public void testIndexPointsFromPolygon() throws Exception {
@@ -643,13 +552,9 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
         }
         client().admin().indices().prepareRefresh(defaultIndexName).get();
         // all points from a polygon intersect with the polygon
-        SearchResponse searchResponse = client().prepareSearch(defaultIndexName)
+        assertHitCountAndNoFailures(client().prepareSearch(defaultIndexName)
             .setTrackTotalHits(true)
-            .setQuery(queryBuilder().shapeQuery(defaultFieldName, polygon).relation(ShapeRelation.INTERSECTS))
-            .get();
-        assertNoFailures(searchResponse);
-        SearchHits searchHits = searchResponse.getHits();
-        assertThat(searchHits.getTotalHits().value, equalTo((long) linearRing.length()));
+            .setQuery(queryBuilder().shapeQuery(defaultFieldName, polygon).relation(ShapeRelation.INTERSECTS)), linearRing.length());
     }
 
     /** Only LegacyGeoShape has limited support, so other tests will ignore nothing */

--- a/test/framework/src/main/java/org/elasticsearch/search/geo/DatelinePointShapeQueryTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/geo/DatelinePointShapeQueryTestCase.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.search.geo;
 
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.geometry.LinearRing;
 import org.elasticsearch.geometry.MultiPolygon;
@@ -18,12 +17,14 @@ import org.elasticsearch.index.query.GeoShapeQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.SearchHits;
 
+
 import java.util.List;
 
 import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 
 /**
  * Some tests are specific to geographic test cases, notably those involving special behaviour
@@ -65,11 +66,12 @@ public class DatelinePointShapeQueryTestCase {
         Rectangle rectangle = new Rectangle(169, -178, 1, -1);
 
         GeoShapeQueryBuilder geoShapeQueryBuilder = QueryBuilders.geoShapeQuery(defaultFieldName, rectangle);
-        SearchResponse response = tests.client().prepareSearch(defaultIndexName).setQuery(geoShapeQueryBuilder).get();
-        SearchHits searchHits = response.getHits();
-        assertEquals(2, searchHits.getTotalHits().value);
-        assertNotEquals("1", searchHits.getAt(0).getId());
-        assertNotEquals("1", searchHits.getAt(1).getId());
+        assertResponse(tests.client().prepareSearch(defaultIndexName).setQuery(geoShapeQueryBuilder), response -> {
+            SearchHits searchHits = response.getHits();
+            assertEquals(2, searchHits.getTotalHits().value);
+            assertNotEquals("1", searchHits.getAt(0).getId());
+            assertNotEquals("1", searchHits.getAt(1).getId());
+        });
     }
 
     public void testPolygonSpanningDateline(BasePointShapeQueryTestCase<GeoShapeQueryBuilder> tests) throws Exception {
@@ -108,13 +110,14 @@ public class DatelinePointShapeQueryTestCase {
 
         GeoShapeQueryBuilder geoShapeQueryBuilder = QueryBuilders.geoShapeQuery(defaultFieldName, polygon);
         geoShapeQueryBuilder.relation(ShapeRelation.INTERSECTS);
-        SearchResponse response = tests.client().prepareSearch(defaultIndexName).setQuery(geoShapeQueryBuilder).get();
-        SearchHits searchHits = response.getHits();
-        assertEquals(2, searchHits.getTotalHits().value);
-        assertNotEquals("1", searchHits.getAt(0).getId());
-        assertNotEquals("4", searchHits.getAt(0).getId());
-        assertNotEquals("1", searchHits.getAt(1).getId());
-        assertNotEquals("4", searchHits.getAt(1).getId());
+        assertResponse(tests.client().prepareSearch(defaultIndexName).setQuery(geoShapeQueryBuilder), response -> {
+            SearchHits searchHits = response.getHits();
+            assertEquals(2, searchHits.getTotalHits().value);
+            assertNotEquals("1", searchHits.getAt(0).getId());
+            assertNotEquals("4", searchHits.getAt(0).getId());
+            assertNotEquals("1", searchHits.getAt(1).getId());
+            assertNotEquals("4", searchHits.getAt(1).getId());
+        });
     }
 
     public void testMultiPolygonSpanningDateline(BasePointShapeQueryTestCase<GeoShapeQueryBuilder> tests) throws Exception {
@@ -150,10 +153,11 @@ public class DatelinePointShapeQueryTestCase {
 
         GeoShapeQueryBuilder geoShapeQueryBuilder = QueryBuilders.geoShapeQuery(defaultFieldName, multiPolygon);
         geoShapeQueryBuilder.relation(ShapeRelation.INTERSECTS);
-        SearchResponse response = tests.client().prepareSearch(defaultIndexName).setQuery(geoShapeQueryBuilder).get();
-        SearchHits searchHits = response.getHits();
-        assertEquals(2, searchHits.getTotalHits().value);
-        assertNotEquals("3", searchHits.getAt(0).getId());
-        assertNotEquals("3", searchHits.getAt(1).getId());
+        assertResponse(tests.client().prepareSearch(defaultIndexName).setQuery(geoShapeQueryBuilder), response -> {
+            SearchHits searchHits = response.getHits();
+            assertEquals(2, searchHits.getTotalHits().value);
+            assertNotEquals("3", searchHits.getAt(0).getId());
+            assertNotEquals("3", searchHits.getAt(1).getId());
+        });
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/search/geo/DatelinePointShapeQueryTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/geo/DatelinePointShapeQueryTestCase.java
@@ -17,14 +17,13 @@ import org.elasticsearch.index.query.GeoShapeQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.SearchHits;
 
-
 import java.util.List;
 
 import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 
 /**
  * Some tests are specific to geographic test cases, notably those involving special behaviour

--- a/test/framework/src/main/java/org/elasticsearch/search/geo/GeoShapeIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/geo/GeoShapeIntegTestCase.java
@@ -71,22 +71,24 @@ public abstract class GeoShapeIntegTestCase extends BaseShapeIntegTestCase<GeoSh
             53
         );
 
-        assertResponse(prepareSearch().addStoredField("pin")
-                .setQuery(geoDistanceQuery("pin").distance("425km").point(51.11, 9.851)), response -> {
-            assertHitCount(response, 5L);
-            GeoPoint point = new GeoPoint();
-            for (SearchHit hit : response.getHits()) {
-                String name = hit.getId();
-                point.resetFromString(hit.getFields().get("pin").getValue());
-                double dist = distance(point.getLat(), point.getLon(), 51.11, 9.851);
+        assertResponse(
+            prepareSearch().addStoredField("pin").setQuery(geoDistanceQuery("pin").distance("425km").point(51.11, 9.851)),
+            response -> {
+                assertHitCount(response, 5L);
+                GeoPoint point = new GeoPoint();
+                for (SearchHit hit : response.getHits()) {
+                    String name = hit.getId();
+                    point.resetFromString(hit.getFields().get("pin").getValue());
+                    double dist = distance(point.getLat(), point.getLon(), 51.11, 9.851);
 
-                assertThat("distance to '" + name + "'", dist, lessThanOrEqualTo(425000d));
-                assertThat(name, anyOf(equalTo("CZ"), equalTo("DE"), equalTo("BE"), equalTo("NL"), equalTo("LU")));
-                if (key.equals(name)) {
-                    assertThat(dist, closeTo(0d, 0.1d));
+                    assertThat("distance to '" + name + "'", dist, lessThanOrEqualTo(425000d));
+                    assertThat(name, anyOf(equalTo("CZ"), equalTo("DE"), equalTo("BE"), equalTo("NL"), equalTo("LU")));
+                    if (key.equals(name)) {
+                        assertThat(dist, closeTo(0d, 0.1d));
+                    }
                 }
             }
-        });
+        );
     }
 
     private static double distance(double lat1, double lon1, double lat2, double lon2) {

--- a/test/framework/src/main/java/org/elasticsearch/search/geo/GeoShapeIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/geo/GeoShapeIntegTestCase.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.search.geo;
 
 import org.apache.lucene.util.SloppyMath;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.geometry.Point;
 import org.elasticsearch.index.query.GeoShapeQueryBuilder;
@@ -22,6 +21,7 @@ import static org.elasticsearch.index.query.QueryBuilders.geoDistanceQuery;
 import static org.elasticsearch.index.query.QueryBuilders.geoShapeQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
@@ -57,17 +57,11 @@ public abstract class GeoShapeIntegTestCase extends BaseShapeIntegTestCase<GeoSh
 
         indexRandom(true, client().prepareIndex("test").setId("0").setSource(source, XContentType.JSON));
 
-        SearchResponse searchResponse = prepareSearch("test").setQuery(geoShapeQuery("shape", new Point(-179.75, 1))).get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
+        assertHitCount(prepareSearch("test").setQuery(geoShapeQuery("shape", new Point(-179.75, 1))), 1L);
+        assertHitCount(prepareSearch("test").setQuery(geoShapeQuery("shape", new Point(90, 1))), 0L);
+        assertHitCount(prepareSearch("test").setQuery(geoShapeQuery("shape", new Point(-180, 1))), 1L);
+        assertHitCount(prepareSearch("test").setQuery(geoShapeQuery("shape", new Point(180, 1))), 1L);
 
-        searchResponse = prepareSearch("test").setQuery(geoShapeQuery("shape", new Point(90, 1))).get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(0L));
-
-        searchResponse = prepareSearch("test").setQuery(geoShapeQuery("shape", new Point(-180, 1))).get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
-
-        searchResponse = prepareSearch("test").setQuery(geoShapeQuery("shape", new Point(180, 1))).get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
     }
 
     /** The testBulk method uses this only for Geo-specific tests */
@@ -77,23 +71,22 @@ public abstract class GeoShapeIntegTestCase extends BaseShapeIntegTestCase<GeoSh
             53
         );
 
-        SearchResponse distance = prepareSearch().addStoredField("pin")
-            .setQuery(geoDistanceQuery("pin").distance("425km").point(51.11, 9.851))
-            .get();
+        assertResponse(prepareSearch().addStoredField("pin")
+                .setQuery(geoDistanceQuery("pin").distance("425km").point(51.11, 9.851)), response -> {
+            assertHitCount(response, 5L);
+            GeoPoint point = new GeoPoint();
+            for (SearchHit hit : response.getHits()) {
+                String name = hit.getId();
+                point.resetFromString(hit.getFields().get("pin").getValue());
+                double dist = distance(point.getLat(), point.getLon(), 51.11, 9.851);
 
-        assertHitCount(distance, 5);
-        GeoPoint point = new GeoPoint();
-        for (SearchHit hit : distance.getHits()) {
-            String name = hit.getId();
-            point.resetFromString(hit.getFields().get("pin").getValue());
-            double dist = distance(point.getLat(), point.getLon(), 51.11, 9.851);
-
-            assertThat("distance to '" + name + "'", dist, lessThanOrEqualTo(425000d));
-            assertThat(name, anyOf(equalTo("CZ"), equalTo("DE"), equalTo("BE"), equalTo("NL"), equalTo("LU")));
-            if (key.equals(name)) {
-                assertThat(dist, closeTo(0d, 0.1d));
+                assertThat("distance to '" + name + "'", dist, lessThanOrEqualTo(425000d));
+                assertThat(name, anyOf(equalTo("CZ"), equalTo("DE"), equalTo("BE"), equalTo("NL"), equalTo("LU")));
+                if (key.equals(name)) {
+                    assertThat(dist, closeTo(0d, 0.1d));
+                }
             }
-        }
+        });
     }
 
     private static double distance(double lat1, double lon1, double lat2, double lon2) {

--- a/test/framework/src/main/java/org/elasticsearch/search/geo/GeoShapeQueryTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/geo/GeoShapeQueryTestCase.java
@@ -10,7 +10,6 @@ package org.elasticsearch.search.geo;
 
 import org.apache.lucene.tests.geo.GeoTestUtil;
 import org.elasticsearch.action.index.IndexRequest;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.CheckedSupplier;
 import org.elasticsearch.common.geo.GeoJson;
 import org.elasticsearch.common.geo.GeometryNormalizer;
@@ -37,6 +36,7 @@ import java.util.List;
 
 import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCountAndNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 
 public abstract class GeoShapeQueryTestCase extends BaseShapeQueryTestCase<GeoShapeQueryBuilder> {
@@ -141,11 +141,11 @@ public abstract class GeoShapeQueryTestCase extends BaseShapeQueryTestCase<GeoSh
                 }
             }
         );
-
-        SearchResponse response = client().prepareSearch(defaultIndexName).setQuery(querySupplier.get()).get();
-        assertEquals(2, response.getHits().getTotalHits().value);
-        assertNotEquals("1", response.getHits().getAt(0).getId());
-        assertNotEquals("1", response.getHits().getAt(1).getId());
+        assertResponse(client().prepareSearch(defaultIndexName).setQuery(querySupplier.get()), response -> {
+            assertEquals(2, response.getHits().getTotalHits().value);
+            assertNotEquals("1", response.getHits().getAt(0).getId());
+            assertNotEquals("1", response.getHits().getAt(1).getId());
+        });
     }
 
     public void testIndexRectangleSpanningDateLine() throws Exception {


### PR DESCRIPTION
Another easy one from this saga. 