### PR TITLE
Unmute PkiAuthDelegationIntegTests

### DIFF
--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/pki/PkiAuthDelegationIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/pki/PkiAuthDelegationIntegTests.java
@@ -149,7 +149,6 @@ public class PkiAuthDelegationIntegTests extends SecurityIntegTestCase {
         new ClearRealmCacheRequestBuilder(client()).get();
     }
 
-    // @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/97772")
     public void testDelegateThenAuthenticate() throws Exception {
         final X509Certificate clientCertificate = readCertForPkiDelegation("testClient.crt");
         final X509Certificate intermediateCA = readCertForPkiDelegation("testIntermediateCA.crt");
@@ -192,7 +191,6 @@ public class PkiAuthDelegationIntegTests extends SecurityIntegTestCase {
         }
     }
 
-    // @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/97772")
     public void testTokenInvalidate() throws Exception {
         final X509Certificate clientCertificate = readCertForPkiDelegation("testClient.crt");
         final X509Certificate intermediateCA = readCertForPkiDelegation("testIntermediateCA.crt");
@@ -296,7 +294,6 @@ public class PkiAuthDelegationIntegTests extends SecurityIntegTestCase {
         }
     }
 
-    // @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/97772")
     public void testDelegatePkiWithRoleMapping() throws Exception {
         X509Certificate clientCertificate = readCertForPkiDelegation("testClient.crt");
         X509Certificate intermediateCA = readCertForPkiDelegation("testIntermediateCA.crt");

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/pki/PkiAuthDelegationIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/pki/PkiAuthDelegationIntegTests.java
@@ -149,7 +149,7 @@ public class PkiAuthDelegationIntegTests extends SecurityIntegTestCase {
         new ClearRealmCacheRequestBuilder(client()).get();
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/97772")
+    // @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/97772")
     public void testDelegateThenAuthenticate() throws Exception {
         final X509Certificate clientCertificate = readCertForPkiDelegation("testClient.crt");
         final X509Certificate intermediateCA = readCertForPkiDelegation("testIntermediateCA.crt");
@@ -192,7 +192,7 @@ public class PkiAuthDelegationIntegTests extends SecurityIntegTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/97772")
+    // @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/97772")
     public void testTokenInvalidate() throws Exception {
         final X509Certificate clientCertificate = readCertForPkiDelegation("testClient.crt");
         final X509Certificate intermediateCA = readCertForPkiDelegation("testIntermediateCA.crt");
@@ -296,7 +296,7 @@ public class PkiAuthDelegationIntegTests extends SecurityIntegTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/97772")
+    // @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/97772")
     public void testDelegatePkiWithRoleMapping() throws Exception {
         X509Certificate clientCertificate = readCertForPkiDelegation("testClient.crt");
         X509Certificate intermediateCA = readCertForPkiDelegation("testIntermediateCA.crt");


### PR DESCRIPTION
These tests were muted both at the suite level as well as at the test level for reasons I don't fully understand, and then were unmuted at one level but not the other. They don't appear to fail after a few thousand runs, so this PR unmutes them the rest of the way.

Closes https://github.com/elastic/elasticsearch/issues/97772