### PR TITLE
Don't fork slices creation in ContextIndexSearcher

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/internal/ContextIndexSearcherTests.java
+++ b/server/src/test/java/org/elasticsearch/search/internal/ContextIndexSearcherTests.java
@@ -564,7 +564,7 @@ public class ContextIndexSearcherTests extends ESTestCase {
                         1
                     )
                 ) {
-                    leafSlices = contextIndexSearcher.getSlicesForCollection();
+                    leafSlices = contextIndexSearcher.getSlices();
                     int numThrowingLeafSlices = randomIntBetween(1, 3);
                     for (int i = 0; i < numThrowingLeafSlices; i++) {
                         LeafSlice throwingLeafSlice = leafSlices[randomIntBetween(0, Math.min(leafSlices.length, numAvailableThreads) - 1)];
@@ -700,7 +700,7 @@ public class ContextIndexSearcherTests extends ESTestCase {
                         1
                     )
                 ) {
-                    leafSlices = contextIndexSearcher.getSlicesForCollection();
+                    leafSlices = contextIndexSearcher.getSlices();
                     int numThrowingLeafSlices = randomIntBetween(1, 3);
                     for (int i = 0; i < numThrowingLeafSlices; i++) {
                         LeafSlice throwingLeafSlice = leafSlices[randomIntBetween(0, Math.min(leafSlices.length, numAvailableThreads) - 1)];


### PR DESCRIPTION
We used to have to fork the slices creation with Lucene 9.7, as slices were used for knn searches too. With Lucene 9.8, we can customize how IndexSearcher creates slices, and rely on leafSlices retrieved via IndexSearcher#getSlices.