### PR TITLE
NodeShutdownIT.testShardsMoveOffRemovingNode re-enable

### DIFF
--- a/x-pack/plugin/shutdown/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownIT.java
+++ b/x-pack/plugin/shutdown/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownIT.java
@@ -269,7 +269,6 @@ public class NodeShutdownIT extends ESRestTestCase implements ReadinessClientPro
      * 2) Ensures the status properly comes to rest at COMPLETE after the shards have moved.
      */
     @SuppressWarnings("unchecked")
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/77488")
     public void testShardsMoveOffRemovingNode() throws Exception {
         String nodeIdToShutdown = getRandomNodeId();
 


### PR DESCRIPTION
`testShardsMoveOffRemovingNode` has been muted for a few years.  Re-enabling to see if it's still failing as it doesn't locally reproduce.

Refs #77488