### PR TITLE
[8.10] Include branch information in build scans for buildkite jobs (#101284)

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -95,10 +95,10 @@ buildScan {
       // Disable async upload in CI to ensure scan upload completes before CI agent is terminated
       uploadInBackground = false
 
-      def branch = System.getenv('BUILDKITE_BRANCH')
+      def branch = System.getenv('BUILDKITE_PULL_REQUEST_BASE_BRANCH') ?: System.getenv('BUILDKITE_BRANCH')
       def repoMatcher = System.getenv('BUILDKITE_REPO') =~ /(https:\/\/github\.com\/|git@github\.com:)(\S+)\.git/
       def repository = repoMatcher.matches() ? repoMatcher.group(2) : "<unknown>"
-      def jobName = (System.getenv('BUILDKITE_LABEL') ?: '').replaceAll(/[^a-zA-Z0-9_\-]+/, '_').toLowerCase()
+      def jobName = (System.getenv('BUILDKITE_LABEL') ?: '').replaceAll(/[^a-zA-Z0-9_\-]+/, ' ').trim().replaceAll(' ', '_').toLowerCase()
 
       tag 'CI'
       link 'CI Build', buildKiteUrl
@@ -109,6 +109,11 @@ buildScan {
 
       value 'Job Name', jobName
       tag jobName
+
+      if (branch) {
+        tag branch
+        value 'Git Branch', branch
+      }
 
       // Add SCM information
       def prId = System.getenv('BUILDKITE_PULL_REQUEST')
@@ -122,7 +127,6 @@ buildScan {
       } else {
         value 'Git Commit ID', BuildParams.gitRevision
         link 'Source', "https://github.com/${repository}/tree/${BuildParams.gitRevision}"
-        tag branch
       }
 
       buildScanPublished { scan ->


### PR DESCRIPTION
Backports the following commits to 8.10:
 - Include branch information in build scans for buildkite jobs (#101284)