### PR TITLE
Fix exchange layout of intermediate aggs

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
@@ -1279,7 +1279,7 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
         var functions = List.of("sum", "count", "avg", "count_distinct");
         for (String field : fields) {
             for (String function : functions) {
-                String stat = String.format("stats s = %s(%s)", function, field);
+                String stat = String.format(Locale.ROOT, "stats s = %s(%s)", function, field);
                 String command = String.format(Locale.ROOT, "from foo-index,bar-index | where %s is not null | %s", field, stat);
                 try (var resp = run(command)) {
                     var valuesList = getValuesList(resp);

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
@@ -1257,6 +1257,39 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
         }
     }
 
+    public void testStatsMissingFields() {
+        String node1 = internalCluster().startDataOnlyNode();
+        String node2 = internalCluster().startDataOnlyNode();
+        assertAcked(
+            client().admin()
+                .indices()
+                .prepareCreate("foo-index")
+                .setSettings(Settings.builder().put("index.routing.allocation.require._name", node1))
+                .setMapping("foo_int", "type=integer", "foo_long", "type=long", "foo_float", "type=float", "foo_double", "type=double")
+        );
+        assertAcked(
+            client().admin()
+                .indices()
+                .prepareCreate("bar-index")
+                .setSettings(Settings.builder().put("index.routing.allocation.require._name", node2))
+                .setMapping("bar_int", "type=integer", "bar_long", "type=long", "bar_float", "type=float", "bar_double", "type=double")
+        );
+
+        var fields = List.of("foo_int", "foo_long", "foo_float", "foo_double");
+        var functions = List.of("sum", "count", "avg", "count_distinct");
+        for (String field : fields) {
+            for (String function : functions) {
+                String stat = String.format("stats s = %s(%s)", function, field);
+                String command = String.format(Locale.ROOT, "from foo-index,bar-index | where %s is not null | %s", field, stat);
+                try (var resp = run(command)) {
+                    var valuesList = getValuesList(resp);
+                    assertEquals(1, resp.columns().size());
+                    assertEquals(1, valuesList.size());
+                }
+            }
+        }
+    }
+
     private void createNestedMappingIndex(String indexName) throws IOException {
         XContentBuilder builder = JsonXContent.contentBuilder();
         builder.startObject();

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
@@ -626,11 +626,12 @@ public class LogicalPlanOptimizer extends ParameterizedRuleExecutor<LogicalPlan,
                             blocks.add(new ConstantBooleanVector(true, 1).asBlock());
                         } else {
                             // look for count(literal) with literal != null
-                            Object value = aggFunc instanceof Count count && (count.foldable() == false || count.fold() != null)
-                                ? 0L
-                                : null;
                             var wrapper = BlockUtils.wrapperFor(blockFactory, LocalExecutionPlanner.toElementType(aggFunc.dataType()), 1);
-                            wrapper.accept(value);
+                            if (aggFunc instanceof Count count && (count.foldable() == false || count.fold() != null)) {
+                                wrapper.accept(0L);
+                            } else {
+                                wrapper.accept(null);
+                            }
                             blocks.add(wrapper.builder().build());
                         }
                     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
@@ -602,7 +602,6 @@ public class LogicalPlanOptimizer extends ParameterizedRuleExecutor<LogicalPlan,
                 // only care about non-grouped aggs might return something (count)
                 if (plan instanceof Aggregate agg && agg.groupings().isEmpty()) {
                     List<Block> emptyBlocks = aggsFromEmpty(agg.aggregates());
-                    assert emptyBlocks.size() == local.output().size() : emptyBlocks.size() + " != " + local.output().size();
                     p = skipPlan(plan, LocalSupplier.of(emptyBlocks.toArray(Block[]::new)));
                 } else {
                     p = skipPlan(plan);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BlockUtils;
+import org.elasticsearch.compute.data.ConstantBooleanVector;
 import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.evaluator.predicate.operator.comparison.Equals;
 import org.elasticsearch.xpack.esql.expression.SurrogateExpression;
@@ -25,6 +26,7 @@ import org.elasticsearch.xpack.esql.plan.logical.TopN;
 import org.elasticsearch.xpack.esql.plan.logical.local.EsqlProject;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelation;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalSupplier;
+import org.elasticsearch.xpack.esql.planner.AbstractPhysicalOperationProviders;
 import org.elasticsearch.xpack.esql.planner.LocalExecutionPlanner;
 import org.elasticsearch.xpack.esql.type.EsqlDataTypes;
 import org.elasticsearch.xpack.ql.expression.Alias;
@@ -62,6 +64,7 @@ import org.elasticsearch.xpack.ql.rule.ParameterizedRule;
 import org.elasticsearch.xpack.ql.rule.ParameterizedRuleExecutor;
 import org.elasticsearch.xpack.ql.rule.Rule;
 import org.elasticsearch.xpack.ql.tree.Source;
+import org.elasticsearch.xpack.ql.type.DataType;
 import org.elasticsearch.xpack.ql.type.DataTypes;
 import org.elasticsearch.xpack.ql.util.CollectionUtils;
 import org.elasticsearch.xpack.ql.util.Holder;
@@ -598,7 +601,9 @@ public class LogicalPlanOptimizer extends ParameterizedRuleExecutor<LogicalPlan,
             if (plan.child() instanceof LocalRelation local && local.supplier() == LocalSupplier.EMPTY) {
                 // only care about non-grouped aggs might return something (count)
                 if (plan instanceof Aggregate agg && agg.groupings().isEmpty()) {
-                    p = skipPlan(plan, aggsFromEmpty(agg.aggregates()));
+                    List<Block> emptyBlocks = aggsFromEmpty(agg.aggregates());
+                    assert emptyBlocks.size() == local.output().size() : emptyBlocks.size() + " != " + local.output().size();
+                    p = skipPlan(plan, LocalSupplier.of(emptyBlocks.toArray(Block[]::new)));
                 } else {
                     p = skipPlan(plan);
                 }
@@ -606,25 +611,34 @@ public class LogicalPlanOptimizer extends ParameterizedRuleExecutor<LogicalPlan,
             return p;
         }
 
-        private static LocalSupplier aggsFromEmpty(List<? extends NamedExpression> aggs) {
-            Block[] blocks = new Block[aggs.size()];
+        private static List<Block> aggsFromEmpty(List<? extends NamedExpression> aggs) {
+            // TODO: Should we introduce skip operator that just never queries the source
+            List<Block> blocks = new ArrayList<>();
             var blockFactory = BlockFactory.getNonBreakingInstance();
             int i = 0;
             for (var agg : aggs) {
                 // there needs to be an alias
                 if (agg instanceof Alias a && a.child() instanceof AggregateFunction aggFunc) {
-                    // look for count(literal) with literal != null
-                    Object value = aggFunc instanceof Count count && (count.foldable() == false || count.fold() != null) ? 0L : null;
-                    var wrapper = BlockUtils.wrapperFor(blockFactory, LocalExecutionPlanner.toElementType(aggFunc.dataType()), 1);
-                    wrapper.accept(value);
-                    blocks[i++] = wrapper.builder().build();
-                    BlockUtils.constantBlock(blockFactory, value, 1);
+                    List<Attribute> output = AbstractPhysicalOperationProviders.intermediateAttributes(List.of(agg), List.of());
+                    for (Attribute o : output) {
+                        DataType dataType = o.dataType();
+                        if (dataType == DataTypes.BOOLEAN) {
+                            blocks.add(new ConstantBooleanVector(true, 1).asBlock());
+                        } else {
+                            // look for count(literal) with literal != null
+                            Object value = aggFunc instanceof Count count && (count.foldable() == false || count.fold() != null)
+                                ? 0L
+                                : null;
+                            var wrapper = BlockUtils.wrapperFor(blockFactory, LocalExecutionPlanner.toElementType(aggFunc.dataType()), 1);
+                            wrapper.accept(value);
+                            blocks.add(wrapper.builder().build());
+                        }
+                    }
                 } else {
                     throw new EsqlIllegalArgumentException("Did not expect a non-aliased aggregation {}", agg);
                 }
             }
-
-            return LocalSupplier.of(blocks);
+            return blocks;
         }
 
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
@@ -12,7 +12,6 @@ import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BlockUtils;
-import org.elasticsearch.compute.data.ConstantBooleanVector;
 import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.evaluator.predicate.operator.comparison.Equals;
 import org.elasticsearch.xpack.esql.expression.SurrogateExpression;
@@ -621,11 +620,10 @@ public class LogicalPlanOptimizer extends ParameterizedRuleExecutor<LogicalPlan,
                     List<Attribute> output = AbstractPhysicalOperationProviders.intermediateAttributes(List.of(agg), List.of());
                     for (Attribute o : output) {
                         DataType dataType = o.dataType();
-                        if (dataType == DataTypes.BOOLEAN) {
-                            blocks.add(new ConstantBooleanVector(true, 1).asBlock());
-                        } else {
+                        // fill the boolean block later in LocalExecutionPlanner
+                        if (dataType != DataTypes.BOOLEAN) {
                             // look for count(literal) with literal != null
-                            var wrapper = BlockUtils.wrapperFor(blockFactory, LocalExecutionPlanner.toElementType(aggFunc.dataType()), 1);
+                            var wrapper = BlockUtils.wrapperFor(blockFactory, LocalExecutionPlanner.toElementType(dataType), 1);
                             if (aggFunc instanceof Count count && (count.foldable() == false || count.fold() != null)) {
                                 wrapper.accept(0L);
                             } else {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -13,7 +13,6 @@ import org.elasticsearch.common.util.iterable.Iterables;
 import org.elasticsearch.compute.Describable;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
-import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.lucene.DataPartitioning;
@@ -54,7 +53,6 @@ import org.elasticsearch.xpack.esql.enrich.EnrichLookupOperator;
 import org.elasticsearch.xpack.esql.enrich.EnrichLookupService;
 import org.elasticsearch.xpack.esql.evaluator.EvalMapper;
 import org.elasticsearch.xpack.esql.evaluator.command.GrokEvaluatorExtracter;
-import org.elasticsearch.xpack.esql.plan.logical.local.LocalSupplier;
 import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
 import org.elasticsearch.xpack.esql.plan.physical.DissectExec;
 import org.elasticsearch.xpack.esql.plan.physical.EnrichExec;
@@ -348,30 +346,6 @@ public class LocalExecutionPlanner {
     private PhysicalOperation planExchangeSink(ExchangeSinkExec exchangeSink, LocalExecutionPlannerContext context) {
         Objects.requireNonNull(exchangeSinkHandler, "ExchangeSinkHandler wasn't provided");
         var child = exchangeSink.child();
-        // see https://github.com/elastic/elasticsearch/issues/100807 - handle case where the plan has been fully minimized
-        // to a local relation and the aggregate intermediate data erased. For this scenario, match the output the exchange output
-        // with that of the local relation
-
-        if (child instanceof LocalSourceExec localExec) {
-            var output = exchangeSink.output();
-            var localOutput = localExec.output();
-            if (output.equals(localOutput) == false) {
-                // the outputs are going to be similar except for the bool "seen" flags which are added in below
-                List<Block> blocks = new ArrayList<>(asList(localExec.supplier().get()));
-                if (blocks.size() > 0) {
-                    Block boolBlock = BooleanBlock.newConstantBlockWith(true, 1);
-                    for (int i = 0, s = output.size(); i < s; i++) {
-                        var out = output.get(i);
-                        if (out.dataType() == DataTypes.BOOLEAN) {
-                            blocks.add(i, boolBlock);
-                        }
-                    }
-                }
-                var newSupplier = LocalSupplier.of(blocks.toArray(Block[]::new));
-
-                child = new LocalSourceExec(localExec.source(), output, newSupplier);
-            }
-        }
 
         PhysicalOperation source = plan(child, context);
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.util.iterable.Iterables;
 import org.elasticsearch.compute.Describable;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.lucene.DataPartitioning;
@@ -53,6 +54,7 @@ import org.elasticsearch.xpack.esql.enrich.EnrichLookupOperator;
 import org.elasticsearch.xpack.esql.enrich.EnrichLookupService;
 import org.elasticsearch.xpack.esql.evaluator.EvalMapper;
 import org.elasticsearch.xpack.esql.evaluator.command.GrokEvaluatorExtracter;
+import org.elasticsearch.xpack.esql.plan.logical.local.LocalSupplier;
 import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
 import org.elasticsearch.xpack.esql.plan.physical.DissectExec;
 import org.elasticsearch.xpack.esql.plan.physical.EnrichExec;
@@ -346,6 +348,30 @@ public class LocalExecutionPlanner {
     private PhysicalOperation planExchangeSink(ExchangeSinkExec exchangeSink, LocalExecutionPlannerContext context) {
         Objects.requireNonNull(exchangeSinkHandler, "ExchangeSinkHandler wasn't provided");
         var child = exchangeSink.child();
+        // see https://github.com/elastic/elasticsearch/issues/100807 - handle case where the plan has been fully minimized
+        // to a local relation and the aggregate intermediate data erased. For this scenario, match the output the exchange output
+        // with that of the local relation
+
+        if (child instanceof LocalSourceExec localExec) {
+            var output = exchangeSink.output();
+            var localOutput = localExec.output();
+            if (output.equals(localOutput) == false) {
+                // the outputs are going to be similar except for the bool "seen" flags which are added in below
+                List<Block> blocks = new ArrayList<>(asList(localExec.supplier().get()));
+                if (blocks.size() > 0) {
+                    Block boolBlock = BooleanBlock.newConstantBlockWith(true, 1);
+                    for (int i = 0, s = output.size(); i < s; i++) {
+                        var out = output.get(i);
+                        if (out.dataType() == DataTypes.BOOLEAN) {
+                            blocks.add(i, boolBlock);
+                        }
+                    }
+                }
+                var newSupplier = LocalSupplier.of(blocks.toArray(Block[]::new));
+
+                child = new LocalSourceExec(localExec.source(), output, newSupplier);
+            }
+        }
 
         PhysicalOperation source = plan(child, context);
 


### PR DESCRIPTION
Today, we assume that an intermediate state of a non-grouped aggregation has two blocks. An `avg(float)` or `avg(double)` requires three blocks: sum, delta, and seen. I believe we should introduce a Skip operator that skips querying the source, thus bypassing the execution pipeline, instead of manually manipulating the layout. This pull request, however, is a quick fix for version 8.11.