### PR TITLE
[DOCS] Clarifies that inference input must be single string

### DIFF
--- a/docs/reference/ingest/processors/inference.asciidoc
+++ b/docs/reference/ingest/processors/inference.asciidoc
@@ -25,10 +25,13 @@ ingested in the pipeline.
 include::common-options.asciidoc[]
 |======
 
-IMPORTANT: You cannot use the `input_output` field with the `target_field` and 
+[IMPORTANT]
+==================================================
+* You cannot use the `input_output` field with the `target_field` and 
 `field_map` fields. For NLP models, use the `input_output` option. For 
 {dfanalytics} models, use the `target_field` and `field_map` option.
-
+* The {infer} input fields must be single strings, not arrays of strings.
+==================================================
 
 [discrete]
 [[inference-input-output-example]]

--- a/docs/reference/ingest/processors/inference.asciidoc
+++ b/docs/reference/ingest/processors/inference.asciidoc
@@ -30,7 +30,7 @@ include::common-options.asciidoc[]
 * You cannot use the `input_output` field with the `target_field` and 
 `field_map` fields. For NLP models, use the `input_output` option. For 
 {dfanalytics} models, use the `target_field` and `field_map` option.
-* The {infer} input fields must be single strings, not arrays of strings.
+* Each {infer} input field must be single strings, not arrays of strings.
 ==================================================
 
 [discrete]

--- a/docs/reference/ml/trained-models/apis/infer-trained-model.asciidoc
+++ b/docs/reference/ml/trained-models/apis/infer-trained-model.asciidoc
@@ -57,8 +57,8 @@ Controls the amount of time to wait for {infer} results. Defaults to 10 seconds.
 (Required, array)
 An array of objects to pass to the model for inference. The objects should
 contain the fields matching your configured trained model input. Typically for
-NLP models, the field name is `text_field`. The {infer} input fields must be 
-single strings not arrays of strings.
+NLP models, the field name is `text_field`. Each {infer} input field specified 
+in this property must be single strings not arrays of strings.
 
 //Begin inference_config
 `inference_config`::

--- a/docs/reference/ml/trained-models/apis/infer-trained-model.asciidoc
+++ b/docs/reference/ml/trained-models/apis/infer-trained-model.asciidoc
@@ -57,7 +57,8 @@ Controls the amount of time to wait for {infer} results. Defaults to 10 seconds.
 (Required, array)
 An array of objects to pass to the model for inference. The objects should
 contain the fields matching your configured trained model input. Typically for
-NLP models, the field name is `text_field`.
+NLP models, the field name is `text_field`. The {infer} input fields must be 
+singe strings not arrays of strings.
 
 //Begin inference_config
 `inference_config`::

--- a/docs/reference/ml/trained-models/apis/infer-trained-model.asciidoc
+++ b/docs/reference/ml/trained-models/apis/infer-trained-model.asciidoc
@@ -58,7 +58,7 @@ Controls the amount of time to wait for {infer} results. Defaults to 10 seconds.
 An array of objects to pass to the model for inference. The objects should
 contain the fields matching your configured trained model input. Typically for
 NLP models, the field name is `text_field`. The {infer} input fields must be 
-singe strings not arrays of strings.
+single strings not arrays of strings.
 
 //Begin inference_config
 `inference_config`::


### PR DESCRIPTION
## Overview

This PR adds a sentence to the inference processor documentation and the inference trained model API documentation about the fact that the inference input fields must be single strings and not arrays of strings.

### Preview

* [Inference processor](https://elasticsearch_101301.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/inference-processor.html)
* [Inference trained models API](https://elasticsearch_101301.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/infer-trained-model.html)