### PR TITLE
Proposal: `boost_duplicates` parameter for query_string query

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/query/CombinedFieldsQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/CombinedFieldsQueryBuilder.java
@@ -79,7 +79,7 @@ public class CombinedFieldsQueryBuilder extends AbstractQueryBuilder<CombinedFie
     static {
         PARSER.declareString(ConstructingObjectParser.constructorArg(), QUERY_FIELD);
         PARSER.declareStringArray((builder, values) -> {
-            Map<String, Float> fieldsAndBoosts = QueryParserHelper.parseFieldsAndWeights(values);
+            Map<String, Float> fieldsAndBoosts = QueryParserHelper.parseFieldsAndWeights(values, true);
             builder.fields(fieldsAndBoosts);
         }, FIELDS_FIELD);
 

--- a/server/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
@@ -772,7 +772,7 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
         if (fieldsBoosts.isEmpty()) {
             // no fields provided, defaults to index.query.default_field
             List<String> defaultFields = context.defaultFields();
-            newFieldsBoosts = QueryParserHelper.resolveMappingFields(context, QueryParserHelper.parseFieldsAndWeights(defaultFields));
+            newFieldsBoosts = QueryParserHelper.resolveMappingFields(context, QueryParserHelper.parseFieldsAndWeights(defaultFields, true));
             isAllField = QueryParserHelper.hasAllFieldsWildcard(defaultFields);
         } else {
             newFieldsBoosts = QueryParserHelper.resolveMappingFields(context, fieldsBoosts);

--- a/server/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
@@ -415,7 +415,7 @@ public class SimpleQueryStringBuilder extends AbstractQueryBuilder<SimpleQuerySt
             List<String> defaultFields = context.defaultFields();
             resolvedFieldsAndWeights = QueryParserHelper.resolveMappingFields(
                 context,
-                QueryParserHelper.parseFieldsAndWeights(defaultFields)
+                QueryParserHelper.parseFieldsAndWeights(defaultFields, true)
             );
             isAllField = QueryParserHelper.hasAllFieldsWildcard(defaultFields);
         }
@@ -525,7 +525,7 @@ public class SimpleQueryStringBuilder extends AbstractQueryBuilder<SimpleQuerySt
                     while (parser.nextToken() != XContentParser.Token.END_ARRAY) {
                         fields.add(parser.text());
                     }
-                    fieldsAndWeights = QueryParserHelper.parseFieldsAndWeights(fields);
+                    fieldsAndWeights = QueryParserHelper.parseFieldsAndWeights(fields, true);
                 } else {
                     throw new ParsingException(
                         parser.getTokenLocation(),

--- a/server/src/main/java/org/elasticsearch/index/search/QueryParserHelper.java
+++ b/server/src/main/java/org/elasticsearch/index/search/QueryParserHelper.java
@@ -33,7 +33,7 @@ public final class QueryParserHelper {
      * @param fields The list of fields encoded with optional boosts (e.g. ^0.35).
      * @return The converted map with field names and associated boosts.
      */
-    public static Map<String, Float> parseFieldsAndWeights(List<String> fields) {
+    public static Map<String, Float> parseFieldsAndWeights(List<String> fields, boolean boostDuplicates) {
         final Map<String, Float> fieldsAndWeights = new HashMap<>();
         for (String field : fields) {
             int boostIndex = field.indexOf('^');
@@ -46,7 +46,7 @@ public final class QueryParserHelper {
                 fieldName = field;
             }
             // handle duplicates
-            if (fieldsAndWeights.containsKey(field)) {
+            if (boostDuplicates && fieldsAndWeights.containsKey(field)) {
                 boost *= fieldsAndWeights.get(field);
             }
             fieldsAndWeights.put(fieldName, boost);

--- a/server/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
@@ -186,6 +186,9 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
         if (randomBoolean()) {
             queryStringQueryBuilder.fuzzyTranspositions(randomBoolean());
         }
+        if (randomBoolean()) {
+            queryStringQueryBuilder.boostDuplicates(randomBoolean());
+        }
         queryStringQueryBuilder.type(randomFrom(MultiMatchQueryBuilder.Type.values()));
         return queryStringQueryBuilder;
     }
@@ -215,6 +218,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
         String timeZone = instance.timeZone() == null ? null : instance.timeZone().getId();
         boolean autoGenerateSynonymsPhraseQuery = instance.autoGenerateSynonymsPhraseQuery();
         boolean fuzzyTranspositions = instance.fuzzyTranspositions();
+        boolean boostDuplicates = instance.boostDuplicates();
 
         switch (between(0, 23)) {
             case 0:
@@ -337,6 +341,9 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
                 break;
             case 23:
                 return changeNameOrBoost(instance);
+            case 24:
+                boostDuplicates = (boostDuplicates == false);
+                break;
             default:
                 throw new AssertionError("Illegal randomisation branch");
         }
@@ -386,6 +393,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
         }
         newInstance.autoGenerateSynonymsPhraseQuery(autoGenerateSynonymsPhraseQuery);
         newInstance.fuzzyTranspositions(fuzzyTranspositions);
+        newInstance.boostDuplicates(boostDuplicates);
 
         return newInstance;
     }
@@ -1090,6 +1098,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
                 "escape" : true,
                 "auto_generate_synonyms_phrase_query" : false,
                 "fuzzy_transpositions" : false,
+                "boost_duplicates" : false,
                 "boost" : 2.0
               }
             }""";
@@ -1100,6 +1109,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
         assertEquals(json, "this AND that OR thus", parsed.queryString());
         assertEquals(json, "content", parsed.defaultField());
         assertEquals(json, false, parsed.fuzzyTranspositions());
+        assertEquals(json, false, parsed.boostDuplicates());
     }
 
     public void testSimpleFromJson() throws IOException {
@@ -1118,6 +1128,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
         assertEquals(json, "this AND that OR thus", parsed.queryString());
         assertEquals(json, "content", parsed.defaultField());
         assertEquals(json, true, parsed.fuzzyTranspositions());
+        assertEquals(json, true, parsed.boostDuplicates());
     }
 
     public void testExpandedTerms() throws Exception {


### PR DESCRIPTION
Adds possibility to disable behaviour of auto-boosting fields based on the number of their occurence in the search query.

```
{
  "query": {
    "query_string": {
      "query": "hello:world hello:world",
      "boost_duplicates": false // we don't want this to result in a boosted query
    }
  }
}
```

Rationale: Query string query is often used in scenarios where the query string is passed from the application. Boost queries potentially make queries heavier, so having the option to disable accidental field boosting due to duplicated terms can be beneficial.

So far this PR is just an exploration of what an option like this would look like. Naming and implementation are totally up for discussion!

![Screenshot 2023-10-25 at 11 34 00](https://github.com/elastic/elasticsearch/assets/6105650/11d13966-21a6-4d83-9510-e14868c758db)


