### PR TITLE
Consolidate all Plugin.createComponents arguments into a single accessor class

### DIFF
--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -40,6 +40,7 @@ import org.elasticsearch.cluster.coordination.Reconfigurator;
 import org.elasticsearch.cluster.coordination.StableMasterHealthIndicatorService;
 import org.elasticsearch.cluster.desirednodes.DesiredNodesSettingsValidator;
 import org.elasticsearch.cluster.metadata.IndexMetadataVerifier;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
 import org.elasticsearch.cluster.metadata.MetadataCreateDataStreamService;
 import org.elasticsearch.cluster.metadata.MetadataCreateIndexService;
@@ -52,6 +53,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.routing.BatchedRerouteService;
 import org.elasticsearch.cluster.routing.RerouteService;
+import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.routing.allocation.DiskThresholdMonitor;
 import org.elasticsearch.cluster.routing.allocation.ShardsAvailabilityHealthIndicatorService;
 import org.elasticsearch.cluster.routing.allocation.WriteLoadForecaster;
@@ -739,24 +741,79 @@ class NodeConstruction {
             threadPool
         );
 
-        Collection<Object> pluginComponents = pluginsService.flatMap(
-            p -> p.createComponents(
-                client,
-                clusterService,
-                threadPool,
-                resourceWatcherService,
-                scriptService,
-                xContentRegistry,
-                environment,
-                nodeEnvironment,
-                namedWriteableRegistry,
-                clusterModule.getIndexNameExpressionResolver(),
-                repositoriesServiceReference::get,
-                telemetryProvider,
-                clusterModule.getAllocationService(),
-                indicesService
-            )
-        ).toList();
+        Plugin.PluginServices services = new Plugin.PluginServices() {
+            @Override
+            public Client client() {
+                return client;
+            }
+
+            @Override
+            public ClusterService clusterService() {
+                return clusterService;
+            }
+
+            @Override
+            public ThreadPool threadPool() {
+                return threadPool;
+            }
+
+            @Override
+            public ResourceWatcherService resourceWatcherService() {
+                return resourceWatcherService;
+            }
+
+            @Override
+            public ScriptService scriptService() {
+                return scriptService;
+            }
+
+            @Override
+            public NamedXContentRegistry xContentRegistry() {
+                return xContentRegistry;
+            }
+
+            @Override
+            public Environment environment() {
+                return environment;
+            }
+
+            @Override
+            public NodeEnvironment nodeEnvironment() {
+                return nodeEnvironment;
+            }
+
+            @Override
+            public NamedWriteableRegistry namedWriteableRegistry() {
+                return namedWriteableRegistry;
+            }
+
+            @Override
+            public IndexNameExpressionResolver indexNameExpressionResolver() {
+                return clusterModule.getIndexNameExpressionResolver();
+            }
+
+            @Override
+            public Supplier<RepositoriesService> repositoriesServiceSupplier() {
+                return repositoriesServiceReference::get;
+            }
+
+            @Override
+            public TelemetryProvider telemetryProvider() {
+                return telemetryProvider;
+            }
+
+            @Override
+            public AllocationService allocationService() {
+                return clusterModule.getAllocationService();
+            }
+
+            @Override
+            public IndicesService indicesService() {
+                return indicesService;
+            }
+        };
+
+        Collection<Object> pluginComponents = pluginsService.flatMap(p -> p.createComponents(services)).toList();
 
         List<ReservedClusterStateHandler<?>> reservedStateHandlers = new ArrayList<>();
 

--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -741,79 +741,40 @@ class NodeConstruction {
             threadPool
         );
 
-        Plugin.PluginServices services = new Plugin.PluginServices() {
-            @Override
-            public Client client() {
-                return client;
-            }
+        record PluginServiceInstances(
+            Client client,
+            ClusterService clusterService,
+            ThreadPool threadPool,
+            ResourceWatcherService resourceWatcherService,
+            ScriptService scriptService,
+            NamedXContentRegistry xContentRegistry,
+            Environment environment,
+            NodeEnvironment nodeEnvironment,
+            NamedWriteableRegistry namedWriteableRegistry,
+            IndexNameExpressionResolver indexNameExpressionResolver,
+            Supplier<RepositoriesService> repositoriesServiceSupplier,
+            TelemetryProvider telemetryProvider,
+            AllocationService allocationService,
+            IndicesService indicesService
+        ) implements Plugin.PluginServices {}
+        PluginServiceInstances pluginServices = new PluginServiceInstances(
+            client,
+            clusterService,
+            threadPool,
+            resourceWatcherService,
+            scriptService,
+            xContentRegistry,
+            environment,
+            nodeEnvironment,
+            namedWriteableRegistry,
+            clusterModule.getIndexNameExpressionResolver(),
+            repositoriesServiceReference::get,
+            telemetryProvider,
+            clusterModule.getAllocationService(),
+            indicesService
+        );
 
-            @Override
-            public ClusterService clusterService() {
-                return clusterService;
-            }
-
-            @Override
-            public ThreadPool threadPool() {
-                return threadPool;
-            }
-
-            @Override
-            public ResourceWatcherService resourceWatcherService() {
-                return resourceWatcherService;
-            }
-
-            @Override
-            public ScriptService scriptService() {
-                return scriptService;
-            }
-
-            @Override
-            public NamedXContentRegistry xContentRegistry() {
-                return xContentRegistry;
-            }
-
-            @Override
-            public Environment environment() {
-                return environment;
-            }
-
-            @Override
-            public NodeEnvironment nodeEnvironment() {
-                return nodeEnvironment;
-            }
-
-            @Override
-            public NamedWriteableRegistry namedWriteableRegistry() {
-                return namedWriteableRegistry;
-            }
-
-            @Override
-            public IndexNameExpressionResolver indexNameExpressionResolver() {
-                return clusterModule.getIndexNameExpressionResolver();
-            }
-
-            @Override
-            public Supplier<RepositoriesService> repositoriesServiceSupplier() {
-                return repositoriesServiceReference::get;
-            }
-
-            @Override
-            public TelemetryProvider telemetryProvider() {
-                return telemetryProvider;
-            }
-
-            @Override
-            public AllocationService allocationService() {
-                return clusterModule.getAllocationService();
-            }
-
-            @Override
-            public IndicesService indicesService() {
-                return indicesService;
-            }
-        };
-
-        Collection<?> pluginComponents = pluginsService.flatMap(p -> p.createComponents(services)).toList();
+        Collection<?> pluginComponents = pluginsService.flatMap(p -> p.createComponents(pluginServices)).toList();
 
         List<ReservedClusterStateHandler<?>> reservedStateHandlers = new ArrayList<>();
 

--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -813,7 +813,7 @@ class NodeConstruction {
             }
         };
 
-        Collection<Object> pluginComponents = pluginsService.flatMap(p -> p.createComponents(services)).toList();
+        Collection<?> pluginComponents = pluginsService.flatMap(p -> p.createComponents(services)).toList();
 
         List<ReservedClusterStateHandler<?>> reservedStateHandlers = new ArrayList<>();
 

--- a/server/src/main/java/org/elasticsearch/plugins/Plugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/Plugin.java
@@ -62,8 +62,67 @@ import java.util.function.UnaryOperator;
  */
 public abstract class Plugin implements Closeable {
 
+    public interface PluginServices {
+        Client client();
+
+        ClusterService clusterService();
+
+        ThreadPool threadPool();
+
+        ResourceWatcherService resourceWatcherService();
+
+        ScriptService scriptService();
+
+        NamedXContentRegistry xContentRegistry();
+
+        Environment environment();
+
+        NodeEnvironment nodeEnvironment();
+
+        NamedWriteableRegistry namedWriteableRegistry();
+
+        IndexNameExpressionResolver indexNameExpressionResolver();
+
+        Supplier<RepositoriesService> repositoriesServiceSupplier();
+
+        TelemetryProvider telemetryProvider();
+
+        AllocationService allocationService();
+
+        IndicesService indicesService();
+    }
+
     /**
      * Returns components added by this plugin.
+     * <p>
+     * Any components returned that implement {@link LifecycleComponent} will have their lifecycle managed.
+     * Note: To aid in the migration away from guice, all objects returned as components will be bound in guice
+     * to themselves.
+     *
+     * @param services                    Provides access to various Elasticsearch services
+     */
+    public Collection<Object> createComponents(PluginServices services) {
+        return createComponents(
+            services.client(),
+            services.clusterService(),
+            services.threadPool(),
+            services.resourceWatcherService(),
+            services.scriptService(),
+            services.xContentRegistry(),
+            services.environment(),
+            services.nodeEnvironment(),
+            services.namedWriteableRegistry(),
+            services.indexNameExpressionResolver(),
+            services.repositoriesServiceSupplier(),
+            services.telemetryProvider(),
+            services.allocationService(),
+            services.indicesService()
+        );
+    }
+
+    /**
+     * Returns components added by this plugin. Either this method or {@link #createComponents(PluginServices)}
+     * should be implemented.
      * <p>
      * Any components returned that implement {@link LifecycleComponent} will have their lifecycle managed.
      * Note: To aid in the migration away from guice, all objects returned as components will be bound in guice
@@ -84,7 +143,10 @@ public abstract class Plugin implements Closeable {
      * @param telemetryProvider           An interface for distributed tracing
      * @param allocationService           A service to manage shard allocation in the cluster
      * @param indicesService              A service to manage indices in the cluster
+     *
+     * @deprecated New services will only be added to {@link PluginServices}
      */
+    @Deprecated
     public Collection<Object> createComponents(
         Client client,
         ClusterService clusterService,

--- a/server/src/main/java/org/elasticsearch/plugins/Plugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/Plugin.java
@@ -62,33 +62,80 @@ import java.util.function.UnaryOperator;
  */
 public abstract class Plugin implements Closeable {
 
+    /**
+     * Provides access to various Elasticsearch services.
+     */
     public interface PluginServices {
+        /**
+         * A client to make requests to the system
+         */
         Client client();
 
+        /**
+         * A service to allow watching and updating cluster state
+         */
         ClusterService clusterService();
 
+        /**
+         * A service to allow retrieving an executor to run an async action
+         */
         ThreadPool threadPool();
 
+        /**
+         * A service to watch for changes to node local files
+         */
         ResourceWatcherService resourceWatcherService();
 
+        /**
+         * A service to allow running scripts on the local node
+         */
         ScriptService scriptService();
 
+        /**
+         * The registry for extensible xContent parsing
+         */
         NamedXContentRegistry xContentRegistry();
 
+        /**
+         * The environment for path and setting configurations
+         */
         Environment environment();
 
+        /**
+         * The node environment used coordinate access to the data paths
+         */
         NodeEnvironment nodeEnvironment();
 
+        /**
+         * The registry for {@link NamedWriteable} object parsing
+         */
         NamedWriteableRegistry namedWriteableRegistry();
 
+        /**
+         * A service that resolves expression to index and alias names
+         */
         IndexNameExpressionResolver indexNameExpressionResolver();
 
+        /**
+         * A supplier for the service that manages snapshot repositories.
+         * This will return null when {@link #createComponents(PluginServices)} is called,
+         * but will return the repositories service once the node is initialized.
+         */
         Supplier<RepositoriesService> repositoriesServiceSupplier();
 
+        /**
+         * An interface for distributed tracing
+         */
         TelemetryProvider telemetryProvider();
 
+        /**
+         * A service to manage shard allocation in the cluster
+         */
         AllocationService allocationService();
 
+        /**
+         * A service to manage indices in the cluster
+         */
         IndicesService indicesService();
     }
 
@@ -99,9 +146,9 @@ public abstract class Plugin implements Closeable {
      * Note: To aid in the migration away from guice, all objects returned as components will be bound in guice
      * to themselves.
      *
-     * @param services                    Provides access to various Elasticsearch services
+     * @param services      Provides access to various Elasticsearch services
      */
-    public Collection<Object> createComponents(PluginServices services) {
+    public Collection<?> createComponents(PluginServices services) {
         return createComponents(
             services.client(),
             services.clusterService(),
@@ -133,10 +180,10 @@ public abstract class Plugin implements Closeable {
      * @param threadPool                  A service to allow retrieving an executor to run an async action
      * @param resourceWatcherService      A service to watch for changes to node local files
      * @param scriptService               A service to allow running scripts on the local node
-     * @param xContentRegistry            the registry for extensible xContent parsing
-     * @param environment                 the environment for path and setting configurations
-     * @param nodeEnvironment             the node environment used coordinate access to the data paths
-     * @param namedWriteableRegistry      the registry for {@link NamedWriteable} object parsing
+     * @param xContentRegistry            The registry for extensible xContent parsing
+     * @param environment                 The environment for path and setting configurations
+     * @param nodeEnvironment             The node environment used coordinate access to the data paths
+     * @param namedWriteableRegistry      The registry for {@link NamedWriteable} object parsing
      * @param indexNameExpressionResolver A service that resolves expression to index and alias names
      * @param repositoriesServiceSupplier A supplier for the service that manages snapshot repositories; will return null when this method
      *                                    is called, but will return the repositories service once the node is initialized.
@@ -144,7 +191,7 @@ public abstract class Plugin implements Closeable {
      * @param allocationService           A service to manage shard allocation in the cluster
      * @param indicesService              A service to manage indices in the cluster
      *
-     * @deprecated New services will only be added to {@link PluginServices}
+     * @deprecated New services will only be added to {@link PluginServices}; this method is maintained for compatibility.
      */
     @Deprecated
     public Collection<Object> createComponents(


### PR DESCRIPTION
Create a `createComponents` overload that only takes a single services argument, allowing new services to be added without breaking API compatibility as much.

Keep the old method for compatibility with existing plugins