### PR TITLE
Cache resolved index for mgets

### DIFF
--- a/docs/changelog/101311.yaml
+++ b/docs/changelog/101311.yaml
@@ -1,0 +1,5 @@
+pr: 101311
+summary: Cache resolved index for mgets
+area: CRUD
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/get/TransportMultiGetAction.java
+++ b/server/src/main/java/org/elasticsearch/action/get/TransportMultiGetAction.java
@@ -21,6 +21,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.tasks.Task;
@@ -60,16 +61,24 @@ public class TransportMultiGetAction extends HandledTransportAction<MultiGetRequ
 
         final AtomicArray<MultiGetItemResponse> responses = new AtomicArray<>(request.items.size());
         final Map<ShardId, MultiGetShardRequest> shardRequests = new HashMap<>();
+        // single item cache that maps the provided index name to the resolved one
+        Tuple<String, String> lastResolvedIndex = Tuple.tuple(null, null);
 
         for (int i = 0; i < request.items.size(); i++) {
             MultiGetRequest.Item item = request.items.get(i);
 
             ShardId shardId;
             try {
-                String concreteSingleIndex = indexNameExpressionResolver.concreteSingleIndex(clusterState, item).getName();
+                String concreteSingleIndex;
+                if (item.index().equals(lastResolvedIndex.v1())) {
+                    concreteSingleIndex = lastResolvedIndex.v2();
+                } else {
+                    concreteSingleIndex = indexNameExpressionResolver.concreteSingleIndex(clusterState, item).getName();
+                    lastResolvedIndex = Tuple.tuple(item.index(), concreteSingleIndex);
+                }
                 item.routing(clusterState.metadata().resolveIndexRouting(item.routing(), item.index()));
                 shardId = clusterService.operationRouting()
-                    .getShards(clusterState, concreteSingleIndex, item.id(), item.routing(), null)
+                    .getIndexShardRoutingTable(clusterState, concreteSingleIndex, item.id(), item.routing())
                     .shardId();
             } catch (RoutingMissingException e) {
                 responses.set(i, newItemFailure(e.getIndex().getName(), e.getId(), e));

--- a/server/src/main/java/org/elasticsearch/action/get/TransportMultiGetAction.java
+++ b/server/src/main/java/org/elasticsearch/action/get/TransportMultiGetAction.java
@@ -77,9 +77,7 @@ public class TransportMultiGetAction extends HandledTransportAction<MultiGetRequ
                     lastResolvedIndex = Tuple.tuple(item.index(), concreteSingleIndex);
                 }
                 item.routing(clusterState.metadata().resolveIndexRouting(item.routing(), item.index()));
-                shardId = clusterService.operationRouting()
-                    .getIndexShardRoutingTable(clusterState, concreteSingleIndex, item.id(), item.routing())
-                    .shardId();
+                shardId = clusterService.operationRouting().shardId(clusterState, concreteSingleIndex, item.id(), item.routing());
             } catch (RoutingMissingException e) {
                 responses.set(i, newItemFailure(e.getIndex().getName(), e.getId(), e));
                 continue;

--- a/server/src/main/java/org/elasticsearch/cluster/routing/OperationRouting.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/OperationRouting.java
@@ -56,11 +56,6 @@ public class OperationRouting {
         this.useAdaptiveReplicaSelection = useAdaptiveReplicaSelection;
     }
 
-    public IndexShardRoutingTable getIndexShardRoutingTable(ClusterState clusterState, String index, String id, @Nullable String routing) {
-        IndexRouting indexRouting = IndexRouting.fromIndexMetadata(indexMetadata(clusterState, index));
-        return clusterState.getRoutingTable().shardRoutingTable(index, indexRouting.getShard(id, routing));
-    }
-
     /**
      * Shards to use for a {@code GET} operation.
      * @return A shard iterator that can be used for GETs, or null if e.g. due to preferences no match is found.
@@ -72,7 +67,8 @@ public class OperationRouting {
         @Nullable String routing,
         @Nullable String preference
     ) {
-        IndexShardRoutingTable shards = getIndexShardRoutingTable(clusterState, index, id, routing);
+        IndexRouting indexRouting = IndexRouting.fromIndexMetadata(indexMetadata(clusterState, index));
+        IndexShardRoutingTable shards = clusterState.getRoutingTable().shardRoutingTable(index, indexRouting.getShard(id, routing));
         return preferenceActiveShardIterator(shards, clusterState.nodes().getLocalNodeId(), clusterState.nodes(), preference, null, null);
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/routing/OperationRouting.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/OperationRouting.java
@@ -56,6 +56,16 @@ public class OperationRouting {
         this.useAdaptiveReplicaSelection = useAdaptiveReplicaSelection;
     }
 
+    public IndexShardRoutingTable getIndexShardRoutingTable(
+        ClusterState clusterState,
+        String index,
+        String id,
+        @Nullable String routing
+    ) {
+        IndexRouting indexRouting = IndexRouting.fromIndexMetadata(indexMetadata(clusterState, index));
+        return clusterState.getRoutingTable().shardRoutingTable(index, indexRouting.getShard(id, routing));
+    }
+
     /**
      * Shards to use for a {@code GET} operation.
      * @return A shard iterator that can be used for GETs, or null if e.g. due to preferences no match is found.
@@ -67,8 +77,7 @@ public class OperationRouting {
         @Nullable String routing,
         @Nullable String preference
     ) {
-        IndexRouting indexRouting = IndexRouting.fromIndexMetadata(indexMetadata(clusterState, index));
-        IndexShardRoutingTable shards = clusterState.getRoutingTable().shardRoutingTable(index, indexRouting.getShard(id, routing));
+        IndexShardRoutingTable shards = getIndexShardRoutingTable(clusterState, index, id, routing);
         return preferenceActiveShardIterator(shards, clusterState.nodes().getLocalNodeId(), clusterState.nodes(), preference, null, null);
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/routing/OperationRouting.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/OperationRouting.java
@@ -56,12 +56,7 @@ public class OperationRouting {
         this.useAdaptiveReplicaSelection = useAdaptiveReplicaSelection;
     }
 
-    public IndexShardRoutingTable getIndexShardRoutingTable(
-        ClusterState clusterState,
-        String index,
-        String id,
-        @Nullable String routing
-    ) {
+    public IndexShardRoutingTable getIndexShardRoutingTable(ClusterState clusterState, String index, String id, @Nullable String routing) {
         IndexRouting indexRouting = IndexRouting.fromIndexMetadata(indexMetadata(clusterState, index));
         return clusterState.getRoutingTable().shardRoutingTable(index, indexRouting.getShard(id, routing));
     }


### PR DESCRIPTION
Mgets need to resolve the provided index to an actual index. This is done for every item in an mget request, even if all mgets target the same index. With this commit we eliminate this overhead when only one index (or a small number of indices with items sorted by index) is affected.
