### PR TITLE
[8.11] esql docs: structure, examples, minor improvements (#101292)

### DIFF
--- a/docs/reference/esql/esql-enrich-data.asciidoc
+++ b/docs/reference/esql/esql-enrich-data.asciidoc
@@ -1,12 +1,13 @@
 [[esql-enrich-data]]
-=== Enrich data
+== Data enrichment
 
 ++++
-<titleabbrev>Enrich data</titleabbrev>
+<titleabbrev>Data enrichment</titleabbrev>
 ++++
 
-You can use {esql}'s <<esql-enrich>> processing command to enrich a table with
-data from indices in {es}.
+The {esql} <<esql-enrich>> processing command combines, at query-time, data from
+one or more source indexes with field-value combinations found in {es} enrich
+indexes.
 
 For example, you can use `ENRICH` to:
 
@@ -14,13 +15,15 @@ For example, you can use `ENRICH` to:
 * Add product information to retail orders based on product IDs
 * Supplement contact information based on an email address
 
+[discrete]
 [[esql-how-enrich-works]]
-==== How the `ENRICH` command works
+=== How the `ENRICH` command works
 
 The `ENRICH` command adds new columns to a table, with data from {es} indices.
 It requires a few special components:
 
 image::images/esql/esql-enrich.png[align="center"]
+
 
 [[esql-enrich-policy]]
 Enrich policy::
@@ -60,8 +63,9 @@ enrich index.
 include::../ingest/enrich.asciidoc[tag=enrich-index]
 --
 
+[discrete]
 [[esql-set-up-enrich-policy]]
-==== Set up an enrich policy
+=== Set up an enrich policy
 
 To start using `ENRICH`, follow these steps:
 
@@ -75,29 +79,35 @@ Once you have enrich policies set up, you can <<esql-update-enrich-data,update
 your enrich data>> and <<esql-update-enrich-policies, update your enrich
 policies>>.
 
+[discrete]
 [IMPORTANT]
 ====
 The `ENRICH` command performs several operations and may impact the speed of
 your query.
+[discrete]
 ====
 
+[discrete]
 [[esql-enrich-prereqs]]
-==== Prerequisites
+=== Prerequisites
 
 include::{es-repo-dir}/ingest/apis/enrich/put-enrich-policy.asciidoc[tag=enrich-policy-api-prereqs]
 
+[discrete]
 [[esql-create-enrich-source-index]]
-==== Add enrich data
+=== Add enrich data
 
 include::../ingest/enrich.asciidoc[tag=create-enrich-source-index]
 
+[discrete]
 [[esql-create-enrich-policy]]
-==== Create an enrich policy
+=== Create an enrich policy
 
 include::../ingest/enrich.asciidoc[tag=create-enrich-policy]
 
+[discrete]
 [[esql-execute-enrich-policy]]
-==== Execute the enrich policy
+=== Execute the enrich policy
 
 include::../ingest/enrich.asciidoc[tag=execute-enrich-policy1]
 
@@ -105,8 +115,9 @@ image::images/esql/esql-enrich-policy.png[align="center"]
 
 include::../ingest/enrich.asciidoc[tag=execute-enrich-policy2]
 
+[discrete]
 [[esql-use-enrich]]
-==== Use the enrich policy
+=== Use the enrich policy
 
 After the policy has been executed, you can use the <<esql-enrich,`ENRICH`
 command>> to enrich your data.
@@ -115,12 +126,14 @@ image::images/esql/esql-enrich-command.png[align="center",width=50%]
 
 include::processing-commands/enrich.asciidoc[tag=examples]
 
+[discrete]
 [[esql-update-enrich-data]]
-==== Update an enrich index
+=== Update an enrich index
 
 include::{es-repo-dir}/ingest/apis/enrich/execute-enrich-policy.asciidoc[tag=update-enrich-index]
 
+[discrete]
 [[esql-update-enrich-policies]]
-==== Update an enrich policy
+=== Update an enrich policy
 
 include::../ingest/enrich.asciidoc[tag=update-enrich-policy]

--- a/docs/reference/esql/esql-examples.asciidoc
+++ b/docs/reference/esql/esql-examples.asciidoc
@@ -1,0 +1,99 @@
+[[esql-examples]]
+== Examples
+
+++++
+<titleabbrev>Examples</titleabbrev>
+++++
+
+
+[discrete]
+=== Aggregating and enriching windows event logs
+
+[source,esql]
+----
+FROM logs-*
+| WHERE event.code IS NOT NULL
+| STATS event_code_count = count(event.code) by event.code,host.name
+| ENRICH win_events on event.code with event_description
+| WHERE event_description IS NOT NULL and host.name IS NOT NULL
+| RENAME event_description as event.description
+| SORT event_code_count desc
+| KEEP event_code_count,event.code,host.name,event.description
+----
+
+* It starts by querying logs from indices that match the pattern "logs-*".
+* Filters events where the "event.code" field is not null.
+* Aggregates the count of events by "event.code" and "host.name."
+* Enriches the events with additional information using the "EVENT_DESCRIPTION" field.
+* Filters out events where "EVENT_DESCRIPTION" or "host.name" is null.
+* Renames "EVENT_DESCRIPTION" as "event.description."
+* Sorts the result by "event_code_count" in descending order.
+* Keeps only selected fields: "event_code_count," "event.code," "host.name," and "event.description."
+
+
+[discrete]
+=== Summing outbound traffic from a process `curl.exe`
+
+[source,esql]
+----
+FROM logs-endpoint
+| WHERE process.name == "curl.exe"
+| STATS bytes = SUM(destination.bytes) BY destination.address
+| EVAL kb =  bytes/1024
+| SORT kb desc
+| LIMIT 10
+| KEEP kb,destination.address
+----
+
+* Queries logs from the "logs-endpoint" source.
+* Filters events where the "process.name" field is "curl.exe."
+* Calculates the sum of bytes sent to destination addresses and converts it to kilobytes (KB).
+* Sorts the results by "kb" (kilobytes) in descending order.
+* Limits the output to the top 10 results.
+* Keeps only the "kb" and "destination.address" fields.
+
+
+[discrete]
+=== Manipulating DNS logs to find a high number of unique dns queries per registered domain
+
+[source,esql]
+----
+FROM logs-*
+| GROK dns.question.name "%{DATA}\\.%{GREEDYDATA:dns.question.registered_domain:string}"
+| STATS unique_queries = count_distinct(dns.question.name) by dns.question.registered_domain, process.name
+| WHERE unique_queries > 10
+| SORT unique_queries DESC
+| RENAME unique_queries AS `Unique Queries`, dns.question.registered_domain AS `Registered Domain`, process.name AS `Process`
+----
+
+* Queries logs from indices matching "logs-*."
+* Uses the "grok" pattern to extract the registered domain from the "dns.question.name" field.
+* Calculates the count of unique DNS queries per registered domain and process name.
+* Filters results where "unique_queries" are greater than 10.
+* Sorts the results by "unique_queries" in descending order.
+* Renames fields for clarity: "unique_queries" to "Unique Queries," "dns.question.registered_domain" to "Registered Domain," and "process.name" to "Process."
+
+
+[discrete]
+=== Identifying high-numbers of outbound user connections
+
+[source,esql]
+----
+FROM logs-*
+| WHERE NOT CIDR_MATCH(destination.ip, "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")
+| STATS destcount = COUNT(destination.ip) BY user.name, host.name
+| ENRICH ldap_lookup_new ON user.name
+| WHERE group.name IS NOT NULL
+| EVAL follow_up = CASE(destcount >= 100, "true","false")
+| SORT destcount desc
+| KEEP destcount, host.name, user.name, group.name, follow_up
+----
+
+* Queries logs from indices matching "logs-*."
+* Filters out events where the destination IP address falls within private IP address ranges (e.g., 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16).
+* Calculates the count of unique destination IPs by "user.name" and "host.name."
+* Enriches the "user.name" field with LDAP group information.
+* Filters out results where "group.name" is not null.
+* Uses a "CASE" statement to create a "follow_up" field, setting it to "true" when "destcount" is greater than or equal to 100 and "false" otherwise.
+* Sorts the results by "destcount" in descending order.
+* Keeps selected fields: "destcount," "host.name," "user.name," "group.name," and "follow_up."

--- a/docs/reference/esql/esql-get-started.asciidoc
+++ b/docs/reference/esql/esql-get-started.asciidoc
@@ -5,4 +5,30 @@
 <titleabbrev>Getting started</titleabbrev>
 ++++
 
-coming::[8.11]
+A simple example of an {esql} query is shown below:
+[source,esql]
+----
+FROM employees
+| EVAL age = DATE_DIFF(NOW(), birth_date, 'Y')
+| STATS AVG(age) BY department
+| SORT age DESC
+----
+
+Each {esql} query starts with a <<esql-commands,source command>>. A source command produces
+a table, typically with data from {es}.
+
+image::images/esql/source-command.svg[A source command producing a table from {es},align="center"]
+
+A source command can be followed by one or more
+<<esql-commands,processing commands>>. Processing commands change an
+input table by adding, removing, or changing rows and columns.
+Processing commands can perform filtering, projection, aggregation, and more.
+
+image::images/esql/processing-command.svg[A processing command changing an input table,align="center"]
+
+You can chain processing commands, separated by a pipe character: `|`. Each
+processing command works on the output table of the previous command.
+
+image::images/esql/chaining-processing-commands.svg[Processing commands can be chained,align="center"]
+
+The result of a query is the table produced by the final processing command.

--- a/docs/reference/esql/esql-language.asciidoc
+++ b/docs/reference/esql/esql-language.asciidoc
@@ -1,8 +1,8 @@
 [[esql-language]]
-== Working with the {esql} language
+== Learning {esql}
 
 ++++
-<titleabbrev>Working with the {esql} language</titleabbrev>
+<titleabbrev>Learning {esql}</titleabbrev>
 ++++
 
 Detailed information about the {esql} language:
@@ -11,14 +11,10 @@ Detailed information about the {esql} language:
 * <<esql-commands>>
 * <<esql-functions>>
 * <<esql-multivalued-fields>>
-* <<esql-metadata-fields>>
 * <<esql-process-data-with-dissect-and-grok>>
-* <<esql-enrich-data>>
 
 include::esql-syntax.asciidoc[]
 include::esql-commands.asciidoc[]
 include::esql-functions-operators.asciidoc[]
 include::multivalued-fields.asciidoc[]
-include::metadata-fields.asciidoc[]
 include::esql-process-data-with-dissect-grok.asciidoc[]
-include::esql-enrich-data.asciidoc[]

--- a/docs/reference/esql/esql-limitations.asciidoc
+++ b/docs/reference/esql/esql-limitations.asciidoc
@@ -5,11 +5,13 @@
 <titleabbrev>Limitations</titleabbrev>
 ++++
 
+This is work in progress.
+
 [discrete]
 [[esql-supported-types]]
 === Supported types
 
-* {esql} currently supports the following <<mapping-types,field types>>:
+{esql} currently supports the following <<mapping-types,field types>>:
 
 ** `alias`
 ** `boolean`
@@ -23,6 +25,12 @@
 ** `text`
 ** `unsigned_long`
 ** `version`
+
+[discrete]
+[[esql-tsdb]]
+=== {esql} and time series data
+
+{esql} does not support time series data (TSDS).
 
 [discrete]
 [[esql-max-rows]]

--- a/docs/reference/esql/esql-process-data-with-dissect-grok.asciidoc
+++ b/docs/reference/esql/esql-process-data-with-dissect-grok.asciidoc
@@ -1,8 +1,8 @@
 [[esql-process-data-with-dissect-and-grok]]
-=== Data processing with `DISSECT` and `GROK`
+=== Data processing with DISSECT and GROK
 
 ++++
-<titleabbrev>Data processing with `DISSECT` and `GROK`</titleabbrev>
+<titleabbrev>Data processing with DISSECT and GROK</titleabbrev>
 ++++
 
 Your data may contain unstructured strings that you want to structure. This

--- a/docs/reference/esql/index.asciidoc
+++ b/docs/reference/esql/index.asciidoc
@@ -8,47 +8,21 @@
 
 preview::[]
 
-The {es} Query Language ({esql}) provides a powerful way to filter, transform, and analyze data stored in {es}.
+The {es} Query Language ({esql}) provides a powerful way to filter, transform, and analyze data stored in {es}, and in the future in other runtimes.
+It is designed to be easy to learn and use, by end users, SRE teams, application developers, and administrators.
+
 Users can author {esql} queries to find specific events, perform statistical analysis, and generate visualizations.
 It supports a wide range of commands and functions that enable users to perform various data operations,
 such as filtering, aggregation, time-series analysis, and more.
 
-The {es} Query Language ({esql}) makes use of "pipes" to manipulate and transform data in a step-by-step fashion.
+The {es} Query Language ({esql}) makes use of "pipes" (|) to manipulate and transform data in a step-by-step fashion.
 This approach allows users to compose a series of operations, where the output of one operation becomes the input for the next,
 enabling complex data transformations and analysis.
-
-A simple example of an {esql} query is shown below:
-[source,esql]
-----
-FROM employees
-| EVAL age = DATE_DIFF(NOW(), birth_date, 'Y')
-| STATS AVG(age) BY department
-| SORT age DESC
-----
-
-Each {esql} query starts with a <<esql-commands,source command>>. A source command produces
-a table, typically with data from {es}.
-
-image::images/esql/source-command.svg[A source command producing a table from {es},align="center"]
-
-A source command can be followed by one or more
-<<esql-commands,processing commands>>. Processing commands change an
-input table by adding, removing, or changing rows and columns.
-Processing commands can perform filtering, projection, aggregation, and more.
-
-image::images/esql/processing-command.svg[A processing command changing an input table,align="center"]
-
-You can chain processing commands, separated by a pipe character: `|`. Each
-processing command works on the output table of the previous command.
-
-image::images/esql/chaining-processing-commands.svg[Processing commands can be chained,align="center"]
-
-The result of a query is the table produced by the final processing command.
 
 [discrete]
 === The {esql} Compute Engine
 
-{esql} is more than a language. It represents a significant investment in new compute capabilities within {es}.
+{esql} is more than a language: it represents a significant investment in new compute capabilities within {es}.
 To achieve both the functional and performance requirements for {esql}, it was necessary to build an entirely new
 compute architecture. {esql} search, aggregation, and transformation functions are directly executed within Elasticsearch
 itself. Query expressions are not transpiled to Query DSL for execution. This approach allows {esql} to be extremely performant and versatile.
@@ -61,11 +35,17 @@ include::esql-language.asciidoc[]
 
 include::esql-rest.asciidoc[]
 
+include::metadata-fields.asciidoc[]
+
 include::esql-kibana.asciidoc[]
 
 include::task-management.asciidoc[]
 
+include::esql-enrich-data.asciidoc[]
+
 include::esql-limitations.asciidoc[]
+
+include::esql-examples.asciidoc[]
 
 :esql-tests!:
 :esql-specs!:

--- a/docs/reference/esql/metadata-fields.asciidoc
+++ b/docs/reference/esql/metadata-fields.asciidoc
@@ -1,5 +1,5 @@
 [[esql-metadata-fields]]
-=== {esql} metadata fields
+== {esql} metadata fields
 
 ++++
 <titleabbrev>Metadata fields</titleabbrev>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.11`:
 - [esql docs: structure, examples, minor improvements (#101292)](https://github.com/elastic/elasticsearch/pull/101292)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)