### PR TITLE
ESQL DOCS: speed note on stats

### DIFF
--- a/docs/reference/esql/processing-commands/stats.asciidoc
+++ b/docs/reference/esql/processing-commands/stats.asciidoc
@@ -43,3 +43,11 @@ include::{esql-specs}/docs.csv-spec[tag=statsGroupByMultipleValues]
 The following aggregation functions are supported:
 
 include::../functions/aggregation-functions.asciidoc[tag=agg_list]
+
+NOTE: `STATS` without any groups is much much faster than adding group.
+
+NOTE: Grouping on a single field is currently much more optimized than grouping
+      on many fields. In some tests we've seen grouping on a single `keyword`
+      field to be five times faster than grouping on two `keyword` fields. Don't
+      try to work around this combining the two fields together with something
+      like <<esql-concat>> and then grouping - that's not going to be faster.


### PR DESCRIPTION
Grouping by no fields is much much faster than grouping by one field. Grouping by one field is like 5x faster than grouping on two fields.
