### PR TITLE
[Transform] Remove last use of Version from TransformConfigVersion

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformConfigVersion.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformConfigVersion.java
@@ -302,17 +302,6 @@ public record TransformConfigVersion(int id) implements VersionId<TransformConfi
         return version1.id > version2.id ? version1 : version2;
     }
 
-    // Visible only for testing
-    static TransformConfigVersion fromVersion(Version version) {
-        if (version.equals(Version.V_8_10_0)) {
-            return V_10;
-        }
-        if (version.after(Version.V_8_10_0)) {
-            throw new IllegalArgumentException("Cannot convert " + version + ". Incompatible version");
-        }
-        return fromId(version.id);
-    }
-
     public static TransformConfigVersion getMinTransformConfigVersion(DiscoveryNodes nodes) {
         return getMinMaxTransformConfigVersion(nodes).v1();
     }
@@ -342,10 +331,10 @@ public record TransformConfigVersion(int id) implements VersionId<TransformConfi
 
     public static TransformConfigVersion getTransformConfigVersionForNode(DiscoveryNode node) {
         String transformConfigVerStr = node.getAttributes().get(TRANSFORM_CONFIG_VERSION_NODE_ATTR);
-        if (transformConfigVerStr == null) {
-            return fromVersion(node.getVersion());
+        if (transformConfigVerStr != null) {
+            return fromString(transformConfigVerStr);
         }
-        return fromString(transformConfigVerStr);
+        return fromId(node.getPre811VersionId().orElseThrow(() -> new IllegalStateException("getting legacy version id not possible")));
     }
 
     // Parse an TransformConfigVersion from a string.
@@ -358,12 +347,17 @@ public record TransformConfigVersion(int id) implements VersionId<TransformConfi
         if (str.equals("8.10.0")) {
             return V_10;
         }
-        Matcher matcher = Pattern.compile("^(\\d+)\\.0\\.0$").matcher(str);
-        int versionNum;
-        if (matcher.matches() == false || (versionNum = Integer.parseInt(matcher.group(1))) < 10) {
-            return fromVersion(Version.fromString(str));
+        Matcher matcher = Pattern.compile("^(\\d+)\\.(\\d+)\\.(\\d+)(?:-\\w+)?$").matcher(str);
+        if (matcher.matches() == false) {
+            throw new IllegalArgumentException("Transform config version [" + str + "] not valid");
         }
-        return fromId(1000000 * versionNum + 99);
+        int first = Integer.parseInt(matcher.group(1));
+        int second = Integer.parseInt(matcher.group(2));
+        int third = Integer.parseInt(matcher.group(3));
+        if (first >= 10 && (second > 0 || third > 0)) {
+            throw new IllegalArgumentException("Transform config version [" + str + "] not valid");
+        }
+        return fromId(1000000 * first + 10000 * second + 100 * third + 99);
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/TransformConfigVersionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/TransformConfigVersionTests.java
@@ -172,7 +172,7 @@ public class TransformConfigVersionTests extends ESTestCase {
             .version(VersionInformation.inferVersions(Version.fromString("8.7.0")))
             .build();
         TransformConfigVersion TransformConfigVersion1 = TransformConfigVersion.getTransformConfigVersionForNode(node1);
-        assertEquals(TransformConfigVersion.fromVersion(Version.V_8_5_0), TransformConfigVersion1);
+        assertEquals(TransformConfigVersion.V_8_5_0, TransformConfigVersion1);
     }
 
     public void testDefinedConstants() throws IllegalAccessException {
@@ -246,19 +246,6 @@ public class TransformConfigVersionTests extends ESTestCase {
         );
     }
 
-    public void testFromVersion() {
-        Version version_V_7_7_0 = Version.V_7_0_0;
-        TransformConfigVersion TransformConfigVersion_V_7_7_0 = TransformConfigVersion.fromVersion(version_V_7_7_0);
-        assertEquals(version_V_7_7_0.id, TransformConfigVersion_V_7_7_0.id());
-
-        // Version 8.10.0 is treated as if it is TransformConfigVersion V_10.
-        assertEquals(TransformConfigVersion.V_10.id(), TransformConfigVersion.fromVersion(Version.V_8_10_0).id());
-
-        // There's no mapping between Version and TransformConfigVersion values after Version.V_8_10_0.
-        Exception e = expectThrows(IllegalArgumentException.class, () -> TransformConfigVersion.fromVersion(Version.fromId(8_11_00_99)));
-        assertEquals("Cannot convert " + Version.fromId(8_11_00_99) + ". Incompatible version", e.getMessage());
-    }
-
     public void testVersionConstantPresent() {
         Set<TransformConfigVersion> ignore = Set.of(
             TransformConfigVersion.ZERO,
@@ -316,13 +303,9 @@ public class TransformConfigVersionTests extends ESTestCase {
         assertEquals(false, KnownTransformConfigVersions.ALL_VERSIONS.contains(unknownVersion));
         assertEquals(TransformConfigVersion.CURRENT.id() + 1, unknownVersion.id());
 
-        for (String version : new String[] { "10.2", "7.17.2.99" }) {
+        for (String version : new String[] { "10.2", "7.17.2.99", "9" }) {
             Exception e = expectThrows(IllegalArgumentException.class, () -> TransformConfigVersion.fromString(version));
-            assertEquals("the version needs to contain major, minor, and revision, and optionally the build: " + version, e.getMessage());
+            assertEquals("Transform config version [" + version + "] not valid", e.getMessage());
         }
-
-        String version = "9";
-        Exception e = expectThrows(IllegalArgumentException.class, () -> TransformConfigVersion.fromString(version));
-        assertEquals("the version needs to contain major, minor, and revision, and optionally the build: " + version, e.getMessage());
     }
 }


### PR DESCRIPTION
Uses the same approach as #100131 to make TransformConfigVersion completely independent of the Version class.