### PR TITLE
[8.11] [DOCS] Clarifies that inference input must be single string (#101301)

### DIFF
--- a/docs/reference/ingest/processors/inference.asciidoc
+++ b/docs/reference/ingest/processors/inference.asciidoc
@@ -25,10 +25,13 @@ ingested in the pipeline.
 include::common-options.asciidoc[]
 |======
 
-IMPORTANT: You cannot use the `input_output` field with the `target_field` and 
+[IMPORTANT]
+==================================================
+* You cannot use the `input_output` field with the `target_field` and 
 `field_map` fields. For NLP models, use the `input_output` option. For 
 {dfanalytics} models, use the `target_field` and `field_map` option.
-
+* Each {infer} input field must be single strings, not arrays of strings.
+==================================================
 
 [discrete]
 [[inference-input-output-example]]

--- a/docs/reference/ml/trained-models/apis/infer-trained-model.asciidoc
+++ b/docs/reference/ml/trained-models/apis/infer-trained-model.asciidoc
@@ -57,7 +57,8 @@ Controls the amount of time to wait for {infer} results. Defaults to 10 seconds.
 (Required, array)
 An array of objects to pass to the model for inference. The objects should
 contain the fields matching your configured trained model input. Typically for
-NLP models, the field name is `text_field`.
+NLP models, the field name is `text_field`. Each {infer} input field specified 
+in this property must be single strings not arrays of strings.
 
 //Begin inference_config
 `inference_config`::


### PR DESCRIPTION
Backports the following commits to 8.11:
 - [DOCS] Clarifies that inference input must be single string (#101301)