### PR TITLE
[ML] Return a no-scale autoscaling response if job size unavailable

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingResourceTracker.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingResourceTracker.java
@@ -141,9 +141,9 @@ public final class MlAutoscalingResourceTracker {
             Long jobMemory = mlMemoryTracker.getAnomalyDetectorJobMemoryRequirement(jobId);
 
             if (jobMemory == null) {
-                // TODO: this indicates a bug, should we indicate that the result is incomplete?
-                logger.debug("could not find memory requirement for job [{}], skipping", jobId);
-                continue;
+                logger.debug("could not find memory requirement for job [{}], returning no-scale", jobId);
+                listener.onResponse(noScaleStats(numberMlNodes));
+                return;
             }
 
             if (AWAITING_LAZY_ASSIGNMENT.equals(task.getAssignment())) {
@@ -169,9 +169,9 @@ public final class MlAutoscalingResourceTracker {
             Long jobMemory = mlMemoryTracker.getDataFrameAnalyticsJobMemoryRequirement(jobId);
 
             if (jobMemory == null) {
-                // TODO: this indicates a bug, should we indicate that the result is incomplete?
-                logger.debug("could not find memory requirement for job [{}], skipping", jobId);
-                continue;
+                logger.debug("could not find memory requirement for job [{}], returning no-scale", jobId);
+                listener.onResponse(noScaleStats(numberMlNodes));
+                return;
             }
 
             if (AWAITING_LAZY_ASSIGNMENT.equals(task.getAssignment())) {
@@ -291,6 +291,10 @@ public final class MlAutoscalingResourceTracker {
      */
     public static MlAutoscalingStats noScaleStats(ClusterState clusterState) {
         int numberMlNodes = (int) clusterState.nodes().stream().filter(node -> node.getRoles().contains(DiscoveryNodeRole.ML_ROLE)).count();
+        return noScaleStats(numberMlNodes);
+    }
+
+    private static MlAutoscalingStats noScaleStats(int numberMlNodes) {
         return new MlAutoscalingStats(
             numberMlNodes,
             0,


### PR DESCRIPTION
It's possible that a job size can be unavailable, if some other problem within a cluster is preventing searches from working.

In this situation we should not return an autoscaling response that ignores the jobs in question, as that can lead to a request to scale down inappropriately.

Instead we should return no-scale events until the cluster can successfully perform searches again.