### PR TITLE
[DOCS] One more round of restructuring the ES|QL documentation

### DIFF
--- a/docs/reference/esql/esql-enrich-data.asciidoc
+++ b/docs/reference/esql/esql-enrich-data.asciidoc
@@ -1,5 +1,5 @@
 [[esql-enrich-data]]
-== Data enrichment
+=== Data enrichment
 
 ++++
 <titleabbrev>Data enrichment</titleabbrev>
@@ -17,7 +17,7 @@ For example, you can use `ENRICH` to:
 
 [discrete]
 [[esql-how-enrich-works]]
-=== How the `ENRICH` command works
+==== How the `ENRICH` command works
 
 The `ENRICH` command adds new columns to a table, with data from {es} indices.
 It requires a few special components:
@@ -65,7 +65,7 @@ include::../ingest/enrich.asciidoc[tag=enrich-index]
 
 [discrete]
 [[esql-set-up-enrich-policy]]
-=== Set up an enrich policy
+==== Set up an enrich policy
 
 To start using `ENRICH`, follow these steps:
 
@@ -89,25 +89,25 @@ your query.
 
 [discrete]
 [[esql-enrich-prereqs]]
-=== Prerequisites
+==== Prerequisites
 
 include::{es-repo-dir}/ingest/apis/enrich/put-enrich-policy.asciidoc[tag=enrich-policy-api-prereqs]
 
 [discrete]
 [[esql-create-enrich-source-index]]
-=== Add enrich data
+==== Add enrich data
 
 include::../ingest/enrich.asciidoc[tag=create-enrich-source-index]
 
 [discrete]
 [[esql-create-enrich-policy]]
-=== Create an enrich policy
+==== Create an enrich policy
 
 include::../ingest/enrich.asciidoc[tag=create-enrich-policy]
 
 [discrete]
 [[esql-execute-enrich-policy]]
-=== Execute the enrich policy
+==== Execute the enrich policy
 
 include::../ingest/enrich.asciidoc[tag=execute-enrich-policy1]
 
@@ -117,7 +117,7 @@ include::../ingest/enrich.asciidoc[tag=execute-enrich-policy2]
 
 [discrete]
 [[esql-use-enrich]]
-=== Use the enrich policy
+==== Use the enrich policy
 
 After the policy has been executed, you can use the <<esql-enrich,`ENRICH`
 command>> to enrich your data.
@@ -128,12 +128,12 @@ include::processing-commands/enrich.asciidoc[tag=examples]
 
 [discrete]
 [[esql-update-enrich-data]]
-=== Update an enrich index
+==== Update an enrich index
 
 include::{es-repo-dir}/ingest/apis/enrich/execute-enrich-policy.asciidoc[tag=update-enrich-index]
 
 [discrete]
 [[esql-update-enrich-policies]]
-=== Update an enrich policy
+==== Update an enrich policy
 
 include::../ingest/enrich.asciidoc[tag=update-enrich-policy]

--- a/docs/reference/esql/esql-examples.asciidoc
+++ b/docs/reference/esql/esql-examples.asciidoc
@@ -1,5 +1,5 @@
 [[esql-examples]]
-== Examples
+== {esql} examples
 
 ++++
 <titleabbrev>Examples</titleabbrev>

--- a/docs/reference/esql/esql-kibana.asciidoc
+++ b/docs/reference/esql/esql-kibana.asciidoc
@@ -1,5 +1,5 @@
 [[esql-kibana]]
-== Using {esql} in {kib}
+=== Using {esql} in {kib}
 
 ++++
 <titleabbrev>Kibana</titleabbrev>

--- a/docs/reference/esql/esql-language.asciidoc
+++ b/docs/reference/esql/esql-language.asciidoc
@@ -10,11 +10,15 @@ Detailed information about the {esql} language:
 * <<esql-syntax>>
 * <<esql-commands>>
 * <<esql-functions>>
+* <<esql-metadata-fields>>
 * <<esql-multivalued-fields>>
+* <<esql-enrich-data>>
 * <<esql-process-data-with-dissect-and-grok>>
 
 include::esql-syntax.asciidoc[]
 include::esql-commands.asciidoc[]
 include::esql-functions-operators.asciidoc[]
+include::metadata-fields.asciidoc[]
 include::multivalued-fields.asciidoc[]
 include::esql-process-data-with-dissect-grok.asciidoc[]
+include::esql-enrich-data.asciidoc[]

--- a/docs/reference/esql/esql-rest.asciidoc
+++ b/docs/reference/esql/esql-rest.asciidoc
@@ -1,5 +1,5 @@
 [[esql-rest]]
-== {esql} REST API
+=== {esql} REST API
 
 ++++
 <titleabbrev>REST API</titleabbrev>
@@ -38,7 +38,7 @@ James S.A. Corey |Leviathan Wakes     |561            |2011-06-02T00:00:00.000Z
 
 [discrete]
 [[esql-kibana-console]]
-=== Kibana Console
+==== Kibana Console
 
 If you are using {kibana-ref}/console-kibana.html[Kibana Console] (which is
 highly recommended), take advantage of the triple quotes `"""` when creating the
@@ -62,7 +62,7 @@ POST /_query?format=txt
 
 [discrete]
 [[esql-rest-format]]
-=== Response formats
+==== Response formats
 
 {esql} can return the data in the following human readable and binary formats.
 You can set the format by specifying the `format` parameter in the URL or by
@@ -121,7 +121,7 @@ Use the `tsv` format instead.
 
 [discrete]
 [[esql-rest-filtering]]
-=== Filtering using {es} Query DSL
+==== Filtering using {es} Query DSL
 
 Specify a Query DSL query in the `filter` parameter to filter the set of
 documents that an {esql} query runs on.
@@ -161,7 +161,7 @@ Douglas Adams  |The Hitchhiker's Guide to the Galaxy|180            |1979-10-12T
 
 [discrete]
 [[esql-rest-columnar]]
-=== Columnar results
+==== Columnar results
 
 By default, {esql} returns results as rows. For example, `FROM` returns each
 individual document as one row. For the `json`, `yaml`, `cbor` and `smile`
@@ -206,7 +206,7 @@ Which returns:
 
 [discrete]
 [[esql-rest-params]]
-=== Passing parameters to a query
+==== Passing parameters to a query
 
 Values, for example for a condition, can be passed to a query "inline", by
 integrating the value in the query string itself:

--- a/docs/reference/esql/esql-using.asciidoc
+++ b/docs/reference/esql/esql-using.asciidoc
@@ -1,0 +1,16 @@
+[[esql-using]]
+== Using {esql}
+
+<<esql-rest>>::
+Information about using the <<esql-query-api,{esql} query API>>.
+
+<<esql-kibana>>::
+Using {esql} in {kib} to query and aggregate your data, create visualizations,
+and set up alerts. 
+
+<<esql-task-management>>::
+Using the <<tasks,task management API>> to list and cancel {esql} queries.
+
+include::esql-rest.asciidoc[]
+include::esql-kibana.asciidoc[]
+include::task-management.asciidoc[]

--- a/docs/reference/esql/index.asciidoc
+++ b/docs/reference/esql/index.asciidoc
@@ -33,15 +33,7 @@ include::esql-get-started.asciidoc[]
 
 include::esql-language.asciidoc[]
 
-include::esql-rest.asciidoc[]
-
-include::metadata-fields.asciidoc[]
-
-include::esql-kibana.asciidoc[]
-
-include::task-management.asciidoc[]
-
-include::esql-enrich-data.asciidoc[]
+include::esql-using.asciidoc[]
 
 include::esql-limitations.asciidoc[]
 

--- a/docs/reference/esql/index.asciidoc
+++ b/docs/reference/esql/index.asciidoc
@@ -8,26 +8,61 @@
 
 preview::[]
 
-The {es} Query Language ({esql}) provides a powerful way to filter, transform, and analyze data stored in {es}, and in the future in other runtimes.
-It is designed to be easy to learn and use, by end users, SRE teams, application developers, and administrators.
+The {es} Query Language ({esql}) provides a powerful way to filter, transform,
+and analyze data stored in {es}, and in the future in other runtimes. It is
+designed to be easy to learn and use, by end users, SRE teams, application
+developers, and administrators.
 
-Users can author {esql} queries to find specific events, perform statistical analysis, and generate visualizations.
-It supports a wide range of commands and functions that enable users to perform various data operations,
-such as filtering, aggregation, time-series analysis, and more.
+Users can author {esql} queries to find specific events, perform statistical
+analysis, and generate visualizations. It supports a wide range of commands and
+functions that enable users to perform various data operations, such as
+filtering, aggregation, time-series analysis, and more.
 
-The {es} Query Language ({esql}) makes use of "pipes" (|) to manipulate and transform data in a step-by-step fashion.
-This approach allows users to compose a series of operations, where the output of one operation becomes the input for the next,
-enabling complex data transformations and analysis.
+The {es} Query Language ({esql}) makes use of "pipes" (|) to manipulate and
+transform data in a step-by-step fashion. This approach allows users to compose
+a series of operations, where the output of one operation becomes the input for
+the next, enabling complex data transformations and analysis.
 
 [discrete]
 === The {esql} Compute Engine
 
-{esql} is more than a language: it represents a significant investment in new compute capabilities within {es}.
-To achieve both the functional and performance requirements for {esql}, it was necessary to build an entirely new
-compute architecture. {esql} search, aggregation, and transformation functions are directly executed within Elasticsearch
-itself. Query expressions are not transpiled to Query DSL for execution. This approach allows {esql} to be extremely performant and versatile.
+{esql} is more than a language: it represents a significant investment in new
+compute capabilities within {es}. To achieve both the functional and performance
+requirements for {esql}, it was necessary to build an entirely new compute
+architecture. {esql} search, aggregation, and transformation functions are
+directly executed within Elasticsearch itself. Query expressions are not
+transpiled to Query DSL for execution. This approach allows {esql} to be
+extremely performant and versatile.
 
-The new {esql} execution engine was designed with performance in mind — it operates on blocks at a time instead of per row, targets vectorization and cache locality, and embraces specialization and multi-threading. It is a separate component from the existing Elasticsearch aggregation framework with different performance characteristics.
+The new {esql} execution engine was designed with performance in mind — it
+operates on blocks at a time instead of per row, targets vectorization and cache
+locality, and embraces specialization and multi-threading. It is a separate
+component from the existing Elasticsearch aggregation framework with different
+performance characteristics.
+
+The {esql} documentation is organized in these sections:
+
+<<esql-getting-started>>::
+A tutorial to help you get started with {esql}.
+
+<<esql-language>>::
+
+Reference documentation for the <<esql-syntax,{esql} syntax>>,
+<<esql-commands,commands>>, and <<esql-functions-operators,functions and
+operators>>. Information about working with <<esql-metadata-fields,metadata
+fields>> and <<esql-multivalued-fields,multivalued fields>>. And guidance for
+<<esql-process-data-with-dissect-and-grok,data processing with DISSECT and
+GROK>> and <<esql-enrich-data,data enrichment with ENRICH>>.
+
+<<esql-using>>::
+An overview of using the <<esql-rest>>, <<esql-kibana>>, and
+<<esql-task-management>>.
+
+<<esql-limitations>>::
+The current limitations of {esql}.
+
+<<esql-examples>>::
+A few examples of what you can with {esql}.
 
 include::esql-get-started.asciidoc[]
 

--- a/docs/reference/esql/metadata-fields.asciidoc
+++ b/docs/reference/esql/metadata-fields.asciidoc
@@ -1,5 +1,5 @@
 [[esql-metadata-fields]]
-== {esql} metadata fields
+=== {esql} metadata fields
 
 ++++
 <titleabbrev>Metadata fields</titleabbrev>

--- a/docs/reference/esql/task-management.asciidoc
+++ b/docs/reference/esql/task-management.asciidoc
@@ -1,5 +1,5 @@
 [[esql-task-management]]
-== {esql} task management
+=== {esql} task management
 
 ++++
 <titleabbrev>Task management</titleabbrev>


### PR DESCRIPTION
One more round of restructuring the ES|QL documentation, after a conversation with @abatsakis :

Moves the following pages under "Learning ES|QL":
- Syntax reference
- Commands
- Functions and operators
- Metadata fields
- Multivalued fields
- Data enrichment
- Data processing with DISSECT and GROK

Moves the following pages under "Using ES|QL":
- REST API
- Kibana
- Task management

Adds links to the different sections to the landing page.