### PR TITLE
[7.17] [ci] Remove unused jjbb variable

### DIFF
--- a/.ci/jobs.t/elastic+elasticsearch+periodic+bwc.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+periodic+bwc.yml
@@ -3,7 +3,6 @@ jjbb-template: matrix-gradle-unix-disabled.yml
 vars:
   - job-name: elastic+elasticsearch+%BRANCH%+periodic+bwc
   - job-display-name: "elastic / elasticsearch # %BRANCH% - backwards compatibility matrix"
-  - job-description: "Testing of the Elasticsearch %BRANCH% branch backwards compatibility matrix.\n"
   - matrix-yaml-file: ".ci/bwcVersions"
   - matrix-variable: BWC_VERSION
   - gradle-args: "-Dbwc.checkout.align=true v$BWC_VERSION#bwcTest"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [ci] Remove unused jjbb variable (91e5259f)

<!--- Backport version: 9.2.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)