### PR TITLE
Report full stack trace for non-state file settings transforms

### DIFF
--- a/docs/changelog/101346.yaml
+++ b/docs/changelog/101346.yaml
@@ -1,0 +1,5 @@
+pr: 101346
+summary: Report full stack trace for non-state file settings transforms
+area: Infra/Settings
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/reservedstate/service/ReservedClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/ReservedClusterStateService.java
@@ -239,7 +239,7 @@ public class ReservedClusterStateService {
             @Override
             public void onFailure(Exception e) {
                 // If we encounter an error while runnin the non-state transforms, we avoid saving any cluster state.
-                errorListener.accept(checkAndReportError(namespace, List.of(e.getMessage()), reservedStateVersion));
+                errorListener.accept(checkAndReportError(namespace, List.of(stackTrace(e)), reservedStateVersion));
             }
         });
     }


### PR DESCRIPTION
In most cases file based settings apply transformations from configuration to cluster state. However, there exists "non state" transformations as well. When these are run, any errors are stored in cluster state. This commit fixes a bug in handling of these exception cases where just the exception messages, instead of the full stack trace, was captured.