### PR TITLE
[8.11] Register `repository_s3` settings (#101344)

### DIFF
--- a/docs/changelog/101344.yaml
+++ b/docs/changelog/101344.yaml
@@ -1,0 +1,5 @@
+pr: 101344
+summary: Register `repository_s3` settings
+area: Snapshot/Restore
+type: bug
+issues: []

--- a/modules/repository-s3/src/internalClusterTest/java/org/elasticsearch/repositories/s3/S3RepositoryThirdPartyTests.java
+++ b/modules/repository-s3/src/internalClusterTest/java/org/elasticsearch/repositories/s3/S3RepositoryThirdPartyTests.java
@@ -67,6 +67,26 @@ public class S3RepositoryThirdPartyTests extends AbstractThirdPartyRepositoryTes
     }
 
     @Override
+    protected Settings nodeSettings() {
+        final var settings = Settings.builder().put(super.nodeSettings());
+        if (randomBoolean()) {
+            final var defaultMillis = S3Service.REPOSITORY_S3_CAS_TTL_SETTING.get(Settings.EMPTY).millis();
+            settings.put(
+                S3Service.REPOSITORY_S3_CAS_TTL_SETTING.getKey(),
+                TimeValue.timeValueMillis(randomLongBetween(defaultMillis, defaultMillis * 2))
+            );
+        }
+        if (randomBoolean()) {
+            final var defaultMillis = S3Service.REPOSITORY_S3_CAS_ANTI_CONTENTION_DELAY_SETTING.get(Settings.EMPTY).millis();
+            settings.put(
+                S3Service.REPOSITORY_S3_CAS_ANTI_CONTENTION_DELAY_SETTING.getKey(),
+                TimeValue.timeValueMillis(randomLongBetween(defaultMillis, defaultMillis * 2))
+            );
+        }
+        return settings.build();
+    }
+
+    @Override
     protected void createRepository(String repoName) {
         Settings.Builder settings = Settings.builder()
             .put("bucket", System.getProperty("test.s3.bucket"))

--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RepositoryPlugin.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RepositoryPlugin.java
@@ -148,6 +148,8 @@ public class S3RepositoryPlugin extends Plugin implements RepositoryPlugin, Relo
             S3ClientSettings.USE_PATH_STYLE_ACCESS,
             S3ClientSettings.SIGNER_OVERRIDE,
             S3ClientSettings.REGION,
+            S3Service.REPOSITORY_S3_CAS_TTL_SETTING,
+            S3Service.REPOSITORY_S3_CAS_ANTI_CONTENTION_DELAY_SETTING,
             S3Repository.ACCESS_KEY_SETTING,
             S3Repository.SECRET_KEY_SETTING
         );

--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Service.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Service.java
@@ -54,13 +54,13 @@ import static java.util.Collections.emptyMap;
 class S3Service implements Closeable {
     private static final Logger LOGGER = LogManager.getLogger(S3Service.class);
 
-    private static final Setting<TimeValue> REPOSITORY_S3_CAS_TTL_SETTING = Setting.timeSetting(
+    static final Setting<TimeValue> REPOSITORY_S3_CAS_TTL_SETTING = Setting.timeSetting(
         "repository_s3.compare_and_exchange.time_to_live",
         StoreHeartbeatService.HEARTBEAT_FREQUENCY,
         Setting.Property.NodeScope
     );
 
-    private static final Setting<TimeValue> REPOSITORY_S3_CAS_ANTI_CONTENTION_DELAY_SETTING = Setting.timeSetting(
+    static final Setting<TimeValue> REPOSITORY_S3_CAS_ANTI_CONTENTION_DELAY_SETTING = Setting.timeSetting(
         "repository_s3.compare_and_exchange.anti_contention_delay",
         TimeValue.timeValueSeconds(1),
         TimeValue.timeValueMillis(1),


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Register `repository_s3` settings (#101344)