### PR TITLE
Enable RemoteClusterClientTests#testConnectAndExecuteRequest

### DIFF
--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterClientTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterClientTests.java
@@ -52,7 +52,6 @@ public class RemoteClusterClientTests extends ESTestCase {
         ThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/97080")
     public void testConnectAndExecuteRequest() throws Exception {
         Settings remoteSettings = Settings.builder()
             .put(ClusterName.CLUSTER_NAME_SETTING.getKey(), "foo_bar_cluster")


### PR DESCRIPTION
The test was muted in #97080 without a follow up. Failures are not reproducible anymore, and couldn't find any specific commits from 21.06.2023 that could cause the issue.

The only suspicious part from me is that failure logs contain extremely verbose TRACE logs, so there might have been some infra problem causing a node to be unreachable and throwing NodeDisconnectedException

Fixes #97080