### PR TITLE
Make DISSECT parameter append_separator case insensitive

### DIFF
--- a/docs/changelog/101358.yaml
+++ b/docs/changelog/101358.yaml
@@ -1,0 +1,6 @@
+pr: 101358
+summary: Make DISSECT parameter `append_separator` case insensitive
+area: ES|QL
+type: bug
+issues:
+ - 101138

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/dissect.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/dissect.csv-spec
@@ -48,6 +48,13 @@ a:keyword        | b:keyword   | c:keyword    | d:keyword
 foo 1 bar 2 baz  | foo,bar,baz | 1            | 2         
 ;
 
+appendSeparatorUppercase
+row a = "foo 1 bar 2 baz" | dissect a "%{+b} %{c} %{+b} %{d} %{+b}" APPEND_SEPARATOR=",";
+
+a:keyword        | b:keyword   | c:keyword    | d:keyword 
+foo 1 bar 2 baz  | foo,bar,baz | 1            | 2         
+;
+
 
 namedSkip
 row a = "foo bar baz" | dissect a "%{b} %{?c} %{d}";

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/LogicalPlanBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/LogicalPlanBuilder.java
@@ -110,7 +110,7 @@ public class LogicalPlanBuilder extends ExpressionBuilder {
             Map<String, Object> options = visitCommandOptions(ctx.commandOptions());
             String appendSeparator = "";
             for (Map.Entry<String, Object> item : options.entrySet()) {
-                if (item.getKey().equals("append_separator") == false) {
+                if (item.getKey().equalsIgnoreCase("append_separator") == false) {
                     throw new ParsingException(source(ctx), "Invalid option for dissect: [{}]", item.getKey());
                 }
                 if (item.getValue() instanceof String == false) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
@@ -613,12 +613,14 @@ public class StatementParserTests extends ESTestCase {
         assertEquals("", dissect.parser().appendSeparator());
         assertEquals(List.of(referenceAttribute("foo", KEYWORD)), dissect.extractedFields());
 
-        cmd = processingCommand("dissect a \"%{foo}\" append_separator=\",\"");
-        assertEquals(Dissect.class, cmd.getClass());
-        dissect = (Dissect) cmd;
-        assertEquals("%{foo}", dissect.parser().pattern());
-        assertEquals(",", dissect.parser().appendSeparator());
-        assertEquals(List.of(referenceAttribute("foo", KEYWORD)), dissect.extractedFields());
+        for (String separatorName : List.of("append_separator", "APPEND_SEPARATOR", "AppEnd_SeparAtor")) {
+            cmd = processingCommand("dissect a \"%{foo}\" " + separatorName + "=\",\"");
+            assertEquals(Dissect.class, cmd.getClass());
+            dissect = (Dissect) cmd;
+            assertEquals("%{foo}", dissect.parser().pattern());
+            assertEquals(",", dissect.parser().appendSeparator());
+            assertEquals(List.of(referenceAttribute("foo", KEYWORD)), dissect.extractedFields());
+        }
 
         for (Tuple<String, String> queryWithUnexpectedCmd : List.of(
             Tuple.tuple("from a | dissect foo \"\"", "[]"),


### PR DESCRIPTION
DISSECT command accepts an `append_separator` parameter for cases where the pattern has multiple occurrences of the same item, eg.

```
ROW a = "john jacob jingleheimer schmidt"
| DISSECT a "%{+name} %{+name} %{+name} %{+name}" append_separator="---""
```

This PR makes this parameter name case insensitive

Fixes https://github.com/elastic/elasticsearch/issues/101138
