### PR TITLE
Use switch expressions in MessagesTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/coordination/MessagesTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/MessagesTests.java
@@ -35,8 +35,7 @@ public class MessagesTests extends ESTestCase {
             randomNonNegativeLong(),
             randomNonNegativeLong()
         );
-        // Note: the explicit type parameter is needed for some IDE (specifically Eclipse 4.8.0) to infer the right type
-        EqualsHashCodeTestUtils.<Join>checkEqualsAndHashCode(
+        EqualsHashCodeTestUtils.checkEqualsAndHashCode(
             initialJoin,
             join -> copyWriteable(join, writableRegistry(), Join::new),
             join -> switch (randomInt(4)) {
@@ -101,8 +100,7 @@ public class MessagesTests extends ESTestCase {
 
     public void testPublishResponseEqualsHashCodeSerialization() {
         PublishResponse initialPublishResponse = new PublishResponse(randomNonNegativeLong(), randomNonNegativeLong());
-        // Note: the explicit type parameter is needed for some IDE (specifically Eclipse 4.8.0) to infer the right type
-        EqualsHashCodeTestUtils.<PublishResponse>checkEqualsAndHashCode(
+        EqualsHashCodeTestUtils.checkEqualsAndHashCode(
             initialPublishResponse,
             publishResponse -> copyWriteable(publishResponse, writableRegistry(), PublishResponse::new),
             publishResponse -> switch (randomInt(1)) {
@@ -136,8 +134,7 @@ public class MessagesTests extends ESTestCase {
             initialPublishResponse,
             randomBoolean() ? Optional.empty() : Optional.of(initialJoin)
         );
-        // Note: the explicit type parameter is needed for some IDE (specifically Eclipse 4.8.0) to infer the right type
-        EqualsHashCodeTestUtils.<PublishWithJoinResponse>checkEqualsAndHashCode(
+        EqualsHashCodeTestUtils.checkEqualsAndHashCode(
             initialPublishWithJoinResponse,
             publishWithJoinResponse -> copyWriteable(publishWithJoinResponse, writableRegistry(), PublishWithJoinResponse::new),
             publishWithJoinResponse -> switch (randomInt(1)) {
@@ -168,8 +165,7 @@ public class MessagesTests extends ESTestCase {
 
     public void testStartJoinRequestEqualsHashCodeSerialization() {
         StartJoinRequest initialStartJoinRequest = new StartJoinRequest(createNode(randomAlphaOfLength(10)), randomNonNegativeLong());
-        // Note: the explicit type parameter is needed for some IDE (specifically Eclipse 4.8.0) to infer the right type
-        EqualsHashCodeTestUtils.<StartJoinRequest>checkEqualsAndHashCode(
+        EqualsHashCodeTestUtils.checkEqualsAndHashCode(
             initialStartJoinRequest,
             startJoinRequest -> copyWriteable(startJoinRequest, writableRegistry(), StartJoinRequest::new),
             startJoinRequest -> switch (randomInt(1)) {
@@ -193,8 +189,7 @@ public class MessagesTests extends ESTestCase {
             randomNonNegativeLong(),
             randomNonNegativeLong()
         );
-        // Note: the explicit type parameter is needed for some IDE (specifically Eclipse 4.8.0) to infer the right type
-        EqualsHashCodeTestUtils.<ApplyCommitRequest>checkEqualsAndHashCode(
+        EqualsHashCodeTestUtils.checkEqualsAndHashCode(
             initialApplyCommit,
             applyCommit -> copyWriteable(applyCommit, writableRegistry(), ApplyCommitRequest::new),
             applyCommit -> switch (randomInt(2)) {
@@ -234,8 +229,7 @@ public class MessagesTests extends ESTestCase {
             randomNonNegativeLong(),
             randomBoolean() ? Optional.empty() : Optional.of(initialJoin)
         );
-        // Note: the explicit type parameter is needed for some IDE (specifically Eclipse 4.8.0) to infer the right type
-        EqualsHashCodeTestUtils.<JoinRequest>checkEqualsAndHashCode(
+        EqualsHashCodeTestUtils.checkEqualsAndHashCode(
             initialJoinRequest,
             joinRequest -> copyWriteable(joinRequest, writableRegistry(), JoinRequest::new),
             joinRequest -> switch (randomInt(3)) {
@@ -297,8 +291,7 @@ public class MessagesTests extends ESTestCase {
 
     public void testPreVoteRequestEqualsHashCodeSerialization() {
         PreVoteRequest initialPreVoteRequest = new PreVoteRequest(createNode(randomAlphaOfLength(10)), randomNonNegativeLong());
-        // Note: the explicit type parameter is needed for some IDE (specifically Eclipse 4.8.0) to infer the right type
-        EqualsHashCodeTestUtils.<PreVoteRequest>checkEqualsAndHashCode(
+        EqualsHashCodeTestUtils.checkEqualsAndHashCode(
             initialPreVoteRequest,
             preVoteRequest -> copyWriteable(preVoteRequest, writableRegistry(), PreVoteRequest::new),
             preVoteRequest -> switch (randomInt(1)) {
@@ -316,8 +309,7 @@ public class MessagesTests extends ESTestCase {
             randomLongBetween(1, currentTerm),
             randomNonNegativeLong()
         );
-        // Note: the explicit type parameter is needed for some IDE (specifically Eclipse 4.8.0) to infer the right type
-        EqualsHashCodeTestUtils.<PreVoteResponse>checkEqualsAndHashCode(
+        EqualsHashCodeTestUtils.checkEqualsAndHashCode(
             initialPreVoteResponse,
             preVoteResponse -> copyWriteable(preVoteResponse, writableRegistry(), PreVoteResponse::new),
             preVoteResponse -> switch (randomInt(2)) {

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/MessagesTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/MessagesTests.java
@@ -15,7 +15,6 @@ import org.elasticsearch.cluster.version.CompatibilityVersionsUtils;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.EqualsHashCodeTestUtils;
-import org.elasticsearch.test.EqualsHashCodeTestUtils.CopyFunction;
 import org.elasticsearch.test.TransportVersionUtils;
 
 import java.util.Map;
@@ -36,59 +35,57 @@ public class MessagesTests extends ESTestCase {
             randomNonNegativeLong(),
             randomNonNegativeLong()
         );
-        // Note: the explicit cast of the CopyFunction is needed for some IDE (specifically Eclipse 4.8.0) to infer the right type
-        EqualsHashCodeTestUtils.checkEqualsAndHashCode(
+        // Note: the explicit type parameter is needed for some IDE (specifically Eclipse 4.8.0) to infer the right type
+        EqualsHashCodeTestUtils.<Join>checkEqualsAndHashCode(
             initialJoin,
-            (CopyFunction<Join>) join -> copyWriteable(join, writableRegistry(), Join::new),
-            join -> {
-                return switch (randomInt(4)) {
-                    case 0 ->
-                        // change sourceNode
-                        new Join(
-                            createNode(randomAlphaOfLength(20)),
-                            join.getTargetNode(),
-                            join.getTerm(),
-                            join.getLastAcceptedTerm(),
-                            join.getLastAcceptedVersion()
-                        );
-                    case 1 ->
-                        // change targetNode
-                        new Join(
-                            join.getSourceNode(),
-                            createNode(randomAlphaOfLength(20)),
-                            join.getTerm(),
-                            join.getLastAcceptedTerm(),
-                            join.getLastAcceptedVersion()
-                        );
-                    case 2 ->
-                        // change term
-                        new Join(
-                            join.getSourceNode(),
-                            join.getTargetNode(),
-                            randomValueOtherThan(join.getTerm(), ESTestCase::randomNonNegativeLong),
-                            join.getLastAcceptedTerm(),
-                            join.getLastAcceptedVersion()
-                        );
-                    case 3 ->
-                        // change last accepted term
-                        new Join(
-                            join.getSourceNode(),
-                            join.getTargetNode(),
-                            join.getTerm(),
-                            randomValueOtherThan(join.getLastAcceptedTerm(), ESTestCase::randomNonNegativeLong),
-                            join.getLastAcceptedVersion()
-                        );
-                    case 4 ->
-                        // change version
-                        new Join(
-                            join.getSourceNode(),
-                            join.getTargetNode(),
-                            join.getTerm(),
-                            join.getLastAcceptedTerm(),
-                            randomValueOtherThan(join.getLastAcceptedVersion(), ESTestCase::randomNonNegativeLong)
-                        );
-                    default -> throw new AssertionError();
-                };
+            join -> copyWriteable(join, writableRegistry(), Join::new),
+            join -> switch (randomInt(4)) {
+                case 0 ->
+                    // change sourceNode
+                    new Join(
+                        createNode(randomAlphaOfLength(20)),
+                        join.getTargetNode(),
+                        join.getTerm(),
+                        join.getLastAcceptedTerm(),
+                        join.getLastAcceptedVersion()
+                    );
+                case 1 ->
+                    // change targetNode
+                    new Join(
+                        join.getSourceNode(),
+                        createNode(randomAlphaOfLength(20)),
+                        join.getTerm(),
+                        join.getLastAcceptedTerm(),
+                        join.getLastAcceptedVersion()
+                    );
+                case 2 ->
+                    // change term
+                    new Join(
+                        join.getSourceNode(),
+                        join.getTargetNode(),
+                        randomValueOtherThan(join.getTerm(), ESTestCase::randomNonNegativeLong),
+                        join.getLastAcceptedTerm(),
+                        join.getLastAcceptedVersion()
+                    );
+                case 3 ->
+                    // change last accepted term
+                    new Join(
+                        join.getSourceNode(),
+                        join.getTargetNode(),
+                        join.getTerm(),
+                        randomValueOtherThan(join.getLastAcceptedTerm(), ESTestCase::randomNonNegativeLong),
+                        join.getLastAcceptedVersion()
+                    );
+                case 4 ->
+                    // change version
+                    new Join(
+                        join.getSourceNode(),
+                        join.getTargetNode(),
+                        join.getTerm(),
+                        join.getLastAcceptedTerm(),
+                        randomValueOtherThan(join.getLastAcceptedVersion(), ESTestCase::randomNonNegativeLong)
+                    );
+                default -> throw new AssertionError();
             }
         );
     }
@@ -104,26 +101,24 @@ public class MessagesTests extends ESTestCase {
 
     public void testPublishResponseEqualsHashCodeSerialization() {
         PublishResponse initialPublishResponse = new PublishResponse(randomNonNegativeLong(), randomNonNegativeLong());
-        // Note: the explicit cast of the CopyFunction is needed for some IDE (specifically Eclipse 4.8.0) to infer the right type
-        EqualsHashCodeTestUtils.checkEqualsAndHashCode(
+        // Note: the explicit type parameter is needed for some IDE (specifically Eclipse 4.8.0) to infer the right type
+        EqualsHashCodeTestUtils.<PublishResponse>checkEqualsAndHashCode(
             initialPublishResponse,
-            (CopyFunction<PublishResponse>) publishResponse -> copyWriteable(publishResponse, writableRegistry(), PublishResponse::new),
-            publishResponse -> {
-                return switch (randomInt(1)) {
-                    case 0 ->
-                        // change term
-                        new PublishResponse(
-                            randomValueOtherThan(publishResponse.getTerm(), ESTestCase::randomNonNegativeLong),
-                            publishResponse.getVersion()
-                        );
-                    case 1 ->
-                        // change version
-                        new PublishResponse(
-                            publishResponse.getTerm(),
-                            randomValueOtherThan(publishResponse.getVersion(), ESTestCase::randomNonNegativeLong)
-                        );
-                    default -> throw new AssertionError();
-                };
+            publishResponse -> copyWriteable(publishResponse, writableRegistry(), PublishResponse::new),
+            publishResponse -> switch (randomInt(1)) {
+                case 0 ->
+                    // change term
+                    new PublishResponse(
+                        randomValueOtherThan(publishResponse.getTerm(), ESTestCase::randomNonNegativeLong),
+                        publishResponse.getVersion()
+                    );
+                case 1 ->
+                    // change version
+                    new PublishResponse(
+                        publishResponse.getTerm(),
+                        randomValueOtherThan(publishResponse.getVersion(), ESTestCase::randomNonNegativeLong)
+                    );
+                default -> throw new AssertionError();
             }
         );
     }
@@ -141,61 +136,53 @@ public class MessagesTests extends ESTestCase {
             initialPublishResponse,
             randomBoolean() ? Optional.empty() : Optional.of(initialJoin)
         );
-        // Note: the explicit cast of the CopyFunction is needed for some IDE (specifically Eclipse 4.8.0) to infer the right type
-        EqualsHashCodeTestUtils.checkEqualsAndHashCode(
+        // Note: the explicit type parameter is needed for some IDE (specifically Eclipse 4.8.0) to infer the right type
+        EqualsHashCodeTestUtils.<PublishWithJoinResponse>checkEqualsAndHashCode(
             initialPublishWithJoinResponse,
-            (CopyFunction<PublishWithJoinResponse>) publishWithJoinResponse -> copyWriteable(
-                publishWithJoinResponse,
-                writableRegistry(),
-                PublishWithJoinResponse::new
-            ),
-            publishWithJoinResponse -> {
-                switch (randomInt(1)) {
-                    case 0:
-                        // change publish response
-                        return new PublishWithJoinResponse(
-                            new PublishResponse(randomNonNegativeLong(), randomNonNegativeLong()),
-                            publishWithJoinResponse.getJoin()
-                        );
-                    case 1:
-                        // change optional join
-                        Join newJoin = new Join(
-                            createNode(randomAlphaOfLength(10)),
-                            createNode(randomAlphaOfLength(10)),
-                            randomNonNegativeLong(),
-                            randomNonNegativeLong(),
-                            randomNonNegativeLong()
-                        );
-                        return new PublishWithJoinResponse(
-                            publishWithJoinResponse.getPublishResponse(),
-                            publishWithJoinResponse.getJoin().isPresent() && randomBoolean() ? Optional.empty() : Optional.of(newJoin)
-                        );
-                    default:
-                        throw new AssertionError();
+            publishWithJoinResponse -> copyWriteable(publishWithJoinResponse, writableRegistry(), PublishWithJoinResponse::new),
+            publishWithJoinResponse -> switch (randomInt(1)) {
+                case 0 ->
+                    // change publish response
+                    new PublishWithJoinResponse(
+                        new PublishResponse(randomNonNegativeLong(), randomNonNegativeLong()),
+                        publishWithJoinResponse.getJoin()
+                    );
+                case 1 -> {
+                    // change optional join
+                    Join newJoin = new Join(
+                        createNode(randomAlphaOfLength(10)),
+                        createNode(randomAlphaOfLength(10)),
+                        randomNonNegativeLong(),
+                        randomNonNegativeLong(),
+                        randomNonNegativeLong()
+                    );
+                    yield new PublishWithJoinResponse(
+                        publishWithJoinResponse.getPublishResponse(),
+                        publishWithJoinResponse.getJoin().isPresent() && randomBoolean() ? Optional.empty() : Optional.of(newJoin)
+                    );
                 }
+                default -> throw new AssertionError();
             }
         );
     }
 
     public void testStartJoinRequestEqualsHashCodeSerialization() {
         StartJoinRequest initialStartJoinRequest = new StartJoinRequest(createNode(randomAlphaOfLength(10)), randomNonNegativeLong());
-        // Note: the explicit cast of the CopyFunction is needed for some IDE (specifically Eclipse 4.8.0) to infer the right type
-        EqualsHashCodeTestUtils.checkEqualsAndHashCode(
+        // Note: the explicit type parameter is needed for some IDE (specifically Eclipse 4.8.0) to infer the right type
+        EqualsHashCodeTestUtils.<StartJoinRequest>checkEqualsAndHashCode(
             initialStartJoinRequest,
-            (CopyFunction<StartJoinRequest>) startJoinRequest -> copyWriteable(startJoinRequest, writableRegistry(), StartJoinRequest::new),
-            startJoinRequest -> {
-                return switch (randomInt(1)) {
-                    case 0 ->
-                        // change sourceNode
-                        new StartJoinRequest(createNode(randomAlphaOfLength(20)), startJoinRequest.getTerm());
-                    case 1 ->
-                        // change term
-                        new StartJoinRequest(
-                            startJoinRequest.getSourceNode(),
-                            randomValueOtherThan(startJoinRequest.getTerm(), ESTestCase::randomNonNegativeLong)
-                        );
-                    default -> throw new AssertionError();
-                };
+            startJoinRequest -> copyWriteable(startJoinRequest, writableRegistry(), StartJoinRequest::new),
+            startJoinRequest -> switch (randomInt(1)) {
+                case 0 ->
+                    // change sourceNode
+                    new StartJoinRequest(createNode(randomAlphaOfLength(20)), startJoinRequest.getTerm());
+                case 1 ->
+                    // change term
+                    new StartJoinRequest(
+                        startJoinRequest.getSourceNode(),
+                        randomValueOtherThan(startJoinRequest.getTerm(), ESTestCase::randomNonNegativeLong)
+                    );
+                default -> throw new AssertionError();
             }
         );
     }
@@ -206,31 +193,29 @@ public class MessagesTests extends ESTestCase {
             randomNonNegativeLong(),
             randomNonNegativeLong()
         );
-        // Note: the explicit cast of the CopyFunction is needed for some IDE (specifically Eclipse 4.8.0) to infer the right type
-        EqualsHashCodeTestUtils.checkEqualsAndHashCode(
+        // Note: the explicit type parameter is needed for some IDE (specifically Eclipse 4.8.0) to infer the right type
+        EqualsHashCodeTestUtils.<ApplyCommitRequest>checkEqualsAndHashCode(
             initialApplyCommit,
-            (CopyFunction<ApplyCommitRequest>) applyCommit -> copyWriteable(applyCommit, writableRegistry(), ApplyCommitRequest::new),
-            applyCommit -> {
-                return switch (randomInt(2)) {
-                    case 0 ->
-                        // change sourceNode
-                        new ApplyCommitRequest(createNode(randomAlphaOfLength(20)), applyCommit.getTerm(), applyCommit.getVersion());
-                    case 1 ->
-                        // change term
-                        new ApplyCommitRequest(
-                            applyCommit.getSourceNode(),
-                            randomValueOtherThan(applyCommit.getTerm(), ESTestCase::randomNonNegativeLong),
-                            applyCommit.getVersion()
-                        );
-                    case 2 ->
-                        // change version
-                        new ApplyCommitRequest(
-                            applyCommit.getSourceNode(),
-                            applyCommit.getTerm(),
-                            randomValueOtherThan(applyCommit.getVersion(), ESTestCase::randomNonNegativeLong)
-                        );
-                    default -> throw new AssertionError();
-                };
+            applyCommit -> copyWriteable(applyCommit, writableRegistry(), ApplyCommitRequest::new),
+            applyCommit -> switch (randomInt(2)) {
+                case 0 ->
+                    // change sourceNode
+                    new ApplyCommitRequest(createNode(randomAlphaOfLength(20)), applyCommit.getTerm(), applyCommit.getVersion());
+                case 1 ->
+                    // change term
+                    new ApplyCommitRequest(
+                        applyCommit.getSourceNode(),
+                        randomValueOtherThan(applyCommit.getTerm(), ESTestCase::randomNonNegativeLong),
+                        applyCommit.getVersion()
+                    );
+                case 2 ->
+                    // change version
+                    new ApplyCommitRequest(
+                        applyCommit.getSourceNode(),
+                        applyCommit.getTerm(),
+                        randomValueOtherThan(applyCommit.getVersion(), ESTestCase::randomNonNegativeLong)
+                    );
+                default -> throw new AssertionError();
             }
         );
     }
@@ -249,58 +234,52 @@ public class MessagesTests extends ESTestCase {
             randomNonNegativeLong(),
             randomBoolean() ? Optional.empty() : Optional.of(initialJoin)
         );
-        // Note: the explicit cast of the CopyFunction is needed for some IDE (specifically Eclipse 4.8.0) to infer the right type
-        EqualsHashCodeTestUtils.checkEqualsAndHashCode(
+        // Note: the explicit type parameter is needed for some IDE (specifically Eclipse 4.8.0) to infer the right type
+        EqualsHashCodeTestUtils.<JoinRequest>checkEqualsAndHashCode(
             initialJoinRequest,
-            (CopyFunction<JoinRequest>) joinRequest -> copyWriteable(joinRequest, writableRegistry(), JoinRequest::new),
-            joinRequest -> {
-                if (randomBoolean() && joinRequest.getOptionalJoin().isPresent() == false) {
-                    return new JoinRequest(
+            joinRequest -> copyWriteable(joinRequest, writableRegistry(), JoinRequest::new),
+            joinRequest -> switch (randomInt(3)) {
+                case 0 -> {
+                    assumeTrue("Optional join needs to be empty", joinRequest.getOptionalJoin().isEmpty());
+                    yield new JoinRequest(
                         createNode(randomAlphaOfLength(10)),
                         joinRequest.getCompatibilityVersions(),
                         joinRequest.getMinimumTerm(),
                         joinRequest.getOptionalJoin()
                     );
-                } else if (randomBoolean()) {
-                    return new JoinRequest(
-                        joinRequest.getSourceNode(),
-                        new CompatibilityVersions(
-                            TransportVersionUtils.randomVersion(Set.of(joinRequest.getCompatibilityVersions().transportVersion())),
-                            Map.of()
-                        ),
-                        joinRequest.getMinimumTerm(),
-                        joinRequest.getOptionalJoin()
-                    );
-                } else if (randomBoolean()) {
-                    return new JoinRequest(
-                        joinRequest.getSourceNode(),
-                        joinRequest.getCompatibilityVersions(),
-                        randomValueOtherThan(joinRequest.getMinimumTerm(), ESTestCase::randomNonNegativeLong),
-                        joinRequest.getOptionalJoin()
-                    );
-                } else {
+                }
+                case 1 -> new JoinRequest(
+                    joinRequest.getSourceNode(),
+                    new CompatibilityVersions(
+                        TransportVersionUtils.randomVersion(Set.of(joinRequest.getCompatibilityVersions().transportVersion())),
+                        Map.of()
+                    ),
+                    joinRequest.getMinimumTerm(),
+                    joinRequest.getOptionalJoin()
+                );
+                case 2 -> new JoinRequest(
+                    joinRequest.getSourceNode(),
+                    joinRequest.getCompatibilityVersions(),
+                    randomValueOtherThan(joinRequest.getMinimumTerm(), ESTestCase::randomNonNegativeLong),
+                    joinRequest.getOptionalJoin()
+                );
+                case 3 -> {
                     // change OptionalJoin
-                    final Optional<Join> newOptionalJoin;
-                    if (joinRequest.getOptionalJoin().isPresent() && randomBoolean()) {
-                        newOptionalJoin = Optional.empty();
-                    } else {
-                        newOptionalJoin = Optional.of(
-                            new Join(
-                                joinRequest.getSourceNode(),
-                                createNode(randomAlphaOfLength(10)),
-                                randomNonNegativeLong(),
-                                randomNonNegativeLong(),
-                                randomNonNegativeLong()
-                            )
-                        );
-                    }
-                    return new JoinRequest(
+                    Join newJoin = new Join(
+                        joinRequest.getSourceNode(),
+                        createNode(randomAlphaOfLength(10)),
+                        randomNonNegativeLong(),
+                        randomNonNegativeLong(),
+                        randomNonNegativeLong()
+                    );
+                    yield new JoinRequest(
                         joinRequest.getSourceNode(),
                         joinRequest.getCompatibilityVersions(),
                         joinRequest.getMinimumTerm(),
-                        newOptionalJoin
+                        joinRequest.getOptionalJoin().isPresent() && randomBoolean() ? Optional.empty() : Optional.of(newJoin)
                     );
                 }
+                default -> throw new AssertionError();
             }
         );
     }
@@ -318,16 +297,14 @@ public class MessagesTests extends ESTestCase {
 
     public void testPreVoteRequestEqualsHashCodeSerialization() {
         PreVoteRequest initialPreVoteRequest = new PreVoteRequest(createNode(randomAlphaOfLength(10)), randomNonNegativeLong());
-        // Note: the explicit cast of the CopyFunction is needed for some IDE (specifically Eclipse 4.8.0) to infer the right type
-        EqualsHashCodeTestUtils.checkEqualsAndHashCode(
+        // Note: the explicit type parameter is needed for some IDE (specifically Eclipse 4.8.0) to infer the right type
+        EqualsHashCodeTestUtils.<PreVoteRequest>checkEqualsAndHashCode(
             initialPreVoteRequest,
-            (CopyFunction<PreVoteRequest>) preVoteRequest -> copyWriteable(preVoteRequest, writableRegistry(), PreVoteRequest::new),
-            preVoteRequest -> {
-                if (randomBoolean()) {
-                    return new PreVoteRequest(createNode(randomAlphaOfLength(10)), preVoteRequest.getCurrentTerm());
-                } else {
-                    return new PreVoteRequest(preVoteRequest.getSourceNode(), randomNonNegativeLong());
-                }
+            preVoteRequest -> copyWriteable(preVoteRequest, writableRegistry(), PreVoteRequest::new),
+            preVoteRequest -> switch (randomInt(1)) {
+                case 0 -> new PreVoteRequest(createNode(randomAlphaOfLength(10)), preVoteRequest.getCurrentTerm());
+                case 1 -> new PreVoteRequest(preVoteRequest.getSourceNode(), randomNonNegativeLong());
+                default -> throw new AssertionError();
             }
         );
     }
@@ -339,41 +316,39 @@ public class MessagesTests extends ESTestCase {
             randomLongBetween(1, currentTerm),
             randomNonNegativeLong()
         );
-        // Note: the explicit cast of the CopyFunction is needed for some IDE (specifically Eclipse 4.8.0) to infer the right type
-        EqualsHashCodeTestUtils.checkEqualsAndHashCode(
+        // Note: the explicit type parameter is needed for some IDE (specifically Eclipse 4.8.0) to infer the right type
+        EqualsHashCodeTestUtils.<PreVoteResponse>checkEqualsAndHashCode(
             initialPreVoteResponse,
-            (CopyFunction<PreVoteResponse>) preVoteResponse -> copyWriteable(preVoteResponse, writableRegistry(), PreVoteResponse::new),
-            preVoteResponse -> {
-                switch (randomInt(2)) {
-                    case 0:
-                        assumeTrue("last-accepted term is Long.MAX_VALUE", preVoteResponse.getLastAcceptedTerm() < Long.MAX_VALUE);
-                        return new PreVoteResponse(
-                            randomValueOtherThan(
-                                preVoteResponse.getCurrentTerm(),
-                                () -> randomLongBetween(preVoteResponse.getLastAcceptedTerm(), Long.MAX_VALUE)
-                            ),
-                            preVoteResponse.getLastAcceptedTerm(),
-                            preVoteResponse.getLastAcceptedVersion()
-                        );
-                    case 1:
-                        assumeTrue("current term is 1", 1 < preVoteResponse.getCurrentTerm());
-                        return new PreVoteResponse(
+            preVoteResponse -> copyWriteable(preVoteResponse, writableRegistry(), PreVoteResponse::new),
+            preVoteResponse -> switch (randomInt(2)) {
+                case 0 -> {
+                    assumeTrue("last-accepted term is Long.MAX_VALUE", preVoteResponse.getLastAcceptedTerm() < Long.MAX_VALUE);
+                    yield new PreVoteResponse(
+                        randomValueOtherThan(
                             preVoteResponse.getCurrentTerm(),
-                            randomValueOtherThan(
-                                preVoteResponse.getLastAcceptedTerm(),
-                                () -> randomLongBetween(1, preVoteResponse.getCurrentTerm())
-                            ),
-                            preVoteResponse.getLastAcceptedVersion()
-                        );
-                    case 2:
-                        return new PreVoteResponse(
-                            preVoteResponse.getCurrentTerm(),
-                            preVoteResponse.getLastAcceptedTerm(),
-                            randomValueOtherThan(preVoteResponse.getLastAcceptedVersion(), ESTestCase::randomNonNegativeLong)
-                        );
-                    default:
-                        throw new AssertionError();
+                            () -> randomLongBetween(preVoteResponse.getLastAcceptedTerm(), Long.MAX_VALUE)
+                        ),
+                        preVoteResponse.getLastAcceptedTerm(),
+                        preVoteResponse.getLastAcceptedVersion()
+                    );
                 }
+                case 1 -> {
+                    assumeTrue("current term is 1", 1 < preVoteResponse.getCurrentTerm());
+                    yield new PreVoteResponse(
+                        preVoteResponse.getCurrentTerm(),
+                        randomValueOtherThan(
+                            preVoteResponse.getLastAcceptedTerm(),
+                            () -> randomLongBetween(1, preVoteResponse.getCurrentTerm())
+                        ),
+                        preVoteResponse.getLastAcceptedVersion()
+                    );
+                }
+                case 2 -> new PreVoteResponse(
+                    preVoteResponse.getCurrentTerm(),
+                    preVoteResponse.getLastAcceptedTerm(),
+                    randomValueOtherThan(preVoteResponse.getLastAcceptedVersion(), ESTestCase::randomNonNegativeLong)
+                );
+                default -> throw new AssertionError();
             }
         );
     }


### PR DESCRIPTION
Refactor MessagesTests to use switch expressions & the same pattern of random change selection throughout