### PR TITLE
Cleanup Nodes class

### DIFF
--- a/qa/mixed-cluster/src/test/java/org/elasticsearch/backwards/HotThreadsIT.java
+++ b/qa/mixed-cluster/src/test/java/org/elasticsearch/backwards/HotThreadsIT.java
@@ -17,8 +17,10 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class HotThreadsIT extends ESRestTestCase {
 
+    private static final String BWC_NODES_VERSION = System.getProperty("tests.bwc_nodes_version");
+
     public void testHotThreads() throws Exception {
-        final IndexingIT.Nodes nodes = IndexingIT.buildNodeAndVersions(client());
+        final MixedClusterTestNodes nodes = MixedClusterTestNodes.buildNodes(client(), BWC_NODES_VERSION);
         assumeFalse("no new node found", nodes.getNewNodes().isEmpty());
         assumeFalse("no bwc node found", nodes.getBWCNodes().isEmpty());
         assumeTrue(

--- a/qa/mixed-cluster/src/test/java/org/elasticsearch/backwards/MixedClusterTestNode.java
+++ b/qa/mixed-cluster/src/test/java/org/elasticsearch/backwards/MixedClusterTestNode.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.backwards;
+
+import org.apache.http.HttpHost;
+
+record MixedClusterTestNode(String id, String nodeName, String version, HttpHost publishAddress) {}

--- a/qa/mixed-cluster/src/test/java/org/elasticsearch/backwards/MixedClusterTestNodes.java
+++ b/qa/mixed-cluster/src/test/java/org/elasticsearch/backwards/MixedClusterTestNodes.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.backwards;
+
+import org.apache.http.HttpHost;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.test.rest.ObjectPath;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+final class MixedClusterTestNodes {
+    private final Map<String, MixedClusterTestNode> nodesById;
+    private final String bwcNodesVersion;
+
+    private MixedClusterTestNodes(String bwcNodesVersion, Map<String, MixedClusterTestNode> nodesById) {
+        this.bwcNodesVersion = bwcNodesVersion;
+        this.nodesById = nodesById;
+    }
+
+    public List<MixedClusterTestNode> getNewNodes() {
+        return nodesById.values().stream().filter(n -> n.version().equals(bwcNodesVersion) == false).collect(Collectors.toList());
+    }
+
+    public List<MixedClusterTestNode> getBWCNodes() {
+        return nodesById.values().stream().filter(n -> n.version().equals(bwcNodesVersion)).collect(Collectors.toList());
+    }
+
+    public MixedClusterTestNode getSafe(String id) {
+        MixedClusterTestNode node = nodesById.get(id);
+        if (node == null) {
+            throw new IllegalArgumentException("node with id [" + id + "] not found");
+        }
+        return node;
+    }
+
+    static MixedClusterTestNodes buildNodes(RestClient client, String bwcNodesVersion) throws IOException {
+        Response response = client.performRequest(new Request("GET", "_nodes"));
+        ObjectPath objectPath = ObjectPath.createFromResponse(response);
+        Map<String, Object> nodesAsMap = objectPath.evaluate("nodes");
+
+        Map<String, MixedClusterTestNode> nodesById = new HashMap<>();
+        for (var id : nodesAsMap.keySet()) {
+            nodesById.put(
+                id,
+                new MixedClusterTestNode(
+                    id,
+                    objectPath.evaluate("nodes." + id + ".name"),
+                    objectPath.evaluate("nodes." + id + ".version"),
+                    HttpHost.create(objectPath.evaluate("nodes." + id + ".http.publish_address"))
+                )
+            );
+        }
+        return new MixedClusterTestNodes(bwcNodesVersion, Collections.unmodifiableMap(nodesById));
+    }
+
+    public int size() {
+        return nodesById.size();
+    }
+}

--- a/qa/mixed-cluster/src/test/java/org/elasticsearch/backwards/SearchWithMinCompatibleSearchNodeIT.java
+++ b/qa/mixed-cluster/src/test/java/org/elasticsearch/backwards/SearchWithMinCompatibleSearchNodeIT.java
@@ -8,8 +8,6 @@
 package org.elasticsearch.backwards;
 
 import org.apache.http.HttpHost;
-import org.elasticsearch.backwards.IndexingIT.Node;
-import org.elasticsearch.backwards.IndexingIT.Nodes;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
@@ -32,19 +30,19 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class SearchWithMinCompatibleSearchNodeIT extends ESRestTestCase {
 
-    protected static final String BWC_NODES_VERSION = System.getProperty("tests.bwc_nodes_version");
-    protected static final String NEW_NODES_VERSION = System.getProperty("tests.new_nodes_version");
+    private static final String BWC_NODES_VERSION = System.getProperty("tests.bwc_nodes_version");
+    private static final String NEW_NODES_VERSION = System.getProperty("tests.new_nodes_version");
 
     private static String index = "test_min_version";
     private static int numShards;
     private static int numReplicas = 1;
     private static int numDocs;
-    private static Nodes nodes;
-    private static List<Node> allNodes;
+    private static MixedClusterTestNodes nodes;
+    private static List<MixedClusterTestNode> allNodes;
 
     @Before
     public void prepareTestData() throws IOException {
-        nodes = IndexingIT.buildNodeAndVersions(client());
+        nodes = MixedClusterTestNodes.buildNodes(client(), BWC_NODES_VERSION);
         numShards = nodes.size();
         numDocs = randomIntBetween(numShards, 16);
         allNodes = new ArrayList<>();
@@ -69,7 +67,12 @@ public class SearchWithMinCompatibleSearchNodeIT extends ESRestTestCase {
     }
 
     public void testMinVersionAsNewVersion() throws Exception {
-        try (RestClient client = buildClient(restClientSettings(), allNodes.stream().map(Node::publishAddress).toArray(HttpHost[]::new))) {
+        try (
+            RestClient client = buildClient(
+                restClientSettings(),
+                allNodes.stream().map(MixedClusterTestNode::publishAddress).toArray(HttpHost[]::new)
+            )
+        ) {
             Request newVersionRequest = new Request(
                 "POST",
                 index + "/_search?min_compatible_shard_node=" + NEW_NODES_VERSION + "&ccs_minimize_roundtrips=false"
@@ -90,7 +93,12 @@ public class SearchWithMinCompatibleSearchNodeIT extends ESRestTestCase {
     }
 
     public void testMinVersionAsOldVersion() throws Exception {
-        try (RestClient client = buildClient(restClientSettings(), allNodes.stream().map(Node::publishAddress).toArray(HttpHost[]::new))) {
+        try (
+            RestClient client = buildClient(
+                restClientSettings(),
+                allNodes.stream().map(MixedClusterTestNode::publishAddress).toArray(HttpHost[]::new)
+            )
+        ) {
             Request oldVersionRequest = new Request(
                 "POST",
                 index + "/_search?min_compatible_shard_node=" + BWC_NODES_VERSION + "&ccs_minimize_roundtrips=false"
@@ -112,7 +120,12 @@ public class SearchWithMinCompatibleSearchNodeIT extends ESRestTestCase {
     }
 
     public void testCcsMinimizeRoundtripsIsFalse() throws Exception {
-        try (RestClient client = buildClient(restClientSettings(), allNodes.stream().map(Node::publishAddress).toArray(HttpHost[]::new))) {
+        try (
+            RestClient client = buildClient(
+                restClientSettings(),
+                allNodes.stream().map(MixedClusterTestNode::publishAddress).toArray(HttpHost[]::new)
+            )
+        ) {
             String version = randomBoolean() ? NEW_NODES_VERSION : BWC_NODES_VERSION;
 
             Request request = new Request(


### PR DESCRIPTION
Following comments from a previous PR (https://github.com/elastic/elasticsearch/pull/100838#discussion_r1370126923), former inner `Nodes` class has been renamed, moved to a separate file, switched from inheritance to composition.