### PR TITLE
Enable test that was fixed before

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/node/tasks/TasksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/node/tasks/TasksIT.java
@@ -522,7 +522,6 @@ public class TasksIT extends ESIntegTestCase {
         assertEquals(0, clusterAdmin().prepareListTasks().setActions(TEST_TASK_ACTION.name() + "*").get().getTasks().size());
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/95325")
     public void testTasksUnblocking() throws Exception {
         // Start blocking test task
         TestTaskPlugin.NodesRequest request = new TestTaskPlugin.NodesRequest("test");


### PR DESCRIPTION
This test was fixed in https://github.com/elastic/elasticsearch/pull/95584, however the await fix annotation was not removed (possibly it was added later by merge?). This change removes AwaitsFix for it

Related to: #95325