### PR TITLE
Add Apm Integration test

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/RestrictedBuildApiService.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/RestrictedBuildApiService.java
@@ -76,6 +76,7 @@ public abstract class RestrictedBuildApiService implements BuildService<Restrict
         map.put(LegacyRestTestBasePlugin.class, ":qa:verify-version-constants");
         map.put(LegacyRestTestBasePlugin.class, ":test:external-modules:test-delayed-aggs");
         map.put(LegacyRestTestBasePlugin.class, ":test:external-modules:test-die-with-dignity");
+        map.put(LegacyRestTestBasePlugin.class, ":test:external-modules:test-apm-integration");
         map.put(LegacyRestTestBasePlugin.class, ":test:external-modules:test-error-query");
         map.put(LegacyRestTestBasePlugin.class, ":test:external-modules:test-latency-simulating-directory");
         map.put(LegacyRestTestBasePlugin.class, ":test:external-modules:test-seek-tracking-directory");

--- a/test/external-modules/apm-integration/build.gradle
+++ b/test/external-modules/apm-integration/build.gradle
@@ -1,0 +1,30 @@
+import org.elasticsearch.gradle.internal.info.BuildParams
+import org.elasticsearch.gradle.util.GradleUtils
+
+apply plugin: 'elasticsearch.internal-java-rest-test'
+apply plugin: 'elasticsearch.internal-es-plugin'
+
+esplugin {
+  description 'Apm integration plugin'
+  classname 'org.elasticsearch.test.apmintegration.ApmIntegrationPlugin'
+}
+
+// let the javaRestTest see the classpath of main
+GradleUtils.extendSourceSet(project, "main", "javaRestTest", tasks.named("javaRestTest"))
+
+tasks.named("test").configure {
+  enabled = false
+}
+
+tasks.named("yamlRestTest").configure {
+  enabled = false
+}
+
+tasks.named('javaRestTest').configure {
+  it.onlyIf("snapshot build") { BuildParams.isSnapshotBuild() }
+}
+
+
+dependencies {
+  clusterModules project(':modules:apm')
+}

--- a/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/ApmIT.java
+++ b/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/ApmIT.java
@@ -13,6 +13,7 @@ import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.hamcrest.Matcher;
+import org.hamcrest.StringDescription;
 import org.junit.ClassRule;
 import org.junit.Rule;
 
@@ -70,7 +71,7 @@ public class ApmIT extends ESRestTestCase {
         client().performRequest(new Request("GET", "/_use_apm_metrics"));
 
         finished.await(30, TimeUnit.SECONDS);
-        assertThat(assertions, empty());
+        assertThat(mockApmServer.getMessageAssertions(), empty());
     }
 
     private <T> Predicate<RecordingApmServer.APMMessage> assertionWithDescription(
@@ -86,7 +87,9 @@ public class ApmIT extends ESRestTestCase {
 
             @Override
             public String toString() {
-                return description;
+                StringDescription matcherDescription = new StringDescription();
+                expected.describeTo(matcherDescription);
+                return description + " " + matcherDescription;
             }
         };
     }

--- a/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/ApmIT.java
+++ b/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/ApmIT.java
@@ -16,6 +16,8 @@ import org.hamcrest.Matchers;
 import org.junit.ClassRule;
 import org.junit.Rule;
 
+import static org.hamcrest.Matchers.containsString;
+
 public class ApmIT extends ESRestTestCase {
     @ClassRule
     public static RecordingApmServer mockApmServer = new RecordingApmServer();
@@ -44,12 +46,13 @@ public class ApmIT extends ESRestTestCase {
             assertThat(
                 usageRecords,
                 Matchers.hasItems(
-                    Matchers.containsString("\"testDoubleCounter\":{\"value\":1.0}"),
-                    Matchers.containsString("\"testLongCounter\":{\"value\":1.0}"),
-                    Matchers.containsString("\"testDoubleHistogram\":{\"values\":["),// value?
-                    Matchers.containsString("\"testLongHistogram\":{\"values\":["),// value?
-                    Matchers.containsString("\"testDoubleGauge\":{\"value\":1.0}"),
-                    Matchers.containsString("\"testLongGauge\":{\"value\":1}")
+                    containsString("\"testDoubleCounter\":{\"value\":1.0}"),
+                    containsString("\"testLongCounter\":{\"value\":1.0}"),
+                    containsString("\"testDoubleHistogram\":{\"values\":[0.8535535000000001,1.7071049999999999],\"counts\":[1,1]"),
+                    // long is represented as doubles in apm server
+                    containsString("\"testLongHistogram\":{\"values\":[0.8535535000000001,1.7071049999999999],\"counts\":[1,1]"),
+                    containsString("\"testDoubleGauge\":{\"value\":1.0}"),
+                    containsString("\"testLongGauge\":{\"value\":1}")
                 )
             );
 

--- a/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/ApmIT.java
+++ b/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/ApmIT.java
@@ -12,11 +12,20 @@ import org.elasticsearch.client.Request;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.rest.ESRestTestCase;
-import org.hamcrest.Matchers;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.json.JsonXContent;
 import org.junit.ClassRule;
 import org.junit.Rule;
 
-import static org.hamcrest.Matchers.containsString;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.equalTo;
 
 public class ApmIT extends ESRestTestCase {
     @ClassRule
@@ -43,19 +52,100 @@ public class ApmIT extends ESRestTestCase {
         // TestMeterUsages for code that is registering & using metrics
         assertBusy(() -> {
             var usageRecords = mockApmServer.getMessages();
-            assertThat(
-                usageRecords,
-                Matchers.hasItems(
-                    containsString("\"testDoubleCounter\":{\"value\":1.0}"),
-                    containsString("\"testLongCounter\":{\"value\":1.0}"),
-                    containsString("\"testDoubleHistogram\":{\"values\":[0.8535535000000001,1.7071049999999999],\"counts\":[1,1]"),
-                    // long is represented as doubles in apm server
-                    containsString("\"testLongHistogram\":{\"values\":[0.8535535000000001,1.7071049999999999],\"counts\":[1,1]"),
-                    containsString("\"testDoubleGauge\":{\"value\":1.0}"),
-                    containsString("\"testLongGauge\":{\"value\":1}")
-                )
-            );
-
+            var maybeUsages = usageRecords.stream().map(APMMessage::new).reduce(APMMessage::merge);
+            assertTrue(maybeUsages.isPresent());
+            var usages = maybeUsages.get();
+            assertThat(usages.getDouble("testDoubleCounter"), closeTo(1.0, 0.001));
+            assertThat(usages.getDouble("testLongCounter"), closeTo(1.0, 0.001));
+            assertThat(usages.getDouble("testDoubleGauge"), closeTo(1.0, 0.001));
+            assertThat(usages.getLong("testLongGauge"), equalTo(1L));
+            assertThat(usages.getHistogram("testDoubleHistogram").stream().mapToInt(Bucket::count).sum(), equalTo(2));
+            assertThat(usages.getHistogram("testLongHistogram").stream().mapToInt(Bucket::count).sum(), equalTo(2));
         });
+    }
+
+    private record Bucket(double value, int count) {}
+
+    private class APMMessage {
+        Map<String, List<Bucket>> histograms = new HashMap<>();
+        Map<String, Double> doubles = new HashMap<>();
+        Map<String, Long> longs = new HashMap<>();
+
+        @SuppressWarnings("unchecked")
+        APMMessage(String message) {
+            Map<String, Object> parsed;
+            try (XContentParser parser = createParser(JsonXContent.jsonXContent, message)) {
+                parsed = parser.map();
+            } catch (IOException e) {
+                fail(e);
+                parsed = Collections.emptyMap();
+            }
+            if ("elasticsearch".equals(getTags(parsed).get("otel_instrumentation_scope_name")) == false) {
+                return;
+            }
+            getSamples(parsed).forEach((name, value) -> {
+                if ("histogram".equals(value.get("type"))) {
+                    List<Double> values = (List<Double>) value.getOrDefault("values", Collections.emptyList());
+                    List<Integer> counts = (List<Integer>) value.getOrDefault("counts", Collections.emptyList());
+                    assertThat(values.size(), equalTo(counts.size()));
+                    List<Bucket> buckets = new ArrayList<>(values.size());
+                    for (int i = 0; i < values.size(); i++) {
+                        buckets.add(new Bucket(values.get(i), counts.get(i)));
+                    }
+                    histograms.put(name, buckets);
+                    return;
+                }
+                if (value.get("value") instanceof Number number) {
+                    if (number instanceof Integer intn) {
+                        longs.put(name, Long.valueOf(intn));
+                    } else if (number instanceof Long longn) {
+                        longs.put(name, longn);
+                    } else if (number instanceof Float floatn) {
+                        doubles.put(name, Double.valueOf(floatn));
+                    } else if (number instanceof Double doublen) {
+                        doubles.put(name, doublen);
+                    } else {
+                        fail("unknown number [" + number.getClass().getName() + "] [" + number + "]");
+                    }
+                }
+            });
+        }
+
+        @SuppressWarnings("unchecked")
+        private static Map<String, String> getTags(Map<String, Object> parsed) {
+            return (Map<String, String>) (getMetricset(parsed).getOrDefault("tags", Collections.emptyMap()));
+        }
+
+        @SuppressWarnings("unchecked")
+        private static Map<String, Map<String, Object>> getSamples(Map<String, Object> parsed) {
+            return (Map<String, Map<String, Object>>) getMetricset(parsed).getOrDefault("samples", Collections.emptyMap());
+        }
+
+        @SuppressWarnings("unchecked")
+        private static Map<String, Map<String, ?>> getMetricset(Map<String, Object> parsed) {
+            if (parsed.get("metricset") instanceof Map<?, ?> map) {
+                return (Map<String, Map<String, ?>>) map;
+            }
+            return Collections.emptyMap();
+        }
+
+        public List<Bucket> getHistogram(String name) {
+            return histograms.get(name);
+        }
+
+        public Long getLong(String name) {
+            return longs.get(name);
+        }
+
+        public Double getDouble(String name) {
+            return doubles.get(name);
+        }
+
+        public APMMessage merge(APMMessage other) {
+            histograms.putAll(other.histograms);
+            longs.putAll(other.longs);
+            doubles.putAll(other.doubles);
+            return this;
+        }
     }
 }

--- a/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/ApmIT.java
+++ b/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/ApmIT.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.test.apmintegration;
+
+import org.elasticsearch.client.Request;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.local.distribution.DistributionType;
+import org.elasticsearch.test.rest.ESRestTestCase;
+import org.hamcrest.Matchers;
+import org.junit.ClassRule;
+import org.junit.Rule;
+
+public class ApmIT extends ESRestTestCase {
+    @ClassRule
+    public static RecordingApmServer mockApmServer = new RecordingApmServer();
+
+    @Rule
+    public ElasticsearchCluster cluster = ElasticsearchCluster.local()
+        .distribution(DistributionType.INTEG_TEST)
+        .module("test-apm-integration")
+        .module("apm")
+        .setting("telemetry.metrics.enabled", "true")
+        .setting("tracing.apm.agent.metrics_interval", "1s")
+        .setting("tracing.apm.agent.server_url", "http://127.0.0.1:" + mockApmServer.getPort())
+        .build();
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
+    }
+
+    public void testApmIntegration() throws Exception {
+        client().performRequest(new Request("GET", "/_use_apm_metrics"));
+
+        // TestMeterUsages for code that is registering & using metrics
+        assertBusy(() -> {
+            var usageRecords = mockApmServer.getMessages();
+            assertThat(
+                usageRecords,
+                Matchers.hasItems(
+                    Matchers.containsString("\"testDoubleCounter\":{\"value\":1.0}"),
+                    Matchers.containsString("\"testLongCounter\":{\"value\":1.0}"),
+                    Matchers.containsString("\"testDoubleHistogram\":{\"values\":["),// value?
+                    Matchers.containsString("\"testLongHistogram\":{\"values\":["),// value?
+                    Matchers.containsString("\"testDoubleGauge\":{\"value\":1.0}"),
+                    Matchers.containsString("\"testLongGauge\":{\"value\":1}")
+                )
+            );
+
+        });
+    }
+}

--- a/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/ApmIT.java
+++ b/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/ApmIT.java
@@ -12,19 +12,19 @@ import org.elasticsearch.client.Request;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.rest.ESRestTestCase;
-import org.elasticsearch.xcontent.XContentParser;
-import org.elasticsearch.xcontent.json.JsonXContent;
+import org.hamcrest.Matcher;
 import org.junit.ClassRule;
 import org.junit.Rule;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 
 public class ApmIT extends ESRestTestCase {
@@ -47,105 +47,48 @@ public class ApmIT extends ESRestTestCase {
     }
 
     public void testApmIntegration() throws Exception {
+        Set<Predicate<RecordingApmServer.APMMessage>> assertions = new HashSet<>(
+            Set.of(
+                assertionWithDescription("testLongCounter", msg -> msg.getDouble("testLongCounter"), closeTo(1.0, 0.001)),
+                assertionWithDescription("testDoubleCounter", msg -> msg.getDouble("testDoubleCounter"), closeTo(1.0, 0.001)),
+                assertionWithDescription("testDoubleGauge", msg -> msg.getDouble("testDoubleGauge"), closeTo(1.0, 0.001)),
+                assertionWithDescription("testLongGauge", msg -> msg.getLong("testLongGauge"), equalTo(1L)),
+                assertionWithDescription(
+                    "testDoubleHistogram",
+                    msg -> msg.getHistogram("testDoubleHistogram").stream().mapToInt(RecordingApmServer.Bucket::count).sum(),
+                    equalTo(2)
+                ),
+                assertionWithDescription(
+                    "testLongHistogram",
+                    msg -> msg.getHistogram("testLongHistogram").stream().mapToInt(RecordingApmServer.Bucket::count).sum(),
+                    equalTo(2)
+                )
+            )
+        );
+        CountDownLatch finished = mockApmServer.addMessageAssertions(assertions);
+
         client().performRequest(new Request("GET", "/_use_apm_metrics"));
 
-        // TestMeterUsages for code that is registering & using metrics
-        assertBusy(() -> {
-            var usageRecords = mockApmServer.getMessages();
-            var maybeUsages = usageRecords.stream().map(APMMessage::new).reduce(APMMessage::merge);
-            assertTrue(maybeUsages.isPresent());
-            var usages = maybeUsages.get();
-            assertThat(usages.getDouble("testDoubleCounter"), closeTo(1.0, 0.001));
-            assertThat(usages.getDouble("testLongCounter"), closeTo(1.0, 0.001));
-            assertThat(usages.getDouble("testDoubleGauge"), closeTo(1.0, 0.001));
-            assertThat(usages.getLong("testLongGauge"), equalTo(1L));
-            assertThat(usages.getHistogram("testDoubleHistogram").stream().mapToInt(Bucket::count).sum(), equalTo(2));
-            assertThat(usages.getHistogram("testLongHistogram").stream().mapToInt(Bucket::count).sum(), equalTo(2));
-        });
+        finished.await(30, TimeUnit.SECONDS);
+        assertThat(assertions, empty());
     }
 
-    private record Bucket(double value, int count) {}
-
-    private class APMMessage {
-        Map<String, List<Bucket>> histograms = new HashMap<>();
-        Map<String, Double> doubles = new HashMap<>();
-        Map<String, Long> longs = new HashMap<>();
-
-        @SuppressWarnings("unchecked")
-        APMMessage(String message) {
-            Map<String, Object> parsed;
-            try (XContentParser parser = createParser(JsonXContent.jsonXContent, message)) {
-                parsed = parser.map();
-            } catch (IOException e) {
-                fail(e);
-                parsed = Collections.emptyMap();
+    private <T> Predicate<RecordingApmServer.APMMessage> assertionWithDescription(
+        String description,
+        Function<RecordingApmServer.APMMessage, T> actual,
+        Matcher<T> expected
+    ) {
+        return new Predicate<>() {
+            @Override
+            public boolean test(RecordingApmServer.APMMessage message) {
+                return expected.matches(actual.apply(message));
             }
-            if ("elasticsearch".equals(getTags(parsed).get("otel_instrumentation_scope_name")) == false) {
-                return;
+
+            @Override
+            public String toString() {
+                return description;
             }
-            getSamples(parsed).forEach((name, value) -> {
-                if ("histogram".equals(value.get("type"))) {
-                    List<Double> values = (List<Double>) value.getOrDefault("values", Collections.emptyList());
-                    List<Integer> counts = (List<Integer>) value.getOrDefault("counts", Collections.emptyList());
-                    assertThat(values.size(), equalTo(counts.size()));
-                    List<Bucket> buckets = new ArrayList<>(values.size());
-                    for (int i = 0; i < values.size(); i++) {
-                        buckets.add(new Bucket(values.get(i), counts.get(i)));
-                    }
-                    histograms.put(name, buckets);
-                    return;
-                }
-                if (value.get("value") instanceof Number number) {
-                    if (number instanceof Integer intn) {
-                        longs.put(name, Long.valueOf(intn));
-                    } else if (number instanceof Long longn) {
-                        longs.put(name, longn);
-                    } else if (number instanceof Float floatn) {
-                        doubles.put(name, Double.valueOf(floatn));
-                    } else if (number instanceof Double doublen) {
-                        doubles.put(name, doublen);
-                    } else {
-                        fail("unknown number [" + number.getClass().getName() + "] [" + number + "]");
-                    }
-                }
-            });
-        }
-
-        @SuppressWarnings("unchecked")
-        private static Map<String, String> getTags(Map<String, Object> parsed) {
-            return (Map<String, String>) (getMetricset(parsed).getOrDefault("tags", Collections.emptyMap()));
-        }
-
-        @SuppressWarnings("unchecked")
-        private static Map<String, Map<String, Object>> getSamples(Map<String, Object> parsed) {
-            return (Map<String, Map<String, Object>>) getMetricset(parsed).getOrDefault("samples", Collections.emptyMap());
-        }
-
-        @SuppressWarnings("unchecked")
-        private static Map<String, Map<String, ?>> getMetricset(Map<String, Object> parsed) {
-            if (parsed.get("metricset") instanceof Map<?, ?> map) {
-                return (Map<String, Map<String, ?>>) map;
-            }
-            return Collections.emptyMap();
-        }
-
-        public List<Bucket> getHistogram(String name) {
-            return histograms.get(name);
-        }
-
-        public Long getLong(String name) {
-            return longs.get(name);
-        }
-
-        public Double getDouble(String name) {
-            return doubles.get(name);
-        }
-
-        public APMMessage merge(APMMessage other) {
-            histograms.putAll(other.histograms);
-            longs.putAll(other.longs);
-            doubles.putAll(other.doubles);
-            return this;
-        }
+        };
     }
+
 }

--- a/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/ApmIT.java
+++ b/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/ApmIT.java
@@ -131,7 +131,7 @@ public class ApmIT extends ESRestTestCase {
     private static boolean isElasticsearchMetric(Map<String, Object> apmMessage) {
         var metricset = (Map<String, Object>) apmMessage.getOrDefault("metricset", Collections.emptyMap());
         var tags = (Map<String, Object>) metricset.getOrDefault("tags", Collections.emptyMap());
-        return "elasticsearch".equals(tags.getOrDefault("otel_instrumentation_scope_name", "not_found"));
+        return "elasticsearch".equals(tags.get("otel_instrumentation_scope_name"));
     }
 
     private Map<String, Object> parseMap(String message) {

--- a/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/RecordingApmServer.java
+++ b/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/RecordingApmServer.java
@@ -14,6 +14,8 @@ import com.sun.net.httpserver.HttpServer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.spi.XContentProvider;
 import org.junit.rules.ExternalResource;
 
@@ -22,9 +24,22 @@ import java.io.InputStream;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+import static org.elasticsearch.test.ESTestCase.fail;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
 
 @SuppressForbidden(reason = "Uses an HTTP server for testing")
 public class RecordingApmServer extends ExternalResource {
@@ -32,9 +47,12 @@ public class RecordingApmServer extends ExternalResource {
 
     private static final XContentProvider.FormatProvider XCONTENT = XContentProvider.provider().getJsonXContent();
 
-    final List<String> received = new CopyOnWriteArrayList<>();
+    final ArrayBlockingQueue<String> received = new ArrayBlockingQueue<>(1000);
 
     private static HttpServer server;
+    private volatile Consumer<String> consumer;
+    private Thread thread;
+    private volatile boolean consumerRunning = true;
 
     @Override
     protected void before() throws Throwable {
@@ -42,11 +60,34 @@ public class RecordingApmServer extends ExternalResource {
         server.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
         server.createContext("/", this::handle);
         server.start();
+
+        this.thread = new Thread(consumerTask());
+        thread.start();
+    }
+
+    private Runnable consumerTask() {
+        return () -> {
+            while (consumerRunning) {
+                if (consumer != null) {
+                    try {
+                        String msg = received.poll(1L, TimeUnit.SECONDS);
+                        if (msg != null && msg.isEmpty() == false) {
+                            System.out.println("received" + msg);
+                            consumer.accept(msg);
+                        }
+
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+        };
     }
 
     @Override
     protected void after() {
         server.stop(1);
+        consumerRunning = false;
     }
 
     private void handle(HttpExchange exchange) throws IOException {
@@ -77,6 +118,99 @@ public class RecordingApmServer extends ExternalResource {
     }
 
     public List<String> getMessages() {
-        return received;
+        List<String> list = new ArrayList<>(received.size());
+        received.drainTo(list);
+        return list;
+    }
+
+    public CountDownLatch addMessageAssertions(Set<Predicate<APMMessage>> assertions) {
+        CountDownLatch success = new CountDownLatch(1);
+        this.consumer = (String message) -> {
+            var apmMessage = new APMMessage(message);
+            assertions.removeIf(c -> c.test(apmMessage));
+
+            if (assertions.isEmpty()) {
+                success.countDown();
+            }
+        };
+        return success;
+    }
+
+    public record Bucket(double value, int count) {}
+
+    public static class APMMessage {
+        Map<String, List<Bucket>> histograms = new HashMap<>();
+        Map<String, Double> doubles = new HashMap<>();
+        Map<String, Long> longs = new HashMap<>();
+
+        @SuppressWarnings("unchecked")
+        APMMessage(String message) {
+            Map<String, Object> parsed;
+            try (XContentParser parser = XCONTENT.XContent().createParser(XContentParserConfiguration.EMPTY, message)) {
+                parsed = parser.map();
+            } catch (IOException e) {
+                fail(e);
+                parsed = Collections.emptyMap();
+            }
+            if ("elasticsearch".equals(getTags(parsed).get("otel_instrumentation_scope_name")) == false) {
+                return;
+            }
+            getSamples(parsed).forEach((name, value) -> {
+                if ("histogram".equals(value.get("type"))) {
+                    List<Double> values = (List<Double>) value.getOrDefault("values", Collections.emptyList());
+                    List<Integer> counts = (List<Integer>) value.getOrDefault("counts", Collections.emptyList());
+                    assertThat(values.size(), equalTo(counts.size()));
+                    List<Bucket> buckets = new ArrayList<>(values.size());
+                    for (int i = 0; i < values.size(); i++) {
+                        buckets.add(new Bucket(values.get(i), counts.get(i)));
+                    }
+                    histograms.put(name, buckets);
+                    return;
+                }
+                if (value.get("value") instanceof Number number) {
+                    if (number instanceof Integer intn) {
+                        longs.put(name, Long.valueOf(intn));
+                    } else if (number instanceof Long longn) {
+                        longs.put(name, longn);
+                    } else if (number instanceof Float floatn) {
+                        doubles.put(name, Double.valueOf(floatn));
+                    } else if (number instanceof Double doublen) {
+                        doubles.put(name, doublen);
+                    } else {
+                        fail("unknown number [" + number.getClass().getName() + "] [" + number + "]");
+                    }
+                }
+            });
+        }
+
+        @SuppressWarnings("unchecked")
+        private static Map<String, String> getTags(Map<String, Object> parsed) {
+            return (Map<String, String>) (getMetricset(parsed).getOrDefault("tags", Collections.emptyMap()));
+        }
+
+        @SuppressWarnings("unchecked")
+        private static Map<String, Map<String, Object>> getSamples(Map<String, Object> parsed) {
+            return (Map<String, Map<String, Object>>) getMetricset(parsed).getOrDefault("samples", Collections.emptyMap());
+        }
+
+        @SuppressWarnings("unchecked")
+        private static Map<String, Map<String, ?>> getMetricset(Map<String, Object> parsed) {
+            if (parsed.get("metricset") instanceof Map<?, ?> map) {
+                return (Map<String, Map<String, ?>>) map;
+            }
+            return Collections.emptyMap();
+        }
+
+        public List<Bucket> getHistogram(String name) {
+            return histograms.getOrDefault(name, Collections.emptyList());
+        }
+
+        public Long getLong(String name) {
+            return longs.get(name);
+        }
+
+        public Double getDouble(String name) {
+            return doubles.get(name);
+        }
     }
 }

--- a/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/RecordingApmServer.java
+++ b/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/RecordingApmServer.java
@@ -68,11 +68,7 @@ public class RecordingApmServer extends ExternalResource {
     }
 
     private List<String> readJsonMessages(InputStream input) throws IOException {
-        // XContentParser parser = XCONTENT.XContent().createParser(XContentParserConfiguration.EMPTY, input);
-        // if (parser.currentToken() == null) {
-        // parser.nextToken();
-        // }
-        // return XContentParserUtils.parseList(parser, XContentParser::textOrNull);
+        // parse NDJSON
         return Arrays.stream(new String(input.readAllBytes(), StandardCharsets.UTF_8).split(System.lineSeparator())).toList();
     }
 

--- a/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/RecordingApmServer.java
+++ b/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/RecordingApmServer.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.test.apmintegration;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.xcontent.spi.XContentProvider;
+import org.junit.rules.ExternalResource;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+@SuppressForbidden(reason = "Uses an HTTP server for testing")
+public class RecordingApmServer extends ExternalResource {
+    private static final Logger logger = LogManager.getLogger(RecordingApmServer.class);
+
+    private static final XContentProvider.FormatProvider XCONTENT = XContentProvider.provider().getJsonXContent();
+
+    final List<String> received = new CopyOnWriteArrayList<>();
+
+    private static HttpServer server;
+
+    @Override
+    protected void before() throws Throwable {
+        server = HttpServer.create();
+        server.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+        server.createContext("/", this::handle);
+        server.start();
+    }
+
+    @Override
+    protected void after() {
+        server.stop(1);
+    }
+
+    private void handle(HttpExchange exchange) throws IOException {
+        try (exchange) {
+            try {
+                try (InputStream requestBody = exchange.getRequestBody()) {
+                    if (requestBody != null) {
+                        var read = readJsonMessages(requestBody);
+                        read.forEach(s -> logger.debug(s));
+                        received.addAll(read);
+                    }
+                }
+
+            } catch (RuntimeException e) {
+                logger.warn("failed to parse request", e);
+            }
+            exchange.sendResponseHeaders(201, 0);
+        }
+    }
+
+    private List<String> readJsonMessages(InputStream input) throws IOException {
+        // XContentParser parser = XCONTENT.XContent().createParser(XContentParserConfiguration.EMPTY, input);
+        // if (parser.currentToken() == null) {
+        // parser.nextToken();
+        // }
+        // return XContentParserUtils.parseList(parser, XContentParser::textOrNull);
+        return Arrays.stream(new String(input.readAllBytes(), StandardCharsets.UTF_8).split(System.lineSeparator())).toList();
+    }
+
+    public int getPort() {
+        return server.getAddress().getPort();
+    }
+
+    public List<String> getMessages() {
+        return received;
+    }
+}

--- a/test/external-modules/apm-integration/src/main/java/org/elasticsearch/test/apmintegration/ApmIntegrationPlugin.java
+++ b/test/external-modules/apm-integration/src/main/java/org/elasticsearch/test/apmintegration/ApmIntegrationPlugin.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.test.apmintegration;
+
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.IndexScopedSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.settings.SettingsFilter;
+import org.elasticsearch.plugins.ActionPlugin;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestHandler;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Supplier;
+
+public class ApmIntegrationPlugin extends Plugin implements ActionPlugin {
+    private final TestApmIntegrationRestHandler testApmIntegrationRestHandler = new TestApmIntegrationRestHandler();
+
+    @Override
+    public List<RestHandler> getRestHandlers(
+        final Settings settings,
+        final RestController restController,
+        final ClusterSettings clusterSettings,
+        final IndexScopedSettings indexScopedSettings,
+        final SettingsFilter settingsFilter,
+        final IndexNameExpressionResolver indexNameExpressionResolver,
+        final Supplier<DiscoveryNodes> nodesInCluster
+    ) {
+        return Collections.singletonList(testApmIntegrationRestHandler);
+    }
+
+    @Override
+    public Collection<?> createComponents(PluginServices services) {
+        TestMeterUsages testMeterUsages = new TestMeterUsages(services.telemetryProvider().getMeterRegistry());
+        testApmIntegrationRestHandler.setTestMeterUsages(testMeterUsages);
+        return super.createComponents(services);
+    }
+}

--- a/test/external-modules/apm-integration/src/main/java/org/elasticsearch/test/apmintegration/TestApmIntegrationRestHandler.java
+++ b/test/external-modules/apm-integration/src/main/java/org/elasticsearch/test/apmintegration/TestApmIntegrationRestHandler.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.test.apmintegration;
+
+import org.apache.lucene.util.SetOnce;
+import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestResponse;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.util.List;
+
+import static org.elasticsearch.rest.RestRequest.Method.GET;
+
+public class TestApmIntegrationRestHandler extends BaseRestHandler {
+
+    private SetOnce<TestMeterUsages> testMeterUsages = new SetOnce<>();
+
+    TestApmIntegrationRestHandler() {}
+
+    @Override
+    public List<Route> routes() {
+        return List.of(new Route(GET, "/_use_apm_metrics"));
+    }
+
+    @Override
+    public String getName() {
+        return "apm_integration_action";
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
+        return channel -> {
+            testMeterUsages.get().testUponRequest();
+
+            try (XContentBuilder builder = channel.newBuilder()) {
+                channel.sendResponse(new RestResponse(RestStatus.OK, builder));
+            }
+        };
+    }
+
+    public void setTestMeterUsages(TestMeterUsages testMeterUsages) {
+        this.testMeterUsages.set(testMeterUsages);
+    }
+}

--- a/test/external-modules/apm-integration/src/main/java/org/elasticsearch/test/apmintegration/TestMeterUsages.java
+++ b/test/external-modules/apm-integration/src/main/java/org/elasticsearch/test/apmintegration/TestMeterUsages.java
@@ -41,8 +41,6 @@ public class TestMeterUsages {
         longCounter.increment();
         doubleHistogram.record(1.0);
         doubleHistogram.record(2.0);
-        doubleHistogram.record(2.0);
-        longHistogram.record(1);
         longHistogram.record(1);
         longHistogram.record(2);
         doubleWithAttributes.set(new DoubleWithAttributes(1.0, Map.of()));

--- a/test/external-modules/apm-integration/src/main/java/org/elasticsearch/test/apmintegration/TestMeterUsages.java
+++ b/test/external-modules/apm-integration/src/main/java/org/elasticsearch/test/apmintegration/TestMeterUsages.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.test.apmintegration;
+
+import org.elasticsearch.telemetry.metric.DoubleCounter;
+import org.elasticsearch.telemetry.metric.DoubleHistogram;
+import org.elasticsearch.telemetry.metric.DoubleWithAttributes;
+import org.elasticsearch.telemetry.metric.LongHistogram;
+import org.elasticsearch.telemetry.metric.LongWithAttributes;
+import org.elasticsearch.telemetry.metric.MeterRegistry;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class TestMeterUsages {
+
+    private final DoubleCounter doubleCounter;
+    private final DoubleCounter longCounter;
+    private final DoubleHistogram doubleHistogram;
+    private final LongHistogram longHistogram;
+    private final AtomicReference<DoubleWithAttributes> doubleWithAttributes = new AtomicReference<>();
+    private final AtomicReference<LongWithAttributes> longWithAttributes = new AtomicReference<>();
+
+    public TestMeterUsages(MeterRegistry meterRegistry) {
+        this.doubleCounter = meterRegistry.registerDoubleCounter("testDoubleCounter", "test", "unit");
+        this.longCounter = meterRegistry.registerDoubleCounter("testLongCounter", "test", "unit");
+        this.doubleHistogram = meterRegistry.registerDoubleHistogram("testDoubleHistogram", "test", "unit");
+        this.longHistogram = meterRegistry.registerLongHistogram("testLongHistogram", "test", "unit");
+        meterRegistry.registerDoubleGauge("testDoubleGauge", "test", "unit", doubleWithAttributes::get);
+        meterRegistry.registerLongGauge("testLongGauge", "test", "unit", longWithAttributes::get);
+    }
+
+    public void testUponRequest() {
+        doubleCounter.increment();
+        longCounter.increment();
+        doubleHistogram.record(1.0);
+        doubleHistogram.record(2.0);
+        doubleHistogram.record(2.0);
+        longHistogram.record(1);
+        longHistogram.record(1);
+        longHistogram.record(2);
+        doubleWithAttributes.set(new DoubleWithAttributes(1.0, Map.of()));
+        longWithAttributes.set(new LongWithAttributes(1, Map.of()));
+    }
+}


### PR DESCRIPTION
this commit adds an integration test for APM module. In these tests we want to be independent to metrics generated by server, to avoid accidental failures when a code in server is refactored. This test is implemented as a separate gradle module with a test plugin that is exposing a rest endpoint and executes metrics registration & reporting.