### PR TITLE
Avoid recovery failures triggering unnecessary shard failures

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
@@ -336,8 +336,18 @@ public class PeerRecoveryTargetService implements IndexEventListener {
 
                         @Override
                         public void onFailure(Exception e) {
+                            final var cause = ExceptionsHelper.unwrapCause(e);
+                            final var sendShardFailure =
+                                // these indicate the source shard has already failed, which will independently notify the master and fail
+                                // the target shard
+                                false == (cause instanceof ShardNotFoundException || cause instanceof IndexNotFoundException);
+
                             // TODO retries? See RecoveryResponseHandler#handleException
-                            onGoingRecoveries.failRecovery(recoveryId, new RecoveryFailedException(recoveryState, null, e), true);
+                            onGoingRecoveries.failRecovery(
+                                recoveryId,
+                                new RecoveryFailedException(recoveryState, null, e),
+                                sendShardFailure
+                            );
                         }
                     }
                 );


### PR DESCRIPTION
Part of ES-6938: if a recovery fails with an `IndexNotFoundException` or
a `ShardNotFoundException` then the relevant shards are already being
failed, there's no need for the recovery to send more notifications and
it's best not to so that we don't emit spurious `WARN` logs.