### PR TITLE
ESQL: Fix planning of MV_EXPAND with foldable expressions

### DIFF
--- a/docs/changelog/101385.yaml
+++ b/docs/changelog/101385.yaml
@@ -1,0 +1,6 @@
+pr: 101385
+summary: "ESQL: Fix planning of MV_EXPAND with foldable expressions"
+area: ES|QL
+type: bug
+issues:
+ - 101118

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/mv_expand.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/mv_expand.csv-spec
@@ -225,3 +225,11 @@ emp_no:integer |  job_positions:keyword
 10004          |Head Human Resources
 10004          |Reporting Analyst
 ;
+
+
+expandFoldable
+row a = "foobar", b = ["foo", "bar"], c = 12 | mv_expand b | where b LIKE "fo*";
+
+a:keyword   | b:keyword | c:integer
+foobar      | foo       | 12
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -19,6 +19,7 @@ import org.elasticsearch.xpack.esql.plan.logical.Enrich;
 import org.elasticsearch.xpack.esql.plan.logical.EsqlUnresolvedRelation;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.Keep;
+import org.elasticsearch.xpack.esql.plan.logical.MvExpand;
 import org.elasticsearch.xpack.esql.plan.logical.Rename;
 import org.elasticsearch.xpack.esql.plan.logical.local.EsqlProject;
 import org.elasticsearch.xpack.esql.type.EsqlDataTypes;
@@ -324,7 +325,27 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                 return resolveEnrich(p, childrenOutput);
             }
 
+            if (plan instanceof MvExpand p) {
+                return resolveMvExpand(p, childrenOutput);
+            }
+
             return plan.transformExpressionsUp(UnresolvedAttribute.class, ua -> maybeResolveAttribute(ua, childrenOutput));
+        }
+
+        private LogicalPlan resolveMvExpand(MvExpand p, List<Attribute> childrenOutput) {
+            if (p.target() instanceof UnresolvedAttribute ua) {
+                Attribute resolved = maybeResolveAttribute(ua, childrenOutput);
+                if (resolved == ua) {
+                    return p;
+                }
+                return new MvExpand(
+                    p.source(),
+                    p.child(),
+                    resolved,
+                    new ReferenceAttribute(resolved.source(), resolved.name(), resolved.dataType(), null, resolved.nullable(), null, false)
+                );
+            }
+            return p;
         }
 
         private Attribute maybeResolveAttribute(UnresolvedAttribute ua, List<Attribute> childrenOutput) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypes.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypes.java
@@ -585,13 +585,14 @@ public final class PlanNamedTypes {
     }
 
     static MvExpandExec readMvExpandExec(PlanStreamInput in) throws IOException {
-        return new MvExpandExec(in.readSource(), in.readPhysicalPlanNode(), in.readNamedExpression());
+        return new MvExpandExec(in.readSource(), in.readPhysicalPlanNode(), in.readNamedExpression(), in.readAttribute());
     }
 
     static void writeMvExpandExec(PlanStreamOutput out, MvExpandExec mvExpandExec) throws IOException {
         out.writeNoSource();
         out.writePhysicalPlanNode(mvExpandExec.child());
         out.writeNamedExpression(mvExpandExec.target());
+        out.writeAttribute(mvExpandExec.expanded());
     }
 
     static OrderExec readOrderExec(PlanStreamInput in) throws IOException {
@@ -780,13 +781,14 @@ public final class PlanNamedTypes {
     }
 
     static MvExpand readMvExpand(PlanStreamInput in) throws IOException {
-        return new MvExpand(in.readSource(), in.readLogicalPlanNode(), in.readNamedExpression());
+        return new MvExpand(in.readSource(), in.readLogicalPlanNode(), in.readNamedExpression(), in.readAttribute());
     }
 
     static void writeMvExpand(PlanStreamOutput out, MvExpand mvExpand) throws IOException {
         out.writeNoSource();
         out.writeLogicalPlanNode(mvExpand.child());
         out.writeNamedExpression(mvExpand.target());
+        out.writeAttribute(mvExpand.expanded());
     }
 
     static OrderBy readOrderBy(PlanStreamInput in) throws IOException {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizer.java
@@ -12,6 +12,7 @@ import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
 import org.elasticsearch.xpack.esql.plan.physical.EnrichExec;
 import org.elasticsearch.xpack.esql.plan.physical.ExchangeExec;
 import org.elasticsearch.xpack.esql.plan.physical.FragmentExec;
+import org.elasticsearch.xpack.esql.plan.physical.MvExpandExec;
 import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
 import org.elasticsearch.xpack.esql.plan.physical.ProjectExec;
 import org.elasticsearch.xpack.esql.plan.physical.RegexExtractExec;
@@ -114,6 +115,9 @@ public class PhysicalPlanOptimizer extends ParameterizedRuleExecutor<PhysicalPla
                     });
                     if (p instanceof RegexExtractExec ree) {
                         attributes.removeAll(ree.extractedFields());
+                    }
+                    if (p instanceof MvExpandExec mvee) {
+                        attributes.remove(mvee.expanded());
                     }
                     if (p instanceof EnrichExec ee) {
                         for (NamedExpression enrichField : ee.enrichFields()) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/LogicalPlanBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/LogicalPlanBuilder.java
@@ -150,7 +150,8 @@ public class LogicalPlanBuilder extends ExpressionBuilder {
     @Override
     public PlanFactory visitMvExpandCommand(EsqlBaseParser.MvExpandCommandContext ctx) {
         String identifier = visitSourceIdentifier(ctx.sourceIdentifier());
-        return child -> new MvExpand(source(ctx), child, new UnresolvedAttribute(source(ctx), identifier));
+        Source src = source(ctx);
+        return child -> new MvExpand(src, child, new UnresolvedAttribute(src, identifier), new UnresolvedAttribute(src, identifier));
 
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/MvExpand.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/MvExpand.java
@@ -7,24 +7,48 @@
 
 package org.elasticsearch.xpack.esql.plan.logical;
 
+import org.elasticsearch.xpack.ql.expression.Attribute;
 import org.elasticsearch.xpack.ql.expression.NamedExpression;
 import org.elasticsearch.xpack.ql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.ql.plan.logical.UnaryPlan;
 import org.elasticsearch.xpack.ql.tree.NodeInfo;
 import org.elasticsearch.xpack.ql.tree.Source;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 public class MvExpand extends UnaryPlan {
     private final NamedExpression target;
+    private final Attribute expanded;
 
-    public MvExpand(Source source, LogicalPlan child, NamedExpression target) {
+    private final List<Attribute> output;
+
+    public MvExpand(Source source, LogicalPlan child, NamedExpression target, Attribute expanded) {
         super(source, child);
         this.target = target;
+        this.expanded = expanded;
+        this.output = calculateOutput(child.output(), target, expanded);
+    }
+
+    public static List<Attribute> calculateOutput(List<Attribute> input, NamedExpression target, Attribute expanded) {
+        List<Attribute> result = new ArrayList<>();
+        for (Attribute attribute : input) {
+            if (attribute.name().equals(target.name())) {
+                result.add(expanded);
+            } else {
+                result.add(attribute);
+            }
+        }
+        return result;
     }
 
     public NamedExpression target() {
         return target;
+    }
+
+    public Attribute expanded() {
+        return expanded;
     }
 
     @Override
@@ -34,17 +58,22 @@ public class MvExpand extends UnaryPlan {
 
     @Override
     public UnaryPlan replaceChild(LogicalPlan newChild) {
-        return new MvExpand(source(), newChild, target);
+        return new MvExpand(source(), newChild, target, expanded);
+    }
+
+    @Override
+    public List<Attribute> output() {
+        return output;
     }
 
     @Override
     protected NodeInfo<? extends LogicalPlan> info() {
-        return NodeInfo.create(this, MvExpand::new, child(), target);
+        return NodeInfo.create(this, MvExpand::new, child(), target, expanded);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), target);
+        return Objects.hash(super.hashCode(), target, expanded);
     }
 
     @Override
@@ -52,6 +81,6 @@ public class MvExpand extends UnaryPlan {
         if (false == super.equals(obj)) {
             return false;
         }
-        return Objects.equals(target, ((MvExpand) obj).target);
+        return Objects.equals(target, ((MvExpand) obj).target) && Objects.equals(expanded, ((MvExpand) obj).expanded);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/MvExpandExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/MvExpandExec.java
@@ -6,38 +6,55 @@
  */
 package org.elasticsearch.xpack.esql.plan.physical;
 
+import org.elasticsearch.xpack.ql.expression.Attribute;
 import org.elasticsearch.xpack.ql.expression.NamedExpression;
 import org.elasticsearch.xpack.ql.tree.NodeInfo;
 import org.elasticsearch.xpack.ql.tree.Source;
 
+import java.util.List;
 import java.util.Objects;
+
+import static org.elasticsearch.xpack.esql.plan.logical.MvExpand.calculateOutput;
 
 public class MvExpandExec extends UnaryExec {
 
     private final NamedExpression target;
+    private final Attribute expanded;
+    private final List<Attribute> output;
 
-    public MvExpandExec(Source source, PhysicalPlan child, NamedExpression target) {
+    public MvExpandExec(Source source, PhysicalPlan child, NamedExpression target, Attribute expanded) {
         super(source, child);
         this.target = target;
+        this.expanded = expanded;
+        this.output = calculateOutput(child.output(), target, expanded);
     }
 
     @Override
     protected NodeInfo<MvExpandExec> info() {
-        return NodeInfo.create(this, MvExpandExec::new, child(), target);
+        return NodeInfo.create(this, MvExpandExec::new, child(), target, expanded);
     }
 
     @Override
     public MvExpandExec replaceChild(PhysicalPlan newChild) {
-        return new MvExpandExec(source(), newChild, target);
+        return new MvExpandExec(source(), newChild, target, expanded);
     }
 
     public NamedExpression target() {
         return target;
     }
 
+    public Attribute expanded() {
+        return expanded;
+    }
+
+    @Override
+    public List<Attribute> output() {
+        return output;
+    }
+
     @Override
     public int hashCode() {
-        return Objects.hash(target, child());
+        return Objects.hash(target, child(), expanded);
     }
 
     @Override
@@ -51,6 +68,6 @@ public class MvExpandExec extends UnaryExec {
 
         MvExpandExec other = (MvExpandExec) obj;
 
-        return Objects.equals(target, other.target) && Objects.equals(child(), other.child());
+        return Objects.equals(target, other.target) && Objects.equals(child(), other.child()) && Objects.equals(expanded, other.expanded);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -617,8 +617,9 @@ public class LocalExecutionPlanner {
 
         Layout.Builder layout = new Layout.Builder();
         List<Layout.ChannelSet> inverse = source.layout.inverse();
-        for (int index = 0, size = childOutput.size(); index < size; index++) {
-            if (childOutput.get(index).name().equals(mvExpandExec.expanded().name())) {
+        var expandedName = mvExpandExec.expanded().name();
+        for (int index = 0; index < inverse.size(); index++) {
+            if (childOutput.get(index).name().equals(expandedName)) {
                 layout.append(mvExpandExec.expanded());
             } else {
                 layout.append(inverse.get(index));

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/Mapper.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/Mapper.java
@@ -151,7 +151,7 @@ public class Mapper {
         }
 
         if (p instanceof MvExpand mvExpand) {
-            return new MvExpandExec(mvExpand.source(), map(mvExpand.child()), mvExpand.target());
+            return new MvExpandExec(mvExpand.source(), map(mvExpand.child()), mvExpand.target(), mvExpand.expanded());
         }
 
         //

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypesTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypesTests.java
@@ -488,7 +488,7 @@ public class PlanNamedTypesTests extends ESTestCase {
 
     public void testMvExpand() throws IOException {
         var esRelation = new EsRelation(Source.EMPTY, randomEsIndex(), List.of(randomFieldAttribute()), randomBoolean());
-        var orig = new MvExpand(Source.EMPTY, esRelation, randomFieldAttribute());
+        var orig = new MvExpand(Source.EMPTY, esRelation, randomFieldAttribute(), randomFieldAttribute());
         BytesStreamOutput bso = new BytesStreamOutput();
         PlanStreamOutput out = new PlanStreamOutput(bso, planNameRegistry);
         PlanNamedTypes.writeMvExpand(out, orig);


### PR DESCRIPTION
MV_EXPAND command has an output schema that seems exactly the same as the input, but it is not completely true for the expanded field. 
In particular, some of the properties of the expanding field (in particular the foldability) can be lost after the expansion.
Not taking it into account led to planning issues like https://github.com/elastic/elasticsearch/issues/101118

This PR replaces the expanding field with a new attribute (same name and type, but different ID), so that the planner can distinguish between the two and avoid confusion, like trying to fold an expression that is no longer foldable after the expansion.

Fixes https://github.com/elastic/elasticsearch/issues/101118
