### PR TITLE
Introduce MockTransportService#getInstance

### DIFF
--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
@@ -90,7 +90,6 @@ import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.fetch.subphase.FieldAndFormat;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.transport.MockTransportService;
-import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.ObjectPath;
 import org.elasticsearch.xcontent.XContentType;
 
@@ -2157,11 +2156,11 @@ public class DataStreamIT extends ESIntegTestCase {
 
         for (String nodeId : failingIndicesStatsNodeIds) {
             String nodeName = clusterStateBeforeRollover.nodes().resolveNode(nodeId).getName();
-            MockTransportService transportService = (MockTransportService) internalCluster().getInstance(TransportService.class, nodeName);
-            transportService.addRequestHandlingBehavior(
-                IndicesStatsAction.NAME + "[n]",
-                (handler, request, channel, task) -> channel.sendResponse(new RuntimeException("Unable to get stats"))
-            );
+            MockTransportService.getInstance(nodeName)
+                .addRequestHandlingBehavior(
+                    IndicesStatsAction.NAME + "[n]",
+                    (handler, request, channel, task) -> channel.sendResponse(new RuntimeException("Unable to get stats"))
+                );
         }
 
         logger.info(
@@ -2223,14 +2222,11 @@ public class DataStreamIT extends ESIntegTestCase {
             .currentNodeId();
 
         final String nodeName = clusterStateBeforeRollover.nodes().resolveNode(assignedShardNodeId).getName();
-        final MockTransportService transportService = (MockTransportService) internalCluster().getInstance(
-            TransportService.class,
-            nodeName
-        );
-        transportService.addRequestHandlingBehavior(
-            IndicesStatsAction.NAME + "[n]",
-            (handler, request, channel, task) -> channel.sendResponse(new RuntimeException("Unable to get stats"))
-        );
+        MockTransportService.getInstance(nodeName)
+            .addRequestHandlingBehavior(
+                IndicesStatsAction.NAME + "[n]",
+                (handler, request, channel, task) -> channel.sendResponse(new RuntimeException("Unable to get stats"))
+            );
 
         assertAcked(indicesAdmin().rolloverIndex(new RolloverRequest(dataStreamName, null)).actionGet());
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateActionDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateActionDisruptionIT.java
@@ -193,12 +193,9 @@ public class TransportClusterStateActionDisruptionIT extends ESIntegTestCase {
         assertingThread.start();
         updatingThread.start();
 
-        final MockTransportService masterTransportService = (MockTransportService) internalCluster().getInstance(
-            TransportService.class,
-            masterName
-        );
+        final var masterTransportService = MockTransportService.getInstance(masterName);
 
-        for (MockTransportService mockTransportService : mockTransportServices) {
+        for (final var mockTransportService : mockTransportServices) {
             if (masterTransportService != mockTransportService) {
                 masterTransportService.addFailToSendNoConnectRule(mockTransportService);
                 mockTransportService.addFailToSendNoConnectRule(masterTransportService);

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageAnalyzerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageAnalyzerIT.java
@@ -26,7 +26,6 @@ import org.elasticsearch.plugins.EnginePlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.transport.MockTransportService;
-import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.junit.Before;
@@ -249,23 +248,23 @@ public class IndexDiskUsageAnalyzerIT extends ESIntegTestCase {
         final AtomicInteger successfulShards = new AtomicInteger();
         try {
             for (String node : internalCluster().getNodeNames()) {
-                MockTransportService transportService = (MockTransportService) internalCluster().getInstance(TransportService.class, node);
-                transportService.addRequestHandlingBehavior(AnalyzeIndexDiskUsageAction.NAME + "[s]", (handler, request, channel, task) -> {
-                    AnalyzeDiskUsageShardRequest shardRequest = (AnalyzeDiskUsageShardRequest) request;
-                    IndicesService indicesService = internalCluster().getInstance(IndicesService.class, node);
-                    logger.info("--> handling shard request {} on node {}", shardRequest.shardId(), node);
-                    ShardId shardId = shardRequest.shardId();
-                    if (failingShards.contains(shardId)) {
-                        IndexShard indexShard = indicesService.getShardOrNull(shardId);
-                        assertNotNull("No shard found for shard " + shardId, indexShard);
-                        logger.info("--> failing shard {} on node {}", shardRequest.shardId(), node);
-                        indexShard.close("test", randomBoolean());
-                        failedShards.incrementAndGet();
-                    } else {
-                        successfulShards.incrementAndGet();
-                    }
-                    handler.messageReceived(request, channel, task);
-                });
+                MockTransportService.getInstance(node)
+                    .addRequestHandlingBehavior(AnalyzeIndexDiskUsageAction.NAME + "[s]", (handler, request, channel, task) -> {
+                        AnalyzeDiskUsageShardRequest shardRequest = (AnalyzeDiskUsageShardRequest) request;
+                        IndicesService indicesService = internalCluster().getInstance(IndicesService.class, node);
+                        logger.info("--> handling shard request {} on node {}", shardRequest.shardId(), node);
+                        ShardId shardId = shardRequest.shardId();
+                        if (failingShards.contains(shardId)) {
+                            IndexShard indexShard = indicesService.getShardOrNull(shardId);
+                            assertNotNull("No shard found for shard " + shardId, indexShard);
+                            logger.info("--> failing shard {} on node {}", shardRequest.shardId(), node);
+                            indexShard.close("test", randomBoolean());
+                            failedShards.incrementAndGet();
+                        } else {
+                            successfulShards.incrementAndGet();
+                        }
+                        handler.messageReceived(request, channel, task);
+                    });
             }
             AnalyzeIndexDiskUsageResponse resp = client().execute(
                 AnalyzeIndexDiskUsageAction.INSTANCE,
@@ -279,8 +278,7 @@ public class IndexDiskUsageAnalyzerIT extends ESIntegTestCase {
             assertThat(resp.getShardFailures(), arrayWithSize(failedShards.get()));
         } finally {
             for (String node : internalCluster().getNodeNames()) {
-                MockTransportService transportService = (MockTransportService) internalCluster().getInstance(TransportService.class, node);
-                transportService.clearAllRules();
+                MockTransportService.getInstance(node).clearAllRules();
             }
         }
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/search/PointInTimeIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/search/PointInTimeIT.java
@@ -37,7 +37,6 @@ import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.tasks.TaskInfo;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.transport.MockTransportService;
-import org.elasticsearch.transport.TransportService;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -449,7 +448,7 @@ public class PointInTimeIT extends ESIntegTestCase {
                         .build()
                 )
         );
-        var transportService = (MockTransportService) internalCluster().getInstance(TransportService.class, dataNode.getName());
+        final var transportService = MockTransportService.getInstance(dataNode.getName());
         try {
             CountDownLatch sentLatch = new CountDownLatch(maxConcurrentRequests);
             CountDownLatch readyLatch = new CountDownLatch(1);

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/support/replication/TransportReplicationActionRetryOnClosedNodeIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/support/replication/TransportReplicationActionRetryOnClosedNodeIT.java
@@ -205,13 +205,9 @@ public class TransportReplicationActionRetryOnClosedNodeIT extends ESIntegTestCa
 
         assertTrue(primaryTestPlugin.actionRunningLatch.await(10, TimeUnit.SECONDS));
 
-        MockTransportService primaryTransportService = (MockTransportService) internalCluster().getInstance(
-            TransportService.class,
-            primary
-        );
         // we pause node after TransportService has moved to stopped, but before closing connections, since if connections are closed
         // we would not hit the transport service closed case.
-        primaryTransportService.addOnStopListener(() -> {
+        MockTransportService.getInstance(primary).addOnStopListener(() -> {
             primaryTestPlugin.actionWaitLatch.countDown();
             safeAwait(doneLatch);
         });

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterInfoServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterInfoServiceIT.java
@@ -240,10 +240,7 @@ public class ClusterInfoServiceIT extends ESIntegTestCase {
             );
         }
 
-        MockTransportService mockTransportService = (MockTransportService) internalCluster().getInstance(
-            TransportService.class,
-            internalTestCluster.getMasterName()
-        );
+        final var masterTransportService = MockTransportService.getInstance(internalTestCluster.getMasterName());
 
         final AtomicBoolean timeout = new AtomicBoolean(false);
         final Set<String> blockedActions = newHashSet(
@@ -254,7 +251,7 @@ public class ClusterInfoServiceIT extends ESIntegTestCase {
         );
         // drop all outgoing stats requests to force a timeout.
         for (DiscoveryNode node : internalTestCluster.clusterService().state().getNodes()) {
-            mockTransportService.addSendBehavior(
+            masterTransportService.addSendBehavior(
                 internalTestCluster.getInstance(TransportService.class, node.getName()),
                 (connection, requestId, action, request, options) -> {
                     if (blockedActions.contains(action)) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/PrevalidateNodeRemovalIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/PrevalidateNodeRemovalIT.java
@@ -28,7 +28,6 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.transport.ConnectTransportException;
-import org.elasticsearch.transport.TransportService;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -131,16 +130,15 @@ public class PrevalidateNodeRemovalIT extends ESIntegTestCase {
         // its ACTION_SHARD_EXISTS requests since after a relocation, the source first waits
         // until the shard exists somewhere else, then it removes it locally.
         final CountDownLatch shardActiveRequestSent = new CountDownLatch(1);
-        MockTransportService node1transport = (MockTransportService) internalCluster().getInstance(TransportService.class, node1);
-        TransportService node2transport = internalCluster().getInstance(TransportService.class, node2);
-        node1transport.addSendBehavior(node2transport, (connection, requestId, action, request, options) -> {
-            if (action.equals(IndicesStore.ACTION_SHARD_EXISTS)) {
-                shardActiveRequestSent.countDown();
-                logger.info("prevent shard active request from being sent");
-                throw new ConnectTransportException(connection.getNode(), "DISCONNECT: simulated");
-            }
-            connection.sendRequest(requestId, action, request, options);
-        });
+        MockTransportService.getInstance(node1)
+            .addSendBehavior(MockTransportService.getInstance(node2), (connection, requestId, action, request, options) -> {
+                if (action.equals(IndicesStore.ACTION_SHARD_EXISTS)) {
+                    shardActiveRequestSent.countDown();
+                    logger.info("prevent shard active request from being sent");
+                    throw new ConnectTransportException(connection.getNode(), "DISCONNECT: simulated");
+                }
+                connection.sendRequest(requestId, action, request, options);
+            });
         logger.info("--> move shard from {} to {}, and wait for relocation to finish", node1, node2);
         updateIndexSettings(Settings.builder().put("index.routing.allocation.require._name", node2), indexName);
         shardActiveRequestSent.await();
@@ -179,13 +177,10 @@ public class PrevalidateNodeRemovalIT extends ESIntegTestCase {
         // make it red!
         internalCluster().stopNode(node1);
         ensureRed(indexName);
-        MockTransportService node2TransportService = (MockTransportService) internalCluster().getInstance(TransportService.class, node2);
-        node2TransportService.addRequestHandlingBehavior(
-            TransportPrevalidateShardPathAction.ACTION_NAME + "[n]",
-            (handler, request, channel, task) -> {
+        MockTransportService.getInstance(node2)
+            .addRequestHandlingBehavior(TransportPrevalidateShardPathAction.ACTION_NAME + "[n]", (handler, request, channel, task) -> {
                 logger.info("drop the check shards request");
-            }
-        );
+            });
         PrevalidateNodeRemovalRequest req = PrevalidateNodeRemovalRequest.builder()
             .setNames(node2)
             .build()

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/VotingConfigurationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/VotingConfigurationIT.java
@@ -92,10 +92,7 @@ public class VotingConfigurationIT extends ESIntegTestCase {
             if (sender.equals(excludedNodeName)) {
                 continue;
             }
-            final MockTransportService senderTransportService = (MockTransportService) internalCluster().getInstance(
-                TransportService.class,
-                sender
-            );
+            final var senderTransportService = MockTransportService.getInstance(sender);
             for (final String receiver : nodeNames) {
                 senderTransportService.addSendBehavior(
                     internalCluster().getInstance(TransportService.class, receiver),

--- a/server/src/internalClusterTest/java/org/elasticsearch/discovery/ClusterDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/discovery/ClusterDisruptionIT.java
@@ -42,7 +42,6 @@ import org.elasticsearch.test.disruption.NetworkDisruption.TwoPartitions;
 import org.elasticsearch.test.disruption.ServiceDisruptionScheme;
 import org.elasticsearch.test.junit.annotations.TestIssueLogging;
 import org.elasticsearch.test.transport.MockTransportService;
-import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.XContentType;
 
 import java.util.ArrayList;
@@ -573,17 +572,14 @@ public class ClusterDisruptionIT extends AbstractDisruptionTestCase {
             }
         });
 
-        final MockTransportService dataTransportService = (MockTransportService) internalCluster().getInstance(
-            TransportService.class,
-            dataNode
-        );
-        dataTransportService.addRequestHandlingBehavior(FollowersChecker.FOLLOWER_CHECK_ACTION_NAME, (handler, request, channel, task) -> {
-            if (removedNode.isDone() == false) {
-                channel.sendResponse(new ElasticsearchException("simulated check failure"));
-            } else {
-                handler.messageReceived(request, channel, task);
-            }
-        });
+        MockTransportService.getInstance(dataNode)
+            .addRequestHandlingBehavior(FollowersChecker.FOLLOWER_CHECK_ACTION_NAME, (handler, request, channel, task) -> {
+                if (removedNode.isDone() == false) {
+                    channel.sendResponse(new ElasticsearchException("simulated check failure"));
+                } else {
+                    handler.messageReceived(request, channel, task);
+                }
+            });
 
         removedNode.actionGet(10, TimeUnit.SECONDS);
         ensureStableCluster(2);

--- a/server/src/internalClusterTest/java/org/elasticsearch/discovery/DiscoveryDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/discovery/DiscoveryDisruptionIT.java
@@ -57,19 +57,13 @@ public class DiscoveryDisruptionIT extends AbstractDisruptionTestCase {
         );
 
         logger.info("blocking requests from non master [{}] to master [{}]", nonMasterNode, masterNode);
-        MockTransportService nonMasterTransportService = (MockTransportService) internalCluster().getInstance(
-            TransportService.class,
-            nonMasterNode
-        );
+        final var nonMasterTransportService = MockTransportService.getInstance(nonMasterNode);
         nonMasterTransportService.addFailToSendNoConnectRule(masterTranspotService);
 
         assertNoMaster(nonMasterNode);
 
         logger.info("blocking cluster state publishing from master [{}] to non master [{}]", masterNode, nonMasterNode);
-        MockTransportService masterTransportService = (MockTransportService) internalCluster().getInstance(
-            TransportService.class,
-            masterNode
-        );
+        final var masterTransportService = MockTransportService.getInstance(masterNode);
         TransportService localTransportService = internalCluster().getInstance(
             TransportService.class,
             discoveryNodes.getLocalNode().getName()
@@ -188,10 +182,7 @@ public class DiscoveryDisruptionIT extends AbstractDisruptionTestCase {
         }
 
         logger.info("blocking request from master [{}] to [{}]", masterNode, nonMasterNode);
-        MockTransportService masterTransportService = (MockTransportService) internalCluster().getInstance(
-            TransportService.class,
-            masterNode
-        );
+        final var masterTransportService = MockTransportService.getInstance(masterNode);
         if (randomBoolean()) {
             masterTransportService.addUnresponsiveRule(internalCluster().getInstance(TransportService.class, nonMasterNode));
         } else {
@@ -232,13 +223,13 @@ public class DiscoveryDisruptionIT extends AbstractDisruptionTestCase {
         safeAwait(barrier);
 
         // drop the victim from the cluster with a network disruption
-        final var masterTransportService = (MockTransportService) internalCluster().getInstance(TransportService.class, masterName);
+        final var masterTransportService = MockTransportService.getInstance(masterName);
         masterTransportService.addFailToSendNoConnectRule(internalCluster().getInstance(TransportService.class, victimName));
         logger.info("--> waiting for victim's departure");
         ensureStableCluster(2, masterName);
 
         // verify that the victim sends no joins while the applier is blocked
-        final var victimTransportService = (MockTransportService) internalCluster().getInstance(TransportService.class, victimName);
+        final var victimTransportService = MockTransportService.getInstance(victimName);
         victimTransportService.addSendBehavior((connection, requestId, action, request, options) -> {
             assertNotEquals(action, JoinHelper.JOIN_ACTION_NAME);
             connection.sendRequest(requestId, action, request, options);
@@ -283,13 +274,13 @@ public class DiscoveryDisruptionIT extends AbstractDisruptionTestCase {
         }
 
         // drop the victim from the cluster with a network disruption
-        final var masterTransportService = (MockTransportService) internalCluster().getInstance(TransportService.class, masterName);
+        final var masterTransportService = MockTransportService.getInstance(masterName);
         masterTransportService.addFailToSendNoConnectRule(internalCluster().getInstance(TransportService.class, victimName));
         logger.info("--> waiting for victim's departure");
         ensureStableCluster(2, masterName);
 
         // verify that the victim sends no joins while the circuit breaker is breaking
-        final var victimTransportService = (MockTransportService) internalCluster().getInstance(TransportService.class, victimName);
+        final var victimTransportService = MockTransportService.getInstance(victimName);
         victimTransportService.addSendBehavior((connection, requestId, action, request, options) -> {
             assertNotEquals(action, JoinHelper.JOIN_ACTION_NAME);
             connection.sendRequest(requestId, action, request, options);

--- a/server/src/internalClusterTest/java/org/elasticsearch/gateway/ReplicaShardAllocatorIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/gateway/ReplicaShardAllocatorIT.java
@@ -34,7 +34,6 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.InternalSettingsPlugin;
 import org.elasticsearch.test.transport.MockTransportService;
-import org.elasticsearch.transport.TransportService;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -108,10 +107,7 @@ public class ReplicaShardAllocatorIT extends ESIntegTestCase {
         }
         CountDownLatch blockRecovery = new CountDownLatch(1);
         CountDownLatch recoveryStarted = new CountDownLatch(1);
-        MockTransportService transportServiceOnPrimary = (MockTransportService) internalCluster().getInstance(
-            TransportService.class,
-            nodeWithPrimary
-        );
+        final var transportServiceOnPrimary = MockTransportService.getInstance(nodeWithPrimary);
         transportServiceOnPrimary.addSendBehavior((connection, requestId, action, request, options) -> {
             if (PeerRecoveryTargetService.Actions.FILES_INFO.equals(action)) {
                 recoveryStarted.countDown();
@@ -169,10 +165,7 @@ public class ReplicaShardAllocatorIT extends ESIntegTestCase {
         }
         CountDownLatch blockRecovery = new CountDownLatch(1);
         CountDownLatch recoveryStarted = new CountDownLatch(1);
-        MockTransportService transportServiceOnPrimary = (MockTransportService) internalCluster().getInstance(
-            TransportService.class,
-            nodeWithPrimary
-        );
+        final var transportServiceOnPrimary = MockTransportService.getInstance(nodeWithPrimary);
         transportServiceOnPrimary.addSendBehavior((connection, requestId, action, request, options) -> {
             if (PeerRecoveryTargetService.Actions.FILES_INFO.equals(action)) {
                 recoveryStarted.countDown();
@@ -349,10 +342,7 @@ public class ReplicaShardAllocatorIT extends ESIntegTestCase {
         );
         indicesAdmin().prepareFlush(indexName).get();
         String brokenNode = internalCluster().startDataOnlyNode();
-        MockTransportService transportService = (MockTransportService) internalCluster().getInstance(
-            TransportService.class,
-            nodeWithPrimary
-        );
+        final var transportService = MockTransportService.getInstance(nodeWithPrimary);
         CountDownLatch newNodeStarted = new CountDownLatch(1);
         transportService.addSendBehavior((connection, requestId, action, request, options) -> {
             if (action.equals(PeerRecoveryTargetService.Actions.TRANSLOG_OPS)) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/gateway/ReplicaShardAllocatorSyncIdIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/gateway/ReplicaShardAllocatorSyncIdIT.java
@@ -35,7 +35,6 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.InternalSettingsPlugin;
 import org.elasticsearch.test.transport.MockTransportService;
-import org.elasticsearch.transport.TransportService;
 import org.junit.Before;
 
 import java.io.IOException;
@@ -187,10 +186,7 @@ public class ReplicaShardAllocatorSyncIdIT extends ESIntegTestCase {
         });
         CountDownLatch blockRecovery = new CountDownLatch(1);
         CountDownLatch recoveryStarted = new CountDownLatch(1);
-        MockTransportService transportServiceOnPrimary = (MockTransportService) internalCluster().getInstance(
-            TransportService.class,
-            nodeWithPrimary
-        );
+        final var transportServiceOnPrimary = MockTransportService.getInstance(nodeWithPrimary);
         transportServiceOnPrimary.addSendBehavior((connection, requestId, action, request, options) -> {
             if (PeerRecoveryTargetService.Actions.FILES_INFO.equals(action)) {
                 recoveryStarted.countDown();
@@ -279,7 +275,7 @@ public class ReplicaShardAllocatorSyncIdIT extends ESIntegTestCase {
             syncFlush(indexName);
         }
         internalCluster().startDataOnlyNode();
-        MockTransportService transportService = (MockTransportService) internalCluster().getInstance(TransportService.class, source);
+        final var transportService = MockTransportService.getInstance(source);
         Semaphore failRecovery = new Semaphore(1);
         transportService.addSendBehavior((connection, requestId, action, request, options) -> {
             if (action.equals(PeerRecoveryTargetService.Actions.CLEAN_FILES)) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/seqno/GlobalCheckpointSyncIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/seqno/GlobalCheckpointSyncIT.java
@@ -23,7 +23,6 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.InternalSettingsPlugin;
 import org.elasticsearch.test.transport.MockTransportService;
-import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.XContentType;
 
 import java.util.ArrayList;
@@ -95,21 +94,17 @@ public class GlobalCheckpointSyncIT extends ESIntegTestCase {
                     if (node == other) {
                         continue;
                     }
-                    final MockTransportService senderTransportService = (MockTransportService) internalCluster().getInstance(
-                        TransportService.class,
-                        node.getName()
-                    );
-                    final MockTransportService receiverTransportService = (MockTransportService) internalCluster().getInstance(
-                        TransportService.class,
-                        other.getName()
-                    );
-                    senderTransportService.addSendBehavior(receiverTransportService, (connection, requestId, action, request, options) -> {
-                        if ("indices:admin/seq_no/global_checkpoint_sync[r]".equals(action)) {
-                            throw new IllegalStateException("blocking indices:admin/seq_no/global_checkpoint_sync[r]");
-                        } else {
-                            connection.sendRequest(requestId, action, request, options);
-                        }
-                    });
+                    MockTransportService.getInstance(node.getName())
+                        .addSendBehavior(
+                            MockTransportService.getInstance(other.getName()),
+                            (connection, requestId, action, request, options) -> {
+                                if ("indices:admin/seq_no/global_checkpoint_sync[r]".equals(action)) {
+                                    throw new IllegalStateException("blocking indices:admin/seq_no/global_checkpoint_sync[r]");
+                                } else {
+                                    connection.sendRequest(requestId, action, request, options);
+                                }
+                            }
+                        );
                 }
             }
         }, client -> {
@@ -120,15 +115,7 @@ public class GlobalCheckpointSyncIT extends ESIntegTestCase {
                     if (node == other) {
                         continue;
                     }
-                    final MockTransportService senderTransportService = (MockTransportService) internalCluster().getInstance(
-                        TransportService.class,
-                        node.getName()
-                    );
-                    final MockTransportService receiverTransportService = (MockTransportService) internalCluster().getInstance(
-                        TransportService.class,
-                        other.getName()
-                    );
-                    senderTransportService.clearOutboundRules(receiverTransportService);
+                    MockTransportService.getInstance(node.getName()).clearOutboundRules(MockTransportService.getInstance(other.getName()));
                 }
             }
         });

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/seqno/RetentionLeaseIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/seqno/RetentionLeaseIT.java
@@ -352,10 +352,7 @@ public class RetentionLeaseIT extends ESIntegTestCase {
             Settings.builder().put(INDICES_RECOVERY_RETRY_DELAY_NETWORK_SETTING.getKey(), TimeValue.timeValueMillis(100))
         );
         final Semaphore recoveriesToDisrupt = new Semaphore(scaledRandomIntBetween(0, 4));
-        final MockTransportService primaryTransportService = (MockTransportService) internalCluster().getInstance(
-            TransportService.class,
-            primaryShardNodeName
-        );
+        final var primaryTransportService = MockTransportService.getInstance(primaryShardNodeName);
         primaryTransportService.addSendBehavior((connection, requestId, action, request, options) -> {
             if (action.equals(PeerRecoveryTargetService.Actions.FINALIZE) && recoveriesToDisrupt.tryAcquire()) {
                 if (randomBoolean()) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/store/CorruptedFileIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/store/CorruptedFileIT.java
@@ -350,23 +350,20 @@ public class CorruptedFileIT extends ESIntegTestCase {
         final AtomicBoolean corrupt = new AtomicBoolean(true);
         final CountDownLatch hasCorrupted = new CountDownLatch(1);
         for (var dataNode : dataNodes) {
-            MockTransportService mockTransportService = ((MockTransportService) internalCluster().getInstance(
-                TransportService.class,
-                dataNode.getName()
-            ));
-            mockTransportService.addSendBehavior(
-                internalCluster().getInstance(TransportService.class, unluckyNode.getName()),
-                (connection, requestId, action, request, options) -> {
-                    if (corrupt.get() && action.equals(PeerRecoveryTargetService.Actions.FILE_CHUNK)) {
-                        RecoveryFileChunkRequest req = (RecoveryFileChunkRequest) request;
-                        byte[] array = BytesRef.deepCopyOf(req.content().toBytesRef()).bytes;
-                        int i = randomIntBetween(0, req.content().length() - 1);
-                        array[i] = (byte) ~array[i]; // flip one byte in the content
-                        hasCorrupted.countDown();
+            MockTransportService.getInstance(dataNode.getName())
+                .addSendBehavior(
+                    internalCluster().getInstance(TransportService.class, unluckyNode.getName()),
+                    (connection, requestId, action, request, options) -> {
+                        if (corrupt.get() && action.equals(PeerRecoveryTargetService.Actions.FILE_CHUNK)) {
+                            RecoveryFileChunkRequest req = (RecoveryFileChunkRequest) request;
+                            byte[] array = BytesRef.deepCopyOf(req.content().toBytesRef()).bytes;
+                            int i = randomIntBetween(0, req.content().length() - 1);
+                            array[i] = (byte) ~array[i]; // flip one byte in the content
+                            hasCorrupted.countDown();
+                        }
+                        connection.sendRequest(requestId, action, request, options);
                     }
-                    connection.sendRequest(requestId, action, request, options);
-                }
-            );
+                );
         }
 
         updateIndexSettings(
@@ -413,8 +410,8 @@ public class CorruptedFileIT extends ESIntegTestCase {
         // we have to flush at least once here since we don't corrupt the translog
         assertHitCount(prepareSearch().setSize(0), numDocs);
 
-        var source = (MockTransportService) internalCluster().getInstance(TransportService.class, primariesNode.getName());
-        var target = internalCluster().getInstance(TransportService.class, unluckyNode.getName());
+        final var source = MockTransportService.getInstance(primariesNode.getName());
+        final var target = MockTransportService.getInstance(unluckyNode.getName());
 
         final boolean truncate = randomBoolean();
         source.addSendBehavior(target, (connection, requestId, action, request, options) -> {

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
@@ -486,7 +486,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         // hold peer recovery on phase 2 after nodeB down
         CountDownLatch phase1ReadyBlocked = new CountDownLatch(1);
         CountDownLatch allowToCompletePhase1Latch = new CountDownLatch(1);
-        MockTransportService transportService = (MockTransportService) internalCluster().getInstance(TransportService.class, nodeA);
+        final var transportService = MockTransportService.getInstance(nodeA);
         transportService.addSendBehavior((connection, requestId, action, request, options) -> {
             if (PeerRecoveryTargetService.Actions.CLEAN_FILES.equals(action)) {
                 phase1ReadyBlocked.countDown();
@@ -1046,11 +1046,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         }
         Semaphore recoveryBlocked = new Semaphore(1);
         for (DiscoveryNode node : clusterService().state().nodes()) {
-            MockTransportService transportService = (MockTransportService) internalCluster().getInstance(
-                TransportService.class,
-                node.getName()
-            );
-            transportService.addSendBehavior((connection, requestId, action, request, options) -> {
+            MockTransportService.getInstance(node.getName()).addSendBehavior((connection, requestId, action, request, options) -> {
                 if (action.equals(PeerRecoverySourceService.Actions.START_RECOVERY)) {
                     if (recoveryBlocked.tryAcquire()) {
                         PluginsService pluginService = internalCluster().getInstance(PluginsService.class, node.getName());
@@ -1088,11 +1084,10 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
             indicesAdmin().prepareCreate(indexName)
                 .setSettings(indexSettings(1, 0).put("index.routing.allocation.include._name", nodeWithPrimary))
         );
-        MockTransportService transport = (MockTransportService) internalCluster().getInstance(TransportService.class, nodeWithPrimary);
         CountDownLatch phase1ReadyBlocked = new CountDownLatch(1);
         CountDownLatch allowToCompletePhase1Latch = new CountDownLatch(1);
         Semaphore blockRecovery = new Semaphore(1);
-        transport.addSendBehavior((connection, requestId, action, request, options) -> {
+        MockTransportService.getInstance(nodeWithPrimary).addSendBehavior((connection, requestId, action, request, options) -> {
             if (PeerRecoveryTargetService.Actions.CLEAN_FILES.equals(action) && blockRecovery.tryAcquire()) {
                 phase1ReadyBlocked.countDown();
                 safeAwait(allowToCompletePhase1Latch);
@@ -1159,8 +1154,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         // first try because the local recovery happens once and its stats is reset when the recovery fails.
         SetOnce<Integer> localRecoveredOps = new SetOnce<>();
         for (String node : nodes) {
-            MockTransportService transportService = (MockTransportService) internalCluster().getInstance(TransportService.class, node);
-            transportService.addSendBehavior((connection, requestId, action, request, options) -> {
+            MockTransportService.getInstance(node).addSendBehavior((connection, requestId, action, request, options) -> {
                 if (action.equals(PeerRecoverySourceService.Actions.START_RECOVERY)) {
                     final RecoveryState recoveryState = internalCluster().getInstance(IndicesService.class, failingNode)
                         .getShardOrNull(new ShardId(resolveIndex(indexName), 0))
@@ -1223,8 +1217,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
             }
         }
         for (String node : nodes) {
-            MockTransportService transportService = (MockTransportService) internalCluster().getInstance(TransportService.class, node);
-            transportService.clearAllRules();
+            MockTransportService.getInstance(node).clearAllRules();
         }
     }
 
@@ -1669,10 +1662,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         ClusterState clusterState = clusterAdmin().prepareState().get().getState();
         DiscoveryNode nodeWithOldPrimary = clusterState.nodes()
             .get(clusterState.routingTable().index(indexName).shard(0).primaryShard().currentNodeId());
-        MockTransportService transportService = (MockTransportService) internalCluster().getInstance(
-            TransportService.class,
-            nodeWithOldPrimary.getName()
-        );
+        final var transportService = MockTransportService.getInstance(nodeWithOldPrimary.getName());
         CountDownLatch readyToRestartNode = new CountDownLatch(1);
         AtomicBoolean stopped = new AtomicBoolean();
         transportService.addSendBehavior((connection, requestId, action, request, options) -> {
@@ -1745,14 +1735,10 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         ClusterState clusterState = clusterAdmin().prepareState().get().getState();
         DiscoveryNode nodeWithPrimary = clusterState.nodes()
             .get(clusterState.routingTable().index(indexName).shard(0).primaryShard().currentNodeId());
-        MockTransportService transportService = (MockTransportService) internalCluster().getInstance(
-            TransportService.class,
-            nodeWithPrimary.getName()
-        );
 
         final AtomicBoolean fileInfoIntercepted = new AtomicBoolean();
         final AtomicBoolean fileChunkIntercepted = new AtomicBoolean();
-        transportService.addSendBehavior((connection, requestId, action, request, options) -> {
+        MockTransportService.getInstance(nodeWithPrimary.getName()).addSendBehavior((connection, requestId, action, request, options) -> {
             if (action.equals(PeerRecoveryTargetService.Actions.FILES_INFO)) {
                 if (fileInfoIntercepted.compareAndSet(false, true)) {
                     final NodeIndicesStats nodeIndicesStats = clusterAdmin().prepareNodesStats(connection.getNode().getId())
@@ -1825,10 +1811,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         final long initialClusterStateVersion = clusterService().state().version();
 
         try (var recoveryClusterStateDelayListeners = new RecoveryClusterStateDelayListeners(initialClusterStateVersion)) {
-            final var primaryNodeTransportService = (MockTransportService) internalCluster().getInstance(
-                TransportService.class,
-                primaryNode
-            );
+            final var primaryNodeTransportService = MockTransportService.getInstance(primaryNode);
             primaryNodeTransportService.addRequestHandlingBehavior(
                 Coordinator.COMMIT_STATE_ACTION_NAME,
                 (handler, request, channel, task) -> {

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/state/CloseWhileRelocatingShardsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/state/CloseWhileRelocatingShardsIT.java
@@ -31,7 +31,6 @@ import org.elasticsearch.test.BackgroundIndexer;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.test.transport.StubbableTransport;
-import org.elasticsearch.transport.TransportService;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -177,15 +176,11 @@ public class CloseWhileRelocatingShardsIT extends ESIntegTestCase {
                 connection.sendRequest(requestId, action, request, options);
             };
 
-            final MockTransportService targetTransportService = (MockTransportService) internalCluster().getInstance(
-                TransportService.class,
-                targetNode
-            );
+            final var targetTransportService = MockTransportService.getInstance(targetNode);
 
             for (DiscoveryNode node : state.getNodes()) {
                 if (node.canContainData() && node.getName().equals(targetNode) == false) {
-                    final TransportService sourceTransportService = internalCluster().getInstance(TransportService.class, node.getName());
-                    targetTransportService.addSendBehavior(sourceTransportService, sendBehavior);
+                    targetTransportService.addSendBehavior(MockTransportService.getInstance(node.getName()), sendBehavior);
                 }
             }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/state/ReopenWhileClosingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/state/ReopenWhileClosingIT.java
@@ -127,10 +127,7 @@ public class ReopenWhileClosingIT extends ESIntegTestCase {
      * Intercepts and blocks the {@link TransportVerifyShardBeforeCloseAction} executed for the given index pattern.
      */
     private Releasable interceptVerifyShardBeforeCloseActions(final String indexPattern, final Runnable onIntercept) {
-        final MockTransportService mockTransportService = (MockTransportService) internalCluster().getInstance(
-            TransportService.class,
-            internalCluster().getMasterName()
-        );
+        final var mockTransportService = MockTransportService.getInstance(internalCluster().getMasterName());
         final ListenableFuture<Void> release = new ListenableFuture<>();
         for (DiscoveryNode node : internalCluster().clusterService().state().getNodes()) {
             mockTransportService.addSendBehavior(

--- a/server/src/internalClusterTest/java/org/elasticsearch/recovery/RelocationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/recovery/RelocationIT.java
@@ -404,7 +404,7 @@ public class RelocationIT extends ESIntegTestCase {
         logger.info("--> blocking recoveries from primary (allowed failures: [{}])", allowedFailures);
         CountDownLatch corruptionCount = new CountDownLatch(allowedFailures);
         ClusterService clusterService = internalCluster().getInstance(ClusterService.class, p_node);
-        MockTransportService mockTransportService = (MockTransportService) internalCluster().getInstance(TransportService.class, p_node);
+        final var mockTransportService = MockTransportService.getInstance(p_node);
         for (DiscoveryNode node : clusterService.state().nodes()) {
             if (node.equals(clusterService.localNode()) == false) {
                 mockTransportService.addSendBehavior(

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/SearchServiceCleanupOnLostMasterIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/SearchServiceCleanupOnLostMasterIT.java
@@ -16,7 +16,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.transport.MockTransportService;
-import org.elasticsearch.transport.TransportService;
 import org.hamcrest.Matchers;
 
 import java.util.Collection;
@@ -48,11 +47,8 @@ public class SearchServiceCleanupOnLostMasterIT extends ESIntegTestCase {
 
     public void testDroppedOutNode() throws Exception {
         testLostMaster((master, dataNode) -> {
-            final MockTransportService masterTransportService = (MockTransportService) internalCluster().getInstance(
-                TransportService.class,
-                master
-            );
-            final TransportService dataTransportService = internalCluster().getInstance(TransportService.class, dataNode);
+            final var masterTransportService = MockTransportService.getInstance(master);
+            final var dataTransportService = MockTransportService.getInstance(dataNode);
             masterTransportService.addFailToSendNoConnectRule(dataTransportService, FollowersChecker.FOLLOWER_CHECK_ACTION_NAME);
 
             assertBusy(() -> {

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fieldcaps/FieldCapabilitiesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fieldcaps/FieldCapabilitiesIT.java
@@ -58,7 +58,6 @@ import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.MockLogAppender;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.transport.MockTransportService;
-import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
@@ -469,17 +468,14 @@ public class FieldCapabilitiesIT extends ESIntegTestCase {
         try {
             final AtomicBoolean failedRequest = new AtomicBoolean();
             for (String node : internalCluster().getNodeNames()) {
-                MockTransportService transportService = (MockTransportService) internalCluster().getInstance(TransportService.class, node);
-                transportService.addRequestHandlingBehavior(
-                    TransportFieldCapabilitiesAction.ACTION_NODE_NAME,
-                    (handler, request, channel, task) -> {
+                MockTransportService.getInstance(node)
+                    .addRequestHandlingBehavior(TransportFieldCapabilitiesAction.ACTION_NODE_NAME, (handler, request, channel, task) -> {
                         if (failedRequest.compareAndSet(false, true)) {
                             channel.sendResponse(new CircuitBreakingException("Simulated", CircuitBreaker.Durability.TRANSIENT));
                         } else {
                             handler.messageReceived(request, channel, task);
                         }
-                    }
-                );
+                    });
             }
             FieldCapabilitiesRequest request = new FieldCapabilitiesRequest();
             request.indices("log-index-*");
@@ -495,8 +491,7 @@ public class FieldCapabilitiesIT extends ESIntegTestCase {
             assertThat(response.getField("field1"), hasKey("keyword"));
         } finally {
             for (String node : internalCluster().getNodeNames()) {
-                MockTransportService transportService = (MockTransportService) internalCluster().getInstance(TransportService.class, node);
-                transportService.clearAllRules();
+                MockTransportService.getInstance(node).clearAllRules();
             }
         }
     }
@@ -571,16 +566,13 @@ public class FieldCapabilitiesIT extends ESIntegTestCase {
         try {
             final AtomicBoolean relocated = new AtomicBoolean();
             for (String node : internalCluster().getNodeNames()) {
-                MockTransportService transportService = (MockTransportService) internalCluster().getInstance(TransportService.class, node);
-                transportService.addRequestHandlingBehavior(
-                    TransportFieldCapabilitiesAction.ACTION_NODE_NAME,
-                    (handler, request, channel, task) -> {
+                MockTransportService.getInstance(node)
+                    .addRequestHandlingBehavior(TransportFieldCapabilitiesAction.ACTION_NODE_NAME, (handler, request, channel, task) -> {
                         if (relocated.compareAndSet(false, true)) {
                             moveOrCloseShardsOnNodes(node);
                         }
                         handler.messageReceived(request, channel, task);
-                    }
-                );
+                    });
             }
             FieldCapabilitiesRequest request = new FieldCapabilitiesRequest();
             request.indices("log-index-*");
@@ -595,8 +587,7 @@ public class FieldCapabilitiesIT extends ESIntegTestCase {
             assertThat(response.getField("field1"), hasKey("long"));
         } finally {
             for (String node : internalCluster().getNodeNames()) {
-                MockTransportService transportService = (MockTransportService) internalCluster().getInstance(TransportService.class, node);
-                transportService.clearAllRules();
+                MockTransportService.getInstance(node).clearAllRules();
             }
         }
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
@@ -1094,14 +1094,12 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
 
         // Drop all file chunk requests so that below relocation takes forever and we're guaranteed to run the snapshot in parallel to it
         for (String nodeName : dataNodes) {
-            ((MockTransportService) internalCluster().getInstance(TransportService.class, nodeName)).addSendBehavior(
-                (connection, requestId, action, request, options) -> {
-                    if (PeerRecoveryTargetService.Actions.FILE_CHUNK.equals(action)) {
-                        return;
-                    }
-                    connection.sendRequest(requestId, action, request, options);
+            MockTransportService.getInstance(nodeName).addSendBehavior((connection, requestId, action, request, options) -> {
+                if (PeerRecoveryTargetService.Actions.FILE_CHUNK.equals(action)) {
+                    return;
                 }
-            );
+                connection.sendRequest(requestId, action, request, options);
+            });
         }
 
         logger.info("--> start relocations");

--- a/test/framework/src/main/java/org/elasticsearch/indices/recovery/AbstractIndexRecoveryIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/indices/recovery/AbstractIndexRecoveryIntegTestCase.java
@@ -147,14 +147,8 @@ public abstract class AbstractIndexRecoveryIntegTestCase extends ESIntegTestCase
             createSnapshotThatCanBeUsedDuringRecovery(indexName);
         }
 
-        MockTransportService blueTransportService = (MockTransportService) internalCluster().getInstance(
-            TransportService.class,
-            blueNodeName
-        );
-        MockTransportService redTransportService = (MockTransportService) internalCluster().getInstance(
-            TransportService.class,
-            redNodeName
-        );
+        final var blueTransportService = MockTransportService.getInstance(blueNodeName);
+        final var redTransportService = MockTransportService.getInstance(redNodeName);
 
         final AtomicBoolean recoveryStarted = new AtomicBoolean(false);
         final AtomicBoolean finalizeReceived = new AtomicBoolean(false);
@@ -251,14 +245,8 @@ public abstract class AbstractIndexRecoveryIntegTestCase extends ESIntegTestCase
             createSnapshotThatCanBeUsedDuringRecovery(indexName);
         }
 
-        MockTransportService blueMockTransportService = (MockTransportService) internalCluster().getInstance(
-            TransportService.class,
-            blueNodeName
-        );
-        MockTransportService redMockTransportService = (MockTransportService) internalCluster().getInstance(
-            TransportService.class,
-            redNodeName
-        );
+        final var blueMockTransportService = MockTransportService.getInstance(blueNodeName);
+        final var redMockTransportService = MockTransportService.getInstance(redNodeName);
         TransportService redTransportService = internalCluster().getInstance(TransportService.class, redNodeName);
         TransportService blueTransportService = internalCluster().getInstance(TransportService.class, blueNodeName);
         final CountDownLatch requestFailed = new CountDownLatch(1);
@@ -348,18 +336,9 @@ public abstract class AbstractIndexRecoveryIntegTestCase extends ESIntegTestCase
             createSnapshotThatCanBeUsedDuringRecovery(indexName);
         }
 
-        MockTransportService masterTransportService = (MockTransportService) internalCluster().getInstance(
-            TransportService.class,
-            masterNodeName
-        );
-        MockTransportService blueMockTransportService = (MockTransportService) internalCluster().getInstance(
-            TransportService.class,
-            blueNodeName
-        );
-        MockTransportService redMockTransportService = (MockTransportService) internalCluster().getInstance(
-            TransportService.class,
-            redNodeName
-        );
+        final var masterTransportService = MockTransportService.getInstance(masterNodeName);
+        final var blueMockTransportService = MockTransportService.getInstance(blueNodeName);
+        final var redMockTransportService = MockTransportService.getInstance(redNodeName);
 
         redMockTransportService.addSendBehavior(blueMockTransportService, new StubbableTransport.SendRequestBehavior() {
             private final AtomicInteger count = new AtomicInteger();

--- a/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransportService.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransportService.java
@@ -39,6 +39,7 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.tasks.TaskManager;
 import org.elasticsearch.telemetry.tracing.Tracer;
+import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.tasks.MockTaskManager;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -73,6 +74,8 @@ import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Supplier;
+
+import static org.junit.Assert.assertNotNull;
 
 /**
  * A mock delegate service that allows to simulate different network topology failures.
@@ -185,6 +188,14 @@ public class MockTransportService extends TransportService {
                 .build(),
             clusterSettings,
             createTaskManager(settings, threadPool, taskHeaders, Tracer.NOOP)
+        );
+    }
+
+    public static MockTransportService getInstance(String nodeName) {
+        assertNotNull("nodeName must not be null", nodeName);
+        return ESTestCase.asInstanceOf(
+            MockTransportService.class,
+            ESIntegTestCase.internalCluster().getInstance(TransportService.class, nodeName)
         );
     }
 

--- a/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/DownsampleTransportFailureIT.java
+++ b/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/DownsampleTransportFailureIT.java
@@ -32,7 +32,6 @@ import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInter
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.test.transport.MockTransportService;
-import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentType;
@@ -106,19 +105,8 @@ public class DownsampleTransportFailureIT extends ESIntegTestCase {
             return client(this.cluster.getMasterName());
         }
 
-        public MockTransportService masterMockTransportService() {
-            return (MockTransportService) internalCluster().getInstance(TransportService.class, internalCluster().getMasterName());
-        }
-
-        public MockTransportService coordinatorMockTransportService() {
-            assert this.coordinator != null;
-            return (MockTransportService) internalCluster().getInstance(TransportService.class, this.coordinator);
-        }
-
         public List<MockTransportService> allMockTransportServices() {
-            return Arrays.stream(cluster.getNodeNames())
-                .map(nodeName -> (MockTransportService) internalCluster().getInstance(TransportService.class, nodeName))
-                .collect(Collectors.toList());
+            return Arrays.stream(cluster.getNodeNames()).map(MockTransportService::getInstance).collect(Collectors.toList());
         }
 
         public String coordinatorName() {
@@ -301,7 +289,7 @@ public class DownsampleTransportFailureIT extends ESIntegTestCase {
 
     public void testDownsampleActionExceptionDisruption() {
         // GIVEN
-        final MockTransportService coordinator = testCluster.coordinatorMockTransportService();
+        final MockTransportService coordinator = MockTransportService.getInstance(testCluster.coordinator);
         final DownsampleAction.Request downsampleRequest = new DownsampleAction.Request(
             SOURCE_INDEX_NAME,
             TARGET_INDEX_NAME,

--- a/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/DownsampleTransportFailureIT.java
+++ b/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/DownsampleTransportFailureIT.java
@@ -106,7 +106,7 @@ public class DownsampleTransportFailureIT extends ESIntegTestCase {
         }
 
         public List<MockTransportService> allMockTransportServices() {
-            return Arrays.stream(cluster.getNodeNames()).map(MockTransportService::getInstance).collect(Collectors.toList());
+            return Arrays.stream(cluster.getNodeNames()).map(MockTransportService::getInstance).toList();
         }
 
         public String coordinatorName() {

--- a/x-pack/plugin/snapshot-based-recoveries/src/internalClusterTest/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/SnapshotBasedIndexRecoveryIT.java
+++ b/x-pack/plugin/snapshot-based-recoveries/src/internalClusterTest/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/SnapshotBasedIndexRecoveryIT.java
@@ -317,19 +317,11 @@ public class SnapshotBasedIndexRecoveryIT extends AbstractSnapshotIntegTestCase 
 
         String targetNode = internalCluster().startDataOnlyNode();
 
-        MockTransportService sourceMockTransportService = (MockTransportService) internalCluster().getInstance(
-            TransportService.class,
-            sourceNode
-        );
-        MockTransportService targetMockTransportService = (MockTransportService) internalCluster().getInstance(
-            TransportService.class,
-            targetNode
-        );
-
-        sourceMockTransportService.addSendBehavior(targetMockTransportService, (connection, requestId, action, request, options) -> {
-            assertNotEquals(PeerRecoveryTargetService.Actions.FILE_CHUNK, action);
-            connection.sendRequest(requestId, action, request, options);
-        });
+        MockTransportService.getInstance(sourceNode)
+            .addSendBehavior(MockTransportService.getInstance(targetNode), (connection, requestId, action, request, options) -> {
+                assertNotEquals(PeerRecoveryTargetService.Actions.FILE_CHUNK, action);
+                connection.sendRequest(requestId, action, request, options);
+            });
 
         updateIndexSettings(Settings.builder().put("index.routing.allocation.require._name", targetNode), indexName);
 
@@ -597,23 +589,19 @@ public class SnapshotBasedIndexRecoveryIT extends AbstractSnapshotIntegTestCase 
                 targetNode = internalCluster().startDataOnlyNode();
             }
 
-            MockTransportService targetMockTransportService = (MockTransportService) internalCluster().getInstance(
-                TransportService.class,
-                targetNode
-            );
-
             CountDownLatch recoverSnapshotFileRequestReceived = new CountDownLatch(1);
             CountDownLatch respondToRecoverSnapshotFile = new CountDownLatch(1);
             AtomicInteger numberOfRecoverSnapshotFileRequestsReceived = new AtomicInteger();
-            targetMockTransportService.addRequestHandlingBehavior(
-                PeerRecoveryTargetService.Actions.RESTORE_FILE_FROM_SNAPSHOT,
-                (handler, request, channel, task) -> {
-                    assertThat(numberOfRecoverSnapshotFileRequestsReceived.incrementAndGet(), is(equalTo(1)));
-                    recoverSnapshotFileRequestReceived.countDown();
-                    respondToRecoverSnapshotFile.await();
-                    handler.messageReceived(request, channel, task);
-                }
-            );
+            MockTransportService.getInstance(targetNode)
+                .addRequestHandlingBehavior(
+                    PeerRecoveryTargetService.Actions.RESTORE_FILE_FROM_SNAPSHOT,
+                    (handler, request, channel, task) -> {
+                        assertThat(numberOfRecoverSnapshotFileRequestsReceived.incrementAndGet(), is(equalTo(1)));
+                        recoverSnapshotFileRequestReceived.countDown();
+                        respondToRecoverSnapshotFile.await();
+                        handler.messageReceived(request, channel, task);
+                    }
+                );
 
             if (seqNoRecovery) {
                 ClusterState clusterState = clusterAdmin().prepareState().get().getState();
@@ -1257,10 +1245,7 @@ public class SnapshotBasedIndexRecoveryIT extends AbstractSnapshotIntegTestCase 
                 recoverySnapshotFileRequests,
                 awaitForRecoverSnapshotFileRequestReceived,
                 respondToRecoverSnapshotFile) -> {
-                MockTransportService sourceMockTransportService = (MockTransportService) internalCluster().getInstance(
-                    TransportService.class,
-                    sourceNode
-                );
+                final var sourceMockTransportService = MockTransportService.getInstance(sourceNode);
 
                 CountDownLatch startRecoveryRetryReceived = new CountDownLatch(1);
                 AtomicBoolean delayRecoveryExceptionSent = new AtomicBoolean();
@@ -1363,15 +1348,8 @@ public class SnapshotBasedIndexRecoveryIT extends AbstractSnapshotIntegTestCase 
             .findFirst()
             .orElseThrow();
 
-        MockTransportService sourceMockTransportService = (MockTransportService) internalCluster().getInstance(
-            TransportService.class,
-            replicaNodeName
-        );
-
-        MockTransportService targetMockTransportService = (MockTransportService) internalCluster().getInstance(
-            TransportService.class,
-            newReplicaNodeName
-        );
+        final var sourceMockTransportService = MockTransportService.getInstance(replicaNodeName);
+        final var targetMockTransportService = MockTransportService.getInstance(newReplicaNodeName);
 
         final CountDownLatch firstDownloadStartLatch = new CountDownLatch(1);
         final CountDownLatch blockSnapshotFileDownload = new CountDownLatch(1);
@@ -1479,10 +1457,7 @@ public class SnapshotBasedIndexRecoveryIT extends AbstractSnapshotIntegTestCase 
 
             String sourceNode = dataNodes.get(0);
             String targetNode = dataNodes.get(1);
-            MockTransportService targetMockTransportService = (MockTransportService) internalCluster().getInstance(
-                TransportService.class,
-                targetNode
-            );
+            final var targetMockTransportService = MockTransportService.getInstance(targetNode);
 
             List<RecoverySnapshotFileRequest> recoverySnapshotFileRequests = Collections.synchronizedList(new ArrayList<>());
             CountDownLatch recoverSnapshotFileRequestReceived = new CountDownLatch(1);


### PR DESCRIPTION
It's a pretty long line of code to get a `TransportService` instance
from an `InternalTestCluster` and cast it to `MockTransportService` so
that you can adjust its behaviour. This commit introduces a utility
method to make it easier.