### PR TITLE
ESQL: Track blocks emitted from lucene

### DIFF
--- a/docs/changelog/101396.yaml
+++ b/docs/changelog/101396.yaml
@@ -1,0 +1,5 @@
+pr: 101396
+summary: "ESQL: Track blocks emitted from lucene"
+area: ES|QL
+type: enhancement
+issues: []

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneOperator.java
@@ -20,6 +20,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.operator.Operator;
 import org.elasticsearch.compute.operator.SourceOperator;
 import org.elasticsearch.logging.LogManager;
@@ -37,6 +38,8 @@ public abstract class LuceneOperator extends SourceOperator {
 
     public static final int NO_LIMIT = Integer.MAX_VALUE;
 
+    protected final BlockFactory blockFactory;
+
     private int processSlices;
     final int maxPageSize;
     private final LuceneSliceQueue sliceQueue;
@@ -49,7 +52,8 @@ public abstract class LuceneOperator extends SourceOperator {
     int pagesEmitted;
     boolean doneCollecting;
 
-    public LuceneOperator(int maxPageSize, LuceneSliceQueue sliceQueue) {
+    public LuceneOperator(BlockFactory blockFactory, int maxPageSize, LuceneSliceQueue sliceQueue) {
+        this.blockFactory = blockFactory;
         this.maxPageSize = maxPageSize;
         this.sliceQueue = sliceQueue;
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneTopNSourceOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneTopNSourceOperator.java
@@ -16,12 +16,14 @@ import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.TopFieldCollector;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.DocVector;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.sort.SortAndFormats;
 import org.elasticsearch.search.sort.SortBuilder;
@@ -38,25 +40,6 @@ import java.util.stream.Collectors;
  * Source operator that builds Pages out of the output of a TopFieldCollector (aka TopN)
  */
 public final class LuceneTopNSourceOperator extends LuceneOperator {
-    /**
-     * Collected docs. {@code null} until we're {@link #emit(boolean)}.
-     */
-    private ScoreDoc[] scoreDocs;
-    /**
-     * The offset in {@link #scoreDocs} of the next page.
-     */
-    private int offset = 0;
-
-    private PerShardCollector perShardCollector;
-    private final List<SortBuilder<?>> sorts;
-    private final int limit;
-
-    public LuceneTopNSourceOperator(int maxPageSize, List<SortBuilder<?>> sorts, int limit, LuceneSliceQueue sliceQueue) {
-        super(maxPageSize, sliceQueue);
-        this.sorts = sorts;
-        this.limit = limit;
-    }
-
     public static final class Factory implements LuceneOperator.Factory {
         private final int taskConcurrency;
         private final int maxPageSize;
@@ -85,7 +68,7 @@ public final class LuceneTopNSourceOperator extends LuceneOperator {
 
         @Override
         public SourceOperator get(DriverContext driverContext) {
-            return new LuceneTopNSourceOperator(maxPageSize, sorts, limit, sliceQueue);
+            return new LuceneTopNSourceOperator(driverContext.blockFactory(), maxPageSize, sorts, limit, sliceQueue);
         }
 
         @Override
@@ -114,6 +97,31 @@ public final class LuceneTopNSourceOperator extends LuceneOperator {
                 + notPrettySorts
                 + "]]";
         }
+    }
+
+    /**
+     * Collected docs. {@code null} until we're {@link #emit(boolean)}.
+     */
+    private ScoreDoc[] scoreDocs;
+    /**
+     * The offset in {@link #scoreDocs} of the next page.
+     */
+    private int offset = 0;
+
+    private PerShardCollector perShardCollector;
+    private final List<SortBuilder<?>> sorts;
+    private final int limit;
+
+    public LuceneTopNSourceOperator(
+        BlockFactory blockFactory,
+        int maxPageSize,
+        List<SortBuilder<?>> sorts,
+        int limit,
+        LuceneSliceQueue sliceQueue
+    ) {
+        super(blockFactory, maxPageSize, sliceQueue);
+        this.sorts = sorts;
+        this.limit = limit;
     }
 
     @Override
@@ -187,29 +195,35 @@ public final class LuceneTopNSourceOperator extends LuceneOperator {
             return null;
         }
         int size = Math.min(maxPageSize, scoreDocs.length - offset);
-        IntVector.Builder currentSegmentBuilder = IntVector.newVectorBuilder(size);
-        IntVector.Builder currentDocsBuilder = IntVector.newVectorBuilder(size);
+        IntBlock shard = null;
+        IntVector segments = null;
+        IntVector docs = null;
+        Page page = null;
+        try (
+            IntVector.Builder currentSegmentBuilder = IntVector.newVectorBuilder(size, blockFactory);
+            IntVector.Builder currentDocsBuilder = IntVector.newVectorBuilder(size, blockFactory)
+        ) {
+            int start = offset;
+            offset += size;
+            List<LeafReaderContext> leafContexts = perShardCollector.searchContext.searcher().getLeafContexts();
+            for (int i = start; i < offset; i++) {
+                int doc = scoreDocs[i].doc;
+                int segment = ReaderUtil.subIndex(doc, leafContexts);
+                currentSegmentBuilder.appendInt(segment);
+                currentDocsBuilder.appendInt(doc - leafContexts.get(segment).docBase); // the offset inside the segment
+            }
 
-        int start = offset;
-        offset += size;
-        List<LeafReaderContext> leafContexts = perShardCollector.searchContext.searcher().getLeafContexts();
-        for (int i = start; i < offset; i++) {
-            int doc = scoreDocs[i].doc;
-            int segment = ReaderUtil.subIndex(doc, leafContexts);
-            currentSegmentBuilder.appendInt(segment);
-            currentDocsBuilder.appendInt(doc - leafContexts.get(segment).docBase); // the offset inside the segment
+            shard = IntBlock.newConstantBlockWith(perShardCollector.shardIndex, size, blockFactory);
+            segments = currentSegmentBuilder.build();
+            docs = currentDocsBuilder.build();
+            page = new Page(size, new DocVector(shard.asVector(), segments, docs, null).asBlock());
+        } finally {
+            if (page == null) {
+                Releasables.close(shard, segments, docs);
+            }
         }
-
         pagesEmitted++;
-        return new Page(
-            size,
-            new DocVector(
-                IntBlock.newConstantBlockWith(perShardCollector.shardIndex, size).asVector(),
-                currentSegmentBuilder.build(),
-                currentDocsBuilder.build(),
-                null
-            ).asBlock()
-        );
+        return page;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AggregatorFunctionTestCase.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AggregatorFunctionTestCase.java
@@ -29,7 +29,7 @@ import org.elasticsearch.compute.operator.ForkingOperatorTestCase;
 import org.elasticsearch.compute.operator.NullInsertingSourceOperator;
 import org.elasticsearch.compute.operator.Operator;
 import org.elasticsearch.compute.operator.PositionMergingSourceOperator;
-import org.elasticsearch.compute.operator.ResultPageSinkOperator;
+import org.elasticsearch.compute.operator.TestResultPageSinkOperator;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -110,7 +110,7 @@ public abstract class AggregatorFunctionTestCase extends ForkingOperatorTestCase
                 driverContext,
                 new NullInsertingSourceOperator(new CannedSourceOperator(input.iterator()), blockFactory),
                 List.of(simple(nonBreakingBigArrays().withCircuitBreaking()).get(driverContext)),
-                new ResultPageSinkOperator(results::add),
+                new TestResultPageSinkOperator(results::add),
                 () -> {}
             )
         ) {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/SumDoubleAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/SumDoubleAggregatorFunctionTests.java
@@ -14,9 +14,9 @@ import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.Driver;
 import org.elasticsearch.compute.operator.DriverContext;
-import org.elasticsearch.compute.operator.ResultPageSinkOperator;
 import org.elasticsearch.compute.operator.SequenceDoubleBlockSourceOperator;
 import org.elasticsearch.compute.operator.SourceOperator;
+import org.elasticsearch.compute.operator.TestResultPageSinkOperator;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.ArrayList;
@@ -57,7 +57,7 @@ public class SumDoubleAggregatorFunctionTests extends AggregatorFunctionTestCase
                 driverContext,
                 new SequenceDoubleBlockSourceOperator(driverContext.blockFactory(), DoubleStream.of(Double.MAX_VALUE - 1, 2)),
                 List.of(simple(nonBreakingBigArrays()).get(driverContext)),
-                new ResultPageSinkOperator(results::add),
+                new TestResultPageSinkOperator(results::add),
                 () -> {}
             )
         ) {
@@ -78,7 +78,7 @@ public class SumDoubleAggregatorFunctionTests extends AggregatorFunctionTestCase
                     DoubleStream.of(0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7)
                 ),
                 List.of(simple(nonBreakingBigArrays()).get(driverContext)),
-                new ResultPageSinkOperator(results::add),
+                new TestResultPageSinkOperator(results::add),
                 () -> {}
             )
         ) {
@@ -104,7 +104,7 @@ public class SumDoubleAggregatorFunctionTests extends AggregatorFunctionTestCase
                 driverContext,
                 new SequenceDoubleBlockSourceOperator(driverContext.blockFactory(), DoubleStream.of(values)),
                 List.of(simple(nonBreakingBigArrays()).get(driverContext)),
-                new ResultPageSinkOperator(results::add),
+                new TestResultPageSinkOperator(results::add),
                 () -> {}
             )
         ) {
@@ -126,7 +126,7 @@ public class SumDoubleAggregatorFunctionTests extends AggregatorFunctionTestCase
                 driverContext,
                 new SequenceDoubleBlockSourceOperator(driverContext.blockFactory(), DoubleStream.of(largeValues)),
                 List.of(simple(nonBreakingBigArrays()).get(driverContext)),
-                new ResultPageSinkOperator(results::add),
+                new TestResultPageSinkOperator(results::add),
                 () -> {}
             )
         ) {
@@ -145,7 +145,7 @@ public class SumDoubleAggregatorFunctionTests extends AggregatorFunctionTestCase
                 driverContext,
                 new SequenceDoubleBlockSourceOperator(driverContext.blockFactory(), DoubleStream.of(largeValues)),
                 List.of(simple(nonBreakingBigArrays()).get(driverContext)),
-                new ResultPageSinkOperator(results::add),
+                new TestResultPageSinkOperator(results::add),
                 () -> {}
             )
         ) {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/LuceneSourceOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/LuceneSourceOperatorTests.java
@@ -16,6 +16,7 @@ import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.Page;
@@ -24,7 +25,7 @@ import org.elasticsearch.compute.operator.Driver;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.Operator;
 import org.elasticsearch.compute.operator.OperatorTestCase;
-import org.elasticsearch.compute.operator.PageConsumerOperator;
+import org.elasticsearch.compute.operator.TestResultPageSinkOperator;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.index.cache.query.TrivialQueryCachingPolicy;
 import org.elasticsearch.index.fielddata.FieldDataContext;
@@ -35,6 +36,7 @@ import org.elasticsearch.index.mapper.NestedLookup;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.support.NestedScope;
+import org.elasticsearch.indices.CrankyCircuitBreakerService;
 import org.elasticsearch.search.internal.ContextIndexSearcher;
 import org.elasticsearch.search.internal.SearchContext;
 import org.junit.After;
@@ -46,6 +48,7 @@ import java.util.List;
 import java.util.function.Function;
 
 import static org.hamcrest.Matchers.both;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.lessThan;
@@ -133,21 +136,53 @@ public class LuceneSourceOperatorTests extends AnyOperatorTestCase {
     public void testShardDataPartitioning() {
         int size = between(1_000, 20_000);
         int limit = between(10, size);
-        testSimple(size, limit);
+        testSimple(driverContext(), size, limit);
     }
 
     public void testEmpty() {
-        testSimple(0, between(10, 10_000));
+        testSimple(driverContext(), 0, between(10, 10_000));
     }
 
-    private void testSimple(int size, int limit) {
-        DriverContext ctx = driverContext();
-        LuceneSourceOperator.Factory factory = simple(nonBreakingBigArrays(), DataPartitioning.SHARD, size, limit);
+    public void testWithCranky() {
+        try {
+            testSimple(crankyDriverContext(), between(1, 10_000), 100);
+            logger.info("cranky didn't break");
+        } catch (CircuitBreakingException e) {
+            logger.info("broken", e);
+            assertThat(e.getMessage(), equalTo(CrankyCircuitBreakerService.ERROR_MESSAGE));
+        }
+    }
+
+    public void testEmptyWithCranky() {
+        try {
+            testSimple(crankyDriverContext(), 0, between(10, 10_000));
+            logger.info("cranky didn't break");
+        } catch (CircuitBreakingException e) {
+            logger.info("broken", e);
+            assertThat(e.getMessage(), equalTo(CrankyCircuitBreakerService.ERROR_MESSAGE));
+        }
+    }
+
+    public void testShardDataPartitioningWithCranky() {
+        int size = between(1_000, 20_000);
+        int limit = between(10, size);
+        try {
+            testSimple(crankyDriverContext(), size, limit);
+            logger.info("cranky didn't break");
+        } catch (CircuitBreakingException e) {
+            logger.info("broken", e);
+            assertThat(e.getMessage(), equalTo(CrankyCircuitBreakerService.ERROR_MESSAGE));
+        }
+    }
+
+    private void testSimple(DriverContext ctx, int size, int limit) {
+        LuceneSourceOperator.Factory factory = simple(ctx.bigArrays(), DataPartitioning.SHARD, size, limit);
         Operator.OperatorFactory readS = ValuesSourceReaderOperatorTests.factory(reader, S_FIELD);
 
         List<Page> results = new ArrayList<>();
+
         OperatorTestCase.runDriver(
-            new Driver(ctx, factory.get(ctx), List.of(readS.get(ctx)), new PageConsumerOperator(page -> results.add(page)), () -> {})
+            new Driver(ctx, factory.get(ctx), List.of(readS.get(ctx)), new TestResultPageSinkOperator(results::add), () -> {})
         );
         OperatorTestCase.assertDriverContext(ctx);
 
@@ -185,5 +220,10 @@ public class LuceneSourceOperatorTests extends AnyOperatorTestCase {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+    }
+
+    @Override
+    protected DriverContext driverContext() {
+        return breakingDriverContext();
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/LuceneTopNSourceOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/LuceneTopNSourceOperatorTests.java
@@ -15,6 +15,7 @@ import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.Page;
@@ -23,7 +24,7 @@ import org.elasticsearch.compute.operator.Driver;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.Operator;
 import org.elasticsearch.compute.operator.OperatorTestCase;
-import org.elasticsearch.compute.operator.PageConsumerOperator;
+import org.elasticsearch.compute.operator.TestResultPageSinkOperator;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.index.fielddata.FieldDataContext;
 import org.elasticsearch.index.fielddata.IndexFieldData;
@@ -33,6 +34,7 @@ import org.elasticsearch.index.mapper.NestedLookup;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.support.NestedScope;
+import org.elasticsearch.indices.CrankyCircuitBreakerService;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.sort.FieldSortBuilder;
 import org.elasticsearch.search.sort.SortBuilder;
@@ -136,23 +138,50 @@ public class LuceneTopNSourceOperatorTests extends AnyOperatorTestCase {
     // TODO tests for the other data partitioning configurations
 
     public void testShardDataPartitioning() {
+        testShardDataPartitioning(driverContext());
+    }
+
+    public void testShardDataPartitioningWithCranky() {
+        try {
+            testShardDataPartitioning(crankyDriverContext());
+            logger.info("cranky didn't break");
+        } catch (CircuitBreakingException e) {
+            logger.info("broken", e);
+            assertThat(e.getMessage(), equalTo(CrankyCircuitBreakerService.ERROR_MESSAGE));
+        }
+    }
+
+    private void testShardDataPartitioning(DriverContext context) {
         int size = between(1_000, 20_000);
         int limit = between(10, size);
-        testSimple(size, limit);
+        testSimple(context, size, limit);
     }
 
     public void testEmpty() {
-        testSimple(0, between(10, 10_000));
+        testEmpty(driverContext());
     }
 
-    private void testSimple(int size, int limit) {
-        DriverContext ctx = driverContext();
-        LuceneTopNSourceOperator.Factory factory = simple(nonBreakingBigArrays(), DataPartitioning.SHARD, size, limit);
+    public void testEmptyWithCranky() {
+        try {
+            testEmpty(crankyDriverContext());
+            logger.info("cranky didn't break");
+        } catch (CircuitBreakingException e) {
+            logger.info("broken", e);
+            assertThat(e.getMessage(), equalTo(CrankyCircuitBreakerService.ERROR_MESSAGE));
+        }
+    }
+
+    private void testEmpty(DriverContext context) {
+        testSimple(context, 0, between(10, 10_000));
+    }
+
+    private void testSimple(DriverContext ctx, int size, int limit) {
+        LuceneTopNSourceOperator.Factory factory = simple(ctx.bigArrays(), DataPartitioning.SHARD, size, limit);
         Operator.OperatorFactory readS = ValuesSourceReaderOperatorTests.factory(reader, S_FIELD);
 
         List<Page> results = new ArrayList<>();
         OperatorTestCase.runDriver(
-            new Driver(ctx, factory.get(ctx), List.of(readS.get(ctx)), new PageConsumerOperator(page -> results.add(page)), () -> {})
+            new Driver(ctx, factory.get(ctx), List.of(readS.get(ctx)), new TestResultPageSinkOperator(results::add), () -> {})
         );
         OperatorTestCase.assertDriverContext(ctx);
 
@@ -170,5 +199,10 @@ public class LuceneTopNSourceOperatorTests extends AnyOperatorTestCase {
         }
         int pages = (int) Math.ceil((float) Math.min(size, limit) / factory.maxPageSize());
         assertThat(results, hasSize(pages));
+    }
+
+    @Override
+    protected DriverContext driverContext() {
+        return breakingDriverContext();
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/AnyOperatorTestCase.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/AnyOperatorTestCase.java
@@ -16,6 +16,7 @@ import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.MockBlockFactory;
+import org.elasticsearch.indices.CrankyCircuitBreakerService;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.After;
@@ -34,7 +35,7 @@ public abstract class AnyOperatorTestCase extends ESTestCase {
      * The operator configured a "simple" or basic way, used for smoke testing
      * descriptions and {@link BigArrays} and scatter/gather.
      */
-    protected abstract Operator.OperatorFactory simple(BigArrays bigArrays);
+    protected abstract Operator.OperatorFactory simple(BigArrays bigArrays);  // TODO remove BigArrays - that's part of the context
 
     /**
      * The description of the operator produced by {@link #simple}.
@@ -117,6 +118,16 @@ public abstract class AnyOperatorTestCase extends ESTestCase {
         BlockFactory factory = new MockBlockFactory(breaker, bigArrays);
         blockFactories.add(factory);
         return new DriverContext(bigArrays, factory);
+    }
+
+    protected final DriverContext crankyDriverContext() {
+        CrankyCircuitBreakerService cranky = new CrankyCircuitBreakerService();
+        BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, cranky).withCircuitBreaking();
+        CircuitBreaker breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
+        breakers.add(breaker);
+        BlockFactory blockFactory = new MockBlockFactory(breaker, bigArrays);
+        blockFactories.add(blockFactory);
+        return new DriverContext(bigArrays, blockFactory);
     }
 
     @After

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/ForkingOperatorTestCase.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/ForkingOperatorTestCase.java
@@ -71,7 +71,7 @@ public abstract class ForkingOperatorTestCase extends OperatorTestCase {
                     simpleWithMode(bigArrays, AggregatorMode.INITIAL).get(driverContext),
                     simpleWithMode(bigArrays, AggregatorMode.FINAL).get(driverContext)
                 ),
-                new ResultPageSinkOperator(page -> results.add(page)),
+                new TestResultPageSinkOperator(page -> results.add(page)),
                 () -> {}
             )
         ) {
@@ -93,7 +93,7 @@ public abstract class ForkingOperatorTestCase extends OperatorTestCase {
                 driverContext,
                 new CannedSourceOperator(partials.iterator()),
                 List.of(simpleWithMode(bigArrays, AggregatorMode.FINAL).get(driverContext)),
-                new ResultPageSinkOperator(results::add),
+                new TestResultPageSinkOperator(results::add),
                 () -> {}
             )
         ) {
@@ -119,7 +119,7 @@ public abstract class ForkingOperatorTestCase extends OperatorTestCase {
                     simpleWithMode(bigArrays, AggregatorMode.INTERMEDIATE).get(driverContext),
                     simpleWithMode(bigArrays, AggregatorMode.FINAL).get(driverContext)
                 ),
-                new ResultPageSinkOperator(page -> results.add(page)),
+                new TestResultPageSinkOperator(page -> results.add(page)),
                 () -> {}
             )
         ) {
@@ -148,7 +148,7 @@ public abstract class ForkingOperatorTestCase extends OperatorTestCase {
                 driverContext,
                 new CannedSourceOperator(intermediates.iterator()),
                 List.of(simpleWithMode(bigArrays, AggregatorMode.FINAL).get(driverContext)),
-                new ResultPageSinkOperator(results::add),
+                new TestResultPageSinkOperator(results::add),
                 () -> {}
             )
         ) {
@@ -255,7 +255,7 @@ public abstract class ForkingOperatorTestCase extends OperatorTestCase {
                     simpleWithMode(bigArrays, AggregatorMode.FINAL).get(driver2Context),
                     intermediateOperatorItr.next()
                 ),
-                new ResultPageSinkOperator(results::add),
+                new TestResultPageSinkOperator(results::add),
                 () -> {}
             )
         );

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/TestResultPageSinkOperator.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/TestResultPageSinkOperator.java
@@ -17,9 +17,9 @@ import java.util.function.Consumer;
  * Page Consumer operator that deep copies the input page, closes it, and then passes the copy
  * to the underlying page consumer.
  */
-public class ResultPageSinkOperator extends PageConsumerOperator {
+public class TestResultPageSinkOperator extends PageConsumerOperator {
 
-    public ResultPageSinkOperator(Consumer<Page> pageConsumer) {
+    public TestResultPageSinkOperator(Consumer<Page> pageConsumer) {
         super(page -> {
             Page copy = BlockTestUtils.deepCopyOf(page, BlockFactory.getNonBreakingInstance());
             page.releaseBlocks();


### PR DESCRIPTION
This enables memory tracking for blocks emitted by all of the `LuceneOperator` subclasses. They don't use a ton of memory, but we'd like to get everything tracked.
