### PR TITLE
[7.17] Update IronBank docker image base to ubi:9.2 (#101393)

### DIFF
--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -311,7 +311,7 @@ void addBuildDockerImageTask(Architecture architecture, DockerBase base) {
       if (base == DockerBase.IRON_BANK) {
         Map<String, String> buildArgsMap = [
           'BASE_REGISTRY': 'docker.elastic.co',
-          'BASE_IMAGE'   : 'ubi8/ubi',
+          'BASE_IMAGE'   : 'ubi9/ubi',
           'BASE_TAG'     : 'latest'
         ]
 

--- a/distribution/docker/src/docker/Dockerfile
+++ b/distribution/docker/src/docker/Dockerfile
@@ -26,8 +26,8 @@
 ################################################################################
 
 ARG BASE_REGISTRY=registry1.dso.mil
-ARG BASE_IMAGE=ironbank/redhat/ubi/ubi8
-ARG BASE_TAG=8.5
+ARG BASE_IMAGE=redhat/ubi/ubi9
+ARG BASE_TAG=9.2
 
 FROM ${base_image} AS builder
 

--- a/distribution/docker/src/docker/iron_bank/hardening_manifest.yaml
+++ b/distribution/docker/src/docker/iron_bank/hardening_manifest.yaml
@@ -13,8 +13,8 @@ tags:
 
 # Build args passed to Dockerfile ARGs
 args:
-  BASE_IMAGE: "redhat/ubi/ubi8"
-  BASE_TAG: "8.5"
+  BASE_IMAGE: "redhat/ubi/ubi9"
+  BASE_TAG: "9.2"
 
 # Docker image labels
 labels:


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Update IronBank docker image base to ubi:9.2 (#101393)