### PR TITLE
[7.17] [ci] Disable remaining periodic jobs in Jenkins, except third-party tests (#101403)

### DIFF
--- a/.ci/jobs.t/elastic+elasticsearch+periodic+ear-trigger.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+periodic+ear-trigger.yml
@@ -1,6 +1,0 @@
----
-jjbb-template: periodic-trigger-lgc.yml
-vars:
-  - periodic-job: elastic+elasticsearch+%BRANCH%+periodic+ear
-  - lgc-job: elastic+elasticsearch+%BRANCH%+intake
-  - cron: "H H/12 * * *"

--- a/.ci/jobs.t/elastic+elasticsearch+periodic+ear.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+periodic+ear.yml
@@ -2,7 +2,8 @@
 - job:
     name: elastic+elasticsearch+%BRANCH%+periodic+ear
     display-name: "elastic / elasticsearch # %BRANCH% - encryption at rest"
-    description: "The Elasticsearch %BRANCH% branch encryption at rest compatibility tests.\n\n"
+    description: "This job has been migrated to Buildkite.\n"
+    disabled: true
     node: packaging-large
     builders:
       - inject:

--- a/.ci/jobs.t/elastic+elasticsearch+periodic+eql-correctness-trigger.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+periodic+eql-correctness-trigger.yml
@@ -1,6 +1,0 @@
----
-jjbb-template: periodic-trigger-lgc.yml
-vars:
-  - periodic-job: elastic+elasticsearch+%BRANCH%+periodic+eql-correctness
-  - lgc-job: elastic+elasticsearch+%BRANCH%+intake
-  - cron: "H H/8 * * *"

--- a/.ci/jobs.t/elastic+elasticsearch+periodic+eql-correctness.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+periodic+eql-correctness.yml
@@ -3,7 +3,8 @@
     name: elastic+elasticsearch+%BRANCH%+periodic+eql-correctness
     workspace: /dev/shm/elastic+elasticsearch+%BRANCH%+periodic+eql-correctness
     display-name: "elastic / elasticsearch # %BRANCH% - eql correctness tests"
-    description: "Testing of Elasticsearch %BRANCH% EQL.\n"
+    description: "This job has been migrated to Buildkite.\n"
+    disabled: true
     builders:
       - inject:
           properties-file: '.ci/java-versions.properties'

--- a/.ci/jobs.t/elastic+elasticsearch+periodic+example-plugins-trigger.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+periodic+example-plugins-trigger.yml
@@ -1,6 +1,0 @@
----
-jjbb-template: periodic-trigger-lgc.yml
-vars:
-  - periodic-job: elastic+elasticsearch+%BRANCH%+periodic+example-plugins
-  - lgc-job: elastic+elasticsearch+%BRANCH%+intake
-  - cron: "H H/12 * * *"

--- a/.ci/jobs.t/elastic+elasticsearch+periodic+example-plugins.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+periodic+example-plugins.yml
@@ -3,7 +3,8 @@
     name: elastic+elasticsearch+%BRANCH%+periodic+example-plugins
     workspace: /dev/shm/elastic+elasticsearch+%BRANCH%+periodic+example-plugins
     display-name: "elastic / elasticsearch # %BRANCH% - example plugin tests"
-    description: "Testing of Elasticsearch %BRANCH% example plugins.\n"
+    description: "This job has been migrated to Buildkite.\n"
+    disabled: true
     builders:
       - inject:
           properties-file: '.ci/java-versions.properties'

--- a/.ci/jobs.t/elastic+elasticsearch+periodic+release-tests-trigger.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+periodic+release-tests-trigger.yml
@@ -1,6 +1,0 @@
----
-jjbb-template: periodic-trigger-lgc.yml
-vars:
-  - periodic-job: elastic+elasticsearch+%BRANCH%+periodic+release-tests
-  - lgc-job: elastic+elasticsearch+%BRANCH%+intake
-  - cron: "H H/12 * * *"

--- a/.ci/jobs.t/elastic+elasticsearch+periodic+release-tests.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+periodic+release-tests.yml
@@ -3,7 +3,8 @@
     name: elastic+elasticsearch+%BRANCH%+periodic+release-tests
     workspace: /dev/shm/elastic+elasticsearch+%BRANCH%+periodic+release-tests
     display-name: "elastic / elasticsearch # %BRANCH% - release tests"
-    description: "Release version tests for the Elasticsearch %BRANCH% branch.\n"
+    description: "This job has been migrated to Buildkite.\n"
+    disabled: true
     node: "general-purpose && docker"
     builders:
       - inject:

--- a/.ci/jobs.t/elastic+elasticsearch+periodic+snyk-dependency-monitoring-trigger.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+periodic+snyk-dependency-monitoring-trigger.yml
@@ -1,6 +1,0 @@
----
-jjbb-template: periodic-trigger-lgc.yml
-vars:
-  - periodic-job: elastic+elasticsearch+%BRANCH%+snyk-dependency-monitoring
-  - lgc-job: elastic+elasticsearch+%BRANCH%+intake
-  - cron: "H H * * *"

--- a/.ci/jobs.t/elastic+elasticsearch+periodic+snyk-dependency-monitoring.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+periodic+snyk-dependency-monitoring.yml
@@ -3,7 +3,8 @@
     name: elastic+elasticsearch+%BRANCH%+snyk-dependency-monitoring
     workspace: /dev/shm/elastic+elasticsearch+%BRANCH%+snyk-dependency-monitoring
     display-name: "elastic / elasticsearch # %BRANCH% - snyk dependency monitoring"
-    description: "Publishing of the Elasticsearch %BRANCH% dependencies graph to snyk dependency monitoring"
+    description: "This job has been migrated to Buildkite.\n"
+    disabled: true
     builders:
       - inject:
           properties-file: '.ci/java-versions.properties'


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[ci] Disable remaining periodic jobs in Jenkins, except third-party tests (#101403)](https://github.com/elastic/elasticsearch/pull/101403)

<!--- Backport version: 9.2.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)