### PR TITLE
[8.11] Removing trace logging for issue #100502 (#101404)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/60_dense_vector_dynamic_mapping.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/60_dense_vector_dynamic_mapping.yml
@@ -3,30 +3,6 @@ setup:
       version: ' - 8.10.99'
       reason: 'Dynamic mapping of floats to dense_vector was added in 8.11'
 
-  # Additional logging for issue: https://github.com/elastic/elasticsearch/issues/100502
-  - do:
-      cluster.put_settings:
-        body: >
-          {
-            "persistent": {
-              "logger.org.elasticsearch.index": "TRACE"
-            }
-          }
-
----
-teardown:
-  - skip:
-      version: ' - 8.10.99'
-      reason: 'Dynamic mapping of floats to dense_vector was added in 8.11'
-
-  - do:
-      cluster.put_settings:
-          body: >
-            {
-              "persistent": {
-                "logger.org.elasticsearch.index": null
-              }
-            }
 ---
 "Fields with float arrays below the threshold still map as float":
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.11`:
 - [Removing trace logging for issue #100502 (#101404)](https://github.com/elastic/elasticsearch/pull/101404)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)