### PR TITLE
[8.10] Backport Exclude desired_nodes validation tests from mixed-cluster QA

### DIFF
--- a/qa/mixed-cluster/build.gradle
+++ b/qa/mixed-cluster/build.gradle
@@ -27,6 +27,24 @@ restResources {
   }
 }
 
+def excludeList = []
+
+// These tests check setting validations in the desired_node API.
+// Validation (and associated tests) are supposed to be skipped/have
+// different behaviour for versions before and after 8.10 but mixed
+// cluster tests may not respect that.
+// The qa cluster consists of 4 nodes. Two nodes are on old version and the
+// other two nodes on the current version. The node selector skips
+// the nodes on current version. The rest client then round robins
+// between the two nodes on old version. In order to unmute this,
+// we need a different node selector, that always consistently
+// selects the same node.
+excludeList.add('cluster.desired_nodes/10_basic/Test settings are validated')
+excludeList.add('cluster.desired_nodes/10_basic/Test unknown settings are forbidden in known versions')
+excludeList.add('cluster.desired_nodes/10_basic/Test unknown settings are allowed in future versions')
+excludeList.add('cluster.desired_nodes/10_basic/Test some settings can be overridden')
+excludeList.add('cluster.desired_nodes/20_dry_run/Test validation works for dry run updates')
+
 BuildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
 
   if (bwcVersion != VersionProperties.getElasticsearchVersion()) {
@@ -56,6 +74,9 @@ BuildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
         baseCluster.get().nextNodeToNextVersion()
         nonInputProperties.systemProperty('tests.rest.cluster', baseCluster.map(c -> c.allHttpSocketURI.join(",")))
         nonInputProperties.systemProperty('tests.clustername', baseName)
+        if (excludeList.isEmpty() == false) {
+          systemProperty 'tests.rest.blacklist', excludeList.join(',')
+        }
       }
       systemProperty 'tests.path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
       onlyIf("BWC tests disabled") { project.bwc_tests_enabled }


### PR DESCRIPTION
Backport of https://github.com/elastic/elasticsearch/pull/100682 to 8.10

Closes https://github.com/elastic/elasticsearch/issues/101419