### PR TITLE
[8.4] Updating percolate query docs to account for custom similarity limitation (#101386)

### DIFF
--- a/docs/reference/query-dsl/percolate-query.asciidoc
+++ b/docs/reference/query-dsl/percolate-query.asciidoc
@@ -685,3 +685,6 @@ a different index configuration, like the number of primary shards.
 ===== Allow expensive queries
 Percolate queries will not be executed if <<query-dsl-allow-expensive-queries, `search.allow_expensive_queries`>>
 is set to false.
+
+===== Using custom similarities
+Percolate queries will not respect any configured <<index-modules-similarity, custom similarity>>. They always use the default Lucene similarity.


### PR DESCRIPTION
Backports the following commits to 8.4:
 - Updating percolate query docs to account for custom similarity limitation (#101386)