### PR TITLE
[TEST] Use larger compression values in InternalMedianAbsoluteDeviationTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalMedianAbsoluteDeviationTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalMedianAbsoluteDeviationTests.java
@@ -24,7 +24,7 @@ public class InternalMedianAbsoluteDeviationTests extends InternalAggregationTes
 
     @Override
     protected InternalMedianAbsoluteDeviation createTestInstance(String name, Map<String, Object> metadata) {
-        final TDigestState valuesSketch = TDigestState.create(randomDoubleBetween(20, 1000, true));
+        final TDigestState valuesSketch = TDigestState.create(randomFrom(50.0, 100.0, 200.0, 500.0, 1000.0));
         final int numberOfValues = frequently() ? randomIntBetween(0, 1000) : 0;
         for (int i = 0; i < numberOfValues; i++) {
             valuesSketch.add(randomDouble());


### PR DESCRIPTION
InternalMedianAbsoluteDeviation uses TDigest internally to track median values. For small compression values, TDigest may switch to the MergingDigest implementation that's not deterministic. This may lead to noise in tests like testConcurrentEquals, that create a clone of InternalMedianAbsoluteDeviation through (de)serialization and expect it to be an exact copy of the original object.

Larger compression values avoid this. Since this is not a unittest for TDigest, it's deemed ok to limit coverage to a simpler version of the latter.

Fixes #101417