### PR TITLE
[8.11] ESQL: Fix eval of functions on foldable literals (#101438)

### DIFF
--- a/docs/changelog/101438.yaml
+++ b/docs/changelog/101438.yaml
@@ -1,0 +1,6 @@
+pr: 101438
+summary: "ESQL: Fix eval of functions on foldable literals"
+area: ES|QL
+type: bug
+issues:
+ - 101425

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/eval.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/eval.csv-spec
@@ -206,3 +206,12 @@ row a = [1.2], b = [2.4, 7.9] | eval c = round(a), d = round(b), e = round([1.2]
 a:double | b:double   | c:double | d: double | e:double  | f:double  | g:double  | h:double 
 1.2      | [2.4, 7.9] | 1.0      | null      | 1.0       | null      | 1.1       | null
 ;
+
+
+evalSplitFoldable
+from employees | sort emp_no | eval foldable = "foo,bar" | eval folded_mv = split(foldable, ",") | keep emp_no, foldable, folded_mv | limit 2;
+
+emp_no:integer  | foldable:keyword | folded_mv:keyword
+10001           | "foo,bar"        | [foo, bar]
+10002           | "foo,bar"        | [foo, bar]
+;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/mv_expand.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/mv_expand.csv-spec
@@ -233,3 +233,22 @@ row a = "foobar", b = ["foo", "bar"], c = 12 | mv_expand b | where b LIKE "fo*";
 a:keyword   | b:keyword | c:integer
 foobar      | foo       | 12
 ;
+
+expandEvalFoldable
+from employees | sort emp_no | limit 2 | eval foldable = "foo,bar" | eval generate_mv = split(foldable,",") | mv_expand generate_mv | keep emp_no, first_name, generate_mv | sort emp_no asc, generate_mv desc;
+
+emp_no:integer  | first_name:keyword | generate_mv:keyword
+10001           | Georgi             | foo
+10001           | Georgi             | bar
+10002           | Bezalel            | foo
+10002           | Bezalel            | bar
+;
+
+
+expandEvalFoldableWhere
+from employees | sort emp_no | limit 2 | eval foldable = "foo,bar" | eval generate_mv = split(foldable,",") | mv_expand generate_mv | keep emp_no, first_name, generate_mv | where generate_mv LIKE "fo*";
+
+emp_no:integer  | first_name:keyword | generate_mv:keyword
+10001           | Georgi             | foo
+10002           | Bezalel            | foo
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/evaluator/EvalMapper.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/evaluator/EvalMapper.java
@@ -209,7 +209,9 @@ public final class EvalMapper {
                     return Block.constantNullBlock(positions, blockFactory);
                 }
                 var wrapper = BlockUtils.wrapperFor(blockFactory, ElementType.fromJava(multiValue.get(0).getClass()), positions);
-                wrapper.accept(multiValue);
+                for (int i = 0; i < positions; i++) {
+                    wrapper.accept(multiValue);
+                }
                 return wrapper.builder().build();
             }
             return BlockUtils.constantBlock(blockFactory, value, positions);


### PR DESCRIPTION
Backports the following commits to 8.11:
 - ESQL: Fix eval of functions on foldable literals (#101438)