### PR TITLE
Remove Plugin.createComponents method that specifies individual services

### DIFF
--- a/docs/changelog/101457.yaml
+++ b/docs/changelog/101457.yaml
@@ -1,0 +1,14 @@
+pr: 101457
+summary: "Remove Plugin.createComponents method in favour of overload with a PluginServices object"
+area: Infra/Plugins
+type: breaking-java
+breaking:
+  area: "Java API"
+  title: "Plugin.createComponents method has been refactored to take a single PluginServices object"
+  details: >
+    Plugin.createComponents currently takes a set of different objects. This signature changes
+    every time a new service is added. This changes the method to take a single PluginServices object
+    that new services are added to. This will reduce API incompatibility issues when a new service
+    is introduced in the future.
+  impact: "All plugins will need to be refactored to override the new method to work on ES 8.12+"
+  notable: false

--- a/docs/changelog/101457.yaml
+++ b/docs/changelog/101457.yaml
@@ -10,5 +10,5 @@ breaking:
     every time a new service is added. This changes the method to take a single PluginServices object
     that new services are added to. This will reduce API incompatibility issues when a new service
     is introduced in the future.
-  impact: "All plugins will need to be refactored to override the new method to work on ES 8.12+"
+  impact: "Plugins that override createComponents will need to be refactored to override the new method on ES 8.12+"
   notable: false

--- a/docs/changelog/101457.yaml
+++ b/docs/changelog/101457.yaml
@@ -6,8 +6,8 @@ breaking:
   area: "Java API"
   title: "Plugin.createComponents method has been refactored to take a single PluginServices object"
   details: >
-    Plugin.createComponents currently takes a set of different objects. This signature changes
-    every time a new service is added. This changes the method to take a single PluginServices object
+    Plugin.createComponents currently takes several different service arguments. The signature of this method changes
+    every time a new service is added. The method has now been modified to take a single interface object
     that new services are added to. This will reduce API incompatibility issues when a new service
     is introduced in the future.
   impact: "Plugins that override createComponents will need to be refactored to override the new method on ES 8.12+"

--- a/server/src/main/java/org/elasticsearch/plugins/Plugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/Plugin.java
@@ -149,67 +149,6 @@ public abstract class Plugin implements Closeable {
      * @param services      Provides access to various Elasticsearch services
      */
     public Collection<?> createComponents(PluginServices services) {
-        return createComponents(
-            services.client(),
-            services.clusterService(),
-            services.threadPool(),
-            services.resourceWatcherService(),
-            services.scriptService(),
-            services.xContentRegistry(),
-            services.environment(),
-            services.nodeEnvironment(),
-            services.namedWriteableRegistry(),
-            services.indexNameExpressionResolver(),
-            services.repositoriesServiceSupplier(),
-            services.telemetryProvider(),
-            services.allocationService(),
-            services.indicesService()
-        );
-    }
-
-    /**
-     * Returns components added by this plugin. Either this method or {@link #createComponents(PluginServices)}
-     * should be implemented.
-     * <p>
-     * Any components returned that implement {@link LifecycleComponent} will have their lifecycle managed.
-     * Note: To aid in the migration away from guice, all objects returned as components will be bound in guice
-     * to themselves.
-     *
-     * @param client                      A client to make requests to the system
-     * @param clusterService              A service to allow watching and updating cluster state
-     * @param threadPool                  A service to allow retrieving an executor to run an async action
-     * @param resourceWatcherService      A service to watch for changes to node local files
-     * @param scriptService               A service to allow running scripts on the local node
-     * @param xContentRegistry            The registry for extensible xContent parsing
-     * @param environment                 The environment for path and setting configurations
-     * @param nodeEnvironment             The node environment used coordinate access to the data paths
-     * @param namedWriteableRegistry      The registry for {@link NamedWriteable} object parsing
-     * @param indexNameExpressionResolver A service that resolves expression to index and alias names
-     * @param repositoriesServiceSupplier A supplier for the service that manages snapshot repositories; will return null when this method
-     *                                    is called, but will return the repositories service once the node is initialized.
-     * @param telemetryProvider           An interface for distributed tracing
-     * @param allocationService           A service to manage shard allocation in the cluster
-     * @param indicesService              A service to manage indices in the cluster
-     *
-     * @deprecated New services will only be added to {@link PluginServices}; this method is maintained for compatibility.
-     */
-    @Deprecated
-    public Collection<Object> createComponents(
-        Client client,
-        ClusterService clusterService,
-        ThreadPool threadPool,
-        ResourceWatcherService resourceWatcherService,
-        ScriptService scriptService,
-        NamedXContentRegistry xContentRegistry,
-        Environment environment,
-        NodeEnvironment nodeEnvironment,
-        NamedWriteableRegistry namedWriteableRegistry,
-        IndexNameExpressionResolver indexNameExpressionResolver,
-        Supplier<RepositoriesService> repositoriesServiceSupplier,
-        TelemetryProvider telemetryProvider,
-        AllocationService allocationService,
-        IndicesService indicesService
-    ) {
         return Collections.emptyList();
     }
 


### PR DESCRIPTION
Remove the `createComponents` method that specifies individual services, in favour of the `PluginServices` method.

This is a breaking change for all plugin implementations; implementations should move to the `createComponents(PluginServices)` method