### PR TITLE
ValuesSourceConfig to not depend on entire AggregationContext

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/CoreValuesSourceType.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/CoreValuesSourceType.java
@@ -40,6 +40,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.function.Function;
+import java.util.function.LongSupplier;
 
 /**
  * {@link CoreValuesSourceType} holds the {@link ValuesSourceType} implementations for the core aggregations package.
@@ -79,13 +80,13 @@ public enum CoreValuesSourceType implements ValuesSourceType {
             ValuesSource valuesSource,
             Object rawMissing,
             DocValueFormat docValueFormat,
-            AggregationContext context
+            LongSupplier nowInMillis
         ) {
             Number missing;
             if (rawMissing instanceof Number) {
                 missing = (Number) rawMissing;
             } else {
-                missing = docValueFormat.parseDouble(rawMissing.toString(), false, context::nowInMillis);
+                missing = docValueFormat.parseDouble(rawMissing.toString(), false, nowInMillis);
             }
             return MissingValues.replaceMissing((ValuesSource.Numeric) valuesSource, missing);
         }
@@ -138,7 +139,7 @@ public enum CoreValuesSourceType implements ValuesSourceType {
             ValuesSource valuesSource,
             Object rawMissing,
             DocValueFormat docValueFormat,
-            AggregationContext context
+            LongSupplier nowInMillis
         ) {
             final BytesRef missing = docValueFormat.parseBytesRef(rawMissing.toString());
             if (valuesSource instanceof ValuesSource.Bytes.WithOrdinals) {
@@ -174,7 +175,7 @@ public enum CoreValuesSourceType implements ValuesSourceType {
             ValuesSource valuesSource,
             Object rawMissing,
             DocValueFormat docValueFormat,
-            AggregationContext context
+            LongSupplier nowInMillis
         ) {
             // TODO: also support the structured formats of geo points
             final GeoPoint missing = new GeoPoint(rawMissing.toString());
@@ -213,7 +214,7 @@ public enum CoreValuesSourceType implements ValuesSourceType {
             ValuesSource valuesSource,
             Object rawMissing,
             DocValueFormat docValueFormat,
-            AggregationContext context
+            LongSupplier nowInMillis
         ) {
             throw new IllegalArgumentException("Can't apply missing values on a " + valuesSource.getClass());
         }
@@ -239,9 +240,9 @@ public enum CoreValuesSourceType implements ValuesSourceType {
             ValuesSource valuesSource,
             Object rawMissing,
             DocValueFormat docValueFormat,
-            AggregationContext context
+            LongSupplier nowInMillis
         ) {
-            return KEYWORD.replaceMissing(valuesSource, rawMissing, docValueFormat, context);
+            return KEYWORD.replaceMissing(valuesSource, rawMissing, docValueFormat, nowInMillis);
         }
 
         @Override
@@ -385,9 +386,9 @@ public enum CoreValuesSourceType implements ValuesSourceType {
             ValuesSource valuesSource,
             Object rawMissing,
             DocValueFormat docValueFormat,
-            AggregationContext context
+            LongSupplier nowInMillis
         ) {
-            return NUMERIC.replaceMissing(valuesSource, rawMissing, docValueFormat, context);
+            return NUMERIC.replaceMissing(valuesSource, rawMissing, docValueFormat, nowInMillis);
         }
 
         @Override
@@ -422,9 +423,9 @@ public enum CoreValuesSourceType implements ValuesSourceType {
             ValuesSource valuesSource,
             Object rawMissing,
             DocValueFormat docValueFormat,
-            AggregationContext context
+            LongSupplier nowInMillis
         ) {
-            return NUMERIC.replaceMissing(valuesSource, rawMissing, docValueFormat, context);
+            return NUMERIC.replaceMissing(valuesSource, rawMissing, docValueFormat, nowInMillis);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/TimeSeriesValuesSourceType.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/TimeSeriesValuesSourceType.java
@@ -14,6 +14,7 @@ import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.AggregationErrors;
 
 import java.util.Locale;
+import java.util.function.LongSupplier;
 
 import static org.elasticsearch.search.aggregations.support.CoreValuesSourceType.GEOPOINT;
 
@@ -51,7 +52,7 @@ public enum TimeSeriesValuesSourceType implements ValuesSourceType {
             ValuesSource valuesSource,
             Object rawMissing,
             DocValueFormat docValueFormat,
-            AggregationContext context
+            LongSupplier nowInMillis
         ) {
             throw new IllegalArgumentException("Cannot replace missing values for time-series counters");
         }
@@ -77,9 +78,9 @@ public enum TimeSeriesValuesSourceType implements ValuesSourceType {
             ValuesSource valuesSource,
             Object rawMissing,
             DocValueFormat docValueFormat,
-            AggregationContext context
+            LongSupplier nowInMillis
         ) {
-            return GEOPOINT.replaceMissing(valuesSource, rawMissing, docValueFormat, context);
+            return GEOPOINT.replaceMissing(valuesSource, rawMissing, docValueFormat, nowInMillis);
         }
     };
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceConfig.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceConfig.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.time.ZoneId;
 import java.util.function.DoubleUnaryOperator;
 import java.util.function.Function;
+import java.util.function.LongSupplier;
 
 /**
  * A configuration that tells aggregations how to retrieve data from the index
@@ -183,7 +184,7 @@ public class ValuesSourceConfig {
             missing,
             timeZone,
             docValueFormat,
-            context
+            context::nowInMillis
         );
         return config;
     }
@@ -257,14 +258,14 @@ public class ValuesSourceConfig {
     public static ValuesSourceConfig resolveFieldOnly(MappedFieldType fieldType, AggregationContext context) {
         FieldContext fieldContext = context.buildFieldContext(fieldType);
         ValuesSourceType vstype = fieldContext.indexFieldData().getValuesSourceType();
-        return new ValuesSourceConfig(vstype, fieldContext, false, null, null, null, null, null, context);
+        return new ValuesSourceConfig(vstype, fieldContext, false, null, null, null, null, null, context::nowInMillis);
     }
 
     /**
      * Convenience method for creating unmapped configs
      */
     public static ValuesSourceConfig resolveUnmapped(ValuesSourceType valuesSourceType, AggregationContext context) {
-        return new ValuesSourceConfig(valuesSourceType, null, true, null, null, null, null, null, context);
+        return new ValuesSourceConfig(valuesSourceType, null, true, null, null, null, null, null, context::nowInMillis);
     }
 
     private final ValuesSourceType valuesSourceType;
@@ -277,10 +278,6 @@ public class ValuesSourceConfig {
     private final ZoneId timeZone;
     private final ValuesSource valuesSource;
 
-    private ValuesSourceConfig() {
-        throw new UnsupportedOperationException();
-    }
-
     @SuppressWarnings("this-escape")
     public ValuesSourceConfig(
         ValuesSourceType valuesSourceType,
@@ -291,7 +288,7 @@ public class ValuesSourceConfig {
         Object missing,
         ZoneId timeZone,
         DocValueFormat format,
-        AggregationContext context
+        LongSupplier nowInMillis
     ) {
         if (unmapped && fieldContext != null) {
             throw new IllegalStateException("value source config is invalid; marked as unmapped but specified a mapped field");
@@ -311,10 +308,10 @@ public class ValuesSourceConfig {
                 "value source config is invalid; must have either a field context or a script or marked as unwrapped"
             );
         }
-        valuesSource = constructValuesSource(missing, format, context);
+        valuesSource = constructValuesSource(missing, format, nowInMillis);
     }
 
-    private ValuesSource constructValuesSource(Object missing, DocValueFormat format, AggregationContext context) {
+    private ValuesSource constructValuesSource(Object missing, DocValueFormat format, LongSupplier nowInMillis) {
         final ValuesSource vs;
         if (this.unmapped) {
             vs = valueSourceType().getEmpty();
@@ -329,7 +326,7 @@ public class ValuesSourceConfig {
         }
 
         if (missing() != null) {
-            return valueSourceType().replaceMissing(vs, missing, format, context);
+            return valueSourceType().replaceMissing(vs, missing, format, nowInMillis);
         } else {
             return vs;
         }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceType.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceType.java
@@ -12,6 +12,7 @@ import org.elasticsearch.script.AggregationScript;
 import org.elasticsearch.search.DocValueFormat;
 
 import java.time.ZoneId;
+import java.util.function.LongSupplier;
 
 /**
  * {@link ValuesSourceType} represents a collection of fields that share a common set of operations, for example all numeric fields.
@@ -64,13 +65,13 @@ public interface ValuesSourceType {
      * Apply the given missing value to an already-constructed {@link ValuesSource}.  Types which do not support missing values should throw
      * {@link org.elasticsearch.search.aggregations.AggregationExecutionException}
      *
-     * @param valuesSource - The original {@link ValuesSource}
-     * @param rawMissing - The missing value we got from the parser, typically a string or number
+     * @param valuesSource   - The original {@link ValuesSource}
+     * @param rawMissing     - The missing value we got from the parser, typically a string or number
      * @param docValueFormat - The format to use for further parsing the user supplied value, e.g. a date format
-     * @param context - Context for this aggregation used to handle {@link AggregationContext#nowInMillis() "now"}
+     * @param nowInMillis    - supplier of current time and date in milliseconds
      * @return - Wrapper over the provided {@link ValuesSource} to apply the given missing value
      */
-    ValuesSource replaceMissing(ValuesSource valuesSource, Object rawMissing, DocValueFormat docValueFormat, AggregationContext context);
+    ValuesSource replaceMissing(ValuesSource valuesSource, Object rawMissing, DocValueFormat docValueFormat, LongSupplier nowInMillis);
 
     /**
      * This method provides a hook for specifying a type-specific formatter.  When {@link ValuesSourceConfig} can resolve a

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/support/AnalyticsValuesSourceType.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/support/AnalyticsValuesSourceType.java
@@ -11,13 +11,13 @@ import org.elasticsearch.index.fielddata.IndexHistogramFieldData;
 import org.elasticsearch.script.AggregationScript;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.AggregationErrors;
-import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.FieldContext;
 import org.elasticsearch.search.aggregations.support.ValueType;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 
 import java.util.Locale;
+import java.util.function.LongSupplier;
 
 public enum AnalyticsValuesSourceType implements ValuesSourceType {
     HISTOGRAM() {
@@ -49,7 +49,7 @@ public enum AnalyticsValuesSourceType implements ValuesSourceType {
             ValuesSource valuesSource,
             Object rawMissing,
             DocValueFormat docValueFormat,
-            AggregationContext context
+            LongSupplier nowInMillis
         ) {
             throw new IllegalArgumentException("Can't apply missing values on a " + valuesSource.getClass());
         }

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/rate/RateAggregationBuilder.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/rate/RateAggregationBuilder.java
@@ -194,7 +194,17 @@ public class RateAggregationBuilder extends ValuesSourceAggregationBuilder.Singl
     @Override
     protected ValuesSourceConfig resolveConfig(AggregationContext context) {
         if (field() == null && script() == null) {
-            return new ValuesSourceConfig(CoreValuesSourceType.NUMERIC, null, true, null, null, 1.0, null, DocValueFormat.RAW, context);
+            return new ValuesSourceConfig(
+                CoreValuesSourceType.NUMERIC,
+                null,
+                true,
+                null,
+                null,
+                1.0,
+                null,
+                DocValueFormat.RAW,
+                context::nowInMillis
+            );
         } else {
             return super.resolveConfig(context);
         }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/UnsupportedValueSourceType.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/UnsupportedValueSourceType.java
@@ -9,11 +9,12 @@ package org.elasticsearch.compute.lucene;
 
 import org.elasticsearch.script.AggregationScript;
 import org.elasticsearch.search.DocValueFormat;
-import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.FieldContext;
 import org.elasticsearch.search.aggregations.support.ValueType;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
+
+import java.util.function.LongSupplier;
 
 // just a placeholder class for unsupported data types
 public class UnsupportedValueSourceType implements ValuesSourceType {
@@ -44,7 +45,7 @@ public class UnsupportedValueSourceType implements ValuesSourceType {
         ValuesSource valuesSource,
         Object rawMissing,
         DocValueFormat docValueFormat,
-        AggregationContext context
+        LongSupplier nowInMillis
     ) {
         throw new UnsupportedOperationException();
     }

--- a/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/aggregations/support/AggregateMetricsValuesSourceType.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/aggregations/support/AggregateMetricsValuesSourceType.java
@@ -11,7 +11,6 @@ import org.elasticsearch.script.AggregationScript;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.AggregationErrors;
 import org.elasticsearch.search.aggregations.UnsupportedAggregationOnDownsampledIndex;
-import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.FieldContext;
 import org.elasticsearch.search.aggregations.support.ValueType;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
@@ -19,6 +18,7 @@ import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 import org.elasticsearch.xpack.aggregatemetric.fielddata.IndexAggregateDoubleMetricFieldData;
 
 import java.util.Locale;
+import java.util.function.LongSupplier;
 
 public enum AggregateMetricsValuesSourceType implements ValuesSourceType {
 
@@ -60,7 +60,7 @@ public enum AggregateMetricsValuesSourceType implements ValuesSourceType {
             ValuesSource valuesSource,
             Object rawMissing,
             DocValueFormat docValueFormat,
-            AggregationContext context
+            LongSupplier nowInMillis
         ) {
             throw new IllegalArgumentException("Can't apply missing values on a " + valuesSource.getClass());
         }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/support/CartesianPointValuesSourceType.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/support/CartesianPointValuesSourceType.java
@@ -16,7 +16,6 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.script.AggregationScript;
 import org.elasticsearch.search.DocValueFormat;
-import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.FieldContext;
 import org.elasticsearch.search.aggregations.support.MissingValues;
 import org.elasticsearch.search.aggregations.support.ValueType;
@@ -26,6 +25,7 @@ import org.elasticsearch.xpack.spatial.common.CartesianPoint;
 import org.elasticsearch.xpack.spatial.index.fielddata.IndexCartesianPointFieldData;
 
 import java.io.IOException;
+import java.util.function.LongSupplier;
 
 public class CartesianPointValuesSourceType implements Writeable, ValuesSourceType {
 
@@ -61,7 +61,7 @@ public class CartesianPointValuesSourceType implements Writeable, ValuesSourceTy
         ValuesSource valuesSource,
         Object rawMissing,
         DocValueFormat docValueFormat,
-        AggregationContext context
+        LongSupplier nowInMillis
     ) {
         // TODO: also support the structured formats of points
         final CartesianPointValuesSource pointValuesSource = (CartesianPointValuesSource) valuesSource;

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/support/CartesianShapeValuesSourceType.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/support/CartesianShapeValuesSourceType.java
@@ -12,7 +12,6 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.script.AggregationScript;
 import org.elasticsearch.search.DocValueFormat;
-import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.FieldContext;
 import org.elasticsearch.search.aggregations.support.MissingValues;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
@@ -23,6 +22,7 @@ import org.elasticsearch.xpack.spatial.index.fielddata.IndexShapeFieldData;
 import org.elasticsearch.xpack.spatial.index.fielddata.plain.CartesianShapeIndexFieldData;
 
 import java.io.IOException;
+import java.util.function.LongSupplier;
 
 public class CartesianShapeValuesSourceType extends ShapeValuesSourceType {
 
@@ -61,7 +61,7 @@ public class CartesianShapeValuesSourceType extends ShapeValuesSourceType {
         ValuesSource valuesSource,
         Object rawMissing,
         DocValueFormat docValueFormat,
-        AggregationContext context
+        LongSupplier nowInMillis
     ) {
         CartesianShapeValuesSource shapeValuesSource = (CartesianShapeValuesSource) valuesSource;
         final CartesianShapeValues.CartesianShapeValue missing = CartesianShapeValues.EMPTY.missing(rawMissing.toString());

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/support/GeoShapeValuesSourceType.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/support/GeoShapeValuesSourceType.java
@@ -13,7 +13,6 @@ import org.elasticsearch.index.fielddata.IndexGeoPointFieldData;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.script.AggregationScript;
 import org.elasticsearch.search.DocValueFormat;
-import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.FieldContext;
 import org.elasticsearch.search.aggregations.support.MissingValues;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
@@ -22,6 +21,7 @@ import org.elasticsearch.xpack.spatial.index.fielddata.GeoShapeValues;
 import org.elasticsearch.xpack.spatial.index.fielddata.IndexShapeFieldData;
 
 import java.io.IOException;
+import java.util.function.LongSupplier;
 
 public class GeoShapeValuesSourceType extends ShapeValuesSourceType {
 
@@ -61,7 +61,7 @@ public class GeoShapeValuesSourceType extends ShapeValuesSourceType {
         ValuesSource valuesSource,
         Object rawMissing,
         DocValueFormat docValueFormat,
-        AggregationContext context
+        LongSupplier nowInMillis
     ) {
         GeoShapeValuesSource shapeValuesSource = (GeoShapeValuesSource) valuesSource;
         final GeoShapeValues.GeoShapeValue missing = GeoShapeValues.EMPTY.missing(rawMissing.toString());


### PR DESCRIPTION
ValuesSourceConfig takes in the entire AggregationContext as a constructor argument, but only context::nowInMillis is ever used in the internal replaceMissing call. The constructor argument can be replaced by a LongSupplier.