### PR TITLE
[Search Applications] Return 400 response when template does not render correctly

### DIFF
--- a/docs/changelog/101474.yaml
+++ b/docs/changelog/101474.yaml
@@ -1,0 +1,6 @@
+pr: 101474
+summary: "[Search Applications] Return 400 response when template does not render\
+  \ correctly"
+area: Application
+type: bug
+issues: []

--- a/docs/changelog/101474.yaml
+++ b/docs/changelog/101474.yaml
@@ -1,6 +1,5 @@
 pr: 101474
-summary: "[Search Applications] Return 400 response when template does not render\
-  \ correctly"
+summary: "[Search Applications] Return 400 response when template rendering produces invalid JSON"
 area: Application
 type: bug
 issues: []

--- a/x-pack/plugin/ent-search/qa/rest/roles.yml
+++ b/x-pack/plugin/ent-search/qa/rest/roles.yml
@@ -21,7 +21,8 @@ user:
       "test-index1",
       "test-search-application",
       "test-search-application-1",
-      "test-search-application-with-list"
+      "test-search-application-with-list",
+      "test-search-application-with-list-invalid"
     ]
       privileges: [ "read" ]
 

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/52_search_application_render_query.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/52_search_application_render_query.yml
@@ -44,6 +44,25 @@ setup:
 
   - do:
       search_application.put:
+        name: test-search-application-with-list
+        body:
+          indices: [ "test-search-index1", "test-search-index2" ]
+          template:
+            script:
+              source: "{ \"query\": { \"multi_match\":{ \"query\": \"{{query_string}}\", \"fields\": [{{#text_fields}}\"{{name}}^{{boost}}\",{{/text_fields}}] } } }"
+              params:
+                query_string: "elastic"
+                text_fields:
+                  - name: field1
+                    boost: 1
+                  - name: field2
+                    boost: 2
+                  - name: field3
+                    boost: 3
+              lang: "mustache"
+
+  - do:
+      search_application.put:
         name: test-search-application-with-list-invalid
         body:
           indices: [ "test-search-index1", "test-search-index2" ]
@@ -84,6 +103,11 @@ teardown:
   - do:
       search_application.delete:
         name: test-search-application
+        ignore: 404
+
+  - do:
+      search_application.delete:
+        name: test-search-application-with-list
         ignore: 404
 
   - do:
@@ -165,6 +189,37 @@ teardown:
       }
     }
   }
+
+---
+"Render query for search application with a list of parameters":
+
+  - do:
+      search_application.render_query:
+        name: test-search-application-with-list
+        body:
+          params:
+            query_string: value3
+            text_fields:
+              - name: field1
+                boost: 1
+              - name: field2
+                boost: 2
+              - name: field3
+                boost: 3
+
+  - match: {
+    query: {
+      multi_match: {
+        query: "value3",
+        fields: [
+          "field1^1.0",
+          "field2^2.0",
+          "field3^3.0"
+        ]
+      }
+    }
+  }
+
 ---
 "Render query for search application - not found":
 

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/52_search_application_render_query.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/52_search_application_render_query.yml
@@ -43,6 +43,25 @@ setup:
                 field_value: value1
 
   - do:
+      search_application.put:
+        name: test-search-application-with-list-invalid
+        body:
+          indices: [ "test-search-index1", "test-search-index2" ]
+          template:
+            script:
+              source: "{ \"query\": { \"multi_match\":{ \"query\": \"{{query_string}}\", \"fields\": [{{#text_fields}}\"{{name}}^{{boost}}\"{{/text_fields}}] } } }"
+              params:
+                query_string: "elastic"
+                text_fields:
+                  - name: field1
+                    boost: 1
+                  - name: field2
+                    boost: 2
+                  - name: field3
+                    boost: 3
+              lang: "mustache"
+
+  - do:
       index:
         index: test-search-index1
         id: doc1
@@ -65,6 +84,11 @@ teardown:
   - do:
       search_application.delete:
         name: test-search-application
+        ignore: 404
+
+  - do:
+      search_application.delete:
+        name: test-search-application-with-list-invalid
         ignore: 404
 
   - do:
@@ -166,3 +190,20 @@ teardown:
         body:
           params:
             field_value: puggles
+
+---
+"Render search application query fails on invalid rendered JSON":
+  - do:
+      catch: "bad_request"
+      search_application.render_query:
+        name: test-search-application-with-list-invalid
+        body:
+          params:
+            query_string: value3
+            text_fields:
+              - name: field1
+                boost: 1
+              - name: field2
+                boost: 2
+              - name: field3
+                boost: 3

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/55_search_application_search.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/55_search_application_search.yml
@@ -92,6 +92,25 @@ setup:
               lang: "mustache"
 
   - do:
+      search_application.put:
+        name: test-search-application-with-list-invalid
+        body:
+          indices: [ "test-search-index1", "test-search-index2" ]
+          template:
+            script:
+              source: "{ \"query\": { \"multi_match\":{ \"query\": \"{{query_string}}\", \"fields\": [{{#text_fields}}\"{{name}}^{{boost}}\"{{/text_fields}}] } } }"
+              params:
+                query_string: "elastic"
+                text_fields:
+                  - name: field1
+                    boost: 1
+                  - name: field2
+                    boost: 2
+                  - name: field3
+                    boost: 3
+              lang: "mustache"
+
+  - do:
       index:
         index: test-search-index1
         id: doc1
@@ -124,6 +143,11 @@ teardown:
   - do:
       search_application.delete:
         name: test-search-application-with-list
+        ignore: 404
+
+  - do:
+      search_application.delete:
+        name: test-search-application-with-list-invalid
         ignore: 404
 
   - do:
@@ -271,4 +295,25 @@ teardown:
         body:
           params:
             field_value: puggles
+
+---
+"Search application search fails on invalid rendered JSON":
+  - skip:
+      features: headers
+
+  - do:
+      catch: "bad_request"
+      headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
+      search_application.search:
+        name: test-search-application-with-list-invalid
+        body:
+          params:
+            query_string: value3
+            text_fields:
+              - name: field1
+                boost: 1
+              - name: field2
+                boost: 2
+              - name: field3
+                boost: 3
 

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/55_search_application_search.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/55_search_application_search.yml
@@ -72,6 +72,7 @@ setup:
                   type: string
                 field_value:
                   type: string
+
   - do:
       search_application.put:
         name: test-search-application-with-list

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationTemplateService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationTemplateService.java
@@ -7,6 +7,9 @@
 
 package org.elasticsearch.xpack.application.search;
 
+import com.fasterxml.jackson.core.JsonLocation;
+import com.fasterxml.jackson.core.JsonProcessingException;
+
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.logging.LogManager;
@@ -17,6 +20,8 @@ import org.elasticsearch.script.TemplateScript;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.XContentFactory;
+import org.elasticsearch.xcontent.XContentLocation;
+import org.elasticsearch.xcontent.XContentParseException;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
@@ -38,13 +43,20 @@ public class SearchApplicationTemplateService {
     }
 
     public SearchSourceBuilder renderQuery(SearchApplication searchApplication, Map<String, Object> templateParams) throws IOException,
-        ValidationException {
+        ValidationException, XContentParseException {
         final SearchApplicationTemplate template = searchApplication.searchApplicationTemplateOrDefault();
         template.validateTemplateParams(templateParams);
         final Map<String, Object> renderedTemplateParams = renderTemplateParams(template, templateParams);
         final Script script = template.script();
         TemplateScript compiledTemplate = scriptService.compile(script, TemplateScript.CONTEXT).newInstance(renderedTemplateParams);
-        final String requestSource = SearchTemplateHelper.stripTrailingComma(compiledTemplate.execute());
+        String requestSource;
+        try {
+            requestSource = SearchTemplateHelper.stripTrailingComma(compiledTemplate.execute());
+        } catch (JsonProcessingException e) {
+            JsonLocation loc = e.getLocation();
+            throw new XContentParseException(new XContentLocation(loc.getLineNr(), loc.getColumnNr()), e.getMessage(), e);
+        }
+
         XContentParserConfiguration parserConfig = XContentParserConfiguration.EMPTY.withRegistry(xContentRegistry)
             .withDeprecationHandler(LoggingDeprecationHandler.INSTANCE);
         try (XContentParser parser = XContentFactory.xContent(XContentType.JSON).createParser(parserConfig, requestSource)) {


### PR DESCRIPTION
Return a `400` response when a template does not render correctly, via `_render_query` or `_search`.

The exception thrown in this case is `XContentParseException` to align with:
- How `_render_query` and `_search` handled this scenario prior to #96197 
- How the [search template API](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template-api.html) handles this scenario


