### PR TITLE
Increase timeout for QueryRulesIndexServiceTests

### DIFF
--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/QueryRulesIndexServiceTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/QueryRulesIndexServiceTests.java
@@ -41,6 +41,8 @@ import static org.hamcrest.CoreMatchers.equalTo;
 
 public class QueryRulesIndexServiceTests extends ESSingleNodeTestCase {
 
+    private static final int REQUEST_TIMEOUT = 10;
+
     private QueryRulesIndexService queryRulesIndexService;
 
     @Before
@@ -212,11 +214,11 @@ public class QueryRulesIndexServiceTests extends ESSingleNodeTestCase {
                 latch.countDown();
             }
         });
-        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        assertTrue("Timeout waiting for put request", latch.await(REQUEST_TIMEOUT, TimeUnit.SECONDS));
         if (exc.get() != null) {
             throw exc.get();
         }
-        assertNotNull(resp.get());
+        assertNotNull("Received null response from put request", resp.get());
         return resp.get();
     }
 
@@ -237,11 +239,11 @@ public class QueryRulesIndexServiceTests extends ESSingleNodeTestCase {
                 latch.countDown();
             }
         });
-        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        assertTrue("Timeout waiting for get request", latch.await(REQUEST_TIMEOUT, TimeUnit.SECONDS));
         if (exc.get() != null) {
             throw exc.get();
         }
-        assertNotNull(resp.get());
+        assertNotNull("Received null response from get request", resp.get());
         return resp.get();
     }
 
@@ -262,11 +264,11 @@ public class QueryRulesIndexServiceTests extends ESSingleNodeTestCase {
                 latch.countDown();
             }
         });
-        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        assertTrue("Timeout waiting for delete request", latch.await(REQUEST_TIMEOUT, TimeUnit.SECONDS));
         if (exc.get() != null) {
             throw exc.get();
         }
-        assertNotNull(resp.get());
+        assertNotNull("Received null response from delete request", resp.get());
         return resp.get();
     }
 
@@ -287,11 +289,11 @@ public class QueryRulesIndexServiceTests extends ESSingleNodeTestCase {
                 latch.countDown();
             }
         });
-        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        assertTrue("Timeout waiting for list request", latch.await(REQUEST_TIMEOUT, TimeUnit.SECONDS));
         if (exc.get() != null) {
             throw exc.get();
         }
-        assertNotNull(resp.get());
+        assertNotNull("Received null response from list request", resp.get());
         return resp.get();
     }
 

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/QueryRulesIndexServiceTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/QueryRulesIndexServiceTests.java
@@ -41,7 +41,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 
 public class QueryRulesIndexServiceTests extends ESSingleNodeTestCase {
 
-    private static final int REQUEST_TIMEOUT = 10;
+    private static final int REQUEST_TIMEOUT_SECONDS = 10;
 
     private QueryRulesIndexService queryRulesIndexService;
 
@@ -214,7 +214,7 @@ public class QueryRulesIndexServiceTests extends ESSingleNodeTestCase {
                 latch.countDown();
             }
         });
-        assertTrue("Timeout waiting for put request", latch.await(REQUEST_TIMEOUT, TimeUnit.SECONDS));
+        assertTrue("Timeout waiting for put request", latch.await(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS));
         if (exc.get() != null) {
             throw exc.get();
         }
@@ -239,7 +239,7 @@ public class QueryRulesIndexServiceTests extends ESSingleNodeTestCase {
                 latch.countDown();
             }
         });
-        assertTrue("Timeout waiting for get request", latch.await(REQUEST_TIMEOUT, TimeUnit.SECONDS));
+        assertTrue("Timeout waiting for get request", latch.await(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS));
         if (exc.get() != null) {
             throw exc.get();
         }
@@ -264,7 +264,7 @@ public class QueryRulesIndexServiceTests extends ESSingleNodeTestCase {
                 latch.countDown();
             }
         });
-        assertTrue("Timeout waiting for delete request", latch.await(REQUEST_TIMEOUT, TimeUnit.SECONDS));
+        assertTrue("Timeout waiting for delete request", latch.await(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS));
         if (exc.get() != null) {
             throw exc.get();
         }
@@ -289,7 +289,7 @@ public class QueryRulesIndexServiceTests extends ESSingleNodeTestCase {
                 latch.countDown();
             }
         });
-        assertTrue("Timeout waiting for list request", latch.await(REQUEST_TIMEOUT, TimeUnit.SECONDS));
+        assertTrue("Timeout waiting for list request", latch.await(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS));
         if (exc.get() != null) {
             throw exc.get();
         }


### PR DESCRIPTION
This PR is an attempt to resolve https://github.com/elastic/elasticsearch/issues/101463

The `testUpdateQueryRuleset` test in `QueryRulesetIndexServiceTests` failed due to a timeout waiting on the request. This timeout cannot be reproduced locally. I've doubled the timeout from 5 seconds to 10 seconds and added some more information to latch assert statements so it's clear when this is a timeout condition.