### PR TITLE
[8.11] Fix CanMatchPreFilterSearchPhaseTests#testInvalidSortShards() test & SearchCancellationIT NPE (#101444)

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhaseTests.java
@@ -442,7 +442,7 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
                 shardsIter,
                 timeProvider,
                 null,
-                true,
+                shardsIter.size() > shardToSkip.size(),
                 EMPTY_CONTEXT_PROVIDER,
                 ActionTestUtils.assertNoFailureListener(iter -> {
                     result.set(iter);

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractSearchCancellationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractSearchCancellationTestCase.java
@@ -281,7 +281,9 @@ public class AbstractSearchCancellationTestCase extends ESIntegTestCase {
             indexModule.addSearchOperationListener(new SearchOperationListener() {
                 @Override
                 public void onNewReaderContext(ReaderContext c) {
-                    runOnNewReaderContext.get().accept(c);
+                    if (runOnNewReaderContext.get() != null) {
+                        runOnNewReaderContext.get().accept(c);
+                    }
                 }
             });
         }


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Fix CanMatchPreFilterSearchPhaseTests#testInvalidSortShards() test & SearchCancellationIT NPE (#101444)