### PR TITLE
docs: remove duplicated filter

### DIFF
--- a/docs/reference/analysis/tokenfilters/multiplexer-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/multiplexer-tokenfilter.asciidoc
@@ -47,7 +47,7 @@ PUT /multiplexer_example
       "filter": {
         "my_multiplexer": {
           "type": "multiplexer",
-          "filters": [ "lowercase", "lowercase, porter_stem" ]
+          "filters": [ "lowercase", "porter_stem" ]
         }
       }
     }


### PR DESCRIPTION
Removes duplicated filter from the documentation as it is likely a typo