### PR TITLE
[DSL] skip deleting indices that have in-progress downsampling operations

### DIFF
--- a/docs/changelog/101495.yaml
+++ b/docs/changelog/101495.yaml
@@ -1,0 +1,5 @@
+pr: 101495
+summary: "[DSL] skip deleting indices that have in-progress downsampling operations"
+area: Data streams
+type: bug
+issues: []

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleService.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleService.java
@@ -90,6 +90,7 @@ import java.util.stream.Collectors;
 
 import static org.elasticsearch.cluster.metadata.IndexMetadata.APIBlock.WRITE;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.DownsampleTaskStatus.STARTED;
+import static org.elasticsearch.cluster.metadata.IndexMetadata.DownsampleTaskStatus.UNKNOWN;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_DOWNSAMPLE_STATUS;
 import static org.elasticsearch.datastreams.DataStreamsPlugin.LIFECYCLE_CUSTOM_INDEX_METADATA_KEY;
 
@@ -764,14 +765,30 @@ public class DataStreamLifecycleService implements ClusterStateListener, Closeab
 
             for (Index index : backingIndicesOlderThanRetention) {
                 if (indicesToExcludeForRemainingRun.contains(index) == false) {
-                    indicesToBeRemoved.add(index);
                     IndexMetadata backingIndex = metadata.index(index);
                     assert backingIndex != null : "the data stream backing indices must exist";
 
-                    // there's an opportunity here to batch the delete requests (i.e. delete 100 indices / request)
-                    // let's start simple and reevaluate
-                    String indexName = backingIndex.getIndex().getName();
-                    deleteIndexOnce(indexName, "the lapsed [" + retention + "] retention period");
+                    IndexMetadata.DownsampleTaskStatus downsampleStatus = INDEX_DOWNSAMPLE_STATUS.get(backingIndex.getSettings());
+                    // we don't want to delete the source index if they have an in-progress downsampling operation because the
+                    // target downsample index will remain in the system as a standalone index
+                    if (downsampleStatus.equals(UNKNOWN)) {
+                        indicesToBeRemoved.add(index);
+
+                        // there's an opportunity here to batch the delete requests (i.e. delete 100 indices / request)
+                        // let's start simple and reevaluate
+                        String indexName = backingIndex.getIndex().getName();
+                        deleteIndexOnce(indexName, "the lapsed [" + retention + "] retention period");
+                    } else {
+                        // there's an opportunity here to cancel downsampling and delete the source index now
+                        logger.trace(
+                            "Data stream lifecycle skips deleting index [{}] even though its retention period [{}] has lapsed "
+                                + "because there's a downsampling operation currently in progress for this index. Current downsampling "
+                                + "status is [{}]. When downsampling completes, DSL will delete this index.",
+                            index.getName(),
+                            retention,
+                            downsampleStatus
+                        );
+                    }
                 }
             }
         }


### PR DESCRIPTION
A backing index for which we kicked off downsampling will have a target `downsample-{interval}-.ds...` index created outside the data stream. The source (backing) index will have a downsample status of `STARTED` at this point.
When downsampling completes the downsample status of the source index is changed to `SUCCESS` and DSL will atomically swap the downsample index in the data stream instead of the source index, and delete the source index.

If retention time for the source index lapses before we finished the downsample operation, the target downsample index will remain in the system, outside the data stream as the source index will be deleted.

This makes the DSL retention wait for a potential in-progress downsampling operation to complete, before executing retention.
