### PR TITLE
[8.11] Set longer settings update task timeout

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/settings/ClusterSettingsUpdateWithFaultyMasterIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/settings/ClusterSettingsUpdateWithFaultyMasterIT.java
@@ -57,7 +57,7 @@ public class ClusterSettingsUpdateWithFaultyMasterIT extends ESIntegTestCase {
             .cluster()
             .prepareUpdateSettings()
             .setPersistentSettings(Settings.builder().put(BlockingClusterSettingTestPlugin.TEST_BLOCKING_SETTING.getKey(), true).build())
-            .setMasterNodeTimeout(TimeValue.timeValueMillis(10L))
+            .setMasterNodeTimeout(TimeValue.timeValueMillis(100L))
             .execute();
 
         logger.debug("--> waiting for cluster state update to be blocked");


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Set longer settings update task timeout (#101208)