### PR TITLE
Remove more `throw new AssertionError(e)` calls

### DIFF
--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/remote/RemoteScrollableHitSourceTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/remote/RemoteScrollableHitSourceTests.java
@@ -615,8 +615,7 @@ public class RemoteScrollableHitSourceTests extends ESTestCase {
     }
 
     private <T> RejectAwareActionListener<T> wrapAsListener(Consumer<T> consumer) {
-        Consumer<Exception> throwing = e -> { throw new AssertionError(e); };
-        return RejectAwareActionListener.wrap(consumer::accept, throwing, throwing);
+        return RejectAwareActionListener.wrap(consumer::accept, ESTestCase::fail, ESTestCase::fail);
     }
 
     @SuppressWarnings("unchecked")

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/ShardRoutingRoleIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/ShardRoutingRoleIT.java
@@ -253,7 +253,7 @@ public class ShardRoutingRoleIT extends ESIntegTestCase {
                 }
             }
         } catch (IOException e) {
-            throw new AssertionError("unexpected", e);
+            fail(e);
         }
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/discovery/ClusterDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/discovery/ClusterDisruptionIT.java
@@ -566,7 +566,7 @@ public class ClusterDisruptionIT extends AbstractDisruptionTestCase {
                     try {
                         Thread.sleep(100);
                     } catch (InterruptedException e) {
-                        throw new AssertionError("unexpected", e);
+                        fail(e);
                     }
                 }
             }

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/mapper/DynamicMappingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/mapper/DynamicMappingIT.java
@@ -179,7 +179,7 @@ public class DynamicMappingIT extends ESIntegTestCase {
 
                 @Override
                 public void onFailure(Exception e) {
-                    throw new AssertionError("unexpected", e);
+                    fail(e);
                 }
             });
 
@@ -216,7 +216,7 @@ public class DynamicMappingIT extends ESIntegTestCase {
 
                 @Override
                 public void onFailure(Exception e) {
-                    throw new AssertionError("unexpected", e);
+                    fail(e);
                 }
             });
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/seqno/RetentionLeaseIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/seqno/RetentionLeaseIT.java
@@ -429,7 +429,7 @@ public class RetentionLeaseIT extends ESIntegTestCase {
                     )
                 );
             } catch (final Exception e) {
-                failWithException(e);
+                fail(e);
             }
         });
 
@@ -485,7 +485,7 @@ public class RetentionLeaseIT extends ESIntegTestCase {
 
                 @Override
                 public void onFailure(final Exception e) {
-                    failWithException(e);
+                    fail(e);
                 }
 
             });
@@ -530,7 +530,7 @@ public class RetentionLeaseIT extends ESIntegTestCase {
                     )
                 );
             } catch (final Exception e) {
-                failWithException(e);
+                fail(e);
             }
         });
 
@@ -584,10 +584,6 @@ public class RetentionLeaseIT extends ESIntegTestCase {
         actionLatch.await();
         assertTrue(success.get());
         afterSync.accept(primary);
-    }
-
-    private static void failWithException(Exception e) {
-        throw new AssertionError("unexpected", e);
     }
 
     private static ActionListener<ReplicationResponse> countDownLatchListener(CountDownLatch latch) {

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/TransportClearVotingConfigExclusionsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/TransportClearVotingConfigExclusionsActionTests.java
@@ -199,7 +199,7 @@ public class TransportClearVotingConfigExclusionsActionTests extends ESTestCase 
     }
 
     private TransportResponseHandler<ActionResponse.Empty> expectSuccess(Consumer<ActionResponse.Empty> onResponse) {
-        return responseHandler(onResponse, e -> { throw new AssertionError("unexpected", e); });
+        return responseHandler(onResponse, ESTestCase::fail);
     }
 
     private TransportResponseHandler<ActionResponse.Empty> expectError(Consumer<TransportException> onException) {

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteResponseTests.java
@@ -292,7 +292,7 @@ public class ClusterRerouteResponseTests extends ESTestCase {
             ChunkedToXContent.wrapAsToXContent(response).toXContent(builder, params);
             assertEquals(XContentHelper.stripWhitespace(expectedBody), XContentHelper.stripWhitespace(Strings.toString(builder)));
         } catch (IOException e) {
-            throw new AssertionError("unexpected", e);
+            fail(e);
         }
 
         final var expectedChunks = Objects.equals(params.param("metric"), "none")

--- a/server/src/test/java/org/elasticsearch/action/support/SubscribableListenerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/SubscribableListenerTests.java
@@ -494,7 +494,7 @@ public class SubscribableListenerTests extends ESTestCase {
             try {
                 listener.rawResult();
             } catch (Exception e) {
-                throw new AssertionError("unexpected", e);
+                fail(e);
             }
         } else {
             assertEquals(expectedFailureMessage, expectThrows(ElasticsearchException.class, listener::rawResult).getMessage());

--- a/server/src/test/java/org/elasticsearch/action/support/ThreadedActionListenerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/ThreadedActionListenerTests.java
@@ -83,7 +83,7 @@ public class ThreadedActionListenerTests extends ESTestCase {
                                         e = elasticsearchException;
                                         assertNull(e.getCause());
                                     } else {
-                                        throw new AssertionError("unexpected", e);
+                                        fail(e);
                                     }
                                 }
 
@@ -91,7 +91,7 @@ public class ThreadedActionListenerTests extends ESTestCase {
                                     assertEquals("simulated", e.getMessage());
                                     assertEquals(0, e.getSuppressed().length);
                                 } else {
-                                    throw new AssertionError("unexpected", e);
+                                    fail(e);
                                 }
 
                             }

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/FollowersCheckerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/FollowersCheckerTests.java
@@ -839,7 +839,7 @@ public class FollowersCheckerTests extends ESTestCase {
 
         @Override
         public void handleException(TransportException exp) {
-            throw new AssertionError("unexpected", exp);
+            fail(exp);
         }
 
         public boolean succeeded() {

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTransportHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTransportHandlerTests.java
@@ -155,7 +155,7 @@ public class PublicationTransportHandlerTests extends ESTestCase {
                 IOUtils.close(in);
             }
         } catch (IOException e) {
-            throw new AssertionError("unexpected", e);
+            return fail(e);
         }
     }
 
@@ -387,13 +387,13 @@ public class PublicationTransportHandlerTests extends ESTestCase {
 
                                 @Override
                                 public void onFailure(Exception e) {
-                                    throw new AssertionError("unexpected", e);
+                                    fail(e);
                                 }
                             }), new Task(randomNonNegativeLong(), "test", "test", "", TaskId.EMPTY_TASK_ID, Map.of()));
                     } catch (IncompatibleClusterStateVersionException e) {
                         context.handler().handleException(new RemoteTransportException("wrapped", e));
                     } catch (Exception e) {
-                        throw new AssertionError("unexpected", e);
+                        fail(e);
                     }
                 }
             };

--- a/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodesTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodesTests.java
@@ -464,7 +464,7 @@ public class DiscoveryNodesTests extends ESTestCase {
                             TransportVersion.current()
                         );
                     } catch (IOException e) {
-                        throw new AssertionError("unexpected", e);
+                        fail(e);
                     }
                 }
                 assertEquals(expectedGeneration, discoveryNodes.getNodeLeftGeneration());

--- a/server/src/test/java/org/elasticsearch/cluster/service/MasterServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/service/MasterServiceTests.java
@@ -2302,7 +2302,7 @@ public class MasterServiceTests extends ESTestCase {
 
                 @Override
                 public void onFailure(Exception e) {
-                    throw new AssertionError("unexpected", e);
+                    fail(e);
                 }
             }
 
@@ -2397,7 +2397,7 @@ public class MasterServiceTests extends ESTestCase {
 
                 @Override
                 public void onFailure(Exception e) {
-                    throw new AssertionError("unexpected", e);
+                    fail(e);
                 }
             }
 
@@ -2474,7 +2474,7 @@ public class MasterServiceTests extends ESTestCase {
 
                     @Override
                     public void onFailure(Exception e) {
-                        throw new AssertionError("unexpected", e);
+                        fail(e);
                     }
                 });
             }

--- a/server/src/test/java/org/elasticsearch/common/logging/ChunkedLoggingStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/common/logging/ChunkedLoggingStreamTests.java
@@ -137,7 +137,7 @@ public class ChunkedLoggingStreamTests extends ESTestCase {
             Loggers.addAppender(captureLogger, appender);
             runnable.run();
         } catch (Exception e) {
-            throw new AssertionError("unexpected", e);
+            fail(e);
         } finally {
             Loggers.removeAppender(captureLogger, appender);
             appender.stop();
@@ -177,7 +177,7 @@ public class ChunkedLoggingStreamTests extends ESTestCase {
             Streams.copy(gzipInputStream, bytesStreamOutput);
             return bytesStreamOutput.bytes();
         } catch (Exception e) {
-            throw new AssertionError("unexpected", e);
+            return fail(e);
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/common/util/CancellableSingleObjectCacheTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/CancellableSingleObjectCacheTests.java
@@ -355,7 +355,7 @@ public class CancellableSingleObjectCacheTests extends ESTestCase {
                         if (e instanceof TaskCancelledException) {
                             assertTrue(cancel);
                         } else {
-                            throw new AssertionError("unexpected", e);
+                            fail(e);
                         }
                     }));
                 });

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/PrioritizedThrottledTaskRunnerTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/PrioritizedThrottledTaskRunnerTests.java
@@ -68,7 +68,7 @@ public class PrioritizedThrottledTaskRunnerTests extends ESTestCase {
 
         @Override
         public void onFailure(Exception e) {
-            throw new AssertionError("unexpected", e);
+            fail(e);
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/ThrottledIteratorTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/ThrottledIteratorTests.java
@@ -84,7 +84,7 @@ public class ThrottledIteratorTests extends ESTestCase {
                                     try {
                                         assertTrue(itemStartLatch.await(30, TimeUnit.SECONDS));
                                     } catch (InterruptedException e) {
-                                        throw new AssertionError("unexpected", e);
+                                        fail(e);
                                     } finally {
                                         blockPermits.release();
                                     }
@@ -99,7 +99,7 @@ public class ThrottledIteratorTests extends ESTestCase {
 
                             @Override
                             public void onFailure(Exception e) {
-                                throw new AssertionError("unexpected", e);
+                                fail(e);
                             }
                         });
                     } else {

--- a/server/src/test/java/org/elasticsearch/discovery/PeerFinderTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/PeerFinderTests.java
@@ -556,7 +556,7 @@ public class PeerFinderTests extends ESTestCase {
 
                 @Override
                 public void handleException(TransportException exp) {
-                    throw new AssertionError("unexpected", exp);
+                    fail(exp);
                 }
             }
         );

--- a/server/src/test/java/org/elasticsearch/http/DefaultRestChannelTests.java
+++ b/server/src/test/java/org/elasticsearch/http/DefaultRestChannelTests.java
@@ -692,7 +692,7 @@ public class DefaultRestChannelTests extends ESTestCase {
                     }
                     return new TestHttpResponse(status, bso.bytes());
                 } catch (IOException e) {
-                    throw new AssertionError("unexpected", e);
+                    return fail(e);
                 }
             }
         };

--- a/server/src/test/java/org/elasticsearch/transport/ClusterConnectionManagerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/ClusterConnectionManagerTests.java
@@ -510,7 +510,7 @@ public class ClusterConnectionManagerTests extends ESTestCase {
                                 connectionPermits.release();
                                 runAgain();
                             } else {
-                                throw new AssertionError("unexpected", e);
+                                fail(e);
                             }
                         }
 
@@ -592,7 +592,7 @@ public class ClusterConnectionManagerTests extends ESTestCase {
                                 && e.getMessage().contains("concurrently connecting and disconnecting")) {
                                 runAgain();
                             } else {
-                                throw new AssertionError("unexpected", e);
+                                fail(e);
                             }
                         }
 

--- a/test/fixtures/s3-fixture/src/test/java/fixture/s3/S3HttpHandlerTests.java
+++ b/test/fixtures/s3-fixture/src/test/java/fixture/s3/S3HttpHandlerTests.java
@@ -294,7 +294,7 @@ public class S3HttpHandlerTests extends ESTestCase {
         try {
             handler.handle(httpExchange);
         } catch (IOException e) {
-            throw new AssertionError("unexpected", e);
+            fail(e);
         }
         assertNotEquals(0, httpExchange.getResponseCode());
         return new TestHttpResponse(

--- a/test/framework/src/main/java/org/elasticsearch/cluster/DiskUsageIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/DiskUsageIntegTestCase.java
@@ -207,7 +207,7 @@ public class DiskUsageIntegTestCase extends ESIntegTestCase {
             try {
                 fileStore = super.getFileStore(path);
             } catch (IOException e) {
-                fail(e);
+                throw new AssertionError("unexpected", e);
             }
             assertNull(trackedPaths.put(path, new TestFileStore(fileStore, getScheme(), path)));
         }

--- a/test/framework/src/main/java/org/elasticsearch/cluster/DiskUsageIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/DiskUsageIntegTestCase.java
@@ -83,7 +83,7 @@ public class DiskUsageIntegTestCase extends ESIntegTestCase {
         try {
             Files.createDirectories(dataPath);
         } catch (IOException e) {
-            throw new AssertionError("unexpected", e);
+            fail(e);
         }
         fileSystemProvider.addTrackedPath(dataPath);
         return Settings.builder()
@@ -207,7 +207,7 @@ public class DiskUsageIntegTestCase extends ESIntegTestCase {
             try {
                 fileStore = super.getFileStore(path);
             } catch (IOException e) {
-                throw new AssertionError("unexpected", e);
+                fail(e);
             }
             assertNull(trackedPaths.put(path, new TestFileStore(fileStore, getScheme(), path)));
         }

--- a/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
@@ -2254,7 +2254,7 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
             try {
                 delegate.close();
             } catch (IOException e) {
-                throw new AssertionError("unexpected", e);
+                fail(e);
             }
         }
 

--- a/test/framework/src/main/java/org/elasticsearch/cluster/service/ClusterStateTaskExecutorUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/service/ClusterStateTaskExecutorUtils.java
@@ -19,6 +19,7 @@ import org.elasticsearch.core.Releasable;
 import java.util.function.Consumer;
 import java.util.stream.StreamSupport;
 
+import static org.elasticsearch.test.ESTestCase.fail;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
@@ -36,7 +37,7 @@ public class ClusterStateTaskExecutorUtils {
         ClusterStateTaskExecutor<T> executor,
         Iterable<T> tasks
     ) throws Exception {
-        return executeHandlingResults(originalState, executor, tasks, task -> {}, (task, e) -> { throw new AssertionError(e); });
+        return executeHandlingResults(originalState, executor, tasks, task -> {}, (task, e) -> fail(e));
     }
 
     public static <T extends ClusterStateTaskListener> ClusterState executeAndThrowFirstFailure(

--- a/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
@@ -1637,12 +1637,12 @@ public abstract class EngineTestCase extends ESTestCase {
                 && executionException.getCause() instanceof IOException ioException) {
                 throw ioException;
             } else {
-                throw new AssertionError("unexpected", e);
+                fail(e);
             }
         } catch (RuntimeException e) {
             throw e;
         } catch (Exception e) {
-            throw new AssertionError("unexpected", e);
+            fail(e);
         }
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/rest/RestResponseUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/rest/RestResponseUtils.java
@@ -11,6 +11,7 @@ package org.elasticsearch.rest;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.core.CheckedConsumer;
+import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -45,7 +46,7 @@ public class RestResponseUtils {
             out.flush();
             return out.bytes();
         } catch (Exception e) {
-            throw new AssertionError("unexpected", e);
+            return ESTestCase.fail(e);
         }
     }
 
@@ -57,7 +58,7 @@ public class RestResponseUtils {
             writer.flush();
             return writer.toString();
         } catch (Exception e) {
-            throw new AssertionError("unexpected", e);
+            return ESTestCase.fail(e);
         }
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractChunkedSerializingTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractChunkedSerializingTestCase.java
@@ -66,7 +66,7 @@ public abstract class AbstractChunkedSerializingTestCase<T extends ChunkedToXCon
                 builder.endObject();
             }
         } catch (IOException e) {
-            throw new AssertionError("unexpected", e);
+            fail(e);
         } // closing the builder verifies that the XContent is well-formed
         assertEquals(expectedChunkCount.applyAsInt(instance), chunkCount);
     }

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -2013,9 +2013,9 @@ public abstract class ESTestCase extends LuceneTestCase {
             barrier.await(10, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new AssertionError("unexpected", e);
+            fail(e);
         } catch (Exception e) {
-            throw new AssertionError("unexpected", e);
+            fail(e);
         }
     }
 
@@ -2024,7 +2024,7 @@ public abstract class ESTestCase extends LuceneTestCase {
             assertTrue(countDownLatch.await(10, TimeUnit.SECONDS));
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new AssertionError("unexpected", e);
+            fail(e);
         }
     }
 
@@ -2033,7 +2033,7 @@ public abstract class ESTestCase extends LuceneTestCase {
             Thread.sleep(millis);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new AssertionError("unexpected", e);
+            fail(e);
         }
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -1912,7 +1912,7 @@ public final class InternalTestCluster extends TestCluster {
                         new AddVotingConfigExclusionsRequest(excludedNodeNames.toArray(Strings.EMPTY_ARRAY))
                     ).get();
                 } catch (InterruptedException | ExecutionException e) {
-                    throw new AssertionError("unexpected", e);
+                    ESTestCase.fail(e);
                 }
             }
         }
@@ -1927,7 +1927,7 @@ public final class InternalTestCluster extends TestCluster {
                 Client client = getRandomNodeAndClient(node -> excludedNodeIds.contains(node.name) == false).client();
                 client.execute(ClearVotingConfigExclusionsAction.INSTANCE, new ClearVotingConfigExclusionsRequest()).get();
             } catch (InterruptedException | ExecutionException e) {
-                throw new AssertionError("unexpected", e);
+                ESTestCase.fail(e);
             }
         }
     }

--- a/test/framework/src/main/java/org/elasticsearch/test/ReachabilityChecker.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ReachabilityChecker.java
@@ -116,7 +116,7 @@ public class ReachabilityChecker {
                     assertNull(phantomReference.get()); // always succeeds, we're just doing this to use the phantomReference for something
                 }
             } catch (Exception e) {
-                throw new AssertionError("unexpected", e);
+                ESTestCase.fail(e);
             }
         }
 
@@ -128,7 +128,7 @@ public class ReachabilityChecker {
                 memoryMXBean.gc();
                 assertNull("became unreachable: " + description, referenceQueue.remove(100));
             } catch (Exception e) {
-                throw new AssertionError("unexpected", e);
+                ESTestCase.fail(e);
             }
         }
     }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/exchange/ExchangeBufferTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/exchange/ExchangeBufferTests.java
@@ -21,7 +21,6 @@ import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -38,11 +37,7 @@ public class ExchangeBufferTests extends ESTestCase {
         AtomicInteger addedPages = new AtomicInteger();
         for (int t = 0; t < producers.length; t++) {
             producers[t] = new Thread(() -> {
-                try {
-                    latch.await(10, TimeUnit.SECONDS);
-                } catch (InterruptedException e) {
-                    throw new AssertionError(e);
-                }
+                safeAwait(latch);
                 while (stopped.get() == false && addedPages.incrementAndGet() < 10_000) {
                     buffer.addPage(randomPage(blockFactory));
                 }

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/SearchableSnapshotsBlobStoreCacheIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/SearchableSnapshotsBlobStoreCacheIntegTests.java
@@ -360,7 +360,7 @@ public class SearchableSnapshotsBlobStoreCacheIntegTests extends BaseFrozenSearc
             assertThat(refreshResponse.getSuccessfulShards(), greaterThan(0));
             assertThat(refreshResponse.getFailedShards(), equalTo(0));
         } catch (IndexNotFoundException indexNotFoundException) {
-            throw new AssertionError("unexpected", indexNotFoundException);
+            fail(indexNotFoundException);
         }
     }
 

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/SearchableSnapshotsBlobStoreCacheMaintenanceIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/SearchableSnapshotsBlobStoreCacheMaintenanceIntegTests.java
@@ -335,7 +335,7 @@ public class SearchableSnapshotsBlobStoreCacheMaintenanceIntegTests extends Base
             assertThat(refreshResponse.getSuccessfulShards(), failIfNotExist ? greaterThan(0) : greaterThanOrEqualTo(0));
             assertThat(refreshResponse.getFailedShards(), equalTo(0));
         } catch (IndexNotFoundException indexNotFoundException) {
-            throw new AssertionError("unexpected", indexNotFoundException);
+            fail(indexNotFoundException);
         }
     }
 

--- a/x-pack/plugin/snapshot-based-recoveries/src/internalClusterTest/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/SnapshotBasedIndexRecoveryIT.java
+++ b/x-pack/plugin/snapshot-based-recoveries/src/internalClusterTest/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/SnapshotBasedIndexRecoveryIT.java
@@ -716,7 +716,7 @@ public class SnapshotBasedIndexRecoveryIT extends AbstractSnapshotIntegTestCase 
                                         try {
                                             channel.sendResponse(exception);
                                         } catch (IOException e) {
-                                            throw new AssertionError("unexpected", e);
+                                            fail(e);
                                         }
                                     });
                                 }


### PR DESCRIPTION
Replaces them with calls to `fail(e)` or an `assertNoFailureListener` as
appropriate.