### PR TITLE
[DOCS] One more round of cleaning up ES|QL release notes

### DIFF
--- a/docs/changelog/100238.yaml
+++ b/docs/changelog/100238.yaml
@@ -1,5 +1,5 @@
 pr: 100238
-summary: "ESQL: Remove aliasing inside Eval"
+summary: "Remove aliasing inside Eval"
 area: ES|QL
 type: bug
 issues:

--- a/docs/changelog/100351.yaml
+++ b/docs/changelog/100351.yaml
@@ -1,5 +1,5 @@
 pr: 100351
-summary: "ESQL: support metric tsdb fields while querying index patterns"
+summary: "support metric tsdb fields while querying index patterns"
 area: ES|QL
 type: bug
 issues:

--- a/docs/changelog/100360.yaml
+++ b/docs/changelog/100360.yaml
@@ -1,5 +1,5 @@
 pr: 100360
-summary: "ESQL: Limit how many bytes `concat()` can process"
+summary: "Limit how many bytes `concat()` can process"
 area: ES|QL
 type: bug
 issues: []

--- a/docs/changelog/100370.yaml
+++ b/docs/changelog/100370.yaml
@@ -1,5 +1,5 @@
 pr: 100370
-summary: "ESQL: Page shouldn't close a block twice"
+summary: "Page shouldn't close a block twice"
 area: ES|QL
 type: bug
 issues:

--- a/docs/changelog/100377.yaml
+++ b/docs/changelog/100377.yaml
@@ -1,5 +1,5 @@
 pr: 100377
-summary: "ESQL: Add identity check in Block equality"
+summary: "Add identity check in Block equality"
 area: ES|QL
 type: bug
 issues:

--- a/docs/changelog/100645.yaml
+++ b/docs/changelog/100645.yaml
@@ -1,5 +1,5 @@
 pr: 100645
-summary: "ESQL: Graceful handling of non-bool condition in the filter"
+summary: "Graceful handling of non-bool condition in the filter"
 area: ES|QL
 type: bug
 issues:

--- a/docs/changelog/100647.yaml
+++ b/docs/changelog/100647.yaml
@@ -1,5 +1,5 @@
 pr: 100647
-summary: "ESQL: Handle queries with non-existing enrich policies and no field"
+summary: "Handle queries with non-existing enrich policies and no field"
 area: ES|QL
 type: bug
 issues:

--- a/docs/changelog/100650.yaml
+++ b/docs/changelog/100650.yaml
@@ -1,5 +1,5 @@
 pr: 100650
-summary: "ESQL: Improve verifier error for incorrect agg declaration"
+summary: "Improve verifier error for incorrect agg declaration"
 area: ES|QL
 type: bug
 issues:

--- a/docs/changelog/100656.yaml
+++ b/docs/changelog/100656.yaml
@@ -1,5 +1,5 @@
 pr: 100656
-summary: "ESQL: fix non-null value being returned for unsupported data types in `ValueSources`"
+summary: "Fix non-null value being returned for unsupported data types in `ValueSources`"
 area: ES|QL
 type: bug
 issues:

--- a/docs/changelog/100766.yaml
+++ b/docs/changelog/100766.yaml
@@ -1,5 +1,5 @@
 pr: 100766
-summary: "ESQL: Properly handle multi-values in fold() and date math"
+summary: "Properly handle multi-values in fold() and date math"
 area: ES|QL
 type: bug
 issues:

--- a/docs/changelog/100782.yaml
+++ b/docs/changelog/100782.yaml
@@ -1,5 +1,5 @@
 pr: 100782
-summary: "ESQL: `mv_expand` pushes down limit and project and keep the limit after\
+summary: "`mv_expand` pushes down limit and project and keep the limit after\
   \ it untouched"
 area: ES|QL
 type: bug

--- a/docs/changelog/100866.yaml
+++ b/docs/changelog/100866.yaml
@@ -1,5 +1,5 @@
 pr: 100866
-summary: "ESQL: Preserve intermediate aggregation output in local relation"
+summary: "Preserve intermediate aggregation output in local relation"
 area: ES|QL
 type: bug
 issues:

--- a/docs/changelog/101001.yaml
+++ b/docs/changelog/101001.yaml
@@ -1,5 +1,5 @@
 pr: 101001
-summary: "ESQL: Support date and time intervals as input params"
+summary: "Support date and time intervals as input params"
 area: ES|QL
 type: bug
 issues:

--- a/docs/changelog/101120.yaml
+++ b/docs/changelog/101120.yaml
@@ -1,5 +1,5 @@
 pr: 101120
-summary: "ESQL: Fix escaping of backslash in LIKE operator"
+summary: "Fix escaping of backslash in LIKE operator"
 area: ES|QL
 type: bug
 issues:

--- a/docs/changelog/101362.yaml
+++ b/docs/changelog/101362.yaml
@@ -1,5 +1,5 @@
 pr: 101362
-summary: "ESQL: Remove the swapped-args check for date_xxx()"
+summary: "Remove the swapped-args check for date_xxx()"
 area: ES|QL
 type: enhancement
 issues:

--- a/docs/changelog/101438.yaml
+++ b/docs/changelog/101438.yaml
@@ -1,5 +1,5 @@
 pr: 101438
-summary: "ESQL: Fix eval of functions on foldable literals"
+summary: "Fix eval of functions on foldable literals"
 area: ES|QL
 type: bug
 issues:

--- a/docs/changelog/101456.yaml
+++ b/docs/changelog/101456.yaml
@@ -1,5 +1,5 @@
 pr: 101456
-summary: "ESQL: adds Enrich implicit `match_fields` to `field_caps` call"
+summary: "Adds Enrich implicit `match_fields` to `field_caps` call"
 area: ES|QL
 type: bug
 issues:

--- a/docs/changelog/99827.yaml
+++ b/docs/changelog/99827.yaml
@@ -1,5 +1,5 @@
 pr: 99827
-summary: "ESQL: Fix NPE when aggregating literals"
+summary: "Fix NPE when aggregating literals"
 area: ES|QL
 type: bug
 issues: []


### PR DESCRIPTION
One more round of cleaning up the 8.11 release notes by removing references to "ESQL" without a "|".