### PR TITLE
Avoid `shallowSizeOfInstance` in closure

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockRamUsageEstimator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockRamUsageEstimator.java
@@ -14,6 +14,8 @@ import java.util.BitSet;
 
 public final class BlockRamUsageEstimator {
 
+    private static final long BITSET_BASE_RAM_USAGE = RamUsageEstimator.shallowSizeOfInstance(BitSet.class);
+
     /** Returns the size in bytes of the int[] object. Otherwise, returns 0 if null. */
     public static long sizeOf(@Nullable int[] arr) {
         return arr == null ? 0 : RamUsageEstimator.sizeOf(arr);
@@ -21,6 +23,6 @@ public final class BlockRamUsageEstimator {
 
     /** Returns the size in bytes used by the bitset. Otherwise, returns 0 if null. Not exact, but good enough */
     public static long sizeOfBitSet(@Nullable BitSet bitset) {
-        return bitset == null ? 0 : RamUsageEstimator.shallowSizeOfInstance(BitSet.class) + (bitset.size() / Byte.SIZE);
+        return bitset == null ? 0 : BITSET_BASE_RAM_USAGE + (bitset.size() / Byte.SIZE);
     }
 }


### PR DESCRIPTION
```
  2> "pool-409-thread-5" ID=2115 RUNNABLE
  2> 	at java.base@21.0.1/java.security.AccessController.getStackAccessControlContext(Native Method)
  2> 	at java.base@21.0.1/java.security.AccessController.isPrivileged(AccessController.java:754)
  2> 	at java.base@21.0.1/java.security.AccessController.executePrivileged(AccessController.java:777)
  2> 	at java.base@21.0.1/java.security.AccessController.doPrivileged(AccessController.java:319)
  2> 	at app//org.apache.lucene.util.RamUsageEstimator.shallowSizeOfInstance(RamUsageEstimator.java:598)
  2> 	at app//org.elasticsearch.compute.data.BlockRamUsageEstimator.sizeOfBitSet(BlockRamUsageEstimator.java:24)
  2> 	at app//org.elasticsearch.compute.data.BytesRefArrayBlock.ramBytesEstimated(BytesRefArrayBlock.java:108)
  2> 	at app//org.elasticsearch.compute.data.BytesRefArrayBlock.ramBytesUsed(BytesRefArrayBlock.java:113)
  2> 	at app//org.elasticsearch.compute.data.BytesRefArrayBlock.close(BytesRefArrayBlock.java:147)
  2> 	at app//org.elasticsearch.compute.data.Block$Ref.close(Block.java:250)
  2> 	at app//org.elasticsearch.xpack.esql.expression.function.AbstractFunctionTestCase.lambda$testEvaluateInManyThreads$1(AbstractFunctionTestCase.java:446)
  2> 	at app//org.elasticsearch.xpack.esql.expression.function.AbstractFunctionTestCase$$Lambda/0x000000313d602f28.run(Unknown Source)
  2> 	at java.base@21.0.1/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
  2> 	at java.base@21.0.1/java.util.concurrent.FutureTask.run(FutureTask.java:317)
  2> 	at java.base@21.0.1/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
  2> 	at java.base@21.0.1/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
  2> 	at java.base@21.0.1/java.lang.Thread.runWith(Thread.java:1596)
  2> 	at java.base@21.0.1/java.lang.Thread.run(Thread.java:1583)

```

The test failure relates to the security manager, and this PR calculates the base RAM usage of BitSet statically, similar to other instances.

Closes #101502