### PR TITLE
[8.9] Add docs on constant_score_blended rewrite (#101494)

### DIFF
--- a/docs/reference/query-dsl/fuzzy-query.asciidoc
+++ b/docs/reference/query-dsl/fuzzy-query.asciidoc
@@ -54,7 +54,7 @@ GET /_search
         "max_expansions": 50,
         "prefix_length": 0,
         "transpositions": true,
-        "rewrite": "constant_score"
+        "rewrite": "constant_score_blended"
       }
     }
   }

--- a/docs/reference/query-dsl/multi-term-rewrite.asciidoc
+++ b/docs/reference/query-dsl/multi-term-rewrite.asciidoc
@@ -29,7 +29,19 @@ query or bit set
 [[rewrite-param-valid-values]]
 === Valid values
 
-`constant_score` (Default)::
+`constant_score_blended` (Default)::
+Assigns each document a relevance score equal to the `boost`
+parameter.
++
+This method maintains a <<query-dsl-bool-query, `bool`
+query>> like implementation over the most costly terms while pre-processing
+the less costly terms into a filter bitset.
++
+This method can cause the generated `bool` query to exceed the clause limit in the
+<<indices-query-bool-max-clause-count, `indices.query.bool.max_clause_count`>>
+setting. If the query exceeds this limit, {es} returns an error.
+
+`constant_score` ::
 Uses the `constant_score_boolean` method for fewer matching terms. Otherwise,
 this method finds all matching terms in sequence and returns matching documents
 using a bit set.
@@ -102,7 +114,7 @@ setting.
 [discrete]
 [[rewrite-param-perf-considerations]]
 === Performance considerations for the `rewrite` parameter
-For most uses, we recommend using the `constant_score`,
+For most uses, we recommend using the  `constant_score_blended`, `constant_score`,
 `constant_score_boolean`, or `top_terms_boost_N` rewrite methods.
 
 Other methods calculate relevance scores. These score calculations are often

--- a/docs/reference/query-dsl/regexp-query.asciidoc
+++ b/docs/reference/query-dsl/regexp-query.asciidoc
@@ -30,7 +30,7 @@ GET /_search
         "flags": "ALL",
         "case_insensitive": true,
         "max_determinized_states": 10000,
-        "rewrite": "constant_score"
+        "rewrite": "constant_score_blended"
       }
     }
   }

--- a/docs/reference/query-dsl/wildcard-query.asciidoc
+++ b/docs/reference/query-dsl/wildcard-query.asciidoc
@@ -26,7 +26,7 @@ GET /_search
       "user.id": {
         "value": "ki*y",
         "boost": 1.0,
-        "rewrite": "constant_score"
+        "rewrite": "constant_score_blended"
       }
     }
   }


### PR DESCRIPTION
Backports the following commits to 8.9:
 - Add docs on constant_score_blended rewrite (#101494)