### PR TITLE
[8.11] ESQL: check type before casting (#101492)

### DIFF
--- a/docs/changelog/101492.yaml
+++ b/docs/changelog/101492.yaml
@@ -1,0 +1,6 @@
+pr: 101492
+summary: "ESQL: check type before casting"
+area: ES|QL
+type: bug
+issues:
+ - 101489

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/index/IndexResolver.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/index/IndexResolver.java
@@ -750,6 +750,7 @@ public class IndexResolver {
                         String indexName = indexNameProcessor.apply(index);
                         Fields indexFields = indices.computeIfAbsent(indexName, k -> new Fields());
                         EsField field = indexFields.flattedMapping.get(fieldName);
+                        // create field hierarchy or update it in case of an invalid field
                         if (field == null || (invalidField != null && (field instanceof InvalidMappedField) == false)) {
                             createField(typeRegistry, fieldName, indexFields, fieldCaps, invalidField, typeCap);
 
@@ -766,9 +767,8 @@ public class IndexResolver {
                             // Postpone the call until is really needed
                             if (fieldUpdater != null && field != null) {
                                 EsField newField = indexFields.flattedMapping.get(fieldName);
-
-                                if (newField != field) {
-                                    fieldUpdater.accept(field, (InvalidMappedField) newField);
+                                if (newField != field && newField instanceof InvalidMappedField newInvalidField) {
+                                    fieldUpdater.accept(field, newInvalidField);
                                 }
                             }
                         }

--- a/x-pack/plugin/ql/src/test/resources/fc-unsupported-object-compatible-subfields.json
+++ b/x-pack/plugin/ql/src/test/resources/fc-unsupported-object-compatible-subfields.json
@@ -1,0 +1,48 @@
+{
+  "indices": [
+    "index-1",
+    "index-2"
+  ],
+  "fields": {
+    "file": {
+      "unknown": {
+        "type": "unknown",
+        "metadata_field": false,
+        "searchable": false,
+        "aggregatable": false,
+        "indices": [
+          "index-2"
+        ]
+      },
+      "object": {
+        "type": "object",
+        "metadata_field": false,
+        "searchable": false,
+        "aggregatable": false,
+        "indices": [
+          "index-1"
+        ]
+      }
+    },
+    "file.name": {
+      "keyword": {
+        "type": "keyword",
+        "metadata_field": false,
+        "searchable": true,
+        "aggregatable": true,
+        "indices": [
+          "index-1"
+        ]
+      },
+      "unmapped": {
+        "type": "unmapped",
+        "metadata_field": false,
+        "searchable": false,
+        "aggregatable": false,
+        "indices": [
+          "index-2"
+        ]
+      }
+    }
+  }
+}

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/index/IndexResolverTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/index/IndexResolverTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.xpack.ql.type.DataType;
 import org.elasticsearch.xpack.ql.type.EsField;
 import org.elasticsearch.xpack.ql.type.InvalidMappedField;
 import org.elasticsearch.xpack.ql.type.KeywordEsField;
+import org.elasticsearch.xpack.ql.type.UnsupportedEsField;
 import org.elasticsearch.xpack.sql.type.SqlDataTypeRegistry;
 
 import java.io.IOException;
@@ -431,6 +432,35 @@ public class IndexResolverTests extends ESTestCase {
         assertNotNull(esField);
         assertEquals(esField.getDataType(), KEYWORD);
         assertEquals(KeywordEsField.class, esField.getClass());
+    }
+
+    public void testMergeObjectUnsupportedTypes() throws Exception {
+        var response = readFieldCapsResponse("fc-unsupported-object-compatible-subfields.json");
+
+        IndexResolution resolution = IndexResolver.mergedMappings(
+            SqlDataTypeRegistry.INSTANCE,
+            "*",
+            response,
+            (fieldName, types) -> null,
+            IndexResolver.PRESERVE_PROPERTIES
+
+        );
+
+        assertTrue(resolution.isValid());
+        EsIndex esIndex = resolution.get();
+        assertEquals(Set.of("index-1", "index-2"), esIndex.concreteIndices());
+        EsField esField = esIndex.mapping().get("file");
+        assertEquals(InvalidMappedField.class, esField.getClass());
+
+        assertEquals(
+            "mapped as [2] incompatible types: [unknown] in [index-2], [object] in [index-1]",
+            ((InvalidMappedField) esField).errorMessage()
+        );
+
+        esField = esField.getProperties().get("name");
+        assertNotNull(esField);
+        assertEquals(esField.getDataType(), UNSUPPORTED);
+        assertEquals(UnsupportedEsField.class, esField.getClass());
     }
 
     private static FieldCapabilitiesResponse readFieldCapsResponse(String resourceName) throws IOException {


### PR DESCRIPTION
Backports the following commits to 8.11:
 - ESQL: check type before casting (#101492)