### PR TITLE
[8.9] Clarify that duplicate _name values for queries in the same request is undefined (#101523)

### DIFF
--- a/docs/reference/query-dsl/bool-query.asciidoc
+++ b/docs/reference/query-dsl/bool-query.asciidoc
@@ -149,6 +149,9 @@ Each query accepts a `_name` in its top level definition. You can use named
 queries to track which queries matched returned documents. If named queries are
 used, the response includes a `matched_queries` property for each hit.
 
+NOTE: Supplying duplicate `_name` values in the same request results in undefined behavior. Queries with duplicate names may overwrite
+each other. Query names are assumed to be unique within a single request.
+
 [source,console]
 ----
 GET /_search


### PR DESCRIPTION
Backports the following commits to 8.9:
 - Clarify that duplicate _name values for queries in the same request is undefined (#101523)