### PR TITLE
Drop very old version checks from enrich

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/action/EnrichStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/action/EnrichStatsAction.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.core.enrich.action;
 
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
@@ -62,7 +61,7 @@ public class EnrichStatsAction extends ActionType<EnrichStatsAction.Response> {
             super(in);
             executingPolicies = in.readCollectionAsList(ExecutingPolicy::new);
             coordinatorStats = in.readCollectionAsList(CoordinatorStats::new);
-            cacheStats = in.getTransportVersion().onOrAfter(TransportVersions.V_7_16_0) ? in.readCollectionAsList(CacheStats::new) : null;
+            cacheStats = in.readCollectionAsList(CacheStats::new);
         }
 
         public List<ExecutingPolicy> getExecutingPolicies() {
@@ -81,9 +80,7 @@ public class EnrichStatsAction extends ActionType<EnrichStatsAction.Response> {
         public void writeTo(StreamOutput out) throws IOException {
             out.writeCollection(executingPolicies);
             out.writeCollection(coordinatorStats);
-            if (out.getTransportVersion().onOrAfter(TransportVersions.V_7_16_0)) {
-                out.writeCollection(cacheStats);
-            }
+            out.writeCollection(cacheStats);
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/action/ExecuteEnrichPolicyStatus.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/action/ExecuteEnrichPolicyStatus.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.core.enrich.action;
 
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.tasks.Task;
@@ -46,7 +45,7 @@ public class ExecuteEnrichPolicyStatus implements Task.Status {
 
     public ExecuteEnrichPolicyStatus(StreamInput in) throws IOException {
         this.phase = in.readString();
-        this.step = in.getTransportVersion().onOrAfter(TransportVersions.V_7_16_0) ? in.readOptionalString() : null;
+        this.step = in.readOptionalString();
     }
 
     public String getPhase() {
@@ -69,9 +68,7 @@ public class ExecuteEnrichPolicyStatus implements Task.Status {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(phase);
-        if (out.getTransportVersion().onOrAfter(TransportVersions.V_7_16_0)) {
-            out.writeOptionalString(step);
-        }
+        out.writeOptionalString(step);
     }
 
     @Override

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/EnrichCoordinatorStatsAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/EnrichCoordinatorStatsAction.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.enrich.action;
 
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.support.ActionFilters;
@@ -98,9 +97,7 @@ public class EnrichCoordinatorStatsAction extends ActionType<EnrichCoordinatorSt
 
         NodeResponse(StreamInput in) throws IOException {
             super(in);
-            this.cacheStats = in.getTransportVersion().onOrAfter(TransportVersions.V_7_16_0)
-                ? new EnrichStatsAction.Response.CacheStats(in)
-                : null;
+            this.cacheStats = new EnrichStatsAction.Response.CacheStats(in);
             this.coordinatorStats = new CoordinatorStats(in);
         }
 
@@ -115,9 +112,7 @@ public class EnrichCoordinatorStatsAction extends ActionType<EnrichCoordinatorSt
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
-            if (out.getTransportVersion().onOrAfter(TransportVersions.V_7_16_0)) {
-                cacheStats.writeTo(out);
-            }
+            cacheStats.writeTo(out);
             coordinatorStats.writeTo(out);
         }
     }


### PR DESCRIPTION
Just tidying up some code. Now that we're on 8.x, these pre-7.17 version checks are irrelevant.