### PR TITLE
[8.10] [ci] Migrate third-party tests fully to Buildkite (#101562)

### DIFF
--- a/.ci/jobs.t/elastic+elasticsearch+periodic+third-party-tests.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+periodic+third-party-tests.yml
@@ -2,7 +2,8 @@
 - job:
     name: elastic+elasticsearch+%BRANCH%+periodic+third-party-tests
     display-name: "elastic / elasticsearch # %BRANCH% - third party tests"
-    description: "Testing of the Elasticsearch %BRANCH% branch against third-party service integrations.\n"
+    description: "This job has been migrated to Buildkite.\n"
+    disabled: true
     project-type: multijob
     node: master
     vault: []

--- a/.ci/jobs.t/elastic+elasticsearch+periodic+thrid-party-tests-trigger.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+periodic+thrid-party-tests-trigger.yml
@@ -1,6 +1,0 @@
----
-jjbb-template: periodic-trigger-lgc.yml
-vars:
-  - periodic-job: elastic+elasticsearch+%BRANCH%+periodic+third-party-tests
-  - lgc-job: elastic+elasticsearch+%BRANCH%+intake
-  - cron: "H H * * *"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.10`:
 - [[ci] Migrate third-party tests fully to Buildkite (#101562)](https://github.com/elastic/elasticsearch/pull/101562)

<!--- Backport version: 9.2.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)