### PR TITLE
[8.11] Avoid `shallowSizeOfInstance` in closure (#101534)

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockRamUsageEstimator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockRamUsageEstimator.java
@@ -14,6 +14,8 @@ import java.util.BitSet;
 
 public final class BlockRamUsageEstimator {
 
+    private static final long BITSET_BASE_RAM_USAGE = RamUsageEstimator.shallowSizeOfInstance(BitSet.class);
+
     /** Returns the size in bytes of the int[] object. Otherwise, returns 0 if null. */
     public static long sizeOf(@Nullable int[] arr) {
         return arr == null ? 0 : RamUsageEstimator.sizeOf(arr);
@@ -21,6 +23,6 @@ public final class BlockRamUsageEstimator {
 
     /** Returns the size in bytes used by the bitset. Otherwise, returns 0 if null. Not exact, but good enough */
     public static long sizeOfBitSet(@Nullable BitSet bitset) {
-        return bitset == null ? 0 : RamUsageEstimator.shallowSizeOfInstance(BitSet.class) + (bitset.size() / Byte.SIZE);
+        return bitset == null ? 0 : BITSET_BASE_RAM_USAGE + (bitset.size() / Byte.SIZE);
     }
 }


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Avoid `shallowSizeOfInstance` in closure (#101534)