### PR TITLE
Drop very old version check from this ClusterStateRequestTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequestTests.java
@@ -41,14 +41,11 @@ public class ClusterStateRequestTests extends ESTestCase {
                 TransportVersions.MINIMUM_COMPATIBLE,
                 TransportVersion.current()
             );
-            // TODO: change version to V_6_6_0 after backporting:
-            if (testVersion.onOrAfter(TransportVersions.V_7_0_0)) {
-                if (randomBoolean()) {
-                    clusterStateRequest.waitForMetadataVersion(randomLongBetween(1, Long.MAX_VALUE));
-                }
-                if (randomBoolean()) {
-                    clusterStateRequest.waitForTimeout(new TimeValue(randomNonNegativeLong()));
-                }
+            if (randomBoolean()) {
+                clusterStateRequest.waitForMetadataVersion(randomLongBetween(1, Long.MAX_VALUE));
+            }
+            if (randomBoolean()) {
+                clusterStateRequest.waitForTimeout(new TimeValue(randomNonNegativeLong()));
             }
 
             BytesStreamOutput output = new BytesStreamOutput();


### PR DESCRIPTION
#35535 added this version check, but given the definition of `TransportVersion testVersion` above it, I don't think the conditional is necessary anymore these days -- it's just always on-or-after 7.0.0.

A false positive grep hit on the `V_6` in the comment led me here, and I figured it was easy enough to just fix the code and drop the comment.