### PR TITLE
Add logging of errors in _msearch and msearch template

### DIFF
--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/TransportMultiSearchTemplateAction.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/TransportMultiSearchTemplateAction.java
@@ -86,14 +86,7 @@ public class TransportMultiSearchTemplateAction extends HandledTransportAction<M
             } catch (Exception e) {
                 items[i] = new MultiSearchTemplateResponse.Item(null, e);
                 if (ExceptionsHelper.status(e).getStatus() >= 500 && ExceptionsHelper.isNodeOrShardUnavailableTypeException(e) == false) {
-                    try {
-                        String requestInfo = Strings.toString(
-                            searchTemplateRequest.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS)
-                        );
-                        logger.warn("MultiSearchTemplate convert failure for request " + requestInfo, e);
-                    } catch (IOException ex) {
-                        logger.warn("MultiSearchTemplate convert failure for request (unable to convert request to JSON)" + ex, e);
-                    }
+                    logger.warn("MultiSearchTemplate convert failure for request " + Strings.toString(searchTemplateRequest), e);
                 }
                 continue;
             }

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/TransportMultiSearchTemplateAction.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/TransportMultiSearchTemplateAction.java
@@ -8,6 +8,9 @@
 
 package org.elasticsearch.script.mustache;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.MultiSearchRequest;
 import org.elasticsearch.action.search.MultiSearchResponse;
@@ -30,6 +33,8 @@ import java.util.List;
 import static org.elasticsearch.script.mustache.TransportSearchTemplateAction.convert;
 
 public class TransportMultiSearchTemplateAction extends HandledTransportAction<MultiSearchTemplateRequest, MultiSearchTemplateResponse> {
+
+    private static final Logger logger = LogManager.getLogger(TransportMultiSearchTemplateAction.class);
 
     private final ScriptService scriptService;
     private final NamedXContentRegistry xContentRegistry;
@@ -76,6 +81,9 @@ public class TransportMultiSearchTemplateAction extends HandledTransportAction<M
                 searchRequest = convert(searchTemplateRequest, searchTemplateResponse, scriptService, xContentRegistry, searchUsageHolder);
             } catch (Exception e) {
                 items[i] = new MultiSearchTemplateResponse.Item(null, e);
+                if (ExceptionsHelper.status(e).getStatus() > 500 && ExceptionsHelper.isNodeOrShardUnavailableTypeException(e) == false) {
+                    logger.warn("MultiSearchTemplate convert failure for request " + request, e);
+                }
                 continue;
             }
             items[i] = new MultiSearchTemplateResponse.Item(searchTemplateResponse, null);

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/TransportMultiSearchTemplateAction.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/TransportMultiSearchTemplateAction.java
@@ -18,7 +18,6 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.client.internal.node.NodeClient;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.script.ScriptService;
@@ -27,10 +26,7 @@ import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.usage.SearchUsageHolder;
 import org.elasticsearch.usage.UsageService;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
-import org.elasticsearch.xcontent.ToXContent;
-import org.elasticsearch.xcontent.XContentFactory;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -86,7 +82,7 @@ public class TransportMultiSearchTemplateAction extends HandledTransportAction<M
             } catch (Exception e) {
                 items[i] = new MultiSearchTemplateResponse.Item(null, e);
                 if (ExceptionsHelper.status(e).getStatus() >= 500 && ExceptionsHelper.isNodeOrShardUnavailableTypeException(e) == false) {
-                    logger.warn("MultiSearchTemplate convert failure for request " + Strings.toString(searchTemplateRequest), e);
+                    logger.warn("MultiSearchTemplate convert failure", e);
                 }
                 continue;
             }

--- a/server/src/main/java/org/elasticsearch/action/search/TransportMultiSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportMultiSearchAction.java
@@ -160,7 +160,7 @@ public class TransportMultiSearchAction extends HandledTransportAction<MultiSear
             @Override
             public void onFailure(final Exception e) {
                 if (ExceptionsHelper.status(e).getStatus() >= 500 && ExceptionsHelper.isNodeOrShardUnavailableTypeException(e) == false) {
-                    logger.warn("TransportMultiSearchAction failure for request " + request.request, e);
+                    logger.warn("TransportMultiSearchAction failure", e);
                 }
                 handleResponse(request.responseSlot, new MultiSearchResponse.Item(null, e));
             }

--- a/server/src/main/java/org/elasticsearch/action/search/TransportMultiSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportMultiSearchAction.java
@@ -8,6 +8,9 @@
 
 package org.elasticsearch.action.search;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
@@ -31,6 +34,7 @@ import java.util.function.LongSupplier;
 
 public class TransportMultiSearchAction extends HandledTransportAction<MultiSearchRequest, MultiSearchResponse> {
 
+    private static final Logger logger = LogManager.getLogger(TransportMultiSearchAction.class);
     private final int allocatedProcessors;
     private final ThreadPool threadPool;
     private final ClusterService clusterService;
@@ -155,6 +159,9 @@ public class TransportMultiSearchAction extends HandledTransportAction<MultiSear
 
             @Override
             public void onFailure(final Exception e) {
+                if (ExceptionsHelper.status(e).getStatus() >= 500 && ExceptionsHelper.isNodeOrShardUnavailableTypeException(e) == false) {
+                    logger.warn("TransportMultiSearchAction failure for request " + request.request, e);
+                }
                 handleResponse(request.responseSlot, new MultiSearchResponse.Item(null, e));
             }
 


### PR DESCRIPTION
Even when msearch and msearch template endpoints return partial
results, log errors that would normally count as "5xx" system errors
at WARN level to detect issues with Elasticsearch.