### PR TITLE
EQL doc wrong description in query example

### DIFF
--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -243,7 +243,7 @@ my_field like  ("Value-*", "VALUE2", "VAL?")              // case-sensitive
 my_field like~ ("value-*", "value2", "val?")              // case-insensitive
 
 my_field regex  ("[vV]alue-[0-9]", "VALUE[^2].?", "VAL3") // case-sensitive
-my_field regex~  ("value-[0-9]", "value[^2].?", "val3")   // case-sensitive
+my_field regex~  ("value-[0-9]", "value[^2].?", "val3")   // case-insensitive
 ----
 
 `in` (case-sensitive)::


### PR DESCRIPTION
This PR fix the wrong description on the example query. Query  example regex match insensitive
