### PR TITLE
[CI] Mute Failing tests in HeapAttackIT  (#100900)

### DIFF
--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/HeapAttackIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/HeapAttackIT.java
@@ -112,6 +112,7 @@ public class HeapAttackIT extends ESRestTestCase {
     /**
      * This groups on 5000 columns which used to throw a {@link StackOverflowError}.
      */
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/100640")
     public void testGroupOnManyLongs() throws IOException {
         initManyLongs();
         Map<?, ?> map = XContentHelper.convertToMap(


### PR DESCRIPTION
Mute `testGroupOnManyLongs()` like in https://github.com/elastic/elasticsearch/pull/100900.