### PR TITLE
[8.11] Mute MedianAbsoluteDeviationDoubleGroupingAggregatorFunctionTests testMulitvaluedNullGroup (#101581)

### DIFF
--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/GroupingAggregatorFunctionTestCase.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/GroupingAggregatorFunctionTestCase.java
@@ -309,7 +309,7 @@ public abstract class GroupingAggregatorFunctionTestCase extends ForkingOperator
         assertSimpleOutput(origInput, results);
     }
 
-    public final void testMulitvaluedNullGroup() {
+    public void testMulitvaluedNullGroup() {
         DriverContext driverContext = driverContext();
         BlockFactory blockFactory = driverContext.blockFactory();
         int end = between(1, 2);  // TODO revert

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleGroupingAggregatorFunctionTests.java
@@ -79,4 +79,9 @@ public class MedianAbsoluteDeviationDoubleGroupingAggregatorFunctionTests extend
         int c = data.length / 2;
         return data.length % 2 == 0 ? (data[c - 1] + data[c]) / 2 : data[c];
     }
+
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/101569")
+    public void testMulitvaluedNullGroup() {
+        // only here for muting it
+    }
 }


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Mute MedianAbsoluteDeviationDoubleGroupingAggregatorFunctionTests testMulitvaluedNullGroup (#101581)