### PR TITLE
Unmute RestClientMultipleHostsIntegTests.testCancelAsyncRequests

### DIFF
--- a/client/rest/src/test/java/org/elasticsearch/client/RestClientMultipleHostsIntegTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/RestClientMultipleHostsIntegTests.java
@@ -258,7 +258,6 @@ public class RestClientMultipleHostsIntegTests extends RestClientTestCase {
         }
     }
 
-    @Ignore("https://github.com/elastic/elasticsearch/issues/45577")
     public void testCancelAsyncRequests() throws Exception {
         int numRequests = randomIntBetween(5, 20);
         final List<Response> responses = new CopyOnWriteArrayList<>();


### PR DESCRIPTION
The underlying issue is closed, so either this test should be running correctly now, is still failing for valid reasons or can be removed. Either way we need to enable it to see.

