### PR TITLE
[8.11] Unmute RestClientMultipleHostsIntegTests.testCancelAsyncRequests (#101592)

### DIFF
--- a/client/rest/src/test/java/org/elasticsearch/client/RestClientMultipleHostsIntegTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/RestClientMultipleHostsIntegTests.java
@@ -258,7 +258,6 @@ public class RestClientMultipleHostsIntegTests extends RestClientTestCase {
         }
     }
 
-    @Ignore("https://github.com/elastic/elasticsearch/issues/45577")
     public void testCancelAsyncRequests() throws Exception {
         int numRequests = randomIntBetween(5, 20);
         final List<Response> responses = new CopyOnWriteArrayList<>();


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Unmute RestClientMultipleHostsIntegTests.testCancelAsyncRequests (#101592)