### PR TITLE
Miscellaneous tidying towards removing the HLRC

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
@@ -257,7 +257,7 @@ public class RestHighLevelClient implements Closeable {
      * The consumer argument allows to control what needs to be done when the {@link #close()} method is called.
      * Also subclasses can provide parsers for custom response sections added to Elasticsearch through plugins.
      */
-    protected RestHighLevelClient(
+    private RestHighLevelClient(
         RestClient restClient,
         CheckedConsumer<RestClient, IOException> doClose,
         List<NamedXContentRegistry.Entry> namedXContentEntries,
@@ -402,7 +402,7 @@ public class RestHighLevelClient implements Closeable {
      * layer has been added to the ReST client, and requests should extend {@link Validatable} instead of {@link ActionRequest}.
      */
     @Deprecated
-    protected final <Req extends ActionRequest, Resp> Resp performRequestAndParseEntity(
+    private <Req extends ActionRequest, Resp> Resp performRequestAndParseEntity(
         Req request,
         CheckedFunction<Req, Request, IOException> requestConverter,
         RequestOptions options,
@@ -417,7 +417,7 @@ public class RestHighLevelClient implements Closeable {
      * layer has been added to the ReST client, and requests should extend {@link Validatable} instead of {@link ActionRequest}.
      */
     @Deprecated
-    protected final <Req extends ActionRequest, Resp> Resp performRequest(
+    private <Req extends ActionRequest, Resp> Resp performRequest(
         Req request,
         CheckedFunction<Req, Request, IOException> requestConverter,
         RequestOptions options,
@@ -474,7 +474,7 @@ public class RestHighLevelClient implements Closeable {
      * @return Cancellable instance that may be used to cancel the request
      */
     @Deprecated
-    protected final <Req extends ActionRequest, Resp> Cancellable performRequestAsyncAndParseEntity(
+    private <Req extends ActionRequest, Resp> Cancellable performRequestAsyncAndParseEntity(
         Req request,
         CheckedFunction<Req, Request, IOException> requestConverter,
         RequestOptions options,
@@ -498,7 +498,7 @@ public class RestHighLevelClient implements Closeable {
      * @return Cancellable instance that may be used to cancel the request
      */
     @Deprecated
-    protected final <Req extends ActionRequest, Resp> Cancellable performRequestAsync(
+    private <Req extends ActionRequest, Resp> Cancellable performRequestAsync(
         Req request,
         CheckedFunction<Req, Request, IOException> requestConverter,
         RequestOptions options,
@@ -539,7 +539,7 @@ public class RestHighLevelClient implements Closeable {
         return performClientRequestAsync(req, responseListener);
     }
 
-    final <Resp> ResponseListener wrapResponseListener(
+    private <Resp> ResponseListener wrapResponseListener(
         CheckedFunction<Response, Resp, IOException> responseConverter,
         ActionListener<Resp> actionListener,
         Set<Integer> ignores
@@ -586,7 +586,7 @@ public class RestHighLevelClient implements Closeable {
      * that wraps the original {@link ResponseException}. The potential exception obtained while parsing is added to the returned
      * exception as a suppressed exception. This method is guaranteed to not throw any exception eventually thrown while parsing.
      */
-    protected final ElasticsearchStatusException parseResponseException(ResponseException responseException) {
+    private ElasticsearchStatusException parseResponseException(ResponseException responseException) {
         Response response = responseException.getResponse();
         HttpEntity entity = response.getEntity();
         ElasticsearchStatusException elasticsearchException;
@@ -606,7 +606,7 @@ public class RestHighLevelClient implements Closeable {
         return elasticsearchException;
     }
 
-    protected final <Resp> Resp parseEntity(final HttpEntity entity, final CheckedFunction<XContentParser, Resp, IOException> entityParser)
+    private <Resp> Resp parseEntity(final HttpEntity entity, final CheckedFunction<XContentParser, Resp, IOException> entityParser)
         throws IOException {
         if (entity == null) {
             throw new IllegalStateException("Response body expected but not returned");
@@ -760,7 +760,7 @@ public class RestHighLevelClient implements Closeable {
      * Go through all the request's existing headers, looking for {@code headerName} headers and if they exist,
      * changing them to use version compatibility. If no request headers are changed, modify the entity type header if appropriate
      */
-    boolean addCompatibilityFor(RequestOptions.Builder newOptions, Header entityHeader, String headerName) {
+    private boolean addCompatibilityFor(RequestOptions.Builder newOptions, Header entityHeader, String headerName) {
         // Modify any existing "Content-Type" headers on the request to use the version compatibility, if available
         boolean contentTypeModified = false;
         for (Header header : new ArrayList<>(newOptions.getHeaders())) {
@@ -782,7 +782,7 @@ public class RestHighLevelClient implements Closeable {
      * Modify the given header to be version compatible, if necessary.
      * Returns true if a modification was made, false otherwise.
      */
-    boolean modifyHeader(RequestOptions.Builder newOptions, Header header, String headerName) {
+    private boolean modifyHeader(RequestOptions.Builder newOptions, Header header, String headerName) {
         for (EntityType type : EntityType.values()) {
             final String headerValue = header.getValue();
             if (headerValue.startsWith(type.header())) {
@@ -800,7 +800,7 @@ public class RestHighLevelClient implements Closeable {
      * modifying the "Content-Type" and "Accept" headers if present, or modifying the header based
      * on the request's entity type.
      */
-    void modifyRequestForCompatibility(Request request) {
+    private void modifyRequestForCompatibility(Request request) {
         final Header entityHeader = request.getEntity() == null ? null : request.getEntity().getContentType();
         final RequestOptions.Builder newOptions = request.getOptions().toBuilder();
 
@@ -957,7 +957,7 @@ public class RestHighLevelClient implements Closeable {
         return Optional.empty();
     }
 
-    static List<NamedXContentRegistry.Entry> getDefaultNamedXContents() {
+    private static List<NamedXContentRegistry.Entry> getDefaultNamedXContents() {
         Map<String, ContextParser<Object, ? extends Aggregation>> map = new HashMap<>();
         map.put(CardinalityAggregationBuilder.NAME, (p, c) -> ParsedCardinality.fromXContent(p, (String) c));
         map.put(InternalHDRPercentiles.NAME, (p, c) -> ParsedHDRPercentiles.fromXContent(p, (String) c));
@@ -1043,7 +1043,7 @@ public class RestHighLevelClient implements Closeable {
     /**
      * Loads and returns the {@link NamedXContentRegistry.Entry} parsers provided by plugins.
      */
-    static List<NamedXContentRegistry.Entry> getProvidedNamedXContents() {
+    private static List<NamedXContentRegistry.Entry> getProvidedNamedXContents() {
         List<NamedXContentRegistry.Entry> entries = new ArrayList<>();
         for (NamedXContentProvider service : ServiceLoader.load(NamedXContentProvider.class)) {
             entries.addAll(service.getNamedXContentParsers());

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
@@ -440,23 +440,6 @@ public class RestHighLevelClient implements Closeable {
     }
 
     /**
-     * Defines a helper method for performing a request.
-     */
-    protected final <Req extends Validatable, Resp> Resp performRequest(
-        Req request,
-        CheckedFunction<Req, Request, IOException> requestConverter,
-        RequestOptions options,
-        CheckedFunction<Response, Resp, IOException> responseConverter,
-        Set<Integer> ignores
-    ) throws IOException {
-        Optional<ValidationException> validationException = request.validate();
-        if (validationException != null && validationException.isPresent()) {
-            throw validationException.get();
-        }
-        return internalPerformRequest(request, requestConverter, options, responseConverter, ignores);
-    }
-
-    /**
      * Provides common functionality for performing a request.
      */
     private <Req, Resp> Resp internalPerformRequest(

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
@@ -735,7 +735,7 @@ public class RestHighLevelClient implements Closeable {
         ListenableFuture<Optional<String>> versionCheck = getVersionValidationFuture();
 
         // Create a future that tracks cancellation of this method's result and forwards cancellation to the actual LLRC request.
-        CompletableFuture<Void> cancellationForwarder = new CompletableFuture<Void>();
+        CompletableFuture<Void> cancellationForwarder = new CompletableFuture<>();
         Cancellable result = new Cancellable() {
             @Override
             public void cancel() {
@@ -754,7 +754,7 @@ public class RestHighLevelClient implements Closeable {
 
         // Send the request after we have done the version compatibility check. Note that if it has already happened, the listener will
         // be called immediately on the same thread with no asynchronous scheduling overhead.
-        versionCheck.addListener(new ActionListener<Optional<String>>() {
+        versionCheck.addListener(new ActionListener<>() {
             @Override
             public void onResponse(Optional<String> validation) {
                 if (validation.isPresent() == false) {
@@ -779,7 +779,7 @@ public class RestHighLevelClient implements Closeable {
         });
 
         return result;
-    };
+    }
 
     /**
      * Go through all the request's existing headers, looking for {@code headerName} headers and if they exist,

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
@@ -232,15 +232,7 @@ public class RestHighLevelClient implements Closeable {
      * {@link RestClient} to be used to perform requests.
      */
     public RestHighLevelClient(RestClientBuilder restClientBuilder) {
-        this(restClientBuilder, Collections.emptyList());
-    }
-
-    /**
-     * Creates a {@link RestHighLevelClient} given the low level {@link RestClientBuilder} that allows to build the
-     * {@link RestClient} to be used to perform requests and parsers for custom response sections added to Elasticsearch through plugins.
-     */
-    protected RestHighLevelClient(RestClientBuilder restClientBuilder, List<NamedXContentRegistry.Entry> namedXContentEntries) {
-        this(restClientBuilder.build(), RestClient::close, namedXContentEntries);
+        this(restClientBuilder.build(), RestClient::close, Collections.emptyList());
     }
 
     /**


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/issues/83423

Some work I did yesterday reminded me that this was still out there, so I thought I'd check to see if much has changed on the ground with it. The answer is mostly no, but I made these cleanups while I was there.

There are still ten classes that import the `RestHighLevelClient`:

```
joegallo@simulacron:~/Code/elastic/elasticsearch $ git grep 'import org.elasticsearch.client.RestHighLevelClient' | wc -l
      10
joegallo@simulacron:~/Code/elastic/elasticsearch $ git grep 'import org.elasticsearch.client.RestHighLevelClient'
qa/ccs-rolling-upgrade-remote-cluster/src/test/java/org/elasticsearch/upgrades/SearchStatesIT.java:import org.elasticsearch.client.RestHighLevelClient;
qa/ccs-unavailable-clusters/src/javaRestTest/java/org/elasticsearch/search/CrossClusterSearchUnavailableClusterIT.java:import org.elasticsearch.client.RestHighLevelClient;
qa/multi-cluster-search/src/test/java/org/elasticsearch/search/CCSDuelIT.java:import org.elasticsearch.client.RestHighLevelClient;
qa/remote-clusters/src/test/java/org/elasticsearch/cluster/remote/test/AbstractMultiClusterRemoteTestCase.java:import org.elasticsearch.client.RestHighLevelClient;
x-pack/plugin/eql/qa/ccs-rolling-upgrade/src/test/java/org/elasticsearch/xpack/eql/qa/ccs_rolling_upgrade/EqlCcsRollingUpgradeIT.java:import org.elasticsearch.client.RestHighLevelClient;
x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/DataLoader.java:import org.elasticsearch.client.RestHighLevelClient;
x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/RemoteClusterAwareEqlRestTestCase.java:import org.elasticsearch.client.RestHighLevelClient;
x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/stats/EqlUsageRestTestCase.java:import org.elasticsearch.client.RestHighLevelClient;
x-pack/plugin/eql/qa/correctness/src/javaRestTest/java/org/elasticsearch/xpack/eql/EsEQLCorrectnessIT.java:import org.elasticsearch.client.RestHighLevelClient;
x-pack/qa/repository-old-versions/src/test/java/org/elasticsearch/oldrepos/OldRepositoryAccessIT.java:import org.elasticsearch.client.RestHighLevelClient;
```