### PR TITLE
Drop very old version checks from searchable snapshots

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/searchablesnapshots/SearchableSnapshotShardStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/searchablesnapshots/SearchableSnapshotShardStats.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.core.searchablesnapshots;
 
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -199,23 +198,11 @@ public class SearchableSnapshotShardStats implements Writeable, ToXContentObject
         }
 
         CacheIndexInputStats(final StreamInput in) throws IOException {
-            if (in.getTransportVersion().before(TransportVersions.V_7_12_0)) {
-                // This API is currently only used internally for testing, so BWC breaking changes are OK.
-                // We just throw an exception here to get a better error message in case this would be called
-                // in a mixed version cluster
-                throw new IllegalArgumentException("BWC breaking change for internal API");
-            }
             this.fileExt = in.readString();
             this.numFiles = in.readVLong();
-            if (in.getTransportVersion().before(TransportVersions.V_7_13_0)) {
-                this.totalSize = ByteSizeValue.ofBytes(in.readVLong());
-                this.minSize = ByteSizeValue.ZERO;
-                this.maxSize = ByteSizeValue.ZERO;
-            } else {
-                this.totalSize = ByteSizeValue.readFrom(in);
-                this.minSize = ByteSizeValue.readFrom(in);
-                this.maxSize = ByteSizeValue.readFrom(in);
-            }
+            this.totalSize = ByteSizeValue.readFrom(in);
+            this.minSize = ByteSizeValue.readFrom(in);
+            this.maxSize = ByteSizeValue.readFrom(in);
             this.openCount = in.readVLong();
             this.closeCount = in.readVLong();
             this.forwardSmallSeeks = new Counter(in);
@@ -230,11 +217,7 @@ public class SearchableSnapshotShardStats implements Writeable, ToXContentObject
             this.directBytesRead = new TimedCounter(in);
             this.optimizedBytesRead = new TimedCounter(in);
             this.blobStoreBytesRequested = new Counter(in);
-            if (in.getTransportVersion().onOrAfter(TransportVersions.V_7_13_0)) {
-                this.luceneBytesRead = new Counter(in);
-            } else {
-                this.luceneBytesRead = new Counter(0, 0, 0, 0);
-            }
+            this.luceneBytesRead = new Counter(in);
             this.currentIndexCacheFills = in.readVLong();
         }
 
@@ -272,21 +255,11 @@ public class SearchableSnapshotShardStats implements Writeable, ToXContentObject
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            if (out.getTransportVersion().before(TransportVersions.V_7_12_0)) {
-                // This API is currently only used internally for testing, so BWC breaking changes are OK.
-                // We just throw an exception here to get a better error message in case this would be called
-                // in a mixed version cluster
-                throw new IllegalArgumentException("BWC breaking change for internal API");
-            }
             out.writeString(fileExt);
             out.writeVLong(numFiles);
-            if (out.getTransportVersion().before(TransportVersions.V_7_13_0)) {
-                out.writeVLong(totalSize.getBytes());
-            } else {
-                totalSize.writeTo(out);
-                minSize.writeTo(out);
-                maxSize.writeTo(out);
-            }
+            totalSize.writeTo(out);
+            minSize.writeTo(out);
+            maxSize.writeTo(out);
             out.writeVLong(openCount);
             out.writeVLong(closeCount);
 
@@ -302,9 +275,7 @@ public class SearchableSnapshotShardStats implements Writeable, ToXContentObject
             directBytesRead.writeTo(out);
             optimizedBytesRead.writeTo(out);
             blobStoreBytesRequested.writeTo(out);
-            if (out.getTransportVersion().onOrAfter(TransportVersions.V_7_13_0)) {
-                luceneBytesRead.writeTo(out);
-            }
+            luceneBytesRead.writeTo(out);
             out.writeVLong(currentIndexCacheFills);
         }
 

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/TransportMountSearchableSnapshotAction.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/TransportMountSearchableSnapshotAction.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.searchablesnapshots.action;
 
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotRequest;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
@@ -122,8 +121,7 @@ public class TransportMountSearchableSnapshotAction extends TransportMasterNodeA
         String repoName,
         SnapshotId snapshotId,
         IndexId indexId,
-        MountSearchableSnapshotRequest.Storage storage,
-        Version minNodeVersion
+        MountSearchableSnapshotRequest.Storage storage
     ) {
         final Settings.Builder settings = Settings.builder();
 
@@ -142,16 +140,10 @@ public class TransportMountSearchableSnapshotAction extends TransportMasterNodeA
             .put(INDEX_RECOVERY_TYPE_SETTING.getKey(), SearchableSnapshots.SNAPSHOT_RECOVERY_STATE_FACTORY_KEY);
 
         if (storage == MountSearchableSnapshotRequest.Storage.SHARED_CACHE) {
-            if (minNodeVersion.before(Version.V_7_12_0)) {
-                throw new IllegalArgumentException("shared cache searchable snapshots require minimum node version " + Version.V_7_12_0);
-            }
             settings.put(SearchableSnapshotsSettings.SNAPSHOT_PARTIAL_SETTING.getKey(), true)
                 .put(DiskThresholdDecider.SETTING_IGNORE_DISK_WATERMARKS.getKey(), true);
 
-            // we cannot apply this setting during rolling upgrade.
-            if (minNodeVersion.onOrAfter(Version.V_7_13_0)) {
-                settings.put(ShardLimitValidator.INDEX_SETTING_SHARD_LIMIT_GROUP.getKey(), ShardLimitValidator.FROZEN_GROUP);
-            }
+            settings.put(ShardLimitValidator.INDEX_SETTING_SHARD_LIMIT_GROUP.getKey(), ShardLimitValidator.FROZEN_GROUP);
         }
 
         return settings.build();
@@ -236,16 +228,7 @@ public class TransportMountSearchableSnapshotAction extends TransportMasterNodeA
                 .put(IndexSettings.INDEX_CHECK_ON_STARTUP.getKey(), false) // can be overridden
                 .put(DataTier.TIER_PREFERENCE, request.storage().defaultDataTiersPreference())
                 .put(request.indexSettings())
-                .put(
-                    buildIndexSettings(
-                        repoData.getUuid(),
-                        request.repositoryName(),
-                        snapshotId,
-                        indexId,
-                        request.storage(),
-                        state.nodes().getMinNodeVersion()
-                    )
-                )
+                .put(buildIndexSettings(repoData.getUuid(), request.repositoryName(), snapshotId, indexId, request.storage()))
                 .build();
 
             // todo: restore archives bad settings, for now we verify just the data tiers, since we know their dependencies are available

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/cache/FrozenCacheInfoAction.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/cache/FrozenCacheInfoAction.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.searchablesnapshots.action.cache;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionListenerResponseHandler;
 import org.elasticsearch.action.ActionRequest;
@@ -72,18 +71,14 @@ public class FrozenCacheInfoAction extends ActionType<FrozenCacheInfoResponse> {
 
         @Override
         protected void doExecute(Task task, Request request, ActionListener<FrozenCacheInfoResponse> listener) {
-            if (request.discoveryNode.getVersion().onOrAfter(Version.V_7_12_0)) {
-                transportService.sendChildRequest(
-                    request.discoveryNode,
-                    FrozenCacheInfoNodeAction.NAME,
-                    nodeRequest,
-                    task,
-                    TransportRequestOptions.EMPTY,
-                    new ActionListenerResponseHandler<>(listener, FrozenCacheInfoResponse::new, TransportResponseHandler.TRANSPORT_WORKER)
-                );
-            } else {
-                listener.onResponse(new FrozenCacheInfoResponse(false));
-            }
+            transportService.sendChildRequest(
+                request.discoveryNode,
+                FrozenCacheInfoNodeAction.NAME,
+                nodeRequest,
+                task,
+                TransportRequestOptions.EMPTY,
+                new ActionListenerResponseHandler<>(listener, FrozenCacheInfoResponse::new, TransportResponseHandler.TRANSPORT_WORKER)
+            );
         }
 
     }

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/upgrade/SearchableSnapshotIndexMetadataUpgrader.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/upgrade/SearchableSnapshotIndexMetadataUpgrader.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.searchablesnapshots.upgrade;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateListener;
@@ -51,7 +50,7 @@ public class SearchableSnapshotIndexMetadataUpgrader {
             return;
         }
 
-        if (event.localNodeMaster() && event.state().nodes().getMinNodeVersion().onOrAfter(Version.V_7_13_0)) {
+        if (event.localNodeMaster()) {
             // only want one doing this at a time, assume it succeeds and reset if not.
             if (upgraded.compareAndSet(false, true)) {
                 final Executor executor = threadPool.generic();

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/common/TestUtils.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/cache/common/TestUtils.java
@@ -271,11 +271,6 @@ public final class TestUtils {
         }
 
         @Override
-        protected boolean useLegacyCachedBlobSizes() {
-            return false;
-        }
-
-        @Override
         protected void innerGet(GetRequest request, ActionListener<GetResponse> listener) {
             listener.onFailure(new IndexNotFoundException(request.index()));
         }
@@ -297,11 +292,6 @@ public final class TestUtils {
 
         public SimpleBlobStoreCacheService() {
             super(null, mock(Client.class), SNAPSHOT_BLOB_CACHE_INDEX);
-        }
-
-        @Override
-        protected boolean useLegacyCachedBlobSizes() {
-            return false;
         }
 
         @Override


### PR DESCRIPTION
Just tidying up some code. Now that we're on 8.x, these pre-7.17 version checks are irrelevant, or so I think.