### PR TITLE
[Transform] Log stacktrace together with log message in order to help debugging.

### DIFF
--- a/docs/changelog/101607.yaml
+++ b/docs/changelog/101607.yaml
@@ -1,0 +1,5 @@
+pr: 101607
+summary: Log stacktrace together with log message in order to help debugging
+area: Transform
+type: bug
+issues: []

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformFailureHandler.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformFailureHandler.java
@@ -248,7 +248,7 @@ class TransformFailureHandler {
                 numFailureRetries
             );
 
-            logger.log(unattended ? Level.INFO : Level.WARN, () -> "[" + transformId + "] " + retryMessage);
+            logger.log(unattended ? Level.INFO : Level.WARN, () -> "[" + transformId + "] " + retryMessage, unwrappedException);
             auditor.audit(unattended ? INFO : WARNING, transformId, retryMessage);
         }
     }


### PR DESCRIPTION
Currently, when `TransformFailureHandler` decides to log an exception, it only logs the message, **not** the stacktrace.
This PR also logs a stacktrace to help debugging where does the exception comes from.