### PR TITLE
Make collections in telemetry metrics threadsafe

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/telemetry/MetricRecorder.java
+++ b/test/framework/src/main/java/org/elasticsearch/telemetry/MetricRecorder.java
@@ -11,12 +11,12 @@ package org.elasticsearch.telemetry;
 import org.elasticsearch.core.Strings;
 import org.elasticsearch.telemetry.metric.Instrument;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * Container for registered Instruments (either {@link Instrument} or Otel's versions).
@@ -49,7 +49,7 @@ public class MetricRecorder<I> {
 
         void call(String name, Measurement call) {
             assert registered.containsKey(name) : Strings.format("call for unregistered metric [{}]: [{}]", name, call);
-            called.computeIfAbsent(Objects.requireNonNull(name), k -> new ArrayList<>()).add(call);
+            called.computeIfAbsent(Objects.requireNonNull(name), k -> new CopyOnWriteArrayList<>()).add(call);
         }
 
     }
@@ -60,9 +60,17 @@ public class MetricRecorder<I> {
     private final Map<InstrumentType, RegisteredMetric<I>> metrics;
 
     public MetricRecorder() {
-        metrics = new HashMap<>(InstrumentType.values().length);
+        metrics = new ConcurrentHashMap<>(InstrumentType.values().length);
         for (var instrument : InstrumentType.values()) {
-            metrics.put(instrument, new RegisteredMetric<>(new HashMap<>(), new HashMap<>(), new HashMap<>(), new ArrayList<>()));
+            metrics.put(
+                instrument,
+                new RegisteredMetric<>(
+                    new ConcurrentHashMap<>(),
+                    new ConcurrentHashMap<>(),
+                    new ConcurrentHashMap<>(),
+                    new CopyOnWriteArrayList<>()
+                )
+            );
         }
     }
 


### PR DESCRIPTION
there is usually only once instance of MeterRegistry, so all the collections used by this class should be thread safe

closes #101602