### PR TITLE
Create file watcher for master nodes

### DIFF
--- a/server/src/main/java/org/elasticsearch/reservedstate/service/FileSettingsService.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/FileSettingsService.java
@@ -11,22 +11,17 @@ package org.elasticsearch.reservedstate.service;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.support.PlainActionFuture;
-import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateListener;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.ReservedStateMetadata;
-import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.file.AbstractFileWatchingService;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.attribute.FileTime;
-import java.time.Instant;
 import java.util.concurrent.ExecutionException;
 
 import static org.elasticsearch.xcontent.XContentType.JSON;
@@ -42,16 +37,14 @@ import static org.elasticsearch.xcontent.XContentType.JSON;
  * the service as a listener to cluster state changes, so that we can enable the file watcher thread when this
  * node becomes a master node.
  */
-public class FileSettingsService extends AbstractFileWatchingService implements ClusterStateListener {
+public class FileSettingsService extends MasterNodeFileWatchingService implements ClusterStateListener {
 
     private static final Logger logger = LogManager.getLogger(FileSettingsService.class);
 
     public static final String SETTINGS_FILE_NAME = "settings.json";
     public static final String NAMESPACE = "file_settings";
     public static final String OPERATOR_DIRECTORY = "operator";
-    private final ClusterService clusterService;
     private final ReservedClusterStateService stateService;
-    private volatile boolean active = false;
 
     /**
      * Constructs the {@link FileSettingsService}
@@ -61,68 +54,8 @@ public class FileSettingsService extends AbstractFileWatchingService implements 
      * @param environment we need the environment to pull the location of the config and operator directories
      */
     public FileSettingsService(ClusterService clusterService, ReservedClusterStateService stateService, Environment environment) {
-        super(environment.configFile().toAbsolutePath().resolve(OPERATOR_DIRECTORY).resolve(SETTINGS_FILE_NAME));
-        this.clusterService = clusterService;
+        super(clusterService, environment.configFile().toAbsolutePath().resolve(OPERATOR_DIRECTORY).resolve(SETTINGS_FILE_NAME));
         this.stateService = stateService;
-    }
-
-    @Override
-    protected void doStart() {
-        // We start the file watcher when we know we are master from a cluster state change notification.
-        // We need the additional active flag, since cluster state can change after we've shutdown the service
-        // causing the watcher to start again.
-        this.active = Files.exists(watchedFileDir().getParent());
-        if (active == false) {
-            // we don't have a config directory, we can't possibly launch the file settings service
-            return;
-        }
-        if (DiscoveryNode.isMasterNode(clusterService.getSettings())) {
-            clusterService.addListener(this);
-        }
-    }
-
-    @Override
-    protected void doStop() {
-        this.active = false;
-        super.doStop();
-    }
-
-    @Override
-    public final void clusterChanged(ClusterChangedEvent event) {
-        ClusterState clusterState = event.state();
-        if (clusterState.nodes().isLocalNodeElectedMaster()) {
-            synchronized (this) {
-                if (watching() || active == false) {
-                    refreshExistingFileStateIfNeeded(clusterState);
-                    return;
-                }
-                startWatcher();
-            }
-        } else if (event.previousState().nodes().isLocalNodeElectedMaster()) {
-            stopWatcher();
-        }
-    }
-
-    /**
-     * 'Touches' the settings file so the file watcher will re-processes it.
-     * <p>
-     * The file processing is asynchronous, the cluster state or the file must be already updated such that
-     * the version information in the file is newer than what's already saved as processed in the
-     * cluster state.
-     *
-     * For snapshot restores we first must restore the snapshot and then force a refresh, since the cluster state
-     * metadata version must be reset to 0 and saved in the cluster state.
-     */
-    private void refreshExistingFileStateIfNeeded(ClusterState clusterState) {
-        if (watching()) {
-            if (shouldRefreshFileState(clusterState) && Files.exists(watchedFile())) {
-                try {
-                    Files.setLastModifiedTime(watchedFile(), FileTime.from(Instant.now()));
-                } catch (IOException e) {
-                    logger.warn("encountered I/O error trying to update file settings timestamp", e);
-                }
-            }
-        }
     }
 
     /**
@@ -162,7 +95,8 @@ public class FileSettingsService extends AbstractFileWatchingService implements 
      * @param clusterState State of the cluster
      * @return true if file settings metadata version is exactly 0, false otherwise.
      */
-    private boolean shouldRefreshFileState(ClusterState clusterState) {
+    @Override
+    protected boolean shouldRefreshFileState(ClusterState clusterState) {
         // We check if the version was reset to 0, and force an update if a file exists. This can happen in situations
         // like snapshot restores.
         ReservedStateMetadata fileSettingsMetadata = clusterState.metadata().reservedStateMetadata().get(NAMESPACE);

--- a/server/src/main/java/org/elasticsearch/reservedstate/service/MasterNodeFileWatchingService.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/MasterNodeFileWatchingService.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.reservedstate.service;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateListener;
+import org.elasticsearch.cluster.metadata.ReservedStateMetadata;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.file.AbstractFileWatchingService;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.time.Instant;
+
+public abstract class MasterNodeFileWatchingService extends AbstractFileWatchingService implements ClusterStateListener {
+
+    private static final Logger logger = LogManager.getLogger(MasterNodeFileWatchingService.class);
+
+    private final ClusterService clusterService;
+    private volatile boolean active = false;
+
+    protected MasterNodeFileWatchingService(ClusterService clusterService, Path watchedFile) {
+        super(watchedFile);
+        this.clusterService = clusterService;
+    }
+
+    @Override
+    protected void doStart() {
+        // We start the file watcher when we know we are master from a cluster state change notification.
+        // We need the additional active flag, since cluster state can change after we've shutdown the service
+        // causing the watcher to start again.
+        this.active = Files.exists(watchedFileDir().getParent());
+        if (active == false) {
+            // we don't have a config directory, we can't possibly launch the file settings service
+            return;
+        }
+        if (DiscoveryNode.isMasterNode(clusterService.getSettings())) {
+            clusterService.addListener(this);
+        }
+    }
+
+    @Override
+    protected void doStop() {
+        this.active = false;
+        super.doStop();
+    }
+
+    @Override
+    public final void clusterChanged(ClusterChangedEvent event) {
+        ClusterState clusterState = event.state();
+        if (clusterState.nodes().isLocalNodeElectedMaster()) {
+            synchronized (this) {
+                if (watching() || active == false) {
+                    refreshExistingFileStateIfNeeded(clusterState);
+                    return;
+                }
+                startWatcher();
+            }
+        } else if (event.previousState().nodes().isLocalNodeElectedMaster()) {
+            stopWatcher();
+        }
+    }
+
+    /**
+     * 'Touches' the settings file so the file watcher will re-processes it.
+     * <p>
+     * The file processing is asynchronous, the cluster state or the file must be already updated such that
+     * the version information in the file is newer than what's already saved as processed in the
+     * cluster state.
+     *
+     * For snapshot restores we first must restore the snapshot and then force a refresh, since the cluster state
+     * metadata version must be reset to 0 and saved in the cluster state.
+     */
+    private void refreshExistingFileStateIfNeeded(ClusterState clusterState) {
+        if (watching()) {
+            if (shouldRefreshFileState(clusterState) && Files.exists(watchedFile())) {
+                try {
+                    Files.setLastModifiedTime(watchedFile(), FileTime.from(Instant.now()));
+                } catch (IOException e) {
+                    logger.warn("encountered I/O error trying to update file settings timestamp", e);
+                }
+            }
+        }
+    }
+
+    /**
+     * There may be an indication in cluster state that the file we are watching
+     * should be re-processed: for example, after cluster state has been restored
+     * from a snapshot. By default, we do nothing, but this method should be overridden
+     * if different behavior is desired.
+     * @param clusterState State of the cluster
+     * @return false, by default
+     */
+    protected boolean shouldRefreshFileState(ClusterState clusterState) {
+        return false;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/reservedstate/service/MasterNodeFileWatchingService.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/MasterNodeFileWatchingService.java
@@ -13,7 +13,6 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateListener;
-import org.elasticsearch.cluster.metadata.ReservedStateMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.file.AbstractFileWatchingService;


### PR DESCRIPTION
This commit moves the logic of watchign a file only on the master node into a new shared class, MasterNodeFileWatchingService.

relates #101572