### PR TITLE
Add elasticsearch- prefix to CLI tool docs

### DIFF
--- a/docs/reference/commands/cli-jvm-options.asciidoc
+++ b/docs/reference/commands/cli-jvm-options.asciidoc
@@ -3,7 +3,7 @@
 ==== JVM options
 
 CLI tools run with 64MB of heap. For most tools, this value is fine. However, if
-needed this can be overriden by setting the CLI_JAVA_OPTS environment variable.
+needed this can be overriden by setting the `CLI_JAVA_OPTS` environment variable.
 For example, the following increases the heap size used by the
 `pass:a[elasticsearch-{tool-name}]` tool to 1GB.
 

--- a/docs/reference/commands/cli-jvm-options.asciidoc
+++ b/docs/reference/commands/cli-jvm-options.asciidoc
@@ -2,9 +2,10 @@
 [float]
 ==== JVM options
 
-CLI tools run with 64MB of heap. For most tools, this value is fine. However, if needed
-this can be overriden by setting the CLI_JAVA_OPTS environment variable. For example,
-the following increases the heap size used by the `pass:a[{tool-name}]` tool to 1GB.
+CLI tools run with 64MB of heap. For most tools, this value is fine. However, if
+needed this can be overriden by setting the CLI_JAVA_OPTS environment variable.
+For example, the following increases the heap size used by the
+`pass:a[elasticsearch-{tool-name}]` tool to 1GB.
 
 [source,shell,subs=attributes+]
 --------------------------------------------------


### PR DESCRIPTION
The tools are called `elasticsearch-shard` and `elasticsearch-node` and
so on, but in the docs about their JVM options the `elasticsearch-`
prefix is omitted. This commit fixes that.