### PR TITLE
Health report infrastructure doesn't trip the circuit breakers

### DIFF
--- a/docs/changelog/101629.yaml
+++ b/docs/changelog/101629.yaml
@@ -1,0 +1,5 @@
+pr: 101629
+summary: Health report infrastructure doesn't trip the circuit breakers
+area: Health
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/health/RestGetHealthAction.java
+++ b/server/src/main/java/org/elasticsearch/health/RestGetHealthAction.java
@@ -51,4 +51,9 @@ public class RestGetHealthAction extends BaseRestHandler {
             new RestChunkedToXContentListener<>(channel)
         );
     }
+
+    @Override
+    public boolean canTripCircuitBreaker() {
+        return false;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/health/node/action/TransportHealthNodeAction.java
+++ b/server/src/main/java/org/elasticsearch/health/node/action/TransportHealthNodeAction.java
@@ -74,7 +74,7 @@ public abstract class TransportHealthNodeAction<Request extends HealthNodeReques
         Writeable.Reader<Response> response,
         Executor executor
     ) {
-        super(actionName, true, transportService, actionFilters, request, EsExecutors.DIRECT_EXECUTOR_SERVICE);
+        super(actionName, false, transportService, actionFilters, request, EsExecutors.DIRECT_EXECUTOR_SERVICE);
         this.transportService = transportService;
         this.clusterService = clusterService;
         this.threadPool = threadPool;

--- a/server/src/test/java/org/elasticsearch/health/RestGetHealthActionTests.java
+++ b/server/src/test/java/org/elasticsearch/health/RestGetHealthActionTests.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.health;
+
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.is;
+
+public class RestGetHealthActionTests extends ESTestCase {
+
+    public void testHealthReportAPIDoesNotTripCircuitBreakers() {
+        assertThat(new RestGetHealthAction().canTripCircuitBreaker(), is(false));
+    }
+}

--- a/server/src/test/java/org/elasticsearch/health/node/action/TransportHealthNodeActionTests.java
+++ b/server/src/test/java/org/elasticsearch/health/node/action/TransportHealthNodeActionTests.java
@@ -52,6 +52,7 @@ import static org.elasticsearch.test.ClusterServiceUtils.createClusterService;
 import static org.elasticsearch.test.ClusterServiceUtils.setState;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 
 public class TransportHealthNodeActionTests extends ESTestCase {
     private static ThreadPool threadPool;
@@ -250,6 +251,7 @@ public class TransportHealthNodeActionTests extends ESTestCase {
             }
         }, null, request, listener);
         assertTrue(listener.isDone());
+        assertThat(transportService.getRequestHandler("internal:testAction").canTripCircuitBreaker(), is(false));
 
         if (healthOperationFailure) {
             try {
@@ -283,6 +285,7 @@ public class TransportHealthNodeActionTests extends ESTestCase {
 
         PlainActionFuture<Response> listener = new PlainActionFuture<>();
         ActionTestUtils.execute(new Action("internal:testAction", transportService, clusterService, threadPool), null, request, listener);
+        assertThat(transportService.getRequestHandler("internal:testAction").canTripCircuitBreaker(), is(false));
 
         assertThat(transport.capturedRequests().length, equalTo(1));
         CapturingTransport.CapturedRequest capturedRequest = transport.capturedRequests()[0];
@@ -303,6 +306,7 @@ public class TransportHealthNodeActionTests extends ESTestCase {
         PlainActionFuture<Response> listener = new PlainActionFuture<>();
         final CancellableTask task = (CancellableTask) taskManager.register("type", "internal:testAction", request);
         ActionTestUtils.execute(new Action("internal:testAction", transportService, clusterService, threadPool), task, request, listener);
+        assertThat(transportService.getRequestHandler("internal:testAction").canTripCircuitBreaker(), is(false));
 
         assertThat(transport.capturedRequests().length, equalTo(1));
         CapturingTransport.CapturedRequest capturedRequest = transport.capturedRequests()[0];
@@ -327,6 +331,8 @@ public class TransportHealthNodeActionTests extends ESTestCase {
             listener
         );
         assertTrue(listener.isDone());
+        assertThat(transportService.getRequestHandler("internal:testAction").canTripCircuitBreaker(), is(false));
+
         try {
             listener.get();
             fail("A simulated RuntimeException should be thrown");


### PR DESCRIPTION
This makes sure the `_health_report` rest API and its
associated health transport actions do not trip the
circuit breakers.