### PR TITLE
Forbid non-named threads

### DIFF
--- a/build-tools-internal/src/main/resources/forbidden/es-server-signatures.txt
+++ b/build-tools-internal/src/main/resources/forbidden/es-server-signatures.txt
@@ -160,3 +160,7 @@ org.elasticsearch.cluster.ClusterState#compatibilityVersions()
 org.elasticsearch.cluster.ClusterFeatures#nodeFeatures()
 @defaultMessage ClusterFeatures#clusterHasFeature is for internal use only. Use FeatureService#clusterHasFeature to determine if a feature is present on the cluster.
 org.elasticsearch.cluster.ClusterFeatures#clusterHasFeature(org.elasticsearch.features.NodeFeature)
+
+@defaultMessage Use a Thread constructor with a name, anonymous threads are more difficult to debug
+java.lang.Thread#<init>(java.lang.Runnable)
+java.lang.Thread#<init>(java.lang.ThreadGroup, java.lang.Runnable)

--- a/distribution/tools/cli-launcher/src/main/java/org/elasticsearch/launcher/CliToolLauncher.java
+++ b/distribution/tools/cli-launcher/src/main/java/org/elasticsearch/launcher/CliToolLauncher.java
@@ -94,7 +94,7 @@ class CliToolLauncher {
                 e.printStackTrace(terminal.getErrorWriter());
             }
             terminal.flush(); // make sure to flush whatever the close or error might have written
-        });
+        }, "elasticsearch-cli-shutdown");
 
     }
 

--- a/server/src/main/java/org/elasticsearch/ExceptionsHelper.java
+++ b/server/src/main/java/org/elasticsearch/ExceptionsHelper.java
@@ -257,7 +257,7 @@ public final class ExceptionsHelper {
                 final String formatted = ExceptionsHelper.formatStackTrace(Thread.currentThread().getStackTrace());
                 logger.error("fatal error {}: {}\n{}", error.getClass().getCanonicalName(), error.getMessage(), formatted);
             } finally {
-                new Thread(() -> { throw error; }).start();
+                new Thread(() -> { throw error; }, "elasticsearch-error-rethrower").start();
             }
         });
     }

--- a/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
@@ -174,7 +174,7 @@ class Elasticsearch {
         // initialize probes before the security manager is installed
         initializeProbes();
 
-        Runtime.getRuntime().addShutdownHook(new Thread(Elasticsearch::shutdown));
+        Runtime.getRuntime().addShutdownHook(new Thread(Elasticsearch::shutdown, "elasticsearch-shutdown"));
 
         // look for jar hell
         final Logger logger = LogManager.getLogger(JarHell.class);
@@ -376,7 +376,7 @@ class Elasticsearch {
                     Bootstrap.exit(1);
                 }
             }
-        }).start();
+        }, "elasticsearch-cli-monitor-thread").start();
     }
 
     /**

--- a/test/external-modules/die-with-dignity/src/javaRestTest/java/org/elasticsearch/qa/die_with_dignity/DieWithDignityIT.java
+++ b/test/external-modules/die-with-dignity/src/javaRestTest/java/org/elasticsearch/qa/die_with_dignity/DieWithDignityIT.java
@@ -68,7 +68,7 @@ public class DieWithDignityIT extends ESRestTestCase {
                 line,
                 ".*ERROR.*",
                 ".*ElasticsearchUncaughtExceptionHandler.*",
-                ".*fatal error in thread \\[Thread-\\d+\\], exiting.*",
+                ".*fatal error in thread \\[elasticsearch-error-rethrower\\], exiting.*",
                 ".*java.lang.OutOfMemoryError: Requested array size exceeds VM limit.*"
             )) {
                 fatalErrorInThreadExiting = true;


### PR DESCRIPTION
This commit forbids the use of Thread constructors that do not take a name. In general nameless threads are more difficult to understand their purpose when debugging. Note that this is only added to production signatures. Tests are not forbidden here so as not to be pedantic (or require a larger change since many tests create anonymous threads).

relates #101628