### PR TITLE
Make sure onPublishSuccess is called during cluster state tests

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/action/shard/ShardFailedClusterStateTaskExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/action/shard/ShardFailedClusterStateTaskExecutorTests.java
@@ -354,6 +354,14 @@ public class ShardFailedClusterStateTaskExecutorTests extends ESAllocationTestCa
     }
 
     private static <T> ActionListener<T> createTestListener() {
-        return ActionListener.running(() -> { throw new AssertionError("task should not complete"); });
+        return new ActionListener<>() {
+            @Override
+            public void onResponse(T t) {}
+
+            @Override
+            public void onFailure(Exception e) {
+                throw new AssertionError(e);
+            }
+        };
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/action/shard/ShardFailedClusterStateTaskExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/action/shard/ShardFailedClusterStateTaskExecutorTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.cluster.action.shard;
 
 import org.apache.lucene.index.CorruptIndexException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ESAllocationTestCase;
@@ -354,14 +355,6 @@ public class ShardFailedClusterStateTaskExecutorTests extends ESAllocationTestCa
     }
 
     private static <T> ActionListener<T> createTestListener() {
-        return new ActionListener<>() {
-            @Override
-            public void onResponse(T t) {}
-
-            @Override
-            public void onFailure(Exception e) {
-                throw new AssertionError(e);
-            }
-        };
+        return ActionTestUtils.assertNoFailureListener(t -> {});
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/action/shard/ShardStartedClusterStateTaskExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/action/shard/ShardStartedClusterStateTaskExecutorTests.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.cluster.action.shard;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ESAllocationTestCase;
 import org.elasticsearch.cluster.action.shard.ShardStateAction.StartedShardEntry;
@@ -408,14 +409,6 @@ public class ShardStartedClusterStateTaskExecutorTests extends ESAllocationTestC
     }
 
     private static <T> ActionListener<T> createTestListener() {
-        return new ActionListener<>() {
-            @Override
-            public void onResponse(T t) {}
-
-            @Override
-            public void onFailure(Exception e) {
-                throw new AssertionError(e);
-            }
-        };
+        return ActionTestUtils.assertNoFailureListener(t -> {});
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/action/shard/ShardStartedClusterStateTaskExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/action/shard/ShardStartedClusterStateTaskExecutorTests.java
@@ -408,6 +408,14 @@ public class ShardStartedClusterStateTaskExecutorTests extends ESAllocationTestC
     }
 
     private static <T> ActionListener<T> createTestListener() {
-        return ActionListener.running(() -> { throw new AssertionError("task should not complete"); });
+        return new ActionListener<>() {
+            @Override
+            public void onResponse(T t) {}
+
+            @Override
+            public void onFailure(Exception e) {
+                throw new AssertionError(e);
+            }
+        };
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinExecutorTests.java
@@ -480,7 +480,10 @@ public class NodeJoinExecutorTests extends ESTestCase {
                         CompatibilityVersionsUtils.staticCurrent(),
                         Set.of(),
                         TEST_REASON,
-                        ActionListener.wrap(r -> fail("Task should have failed"), e -> assertThat(e.getMessage(), containsString("found existing node"))),
+                        ActionListener.wrap(
+                            r -> fail("Task should have failed"),
+                            e -> assertThat(e.getMessage(), containsString("found existing node"))
+                        ),
                         executorTerm
                     )
                 )

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinExecutorTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.cluster.coordination;
 import org.apache.logging.log4j.Level;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
@@ -71,9 +72,7 @@ import static org.mockito.Mockito.when;
 
 public class NodeJoinExecutorTests extends ESTestCase {
 
-    private static final ActionListener<Void> NOT_COMPLETED_LISTENER = ActionListener.running(() -> {
-        throw new AssertionError("should not complete publication");
-    });
+    private static final ActionListener<Void> NOT_COMPLETED_LISTENER = ActionTestUtils.assertNoFailureListener(t -> {});
 
     public void testPreventJoinClusterWithNewerIndices() {
         Settings.builder().build();
@@ -481,7 +480,7 @@ public class NodeJoinExecutorTests extends ESTestCase {
                         CompatibilityVersionsUtils.staticCurrent(),
                         Set.of(),
                         TEST_REASON,
-                        NOT_COMPLETED_LISTENER,
+                        ActionListener.wrap(r -> fail("Task should have failed"), e -> assertThat(e.getMessage(), containsString("found existing node"))),
                         executorTerm
                     )
                 )

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/InSyncAllocationIdTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/InSyncAllocationIdTests.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.cluster.routing.allocation;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ESAllocationTestCase;
@@ -419,6 +420,6 @@ public class InSyncAllocationIdTests extends ESAllocationTestCase {
     }
 
     private static <T> ActionListener<T> createTestListener() {
-        return ActionListener.running(() -> { throw new AssertionError("task should not complete"); });
+        return ActionTestUtils.assertNoFailureListener(t -> {});
     }
 }

--- a/server/src/test/java/org/elasticsearch/indices/cluster/ClusterStateChanges.java
+++ b/server/src/test/java/org/elasticsearch/indices/cluster/ClusterStateChanges.java
@@ -413,9 +413,7 @@ public class ClusterStateChanges {
                     new CompatibilityVersions(transportVersion, Map.of()),
                     Set.of(),
                     DUMMY_REASON,
-                    ActionListener.running(() -> {
-                        throw new AssertionError("should not complete publication");
-                    }),
+                    createTestListener(),
                     clusterState.term()
                 )
             )
@@ -435,9 +433,7 @@ public class ClusterStateChanges {
                                 new CompatibilityVersions(transportVersion, Map.of()),
                                 Set.of(),
                                 DUMMY_REASON,
-                                ActionListener.running(() -> {
-                                    throw new AssertionError("should not complete publication");
-                                })
+                                createTestListener()
                             )
                         ),
                     clusterState.term() + between(1, 10)
@@ -552,7 +548,15 @@ public class ClusterStateChanges {
         }
     }
 
-    private ActionListener<Void> createTestListener() {
-        return ActionListener.running(() -> { throw new AssertionError("task should not complete"); });
+    private static ActionListener<Void> createTestListener() {
+        return new ActionListener<>() {
+            @Override
+            public void onResponse(Void unused) {}
+
+            @Override
+            public void onFailure(Exception e) {
+                throw new AssertionError(e);
+            }
+        };
     }
 }

--- a/server/src/test/java/org/elasticsearch/indices/cluster/ClusterStateChanges.java
+++ b/server/src/test/java/org/elasticsearch/indices/cluster/ClusterStateChanges.java
@@ -28,6 +28,7 @@ import org.elasticsearch.action.admin.indices.open.TransportOpenIndexAction;
 import org.elasticsearch.action.admin.indices.settings.put.TransportUpdateSettingsAction;
 import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.action.support.DestructiveOperations;
 import org.elasticsearch.action.support.PlainActionFuture;
@@ -549,14 +550,6 @@ public class ClusterStateChanges {
     }
 
     private static ActionListener<Void> createTestListener() {
-        return new ActionListener<>() {
-            @Override
-            public void onResponse(Void unused) {}
-
-            @Override
-            public void onFailure(Exception e) {
-                throw new AssertionError(e);
-            }
-        };
+        return ActionTestUtils.assertNoFailureListener(t -> {});
     }
 }

--- a/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.ingest.DeletePipelineRequest;
 import org.elasticsearch.action.ingest.PutPipelineRequest;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.client.internal.Client;
@@ -2664,7 +2665,7 @@ public class IngestServiceTests extends ESTestCase {
     }
 
     private static List<IngestService.PipelineClusterStateUpdateTask> oneTask(DeletePipelineRequest request) {
-        return List.of(new IngestService.DeletePipelineClusterStateUpdateTask(createTestListener(), request));
+        return List.of(new IngestService.DeletePipelineClusterStateUpdateTask(ActionTestUtils.assertNoFailureListener(t -> {}), request));
     }
 
     private static ClusterState executeDelete(DeletePipelineRequest request, ClusterState clusterState) {
@@ -2680,19 +2681,7 @@ public class IngestServiceTests extends ESTestCase {
     }
 
     private static List<IngestService.PipelineClusterStateUpdateTask> oneTask(PutPipelineRequest request) {
-        return List.of(new IngestService.PutPipelineClusterStateUpdateTask(createTestListener(), request));
-    }
-
-    private static <T> ActionListener<T> createTestListener() {
-        return new ActionListener<>() {
-            @Override
-            public void onResponse(T t) {}
-
-            @Override
-            public void onFailure(Exception e) {
-                throw new AssertionError(e);
-            }
-        };
+        return List.of(new IngestService.PutPipelineClusterStateUpdateTask(ActionTestUtils.assertNoFailureListener(t -> {}), request));
     }
 
     private static ClusterState executePut(PutPipelineRequest request, ClusterState clusterState) {

--- a/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
@@ -2664,7 +2664,7 @@ public class IngestServiceTests extends ESTestCase {
     }
 
     private static List<IngestService.PipelineClusterStateUpdateTask> oneTask(DeletePipelineRequest request) {
-        return List.of(new IngestService.DeletePipelineClusterStateUpdateTask(ActionListener.running(() -> fail("not called")), request));
+        return List.of(new IngestService.DeletePipelineClusterStateUpdateTask(createTestListener(), request));
     }
 
     private static ClusterState executeDelete(DeletePipelineRequest request, ClusterState clusterState) {
@@ -2680,7 +2680,19 @@ public class IngestServiceTests extends ESTestCase {
     }
 
     private static List<IngestService.PipelineClusterStateUpdateTask> oneTask(PutPipelineRequest request) {
-        return List.of(new IngestService.PutPipelineClusterStateUpdateTask(ActionListener.running(() -> fail("not called")), request));
+        return List.of(new IngestService.PutPipelineClusterStateUpdateTask(createTestListener(), request));
+    }
+
+    private static <T> ActionListener<T> createTestListener() {
+        return new ActionListener<>() {
+            @Override
+            public void onResponse(T t) {}
+
+            @Override
+            public void onFailure(Exception e) {
+                throw new AssertionError(e);
+            }
+        };
     }
 
     private static ClusterState executePut(PutPipelineRequest request, ClusterState clusterState) {

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotsServiceTests.java
@@ -8,7 +8,7 @@
 
 package org.elasticsearch.snapshots;
 
-import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.SnapshotsInProgress;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -433,7 +433,7 @@ public class SnapshotsServiceTests extends ESTestCase {
             shardId,
             null,
             successfulShardStatus(nodeId),
-            ActionListener.running(() -> fail("should not complete publication"))
+            ActionTestUtils.assertNoFailureListener(t -> {})
         );
     }
 
@@ -443,7 +443,7 @@ public class SnapshotsServiceTests extends ESTestCase {
             null,
             shardId,
             successfulShardStatus(nodeId),
-            ActionListener.running(() -> fail("should not complete publication"))
+            ActionTestUtils.assertNoFailureListener(t -> {})
         );
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/cluster/service/ClusterStateTaskExecutorUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/service/ClusterStateTaskExecutorUtils.java
@@ -123,6 +123,7 @@ public class ClusterStateTaskExecutorUtils {
             assert clusterStateAckListener != null;
             assert task == clusterStateAckListener || (task instanceof ClusterStateAckListener == false);
             this.succeeded = true;
+            onPublishSuccess.run();
         }
 
         @Override
@@ -131,6 +132,7 @@ public class ClusterStateTaskExecutorUtils {
             assert onPublishSuccess != null;
             assert task instanceof ClusterStateAckListener == false;
             this.succeeded = true;
+            onPublishSuccess.run();
         }
 
         @Override

--- a/test/framework/src/main/java/org/elasticsearch/cluster/service/ClusterStateTaskExecutorUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/service/ClusterStateTaskExecutorUtils.java
@@ -16,8 +16,8 @@ import org.elasticsearch.common.CheckedBiConsumer;
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.core.Releasable;
 
+import java.util.Collection;
 import java.util.function.Consumer;
-import java.util.stream.StreamSupport;
 
 import static org.elasticsearch.test.ESTestCase.fail;
 import static org.junit.Assert.assertFalse;
@@ -35,7 +35,7 @@ public class ClusterStateTaskExecutorUtils {
     public static <T extends ClusterStateTaskListener> ClusterState executeAndAssertSuccessful(
         ClusterState originalState,
         ClusterStateTaskExecutor<T> executor,
-        Iterable<T> tasks
+        Collection<T> tasks
     ) throws Exception {
         return executeHandlingResults(originalState, executor, tasks, task -> {}, (task, e) -> fail(e));
     }
@@ -43,7 +43,7 @@ public class ClusterStateTaskExecutorUtils {
     public static <T extends ClusterStateTaskListener> ClusterState executeAndThrowFirstFailure(
         ClusterState originalState,
         ClusterStateTaskExecutor<T> executor,
-        Iterable<T> tasks
+        Collection<T> tasks
     ) throws Exception {
         return executeHandlingResults(originalState, executor, tasks, task -> {}, (task, e) -> { throw e; });
     }
@@ -51,7 +51,7 @@ public class ClusterStateTaskExecutorUtils {
     public static <T extends ClusterStateTaskListener> ClusterState executeIgnoringFailures(
         ClusterState originalState,
         ClusterStateTaskExecutor<T> executor,
-        Iterable<T> tasks
+        Collection<T> tasks
     ) throws Exception {
         return executeHandlingResults(originalState, executor, tasks, task -> {}, (task, e) -> {});
     }
@@ -59,26 +59,30 @@ public class ClusterStateTaskExecutorUtils {
     public static <T extends ClusterStateTaskListener> ClusterState executeHandlingResults(
         ClusterState originalState,
         ClusterStateTaskExecutor<T> executor,
-        Iterable<T> tasks,
+        Collection<T> tasks,
         CheckedConsumer<T, Exception> onTaskSuccess,
         CheckedBiConsumer<T, Exception, Exception> onTaskFailure
     ) throws Exception {
-        final var taskContexts = StreamSupport.stream(tasks.spliterator(), false).<ClusterStateTaskExecutor.TaskContext<T>>map(
-            TestTaskContext::new
-        ).toList();
-        final var resultingState = executor.execute(
+        final var taskContexts = tasks.stream().map(TestTaskContext::new).toList();
+        ClusterState resultingState = executor.execute(
             new ClusterStateTaskExecutor.BatchExecutionContext<>(originalState, taskContexts, () -> null)
         );
         assertNotNull(resultingState);
-        for (final var taskContext : taskContexts) {
-            final var testTaskContext = (TestTaskContext<T>) taskContext;
-            assertFalse(taskContext + " should have completed", testTaskContext.incomplete());
+        boolean allSuccess = true;
+        for (final var testTaskContext : taskContexts) {
+            assertFalse(testTaskContext + " should have completed", testTaskContext.incomplete());
             if (testTaskContext.succeeded()) {
                 onTaskSuccess.accept(testTaskContext.getTask());
             } else {
                 onTaskFailure.accept(testTaskContext.getTask(), testTaskContext.getFailure());
+                allSuccess = false;
             }
         }
+
+        if (allSuccess) {
+            taskContexts.forEach(TestTaskContext::onPublishSuccess);
+        }
+
         return resultingState;
     }
 
@@ -86,6 +90,7 @@ public class ClusterStateTaskExecutorUtils {
         private final T task;
         private Exception failure;
         private boolean succeeded;
+        private Runnable onPublishSuccess;
 
         TestTaskContext(T task) {
             this.task = task;
@@ -109,6 +114,11 @@ public class ClusterStateTaskExecutorUtils {
             return failure;
         }
 
+        void onPublishSuccess() {
+            assert onPublishSuccess != null;
+            onPublishSuccess.run();
+        }
+
         @Override
         public void onFailure(Exception failure) {
             assert incomplete();
@@ -123,7 +133,7 @@ public class ClusterStateTaskExecutorUtils {
             assert clusterStateAckListener != null;
             assert task == clusterStateAckListener || (task instanceof ClusterStateAckListener == false);
             this.succeeded = true;
-            onPublishSuccess.run();
+            this.onPublishSuccess = onPublishSuccess;
         }
 
         @Override
@@ -132,7 +142,7 @@ public class ClusterStateTaskExecutorUtils {
             assert onPublishSuccess != null;
             assert task instanceof ClusterStateAckListener == false;
             this.succeeded = true;
-            onPublishSuccess.run();
+            this.onPublishSuccess = onPublishSuccess;
         }
 
         @Override


### PR DESCRIPTION
Make sure `onPublishSuccess` is actually called in test scenarios. This is to help with testing of #101609