### PR TITLE
[8.10] Add elasticsearch- prefix to CLI tool docs (#101626)

### DIFF
--- a/docs/reference/commands/cli-jvm-options.asciidoc
+++ b/docs/reference/commands/cli-jvm-options.asciidoc
@@ -2,9 +2,10 @@
 [float]
 ==== JVM options
 
-CLI tools run with 64MB of heap. For most tools, this value is fine. However, if needed
-this can be overriden by setting the CLI_JAVA_OPTS environment variable. For example,
-the following increases the heap size used by the `pass:a[{tool-name}]` tool to 1GB.
+CLI tools run with 64MB of heap. For most tools, this value is fine. However, if
+needed this can be overriden by setting the `CLI_JAVA_OPTS` environment variable.
+For example, the following increases the heap size used by the
+`pass:a[elasticsearch-{tool-name}]` tool to 1GB.
 
 [source,shell,subs=attributes+]
 --------------------------------------------------


### PR DESCRIPTION
Backports the following commits to 8.10:
 - Add elasticsearch- prefix to CLI tool docs (#101626)