### PR TITLE
Fix race condition in SnapshotsService

### DIFF
--- a/docs/changelog/101652.yaml
+++ b/docs/changelog/101652.yaml
@@ -1,0 +1,5 @@
+pr: 101652
+summary: Fix race condition in `SnapshotsService`
+area: Snapshot/Restore
+type: bug
+issues: []

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
@@ -1066,7 +1066,6 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/99355")
     public void testMasterFailoverOnFinalizationLoop() throws Exception {
         internalCluster().startMasterOnlyNodes(3);
         final String dataNode = internalCluster().startDataOnlyNode();

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -164,7 +164,7 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
     /**
      * Listeners for snapshot deletion keyed by delete uuid as returned from {@link SnapshotDeletionsInProgress.Entry#uuid()}
      */
-    private final Map<String, List<ActionListener<Void>>> snapshotDeletionListeners = new HashMap<>();
+    private final Map<String, List<ActionListener<Void>>> snapshotDeletionListeners = new ConcurrentHashMap<>();
 
     // Set of repositories currently running either a snapshot finalization or a snapshot delete.
     private final Set<String> currentlyFinalizing = Collections.synchronizedSet(new HashSet<>());


### PR DESCRIPTION
Root cause: race condition between *masterService#updateTask* and *clusterApplierService#updateTask* threads on concurrent updates of `snapshotDeletionListeners`.

Test failures contain this exception deep in the logs, (e.g. [here](https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+8.10+multijob+platform-support-arm/GRADLE_TASK=checkPart1,os=almalinux-8-aarch64&&immutable/122/consoleFull))

```
15:59:51   1> [2023-10-17T09:58:51,223][ERROR][o.e.c.s.MasterService    ] [node_t0] exception thrown by listener notifying of failure
15:59:51   1> java.util.ConcurrentModificationException: null
15:59:51   1> 	at java.util.HashMap$HashIterator.nextNode(HashMap.java:1605) ~[?:?]
15:59:51   1> 	at java.util.HashMap$ValueIterator.next(HashMap.java:1633) ~[?:?]
15:59:51   1> 	at org.elasticsearch.snapshots.SnapshotsService.failAllListenersOnMasterFailOver(SnapshotsService.java:2466) ~[main/:?]
15:59:51   1> 	at org.elasticsearch.snapshots.SnapshotsService$RemoveSnapshotDeletionAndContinueTask.onFailure(SnapshotsService.java:2521) ~[main/:?]
15:59:51   1> 	at org.elasticsearch.cluster.service.MasterService$ExecutionResult.notifyFailure(MasterService.java:975) ~[main/:?]

```

It can happen when a task is being processed in *masterService* and node gets [cluster state update](https://github.com/elastic/elasticsearch/blob/a95fcfa08f9c673d1f146b59042b518d58574a50/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java#L845) notifying that the node is not master any longer (as per test logic)

If thrown [here](https://github.com/elastic/elasticsearch/blob/509e961bbc0c9218115f1a12ba50b4a13be5da6f/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java#L2478), it prevents [proper clean up](https://github.com/elastic/elasticsearch/blob/a95fcfa08f9c673d1f146b59042b518d58574a50/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java#L2488) of `currentlyFinalizing` set down the road and hence trips over assert logic in IT test.


Fix: make iterator weakly consistent with backing map collection to tolerate concurrent updates.

#99355