### PR TITLE
[ci] Add rocky-9 to matrix in packaging and platform jobs

### DIFF
--- a/.buildkite/pipelines/periodic-packaging.template.yml
+++ b/.buildkite/pipelines/periodic-packaging.template.yml
@@ -19,6 +19,7 @@ steps:
               - ubuntu-2004
               - ubuntu-2204
               - rocky-8
+              - rocky-9
               - rhel-7
               - rhel-8
               - rhel-9

--- a/.buildkite/pipelines/periodic-packaging.yml
+++ b/.buildkite/pipelines/periodic-packaging.yml
@@ -20,6 +20,7 @@ steps:
               - ubuntu-2004
               - ubuntu-2204
               - rocky-8
+              - rocky-9
               - rhel-7
               - rhel-8
               - rhel-9

--- a/.buildkite/pipelines/periodic-platform-support.yml
+++ b/.buildkite/pipelines/periodic-platform-support.yml
@@ -19,6 +19,7 @@ steps:
               - ubuntu-2004
               - ubuntu-2204
               - rocky-8
+              - rocky-9
               - rhel-7
               - rhel-8
               - rhel-9

--- a/.buildkite/pipelines/pull-request/packaging-tests-unix.yml
+++ b/.buildkite/pipelines/pull-request/packaging-tests-unix.yml
@@ -32,8 +32,6 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           diskSizeGb: 350
           machineType: custom-16-32768
-        env:
-          PACKAGING_TASK: "{{matrix.PACKAGING_TASK}}"
       - label: "{{matrix.image}} / packages / packaging-tests-unix"
         key: "packaging-tests-unix-packages"
         command: ./.ci/scripts/packaging-test.sh destructiveDistroTest.packages
@@ -58,6 +56,11 @@ steps:
               - rhel-8
               - rhel-9
               - almalinux-8
+        agents:
+          provider: gcp
+          image: family/elasticsearch-{{matrix.image}}
+          diskSizeGb: 350
+          machineType: custom-16-32768
       - label: "{{matrix.image}} / archives / packaging-tests-unix"
         key: "packaging-tests-unix-archives"
         command: ./.ci/scripts/packaging-test.sh destructiveDistroTest.archives
@@ -82,3 +85,8 @@ steps:
               - rhel-8
               - rhel-9
               - almalinux-8
+        agents:
+          provider: gcp
+          image: family/elasticsearch-{{matrix.image}}
+          diskSizeGb: 350
+          machineType: custom-16-32768

--- a/.buildkite/pipelines/pull-request/packaging-tests-unix.yml
+++ b/.buildkite/pipelines/pull-request/packaging-tests-unix.yml
@@ -3,9 +3,9 @@ config:
 steps:
   - group: packaging-tests-unix
     steps:
-      - label: "{{matrix.image}} / {{matrix.PACKAGING_TASK}} / packaging-tests-unix"
-        key: "packaging-tests-unix"
-        command: ./.ci/scripts/packaging-test.sh $$PACKAGING_TASK
+      - label: "{{matrix.image}} / docker / packaging-tests-unix"
+        key: "packaging-tests-unix-docker"
+        command: ./.ci/scripts/packaging-test.sh destructiveDistroTest.docker
         timeout_in_minutes: 300
         matrix:
           setup:
@@ -27,10 +27,6 @@ steps:
               - rhel-8
               - rhel-9
               - almalinux-8
-            PACKAGING_TASK:
-              - destructiveDistroTest.docker
-              - destructiveDistroTest.packages
-              - destructiveDistroTest.archives
         agents:
           provider: gcp
           image: family/elasticsearch-{{matrix.image}}
@@ -38,3 +34,51 @@ steps:
           machineType: custom-16-32768
         env:
           PACKAGING_TASK: "{{matrix.PACKAGING_TASK}}"
+      - label: "{{matrix.image}} / packages / packaging-tests-unix"
+        key: "packaging-tests-unix-packages"
+        command: ./.ci/scripts/packaging-test.sh destructiveDistroTest.packages
+        timeout_in_minutes: 300
+        matrix:
+          setup:
+            image:
+              - centos-7
+              - debian-10
+              - debian-11
+              - opensuse-leap-15
+              - oraclelinux-7
+              - oraclelinux-8
+              - sles-12
+              - sles-15
+              - ubuntu-1804
+              - ubuntu-2004
+              - ubuntu-2204
+              - rocky-8
+              - rocky-9
+              - rhel-7
+              - rhel-8
+              - rhel-9
+              - almalinux-8
+      - label: "{{matrix.image}} / archives / packaging-tests-unix"
+        key: "packaging-tests-unix-archives"
+        command: ./.ci/scripts/packaging-test.sh destructiveDistroTest.archives
+        timeout_in_minutes: 300
+        matrix:
+          setup:
+            image:
+              - centos-7
+              - debian-10
+              - debian-11
+              - opensuse-leap-15
+              - oraclelinux-7
+              - oraclelinux-8
+              - sles-12
+              - sles-15
+              - ubuntu-1804
+              - ubuntu-2004
+              - ubuntu-2204
+              - rocky-8
+              - rocky-9
+              - rhel-7
+              - rhel-8
+              - rhel-9
+              - almalinux-8

--- a/.buildkite/pipelines/pull-request/packaging-tests-unix.yml
+++ b/.buildkite/pipelines/pull-request/packaging-tests-unix.yml
@@ -22,6 +22,7 @@ steps:
               - ubuntu-2004
               - ubuntu-2204
               - rocky-8
+              - rocky-9
               - rhel-7
               - rhel-8
               - rhel-9


### PR DESCRIPTION
- Add rocky-9 to the packaging and platform jobs that test the support matrix
- Split the PR packaging-unix matrix up by gradle task, it got too big for Buildkite

Manually triggered periodic pipelines in Buildkite and those look good as well.