### PR TITLE
Get rid of "this-escape" warning in NodeShutdownTasksIT

### DIFF
--- a/x-pack/plugin/shutdown/src/internalClusterTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownTasksIT.java
+++ b/x-pack/plugin/shutdown/src/internalClusterTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownTasksIT.java
@@ -160,11 +160,10 @@ public class NodeShutdownTasksIT extends ESIntegTestCase {
         }
     }
 
-    public static class TaskExecutor extends PersistentTasksExecutor<TestTaskParams> implements ClusterStateListener {
+    public static final class TaskExecutor extends PersistentTasksExecutor<TestTaskParams> implements ClusterStateListener {
 
         private final PersistentTasksService persistentTasksService;
 
-        @SuppressWarnings("this-escape")
         protected TaskExecutor(Client client, ClusterService clusterService, ThreadPool threadPool) {
             super("task_name", ThreadPool.Names.GENERIC);
             persistentTasksService = new PersistentTasksService(clusterService, threadPool, client);

--- a/x-pack/plugin/shutdown/src/internalClusterTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownTasksIT.java
+++ b/x-pack/plugin/shutdown/src/internalClusterTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownTasksIT.java
@@ -164,6 +164,7 @@ public class NodeShutdownTasksIT extends ESIntegTestCase {
 
         private final PersistentTasksService persistentTasksService;
 
+        @SuppressWarnings("this-escape")
         protected TaskExecutor(Client client, ClusterService clusterService, ThreadPool threadPool) {
             super("task_name", ThreadPool.Names.GENERIC);
             persistentTasksService = new PersistentTasksService(clusterService, threadPool, client);


### PR DESCRIPTION
When running `./gradlew precommit`, I got the following failure:

```
> Task :x-pack:plugin:shutdown:compileInternalClusterTestJava FAILED
/Users/wbrafford/work/repos/elasticsearch/x-pack/plugin/shutdown/src/internalClusterTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownTasksIT.java:170: warning: [this-escape] possible 'this' escape before subclass is fully initialized
            clusterService.addListener(this);
                                       ^
error: warnings found and -Werror specified
1 error
1 warning
```

In #99848, we suppressed this warning rather than fixing every instance of it. But here, the quick fix is just making the problematic constructor's class final.