### PR TITLE
Remove IndexShardSnapshotStatus#isAborted

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/snapshots/IndexShardSnapshotStatus.java
+++ b/server/src/main/java/org/elasticsearch/index/snapshots/IndexShardSnapshotStatus.java
@@ -119,9 +119,8 @@ public class IndexShardSnapshotStatus {
             this.totalFileCount = totalFileCount;
             this.incrementalSize = incrementalSize;
             this.totalSize = totalSize;
-        } else if (isAborted()) {
-            throw new AbortedSnapshotException();
         } else {
+            ensureNotAborted();
             assert false : "Should not try to move stage [" + stage.get() + "] to [STARTED]";
             throw new IllegalStateException(
                 "Unable to move the shard snapshot status to [STARTED]: " + "expecting [INIT] but got [" + stage.get() + "]"
@@ -195,12 +194,8 @@ public class IndexShardSnapshotStatus {
         return shardSnapshotResult.get();
     }
 
-    public boolean isAborted() {
-        return stage.get() == Stage.ABORTED;
-    }
-
     public void ensureNotAborted() {
-        if (isAborted()) {
+        if (stage.get() == Stage.ABORTED) {
             throw new AbortedSnapshotException();
         }
     }

--- a/server/src/main/java/org/elasticsearch/repositories/Repository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/Repository.java
@@ -208,7 +208,7 @@ public interface Repository extends LifecycleComponent {
      * Creates a snapshot of the shard referenced by the given {@link SnapshotShardContext}.
      * <p>
      * As snapshot process progresses, implementation of this method should update {@link IndexShardSnapshotStatus} object returned by
-     * {@link SnapshotShardContext#status()} and check its {@link IndexShardSnapshotStatus#isAborted()} to see if the snapshot process
+     * {@link SnapshotShardContext#status()} and call {@link IndexShardSnapshotStatus#ensureNotAborted()} to see if the snapshot process
      * should be aborted.
      *
      * @param snapshotShardContext snapshot shard context that must be completed via {@link SnapshotShardContext#onResponse} or

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -3040,10 +3040,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                     }
                 }
                 for (String fileName : fileNames) {
-                    if (snapshotStatus.isAborted()) {
-                        logger.debug("[{}] [{}] Aborted on the file [{}], exiting", shardId, snapshotId, fileName);
-                        throw new AbortedSnapshotException();
-                    }
+                    ensureNotAborted(shardId, snapshotId, snapshotStatus, fileName);
 
                     logger.trace("[{}] [{}] Processing [{}]", shardId, snapshotId, fileName);
                     final StoreFileMetadata md = metadataFromStore.get(fileName);
@@ -3245,6 +3242,16 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         }
     }
 
+    private static void ensureNotAborted(ShardId shardId, SnapshotId snapshotId, IndexShardSnapshotStatus snapshotStatus, String fileName) {
+        try {
+            snapshotStatus.ensureNotAborted();
+        } catch (Exception e) {
+            logger.debug("[{}] [{}] {} on the file [{}], exiting", shardId, snapshotId, e.getMessage(), fileName);
+            assert e instanceof AbortedSnapshotException : e;
+            throw e;
+        }
+    }
+
     protected void snapshotFiles(
         SnapshotShardContext context,
         BlockingQueue<FileInfo> filesToSnapshot,
@@ -3273,7 +3280,12 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 store.decRef();
             }
         } else {
-            assert snapshotStatus.isAborted() : "if the store is already closed we must have been aborted";
+            try {
+                snapshotStatus.ensureNotAborted();
+                assert false : "if the store is already closed we must have been aborted";
+            } catch (Exception e) {
+                assert e instanceof AbortedSnapshotException : e;
+            }
         }
         return true;
     }
@@ -3712,10 +3724,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                     }
 
                     private void checkAborted() {
-                        if (snapshotStatus.isAborted()) {
-                            logger.debug("[{}] [{}] Aborted on the file [{}], exiting", shardId, snapshotId, fileInfo.physicalName());
-                            throw new AbortedSnapshotException();
-                        }
+                        ensureNotAborted(shardId, snapshotId, snapshotStatus, fileInfo.physicalName());
                     }
                 };
                 final String partName = fileInfo.partName(i);


### PR DESCRIPTION
We'd like to add more nuance to the aborted status of
`IndexShardSnapshotStatus` than can be carried in a plain boolean, so
this commit replaces all usages of the `isAborted()` method with calls
to `ensureNotAborted()`.