### PR TITLE
Drop ancient version checks from some Data Management code

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/datastreams/CreateDataStreamAction.java
+++ b/server/src/main/java/org/elasticsearch/action/datastreams/CreateDataStreamAction.java
@@ -7,7 +7,6 @@
  */
 package org.elasticsearch.action.datastreams;
 
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.IndicesRequest;
@@ -66,20 +65,14 @@ public class CreateDataStreamAction extends ActionType<AcknowledgedResponse> {
         public Request(StreamInput in) throws IOException {
             super(in);
             this.name = in.readString();
-            if (in.getTransportVersion().onOrAfter(TransportVersions.V_7_16_0)) {
-                this.startTime = in.readVLong();
-            } else {
-                this.startTime = System.currentTimeMillis();
-            }
+            this.startTime = in.readVLong();
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             out.writeString(name);
-            if (out.getTransportVersion().onOrAfter(TransportVersions.V_7_16_0)) {
-                out.writeVLong(startTime);
-            }
+            out.writeVLong(startTime);
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/action/MigrateToDataTiersResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/cluster/action/MigrateToDataTiersResponse.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.cluster.action;
 
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -63,15 +62,9 @@ public class MigrateToDataTiersResponse extends ActionResponse implements ToXCon
         migratedPolicies = in.readStringCollectionAsList();
         migratedIndices = in.readStringCollectionAsList();
         dryRun = in.readBoolean();
-        if (in.getTransportVersion().onOrAfter(TransportVersions.V_7_17_0)) {
-            migratedLegacyTemplates = in.readStringCollectionAsList();
-            migratedComposableTemplates = in.readStringCollectionAsList();
-            migratedComponentTemplates = in.readStringCollectionAsList();
-        } else {
-            migratedLegacyTemplates = List.of();
-            migratedComposableTemplates = List.of();
-            migratedComponentTemplates = List.of();
-        }
+        migratedLegacyTemplates = in.readStringCollectionAsList();
+        migratedComposableTemplates = in.readStringCollectionAsList();
+        migratedComponentTemplates = in.readStringCollectionAsList();
     }
 
     @Override
@@ -154,11 +147,9 @@ public class MigrateToDataTiersResponse extends ActionResponse implements ToXCon
         out.writeStringCollection(migratedPolicies);
         out.writeStringCollection(migratedIndices);
         out.writeBoolean(dryRun);
-        if (out.getTransportVersion().onOrAfter(TransportVersions.V_7_17_0)) {
-            out.writeStringCollection(migratedLegacyTemplates);
-            out.writeStringCollection(migratedComposableTemplates);
-            out.writeStringCollection(migratedComponentTemplates);
-        }
+        out.writeStringCollection(migratedLegacyTemplates);
+        out.writeStringCollection(migratedComposableTemplates);
+        out.writeStringCollection(migratedComponentTemplates);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/AllocateAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/AllocateAction.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.core.ilm;
 
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.routing.allocation.decider.ShardsLimitAllocationDecider;
@@ -123,7 +122,7 @@ public class AllocateAction implements LifecycleAction {
     public AllocateAction(StreamInput in) throws IOException {
         this(
             in.readOptionalVInt(),
-            in.getTransportVersion().onOrAfter(TransportVersions.V_7_16_0) ? in.readOptionalInt() : null,
+            in.readOptionalInt(),
             (Map<String, String>) in.readGenericValue(),
             (Map<String, String>) in.readGenericValue(),
             (Map<String, String>) in.readGenericValue()
@@ -153,9 +152,7 @@ public class AllocateAction implements LifecycleAction {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeOptionalVInt(numberOfReplicas);
-        if (out.getTransportVersion().onOrAfter(TransportVersions.V_7_16_0)) {
-            out.writeOptionalInt(totalShardsPerNode);
-        }
+        out.writeOptionalInt(totalShardsPerNode);
         out.writeGenericValue(include);
         out.writeGenericValue(exclude);
         out.writeGenericValue(require);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/searchablesnapshots/SearchableSnapshotFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/searchablesnapshots/SearchableSnapshotFeatureSetUsage.java
@@ -28,13 +28,8 @@ public class SearchableSnapshotFeatureSetUsage extends XPackFeatureSet.Usage {
     public SearchableSnapshotFeatureSetUsage(StreamInput input) throws IOException {
         super(input);
         numberOfSearchableSnapshotIndices = input.readVInt();
-        if (input.getTransportVersion().onOrAfter(TransportVersions.V_7_13_0)) {
-            numberOfFullCopySearchableSnapshotIndices = input.readVInt();
-            numberOfSharedCacheSearchableSnapshotIndices = input.readVInt();
-        } else {
-            numberOfFullCopySearchableSnapshotIndices = 0;
-            numberOfSharedCacheSearchableSnapshotIndices = 0;
-        }
+        numberOfFullCopySearchableSnapshotIndices = input.readVInt();
+        numberOfSharedCacheSearchableSnapshotIndices = input.readVInt();
     }
 
     @Override
@@ -46,10 +41,8 @@ public class SearchableSnapshotFeatureSetUsage extends XPackFeatureSet.Usage {
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeVInt(numberOfSearchableSnapshotIndices);
-        if (out.getTransportVersion().onOrAfter(TransportVersions.V_7_13_0)) {
-            out.writeVInt(numberOfFullCopySearchableSnapshotIndices);
-            out.writeVInt(numberOfSharedCacheSearchableSnapshotIndices);
-        }
+        out.writeVInt(numberOfFullCopySearchableSnapshotIndices);
+        out.writeVInt(numberOfSharedCacheSearchableSnapshotIndices);
     }
 
     public SearchableSnapshotFeatureSetUsage(


### PR DESCRIPTION
Just tidying up some code. Now that we're on 8.x, these pre-7.17 version checks are irrelevant.