### PR TITLE
Annotate build scan urls in BK for failed builds as error

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -138,10 +138,12 @@ buildScan {
 
         // Add a build annotation
         // See: https://buildkite.com/docs/agent/v3/cli-annotate
-        def body = """<div class="mb3"><span class="p1 border rounded">${System.getenv('BUILDKITE_LABEL')}</span> :gradle: build ran: <a href="${scan.buildScanUri}"><code>gradle ${gradle.startParameter.taskNames.join(' ')}</code></a></div>"""
-        new ProcessBuilder('buildkite-agent', 'annotate', '--context', 'gradle-build-scans', '--append', '--style', 'info', body)
-          .start()
-          .waitFor()
+        buildFinished { BuildResult result ->
+          def body = """<div class="mb3"><span class="p1 border rounded">${System.getenv('BUILDKITE_LABEL')}</span> :gradle: build ran: <a href="${scan.buildScanUri}"><code>gradle ${gradle.startParameter.taskNames.join(' ')}</code></a></div>"""
+          new ProcessBuilder('buildkite-agent', 'annotate', '--context', 'gradle-build-scans', '--append', '--style', result.failure ? 'error': 'info', body)
+            .start()
+            .waitFor()
+        }
       }
     } else {
       tag 'LOCAL'

--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -129,7 +129,7 @@ buildScan {
         link 'Source', "https://github.com/${repository}/tree/${BuildParams.gitRevision}"
       }
 
-      buildFinished { BuildResult result ->
+      buildFinished { result ->
         buildScanPublished { scan ->
           // Attach build scan link as build metadata
           // See: https://buildkite.com/docs/pipelines/build-meta-data

--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -139,7 +139,7 @@ buildScan {
         // Add a build annotation
         // See: https://buildkite.com/docs/agent/v3/cli-annotate
         buildFinished { BuildResult result ->
-          def body = """<div class="mb3"><span class="p1 border rounded">${System.getenv('BUILDKITE_LABEL')}</span> :gradle: build ran: <a href="${scan.buildScanUri}"><code>gradle ${gradle.startParameter.taskNames.join(' ')}</code></a></div>"""
+          def body = """<div class="mb3"><span class="p1 border rounded">${System.getenv('BUILDKITE_LABEL')}</span> :gradle: ${result.failure ? 'failed': 'succesful'} build: <a href="${scan.buildScanUri}"><code>gradle ${gradle.startParameter.taskNames.join(' ')}</code></a></div>"""
           new ProcessBuilder('buildkite-agent', 'annotate', '--context', 'gradle-build-scans', '--append', '--style', result.failure ? 'error': 'info', body)
             .start()
             .waitFor()

--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -139,7 +139,7 @@ buildScan {
         // Add a build annotation
         // See: https://buildkite.com/docs/agent/v3/cli-annotate
         buildFinished { BuildResult result ->
-          def body = """<div class="mb3"><span class="p1 border rounded">${System.getenv('BUILDKITE_LABEL')}</span> :gradle: ${result.failure ? 'failed': 'succesful'} build: <a href="${scan.buildScanUri}"><code>gradle ${gradle.startParameter.taskNames.join(' ')}</code></a></div>"""
+          def body = """<div class="mb3"><span class="p1 border rounded">${System.getenv('BUILDKITE_LABEL')}</span> :gradle: ${result.failure ? 'failed': 'successful'} build: <a href="${scan.buildScanUri}"><code>gradle ${gradle.startParameter.taskNames.join(' ')}</code></a></div>"""
           new ProcessBuilder('buildkite-agent', 'annotate', '--context', 'gradle-build-scans', '--append', '--style', result.failure ? 'error': 'info', body)
             .start()
             .waitFor()

--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -129,18 +129,27 @@ buildScan {
         link 'Source', "https://github.com/${repository}/tree/${BuildParams.gitRevision}"
       }
 
-      buildScanPublished { scan ->
-        // Attach build scan link as build metadata
-        // See: https://buildkite.com/docs/pipelines/build-meta-data
-        new ProcessBuilder('buildkite-agent', 'meta-data', 'set', "build-scan-${System.getenv('BUILDKITE_JOB_ID')}", "${scan.buildScanUri}")
-          .start()
-          .waitFor()
+      buildFinished { BuildResult result ->
+        buildScanPublished { scan ->
+          // Attach build scan link as build metadata
+          // See: https://buildkite.com/docs/pipelines/build-meta-data
+          new ProcessBuilder('buildkite-agent', 'meta-data', 'set', "build-scan-${System.getenv('BUILDKITE_JOB_ID')}", "${scan.buildScanUri}")
+            .start()
+            .waitFor()
 
-        // Add a build annotation
-        // See: https://buildkite.com/docs/agent/v3/cli-annotate
-        buildFinished { BuildResult result ->
-          def body = """<div class="mb3"><span class="p1 border rounded">${System.getenv('BUILDKITE_LABEL')}</span> :gradle: ${result.failure ? 'failed': 'successful'} build: <a href="${scan.buildScanUri}"><code>gradle ${gradle.startParameter.taskNames.join(' ')}</code></a></div>"""
-          new ProcessBuilder('buildkite-agent', 'annotate', '--context', 'gradle-build-scans', '--append', '--style', result.failure ? 'error': 'info', body)
+          // Add a build annotation
+          // See: https://buildkite.com/docs/agent/v3/cli-annotate
+          def body = """<div class="mb3"><span class="p1 border rounded">${System.getenv('BUILDKITE_LABEL')}</span> :gradle: ${result.failure ? 'failed' : 'successful'} build: <a href="${scan.buildScanUri}"><code>gradle ${gradle.startParameter.taskNames.join(' ')}</code></a></div>"""
+          new ProcessBuilder(
+            'buildkite-agent',
+            'annotate',
+            '--context',
+            'gradle-build-scans',
+            '--append',
+            '--style',
+            result.failure ? 'error' : 'info',
+            body
+          )
             .start()
             .waitFor()
         }


### PR DESCRIPTION
Making navigating build scans in buildkite a little bit easier by annotating them as failed or successful to find the culprit buildscan of a failed build easier