### PR TITLE
[8.10] Get rid of "this-escape" warning in NodeShutdownTasksIT (#101657)

### DIFF
--- a/x-pack/plugin/shutdown/src/internalClusterTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownTasksIT.java
+++ b/x-pack/plugin/shutdown/src/internalClusterTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownTasksIT.java
@@ -184,7 +184,7 @@ public class NodeShutdownTasksIT extends ESIntegTestCase {
         }
     }
 
-    public static class TaskExecutor extends PersistentTasksExecutor<TestTaskParams> implements ClusterStateListener {
+    public static final class TaskExecutor extends PersistentTasksExecutor<TestTaskParams> implements ClusterStateListener {
 
         private final PersistentTasksService persistentTasksService;
 


### PR DESCRIPTION
Backports the following commits to 8.10:
 - Get rid of "this-escape" warning in NodeShutdownTasksIT (#101657)