### PR TITLE
[DOCS] Add 'Using ES|QL in Elastic Security'

### DIFF
--- a/docs/reference/esql/esql-security-solution.asciidoc
+++ b/docs/reference/esql/esql-security-solution.asciidoc
@@ -15,8 +15,8 @@ questions about the {esql} query language.
 
 You can use {esql} in Timeline to filter, transform, and analyze event data
 stored in {es}. To start using {esql}, open the the **{esql}** tab. To learn
-more, refer to {security-guide}/timelines-ui.html[Investigate events in
-Timeline].
+more, refer to {security-guide}/timelines-ui.html#esql-in-timeline[Investigate
+events in Timeline].
 
 [discrete]
 [[esql-elastic-security-detection-rules]]
@@ -24,7 +24,8 @@ Timeline].
 
 Use the {esql} rule type to create detection rules using {esql} queries. The
 {esql} rule type supports aggregating and non-aggregating queries. To learn
-more, refer to {security-guide}/rules-ui-create.html[Create a detection rule].
+more, refer to {security-guide}/rules-ui-create.html#create-esql-rule[Create an
+{esql} rule].
 
 [discrete]
 [[esql-elastic-security-ai-assistant]]

--- a/docs/reference/esql/esql-security-solution.asciidoc
+++ b/docs/reference/esql/esql-security-solution.asciidoc
@@ -33,3 +33,8 @@ more, refer to {security-guide}/rules-ui-create.html[Create a detection rule].
 Use the Elastic AI Assistant to build {esql} queries, or answer questions about
 the {esql} query language. To learn more, refer to
 {security-guide}/security-assistant.html[AI Assistant].
+
+NOTE: For AI Assistant to answer questions about {esql} and write {esql}
+queries, you need to
+{security-guide}/security-assistant.html#set-up-ai-assistant[enable knowledge
+base].

--- a/docs/reference/esql/esql-security-solution.asciidoc
+++ b/docs/reference/esql/esql-security-solution.asciidoc
@@ -1,0 +1,35 @@
+[[esql-elastic-security]]
+=== Using {esql} in {elastic-sec}
+
+++++
+<titleabbrev>Using {esql} in {elastic-sec}</titleabbrev>
+++++
+
+You can use {esql} in {elastic-sec} to investigate events in Timeline and create
+detection rules. Use the Elastic AI Assistant to build {esql} queries, or answer
+questions about the {esql} query language.
+
+[discrete]
+[[esql-elastic-security-timeline]]
+=== Use {esql} to investigate events in Timeline
+
+You can use {esql} in Timeline to filter, transform, and analyze event data
+stored in {es}. To start using {esql}, open the the **{esql}** tab. To learn
+more, refer to {security-guide}/timelines-ui.html[Investigate events in
+Timeline].
+
+[discrete]
+[[esql-elastic-security-detection-rules]]
+=== Use {esql} to create detection rules
+
+Use the {esql} rule type to create detection rules using {esql} queries. The
+{esql} rule type supports aggregating and non-aggregating queries. To learn
+more, refer to {security-guide}/rules-ui-create.html[Create a detection rule].
+
+[discrete]
+[[esql-elastic-security-ai-assistant]]
+=== Elastic AI Assistant
+
+Use the Elastic AI Assistant to build {esql} queries, or answer questions about
+the {esql} query language. To learn more, refer to
+{security-guide}/security-assistant.html[AI Assistant].

--- a/docs/reference/esql/esql-using.asciidoc
+++ b/docs/reference/esql/esql-using.asciidoc
@@ -6,11 +6,16 @@ Information about using the <<esql-query-api,{esql} query API>>.
 
 <<esql-kibana>>::
 Using {esql} in {kib} to query and aggregate your data, create visualizations,
-and set up alerts. 
+and set up alerts.
+
+<<esql-elastic-security>>::
+Using {esql} in {elastic-sec} to investigate events in Timeline and create
+detection rules.
 
 <<esql-task-management>>::
 Using the <<tasks,task management API>> to list and cancel {esql} queries.
 
 include::esql-rest.asciidoc[]
 include::esql-kibana.asciidoc[]
+include::esql-security-solution.asciidoc[]
 include::task-management.asciidoc[]

--- a/docs/reference/esql/index.asciidoc
+++ b/docs/reference/esql/index.asciidoc
@@ -55,8 +55,8 @@ fields>> and <<esql-multivalued-fields,multivalued fields>>. And guidance for
 GROK>> and <<esql-enrich-data,data enrichment with ENRICH>>.
 
 <<esql-using>>::
-An overview of using the <<esql-rest>>, <<esql-kibana>>, and
-<<esql-task-management>>.
+An overview of using the <<esql-rest>>, <<esql-kibana>>,
+<<esql-elastic-security>>, and <<esql-task-management>>.
 
 <<esql-limitations>>::
 The current limitations of {esql}.


### PR DESCRIPTION
Adds a 'Using ES|QL in Elastic Security' section, similar to 'Using ES|QL in Kibana'.