### PR TITLE
Metrics: Reject names longer than 63 characters

### DIFF
--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/APMMeterRegistry.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/APMMeterRegistry.java
@@ -52,7 +52,7 @@ public class APMMeterRegistry implements MeterRegistry {
     private final Registrar<LongGaugeAdapter> longGauges = new Registrar<>();
     private final Registrar<LongHistogramAdapter> longHistograms = new Registrar<>();
 
-    private final Meter meter;
+    private Meter meter;
 
     public APMMeterRegistry(Meter meter) {
         this.meter = meter;
@@ -170,8 +170,9 @@ public class APMMeterRegistry implements MeterRegistry {
 
     public void setProvider(Meter meter) {
         try (ReleasableLock lock = registerLock.acquire()) {
+            this.meter = meter;
             for (Registrar<?> registrar : registrars) {
-                registrar.setProvider(meter);
+                registrar.setProvider(this.meter);
             }
         }
     }

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/AbstractInstrument.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/AbstractInstrument.java
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * @param <T> delegated instrument
  */
 public abstract class AbstractInstrument<T> implements Instrument {
+    private static final int MAX_NAME_LENGTH = 63; // TODO(stu): change to 255 when we upgrade to otel 1.30+, see #101679
     private final AtomicReference<T> delegate;
     private final String name;
     private final String description;
@@ -33,6 +34,11 @@ public abstract class AbstractInstrument<T> implements Instrument {
     @SuppressWarnings("this-escape")
     public AbstractInstrument(Meter meter, String name, String description, String unit) {
         this.name = Objects.requireNonNull(name);
+        if (name.length() > MAX_NAME_LENGTH) {
+            throw new IllegalArgumentException(
+                "Instrument name [" + name + "] with length [" + name.length() + "] exceeds maximum length [" + MAX_NAME_LENGTH + "]"
+            );
+        }
         this.description = Objects.requireNonNull(description);
         this.unit = Objects.requireNonNull(unit);
         this.delegate = new AtomicReference<>(doBuildInstrument(meter));

--- a/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/APMMeterRegistryTests.java
+++ b/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/APMMeterRegistryTests.java
@@ -16,14 +16,19 @@ import org.elasticsearch.telemetry.apm.internal.APMAgentSettings;
 import org.elasticsearch.telemetry.apm.internal.APMMeterService;
 import org.elasticsearch.telemetry.apm.internal.TestAPMMeterService;
 import org.elasticsearch.telemetry.metric.DoubleCounter;
+import org.elasticsearch.telemetry.metric.LongCounter;
 import org.elasticsearch.test.ESTestCase;
 
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.sameInstance;
 
 public class APMMeterRegistryTests extends ESTestCase {
-    Meter testOtel = OpenTelemetry.noop().getMeter("test");
+    Meter testOtel = new RecordingOtelMeter();
 
     Meter noopOtel = OpenTelemetry.noop().getMeter("noop");
+
+    private Settings TELEMETRY_ENABLED = Settings.builder().put(APMAgentSettings.TELEMETRY_METRICS_ENABLED_SETTING.getKey(), true).build();
 
     public void testMeterIsSetUponConstruction() {
         // test default
@@ -33,14 +38,13 @@ public class APMMeterRegistryTests extends ESTestCase {
         assertThat(meter, sameInstance(noopOtel));
 
         // test explicitly enabled
-        var settings = Settings.builder().put(APMAgentSettings.TELEMETRY_METRICS_ENABLED_SETTING.getKey(), true).build();
-        apmMeter = new APMMeterService(settings, () -> testOtel, () -> noopOtel);
+        apmMeter = new APMMeterService(TELEMETRY_ENABLED, () -> testOtel, () -> noopOtel);
 
         meter = apmMeter.getMeterRegistry().getMeter();
         assertThat(meter, sameInstance(testOtel));
 
         // test explicitly disabled
-        settings = Settings.builder().put(APMAgentSettings.TELEMETRY_METRICS_ENABLED_SETTING.getKey(), true).build();
+        var settings = Settings.builder().put(APMAgentSettings.TELEMETRY_METRICS_ENABLED_SETTING.getKey(), false).build();
         apmMeter = new APMMeterService(settings, () -> testOtel, () -> noopOtel);
 
         meter = apmMeter.getMeterRegistry().getMeter();
@@ -60,9 +64,7 @@ public class APMMeterRegistryTests extends ESTestCase {
     }
 
     public void testLookupByName() {
-        var settings = Settings.builder().put(APMAgentSettings.TELEMETRY_METRICS_ENABLED_SETTING.getKey(), true).build();
-
-        var apmMeter = new APMMeterService(settings, () -> testOtel, () -> noopOtel).getMeterRegistry();
+        var apmMeter = new APMMeterService(TELEMETRY_ENABLED, () -> testOtel, () -> noopOtel).getMeterRegistry();
 
         DoubleCounter registeredCounter = apmMeter.registerDoubleCounter("name", "desc", "unit");
         DoubleCounter lookedUpCounter = apmMeter.getDoubleCounter("name");
@@ -71,8 +73,7 @@ public class APMMeterRegistryTests extends ESTestCase {
     }
 
     public void testNoopIsSetOnStop() {
-        var settings = Settings.builder().put(APMAgentSettings.TELEMETRY_METRICS_ENABLED_SETTING.getKey(), true).build();
-        APMMeterService apmMeter = new APMMeterService(settings, () -> testOtel, () -> noopOtel);
+        APMMeterService apmMeter = new APMMeterService(TELEMETRY_ENABLED, () -> testOtel, () -> noopOtel);
         apmMeter.start();
 
         Meter meter = apmMeter.getMeterRegistry().getMeter();
@@ -84,4 +85,16 @@ public class APMMeterRegistryTests extends ESTestCase {
         assertThat(meter, sameInstance(noopOtel));
     }
 
+    public void testMaxNameLength() {
+        APMMeterService apmMeter = new APMMeterService(TELEMETRY_ENABLED, () -> testOtel, () -> noopOtel);
+        apmMeter.start();
+        int max_length = 63;
+        var counter = apmMeter.getMeterRegistry().registerLongCounter("a".repeat(max_length), "desc", "count");
+        assertThat(counter, instanceOf(LongCounter.class));
+        IllegalArgumentException iae = expectThrows(
+            IllegalArgumentException.class,
+            () -> apmMeter.getMeterRegistry().registerLongCounter("a".repeat(max_length + 1), "desc", "count")
+        );
+        assertThat(iae.getMessage(), containsString("exceeds maximum length [63]"));
+    }
 }


### PR DESCRIPTION
Open Telemetry supports instrument names lengths 63 characters or less for versions before 1.30.

Reject those names early to avoid runtime failures that hit the log.

This change also fixes the fact that we weren't updating the meter field when changing providers.

Refs: #101679