### PR TITLE
Add manage_enrich cluster privilege to kibana_system role

### DIFF
--- a/docs/changelog/101682.yaml
+++ b/docs/changelog/101682.yaml
@@ -1,0 +1,5 @@
+pr: 101682
+summary: "Add manage_enrich cluster priviledge to kibana_system role"
+area: Authentication
+type: enhancement
+issues: []

--- a/docs/changelog/101682.yaml
+++ b/docs/changelog/101682.yaml
@@ -1,5 +1,5 @@
 pr: 101682
-summary: "Add manage_enrich cluster priviledge to kibana_system role"
+summary: "Add manage_enrich cluster privilege to kibana_system role"
 area: Authentication
 type: enhancement
 issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
@@ -64,6 +64,8 @@ class KibanaOwnedReservedRoleDescriptors {
                 "manage_saml",
                 "manage_token",
                 "manage_oidc",
+                // For SLO to install enrich policy
+                "manage_enrich",
                 // For Fleet package upgrade
                 "manage_pipeline",
                 "manage_ilm",

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -432,6 +432,8 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertThat(kibanaRole.cluster().check("cluster:admin/xpack/enrich/put", request, authentication), is(true));
         assertThat(kibanaRole.cluster().check("cluster:admin/xpack/enrich/execute", request, authentication), is(true));
         assertThat(kibanaRole.cluster().check("cluster:admin/xpack/enrich/get", request, authentication), is(true));
+        assertThat(kibanaRole.cluster().check("cluster:admin/xpack/enrich/delete", request, authentication), is(true));
+        assertThat(kibanaRole.cluster().check("cluster:admin/xpack/enrich/stats", request, authentication), is(true));
 
         // SAML and token
         assertThat(kibanaRole.cluster().check(SamlPrepareAuthenticationAction.NAME, request, authentication), is(true));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -428,6 +428,11 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertThat(kibanaRole.cluster().check(ClusterUpdateSettingsAction.NAME, request, authentication), is(false));
         assertThat(kibanaRole.cluster().check(MonitoringBulkAction.NAME, request, authentication), is(true));
 
+        // Enrich
+        assertThat(kibanaRole.cluster().check("cluster:admin/xpack/enrich/put", request, authentication), is(true));
+        assertThat(kibanaRole.cluster().check("cluster:admin/xpack/enrich/execute", request, authentication), is(true));
+        assertThat(kibanaRole.cluster().check("cluster:admin/xpack/enrich/get", request, authentication), is(true));
+
         // SAML and token
         assertThat(kibanaRole.cluster().check(SamlPrepareAuthenticationAction.NAME, request, authentication), is(true));
         assertThat(kibanaRole.cluster().check(SamlAuthenticateAction.NAME, request, authentication), is(true));


### PR DESCRIPTION
## 🍒 Summary

We are refactoring our SLO transforms to reduce the number of runtime fields we are using to inject/enrich our roll-up data with details from the SLO definition which is stored in a Kibana saved object. Part of this refactor is introducing an `enrich` step to the ingest pipeline for both our roll-up SLI data and the SLO summary data.  These pipelines are installed by the `kibana_system` user (which uses the `kibana_system` role).

This PR introduces the `manage_enrich` cluster privilege to the `kibana_system` role to allow the SLO plugin to install our enrich policy and update the ingest pipelines.

### 🤓 Additional Context

Here is what our architecture looks like. The ingest pipelines, enrich policy, and summary transforms are all manged by the `kibana_system` user.  This PR is required for the box labeled "New for 8.12".

<img width="1048" alt="image" src="https://github.com/elastic/elasticsearch/assets/41702/181075cf-37eb-49ca-9767-36a5a48706a2">

### 💑 Related Kibana PR

This is the PR that introduces the enrich policy along with some schema updates we need to for GA: https://github.com/elastic/kibana/pull/169993 

