### PR TITLE
ESQL: Yaml test for https://github.com/elastic/elasticsearch/issues/101489

### DIFF
--- a/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/resources/rest-api-spec/test/100_bug_fix.yml
+++ b/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/resources/rest-api-spec/test/100_bug_fix.yml
@@ -1,5 +1,7 @@
 ---
-setup:
+"Bug fix https://github.com/elastic/elasticsearch/issues/99472":
+  - skip:
+      features: warnings
   - do:
       bulk:
         index: test
@@ -9,11 +11,6 @@ setup:
           - { "emp_no": 10, "ip1": "127.0", "ip2": "0.1" }
           - { "index": { } }
           - { "emp_no": 20 }
-
----
-"Bug fix https://github.com/elastic/elasticsearch/issues/99472":
-  - skip:
-      features: warnings
   - do:
       warnings:
         - "Line 1:37: evaluation of [to_ip(coalesce(ip1.keyword, \"255.255.255.255\"))] failed, treating result as null. Only first 20 failures recorded."
@@ -55,3 +52,70 @@ setup:
   - length: { values: 2 }
   - match: { values.0: [ 10, "127.00.1", "127.00.1", null ] }
   - match: { values.1: [ 20, null, "255.255.255.255", "255.255.255.255"] }
+
+---
+"Bug fix https://github.com/elastic/elasticsearch/issues/101489":
+  - do:
+      indices.create:
+        index: index1
+        body:
+          mappings:
+            properties:
+              http:
+                properties:
+                  headers:
+                    type: flattened
+  - do:
+      indices.create:
+        index: index2
+        body:
+          mappings:
+            properties:
+              http:
+                properties:
+                  headers:
+                    properties:
+                      location:
+                        type: keyword
+  - do:
+      indices.create:
+        index: index3
+        body:
+          mappings:
+            properties:
+              http:
+                properties:
+                  headers:
+                    properties:
+                      location:
+                        type: text
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - { "index": { "_index": "index1" } }
+          - { "http.headers": { "location": "RO","code": 123 } }
+          - { "index": { "_index": "index2" } }
+          - { "http.headers.location": "US" }
+          - { "index": { "_index": "index3" } }
+          - { "http.headers.location": "CN" }
+  - do:
+      esql.query:
+        body:
+          query: 'from index* [metadata _index] | limit 5 | sort _index desc'
+  - match: { columns.0.name: http.headers }
+  - match: { columns.0.type: unsupported }
+  - match: { columns.1.name: http.headers.location }
+  - match: { columns.1.type: unsupported }
+  - match: { columns.2.name: _index }
+  - match: { columns.2.type: keyword }
+  - length: { values: 3 }
+  - match: { values.0.0: null }
+  - match: { values.0.1: null }
+  - match: { values.0.2: index3 }
+  - match: { values.1.0: null }
+  - match: { values.1.1: null }
+  - match: { values.1.2: index2 }
+  - match: { values.2.0: null }
+  - match: { values.2.1: null }
+  - match: { values.2.2: index1 }


### PR DESCRIPTION
Adds an yaml test that reproduces the issue in https://github.com/elastic/elasticsearch/issues/101489. The original PR fixes this test properly.