### PR TITLE
[ci] Don't generate CI artifact for nested builds, tweak build scan data

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.build-complete.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-complete.gradle
@@ -12,7 +12,9 @@ import java.nio.file.Files
 
 String buildNumber = System.getenv('BUILD_NUMBER') ?: System.getenv('BUILDKITE_BUILD_NUMBER')
 String performanceTest = System.getenv('BUILD_PERFORMANCE_TEST')
-if (buildNumber && performanceTest == null && GradleUtils.isIncludedBuild(project) == false) {
+Boolean isNested = System.getProperty("scan.tag.NESTED") != null
+
+if (buildNumber && performanceTest == null && GradleUtils.isIncludedBuild(project) == false && !isNested) {
   def uploadFilePath = "build/${buildNumber}.tar.bz2"
   File uploadFile = file(uploadFilePath)
   project.gradle.buildFinished { result ->

--- a/build-tools-internal/src/main/groovy/elasticsearch.build-complete.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-complete.gradle
@@ -14,7 +14,7 @@ String buildNumber = System.getenv('BUILD_NUMBER') ?: System.getenv('BUILDKITE_B
 String performanceTest = System.getenv('BUILD_PERFORMANCE_TEST')
 Boolean isNested = System.getProperty("scan.tag.NESTED") != null
 
-if (buildNumber && performanceTest == null && GradleUtils.isIncludedBuild(project) == false && !isNested) {
+if (buildNumber && performanceTest == null && GradleUtils.isIncludedBuild(project) == false && isNested == false) {
   def uploadFilePath = "build/${buildNumber}.tar.bz2"
   File uploadFile = file(uploadFilePath)
   project.gradle.buildFinished { result ->

--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -101,8 +101,10 @@ buildScan {
       def jobName = (System.getenv('BUILDKITE_LABEL') ?: '').replaceAll(/[^a-zA-Z0-9_\-]+/, ' ').trim().replaceAll(' ', '_').toLowerCase()
 
       tag 'CI'
-      link 'CI Build', buildKiteUrl
+      link 'CI Build', "${buildKiteUrl}#${System.getenv('BUILDKITE_JOB_ID')}"
       value 'Job Number', System.getenv('BUILDKITE_BUILD_NUMBER')
+      value 'Build ID', System.getenv('BUILDKITE_BUILD_ID')
+      value 'Job ID', System.getenv('BUILDKITE_JOB_ID')
 
       value 'Pipeline', System.getenv('BUILDKITE_PIPELINE_SLUG')
       tag System.getenv('BUILDKITE_PIPELINE_SLUG')


### PR DESCRIPTION
- Don't generate the CI build debugging artifact for nested builds. Multiple artifacts are causing issues elsewhere
- CI Build link in build scan should link directly to the relevant job
- Add Build and Job ID to the build scan values