### PR TITLE
Remove HLRC from EQL tests

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
@@ -302,17 +302,6 @@ public class RestHighLevelClient implements Closeable {
     }
 
     /**
-     * Executes a bulk request using the Bulk API.
-     * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html">Bulk API on elastic.co</a>
-     * @param bulkRequest the request
-     * @param options the request options (e.g. headers), use {@link RequestOptions#DEFAULT} if nothing needs to be customized
-     * @return the response
-     */
-    public final BulkResponse bulk(BulkRequest bulkRequest, RequestOptions options) throws IOException {
-        return performRequestAndParseEntity(bulkRequest, RequestConverters::bulk, options, BulkResponse::fromXContent, emptySet());
-    }
-
-    /**
      * Asynchronously executes a bulk request using the Bulk API.
      * See <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html">Bulk API on elastic.co</a>
      * @param bulkRequest the request

--- a/x-pack/plugin/eql/qa/ccs-rolling-upgrade/src/test/java/org/elasticsearch/xpack/eql/qa/ccs_rolling_upgrade/EqlCcsRollingUpgradeIT.java
+++ b/x-pack/plugin/eql/qa/ccs-rolling-upgrade/src/test/java/org/elasticsearch/xpack/eql/qa/ccs_rolling_upgrade/EqlCcsRollingUpgradeIT.java
@@ -12,13 +12,11 @@ import org.apache.http.util.EntityUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.Version;
-import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.client.Request;
-import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
-import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.test.rest.ObjectPath;
@@ -84,7 +82,7 @@ public class EqlCcsRollingUpgradeIT extends ESRestTestCase {
     public static void configureRemoteClusters(List<Node> remoteNodes) throws Exception {
         assertThat(remoteNodes, hasSize(3));
         final String remoteClusterSettingPrefix = "cluster.remote." + CLUSTER_ALIAS + ".";
-        try (RestClient localClient = newLocalClient().getLowLevelClient()) {
+        try (RestClient localClient = newLocalClient()) {
             final Settings remoteConnectionSettings;
             if (randomBoolean()) {
                 final List<String> seeds = remoteNodes.stream()
@@ -118,28 +116,32 @@ public class EqlCcsRollingUpgradeIT extends ESRestTestCase {
         }
     }
 
-    static RestHighLevelClient newLocalClient() {
+    static RestClient newLocalClient() {
         final List<HttpHost> hosts = parseHosts("tests.rest.cluster");
         final int index = random().nextInt(hosts.size());
         LOGGER.info("Using client node {}", index);
-        return new RestHighLevelClient(RestClient.builder(hosts.get(index)));
+        return RestClient.builder(hosts.get(index)).build();
     }
 
-    static RestHighLevelClient newRemoteClient() {
-        return new RestHighLevelClient(RestClient.builder(randomFrom(parseHosts("tests.rest.remote_cluster"))));
+    static RestClient newRemoteClient() {
+        return RestClient.builder(randomFrom(parseHosts("tests.rest.remote_cluster"))).build();
     }
 
-    static int indexDocs(RestHighLevelClient client, String index, int numDocs) throws IOException {
+    static int indexDocs(RestClient client, String index, int numDocs) throws IOException {
         for (int i = 0; i < numDocs; i++) {
-            client.index(new IndexRequest(index).id("id_" + i).source("f", i, "@timestamp", i), RequestOptions.DEFAULT);
+            Request createDoc = new Request("POST", "/" + index + "/_doc/id_" + i);
+            createDoc.setJsonEntity(Strings.format("""
+                { "f": %s, "@timestamp": %s }
+                """, i, i));
+            assertOK(client.performRequest(createDoc));
         }
 
-        refresh(client.getLowLevelClient(), index);
+        refresh(client, index);
         return numDocs;
     }
 
     void verify(String localIndex, int localNumDocs, String remoteIndex, int remoteNumDocs) {
-        try (RestClient localClient = newLocalClient().getLowLevelClient()) {
+        try (RestClient localClient = newLocalClient()) {
 
             Request request = new Request("POST", "/" + randomFrom(remoteIndex, localIndex + "," + remoteIndex) + "/_eql/search");
             int size = between(1, 100);
@@ -161,9 +163,9 @@ public class EqlCcsRollingUpgradeIT extends ESRestTestCase {
     public void testSequences() throws Exception {
         String localIndex = "test_bwc_search_states_index";
         String remoteIndex = "test_bwc_search_states_remote_index";
-        try (RestHighLevelClient localClient = newLocalClient(); RestHighLevelClient remoteClient = newRemoteClient()) {
+        try (RestClient localClient = newLocalClient(); RestClient remoteClient = newRemoteClient()) {
             createIndex(
-                localClient.getLowLevelClient(),
+                localClient,
                 localIndex,
                 Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, between(1, 5)).build(),
                 "{\"properties\": {\"@timestamp\": {\"type\": \"date\"}}}",
@@ -171,7 +173,7 @@ public class EqlCcsRollingUpgradeIT extends ESRestTestCase {
             );
             int localNumDocs = indexDocs(localClient, localIndex, between(10, 100));
             createIndex(
-                remoteClient.getLowLevelClient(),
+                remoteClient,
                 remoteIndex,
                 Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, between(1, 5)).build(),
                 "{\"properties\": {\"@timestamp\": {\"type\": \"date\"}}}",
@@ -179,13 +181,13 @@ public class EqlCcsRollingUpgradeIT extends ESRestTestCase {
             );
             int remoteNumDocs = indexDocs(remoteClient, remoteIndex, between(10, 100));
 
-            configureRemoteClusters(getNodes(remoteClient.getLowLevelClient()));
+            configureRemoteClusters(getNodes(remoteClient));
             int iterations = between(1, 20);
             for (int i = 0; i < iterations; i++) {
                 verify(localIndex, localNumDocs, CLUSTER_ALIAS + ":" + remoteIndex, remoteNumDocs);
             }
-            deleteIndex(localClient.getLowLevelClient(), localIndex);
-            deleteIndex(remoteClient.getLowLevelClient(), remoteIndex);
+            deleteIndex(localClient, localIndex);
+            deleteIndex(remoteClient, remoteIndex);
         }
     }
 }

--- a/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/BaseEqlSpecTestCase.java
+++ b/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/BaseEqlSpecTestCase.java
@@ -66,7 +66,7 @@ public abstract class BaseEqlSpecTestCase extends RemoteClusterAwareEqlRestTestC
             );
 
         if (dataLoaded == false) {
-            DataLoader.loadDatasetIntoEs(highLevelClient(provisioningClient), this::createParser);
+            DataLoader.loadDatasetIntoEs(provisioningClient, this::createParser);
         }
     }
 

--- a/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/RemoteClusterAwareEqlRestTestCase.java
+++ b/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/RemoteClusterAwareEqlRestTestCase.java
@@ -11,7 +11,6 @@ import org.apache.http.HttpHost;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
-import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
@@ -24,11 +23,9 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
 import java.io.IOException;
-import java.util.Collections;
 
 import static org.elasticsearch.common.Strings.hasText;
 
-@SuppressWarnings("removal")
 public abstract class RemoteClusterAwareEqlRestTestCase extends ESRestTestCase {
 
     private static final long CLIENT_TIMEOUT = 40L; // upped from 10s to accomodate for max measured throughput decline
@@ -59,11 +56,6 @@ public abstract class RemoteClusterAwareEqlRestTestCase extends ESRestTestCase {
         } finally {
             remoteClient = null;
         }
-    }
-
-    protected static RestHighLevelClient highLevelClient(RestClient client) {
-        return new RestHighLevelClient(client, ignore -> {}, Collections.emptyList()) {
-        };
     }
 
     protected static RestClient clientBuilder(Settings settings, HttpHost[] hosts) throws IOException {

--- a/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/stats/EqlUsageRestTestCase.java
+++ b/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/stats/EqlUsageRestTestCase.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.test.eql.stats;
 
 import org.elasticsearch.client.Request;
-import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -20,7 +19,6 @@ import org.junit.Before;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -29,10 +27,8 @@ import java.util.Set;
 /**
  * Tests a random number of queries that increase various (most of the times, one query will "touch" multiple metrics values) metrics.
  */
-@SuppressWarnings("removal")
 public abstract class EqlUsageRestTestCase extends ESRestTestCase {
 
-    private RestHighLevelClient highLevelClient;
     private Map<String, Integer> baseMetrics = new HashMap<>();
     private Integer baseAllTotalQueries = 0;
     private Integer baseAllFailedQueries = 0;
@@ -117,7 +113,7 @@ public abstract class EqlUsageRestTestCase extends ESRestTestCase {
         // it doesn't matter if the index is already there (probably created by another test); _if_ its mapping is the expected one
         // it should be enough
         if (client().performRequest(new Request("HEAD", "/" + DataLoader.TEST_INDEX)).getStatusLine().getStatusCode() == 404) {
-            DataLoader.loadDatasetIntoEs(highLevelClient(), this::createParser);
+            DataLoader.loadDatasetIntoEs(client(), this::createParser);
         }
 
         String defaultPipe = "pipe_tail";
@@ -380,14 +376,6 @@ public abstract class EqlUsageRestTestCase extends ESRestTestCase {
                 assertEquals(baseMetrics.get(metricName), actualValue);
             }
         }
-    }
-
-    private RestHighLevelClient highLevelClient() {
-        if (highLevelClient == null) {
-            highLevelClient = new RestHighLevelClient(client(), ignore -> {}, Collections.emptyList()) {
-            };
-        }
-        return highLevelClient;
     }
 
     @Override

--- a/x-pack/plugin/eql/qa/correctness/src/javaRestTest/java/org/elasticsearch/xpack/eql/EsEQLCorrectnessIT.java
+++ b/x-pack/plugin/eql/qa/correctness/src/javaRestTest/java/org/elasticsearch/xpack/eql/EsEQLCorrectnessIT.java
@@ -19,7 +19,6 @@ import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
-import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
@@ -38,7 +37,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -47,14 +45,12 @@ import static org.elasticsearch.xpack.ql.TestUtils.assertNoSearchContexts;
 
 @TimeoutSuite(millis = 30 * TimeUnits.MINUTE)
 @TestLogging(value = "org.elasticsearch.xpack.eql.EsEQLCorrectnessIT:INFO", reason = "Log query execution time")
-@SuppressWarnings("removal")
 public class EsEQLCorrectnessIT extends ESRestTestCase {
 
     private static final String PARAM_FORMATTING = "%1$s";
     private static final String QUERIES_FILENAME = "queries.toml";
 
     private static Properties CFG;
-    private static RestHighLevelClient highLevelClient;
     private static RequestOptions COMMON_REQUEST_OPTIONS;
     private static long totalTime = 0;
 
@@ -115,14 +111,6 @@ public class EsEQLCorrectnessIT extends ESRestTestCase {
 
     public EsEQLCorrectnessIT(EqlSpec spec) {
         this.spec = spec;
-    }
-
-    private RestHighLevelClient highLevelClient() {
-        if (highLevelClient == null) {
-            highLevelClient = new RestHighLevelClient(client(), ignore -> {}, Collections.emptyList()) {
-            };
-        }
-        return highLevelClient;
     }
 
     @ParametersFactory(shuffle = false, argumentFormatting = PARAM_FORMATTING)


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/issues/83423

Drops HLRC use from some integration tests.