### PR TITLE
Make some classes final to avoid suppressing "this-escape" warning

### DIFF
--- a/libs/ssl-config/src/test/java/org/elasticsearch/common/ssl/SslConfigurationLoaderTests.java
+++ b/libs/ssl-config/src/test/java/org/elasticsearch/common/ssl/SslConfigurationLoaderTests.java
@@ -29,9 +29,8 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
-public class SslConfigurationLoaderTests extends ESTestCase {
+public final class SslConfigurationLoaderTests extends ESTestCase {
 
-    @SuppressWarnings("this-escape")
     private final Path certRoot = getDataPath("/certs/ca1/ca.crt").getParent().getParent();
 
     private Settings settings;

--- a/libs/tdigest/src/main/java/org/elasticsearch/tdigest/Centroid.java
+++ b/libs/tdigest/src/main/java/org/elasticsearch/tdigest/Centroid.java
@@ -26,7 +26,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 /**
  * A single centroid which represents a number of data points.
  */
-public class Centroid implements Comparable<Centroid> {
+public final class Centroid implements Comparable<Centroid> {
     private static final AtomicInteger uniqueCount = new AtomicInteger(1);
 
     private double centroid = 0;
@@ -40,19 +40,16 @@ public class Centroid implements Comparable<Centroid> {
         id = uniqueCount.getAndIncrement();
     }
 
-    @SuppressWarnings("this-escape")
     public Centroid(double x) {
         this();
         start(x, 1, uniqueCount.getAndIncrement());
     }
 
-    @SuppressWarnings("this-escape")
     public Centroid(double x, long w) {
         this();
         start(x, w, uniqueCount.getAndIncrement());
     }
 
-    @SuppressWarnings("this-escape")
     public Centroid(double x, long w, int id) {
         this();
         start(x, w, id);

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/CustomMustacheFactory.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/CustomMustacheFactory.java
@@ -39,7 +39,7 @@ import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class CustomMustacheFactory extends DefaultMustacheFactory {
+public final class CustomMustacheFactory extends DefaultMustacheFactory {
     static final String V7_JSON_MEDIA_TYPE_WITH_CHARSET = "application/json; charset=UTF-8";
     static final String JSON_MEDIA_TYPE_WITH_CHARSET = "application/json;charset=utf-8";
     static final String JSON_MEDIA_TYPE = "application/json";
@@ -63,7 +63,6 @@ public class CustomMustacheFactory extends DefaultMustacheFactory {
 
     private final Encoder encoder;
 
-    @SuppressWarnings("this-escape")
     public CustomMustacheFactory(String mediaType) {
         super();
         setObjectHandler(new CustomReflectionObjectHandler());

--- a/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/RestMultiSearchTemplateActionTests.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/RestMultiSearchTemplateActionTests.java
@@ -23,8 +23,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-public class RestMultiSearchTemplateActionTests extends RestActionTestCase {
-    @SuppressWarnings("this-escape")
+public final class RestMultiSearchTemplateActionTests extends RestActionTestCase {
     final List<String> contentTypeHeader = Collections.singletonList(compatibleMediaType(XContentType.VND_JSON, RestApiVersion.V_7));
 
     @Before

--- a/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/RestSearchTemplateActionTests.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/RestSearchTemplateActionTests.java
@@ -21,8 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class RestSearchTemplateActionTests extends RestActionTestCase {
-    @SuppressWarnings("this-escape")
+public final class RestSearchTemplateActionTests extends RestActionTestCase {
     final List<String> contentTypeHeader = Collections.singletonList(randomCompatibleMediaType(RestApiVersion.V_7));
 
     @Before

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankEvalRequest.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankEvalRequest.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 /**
  * Request to perform a search ranking evaluation.
  */
-public class RankEvalRequest extends ActionRequest implements IndicesRequest.Replaceable {
+public final class RankEvalRequest extends ActionRequest implements IndicesRequest.Replaceable {
 
     private RankEvalSpec rankingEvaluationSpec;
 
@@ -35,7 +35,6 @@ public class RankEvalRequest extends ActionRequest implements IndicesRequest.Rep
 
     private SearchType searchType = SearchType.DEFAULT;
 
-    @SuppressWarnings("this-escape")
     public RankEvalRequest(RankEvalSpec rankingEvaluationSpec, String[] indices) {
         this.rankingEvaluationSpec = Objects.requireNonNull(rankingEvaluationSpec, "ranking evaluation specification must not be null");
         indices(indices);

--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/TransportRankEvalActionTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/TransportRankEvalActionTests.java
@@ -30,10 +30,9 @@ import java.util.List;
 
 import static org.mockito.Mockito.mock;
 
-public class TransportRankEvalActionTests extends ESTestCase {
+public final class TransportRankEvalActionTests extends ESTestCase {
 
-    @SuppressWarnings("this-escape")
-    private Settings settings = Settings.builder()
+    private final Settings settings = Settings.builder()
         .put("path.home", createTempDir().toString())
         .put("node.name", "test-" + getTestName())
         .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir().toString())

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/RestDeleteByQueryActionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/RestDeleteByQueryActionTests.java
@@ -23,9 +23,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-public class RestDeleteByQueryActionTests extends RestActionTestCase {
+public final class RestDeleteByQueryActionTests extends RestActionTestCase {
 
-    @SuppressWarnings("this-escape")
     final List<String> contentTypeHeader = Collections.singletonList(compatibleMediaType(XContentType.VND_JSON, RestApiVersion.V_7));
 
     @Before

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/RestUpdateByQueryActionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/RestUpdateByQueryActionTests.java
@@ -23,9 +23,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-public class RestUpdateByQueryActionTests extends RestActionTestCase {
+public final class RestUpdateByQueryActionTests extends RestActionTestCase {
 
-    @SuppressWarnings("this-escape")
     final List<String> contentTypeHeader = Collections.singletonList(compatibleMediaType(XContentType.VND_JSON, RestApiVersion.V_7));
 
     @Before

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/util/Packages.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/util/Packages.java
@@ -310,7 +310,7 @@ public class Packages {
      * when instantiated, and advancing that cursor when the {@code clear()}
      * method is called.
      */
-    public static class JournaldWrapper {
+    public static final class JournaldWrapper {
         private Shell sh;
         private String cursor;
 
@@ -318,7 +318,6 @@ public class Packages {
          * Create a new wrapper for Elasticsearch JournalD logs.
          * @param sh A shell with appropriate permissions.
          */
-        @SuppressWarnings("this-escape")
         public JournaldWrapper(Shell sh) {
             this.sh = sh;
             clear();

--- a/server/src/main/java/org/elasticsearch/action/NoShardAvailableActionException.java
+++ b/server/src/main/java/org/elasticsearch/action/NoShardAvailableActionException.java
@@ -16,7 +16,7 @@ import org.elasticsearch.rest.RestStatus;
 import java.io.IOException;
 import java.io.PrintWriter;
 
-public class NoShardAvailableActionException extends ElasticsearchException {
+public final class NoShardAvailableActionException extends ElasticsearchException {
 
     private static final StackTraceElement[] EMPTY_STACK_TRACE = new StackTraceElement[0];
 
@@ -28,22 +28,18 @@ public class NoShardAvailableActionException extends ElasticsearchException {
         return new NoShardAvailableActionException(null, msg, null, true);
     }
 
-    @SuppressWarnings("this-escape")
     public NoShardAvailableActionException(ShardId shardId) {
         this(shardId, null, null, false);
     }
 
-    @SuppressWarnings("this-escape")
     public NoShardAvailableActionException(ShardId shardId, String msg) {
         this(shardId, msg, null, false);
     }
 
-    @SuppressWarnings("this-escape")
     public NoShardAvailableActionException(ShardId shardId, String msg, Throwable cause) {
         this(shardId, msg, cause, false);
     }
 
-    @SuppressWarnings("this-escape")
     private NoShardAvailableActionException(ShardId shardId, String msg, Throwable cause, boolean onShardFailureWrapper) {
         super(msg, cause);
         setShard(shardId);

--- a/server/src/main/java/org/elasticsearch/action/RoutingMissingException.java
+++ b/server/src/main/java/org/elasticsearch/action/RoutingMissingException.java
@@ -18,11 +18,10 @@ import org.elasticsearch.rest.RestStatus;
 import java.io.IOException;
 import java.util.Objects;
 
-public class RoutingMissingException extends ElasticsearchException {
+public final class RoutingMissingException extends ElasticsearchException {
 
     private final String id;
 
-    @SuppressWarnings("this-escape")
     public RoutingMissingException(String index, String id) {
         super("routing is required for [" + index + "]/[" + id + "]");
         Objects.requireNonNull(index, "index must not be null");

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequest.java
@@ -20,7 +20,7 @@ import java.util.TreeSet;
 /**
  * A request to get node (cluster) level information.
  */
-public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
+public final class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
 
     private final NodesInfoMetrics nodesInfoMetrics;
 
@@ -39,7 +39,6 @@ public class NodesInfoRequest extends BaseNodesRequest<NodesInfoRequest> {
      * Get information from nodes based on the nodes ids specified. If none are passed, information
      * for all nodes will be returned.
      */
-    @SuppressWarnings("this-escape")
     public NodesInfoRequest(String... nodesIds) {
         super(nodesIds);
         nodesInfoMetrics = new NodesInfoMetrics();

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsRequest.java
@@ -20,7 +20,9 @@ import org.elasticsearch.core.Nullable;
 import java.io.IOException;
 import java.util.Objects;
 
-public class ClusterSearchShardsRequest extends MasterNodeReadRequest<ClusterSearchShardsRequest> implements IndicesRequest.Replaceable {
+public final class ClusterSearchShardsRequest extends MasterNodeReadRequest<ClusterSearchShardsRequest>
+    implements
+        IndicesRequest.Replaceable {
 
     private String[] indices = Strings.EMPTY_ARRAY;
     @Nullable
@@ -31,7 +33,6 @@ public class ClusterSearchShardsRequest extends MasterNodeReadRequest<ClusterSea
 
     public ClusterSearchShardsRequest() {}
 
-    @SuppressWarnings("this-escape")
     public ClusterSearchShardsRequest(String... indices) {
         indices(indices);
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeAction.java
@@ -59,7 +59,7 @@ public class AnalyzeAction extends ActionType<AnalyzeAction.Response> {
      * A request to analyze a text associated with a specific index. Allow to provide
      * the actual analyzer name to perform the analysis with.
      */
-    public static class Request extends SingleShardRequest<Request> {
+    public static final class Request extends SingleShardRequest<Request> {
 
         private String[] text;
         private String analyzer;
@@ -91,7 +91,6 @@ public class AnalyzeAction extends ActionType<AnalyzeAction.Response> {
          *
          * @param index The text to analyze
          */
-        @SuppressWarnings("this-escape")
         public Request(String index) {
             this.index(index);
         }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/close/TransportVerifyShardBeforeCloseAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/close/TransportVerifyShardBeforeCloseAction.java
@@ -163,7 +163,7 @@ public class TransportVerifyShardBeforeCloseAction extends TransportReplicationA
         }
     }
 
-    public static class ShardRequest extends ReplicationRequest<ShardRequest> {
+    public static final class ShardRequest extends ReplicationRequest<ShardRequest> {
 
         private final ClusterBlock clusterBlock;
 
@@ -175,7 +175,6 @@ public class TransportVerifyShardBeforeCloseAction extends TransportReplicationA
             phase1 = in.readBoolean();
         }
 
-        @SuppressWarnings("this-escape")
         public ShardRequest(final ShardId shardId, final ClusterBlock clusterBlock, final boolean phase1, final TaskId parentTaskId) {
             super(shardId);
             this.clusterBlock = Objects.requireNonNull(clusterBlock);

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/readonly/TransportVerifyShardIndexBlockAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/readonly/TransportVerifyShardIndexBlockAction.java
@@ -157,7 +157,7 @@ public class TransportVerifyShardIndexBlockAction extends TransportReplicationAc
         }
     }
 
-    public static class ShardRequest extends ReplicationRequest<ShardRequest> {
+    public static final class ShardRequest extends ReplicationRequest<ShardRequest> {
 
         private final ClusterBlock clusterBlock;
 
@@ -166,7 +166,6 @@ public class TransportVerifyShardIndexBlockAction extends TransportReplicationAc
             clusterBlock = new ClusterBlock(in);
         }
 
-        @SuppressWarnings("this-escape")
         public ShardRequest(final ShardId shardId, final ClusterBlock clusterBlock, final TaskId parentTaskId) {
             super(shardId);
             this.clusterBlock = Objects.requireNonNull(clusterBlock);

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStatsFlags.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/CommonStatsFlags.java
@@ -24,7 +24,7 @@ import java.util.EnumSet;
  * The SHARD_LEVEL flags are for stat fields that can be calculated at the shard level and then may be later aggregated at the index level
  * along with index-level flag stat fields (e.g., Mappings).
  */
-public class CommonStatsFlags implements Writeable, Cloneable {
+public final class CommonStatsFlags implements Writeable, Cloneable {
 
     public static final CommonStatsFlags ALL = new CommonStatsFlags().all();
     public static final CommonStatsFlags SHARD_LEVEL = new CommonStatsFlags().all().set(Flag.Mappings, false);
@@ -40,7 +40,6 @@ public class CommonStatsFlags implements Writeable, Cloneable {
     /**
      * @param flags flags to set. If no flags are supplied, default flags will be set.
      */
-    @SuppressWarnings("this-escape")
     public CommonStatsFlags(Flag... flags) {
         if (flags.length > 0) {
             clear();

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryRequest.java
@@ -29,7 +29,7 @@ import java.util.Arrays;
  * <p>
  * The request requires the query to be set using {@link #query(QueryBuilder)}
  */
-public class ValidateQueryRequest extends BroadcastRequest<ValidateQueryRequest> implements ToXContentObject {
+public final class ValidateQueryRequest extends BroadcastRequest<ValidateQueryRequest> implements ToXContentObject {
 
     public static final IndicesOptions DEFAULT_INDICES_OPTIONS = IndicesOptions.fromOptions(false, false, true, false);
 
@@ -65,7 +65,6 @@ public class ValidateQueryRequest extends BroadcastRequest<ValidateQueryRequest>
      * Constructs a new validate request against the provided indices. No indices provided means it will
      * run against all indices.
      */
-    @SuppressWarnings("this-escape")
     public ValidateQueryRequest(String... indices) {
         super(indices);
         indicesOptions(DEFAULT_INDICES_OPTIONS);

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkShardRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkShardRequest.java
@@ -24,7 +24,7 @@ import org.elasticsearch.transport.RawIndexingDataTransportRequest;
 import java.io.IOException;
 import java.util.Set;
 
-public class BulkShardRequest extends ReplicatedWriteRequest<BulkShardRequest> implements Accountable, RawIndexingDataTransportRequest {
+public final class BulkShardRequest extends ReplicatedWriteRequest<BulkShardRequest> implements Accountable, RawIndexingDataTransportRequest {
 
     private static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(BulkShardRequest.class);
 
@@ -35,7 +35,6 @@ public class BulkShardRequest extends ReplicatedWriteRequest<BulkShardRequest> i
         items = in.readArray(i -> i.readOptionalWriteable(inpt -> new BulkItemRequest(shardId, inpt)), BulkItemRequest[]::new);
     }
 
-    @SuppressWarnings("this-escape")
     public BulkShardRequest(ShardId shardId, RefreshPolicy refreshPolicy, BulkItemRequest[] items) {
         super(shardId);
         this.items = items;

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkShardRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkShardRequest.java
@@ -24,7 +24,10 @@ import org.elasticsearch.transport.RawIndexingDataTransportRequest;
 import java.io.IOException;
 import java.util.Set;
 
-public final class BulkShardRequest extends ReplicatedWriteRequest<BulkShardRequest> implements Accountable, RawIndexingDataTransportRequest {
+public final class BulkShardRequest extends ReplicatedWriteRequest<BulkShardRequest>
+    implements
+        Accountable,
+        RawIndexingDataTransportRequest {
 
     private static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(BulkShardRequest.class);
 

--- a/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
@@ -455,7 +455,7 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
      * and how many of them were skipped and further details in a Map of Cluster objects
      * (when doing a cross-cluster search).
      */
-    public static class Clusters implements ToXContentFragment, Writeable {
+    public static final class Clusters implements ToXContentFragment, Writeable {
 
         public static final Clusters EMPTY = new Clusters(0, 0, 0);
 
@@ -538,7 +538,6 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
             this.clusterInfo = Collections.emptyMap();  // will never be used if created from this constructor
         }
 
-        @SuppressWarnings("this-escape")
         public Clusters(StreamInput in) throws IOException {
             this.total = in.readVInt();
             int successfulTemp = in.readVInt();

--- a/server/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastShardOperationFailedException.java
+++ b/server/src/main/java/org/elasticsearch/action/support/broadcast/BroadcastShardOperationFailedException.java
@@ -20,7 +20,7 @@ import java.io.IOException;
  *
  *
  */
-public class BroadcastShardOperationFailedException extends ElasticsearchException implements ElasticsearchWrapperException {
+public final class BroadcastShardOperationFailedException extends ElasticsearchException implements ElasticsearchWrapperException {
 
     public BroadcastShardOperationFailedException(ShardId shardId, String msg) {
         this(shardId, msg, null);
@@ -30,7 +30,6 @@ public class BroadcastShardOperationFailedException extends ElasticsearchExcepti
         this(shardId, "", cause);
     }
 
-    @SuppressWarnings("this-escape")
     public BroadcastShardOperationFailedException(ShardId shardId, String msg, Throwable cause) {
         super(msg, cause);
         setShard(shardId);

--- a/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationOperation.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationOperation.java
@@ -661,13 +661,11 @@ public class ReplicationOperation<
 
     }
 
-    public static class RetryOnPrimaryException extends ElasticsearchException {
-        @SuppressWarnings("this-escape")
+    public static final class RetryOnPrimaryException extends ElasticsearchException {
         public RetryOnPrimaryException(ShardId shardId, String msg) {
             this(shardId, msg, null);
         }
 
-        @SuppressWarnings("this-escape")
         RetryOnPrimaryException(ShardId shardId, String msg, Throwable cause) {
             super(msg, cause);
             setShard(shardId);

--- a/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
@@ -605,9 +605,8 @@ public abstract class TransportReplicationAction<
         return () -> {};
     }
 
-    public static class RetryOnReplicaException extends ElasticsearchException {
+    public static final class RetryOnReplicaException extends ElasticsearchException {
 
-        @SuppressWarnings("this-escape")
         public RetryOnReplicaException(ShardId shardId, String msg) {
             super(msg);
             setShard(shardId);

--- a/server/src/main/java/org/elasticsearch/action/termvectors/TermVectorsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/termvectors/TermVectorsRequest.java
@@ -50,7 +50,7 @@ import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
  */
 // It's not possible to suppress teh warning at #realtime(boolean) at a method-level.
 @SuppressWarnings("unchecked")
-public class TermVectorsRequest extends SingleShardRequest<TermVectorsRequest> implements RealtimeRequest {
+public final class TermVectorsRequest extends SingleShardRequest<TermVectorsRequest> implements RealtimeRequest {
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(TermVectorsRequest.class);
 
     private static final ParseField INDEX = new ParseField("_index");
@@ -204,7 +204,6 @@ public class TermVectorsRequest extends SingleShardRequest<TermVectorsRequest> i
         this.filterSettings = other.filterSettings();
     }
 
-    @SuppressWarnings("this-escape")
     public TermVectorsRequest(MultiGetRequest.Item item) {
         super(item.index());
         this.id = item.id();

--- a/server/src/main/java/org/elasticsearch/action/termvectors/TermVectorsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/termvectors/TermVectorsRequest.java
@@ -79,7 +79,7 @@ public final class TermVectorsRequest extends SingleShardRequest<TermVectorsRequ
 
     private long version = Versions.MATCH_ANY;
 
-    protected String preference;
+    private String preference;
 
     private static final AtomicInteger randomInt = new AtomicInteger(0);
 

--- a/server/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
+++ b/server/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
@@ -841,9 +841,8 @@ public class ShardStateAction {
         }
     }
 
-    public static class NoLongerPrimaryShardException extends ElasticsearchException {
+    public static final class NoLongerPrimaryShardException extends ElasticsearchException {
 
-        @SuppressWarnings("this-escape")
         public NoLongerPrimaryShardException(ShardId shardId, String msg) {
             super(msg);
             setShard(shardId);

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/FollowersChecker.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/FollowersChecker.java
@@ -61,7 +61,7 @@ import static org.elasticsearch.monitor.StatusInfo.Status.UNHEALTHY;
  * considering a follower to be faulty, to allow for a brief network partition or a long GC cycle to occur without triggering the removal of
  * a node and the consequent shard reallocation.
  */
-public class FollowersChecker {
+public final class FollowersChecker {
 
     private static final Logger logger = LogManager.getLogger(FollowersChecker.class);
 
@@ -105,7 +105,6 @@ public class FollowersChecker {
     private final NodeHealthService nodeHealthService;
     private volatile FastResponseState fastResponseState;
 
-    @SuppressWarnings("this-escape")
     public FollowersChecker(
         Settings settings,
         TransportService transportService,

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexTemplateMetadata.java
@@ -224,7 +224,7 @@ public class IndexTemplateMetadata implements SimpleDiffable<IndexTemplateMetada
         }
     }
 
-    public static class Builder {
+    public static final class Builder {
 
         private static final Set<String> VALID_FIELDS = Set.of("order", "mappings", "settings", "index_patterns", "aliases", "version");
 
@@ -248,7 +248,6 @@ public class IndexTemplateMetadata implements SimpleDiffable<IndexTemplateMetada
             aliases = new HashMap<>();
         }
 
-        @SuppressWarnings("this-escape")
         public Builder(IndexTemplateMetadata indexTemplateMetadata) {
             this.name = indexTemplateMetadata.name();
             order(indexTemplateMetadata.order());

--- a/server/src/main/java/org/elasticsearch/common/geo/GeoPoint.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeoPoint.java
@@ -25,10 +25,10 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import java.io.IOException;
 import java.util.Locale;
 
-public class GeoPoint implements SpatialPoint, ToXContentFragment {
+public final class GeoPoint implements SpatialPoint, ToXContentFragment {
 
-    protected double lat;
-    protected double lon;
+    private double lat;
+    private double lon;
 
     public GeoPoint() {}
 
@@ -38,7 +38,6 @@ public class GeoPoint implements SpatialPoint, ToXContentFragment {
      *
      * @param value String to create the point from
      */
-    @SuppressWarnings("this-escape")
     public GeoPoint(String value) {
         this.resetFromString(value);
     }

--- a/server/src/main/java/org/elasticsearch/common/inject/CreationException.java
+++ b/server/src/main/java/org/elasticsearch/common/inject/CreationException.java
@@ -27,13 +27,12 @@ import java.util.Collection;
  *
  * @author crazybob@google.com (Bob Lee)
  */
-public class CreationException extends RuntimeException {
+public final class CreationException extends RuntimeException {
     private final Collection<Message> messages;
 
     /**
      * Creates a CreationException containing {@code messages}.
      */
-    @SuppressWarnings("this-escape")
     public CreationException(Collection<Message> messages) {
         this.messages = messages;
         if (this.messages.isEmpty()) {

--- a/server/src/main/java/org/elasticsearch/common/io/stream/ByteArrayStreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/ByteArrayStreamInput.java
@@ -17,18 +17,16 @@ import java.io.IOException;
  * Resettable {@link StreamInput} that wraps a byte array. It is heavily inspired in Lucene's
  * {@link org.apache.lucene.store.ByteArrayDataInput}.
  */
-public class ByteArrayStreamInput extends StreamInput {
+public final class ByteArrayStreamInput extends StreamInput {
 
     private byte[] bytes;
     private int pos;
     private int limit;
 
-    @SuppressWarnings("this-escape")
     public ByteArrayStreamInput() {
         reset(BytesRef.EMPTY_BYTES);
     }
 
-    @SuppressWarnings("this-escape")
     public ByteArrayStreamInput(byte[] bytes) {
         reset(bytes);
     }

--- a/server/src/main/java/org/elasticsearch/common/io/stream/VersionCheckingStreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/VersionCheckingStreamOutput.java
@@ -17,9 +17,8 @@ import java.io.IOException;
  * This {@link StreamOutput} writes nowhere. It can be used to check if serialization would
  * be successful writing to a specific version.
  */
-public class VersionCheckingStreamOutput extends StreamOutput {
+public final class VersionCheckingStreamOutput extends StreamOutput {
 
-    @SuppressWarnings("this-escape")
     public VersionCheckingStreamOutput(TransportVersion version) {
         setTransportVersion(version);
     }

--- a/server/src/main/java/org/elasticsearch/common/logging/ECSJsonLayout.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/ECSJsonLayout.java
@@ -32,14 +32,13 @@ public class ECSJsonLayout {
         return new ECSJsonLayout.Builder().asBuilder();
     }
 
-    public static class Builder extends AbstractStringLayout.Builder<Builder>
+    public static final class Builder extends AbstractStringLayout.Builder<Builder>
         implements
             org.apache.logging.log4j.core.util.Builder<EcsLayout> {
 
         @PluginAttribute("dataset")
         String dataset;
 
-        @SuppressWarnings("this-escape")
         public Builder() {
             setCharset(StandardCharsets.UTF_8);
         }

--- a/server/src/main/java/org/elasticsearch/common/logging/ESJsonLayout.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/ESJsonLayout.java
@@ -147,7 +147,7 @@ public class ESJsonLayout extends AbstractStringLayout {
         return patternLayout;
     }
 
-    public static class Builder<B extends ESJsonLayout.Builder<B>> extends AbstractStringLayout.Builder<B>
+    public static final class Builder<B extends ESJsonLayout.Builder<B>> extends AbstractStringLayout.Builder<B>
         implements
             org.apache.logging.log4j.core.util.Builder<ESJsonLayout> {
 
@@ -163,7 +163,6 @@ public class ESJsonLayout extends AbstractStringLayout {
         @PluginConfiguration
         private Configuration config;
 
-        @SuppressWarnings("this-escape")
         public Builder() {
             setCharset(StandardCharsets.UTF_8);
         }

--- a/server/src/main/java/org/elasticsearch/common/metrics/Counters.java
+++ b/server/src/main/java/org/elasticsearch/common/metrics/Counters.java
@@ -28,11 +28,10 @@ import java.util.concurrent.ConcurrentMap;
  * that will not have conflicts, which means that there no counter will have a label which is a substring of the label of another counter.
  * For example, the counters `foo: 1` and `foo.bar: 3` cannot co-exist in a nested map.
  */
-public class Counters implements Writeable {
+public final class Counters implements Writeable {
 
     private final ConcurrentMap<String, CounterMetric> counters = new ConcurrentHashMap<>();
 
-    @SuppressWarnings("this-escape")
     public Counters(StreamInput in) throws IOException {
         int numCounters = in.readVInt();
         for (int i = 0; i < numCounters; i++) {

--- a/server/src/main/java/org/elasticsearch/common/settings/LocallyMountedSecrets.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/LocallyMountedSecrets.java
@@ -65,7 +65,7 @@ import static org.elasticsearch.xcontent.XContentType.JSON;
  *              }
  *         }
  */
-public class LocallyMountedSecrets implements SecureSettings {
+public final class LocallyMountedSecrets implements SecureSettings {
 
     public static final String SECRETS_FILE_NAME = "secrets.json";
     public static final String SECRETS_DIRECTORY = "secrets";
@@ -116,7 +116,6 @@ public class LocallyMountedSecrets implements SecureSettings {
     /**
      * Direct constructor to be used by the CLI
      */
-    @SuppressWarnings("this-escape")
     public LocallyMountedSecrets(Environment environment) {
         var secretsDirPath = resolveSecretsDir(environment);
         var secretsFilePath = resolveSecretsFile(environment);

--- a/server/src/main/java/org/elasticsearch/common/util/BytesRefArray.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BytesRefArray.java
@@ -22,7 +22,7 @@ import java.io.IOException;
 /**
  * Compact serializable container for ByteRefs
  */
-public class BytesRefArray implements Accountable, Releasable, Writeable {
+public final class BytesRefArray implements Accountable, Releasable, Writeable {
 
     // base size of the bytes ref array
     private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(BytesRefArray.class);
@@ -32,7 +32,6 @@ public class BytesRefArray implements Accountable, Releasable, Writeable {
     private ByteArray bytes;
     private long size;
 
-    @SuppressWarnings("this-escape")
     public BytesRefArray(long capacity, BigArrays bigArrays) {
         this.bigArrays = bigArrays;
         boolean success = false;
@@ -49,7 +48,6 @@ public class BytesRefArray implements Accountable, Releasable, Writeable {
         size = 0;
     }
 
-    @SuppressWarnings("this-escape")
     public BytesRefArray(StreamInput in, BigArrays bigArrays) throws IOException {
         this.bigArrays = bigArrays;
         // we allocate big arrays so we have to `close` if we fail here or we'll leak them.

--- a/server/src/main/java/org/elasticsearch/common/util/LongObjectPagedHashMap.java
+++ b/server/src/main/java/org/elasticsearch/common/util/LongObjectPagedHashMap.java
@@ -17,7 +17,7 @@ import java.util.NoSuchElementException;
  * A hash table from native longs to objects. This implementation resolves collisions
  * using open-addressing and does not support null values. This class is not thread-safe.
  */
-public class LongObjectPagedHashMap<T> extends AbstractPagedHashMap implements Iterable<LongObjectPagedHashMap.Cursor<T>> {
+public final class LongObjectPagedHashMap<T> extends AbstractPagedHashMap implements Iterable<LongObjectPagedHashMap.Cursor<T>> {
 
     private LongArray keys;
     private ObjectArray<T> values;
@@ -26,7 +26,6 @@ public class LongObjectPagedHashMap<T> extends AbstractPagedHashMap implements I
         this(capacity, DEFAULT_MAX_LOAD_FACTOR, bigArrays);
     }
 
-    @SuppressWarnings("this-escape")
     public LongObjectPagedHashMap(long capacity, float maxLoadFactor, BigArrays bigArrays) {
         super(capacity, maxLoadFactor, bigArrays);
         boolean success = false;

--- a/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -199,7 +199,7 @@ public final class NodeEnvironment implements Closeable {
      */
     static final String SEARCHABLE_SHARED_CACHE_FILE = "shared_snapshot_cache";
 
-    public static class NodeLock implements Releasable {
+    public static final class NodeLock implements Releasable {
 
         private final Lock[] locks;
         private final DataPath[] dataPaths;
@@ -213,7 +213,6 @@ public final class NodeEnvironment implements Closeable {
          * Tries to acquire a node lock for a node id, throws {@code IOException} if it is unable to acquire it
          * @param pathFunction function to check node path before attempt of acquiring a node lock
          */
-        @SuppressWarnings("this-escape")
         public NodeLock(
             final Logger logger,
             final Environment environment,

--- a/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -989,7 +989,7 @@ public final class NodeEnvironment implements Closeable {
             lockDetails = Tuple.tuple(System.nanoTime(), details);
         }
 
-        protected void release() {
+        private void release() {
             mutex.release();
             decWaitCount();
         }

--- a/server/src/main/java/org/elasticsearch/env/ShardLockObtainFailedException.java
+++ b/server/src/main/java/org/elasticsearch/env/ShardLockObtainFailedException.java
@@ -17,15 +17,13 @@ import java.io.IOException;
 /**
  * Exception used when the in-memory lock for a shard cannot be obtained
  */
-public class ShardLockObtainFailedException extends ElasticsearchException {
+public final class ShardLockObtainFailedException extends ElasticsearchException {
 
-    @SuppressWarnings("this-escape")
     public ShardLockObtainFailedException(ShardId shardId, String message) {
         super(buildMessage(shardId, message));
         this.setShard(shardId);
     }
 
-    @SuppressWarnings("this-escape")
     public ShardLockObtainFailedException(ShardId shardId, String message, Throwable cause) {
         super(buildMessage(shardId, message), cause);
         this.setShard(shardId);

--- a/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
+++ b/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
@@ -495,7 +495,7 @@ public class GatewayMetaState implements Closeable {
     /**
      * Encapsulates the incremental writing of metadata to a {@link PersistedClusterStateService.Writer}.
      */
-    public static class LucenePersistedState implements PersistedState {
+    public static final class LucenePersistedState implements PersistedState {
 
         private long currentTerm;
         private ClusterState lastAcceptedState;
@@ -505,7 +505,6 @@ public class GatewayMetaState implements Closeable {
         private final AtomicReference<PersistedClusterStateService.Writer> persistenceWriter = new AtomicReference<>();
         private boolean writeNextStateFully;
 
-        @SuppressWarnings("this-escape")
         public LucenePersistedState(
             PersistedClusterStateService persistedClusterStateService,
             long currentTerm,

--- a/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
+++ b/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
@@ -525,7 +525,7 @@ public class GatewayMetaState implements Closeable {
             persistenceWriter.set(writer);
         }
 
-        protected void maybeWriteInitialState(long currentTerm, ClusterState lastAcceptedState, PersistedClusterStateService.Writer writer)
+        private void maybeWriteInitialState(long currentTerm, ClusterState lastAcceptedState, PersistedClusterStateService.Writer writer)
             throws IOException {
             try {
                 writer.writeFullStateAndCommit(currentTerm, lastAcceptedState);
@@ -555,7 +555,7 @@ public class GatewayMetaState implements Closeable {
             this.currentTerm = currentTerm;
         }
 
-        protected void writeCurrentTermToDisk(long currentTerm) {
+        private void writeCurrentTermToDisk(long currentTerm) {
             try {
                 if (writeNextStateFully) {
                     getWriterSafe().writeFullStateAndCommit(currentTerm, lastAcceptedState);
@@ -583,7 +583,7 @@ public class GatewayMetaState implements Closeable {
             lastAcceptedState = clusterState;
         }
 
-        protected void writeClusterStateToDisk(ClusterState clusterState) {
+        private void writeClusterStateToDisk(ClusterState clusterState) {
             try {
                 if (writeNextStateFully) {
                     getWriterSafe().writeFullStateAndCommit(currentTerm, clusterState);

--- a/server/src/main/java/org/elasticsearch/index/codec/PerFieldMapperCodec.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/PerFieldMapperCodec.java
@@ -37,7 +37,7 @@ import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
  * per index in real time via the mapping API. If no specific postings format or vector format is
  * configured for a specific field the default postings or vector format is used.
  */
-public class PerFieldMapperCodec extends Lucene95Codec {
+public final class PerFieldMapperCodec extends Lucene95Codec {
 
     private final MapperService mapperService;
     private final DocValuesFormat docValuesFormat = new Lucene90DocValuesFormat();
@@ -49,7 +49,6 @@ public class PerFieldMapperCodec extends Lucene95Codec {
             : "PerFieldMapperCodec must subclass the latest lucene codec: " + Lucene.LATEST_CODEC;
     }
 
-    @SuppressWarnings("this-escape")
     public PerFieldMapperCodec(Mode compressionMode, MapperService mapperService, BigArrays bigArrays) {
         super(compressionMode);
         this.mapperService = mapperService;

--- a/server/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
@@ -191,11 +191,10 @@ public class BinaryFieldMapper extends FieldMapper {
         return CONTENT_TYPE;
     }
 
-    public static class CustomBinaryDocValuesField extends CustomDocValuesField {
+    public static final class CustomBinaryDocValuesField extends CustomDocValuesField {
 
         private final List<byte[]> bytesList;
 
-        @SuppressWarnings("this-escape")
         public CustomBinaryDocValuesField(String name, byte[] bytes) {
             super(name);
             bytesList = new ArrayList<>();

--- a/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
@@ -68,7 +68,7 @@ public class BooleanFieldMapper extends FieldMapper {
         return (BooleanFieldMapper) in;
     }
 
-    public static class Builder extends FieldMapper.Builder {
+    public static final class Builder extends FieldMapper.Builder {
 
         private final Parameter<Boolean> docValues = Parameter.docValuesParam(m -> toType(m).hasDocValues, true);
         private final Parameter<Boolean> indexed = Parameter.indexParam(m -> toType(m).indexed, true);
@@ -93,7 +93,6 @@ public class BooleanFieldMapper extends FieldMapper {
 
         private final IndexVersion indexCreatedVersion;
 
-        @SuppressWarnings("this-escape")
         public Builder(String name, ScriptCompiler scriptCompiler, boolean ignoreMalformedByDefault, IndexVersion indexCreatedVersion) {
             super(name);
             this.scriptCompiler = Objects.requireNonNull(scriptCompiler);

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -223,7 +223,7 @@ public final class DateFieldMapper extends FieldMapper {
         return (DateFieldMapper) in;
     }
 
-    public static class Builder extends FieldMapper.Builder {
+    public static final class Builder extends FieldMapper.Builder {
 
         private final Parameter<Boolean> index = Parameter.indexParam(m -> toType(m).indexed, true);
         private final Parameter<Boolean> docValues = Parameter.docValuesParam(m -> toType(m).hasDocValues, true);
@@ -253,7 +253,6 @@ public final class DateFieldMapper extends FieldMapper {
         private final IndexVersion indexCreatedVersion;
         private final ScriptCompiler scriptCompiler;
 
-        @SuppressWarnings("this-escape")
         public Builder(
             String name,
             Resolution resolution,

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -395,11 +395,11 @@ public final class DateFieldMapper extends FieldMapper {
     }, MINIMUM_COMPATIBILITY_VERSION);
 
     public static final class DateFieldType extends MappedFieldType {
-        protected final DateFormatter dateTimeFormatter;
-        protected final DateMathParser dateMathParser;
-        protected final Resolution resolution;
-        protected final String nullValue;
-        protected final FieldValues<Long> scriptValues;
+        final DateFormatter dateTimeFormatter;
+        final DateMathParser dateMathParser;
+        private final Resolution resolution;
+        private final String nullValue;
+        private final FieldValues<Long> scriptValues;
         private final boolean pointsMetadataAvailable;
 
         public DateFieldType(

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
@@ -76,7 +76,7 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<GeoPoi
         return (GeoPointFieldMapper) in;
     }
 
-    public static class Builder extends FieldMapper.Builder {
+    public static final class Builder extends FieldMapper.Builder {
 
         final Parameter<Explicit<Boolean>> ignoreMalformed;
         final Parameter<Explicit<Boolean>> ignoreZValue = ignoreZValueParam(m -> builder(m).ignoreZValue.get());
@@ -94,7 +94,6 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<GeoPoi
         private final Parameter<Boolean> dimension; // can only support time_series_dimension: false
         private final IndexMode indexMode;  // either STANDARD or TIME_SERIES
 
-        @SuppressWarnings("this-escape")
         public Builder(
             String name,
             ScriptCompiler scriptCompiler,

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -69,7 +69,7 @@ public class IpFieldMapper extends FieldMapper {
         return (IpFieldMapper) in;
     }
 
-    public static class Builder extends FieldMapper.Builder {
+    public static final class Builder extends FieldMapper.Builder {
 
         private final Parameter<Boolean> indexed = Parameter.indexParam(m -> toType(m).indexed, true);
         private final Parameter<Boolean> hasDocValues = Parameter.docValuesParam(m -> toType(m).hasDocValues, true);
@@ -89,7 +89,6 @@ public class IpFieldMapper extends FieldMapper {
         private final IndexVersion indexCreatedVersion;
         private final ScriptCompiler scriptCompiler;
 
-        @SuppressWarnings("this-escape")
         public Builder(String name, ScriptCompiler scriptCompiler, boolean ignoreMalformedByDefault, IndexVersion indexCreatedVersion) {
             super(name);
             this.scriptCompiler = Objects.requireNonNull(scriptCompiler);

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -137,7 +137,7 @@ public final class KeywordFieldMapper extends FieldMapper {
         return (KeywordFieldMapper) in;
     }
 
-    public static class Builder extends FieldMapper.Builder {
+    public static final class Builder extends FieldMapper.Builder {
 
         private final Parameter<Boolean> indexed = Parameter.indexParam(m -> toType(m).indexed, true);
         private final Parameter<Boolean> hasDocValues = Parameter.docValuesParam(m -> toType(m).hasDocValues, true);
@@ -184,7 +184,6 @@ public final class KeywordFieldMapper extends FieldMapper {
         private final ScriptCompiler scriptCompiler;
         private final IndexVersion indexCreatedVersion;
 
-        @SuppressWarnings("this-escape")
         public Builder(String name, IndexAnalyzers indexAnalyzers, ScriptCompiler scriptCompiler, IndexVersion indexCreatedVersion) {
             super(name);
             this.indexAnalyzers = indexAnalyzers;

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -1007,7 +1007,7 @@ public final class KeywordFieldMapper extends FieldMapper {
         return syntheticFieldLoader(simpleName());
     }
 
-    protected SourceLoader.SyntheticFieldLoader syntheticFieldLoader(String simpleName) {
+    SourceLoader.SyntheticFieldLoader syntheticFieldLoader(String simpleName) {
         if (hasScript()) {
             return SourceLoader.SyntheticFieldLoader.NOTHING;
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -89,7 +89,7 @@ public class NumberFieldMapper extends FieldMapper {
 
     private static final IndexVersion MINIMUM_COMPATIBILITY_VERSION = IndexVersion.fromId(5000099);
 
-    public static class Builder extends FieldMapper.Builder {
+    public static final class Builder extends FieldMapper.Builder {
 
         private final Parameter<Boolean> indexed;
         private final Parameter<Boolean> hasDocValues = Parameter.docValuesParam(m -> toType(m).hasDocValues, true);
@@ -143,7 +143,6 @@ public class NumberFieldMapper extends FieldMapper {
             return builder;
         }
 
-        @SuppressWarnings("this-escape")
         public Builder(
             String name,
             NumberType type,

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -87,7 +87,7 @@ import java.util.function.IntPredicate;
 import static org.elasticsearch.search.SearchService.ALLOW_EXPENSIVE_QUERIES;
 
 /** A {@link FieldMapper} for full-text fields. */
-public class TextFieldMapper extends FieldMapper {
+public final class TextFieldMapper extends FieldMapper {
 
     public static final String CONTENT_TYPE = "text";
     private static final String FAST_PHRASE_SUFFIX = "._index_phrase";
@@ -1155,8 +1155,7 @@ public class TextFieldMapper extends FieldMapper {
     private final SubFieldInfo prefixFieldInfo;
     private final SubFieldInfo phraseFieldInfo;
 
-    @SuppressWarnings("this-escape")
-    protected TextFieldMapper(
+    private TextFieldMapper(
         String simpleName,
         FieldType fieldType,
         TextFieldType mappedFieldType,

--- a/server/src/main/java/org/elasticsearch/index/query/CombinedFieldsQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/CombinedFieldsQueryBuilder.java
@@ -50,7 +50,7 @@ import java.util.TreeMap;
  * A query that matches on multiple text fields, as if the field contents had been indexed
  * into a single combined field.
  */
-public class CombinedFieldsQueryBuilder extends AbstractQueryBuilder<CombinedFieldsQueryBuilder> {
+public final class CombinedFieldsQueryBuilder extends AbstractQueryBuilder<CombinedFieldsQueryBuilder> {
     public static final String NAME = "combined_fields";
 
     private static final ParseField QUERY_FIELD = new ParseField("query");
@@ -109,7 +109,6 @@ public class CombinedFieldsQueryBuilder extends AbstractQueryBuilder<CombinedFie
     /**
      * Constructs a new text query.
      */
-    @SuppressWarnings("this-escape")
     public CombinedFieldsQueryBuilder(Object value, String... fields) {
         if (value == null) {
             throw new IllegalArgumentException("[" + NAME + "] requires query value");

--- a/server/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
@@ -41,7 +41,7 @@ import java.util.TreeMap;
 /**
  * Same as {@link MatchQueryBuilder} but supports multiple fields.
  */
-public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQueryBuilder> {
+public final class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQueryBuilder> {
 
     public static final String NAME = "multi_match";
     private static final String CUTOFF_FREQUENCY_DEPRECATION_MSG = "cutoff_freqency is not supported."
@@ -185,7 +185,6 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
     /**
      * Constructs a new text query.
      */
-    @SuppressWarnings("this-escape")
     public MultiMatchQueryBuilder(Object value, String... fields) {
         if (value == null) {
             throw new IllegalArgumentException("[" + NAME + "] requires query value");
@@ -203,7 +202,6 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
     /**
      * Read from a stream.
      */
-    @SuppressWarnings("this-escape")
     public MultiMatchQueryBuilder(StreamInput in) throws IOException {
         super(in);
         value = in.readGenericValue();

--- a/server/src/main/java/org/elasticsearch/index/query/QueryShardException.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryShardException.java
@@ -18,7 +18,7 @@ import java.io.IOException;
 /**
  * Exception that is thrown when creating lucene queries on the shard
  */
-public class QueryShardException extends ElasticsearchException {
+public final class QueryShardException extends ElasticsearchException {
 
     public QueryShardException(QueryRewriteContext context, String msg, Object... args) {
         this(context, msg, null, args);
@@ -32,7 +32,6 @@ public class QueryShardException extends ElasticsearchException {
      * This constructor is provided for use in unit tests where a
      * {@link SearchExecutionContext} may not be available
      */
-    @SuppressWarnings("this-escape")
     public QueryShardException(Index index, String msg, Throwable cause, Object... args) {
         super(msg, cause, args);
         setIndex(index);

--- a/server/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryStringQueryBuilder.java
@@ -45,7 +45,7 @@ import java.util.TreeMap;
  * (using {@link #field(String)}), will run the parsed query against the provided fields, and combine
  * them using Dismax.
  */
-public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQueryBuilder> {
+public final class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQueryBuilder> {
 
     public static final String NAME = "query_string";
 
@@ -153,7 +153,6 @@ public class QueryStringQueryBuilder extends AbstractQueryBuilder<QueryStringQue
     /**
      * Read from a stream.
      */
-    @SuppressWarnings("this-escape")
     public QueryStringQueryBuilder(StreamInput in) throws IOException {
         super(in);
         queryString = in.readString();

--- a/server/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
@@ -69,7 +69,7 @@ import java.util.Objects;
  * "https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html"
  * > online documentation</a>.
  */
-public class SimpleQueryStringBuilder extends AbstractQueryBuilder<SimpleQueryStringBuilder> {
+public final class SimpleQueryStringBuilder extends AbstractQueryBuilder<SimpleQueryStringBuilder> {
 
     /** Default for using lenient query parsing.*/
     public static final boolean DEFAULT_LENIENT = false;
@@ -142,7 +142,6 @@ public class SimpleQueryStringBuilder extends AbstractQueryBuilder<SimpleQuerySt
     /**
      * Read from a stream.
      */
-    @SuppressWarnings("this-escape")
     public SimpleQueryStringBuilder(StreamInput in) throws IOException {
         super(in);
         queryText = in.readString();

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShardRecoveryException.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShardRecoveryException.java
@@ -13,8 +13,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 
 import java.io.IOException;
 
-public class IndexShardRecoveryException extends ElasticsearchException {
-    @SuppressWarnings("this-escape")
+public final class IndexShardRecoveryException extends ElasticsearchException {
     public IndexShardRecoveryException(ShardId shardId, String msg, Throwable cause) {
         super(msg, cause);
         setShard(shardId);

--- a/server/src/main/java/org/elasticsearch/index/shard/ShardNotFoundException.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/ShardNotFoundException.java
@@ -13,7 +13,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 
 import java.io.IOException;
 
-public class ShardNotFoundException extends ResourceNotFoundException {
+public final class ShardNotFoundException extends ResourceNotFoundException {
     public ShardNotFoundException(ShardId shardId) {
         this(shardId, null);
     }
@@ -26,7 +26,6 @@ public class ShardNotFoundException extends ResourceNotFoundException {
         this(shardId, msg, null, args);
     }
 
-    @SuppressWarnings("this-escape")
     public ShardNotFoundException(ShardId shardId, String msg, Throwable ex, Object... args) {
         super(msg, ex, args);
         setShard(shardId);

--- a/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshot.java
+++ b/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/BlobStoreIndexShardSnapshot.java
@@ -38,7 +38,7 @@ public class BlobStoreIndexShardSnapshot implements ToXContentFragment {
     /**
      * Information about snapshotted file
      */
-    public static class FileInfo implements Writeable {
+    public static final class FileInfo implements Writeable {
         public static final String SERIALIZE_WRITER_UUID = "serialize_writer_uuid";
 
         private final String name;
@@ -55,7 +55,6 @@ public class BlobStoreIndexShardSnapshot implements ToXContentFragment {
          * @param metadata  the files meta data
          * @param partSize     size of the single chunk
          */
-        @SuppressWarnings("this-escape")
         public FileInfo(String name, StoreFileMetadata metadata, @Nullable ByteSizeValue partSize) {
             this.name = Objects.requireNonNull(name);
             this.metadata = metadata;

--- a/server/src/main/java/org/elasticsearch/index/translog/TranslogException.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/TranslogException.java
@@ -14,13 +14,12 @@ import org.elasticsearch.index.shard.ShardId;
 
 import java.io.IOException;
 
-public class TranslogException extends ElasticsearchException {
+public final class TranslogException extends ElasticsearchException {
 
     public TranslogException(ShardId shardId, String msg) {
         this(shardId, msg, null);
     }
 
-    @SuppressWarnings("this-escape")
     public TranslogException(ShardId shardId, String msg, Throwable cause) {
         super(msg, cause);
         setShard(shardId);

--- a/server/src/main/java/org/elasticsearch/indices/AliasFilterParsingException.java
+++ b/server/src/main/java/org/elasticsearch/indices/AliasFilterParsingException.java
@@ -14,9 +14,8 @@ import org.elasticsearch.index.Index;
 
 import java.io.IOException;
 
-public class AliasFilterParsingException extends ElasticsearchException {
+public final class AliasFilterParsingException extends ElasticsearchException {
 
-    @SuppressWarnings("this-escape")
     public AliasFilterParsingException(Index index, String name, String desc, Throwable ex) {
         super("[" + name + "], " + desc, ex);
         setIndex(index);

--- a/server/src/main/java/org/elasticsearch/indices/IndexClosedException.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndexClosedException.java
@@ -18,9 +18,8 @@ import java.io.IOException;
 /**
  * Exception indicating that one or more requested indices are closed.
  */
-public class IndexClosedException extends ElasticsearchException {
+public final class IndexClosedException extends ElasticsearchException {
 
-    @SuppressWarnings("this-escape")
     public IndexClosedException(Index index) {
         super("closed");
         setIndex(index);

--- a/server/src/main/java/org/elasticsearch/indices/IndexCreationException.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndexCreationException.java
@@ -14,9 +14,8 @@ import org.elasticsearch.common.io.stream.StreamInput;
 
 import java.io.IOException;
 
-public class IndexCreationException extends ElasticsearchException implements ElasticsearchWrapperException {
+public final class IndexCreationException extends ElasticsearchException implements ElasticsearchWrapperException {
 
-    @SuppressWarnings("this-escape")
     public IndexCreationException(String index, Throwable cause) {
         super("failed to create index [{}]", cause, index);
         setIndex(index);

--- a/server/src/main/java/org/elasticsearch/indices/IndexPrimaryShardNotAllocatedException.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndexPrimaryShardNotAllocatedException.java
@@ -19,12 +19,11 @@ import java.io.IOException;
  * Thrown when some action cannot be performed because the primary shard of
  * some shard group in an index has not been allocated post api action.
  */
-public class IndexPrimaryShardNotAllocatedException extends ElasticsearchException {
+public final class IndexPrimaryShardNotAllocatedException extends ElasticsearchException {
     public IndexPrimaryShardNotAllocatedException(StreamInput in) throws IOException {
         super(in);
     }
 
-    @SuppressWarnings("this-escape")
     public IndexPrimaryShardNotAllocatedException(Index index) {
         super("primary not allocated post api");
         setIndex(index);

--- a/server/src/main/java/org/elasticsearch/indices/InvalidAliasNameException.java
+++ b/server/src/main/java/org/elasticsearch/indices/InvalidAliasNameException.java
@@ -15,9 +15,8 @@ import org.elasticsearch.rest.RestStatus;
 
 import java.io.IOException;
 
-public class InvalidAliasNameException extends ElasticsearchException {
+public final class InvalidAliasNameException extends ElasticsearchException {
 
-    @SuppressWarnings("this-escape")
     public InvalidAliasNameException(Index index, String name, String desc) {
         super("Invalid alias name [{}], {}", name, desc);
         setIndex(index);

--- a/server/src/main/java/org/elasticsearch/indices/InvalidIndexNameException.java
+++ b/server/src/main/java/org/elasticsearch/indices/InvalidIndexNameException.java
@@ -15,15 +15,13 @@ import org.elasticsearch.rest.RestStatus;
 
 import java.io.IOException;
 
-public class InvalidIndexNameException extends ElasticsearchException {
+public final class InvalidIndexNameException extends ElasticsearchException {
 
-    @SuppressWarnings("this-escape")
     public InvalidIndexNameException(String name, String desc) {
         super("Invalid index name [" + name + "], " + desc);
         setIndex(name);
     }
 
-    @SuppressWarnings("this-escape")
     public InvalidIndexNameException(Index index, String name, String desc) {
         super("Invalid index name [" + name + "], " + desc);
         setIndex(index);

--- a/server/src/main/java/org/elasticsearch/indices/TypeMissingException.java
+++ b/server/src/main/java/org/elasticsearch/indices/TypeMissingException.java
@@ -16,21 +16,18 @@ import org.elasticsearch.rest.RestStatus;
 import java.io.IOException;
 import java.util.Arrays;
 
-public class TypeMissingException extends ElasticsearchException {
+public final class TypeMissingException extends ElasticsearchException {
 
-    @SuppressWarnings("this-escape")
     public TypeMissingException(Index index, String... types) {
         super("type" + Arrays.toString(types) + " missing");
         setIndex(index);
     }
 
-    @SuppressWarnings("this-escape")
     public TypeMissingException(Index index, Throwable cause, String... types) {
         super("type" + Arrays.toString(types) + " missing", cause);
         setIndex(index);
     }
 
-    @SuppressWarnings("this-escape")
     public TypeMissingException(String index, String... types) {
         super("type[" + Arrays.toString(types) + "] missing");
         setIndex(index);

--- a/server/src/main/java/org/elasticsearch/indices/analysis/HunspellService.java
+++ b/server/src/main/java/org/elasticsearch/indices/analysis/HunspellService.java
@@ -65,7 +65,7 @@ import static org.elasticsearch.core.Strings.format;
  *
  * @see org.elasticsearch.index.analysis.HunspellTokenFilterFactory
  */
-public class HunspellService {
+public final class HunspellService {
 
     private static final Logger logger = LogManager.getLogger(HunspellService.class);
 
@@ -89,7 +89,6 @@ public class HunspellService {
     private final Path hunspellDir;
     private final Function<String, Dictionary> loadingFunction;
 
-    @SuppressWarnings("this-escape")
     public HunspellService(final Settings settings, final Environment env, final Map<String, Dictionary> knownDictionaries)
         throws IOException {
         this.knownDictionaries = Collections.unmodifiableMap(knownDictionaries);

--- a/server/src/main/java/org/elasticsearch/indices/fielddata/cache/IndicesFieldDataCache.java
+++ b/server/src/main/java/org/elasticsearch/indices/fielddata/cache/IndicesFieldDataCache.java
@@ -39,7 +39,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.ToLongBiFunction;
 
-public class IndicesFieldDataCache implements RemovalListener<IndicesFieldDataCache.Key, Accountable>, Releasable {
+public final class IndicesFieldDataCache implements RemovalListener<IndicesFieldDataCache.Key, Accountable>, Releasable {
 
     private static final Logger logger = LogManager.getLogger(IndicesFieldDataCache.class);
 
@@ -51,7 +51,6 @@ public class IndicesFieldDataCache implements RemovalListener<IndicesFieldDataCa
     private final IndexFieldDataCache.Listener indicesFieldDataCacheListener;
     private final Cache<Key, Accountable> cache;
 
-    @SuppressWarnings("this-escape")
     public IndicesFieldDataCache(Settings settings, IndexFieldDataCache.Listener indicesFieldDataCacheListener) {
         this.indicesFieldDataCacheListener = indicesFieldDataCacheListener;
         final long sizeInBytes = INDICES_FIELDDATA_CACHE_SIZE_KEY.get(settings).getBytes();

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoverFilesRecoveryException.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoverFilesRecoveryException.java
@@ -18,13 +18,12 @@ import org.elasticsearch.index.shard.ShardId;
 import java.io.IOException;
 import java.util.Objects;
 
-public class RecoverFilesRecoveryException extends ElasticsearchException implements ElasticsearchWrapperException {
+public final class RecoverFilesRecoveryException extends ElasticsearchException implements ElasticsearchWrapperException {
 
     private final int numberOfFiles;
 
     private final ByteSizeValue totalFilesSize;
 
-    @SuppressWarnings("this-escape")
     public RecoverFilesRecoveryException(ShardId shardId, int numberOfFiles, ByteSizeValue totalFilesSize, Throwable cause) {
         super("Failed to transfer [{}] files with total size of [{}]", cause, numberOfFiles, totalFilesSize);
         Objects.requireNonNull(totalFilesSize, "totalFilesSize must not be null");

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryCommitTooNewException.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryCommitTooNewException.java
@@ -14,8 +14,7 @@ import org.elasticsearch.index.shard.ShardId;
 
 import java.io.IOException;
 
-public class RecoveryCommitTooNewException extends ElasticsearchException {
-    @SuppressWarnings("this-escape")
+public final class RecoveryCommitTooNewException extends ElasticsearchException {
     public RecoveryCommitTooNewException(ShardId shardId, String message) {
         super(message);
         setShard(shardId);

--- a/server/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
+++ b/server/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
@@ -64,7 +64,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.elasticsearch.core.Strings.format;
 
-public class IndicesStore implements ClusterStateListener, Closeable {
+public final class IndicesStore implements ClusterStateListener, Closeable {
 
     private static final Logger logger = LogManager.getLogger(IndicesStore.class);
 
@@ -88,7 +88,6 @@ public class IndicesStore implements ClusterStateListener, Closeable {
 
     private final TimeValue deleteShardTimeout;
 
-    @SuppressWarnings("this-escape")
     @Inject
     public IndicesStore(
         Settings settings,

--- a/server/src/main/java/org/elasticsearch/lucene/analysis/miscellaneous/DeDuplicatingTokenFilter.java
+++ b/server/src/main/java/org/elasticsearch/lucene/analysis/miscellaneous/DeDuplicatingTokenFilter.java
@@ -36,8 +36,7 @@ import java.util.ArrayList;
  * results or are output (the {@link DuplicateSequenceAttribute} attribute can
  * be used to inspect the number of prior sightings when emitDuplicates is true)
  */
-public class DeDuplicatingTokenFilter extends FilteringTokenFilter {
-    @SuppressWarnings("this-escape")
+public final class DeDuplicatingTokenFilter extends FilteringTokenFilter {
     private final DuplicateSequenceAttribute seqAtt = addAttribute(DuplicateSequenceAttribute.class);
     private final boolean emitDuplicates;
     static final MurmurHash3.Hash128 seed = new MurmurHash3.Hash128();

--- a/server/src/main/java/org/elasticsearch/lucene/search/uhighlight/CustomUnifiedHighlighter.java
+++ b/server/src/main/java/org/elasticsearch/lucene/search/uhighlight/CustomUnifiedHighlighter.java
@@ -50,7 +50,7 @@ import static org.elasticsearch.search.fetch.subphase.highlight.AbstractHighligh
  * value as a discrete passage for highlighting (unless the whole content needs to be highlighted).
  * Supports both returning empty snippets and non highlighted snippets when no highlighting can be performed.
  */
-public class CustomUnifiedHighlighter extends UnifiedHighlighter {
+public final class CustomUnifiedHighlighter extends UnifiedHighlighter {
     public static final char MULTIVAL_SEP_CHAR = (char) 0;
     private static final Snippet[] EMPTY_SNIPPET = new Snippet[0];
 
@@ -79,7 +79,6 @@ public class CustomUnifiedHighlighter extends UnifiedHighlighter {
      *                          offset source for it because it'd be super slow
      * @param weightMatchesEnabled whether the {@link HighlightFlag#WEIGHT_MATCHES} should be enabled
      */
-    @SuppressWarnings("this-escape")
     public CustomUnifiedHighlighter(
         Builder builder,
         OffsetSource offsetSource,

--- a/server/src/main/java/org/elasticsearch/monitor/fs/FsHealthService.java
+++ b/server/src/main/java/org/elasticsearch/monitor/fs/FsHealthService.java
@@ -42,7 +42,7 @@ import static org.elasticsearch.monitor.StatusInfo.Status.UNHEALTHY;
 /**
  * Runs periodically and attempts to create a temp file to see if the filesystem is writable. If not then it marks the path as unhealthy.
  */
-public class FsHealthService extends AbstractLifecycleComponent implements NodeHealthService {
+public final class FsHealthService extends AbstractLifecycleComponent implements NodeHealthService {
 
     private static final Logger logger = LogManager.getLogger(FsHealthService.class);
 
@@ -82,7 +82,6 @@ public class FsHealthService extends AbstractLifecycleComponent implements NodeH
         Setting.Property.Dynamic
     );
 
-    @SuppressWarnings("this-escape")
     public FsHealthService(Settings settings, ClusterSettings clusterSettings, ThreadPool threadPool, NodeEnvironment nodeEnv) {
         this.threadPool = threadPool;
         this.enabled = ENABLED_SETTING.get(settings);

--- a/server/src/main/java/org/elasticsearch/persistent/PersistentTasksClusterService.java
+++ b/server/src/main/java/org/elasticsearch/persistent/PersistentTasksClusterService.java
@@ -46,7 +46,7 @@ import java.util.stream.Collectors;
 /**
  * Component that runs only on the master node and is responsible for assigning running tasks to nodes
  */
-public class PersistentTasksClusterService implements ClusterStateListener, Closeable {
+public final class PersistentTasksClusterService implements ClusterStateListener, Closeable {
 
     public static final Setting<TimeValue> CLUSTER_TASKS_ALLOCATION_RECHECK_INTERVAL_SETTING = Setting.timeSetting(
         "cluster.persistent_tasks.allocation.recheck_interval",
@@ -65,7 +65,6 @@ public class PersistentTasksClusterService implements ClusterStateListener, Clos
     private final PeriodicRechecker periodicRechecker;
     private final AtomicBoolean reassigningTasks = new AtomicBoolean(false);
 
-    @SuppressWarnings("this-escape")
     public PersistentTasksClusterService(
         Settings settings,
         PersistentTasksExecutorRegistry registry,

--- a/server/src/main/java/org/elasticsearch/persistent/decider/EnableAssignmentDecider.java
+++ b/server/src/main/java/org/elasticsearch/persistent/decider/EnableAssignmentDecider.java
@@ -28,7 +28,7 @@ import static org.elasticsearch.common.settings.Setting.Property.NodeScope;
  *
  * @see Allocation
  */
-public class EnableAssignmentDecider {
+public final class EnableAssignmentDecider {
 
     public static final Setting<Allocation> CLUSTER_TASKS_ALLOCATION_ENABLE_SETTING = new Setting<>(
         "cluster.persistent_tasks.allocation.enable",
@@ -41,7 +41,6 @@ public class EnableAssignmentDecider {
 
     private volatile Allocation enableAssignment;
 
-    @SuppressWarnings("this-escape")
     public EnableAssignmentDecider(final Settings settings, final ClusterSettings clusterSettings) {
         this.enableAssignment = CLUSTER_TASKS_ALLOCATION_ENABLE_SETTING.get(settings);
         clusterSettings.addSettingsUpdateConsumer(CLUSTER_TASKS_ALLOCATION_ENABLE_SETTING, this::setEnableAssignment);

--- a/server/src/main/java/org/elasticsearch/repositories/SnapshotIndexCommit.java
+++ b/server/src/main/java/org/elasticsearch/repositories/SnapshotIndexCommit.java
@@ -19,13 +19,12 @@ import org.elasticsearch.index.engine.Engine;
  * A (closeable) {@link IndexCommit} plus ref-counting to keep track of active users, and with the facility to drop the "main" initial ref
  * early if the shard snapshot is aborted.
  */
-public class SnapshotIndexCommit extends AbstractRefCounted {
+public final class SnapshotIndexCommit extends AbstractRefCounted {
 
     private final Engine.IndexCommitRef commitRef;
     private final Runnable releaseInitialRef;
     private final SubscribableListener<Void> completionListeners = new SubscribableListener<>();
 
-    @SuppressWarnings("this-escape")
     public SnapshotIndexCommit(Engine.IndexCommitRef commitRef) {
         this.commitRef = commitRef;
         this.releaseInitialRef = new RunOnce(this::decRef);

--- a/server/src/main/java/org/elasticsearch/rest/RestResponse.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestResponse.java
@@ -36,7 +36,7 @@ import static org.elasticsearch.ElasticsearchException.REST_EXCEPTION_SKIP_STACK
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.elasticsearch.rest.RestController.ELASTIC_PRODUCT_HTTP_HEADER;
 
-public class RestResponse {
+public final class RestResponse {
 
     public static final String TEXT_CONTENT_TYPE = "text/plain; charset=UTF-8";
 
@@ -111,7 +111,6 @@ public class RestResponse {
         this(channel, ExceptionsHelper.status(e), e);
     }
 
-    @SuppressWarnings("this-escape")
     public RestResponse(RestChannel channel, RestStatus status, Exception e) throws IOException {
         this.status = status;
         ToXContent.Params params = channel.request();

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/AliasesNotFoundException.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/AliasesNotFoundException.java
@@ -13,9 +13,8 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import java.io.IOException;
 import java.util.Arrays;
 
-public class AliasesNotFoundException extends ResourceNotFoundException {
+public final class AliasesNotFoundException extends ResourceNotFoundException {
 
-    @SuppressWarnings("this-escape")
     public AliasesNotFoundException(String... names) {
         super("aliases " + Arrays.toString(names) + " missing");
         this.setResources("aliases", names);

--- a/server/src/main/java/org/elasticsearch/script/field/WriteField.java
+++ b/server/src/main/java/org/elasticsearch/script/field/WriteField.java
@@ -23,7 +23,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
-public class WriteField implements Field<Object> {
+public final class WriteField implements Field<Object> {
     protected String path;
     protected Supplier<Map<String, Object>> rootSupplier;
 
@@ -32,7 +32,6 @@ public class WriteField implements Field<Object> {
 
     private static final Object MISSING = new Object();
 
-    @SuppressWarnings("this-escape")
     public WriteField(String path, Supplier<Map<String, Object>> rootSupplier) {
         this.path = path;
         this.rootSupplier = rootSupplier;

--- a/server/src/main/java/org/elasticsearch/script/field/WriteField.java
+++ b/server/src/main/java/org/elasticsearch/script/field/WriteField.java
@@ -24,11 +24,11 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 public final class WriteField implements Field<Object> {
-    protected String path;
-    protected Supplier<Map<String, Object>> rootSupplier;
+    private String path;
+    private Supplier<Map<String, Object>> rootSupplier;
 
-    protected Map<String, Object> container;
-    protected String leaf;
+    private Map<String, Object> container;
+    private String leaf;
 
     private static final Object MISSING = new Object();
 
@@ -500,7 +500,7 @@ public final class WriteField implements Field<Object> {
      * If there is a value that is not a List or a Map, {@throws IllegalStateException}.
      */
     @SuppressWarnings("unchecked")
-    protected List<Map<String, Object>> getDocsAsList() {
+    private List<Map<String, Object>> getDocsAsList() {
         Object value = get(MISSING);
         if (value == MISSING) {
             return null;
@@ -603,7 +603,7 @@ public final class WriteField implements Field<Object> {
      * Change the path and clear the existing resolution by setting {@link #leaf} and {@link #container} to null.
      * Caller needs to re-resolve after this call.
      */
-    protected void setPath(String path) {
+    private void setPath(String path) {
         this.path = path;
         this.leaf = null;
         this.container = null;
@@ -612,7 +612,7 @@ public final class WriteField implements Field<Object> {
     /**
      * Get the path to a leaf or create it if one does not exist.
      */
-    protected void setLeaf() {
+    private void setLeaf() {
         if (leaf == null) {
             resolveDepthFlat();
         }
@@ -635,7 +635,7 @@ public final class WriteField implements Field<Object> {
      * {@link #container} and {@link #leaf} and non-null if resolved.
      */
     @SuppressWarnings("unchecked")
-    protected void resolveDepthFlat() {
+    private void resolveDepthFlat() {
         container = rootSupplier.get();
 
         int index = path.indexOf('.');
@@ -669,7 +669,7 @@ public final class WriteField implements Field<Object> {
      * @throws IllegalArgumentException if a non-leaf segment maps to a non-Map Object.
      */
     @SuppressWarnings("unchecked")
-    protected void createDepth() {
+    private void createDepth() {
         container = rootSupplier.get();
 
         String[] segments = path.split("\\.");
@@ -691,7 +691,7 @@ public final class WriteField implements Field<Object> {
         leaf = segments[segments.length - 1];
     }
 
-    protected String typeName(Object value) {
+    private String typeName(Object value) {
         return value != null ? value.getClass().getName() : "null";
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactories.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactories.java
@@ -274,7 +274,7 @@ public class AggregatorFactories {
      * A mutable collection of {@link AggregationBuilder}s and
      * {@link PipelineAggregationBuilder}s.
      */
-    public static class Builder implements Writeable, ToXContentObject {
+    public static final class Builder implements Writeable, ToXContentObject {
         private final Set<String> names = new HashSet<>();
 
         // Using LinkedHashSets to preserve the order of insertion, that makes the results
@@ -290,7 +290,6 @@ public class AggregatorFactories {
         /**
          * Read from a stream.
          */
-        @SuppressWarnings("this-escape")
         public Builder(StreamInput in) throws IOException {
             int factoriesSize = in.readVInt();
             for (int i = 0; i < factoriesSize; i++) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashGridAggregationBuilder.java
@@ -26,7 +26,7 @@ import org.elasticsearch.xcontent.ObjectParser;
 import java.io.IOException;
 import java.util.Map;
 
-public class GeoHashGridAggregationBuilder extends GeoGridAggregationBuilder {
+public final class GeoHashGridAggregationBuilder extends GeoGridAggregationBuilder {
     public static final String NAME = "geohash_grid";
     public static final int DEFAULT_PRECISION = 5;
     public static final int DEFAULT_MAX_NUM_CELLS = 10000;
@@ -41,7 +41,6 @@ public class GeoHashGridAggregationBuilder extends GeoGridAggregationBuilder {
         GeoHashGridAggregationBuilder::new
     );
 
-    @SuppressWarnings("this-escape")
     public GeoHashGridAggregationBuilder(String name) {
         super(name);
         precision(DEFAULT_PRECISION);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoTileGridAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoTileGridAggregationBuilder.java
@@ -25,7 +25,7 @@ import org.elasticsearch.xcontent.ObjectParser;
 import java.io.IOException;
 import java.util.Map;
 
-public class GeoTileGridAggregationBuilder extends GeoGridAggregationBuilder {
+public final class GeoTileGridAggregationBuilder extends GeoGridAggregationBuilder {
     public static final String NAME = "geotile_grid";
     public static final int DEFAULT_PRECISION = 7;
     private static final int DEFAULT_MAX_NUM_CELLS = 10000;
@@ -40,7 +40,6 @@ public class GeoTileGridAggregationBuilder extends GeoGridAggregationBuilder {
         GeoTileGridAggregationBuilder::new
     );
 
-    @SuppressWarnings("this-escape")
     public GeoTileGridAggregationBuilder(String name) {
         super(name);
         precision(DEFAULT_PRECISION);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/global/GlobalAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/global/GlobalAggregator.java
@@ -24,10 +24,9 @@ import org.elasticsearch.search.aggregations.support.AggregationContext;
 import java.io.IOException;
 import java.util.Map;
 
-public class GlobalAggregator extends BucketsAggregator implements SingleBucketAggregator {
+public final class GlobalAggregator extends BucketsAggregator implements SingleBucketAggregator {
     private final Weight weight;
 
-    @SuppressWarnings("this-escape")
     public GlobalAggregator(String name, AggregatorFactories subFactories, AggregationContext context, Map<String, Object> metadata)
         throws IOException {
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/MapStringTermsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/MapStringTermsAggregator.java
@@ -47,13 +47,12 @@ import static org.elasticsearch.search.aggregations.InternalOrder.isKeyOrder;
  * An aggregator of string values that hashes the strings on the fly rather
  * than up front like the {@link GlobalOrdinalsStringTermsAggregator}.
  */
-public class MapStringTermsAggregator extends AbstractStringTermsAggregator {
+public final class MapStringTermsAggregator extends AbstractStringTermsAggregator {
     private final CollectorSource collectorSource;
     private final ResultStrategy<?, ?> resultStrategy;
     private final BytesKeyedBucketOrds bucketOrds;
     private final IncludeExclude.StringFilter includeExclude;
 
-    @SuppressWarnings("this-escape")
     public MapStringTermsAggregator(
         String name,
         AggregatorFactories factories,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/NumericTermsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/NumericTermsAggregator.java
@@ -45,13 +45,12 @@ import java.util.function.Supplier;
 import static java.util.Collections.emptyList;
 import static org.elasticsearch.search.aggregations.InternalOrder.isKeyOrder;
 
-public class NumericTermsAggregator extends TermsAggregator {
+public final class NumericTermsAggregator extends TermsAggregator {
     private final ResultStrategy<?, ?> resultStrategy;
     private final ValuesSource.Numeric valuesSource;
     private final LongKeyedBucketOrds bucketOrds;
     private final LongFilter longFilter;
 
-    @SuppressWarnings("this-escape")
     public NumericTermsAggregator(
         String name,
         AggregatorFactories factories,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/PercentilesConfig.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/PercentilesConfig.java
@@ -120,7 +120,7 @@ public abstract class PercentilesConfig implements ToXContent, Writeable {
         return Objects.hash(method);
     }
 
-    public static class TDigest extends PercentilesConfig {
+    public static final class TDigest extends PercentilesConfig {
         static final double DEFAULT_COMPRESSION = 100.0;
         private double compression;
 
@@ -134,7 +134,6 @@ public abstract class PercentilesConfig implements ToXContent, Writeable {
             this(compression, null);
         }
 
-        @SuppressWarnings("this-escape")
         public TDigest(double compression, TDigestExecutionHint executionHint) {
             super(PercentilesMethod.TDIGEST);
             this.executionHint = executionHint;
@@ -281,7 +280,7 @@ public abstract class PercentilesConfig implements ToXContent, Writeable {
         }
     }
 
-    public static class Hdr extends PercentilesConfig {
+    public static final class Hdr extends PercentilesConfig {
         static final int DEFAULT_NUMBER_SIG_FIGS = 3;
         private int numberOfSignificantValueDigits;
 
@@ -289,7 +288,6 @@ public abstract class PercentilesConfig implements ToXContent, Writeable {
             this(DEFAULT_NUMBER_SIG_FIGS);
         }
 
-        @SuppressWarnings("this-escape")
         public Hdr(int numberOfSignificantValueDigits) {
             super(PercentilesMethod.HDR);
             setNumberOfSignificantValueDigits(numberOfSignificantValueDigits);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ValueCountAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ValueCountAggregator.java
@@ -31,14 +31,13 @@ import java.util.Map;
  * This aggregator works in a multi-bucket mode, that is, when serves as a sub-aggregator, a single aggregator instance aggregates the
  * counts for all buckets owned by the parent aggregator)
  */
-public class ValueCountAggregator extends NumericMetricsAggregator.SingleValue {
+public final class ValueCountAggregator extends NumericMetricsAggregator.SingleValue {
 
     final ValuesSource valuesSource;
 
     // a count per bucket
     LongArray counts;
 
-    @SuppressWarnings("this-escape")
     public ValueCountAggregator(
         String name,
         ValuesSourceConfig valuesSourceConfig,

--- a/server/src/main/java/org/elasticsearch/search/dfs/DfsSearchResult.java
+++ b/server/src/main/java/org/elasticsearch/search/dfs/DfsSearchResult.java
@@ -26,7 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class DfsSearchResult extends SearchPhaseResult {
+public final class DfsSearchResult extends SearchPhaseResult {
 
     private static final Term[] EMPTY_TERMS = new Term[0];
     private static final TermStatistics[] EMPTY_TERM_STATS = new TermStatistics[0];
@@ -37,7 +37,6 @@ public class DfsSearchResult extends SearchPhaseResult {
     private int maxDoc;
     private SearchProfileDfsPhaseResult searchProfileDfsPhaseResult;
 
-    @SuppressWarnings("this-escape")
     public DfsSearchResult(StreamInput in) throws IOException {
         super(in);
         contextId = new ShardSearchContextId(in);
@@ -70,7 +69,6 @@ public class DfsSearchResult extends SearchPhaseResult {
         }
     }
 
-    @SuppressWarnings("this-escape")
     public DfsSearchResult(ShardSearchContextId contextId, SearchShardTarget shardTarget, ShardSearchRequest shardSearchRequest) {
         this.setSearchShardTarget(shardTarget);
         this.contextId = contextId;

--- a/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
@@ -46,12 +46,11 @@ import java.util.function.Supplier;
  * Fetch phase of a search request, used to fetch the actual top matching documents to be returned to the client, identified
  * after reducing all of the matches returned by the query phase
  */
-public class FetchPhase {
+public final class FetchPhase {
     private static final Logger LOGGER = LogManager.getLogger(FetchPhase.class);
 
     private final FetchSubPhase[] fetchSubPhases;
 
-    @SuppressWarnings("this-escape")
     public FetchPhase(List<FetchSubPhase> fetchSubPhases) {
         this.fetchSubPhases = fetchSubPhases.toArray(new FetchSubPhase[fetchSubPhases.size() + 1]);
         this.fetchSubPhases[fetchSubPhases.size()] = new InnerHitsPhase(this);

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightBuilder.java
@@ -44,7 +44,7 @@ import static org.elasticsearch.xcontent.ObjectParser.fromList;
  *
  * @see org.elasticsearch.search.builder.SearchSourceBuilder#highlight()
  */
-public class HighlightBuilder extends AbstractHighlighterBuilder<HighlightBuilder> {
+public final class HighlightBuilder extends AbstractHighlighterBuilder<HighlightBuilder> {
     /** default for whether to highlight fields based on the source even if stored separately */
     public static final boolean DEFAULT_FORCE_SOURCE = false;
     /** default for whether a field should be highlighted only if a query matches that field */
@@ -124,7 +124,6 @@ public class HighlightBuilder extends AbstractHighlighterBuilder<HighlightBuilde
     /**
      * Read from a stream.
      */
-    @SuppressWarnings("this-escape")
     public HighlightBuilder(StreamInput in) throws IOException {
         super(in);
         encoder(in.readOptionalString());
@@ -445,7 +444,7 @@ public class HighlightBuilder extends AbstractHighlighterBuilder<HighlightBuilde
 
     }
 
-    public static class Field extends AbstractHighlighterBuilder<Field> {
+    public static final class Field extends AbstractHighlighterBuilder<Field> {
         static final NamedObjectParser<Field, Void> PARSER;
         static {
             ObjectParser<Field, Void> parser = new ObjectParser<>("highlight_field");
@@ -475,7 +474,6 @@ public class HighlightBuilder extends AbstractHighlighterBuilder<HighlightBuilde
         /**
          * Read from a stream.
          */
-        @SuppressWarnings("this-escape")
         public Field(StreamInput in) throws IOException {
             super(in);
             name = in.readString();

--- a/server/src/main/java/org/elasticsearch/search/internal/LegacyReaderContext.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/LegacyReaderContext.java
@@ -16,7 +16,7 @@ import org.elasticsearch.search.dfs.AggregatedDfs;
 
 import java.util.Objects;
 
-public class LegacyReaderContext extends ReaderContext {
+public final class LegacyReaderContext extends ReaderContext {
     private final ShardSearchRequest shardSearchRequest;
     private final ScrollContext scrollContext;
     private final Engine.Searcher searcher;
@@ -24,7 +24,6 @@ public class LegacyReaderContext extends ReaderContext {
     private AggregatedDfs aggregatedDfs;
     private RescoreDocIds rescoreDocIds;
 
-    @SuppressWarnings("this-escape")
     public LegacyReaderContext(
         ShardSearchContextId id,
         IndexService indexService,

--- a/server/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
@@ -61,7 +61,7 @@ import static org.elasticsearch.search.sort.NestedSortBuilder.NESTED_FIELD;
 /**
  * A sort builder to sort based on a document field.
  */
-public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
+public final class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
 
     public static final String NAME = "field_sort";
     public static final ParseField MISSING = new ParseField("missing");
@@ -101,7 +101,6 @@ public class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
     private String format;
 
     /** Copy constructor. */
-    @SuppressWarnings("this-escape")
     public FieldSortBuilder(FieldSortBuilder template) {
         this(template.fieldName);
         this.order(template.order());

--- a/server/src/main/java/org/elasticsearch/search/sort/ScoreSortBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/ScoreSortBuilder.java
@@ -29,7 +29,7 @@ import java.util.Objects;
 /**
  * A sort builder allowing to sort by score.
  */
-public class ScoreSortBuilder extends SortBuilder<ScoreSortBuilder> {
+public final class ScoreSortBuilder extends SortBuilder<ScoreSortBuilder> {
 
     public static final String NAME = "_score";
     private static final SortFieldAndFormat SORT_SCORE = new SortFieldAndFormat(
@@ -44,7 +44,6 @@ public class ScoreSortBuilder extends SortBuilder<ScoreSortBuilder> {
     /**
      * Build a ScoreSortBuilder default to descending sort order.
      */
-    @SuppressWarnings("this-escape")
     public ScoreSortBuilder() {
         // order defaults to desc when sorting on the _score
         order(SortOrder.DESC);
@@ -53,7 +52,6 @@ public class ScoreSortBuilder extends SortBuilder<ScoreSortBuilder> {
     /**
      * Read from a stream.
      */
-    @SuppressWarnings("this-escape")
     public ScoreSortBuilder(StreamInput in) throws IOException {
         order(SortOrder.readFromStream(in));
     }

--- a/server/src/main/java/org/elasticsearch/search/suggest/Suggest.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/Suggest.java
@@ -44,7 +44,7 @@ import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpect
 /**
  * Top level suggest result, containing the result for each suggestion.
  */
-public class Suggest implements Iterable<Suggest.Suggestion<? extends Entry<? extends Option>>>, Writeable, ToXContentFragment {
+public final class Suggest implements Iterable<Suggest.Suggestion<? extends Entry<? extends Option>>>, Writeable, ToXContentFragment {
 
     public static final String NAME = "suggest";
 
@@ -61,7 +61,6 @@ public class Suggest implements Iterable<Suggest.Suggestion<? extends Entry<? ex
 
     private Map<String, Suggestion<? extends Entry<? extends Option>>> suggestMap;
 
-    @SuppressWarnings("this-escape")
     public Suggest(List<Suggestion<? extends Entry<? extends Option>>> suggestions) {
         // we sort suggestions by their names to ensure iteration over suggestions are consistent
         // this is needed as we need to fill in suggestion docs in SearchPhaseController#sortDocs

--- a/server/src/main/java/org/elasticsearch/snapshots/InternalSnapshotsInfoService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/InternalSnapshotsInfoService.java
@@ -41,7 +41,7 @@ import java.util.function.Supplier;
 
 import static org.elasticsearch.core.Strings.format;
 
-public class InternalSnapshotsInfoService implements ClusterStateListener, SnapshotsInfoService {
+public final class InternalSnapshotsInfoService implements ClusterStateListener, SnapshotsInfoService {
 
     public static final Setting<Integer> INTERNAL_SNAPSHOT_INFO_MAX_CONCURRENT_FETCHES_SETTING = Setting.intSetting(
         "cluster.snapshot.info.max_concurrent_fetches",
@@ -84,7 +84,6 @@ public class InternalSnapshotsInfoService implements ClusterStateListener, Snaps
 
     private final Object mutex;
 
-    @SuppressWarnings("this-escape")
     public InternalSnapshotsInfoService(
         final Settings settings,
         final ClusterService clusterService,

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -136,7 +136,7 @@ import static org.elasticsearch.snapshots.SnapshotsService.NO_FEATURE_STATES_VAL
  * which removes {@link RestoreInProgress} when all shards are completed. In case of
  * restore failure a normal recovery fail-over process kicks in.
  */
-public class RestoreService implements ClusterStateApplier {
+public final class RestoreService implements ClusterStateApplier {
 
     private static final Logger logger = LogManager.getLogger(RestoreService.class);
 
@@ -190,7 +190,6 @@ public class RestoreService implements ClusterStateApplier {
 
     private volatile boolean refreshRepositoryUuidOnRestore;
 
-    @SuppressWarnings("this-escape")
     public RestoreService(
         ClusterService clusterService,
         RepositoriesService repositoriesService,

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
@@ -68,7 +68,7 @@ import static org.elasticsearch.core.Strings.format;
  * starting and stopping shard level snapshots.
  * See package level documentation of {@link org.elasticsearch.snapshots} for details.
  */
-public class SnapshotShardsService extends AbstractLifecycleComponent implements ClusterStateListener, IndexEventListener {
+public final class SnapshotShardsService extends AbstractLifecycleComponent implements ClusterStateListener, IndexEventListener {
     private static final Logger logger = LogManager.getLogger(SnapshotShardsService.class);
 
     private final ClusterService clusterService;
@@ -89,7 +89,6 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
     // Runs the tasks that promptly notify shards of aborted snapshots so that resources can be released ASAP
     private final ThrottledTaskRunner notifyOnAbortTaskRunner;
 
-    @SuppressWarnings("this-escape")
     public SnapshotShardsService(
         Settings settings,
         ClusterService clusterService,

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -130,7 +130,7 @@ import static org.elasticsearch.core.Strings.format;
  * deletion.
  * See package level documentation of {@link org.elasticsearch.snapshots} for details.
  */
-public class SnapshotsService extends AbstractLifecycleComponent implements ClusterStateApplier {
+public final class SnapshotsService extends AbstractLifecycleComponent implements ClusterStateApplier {
 
     public static final IndexVersion SHARD_GEN_IN_REPO_DATA_VERSION = IndexVersions.V_7_6_0;
 
@@ -200,7 +200,6 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
 
     private volatile int maxConcurrentOperations;
 
-    @SuppressWarnings("this-escape")
     public SnapshotsService(
         Settings settings,
         ClusterService clusterService,

--- a/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperMergeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperMergeTests.java
@@ -13,9 +13,8 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.util.Collections;
 
-public class ObjectMapperMergeTests extends ESTestCase {
+public final class ObjectMapperMergeTests extends ESTestCase {
 
-    @SuppressWarnings("this-escape")
     private final RootObjectMapper rootObjectMapper = createMapping(false, true, true, false);
 
     private RootObjectMapper createMapping(

--- a/server/src/test/java/org/elasticsearch/indices/analysis/lucene/SkipStartingWithDigitTokenFilter.java
+++ b/server/src/test/java/org/elasticsearch/indices/analysis/lucene/SkipStartingWithDigitTokenFilter.java
@@ -14,9 +14,8 @@ import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 
 import java.io.IOException;
 
-public class SkipStartingWithDigitTokenFilter extends FilteringTokenFilter {
+public final class SkipStartingWithDigitTokenFilter extends FilteringTokenFilter {
 
-    @SuppressWarnings("this-escape")
     private final CharTermAttribute termAtt = addAttribute(CharTermAttribute.class);
     private final long asciiDigitsToSkip;
 

--- a/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestGetIndicesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestGetIndicesActionTests.java
@@ -23,8 +23,7 @@ import java.util.Map;
 import static org.elasticsearch.rest.BaseRestHandler.INCLUDE_TYPE_NAME_PARAMETER;
 import static org.mockito.Mockito.mock;
 
-public class RestGetIndicesActionTests extends ESTestCase {
-    @SuppressWarnings("this-escape")
+public final class RestGetIndicesActionTests extends ESTestCase {
     final List<String> contentTypeHeader = Collections.singletonList(randomCompatibleMediaType(RestApiVersion.V_7));
 
     /**

--- a/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestPutIndexTemplateActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestPutIndexTemplateActionTests.java
@@ -28,8 +28,7 @@ import java.util.Map;
 import static org.elasticsearch.rest.BaseRestHandler.INCLUDE_TYPE_NAME_PARAMETER;
 import static org.mockito.Mockito.mock;
 
-public class RestPutIndexTemplateActionTests extends ESTestCase {
-    @SuppressWarnings("this-escape")
+public final class RestPutIndexTemplateActionTests extends ESTestCase {
     final List<String> contentTypeHeader = Collections.singletonList(compatibleMediaType(XContentType.VND_JSON, RestApiVersion.V_7));
 
     private RestPutIndexTemplateAction action;

--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestDeleteActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestDeleteActionTests.java
@@ -20,9 +20,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-public class RestDeleteActionTests extends RestActionTestCase {
+public final class RestDeleteActionTests extends RestActionTestCase {
 
-    @SuppressWarnings("this-escape")
     final List<String> contentTypeHeader = Collections.singletonList(randomCompatibleMediaType(RestApiVersion.V_7));
 
     @Before

--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestGetActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestGetActionTests.java
@@ -23,8 +23,7 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.instanceOf;
 
-public class RestGetActionTests extends RestActionTestCase {
-    @SuppressWarnings("this-escape")
+public final class RestGetActionTests extends RestActionTestCase {
     final List<String> contentTypeHeader = Collections.singletonList(randomCompatibleMediaType(RestApiVersion.V_7));
 
     @Before

--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestGetSourceActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestGetSourceActionTests.java
@@ -37,12 +37,11 @@ import static org.elasticsearch.rest.RestStatus.OK;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 
-public class RestGetSourceActionTests extends RestActionTestCase {
+public final class RestGetSourceActionTests extends RestActionTestCase {
 
     private static RestRequest request = new FakeRestRequest();
     private static FakeRestChannel channel = new FakeRestChannel(request, true, 0);
     private static RestGetSourceResponseListener listener = new RestGetSourceResponseListener(channel, request);
-    @SuppressWarnings("this-escape")
     private final List<String> compatibleMediaType = Collections.singletonList(randomCompatibleMediaType(RestApiVersion.V_7));
 
     @Before

--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestIndexActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestIndexActionTests.java
@@ -37,9 +37,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 
-public class RestIndexActionTests extends RestActionTestCase {
+public final class RestIndexActionTests extends RestActionTestCase {
 
-    @SuppressWarnings("this-escape")
     final List<String> contentTypeHeader = Collections.singletonList(randomCompatibleMediaType(RestApiVersion.V_7));
 
     private final AtomicReference<ClusterState> clusterStateSupplier = new AtomicReference<>();

--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestMultiGetActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestMultiGetActionTests.java
@@ -28,10 +28,8 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.instanceOf;
 
-public class RestMultiGetActionTests extends RestActionTestCase {
-    @SuppressWarnings("this-escape")
+public final class RestMultiGetActionTests extends RestActionTestCase {
     XContentType VND_TYPE = randomVendorType();
-    @SuppressWarnings("this-escape")
     List<String> contentTypeHeader = Collections.singletonList(compatibleMediaType(VND_TYPE, RestApiVersion.V_7));
 
     @Before

--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestMultiTermVectorsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestMultiTermVectorsActionTests.java
@@ -26,8 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class RestMultiTermVectorsActionTests extends RestActionTestCase {
-    @SuppressWarnings("this-escape")
+public final class RestMultiTermVectorsActionTests extends RestActionTestCase {
     final List<String> contentTypeHeader = Collections.singletonList(compatibleMediaType(XContentType.VND_JSON, RestApiVersion.V_7));
 
     @Before

--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestTermVectorsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestTermVectorsActionTests.java
@@ -25,8 +25,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-public class RestTermVectorsActionTests extends RestActionTestCase {
-    @SuppressWarnings("this-escape")
+public final class RestTermVectorsActionTests extends RestActionTestCase {
     final List<String> contentTypeHeader = Collections.singletonList(compatibleMediaType(XContentType.VND_JSON, RestApiVersion.V_7));
 
     @Before

--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestUpdateActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestUpdateActionTests.java
@@ -29,8 +29,7 @@ import java.util.Map;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.mockito.Mockito.mock;
 
-public class RestUpdateActionTests extends RestActionTestCase {
-    @SuppressWarnings("this-escape")
+public final class RestUpdateActionTests extends RestActionTestCase {
     final List<String> contentTypeHeader = Collections.singletonList(randomCompatibleMediaType(RestApiVersion.V_7));
 
     private RestUpdateAction action;

--- a/server/src/test/java/org/elasticsearch/rest/action/search/RestCountActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/search/RestCountActionTests.java
@@ -25,9 +25,8 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.instanceOf;
 
-public class RestCountActionTests extends RestActionTestCase {
+public final class RestCountActionTests extends RestActionTestCase {
 
-    @SuppressWarnings("this-escape")
     final List<String> contentTypeHeader = Collections.singletonList(randomCompatibleMediaType(RestApiVersion.V_7));
 
     @Before

--- a/server/src/test/java/org/elasticsearch/rest/action/search/RestExplainActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/search/RestExplainActionTests.java
@@ -21,8 +21,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-public class RestExplainActionTests extends RestActionTestCase {
-    @SuppressWarnings("this-escape")
+public final class RestExplainActionTests extends RestActionTestCase {
     final List<String> contentTypeHeader = Collections.singletonList(compatibleMediaType(XContentType.VND_JSON, RestApiVersion.V_7));
 
     @Before

--- a/server/src/test/java/org/elasticsearch/rest/action/search/RestMultiSearchActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/search/RestMultiSearchActionTests.java
@@ -25,8 +25,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-public class RestMultiSearchActionTests extends RestActionTestCase {
-    @SuppressWarnings("this-escape")
+public final class RestMultiSearchActionTests extends RestActionTestCase {
     final List<String> contentTypeHeader = Collections.singletonList(compatibleMediaType(XContentType.VND_JSON, RestApiVersion.V_7));
 
     private RestMultiSearchAction action;

--- a/server/src/test/java/org/elasticsearch/rest/action/search/RestSearchActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/search/RestSearchActionTests.java
@@ -28,8 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class RestSearchActionTests extends RestActionTestCase {
-    @SuppressWarnings("this-escape")
+public final class RestSearchActionTests extends RestActionTestCase {
     final List<String> contentTypeHeader = Collections.singletonList(randomCompatibleMediaType(RestApiVersion.V_7));
 
     private RestSearchAction action;

--- a/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
@@ -941,7 +941,7 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
             return 0;
         }
 
-        public class ClusterNode {
+        public final class ClusterNode {
             private final Logger logger = LogManager.getLogger(ClusterNode.class);
 
             private final int nodeIndex;
@@ -962,7 +962,6 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
             private ClearableRecycler clearableRecycler;
             private List<Runnable> blackholedRegisterOperations = new ArrayList<>();
 
-            @SuppressWarnings("this-escape")
             ClusterNode(int nodeIndex, boolean masterEligible, Settings nodeSettings, NodeHealthService nodeHealthService) {
                 this(
                     nodeIndex,

--- a/test/framework/src/main/java/org/elasticsearch/cluster/coordination/CoordinationStateTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/coordination/CoordinationStateTestCluster.java
@@ -37,7 +37,7 @@ import static org.elasticsearch.test.ESTestCase.randomSubsetOf;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertThat;
 
-public class CoordinationStateTestCluster {
+public final class CoordinationStateTestCluster {
 
     public static ClusterState clusterState(
         long term,
@@ -181,7 +181,6 @@ public class CoordinationStateTestCluster {
     final CoordinationMetadata.VotingConfiguration initialConfiguration;
     final long initialValue;
 
-    @SuppressWarnings("this-escape")
     public CoordinationStateTestCluster(List<DiscoveryNode> nodes, ElectionStrategy electionStrategy) {
         this.electionStrategy = electionStrategy;
         messages = new ArrayList<>();

--- a/test/framework/src/main/java/org/elasticsearch/test/BackgroundIndexer.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/BackgroundIndexer.java
@@ -42,7 +42,7 @@ import static org.elasticsearch.core.Strings.format;
 import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.equalTo;
 
-public class BackgroundIndexer implements AutoCloseable {
+public final class BackgroundIndexer implements AutoCloseable {
 
     private final Logger logger = LogManager.getLogger(getClass());
 
@@ -98,7 +98,6 @@ public class BackgroundIndexer implements AutoCloseable {
      * @param autoStart   set to true to start indexing as soon as all threads have been created.
      * @param random      random instance to use
      */
-    @SuppressWarnings("this-escape")
     public BackgroundIndexer(
         final String index,
         final Client client,

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/RestActionTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/RestActionTestCase.java
@@ -74,11 +74,10 @@ public abstract class RestActionTestCase extends ESTestCase {
      * By default, will throw {@link AssertionError} when any execution method is called, unless configured otherwise using
      * {@link #setExecuteVerifier} or {@link #setExecuteLocallyVerifier}.
      */
-    public static class VerifyingClient extends NoOpNodeClient {
+    public static final class VerifyingClient extends NoOpNodeClient {
         AtomicReference<BiFunction<ActionType<?>, ActionRequest, ActionResponse>> executeVerifier = new AtomicReference<>();
         AtomicReference<BiFunction<ActionType<?>, ActionRequest, ActionResponse>> executeLocallyVerifier = new AtomicReference<>();
 
-        @SuppressWarnings("this-escape")
         public VerifyingClient(String testName) {
             super(testName);
             reset();

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultLocalClusterSpecBuilder.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultLocalClusterSpecBuilder.java
@@ -14,9 +14,8 @@ import org.elasticsearch.test.cluster.local.distribution.ReleasedDistributionRes
 import org.elasticsearch.test.cluster.local.distribution.SnapshotDistributionResolver;
 import org.elasticsearch.test.cluster.util.resource.Resource;
 
-public class DefaultLocalClusterSpecBuilder extends AbstractLocalClusterSpecBuilder<ElasticsearchCluster> {
+public final class DefaultLocalClusterSpecBuilder extends AbstractLocalClusterSpecBuilder<ElasticsearchCluster> {
 
-    @SuppressWarnings("this-escape")
     public DefaultLocalClusterSpecBuilder() {
         super();
         this.apply(c -> c.systemProperty("ingest.geoip.downloader.enabled.default", "false"));

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/bucket/histogram/HistoBackedHistogramAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/bucket/histogram/HistoBackedHistogramAggregator.java
@@ -25,11 +25,10 @@ import org.elasticsearch.xpack.analytics.aggregations.support.HistogramValuesSou
 import java.io.IOException;
 import java.util.Map;
 
-public class HistoBackedHistogramAggregator extends AbstractHistogramAggregator {
+public final class HistoBackedHistogramAggregator extends AbstractHistogramAggregator {
 
     private final HistogramValuesSource.Histogram valuesSource;
 
-    @SuppressWarnings("this-escape")
     public HistoBackedHistogramAggregator(
         String name,
         AggregatorFactories factories,

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedAvgAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedAvgAggregator.java
@@ -32,7 +32,7 @@ import java.util.Map;
  * Average aggregator operating over histogram datatypes {@link HistogramValuesSource}
  * The aggregation computes weighted average by taking counts into consideration for each value
  */
-public class HistoBackedAvgAggregator extends NumericMetricsAggregator.SingleValue {
+public final class HistoBackedAvgAggregator extends NumericMetricsAggregator.SingleValue {
 
     private final HistogramValuesSource.Histogram valuesSource;
 
@@ -41,7 +41,6 @@ public class HistoBackedAvgAggregator extends NumericMetricsAggregator.SingleVal
     DoubleArray compensations;
     DocValueFormat format;
 
-    @SuppressWarnings("this-escape")
     public HistoBackedAvgAggregator(
         String name,
         ValuesSourceConfig valuesSourceConfig,

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedMaxAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedMaxAggregator.java
@@ -26,13 +26,12 @@ import org.elasticsearch.xpack.analytics.aggregations.support.HistogramValuesSou
 import java.io.IOException;
 import java.util.Map;
 
-public class HistoBackedMaxAggregator extends NumericMetricsAggregator.SingleValue {
+public final class HistoBackedMaxAggregator extends NumericMetricsAggregator.SingleValue {
 
     private final HistogramValuesSource.Histogram valuesSource;
     final DocValueFormat formatter;
     DoubleArray maxes;
 
-    @SuppressWarnings("this-escape")
     public HistoBackedMaxAggregator(
         String name,
         ValuesSourceConfig config,

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedMinAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedMinAggregator.java
@@ -26,13 +26,12 @@ import org.elasticsearch.xpack.analytics.aggregations.support.HistogramValuesSou
 import java.io.IOException;
 import java.util.Map;
 
-public class HistoBackedMinAggregator extends NumericMetricsAggregator.SingleValue {
+public final class HistoBackedMinAggregator extends NumericMetricsAggregator.SingleValue {
 
     private final HistogramValuesSource.Histogram valuesSource;
     final DocValueFormat format;
     DoubleArray mins;
 
-    @SuppressWarnings("this-escape")
     public HistoBackedMinAggregator(
         String name,
         ValuesSourceConfig config,

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedSumAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedSumAggregator.java
@@ -33,7 +33,7 @@ import java.util.Map;
  * The aggregator sums each histogram value multiplied by its count.
  * Eg for a histogram of response times, this is an approximate "total time spent".
  */
-public class HistoBackedSumAggregator extends NumericMetricsAggregator.SingleValue {
+public final class HistoBackedSumAggregator extends NumericMetricsAggregator.SingleValue {
 
     private final HistogramValuesSource.Histogram valuesSource;
     private final DocValueFormat format;
@@ -41,7 +41,6 @@ public class HistoBackedSumAggregator extends NumericMetricsAggregator.SingleVal
     private DoubleArray sums;
     private DoubleArray compensations;
 
-    @SuppressWarnings("this-escape")
     public HistoBackedSumAggregator(
         String name,
         ValuesSourceConfig valuesSourceConfig,

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedValueCountAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedValueCountAggregator.java
@@ -29,14 +29,13 @@ import java.util.Map;
  * The aggregation counts the number of values a histogram field has within the aggregation context
  * by adding the counts of the histograms.
  */
-public class HistoBackedValueCountAggregator extends NumericMetricsAggregator.SingleValue {
+public final class HistoBackedValueCountAggregator extends NumericMetricsAggregator.SingleValue {
 
     final HistogramValuesSource.Histogram valuesSource;
 
     /** Count per bucket */
     LongArray counts;
 
-    @SuppressWarnings("this-escape")
     public HistoBackedValueCountAggregator(
         String name,
         ValuesSourceConfig valuesSourceConfig,

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/rate/TimeSeriesRateAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/rate/TimeSeriesRateAggregator.java
@@ -28,15 +28,15 @@ import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import java.io.IOException;
 import java.util.Map;
 
-public class TimeSeriesRateAggregator extends NumericMetricsAggregator.SingleValue {
+public final class TimeSeriesRateAggregator extends NumericMetricsAggregator.SingleValue {
 
-    protected final ValuesSource.Numeric valuesSource;
+    private final ValuesSource.Numeric valuesSource;
 
-    protected DoubleArray startValues;
-    protected DoubleArray endValues;
-    protected LongArray startTimes;
-    protected LongArray endTimes;
-    protected DoubleArray resetCompensations;
+    private DoubleArray startValues;
+    private DoubleArray endValues;
+    private LongArray startTimes;
+    private LongArray endTimes;
+    private DoubleArray resetCompensations;
 
     private long currentBucket = -1;
     private long currentEndTime = -1;
@@ -49,8 +49,7 @@ public class TimeSeriesRateAggregator extends NumericMetricsAggregator.SingleVal
     private final Rounding.DateTimeUnit rateUnit;
 
     // Unused parameters are so that the constructor implements `RateAggregatorSupplier`
-    @SuppressWarnings("this-escape")
-    protected TimeSeriesRateAggregator(
+    TimeSeriesRateAggregator(
         String name,
         ValuesSourceConfig valuesSourceConfig,
         Rounding.DateTimeUnit rateUnit,

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowTaskCleaner.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowTaskCleaner.java
@@ -33,7 +33,7 @@ import java.util.Set;
 /**
  * A {@link ClusterStateListener} that completes any {@link ShardFollowTask} which concerns a deleted index.
  */
-public class ShardFollowTaskCleaner implements ClusterStateListener {
+public final class ShardFollowTaskCleaner implements ClusterStateListener {
 
     private static final Logger logger = LogManager.getLogger(ShardFollowTaskCleaner.class);
 
@@ -45,7 +45,6 @@ public class ShardFollowTaskCleaner implements ClusterStateListener {
      */
     private final Set<ShardFollowTask> completing = Collections.synchronizedSet(new HashSet<>());
 
-    @SuppressWarnings("this-escape")
     public ShardFollowTaskCleaner(final ClusterService clusterService, final ThreadPool threadPool, final Client client) {
         this.threadPool = threadPool;
         this.client = client;

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowTasksExecutor.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowTasksExecutor.java
@@ -88,7 +88,7 @@ import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.ccr.CcrLicenseChecker.wrapClient;
 import static org.elasticsearch.xpack.ccr.action.TransportResumeFollowAction.extractLeaderShardHistoryUUIDs;
 
-public class ShardFollowTasksExecutor extends PersistentTasksExecutor<ShardFollowTask> {
+public final class ShardFollowTasksExecutor extends PersistentTasksExecutor<ShardFollowTask> {
 
     private static final Logger logger = LogManager.getLogger(ShardFollowTasksExecutor.class);
 
@@ -100,7 +100,6 @@ public class ShardFollowTasksExecutor extends PersistentTasksExecutor<ShardFollo
     private final TimeValue retentionLeaseRenewInterval;
     private volatile TimeValue waitForMetadataTimeOut;
 
-    @SuppressWarnings("this-escape")
     public ShardFollowTasksExecutor(Client client, ThreadPool threadPool, ClusterService clusterService, SettingsModule settingsModule) {
         super(ShardFollowTask.NAME, Ccr.CCR_THREAD_POOL_NAME);
         this.client = client;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/PutFollowAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/PutFollowAction.java
@@ -40,7 +40,7 @@ public final class PutFollowAction extends ActionType<PutFollowAction.Response> 
         super(NAME, PutFollowAction.Response::new);
     }
 
-    public static class Request extends AcknowledgedRequest<Request> implements IndicesRequest, ToXContentObject {
+    public static final class Request extends AcknowledgedRequest<Request> implements IndicesRequest, ToXContentObject {
 
         private static final ParseField REMOTE_CLUSTER_FIELD = new ParseField("remote_cluster");
         private static final ParseField LEADER_INDEX_FIELD = new ParseField("leader_index");
@@ -188,7 +188,6 @@ public final class PutFollowAction extends ActionType<PutFollowAction.Response> 
             return IndicesOptions.strictSingleIndexNoExpandForbidClosed();
         }
 
-        @SuppressWarnings("this-escape")
         public Request(StreamInput in) throws IOException {
             super(in);
             this.remoteCluster = in.readString();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/DeleteDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/DeleteDataFrameAnalyticsAction.java
@@ -31,7 +31,7 @@ public class DeleteDataFrameAnalyticsAction extends ActionType<AcknowledgedRespo
         super(NAME, AcknowledgedResponse::readFrom);
     }
 
-    public static class Request extends AcknowledgedRequest<Request> {
+    public static final class Request extends AcknowledgedRequest<Request> {
 
         public static final ParseField FORCE = new ParseField("force");
         public static final ParseField TIMEOUT = new ParseField("timeout");
@@ -48,7 +48,6 @@ public class DeleteDataFrameAnalyticsAction extends ActionType<AcknowledgedRespo
             force = in.readBoolean();
         }
 
-        @SuppressWarnings("this-escape")
         public Request() {
             timeout(DEFAULT_TIMEOUT);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDataFrameAnalyticsAction.java
@@ -27,16 +27,14 @@ public class GetDataFrameAnalyticsAction extends ActionType<GetDataFrameAnalytic
         super(NAME, Response::new);
     }
 
-    public static class Request extends AbstractGetResourcesRequest {
+    public static final class Request extends AbstractGetResourcesRequest {
 
         public static final ParseField ALLOW_NO_MATCH = new ParseField("allow_no_match");
 
-        @SuppressWarnings("this-escape")
         public Request() {
             setAllowNoResources(true);
         }
 
-        @SuppressWarnings("this-escape")
         public Request(String id) {
             setResourceId(id);
             setAllowNoResources(true);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedsAction.java
@@ -37,7 +37,7 @@ public class GetDatafeedsAction extends ActionType<GetDatafeedsAction.Response> 
         super(NAME, Response::new);
     }
 
-    public static class Request extends MasterNodeReadRequest<Request> {
+    public static final class Request extends MasterNodeReadRequest<Request> {
 
         public static final String ALLOW_NO_MATCH = "allow_no_match";
 
@@ -49,7 +49,6 @@ public class GetDatafeedsAction extends ActionType<GetDatafeedsAction.Response> 
             this.datafeedId = ExceptionsHelper.requireNonNull(datafeedId, DatafeedConfig.ID.getPreferredName());
         }
 
-        @SuppressWarnings("this-escape")
         public Request() {
             local(true);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetFiltersAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetFiltersAction.java
@@ -27,14 +27,12 @@ public class GetFiltersAction extends ActionType<GetFiltersAction.Response> {
         super(NAME, Response::new);
     }
 
-    public static class Request extends AbstractGetResourcesRequest {
+    public static final class Request extends AbstractGetResourcesRequest {
 
-        @SuppressWarnings("this-escape")
         public Request() {
             setAllowNoResources(true);
         }
 
-        @SuppressWarnings("this-escape")
         public Request(String filterId) {
             setResourceId(filterId);
             setAllowNoResources(true);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetJobsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetJobsAction.java
@@ -35,7 +35,7 @@ public class GetJobsAction extends ActionType<GetJobsAction.Response> {
         super(NAME, Response::new);
     }
 
-    public static class Request extends MasterNodeReadRequest<Request> {
+    public static final class Request extends MasterNodeReadRequest<Request> {
 
         public static final String ALLOW_NO_MATCH = "allow_no_match";
 
@@ -47,7 +47,6 @@ public class GetJobsAction extends ActionType<GetJobsAction.Response> {
             this.jobId = ExceptionsHelper.requireNonNull(jobId, Job.ID.getPreferredName());
         }
 
-        @SuppressWarnings("this-escape")
         public Request() {
             local(true);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetTrainedModelsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetTrainedModelsAction.java
@@ -123,7 +123,7 @@ public class GetTrainedModelsAction extends ActionType<GetTrainedModelsAction.Re
         }
     }
 
-    public static class Request extends AbstractGetResourcesRequest {
+    public static final class Request extends AbstractGetResourcesRequest {
 
         public static final ParseField INCLUDE = new ParseField("include");
         public static final ParseField ALLOW_NO_MATCH = new ParseField("allow_no_match");
@@ -136,7 +136,6 @@ public class GetTrainedModelsAction extends ActionType<GetTrainedModelsAction.Re
             this(id, null, null);
         }
 
-        @SuppressWarnings("this-escape")
         public Request(String id, List<String> tags, Set<String> includes) {
             setResourceId(id);
             setAllowNoResources(true);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetTrainedModelsStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetTrainedModelsStatsAction.java
@@ -52,16 +52,14 @@ public class GetTrainedModelsStatsAction extends ActionType<GetTrainedModelsStat
         super(NAME, GetTrainedModelsStatsAction.Response::new);
     }
 
-    public static class Request extends AbstractGetResourcesRequest {
+    public static final class Request extends AbstractGetResourcesRequest {
 
         public static final ParseField ALLOW_NO_MATCH = new ParseField("allow_no_match");
 
-        @SuppressWarnings("this-escape")
         public Request() {
             setAllowNoResources(true);
         }
 
-        @SuppressWarnings("this-escape")
         public Request(String id) {
             setResourceId(id);
             setAllowNoResources(true);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StopDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StopDataFrameAnalyticsAction.java
@@ -45,7 +45,7 @@ public class StopDataFrameAnalyticsAction extends ActionType<StopDataFrameAnalyt
         super(NAME, StopDataFrameAnalyticsAction.Response::new);
     }
 
-    public static class Request extends BaseTasksRequest<Request> implements ToXContentObject {
+    public static final class Request extends BaseTasksRequest<Request> implements ToXContentObject {
 
         public static final ParseField ALLOW_NO_MATCH = new ParseField("allow_no_match");
         public static final ParseField FORCE = new ParseField("force");
@@ -90,7 +90,6 @@ public class StopDataFrameAnalyticsAction extends ActionType<StopDataFrameAnalyt
             expandedIds = new HashSet<>(Arrays.asList(in.readStringArray()));
         }
 
-        @SuppressWarnings("this-escape")
         public Request() {
             setTimeout(DEFAULT_TIMEOUT);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StopDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StopDataFrameAnalyticsAction.java
@@ -94,7 +94,7 @@ public class StopDataFrameAnalyticsAction extends ActionType<StopDataFrameAnalyt
             setTimeout(DEFAULT_TIMEOUT);
         }
 
-        public final Request setId(String id) {
+        public Request setId(String id) {
             this.id = ExceptionsHelper.requireNonNull(id, DataFrameAnalyticsConfig.ID);
             return this;
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/Classification.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/Classification.java
@@ -31,7 +31,7 @@ import static org.elasticsearch.xpack.core.ml.dataframe.evaluation.MlEvaluationN
 /**
  * Evaluation of classification results.
  */
-public class Classification implements Evaluation {
+public final class Classification implements Evaluation {
 
     public static final ParseField NAME = new ParseField("classification");
 
@@ -75,7 +75,6 @@ public class Classification implements Evaluation {
      */
     private final List<EvaluationMetric> metrics;
 
-    @SuppressWarnings("this-escape")
     public Classification(
         String actualField,
         @Nullable String predictedField,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/outlierdetection/OutlierDetection.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/outlierdetection/OutlierDetection.java
@@ -32,7 +32,7 @@ import static org.elasticsearch.xpack.core.ml.dataframe.evaluation.MlEvaluationN
 /**
  * Evaluation of outlier detection results.
  */
-public class OutlierDetection implements Evaluation {
+public final class OutlierDetection implements Evaluation {
 
     public static final ParseField NAME = new ParseField("outlier_detection", "binary_soft_classification");
 
@@ -75,7 +75,6 @@ public class OutlierDetection implements Evaluation {
      */
     private final List<EvaluationMetric> metrics;
 
-    @SuppressWarnings("this-escape")
     public OutlierDetection(String actualField, String predictedProbabilityField, @Nullable List<EvaluationMetric> metrics) {
         this.fields = new EvaluationFields(
             ExceptionsHelper.requireNonNull(actualField, ACTUAL_FIELD),

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/regression/Regression.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/regression/Regression.java
@@ -30,7 +30,7 @@ import static org.elasticsearch.xpack.core.ml.dataframe.evaluation.MlEvaluationN
 /**
  * Evaluation of regression results.
  */
-public class Regression implements Evaluation {
+public final class Regression implements Evaluation {
 
     public static final ParseField NAME = new ParseField("regression");
 
@@ -69,7 +69,6 @@ public class Regression implements Evaluation {
      */
     private final List<EvaluationMetric> metrics;
 
-    @SuppressWarnings("this-escape")
     public Regression(String actualField, String predictedField, @Nullable List<EvaluationMetric> metrics) {
         this.fields = new EvaluationFields(
             ExceptionsHelper.requireNonNull(actualField, ACTUAL_FIELD),

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignment.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignment.java
@@ -40,7 +40,7 @@ import java.util.Set;
 /**
  * Trained model assignment object that contains assignment options and the assignment routing table
  */
-public class TrainedModelAssignment implements SimpleDiffable<TrainedModelAssignment>, ToXContentObject {
+public final class TrainedModelAssignment implements SimpleDiffable<TrainedModelAssignment>, ToXContentObject {
 
     private static final ParseField REASON = new ParseField("reason");
     private static final ParseField ASSIGNMENT_STATE = new ParseField("assignment_state");
@@ -137,7 +137,6 @@ public class TrainedModelAssignment implements SimpleDiffable<TrainedModelAssign
             : Math.max(maxAssignedAllocations, totalCurrentAllocations());
     }
 
-    @SuppressWarnings("this-escape")
     public TrainedModelAssignment(StreamInput in) throws IOException {
         this.taskParams = new StartTrainedModelDeploymentAction.TaskParams(in);
         this.nodeRoutingTable = in.readOrderedMap(StreamInput::readString, RoutingInfo::new);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/tree/Tree.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/tree/Tree.java
@@ -295,14 +295,13 @@ public class Tree implements LenientlyParsedTrainedModel, StrictlyParsedTrainedM
         return TransportVersions.V_7_6_0;
     }
 
-    public static class Builder {
+    public static final class Builder {
         private List<String> featureNames;
         private ArrayList<TreeNode.Builder> nodes;
         private int numNodes;
         private TargetType targetType = TargetType.REGRESSION;
         private List<String> classificationLabels;
 
-        @SuppressWarnings("this-escape")
         public Builder() {
             nodes = new ArrayList<>();
             // allocate space in the root node and set to a leaf

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/AnalysisConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/AnalysisConfig.java
@@ -448,7 +448,7 @@ public class AnalysisConfig implements ToXContentObject, Writeable {
         );
     }
 
-    public static class Builder {
+    public static final class Builder {
 
         public static final TimeValue DEFAULT_BUCKET_SPAN = TimeValue.timeValueMinutes(5);
 
@@ -464,7 +464,6 @@ public class AnalysisConfig implements ToXContentObject, Writeable {
         private Boolean multivariateByFields;
         private TimeValue modelPruneWindow;
 
-        @SuppressWarnings("this-escape")
         public Builder(List<Detector> detectors) {
             setDetectors(detectors);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/DataCounts.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/DataCounts.java
@@ -35,7 +35,7 @@ import java.util.Objects;
  * so the field is visible.
  */
 
-public class DataCounts implements ToXContentObject, Writeable {
+public final class DataCounts implements ToXContentObject, Writeable {
 
     private static final String DOCUMENT_SUFFIX = "_data_counts";
 
@@ -161,7 +161,6 @@ public class DataCounts implements ToXContentObject, Writeable {
     private Date latestSparseBucketTimeStamp;
     private Instant logTime;
 
-    @SuppressWarnings("this-escape")
     public DataCounts(
         String jobId,
         long processedRecordCount,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/ForecastRequestStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/results/ForecastRequestStats.java
@@ -30,7 +30,7 @@ import java.util.Objects;
  * information about errors, progress and counters. There is exactly 1 document
  * per forecast request, getting updated while the request is processed.
  */
-public class ForecastRequestStats implements ToXContentObject, Writeable {
+public final class ForecastRequestStats implements ToXContentObject, Writeable {
     /**
      * Result type
      */
@@ -147,7 +147,6 @@ public class ForecastRequestStats implements ToXContentObject, Writeable {
         this.status = forecastRequestStats.status;
     }
 
-    @SuppressWarnings("this-escape")
     public ForecastRequestStats(StreamInput in) throws IOException {
         jobId = in.readString();
         forecastId = in.readString();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/RealmConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/RealmConfig.java
@@ -25,7 +25,7 @@ import java.util.function.Supplier;
 
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
-public final class RealmConfig {
+public class RealmConfig {
 
     final RealmIdentifier identifier;
     final boolean enabled;
@@ -34,6 +34,7 @@ public final class RealmConfig {
     private final Settings settings;
     private final ThreadContext threadContext;
 
+    @SuppressWarnings("this-escape")
     public RealmConfig(RealmIdentifier identifier, Settings settings, Environment env, ThreadContext threadContext) {
         this.identifier = identifier;
         this.settings = settings;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/RealmConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/RealmConfig.java
@@ -25,7 +25,7 @@ import java.util.function.Supplier;
 
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
-public class RealmConfig {
+public final class RealmConfig {
 
     final RealmIdentifier identifier;
     final boolean enabled;
@@ -34,7 +34,6 @@ public class RealmConfig {
     private final Settings settings;
     private final ThreadContext threadContext;
 
-    @SuppressWarnings("this-escape")
     public RealmConfig(RealmIdentifier identifier, Settings settings, Environment env, ThreadContext threadContext) {
         this.identifier = identifier;
         this.settings = settings;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ActionClusterPrivilege.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ActionClusterPrivilege.java
@@ -14,7 +14,7 @@ import java.util.Set;
 /**
  * A {@link NamedClusterPrivilege} that can be used to define an access to cluster level actions.
  */
-public class ActionClusterPrivilege implements NamedClusterPrivilege {
+public final class ActionClusterPrivilege implements NamedClusterPrivilege {
     private final String name;
     private final Set<String> allowedActionPatterns;
     private final Set<String> excludedActionPatterns;
@@ -39,7 +39,6 @@ public class ActionClusterPrivilege implements NamedClusterPrivilege {
      * @param allowedActionPatterns  a set of cluster action patterns
      * @param excludedActionPatterns a set of cluster action patterns
      */
-    @SuppressWarnings("this-escape")
     public ActionClusterPrivilege(final String name, final Set<String> allowedActionPatterns, final Set<String> excludedActionPatterns) {
         this.name = name;
         this.allowedActionPatterns = allowedActionPatterns;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/SslSettingsLoader.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/SslSettingsLoader.java
@@ -33,14 +33,13 @@ import java.util.stream.Collectors;
 /**
  * A configuration loader for SSL Settings
  */
-public class SslSettingsLoader extends SslConfigurationLoader {
+public final class SslSettingsLoader extends SslConfigurationLoader {
 
     private final Settings settings;
     private final Map<String, Setting<? extends SecureString>> secureSettings;
     private final Map<String, Setting<?>> standardSettings;
     private final Map<String, Setting<?>> disabledSettings;
 
-    @SuppressWarnings("this-escape")
     public SslSettingsLoader(Settings settings, String settingPrefix, boolean acceptNonSecurePasswords) {
         super(settingPrefix);
         this.settings = settings;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/action/TermsEnumRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/action/TermsEnumRequest.java
@@ -30,7 +30,7 @@ import static org.apache.lucene.index.IndexWriter.MAX_TERM_LENGTH;
 /**
  * A request to gather terms for a given field matching a string prefix
  */
-public class TermsEnumRequest extends BroadcastRequest<TermsEnumRequest> implements ToXContentObject {
+public final class TermsEnumRequest extends BroadcastRequest<TermsEnumRequest> implements ToXContentObject {
 
     public static final IndicesOptions DEFAULT_INDICES_OPTIONS = SearchRequest.DEFAULT_INDICES_OPTIONS;
     public static int DEFAULT_SIZE = 10;
@@ -51,14 +51,12 @@ public class TermsEnumRequest extends BroadcastRequest<TermsEnumRequest> impleme
      * Constructs a new term enum request against the provided indices. No indices provided means it will
      * run against all indices.
      */
-    @SuppressWarnings("this-escape")
     public TermsEnumRequest(String... indices) {
         super(indices);
         indicesOptions(DEFAULT_INDICES_OPTIONS);
         timeout(DEFAULT_TIMEOUT);
     }
 
-    @SuppressWarnings("this-escape")
     public TermsEnumRequest(TermsEnumRequest clone) {
         this.field = clone.field;
         this.string = clone.string;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/textstructure/structurefinder/TextStructure.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/textstructure/structurefinder/TextStructure.java
@@ -523,7 +523,7 @@ public class TextStructure implements ToXContentObject, Writeable {
             && Objects.equals(this.explanation, that.explanation);
     }
 
-    public static class Builder {
+    public static final class Builder {
 
         private int numLinesAnalyzed;
         private int numMessagesAnalyzed;
@@ -553,7 +553,6 @@ public class TextStructure implements ToXContentObject, Writeable {
             this(Format.SEMI_STRUCTURED_TEXT);
         }
 
-        @SuppressWarnings("this-escape")
         public Builder(Format format) {
             setFormat(format);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/GetTransformStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/GetTransformStatsAction.java
@@ -49,7 +49,7 @@ public class GetTransformStatsAction extends ActionType<GetTransformStatsAction.
         super(NAME, GetTransformStatsAction.Response::new);
     }
 
-    public static class Request extends BaseTasksRequest<Request> {
+    public static final class Request extends BaseTasksRequest<Request> {
         private final String id;
         private PageParams pageParams = PageParams.defaultParams();
         private boolean allowNoMatch = true;
@@ -58,7 +58,6 @@ public class GetTransformStatsAction extends ActionType<GetTransformStatsAction.
         // used internally to expand the queried id expression
         private List<String> expandedIds;
 
-        @SuppressWarnings("this-escape")
         public Request(String id, @Nullable TimeValue timeout) {
             setTimeout(timeout);
             if (Strings.isNullOrEmpty(id) || id.equals("*")) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/GetTransformStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/GetTransformStatsAction.java
@@ -95,11 +95,11 @@ public class GetTransformStatsAction extends ActionType<GetTransformStatsAction.
             this.expandedIds = List.copyOf(expandedIds);
         }
 
-        public final void setPageParams(PageParams pageParams) {
+        public void setPageParams(PageParams pageParams) {
             this.pageParams = Objects.requireNonNull(pageParams);
         }
 
-        public final PageParams getPageParams() {
+        public PageParams getPageParams() {
             return pageParams;
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/ScheduleNowTransformAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/ScheduleNowTransformAction.java
@@ -37,11 +37,10 @@ public class ScheduleNowTransformAction extends ActionType<ScheduleNowTransformA
         super(NAME, ScheduleNowTransformAction.Response::new);
     }
 
-    public static class Request extends BaseTasksRequest<Request> {
+    public static final class Request extends BaseTasksRequest<Request> {
 
         private final String id;
 
-        @SuppressWarnings("this-escape")
         public Request(String id, TimeValue timeout) {
             this.id = ExceptionsHelper.requireNonNull(id, TransformField.ID.getPreferredName());
             this.setTimeout(ExceptionsHelper.requireNonNull(timeout, TransformField.TIMEOUT.getPreferredName()));

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/StopTransformAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/StopTransformAction.java
@@ -46,7 +46,7 @@ public class StopTransformAction extends ActionType<StopTransformAction.Response
         super(NAME, StopTransformAction.Response::new);
     }
 
-    public static class Request extends BaseTasksRequest<Request> {
+    public static final class Request extends BaseTasksRequest<Request> {
         private final String id;
         private final boolean waitForCompletion;
         private final boolean force;
@@ -54,7 +54,6 @@ public class StopTransformAction extends ActionType<StopTransformAction.Response
         private final boolean waitForCheckpoint;
         private Set<String> expandedIds;
 
-        @SuppressWarnings("this-escape")
         public Request(
             String id,
             boolean waitForCompletion,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/UpdateTransformAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/UpdateTransformAction.java
@@ -42,7 +42,7 @@ public class UpdateTransformAction extends ActionType<UpdateTransformAction.Resp
         super(NAME, Response::new);
     }
 
-    public static class Request extends BaseTasksRequest<Request> {
+    public static final class Request extends BaseTasksRequest<Request> {
 
         private final TransformConfigUpdate update;
         private final String id;
@@ -50,7 +50,6 @@ public class UpdateTransformAction extends ActionType<UpdateTransformAction.Resp
         private TransformConfig config;
         private AuthorizationState authState;
 
-        @SuppressWarnings("this-escape")
         public Request(TransformConfigUpdate update, String id, boolean deferValidation, TimeValue timeout) {
             this.update = update;
             this.id = id;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfig.java
@@ -53,7 +53,7 @@ import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstr
 /**
  * This class holds the configuration details of a data frame transform
  */
-public class TransformConfig implements SimpleDiffable<TransformConfig>, Writeable, ToXContentObject {
+public final class TransformConfig implements SimpleDiffable<TransformConfig>, Writeable, ToXContentObject {
 
     /**
      * Version of the last time the config defaults have been changed.
@@ -209,7 +209,6 @@ public class TransformConfig implements SimpleDiffable<TransformConfig>, Writeab
         return NAME + "-" + transformId;
     }
 
-    @SuppressWarnings("this-escape")
     public TransformConfig(
         final String id,
         final SourceConfig source,
@@ -245,7 +244,6 @@ public class TransformConfig implements SimpleDiffable<TransformConfig>, Writeab
         this.transformVersion = version == null ? null : TransformConfigVersion.fromString(version);
     }
 
-    @SuppressWarnings("this-escape")
     public TransformConfig(final StreamInput in) throws IOException {
         id = in.readString();
         source = new SourceConfig(in);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfigUpdate.java
@@ -30,7 +30,7 @@ import static org.elasticsearch.xpack.core.transform.transforms.TransformConfig.
 /**
  * This class holds the mutable configuration items for a data frame transform
  */
-public class TransformConfigUpdate implements Writeable {
+public final class TransformConfigUpdate implements Writeable {
 
     public static final String NAME = "data_frame_transform_config_update";
 
@@ -107,7 +107,6 @@ public class TransformConfigUpdate implements Writeable {
         this.retentionPolicyConfig = retentionPolicyConfig;
     }
 
-    @SuppressWarnings("this-escape")
     public TransformConfigUpdate(final StreamInput in) throws IOException {
         source = in.readOptionalWriteable(SourceConfig::new);
         dest = in.readOptionalWriteable(DestConfig::new);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/common/stats/Counters.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/common/stats/Counters.java
@@ -21,11 +21,10 @@ import java.util.Map;
  * Calling toNestedMap() will create a nested map, where each dot of the key name will nest deeper
  * The main reason for this class is that the stats producer should not be worried about how the map is actually nested
  */
-public class Counters implements Writeable {
+public final class Counters implements Writeable {
 
     private Map<String, Long> counters = new HashMap<>();
 
-    @SuppressWarnings("this-escape")
     public Counters(StreamInput in) throws IOException {
         int numCounters = in.readVInt();
         for (int i = 0; i < numCounters; i++) {
@@ -33,7 +32,6 @@ public class Counters implements Writeable {
         }
     }
 
-    @SuppressWarnings("this-escape")
     public Counters(String... names) {
         for (String name : names) {
             set(name);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transform/TransformRegistry.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transform/TransformRegistry.java
@@ -16,13 +16,12 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-public class TransformRegistry {
+public final class TransformRegistry {
 
     private final Map<
         String,
         TransformFactory<? extends Transform, ? extends Transform.Result, ? extends ExecutableTransform<?, ?>>> factories;
 
-    @SuppressWarnings("this-escape")
     public TransformRegistry(
         Map<String, TransformFactory<? extends Transform, ? extends Transform.Result, ? extends ExecutableTransform<?, ?>>> factories
     ) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transform/chain/ChainTransform.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transform/chain/ChainTransform.java
@@ -143,11 +143,10 @@ public class ChainTransform implements Transform {
         }
     }
 
-    public static class Builder implements Transform.Builder<ChainTransform> {
+    public static final class Builder implements Transform.Builder<ChainTransform> {
 
         private final List<Transform> transforms = new ArrayList<>();
 
-        @SuppressWarnings("this-escape")
         public Builder(Transform... transforms) {
             add(transforms);
         }

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/AggregateMetricFieldValueFetcher.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/AggregateMetricFieldValueFetcher.java
@@ -13,14 +13,13 @@ import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateDoubleMetricFieldMapper;
 import org.elasticsearch.xpack.aggregatemetric.mapper.AggregateDoubleMetricFieldMapper.AggregateDoubleMetricFieldType;
 
-public class AggregateMetricFieldValueFetcher extends FieldValueFetcher {
+public final class AggregateMetricFieldValueFetcher extends FieldValueFetcher {
 
     private final AggregateDoubleMetricFieldType aggMetricFieldType;
 
     private final AbstractDownsampleFieldProducer fieldProducer;
 
-    @SuppressWarnings("this-escape")
-    protected AggregateMetricFieldValueFetcher(
+    AggregateMetricFieldValueFetcher(
         MappedFieldType fieldType,
         AggregateDoubleMetricFieldType aggMetricFieldType,
         IndexFieldData<?> fieldData

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/EqlFunctionRegistry.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/EqlFunctionRegistry.java
@@ -40,9 +40,8 @@ import java.util.Locale;
 import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableList;
 
-public class EqlFunctionRegistry extends FunctionRegistry {
+public final class EqlFunctionRegistry extends FunctionRegistry {
 
-    @SuppressWarnings("this-escape")
     public EqlFunctionRegistry() {
         register(functions());
     }

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/math/ToNumber.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/math/ToNumber.java
@@ -36,11 +36,10 @@ import static org.elasticsearch.xpack.ql.expression.gen.script.ParamsBuilder.par
 /**
  * EQL specific function for parsing strings into numbers.
  */
-public class ToNumber extends ScalarFunction implements OptionalArgument {
+public final class ToNumber extends ScalarFunction implements OptionalArgument {
 
     private final Expression value, base;
 
-    @SuppressWarnings("this-escape")
     public ToNumber(Source source, Expression value, Expression base) {
         super(source, Arrays.asList(value, base != null ? base : new Literal(source, null, DataTypes.NULL)));
         this.value = value;

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/Between.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/Between.java
@@ -40,11 +40,10 @@ import static org.elasticsearch.xpack.ql.expression.gen.script.ParamsBuilder.par
  * between(source, left, right[, greedy=false])
  * Extracts a substring from source that’s between left and right substrings
  */
-public class Between extends CaseInsensitiveScalarFunction implements OptionalArgument {
+public final class Between extends CaseInsensitiveScalarFunction implements OptionalArgument {
 
     private final Expression input, left, right, greedy;
 
-    @SuppressWarnings("this-escape")
     public Between(Source source, Expression input, Expression left, Expression right, Expression greedy, boolean caseInsensitive) {
         super(source, Arrays.asList(input, left, right, defaultGreedy(greedy)), caseInsensitive);
         this.input = input;

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/Between.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/Between.java
@@ -134,7 +134,7 @@ public final class Between extends CaseInsensitiveScalarFunction implements Opti
         return asScriptFrom(inputScript, leftScript, rightScript, greedyScript);
     }
 
-    protected ScriptTemplate asScriptFrom(
+    private ScriptTemplate asScriptFrom(
         ScriptTemplate inputScript,
         ScriptTemplate leftScript,
         ScriptTemplate rightScript,

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/IndexOf.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/IndexOf.java
@@ -36,11 +36,10 @@ import static org.elasticsearch.xpack.ql.expression.gen.script.ParamsBuilder.par
  * Find the first position (zero-indexed) of a string where a substring is found.
  * If the optional parameter start is provided, then this will find the first occurrence at or after the start position.
  */
-public class IndexOf extends CaseInsensitiveScalarFunction implements OptionalArgument {
+public final class IndexOf extends CaseInsensitiveScalarFunction implements OptionalArgument {
 
     private final Expression input, substring, start;
 
-    @SuppressWarnings("this-escape")
     public IndexOf(Source source, Expression input, Expression substring, Expression start, boolean caseInsensitive) {
         super(source, asList(input, substring, start != null ? start : new Literal(source, null, DataTypes.NULL)), caseInsensitive);
         this.input = input;

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/IndexOf.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/IndexOf.java
@@ -102,7 +102,7 @@ public final class IndexOf extends CaseInsensitiveScalarFunction implements Opti
         return asScriptFrom(inputScript, substringScript, startScript);
     }
 
-    protected ScriptTemplate asScriptFrom(ScriptTemplate inputScript, ScriptTemplate substringScript, ScriptTemplate startScript) {
+    private ScriptTemplate asScriptFrom(ScriptTemplate inputScript, ScriptTemplate substringScript, ScriptTemplate startScript) {
         return new ScriptTemplate(
             format(
                 Locale.ROOT,

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/Match.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/Match.java
@@ -32,18 +32,16 @@ import static org.elasticsearch.xpack.ql.expression.TypeResolutions.isStringAndE
  * Returns true if the source field matches any of the provided regular expressions
  * Refer to: https://eql.readthedocs.io/en/latest/query-guide/functions.html#match
  */
-public class Match extends BaseSurrogateFunction {
+public final class Match extends BaseSurrogateFunction {
 
     private final Expression field;
     private final List<Expression> patterns;
     private final boolean caseInsensitive;
 
-    @SuppressWarnings("this-escape")
     public Match(Source source, Expression field, List<Expression> patterns, boolean caseInsensitive) {
         this(source, CollectionUtils.combine(singletonList(field), patterns), caseInsensitive);
     }
 
-    @SuppressWarnings("this-escape")
     private Match(Source source, List<Expression> children, boolean caseInsensitive) {
         super(source, children);
         this.field = children().get(0);

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/Substring.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/Substring.java
@@ -38,11 +38,10 @@ import static org.elasticsearch.xpack.ql.expression.gen.script.ParamsBuilder.par
  * EQL specific substring function - similar to the one in Python.
  * Note this is different than the one in SQL.
  */
-public class Substring extends ScalarFunction implements OptionalArgument {
+public final class Substring extends ScalarFunction implements OptionalArgument {
 
     private final Expression input, start, end;
 
-    @SuppressWarnings("this-escape")
     public Substring(Source source, Expression input, Expression start, Expression end) {
         super(source, Arrays.asList(input, start, end != null ? end : new Literal(source, null, DataTypes.NULL)));
         this.input = input;

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/Substring.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/expression/function/scalar/string/Substring.java
@@ -97,7 +97,7 @@ public final class Substring extends ScalarFunction implements OptionalArgument 
         return asScriptFrom(inputScript, startScript, endScript);
     }
 
-    protected ScriptTemplate asScriptFrom(ScriptTemplate inputScript, ScriptTemplate startScript, ScriptTemplate endScript) {
+    private ScriptTemplate asScriptFrom(ScriptTemplate inputScript, ScriptTemplate startScript, ScriptTemplate endScript) {
         return new ScriptTemplate(
             format(
                 Locale.ROOT,

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/TransportEqlSearchAction.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/TransportEqlSearchAction.java
@@ -61,7 +61,7 @@ import static org.elasticsearch.transport.RemoteClusterAware.buildRemoteIndexNam
 import static org.elasticsearch.xpack.core.ClientHelper.ASYNC_SEARCH_ORIGIN;
 import static org.elasticsearch.xpack.ql.plugin.TransportActionUtils.executeRequestWithRetryAttempt;
 
-public class TransportEqlSearchAction extends HandledTransportAction<EqlSearchRequest, EqlSearchResponse>
+public final class TransportEqlSearchAction extends HandledTransportAction<EqlSearchRequest, EqlSearchResponse>
     implements
         AsyncTaskManagementService.AsyncOperation<EqlSearchRequest, EqlSearchResponse, EqlSearchTask> {
 
@@ -73,7 +73,6 @@ public class TransportEqlSearchAction extends HandledTransportAction<EqlSearchRe
     private final TransportService transportService;
     private final AsyncTaskManagementService<EqlSearchRequest, EqlSearchResponse, EqlSearchTask> asyncTaskManagementService;
 
-    @SuppressWarnings("this-escape")
     @Inject
     public TransportEqlSearchAction(
         Settings settings,

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocVector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocVector.java
@@ -16,7 +16,7 @@ import java.util.Objects;
 /**
  * {@link Vector} where each entry references a lucene document.
  */
-public class DocVector extends AbstractVector implements Vector {
+public final class DocVector extends AbstractVector implements Vector {
 
     private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(DocVector.class);
 
@@ -48,7 +48,6 @@ public class DocVector extends AbstractVector implements Vector {
 
     final DocBlock block;
 
-    @SuppressWarnings("this-escape")
     public DocVector(IntVector shards, IntVector segments, IntVector docs, Boolean singleSegmentNonDecreasing) {
         super(shards.getPositionCount(), null);
         this.shards = shards;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistry.java
@@ -92,9 +92,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
 
-public class EsqlFunctionRegistry extends FunctionRegistry {
+public final class EsqlFunctionRegistry extends FunctionRegistry {
 
-    @SuppressWarnings("this-escape")
     public EsqlFunctionRegistry() {
         register(functions());
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/UnsupportedAttribute.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/UnsupportedAttribute.java
@@ -25,7 +25,7 @@ import java.util.Objects;
  * the engine).
  * As such the field is marked as unresolved (so the verifier can pick up its usage outside project).
  */
-public class UnsupportedAttribute extends FieldAttribute implements Unresolvable {
+public final class UnsupportedAttribute extends FieldAttribute implements Unresolvable {
 
     private final String message;
     private final boolean hasCustomMessage;
@@ -42,7 +42,6 @@ public class UnsupportedAttribute extends FieldAttribute implements Unresolvable
         this(source, name, field, customMessage, null);
     }
 
-    @SuppressWarnings("this-escape")
     public UnsupportedAttribute(Source source, String name, UnsupportedEsField field, String customMessage, NameId id) {
         super(source, null, name, field, null, Nullability.TRUE, id, false);
         this.hasCustomMessage = customMessage != null;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/Case.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/Case.java
@@ -37,14 +37,13 @@ import java.util.stream.Stream;
 import static org.elasticsearch.common.logging.LoggerMessageFormat.format;
 import static org.elasticsearch.xpack.ql.type.DataTypes.NULL;
 
-public class Case extends ScalarFunction implements EvaluatorMapper {
+public final class Case extends ScalarFunction implements EvaluatorMapper {
     record Condition(Expression condition, Expression value) {}
 
     private final List<Condition> conditions;
     private final Expression elseValue;
     private DataType dataType;
 
-    @SuppressWarnings("this-escape")
     public Case(Source source, Expression first, List<Expression> rest) {
         super(source, Stream.concat(Stream.of(first), rest.stream()).toList());
         int conditionCount = children().size() / 2;

--- a/x-pack/plugin/graph/src/test/java/org/elasticsearch/xpack/graph/rest/action/RestGraphActionTests.java
+++ b/x-pack/plugin/graph/src/test/java/org/elasticsearch/xpack/graph/rest/action/RestGraphActionTests.java
@@ -25,8 +25,7 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.instanceOf;
 
-public class RestGraphActionTests extends RestActionTestCase {
-    @SuppressWarnings("this-escape")
+public final class RestGraphActionTests extends RestActionTestCase {
     private final List<String> compatibleMediaType = Collections.singletonList(randomCompatibleMediaType(RestApiVersion.V_7));
 
     @Before

--- a/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateDoubleMetricFieldMapper.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateDoubleMetricFieldMapper.java
@@ -115,13 +115,12 @@ public class AggregateDoubleMetricFieldMapper extends FieldMapper {
         public static final EnumSet<Metric> METRICS = EnumSet.noneOf(Metric.class);
     }
 
-    public static class Builder extends FieldMapper.Builder {
+    public static final class Builder extends FieldMapper.Builder {
 
         private final Parameter<Map<String, String>> meta = Parameter.metaParam();
 
         private final Parameter<Boolean> ignoreMalformed;
 
-        @SuppressWarnings("this-escape")
         private final Parameter<EnumSet<Metric>> metrics = new Parameter<>(Names.METRICS, false, () -> Defaults.METRICS, (n, c, o) -> {
             @SuppressWarnings("unchecked")
             List<String> metricsList = (List<String>) o;

--- a/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
@@ -76,7 +76,7 @@ public class UnsignedLongFieldMapper extends FieldMapper {
         return (UnsignedLongFieldMapper) in;
     }
 
-    public static class Builder extends FieldMapper.Builder {
+    public static final class Builder extends FieldMapper.Builder {
         private final Parameter<Boolean> indexed;
         private final Parameter<Boolean> hasDocValues = Parameter.docValuesParam(m -> toType(m).hasDocValues, true);
         private final Parameter<Boolean> stored = Parameter.storeParam(m -> toType(m).stored, false);
@@ -102,7 +102,6 @@ public class UnsignedLongFieldMapper extends FieldMapper {
             this(name, IGNORE_MALFORMED_SETTING.get(settings), mode);
         }
 
-        @SuppressWarnings("this-escape")
         public Builder(String name, boolean ignoreMalformedByDefault, IndexMode mode) {
             super(name);
             this.ignoreMalformed = Parameter.explicitBoolParam(

--- a/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
@@ -437,7 +437,7 @@ public class UnsignedLongFieldMapper extends FieldMapper {
          *         null, if a value represents some other number
          *         throws an exception if a value is wrongly formatted number
          */
-        protected static Long parseTerm(Object value) {
+        static Long parseTerm(Object value) {
             if (value instanceof Number) {
                 if ((value instanceof Long) || (value instanceof Integer) || (value instanceof Short) || (value instanceof Byte)) {
                     long lv = ((Number) value).longValue();
@@ -471,7 +471,7 @@ public class UnsignedLongFieldMapper extends FieldMapper {
          *      null, if value is higher than the maximum allowed value for unsigned long
          *      throws an exception is value represents wrongly formatted number
          */
-        protected static Long parseLowerRangeTerm(Object value, boolean include) {
+        static Long parseLowerRangeTerm(Object value, boolean include) {
             if ((value instanceof Long) || (value instanceof Integer) || (value instanceof Short) || (value instanceof Byte)) {
                 long longValue = ((Number) value).longValue();
                 if (longValue < 0) return 0L; // limit lowerTerm to min value for unsigned long: 0
@@ -508,7 +508,7 @@ public class UnsignedLongFieldMapper extends FieldMapper {
          *      -1 (unsigned long of 18446744073709551615) for values greater than 18446744073709551615
          *      throws an exception is value represents wrongly formatted number
          */
-        protected static Long parseUpperRangeTerm(Object value, boolean include) {
+        static Long parseUpperRangeTerm(Object value, boolean include) {
             if ((value instanceof Long) || (value instanceof Integer) || (value instanceof Short) || (value instanceof Byte)) {
                 long longValue = ((Number) value).longValue();
                 if ((longValue < 0) || (longValue == 0 && include == false)) return null; // upperTerm is below minimum

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlInitializationService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlInitializationService.java
@@ -42,7 +42,7 @@ import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_INDEX_HID
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
 
-public class MlInitializationService implements ClusterStateListener {
+public final class MlInitializationService implements ClusterStateListener {
 
     private static final Logger logger = LogManager.getLogger(MlInitializationService.class);
 
@@ -85,7 +85,6 @@ public class MlInitializationService implements ClusterStateListener {
     }
 
     // For testing
-    @SuppressWarnings("this-escape")
     public MlInitializationService(
         Client client,
         ThreadPool threadPool,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingDeciderService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingDeciderService.java
@@ -30,7 +30,7 @@ import java.util.function.LongSupplier;
 
 import static org.elasticsearch.core.Strings.format;
 
-public class MlAutoscalingDeciderService implements AutoscalingDeciderService, LocalNodeMasterListener {
+public final class MlAutoscalingDeciderService implements AutoscalingDeciderService, LocalNodeMasterListener {
 
     private static final Logger logger = LogManager.getLogger(MlAutoscalingDeciderService.class);
 
@@ -46,7 +46,6 @@ public class MlAutoscalingDeciderService implements AutoscalingDeciderService, L
     private volatile boolean isMaster;
     private volatile int allocatedProcessorsScale;
 
-    @SuppressWarnings("this-escape")
     public MlAutoscalingDeciderService(
         MlMemoryTracker memoryTracker,
         Settings settings,
@@ -56,7 +55,6 @@ public class MlAutoscalingDeciderService implements AutoscalingDeciderService, L
         this(new NodeLoadDetector(memoryTracker), settings, nodeAvailabilityZoneMapper, clusterService, System::currentTimeMillis);
     }
 
-    @SuppressWarnings("this-escape")
     MlAutoscalingDeciderService(
         NodeLoadDetector nodeLoadDetector,
         Settings settings,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/NodeFakeAvailabilityZoneMapper.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/NodeFakeAvailabilityZoneMapper.java
@@ -25,7 +25,7 @@ import java.util.Map;
  * Maintains a list of the nodes in each fake availability zone, where each availability zone
  * corresponds to a single node.
  */
-public final class NodeFakeAvailabilityZoneMapper extends AbstractNodeAvailabilityZoneMapper {
+public class NodeFakeAvailabilityZoneMapper extends AbstractNodeAvailabilityZoneMapper {
 
     private static final Logger logger = LogManager.getLogger(NodeFakeAvailabilityZoneMapper.class);
 
@@ -33,6 +33,7 @@ public final class NodeFakeAvailabilityZoneMapper extends AbstractNodeAvailabili
         this(settings, clusterSettings, null);
     }
 
+    @SuppressWarnings("this-escape")
     public NodeFakeAvailabilityZoneMapper(Settings settings, ClusterSettings clusterSettings, DiscoveryNodes discoveryNodes) {
         super(settings, clusterSettings, discoveryNodes);
         updateNodesByAvailabilityZone();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/NodeFakeAvailabilityZoneMapper.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/NodeFakeAvailabilityZoneMapper.java
@@ -25,16 +25,14 @@ import java.util.Map;
  * Maintains a list of the nodes in each fake availability zone, where each availability zone
  * corresponds to a single node.
  */
-public class NodeFakeAvailabilityZoneMapper extends AbstractNodeAvailabilityZoneMapper {
+public final class NodeFakeAvailabilityZoneMapper extends AbstractNodeAvailabilityZoneMapper {
 
     private static final Logger logger = LogManager.getLogger(NodeFakeAvailabilityZoneMapper.class);
 
-    @SuppressWarnings("this-escape")
     public NodeFakeAvailabilityZoneMapper(Settings settings, ClusterSettings clusterSettings) {
         this(settings, clusterSettings, null);
     }
 
-    @SuppressWarnings("this-escape")
     public NodeFakeAvailabilityZoneMapper(Settings settings, ClusterSettings clusterSettings, DiscoveryNodes discoveryNodes) {
         super(settings, clusterSettings, discoveryNodes);
         updateNodesByAvailabilityZone();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/NodeRealAvailabilityZoneMapper.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/NodeRealAvailabilityZoneMapper.java
@@ -28,7 +28,7 @@ import java.util.Map;
  * means a unique combination of values of the attributes listed in the cluster setting
  * cluster.routing.allocation.awareness.attributes.
  */
-public final class NodeRealAvailabilityZoneMapper extends AbstractNodeAvailabilityZoneMapper {
+public class NodeRealAvailabilityZoneMapper extends AbstractNodeAvailabilityZoneMapper {
 
     private static final Logger logger = LogManager.getLogger(NodeRealAvailabilityZoneMapper.class);
 
@@ -38,6 +38,7 @@ public final class NodeRealAvailabilityZoneMapper extends AbstractNodeAvailabili
         this(settings, clusterSettings, null);
     }
 
+    @SuppressWarnings("this-escape")
     public NodeRealAvailabilityZoneMapper(Settings settings, ClusterSettings clusterSettings, DiscoveryNodes discoveryNodes) {
         super(settings, clusterSettings, discoveryNodes);
         awarenessAttributes = AwarenessAllocationDecider.CLUSTER_ROUTING_ALLOCATION_AWARENESS_ATTRIBUTE_SETTING.get(settings);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/NodeRealAvailabilityZoneMapper.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/NodeRealAvailabilityZoneMapper.java
@@ -28,18 +28,16 @@ import java.util.Map;
  * means a unique combination of values of the attributes listed in the cluster setting
  * cluster.routing.allocation.awareness.attributes.
  */
-public class NodeRealAvailabilityZoneMapper extends AbstractNodeAvailabilityZoneMapper {
+public final class NodeRealAvailabilityZoneMapper extends AbstractNodeAvailabilityZoneMapper {
 
     private static final Logger logger = LogManager.getLogger(NodeRealAvailabilityZoneMapper.class);
 
     private volatile List<String> awarenessAttributes;
 
-    @SuppressWarnings("this-escape")
     public NodeRealAvailabilityZoneMapper(Settings settings, ClusterSettings clusterSettings) {
         this(settings, clusterSettings, null);
     }
 
-    @SuppressWarnings("this-escape")
     public NodeRealAvailabilityZoneMapper(Settings settings, ClusterSettings clusterSettings, DiscoveryNodes discoveryNodes) {
         super(settings, clusterSettings, discoveryNodes);
         awarenessAttributes = AwarenessAllocationDecider.CLUSTER_ROUTING_ALLOCATION_AWARENESS_ATTRIBUTE_SETTING.get(settings);

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/cleaner/CleanerService.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/cleaner/CleanerService.java
@@ -28,7 +28,7 @@ import java.util.concurrent.Executor;
 /**
  * {@code CleanerService} takes care of deleting old monitoring indices.
  */
-public class CleanerService extends AbstractLifecycleComponent {
+public final class CleanerService extends AbstractLifecycleComponent {
     private static final Logger logger = LogManager.getLogger(CleanerService.class);
 
     private final ThreadPool threadPool;
@@ -39,7 +39,6 @@ public class CleanerService extends AbstractLifecycleComponent {
 
     private volatile TimeValue globalRetention;
 
-    @SuppressWarnings("this-escape")
     CleanerService(Settings settings, ClusterSettings clusterSettings, ThreadPool threadPool, ExecutionScheduler executionScheduler) {
         this.threadPool = threadPool;
         this.genericExecutor = threadPool.generic();
@@ -51,7 +50,6 @@ public class CleanerService extends AbstractLifecycleComponent {
         clusterSettings.addSettingsUpdateConsumer(MonitoringField.HISTORY_DURATION, this::setGlobalRetention);
     }
 
-    @SuppressWarnings("this-escape")
     public CleanerService(Settings settings, ClusterSettings clusterSettings, ThreadPool threadPool) {
         this(settings, clusterSettings, threadPool, new DefaultExecutionScheduler());
     }

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/cleaner/CleanerService.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/cleaner/CleanerService.java
@@ -28,7 +28,7 @@ import java.util.concurrent.Executor;
 /**
  * {@code CleanerService} takes care of deleting old monitoring indices.
  */
-public final class CleanerService extends AbstractLifecycleComponent {
+public class CleanerService extends AbstractLifecycleComponent {
     private static final Logger logger = LogManager.getLogger(CleanerService.class);
 
     private final ThreadPool threadPool;
@@ -39,6 +39,7 @@ public final class CleanerService extends AbstractLifecycleComponent {
 
     private volatile TimeValue globalRetention;
 
+    @SuppressWarnings("this-escape")
     CleanerService(Settings settings, ClusterSettings clusterSettings, ThreadPool threadPool, ExecutionScheduler executionScheduler) {
         this.threadPool = threadPool;
         this.genericExecutor = threadPool.generic();

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/local/LocalExporter.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/local/LocalExporter.java
@@ -75,7 +75,7 @@ import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.core.ClientHelper.MONITORING_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
 
-public class LocalExporter extends Exporter implements ClusterStateListener, CleanerService.Listener, LicenseStateListener {
+public final class LocalExporter extends Exporter implements ClusterStateListener, CleanerService.Listener, LicenseStateListener {
 
     private static final Logger logger = LogManager.getLogger(LocalExporter.class);
 
@@ -108,7 +108,6 @@ public class LocalExporter extends Exporter implements ClusterStateListener, Cle
 
     private long stateInitializedTime;
 
-    @SuppressWarnings("this-escape")
     public LocalExporter(
         Exporter.Config config,
         Client client,

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpResourceTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpResourceTests.java
@@ -26,9 +26,8 @@ import static org.mockito.Mockito.when;
 /**
  * Tests {@link HttpResource}.
  */
-public class HttpResourceTests extends ESTestCase {
+public final class HttpResourceTests extends ESTestCase {
 
-    @SuppressWarnings("this-escape")
     private final String owner = getTestName();
     private final RestClient mockClient = mock(RestClient.class);
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/NodeFailureListenerTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/NodeFailureListenerTests.java
@@ -19,10 +19,9 @@ import static org.mockito.Mockito.verify;
 /**
  * Tests {@link NodeFailureListener}.
  */
-public class NodeFailureListenerTests extends ESTestCase {
+public final class NodeFailureListenerTests extends ESTestCase {
 
     private final Sniffer sniffer = mock(Sniffer.class);
-    @SuppressWarnings("this-escape")
     private final HttpResource resource = new MockHttpResource(getTestName(), false);
     private final Node node = new Node(new HttpHost("localhost", 9200));
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/WatcherExistsHttpResourceTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/WatcherExistsHttpResourceTests.java
@@ -32,13 +32,12 @@ import static org.mockito.Mockito.when;
 /**
  * Tests {@link WatcherExistsHttpResource}.
  */
-public class WatcherExistsHttpResourceTests extends AbstractPublishableHttpResourceTestCase {
+public final class WatcherExistsHttpResourceTests extends AbstractPublishableHttpResourceTestCase {
 
     private final ClusterService clusterService = mock(ClusterService.class);
     private final MultiHttpResource mockWatches = mock(MultiHttpResource.class);
 
     private final WatcherExistsHttpResource resource = new WatcherExistsHttpResource(owner, clusterService, mockWatches);
-    @SuppressWarnings("this-escape")
     private final Map<String, String> expectedParameters = getParameters(resource.getDefaultParameters(), GET_EXISTS, XPACK_DOES_NOT_EXIST);
 
     public void testDoCheckIgnoresClientWhenNotElectedMaster() {

--- a/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/FailShardsOnInvalidLicenseClusterListener.java
+++ b/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/FailShardsOnInvalidLicenseClusterListener.java
@@ -26,7 +26,7 @@ import java.util.Set;
 
 import static org.elasticsearch.xpack.lucene.bwc.OldLuceneVersions.ARCHIVE_FEATURE;
 
-public class FailShardsOnInvalidLicenseClusterListener implements LicenseStateListener, IndexEventListener {
+public final class FailShardsOnInvalidLicenseClusterListener implements LicenseStateListener, IndexEventListener {
 
     private static final Logger logger = LogManager.getLogger(FailShardsOnInvalidLicenseClusterListener.class);
 
@@ -38,7 +38,6 @@ public class FailShardsOnInvalidLicenseClusterListener implements LicenseStateLi
 
     private boolean allowed;
 
-    @SuppressWarnings("this-escape")
     public FailShardsOnInvalidLicenseClusterListener(XPackLicenseState xPackLicenseState, RerouteService rerouteService) {
         this.xPackLicenseState = xPackLicenseState;
         this.rerouteService = rerouteService;

--- a/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/codecs/lucene60/Lucene60MetadataOnlyPointsReader.java
+++ b/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/codecs/lucene60/Lucene60MetadataOnlyPointsReader.java
@@ -35,13 +35,12 @@ import java.util.HashMap;
 import java.util.Map;
 
 /** Reads the metadata of point values previously written with Lucene60PointsWriter */
-public class Lucene60MetadataOnlyPointsReader extends PointsReader {
+public final class Lucene60MetadataOnlyPointsReader extends PointsReader {
     final IndexInput dataIn;
     final SegmentReadState readState;
     final Map<Integer, PointValues> readers = new HashMap<>();
 
     /** Sole constructor */
-    @SuppressWarnings("this-escape")
     public Lucene60MetadataOnlyPointsReader(SegmentReadState readState) throws IOException {
         this.readState = readState;
 

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/AttributeMap.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/AttributeMap.java
@@ -32,7 +32,7 @@ import static java.util.Collections.emptyMap;
  * Worth noting the {@link #combine(AttributeMap)}, {@link #intersect(AttributeMap)} and {@link #subtract(AttributeMap)} methods which
  * return copies, decoupled from the input maps. In other words the returned maps can be modified without affecting the input or vice-versa.
  */
-public class AttributeMap<E> implements Map<Attribute, E> {
+public final class AttributeMap<E> implements Map<Attribute, E> {
 
     static class AttributeWrapper {
 
@@ -169,7 +169,6 @@ public class AttributeMap<E> implements Map<Attribute, E> {
         delegate = new LinkedHashMap<>();
     }
 
-    @SuppressWarnings("this-escape")
     public AttributeMap(Attribute key, E value) {
         delegate = new LinkedHashMap<>();
         add(key, value);

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/AttributeMap.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/AttributeMap.java
@@ -155,7 +155,7 @@ public final class AttributeMap<E> implements Map<Attribute, E> {
     private static final AttributeMap EMPTY = new AttributeMap<>(emptyMap());
 
     @SuppressWarnings("unchecked")
-    public static final <E> AttributeMap<E> emptyAttributeMap() {
+    public static <E> AttributeMap<E> emptyAttributeMap() {
         return EMPTY;
     }
 

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/ExpressionSet.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/ExpressionSet.java
@@ -17,7 +17,7 @@ import static java.util.Collections.emptyList;
 /**
  * @param <E> expression type
  */
-public class ExpressionSet<E extends Expression> implements Set<E> {
+public final class ExpressionSet<E extends Expression> implements Set<E> {
 
     @SuppressWarnings("rawtypes")
     public static final ExpressionSet EMPTY = new ExpressionSet<>(emptyList());
@@ -34,7 +34,6 @@ public class ExpressionSet<E extends Expression> implements Set<E> {
         super();
     }
 
-    @SuppressWarnings("this-escape")
     public ExpressionSet(Collection<? extends E> c) {
         addAll(c);
     }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/fulltext/StringQueryPredicate.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/fulltext/StringQueryPredicate.java
@@ -15,11 +15,10 @@ import java.util.Map;
 
 import static java.util.Collections.emptyList;
 
-public class StringQueryPredicate extends FullTextPredicate {
+public final class StringQueryPredicate extends FullTextPredicate {
 
     private final Map<String, Float> fields;
 
-    @SuppressWarnings("this-escape")
     public StringQueryPredicate(Source source, String query, String options) {
         super(source, query, options, emptyList());
 

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/index/RemoteClusterResolver.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/index/RemoteClusterResolver.java
@@ -16,10 +16,9 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.CopyOnWriteArraySet;
 
-public class RemoteClusterResolver extends RemoteClusterAware {
+public final class RemoteClusterResolver extends RemoteClusterAware {
     private final CopyOnWriteArraySet<String> clusters;
 
-    @SuppressWarnings("this-escape")
     public RemoteClusterResolver(Settings settings, ClusterSettings clusterSettings) {
         super(settings);
         clusters = new CopyOnWriteArraySet<>(getEnabledRemoteClusters(settings));

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/UnstableLocalStateSecurity.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/UnstableLocalStateSecurity.java
@@ -31,9 +31,8 @@ import java.util.Optional;
  * in an integration test class, because the reserved handlers are injected through
  * SPI. (see {@link LocalReservedUnstableSecurityStateHandlerProvider})
  */
-public class UnstableLocalStateSecurity extends LocalStateSecurity {
+public final class UnstableLocalStateSecurity extends LocalStateSecurity {
 
-    @SuppressWarnings("this-escape")
     public UnstableLocalStateSecurity(Settings settings, Path configPath) throws Exception {
         super(settings, configPath);
         // We reuse most of the initialization of LocalStateSecurity, we then just overwrite

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/DummyUsernamePasswordRealm.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/DummyUsernamePasswordRealm.java
@@ -21,11 +21,10 @@ import org.elasticsearch.xpack.core.security.user.User;
 import java.util.HashMap;
 import java.util.Map;
 
-public class DummyUsernamePasswordRealm extends UsernamePasswordRealm {
+public final class DummyUsernamePasswordRealm extends UsernamePasswordRealm {
 
     private Map<String, Tuple<SecureString, User>> users;
 
-    @SuppressWarnings("this-escape")
     public DummyUsernamePasswordRealm(RealmConfig config) {
         super(config);
         initRealmRef(

--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/NodeSeenService.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/NodeSeenService.java
@@ -33,14 +33,13 @@ import static org.elasticsearch.core.Strings.format;
  *
  * Currently, this consists of keeping track of whether we've seen nodes which are marked for shutdown.
  */
-public class NodeSeenService implements ClusterStateListener {
+public final class NodeSeenService implements ClusterStateListener {
     private static final Logger logger = LogManager.getLogger(NodeSeenService.class);
 
     final ClusterService clusterService;
 
     private final MasterServiceTaskQueue<SetSeenNodesShutdownTask> setSeenTaskQueue;
 
-    @SuppressWarnings("this-escape")
     public NodeSeenService(ClusterService clusterService) {
         this.clusterService = clusterService;
         this.setSeenTaskQueue = clusterService.createTaskQueue(

--- a/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/SlmHealthIndicatorService.java
+++ b/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/SlmHealthIndicatorService.java
@@ -45,7 +45,7 @@ import static org.elasticsearch.xpack.core.ilm.LifecycleSettings.SLM_HEALTH_FAIL
  *
  * SLM must be running to fix warning reported by this indicator.
  */
-public class SlmHealthIndicatorService implements HealthIndicatorService {
+public final class SlmHealthIndicatorService implements HealthIndicatorService {
 
     public static final String NAME = "slm";
 
@@ -83,7 +83,6 @@ public class SlmHealthIndicatorService implements HealthIndicatorService {
     private final ClusterService clusterService;
     private volatile long failedSnapshotWarnThreshold;
 
-    @SuppressWarnings("this-escape")
     public SlmHealthIndicatorService(ClusterService clusterService) {
         this.clusterService = clusterService;
         this.failedSnapshotWarnThreshold = clusterService.getClusterSettings().get(SLM_HEALTH_FAILED_SNAPSHOT_WARN_THRESHOLD_SETTING);

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapper.java
@@ -108,7 +108,7 @@ public class GeoShapeWithDocValuesFieldMapper extends AbstractShapeGeometryField
         return ((GeoShapeWithDocValuesFieldMapper) in).builder;
     }
 
-    public static class Builder extends FieldMapper.Builder {
+    public static final class Builder extends FieldMapper.Builder {
 
         final Parameter<Boolean> indexed = Parameter.indexParam(m -> builder(m).indexed.get(), true);
         final Parameter<Boolean> stored = Parameter.storeParam(m -> builder(m).stored.get(), false);
@@ -125,7 +125,6 @@ public class GeoShapeWithDocValuesFieldMapper extends AbstractShapeGeometryField
         private final IndexVersion version;
         private final GeoFormatterFactory<Geometry> geoFormatterFactory;
 
-        @SuppressWarnings("this-escape")
         public Builder(
             String name,
             IndexVersion version,

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapper.java
@@ -144,7 +144,7 @@ public class GeoShapeWithDocValuesFieldMapper extends AbstractShapeGeometryField
         }
 
         // for testing
-        protected Builder setStored(boolean stored) {
+        Builder setStored(boolean stored) {
             this.stored.setValue(stored);
             return this;
         }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoHexGridAggregationBuilder.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoHexGridAggregationBuilder.java
@@ -29,7 +29,7 @@ import org.elasticsearch.xcontent.XContentParser;
 import java.io.IOException;
 import java.util.Map;
 
-public class GeoHexGridAggregationBuilder extends GeoGridAggregationBuilder {
+public final class GeoHexGridAggregationBuilder extends GeoGridAggregationBuilder {
     public static final String NAME = "geohex_grid";
     private static final int DEFAULT_PRECISION = 5;
     private static final int DEFAULT_MAX_NUM_CELLS = 10000;
@@ -51,7 +51,6 @@ public class GeoHexGridAggregationBuilder extends GeoGridAggregationBuilder {
         return XContentMapValues.nodeIntegerValue(node);
     }
 
-    @SuppressWarnings("this-escape")
     public GeoHexGridAggregationBuilder(String name) {
         super(name);
         precision(DEFAULT_PRECISION);

--- a/x-pack/plugin/sql/sql-proto/src/main/java/org/elasticsearch/xpack/sql/proto/RequestInfo.java
+++ b/x-pack/plugin/sql/sql-proto/src/main/java/org/elasticsearch/xpack/sql/proto/RequestInfo.java
@@ -13,7 +13,7 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 
-public class RequestInfo {
+public final class RequestInfo {
     private static final String CANVAS = "canvas";
     public static final String ODBC_32 = "odbc32";
     private static final String ODBC_64 = "odbc64";
@@ -46,14 +46,12 @@ public class RequestInfo {
         this(mode, clientId, null);
     }
 
-    @SuppressWarnings("this-escape")
     public RequestInfo(Mode mode, String clientId, String version) {
         mode(mode);
         clientId(clientId);
         version(version);
     }
 
-    @SuppressWarnings("this-escape")
     public RequestInfo(Mode mode, SqlVersion version) {
         mode(mode);
         this.version = version;

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
@@ -78,7 +78,7 @@ import static org.elasticsearch.xpack.ql.analyzer.AnalyzerRules.maybeResolveAgai
 import static org.elasticsearch.xpack.ql.analyzer.AnalyzerRules.resolveFunction;
 import static org.elasticsearch.xpack.ql.util.CollectionUtils.combine;
 
-public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerContext> {
+public final class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerContext> {
 
     private static final Iterable<RuleExecutor.Batch<LogicalPlan>> rules;
 
@@ -114,7 +114,6 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
      */
     private final Verifier verifier;
 
-    @SuppressWarnings("this-escape")
     public Analyzer(AnalyzerContext context, Verifier verifier) {
         super(context);
         context.analyzeWithoutVerify().set(this::execute);

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/SqlFunctionRegistry.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/expression/function/SqlFunctionRegistry.java
@@ -139,9 +139,8 @@ import java.util.List;
 
 import static java.util.Collections.unmodifiableList;
 
-public class SqlFunctionRegistry extends FunctionRegistry {
+public final class SqlFunctionRegistry extends FunctionRegistry {
 
-    @SuppressWarnings("this-escape")
     public SqlFunctionRegistry() {
         register(functions());
     }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/Pivot.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plan/logical/Pivot.java
@@ -29,7 +29,7 @@ import java.util.Objects;
 
 import static java.util.Collections.singletonList;
 
-public class Pivot extends UnaryPlan {
+public final class Pivot extends UnaryPlan {
 
     private final Expression column;
     private final List<NamedExpression> values;
@@ -45,7 +45,6 @@ public class Pivot extends UnaryPlan {
         this(source, child, column, values, aggregates, null);
     }
 
-    @SuppressWarnings("this-escape")
     public Pivot(
         Source source,
         LogicalPlan child,

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlQueryAction.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/plugin/TransportSqlQueryAction.java
@@ -62,7 +62,7 @@ import static org.elasticsearch.xpack.sql.plugin.Transports.clusterName;
 import static org.elasticsearch.xpack.sql.plugin.Transports.username;
 import static org.elasticsearch.xpack.sql.proto.Mode.CLI;
 
-public class TransportSqlQueryAction extends HandledTransportAction<SqlQueryRequest, SqlQueryResponse>
+public final class TransportSqlQueryAction extends HandledTransportAction<SqlQueryRequest, SqlQueryResponse>
     implements
         AsyncTaskManagementService.AsyncOperation<SqlQueryRequest, SqlQueryResponse, SqlQueryTask> {
 
@@ -74,7 +74,6 @@ public class TransportSqlQueryAction extends HandledTransportAction<SqlQueryRequ
     private final TransportService transportService;
     private final AsyncTaskManagementService<SqlQueryRequest, SqlQueryResponse, SqlQueryTask> asyncTaskManagementService;
 
-    @SuppressWarnings("this-escape")
     @Inject
     public TransportSqlQueryAction(
         Settings settings,

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/input/InputRegistry.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/input/InputRegistry.java
@@ -17,10 +17,11 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-public final class InputRegistry {
+public class InputRegistry {
 
     private final Map<String, InputFactory<?, ?, ?>> factories;
 
+    @SuppressWarnings("this-escape")
     public InputRegistry(Map<String, InputFactory<?, ?, ?>> factories) {
         Map<String, InputFactory<?, ?, ?>> map = new HashMap<>(factories);
         map.put(ChainInput.TYPE, new ChainInputFactory(this));

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/input/InputRegistry.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/input/InputRegistry.java
@@ -17,11 +17,10 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-public class InputRegistry {
+public final class InputRegistry {
 
     private final Map<String, InputFactory<?, ?, ?>> factories;
 
-    @SuppressWarnings("this-escape")
     public InputRegistry(Map<String, InputFactory<?, ?, ?>> factories) {
         Map<String, InputFactory<?, ?, ?>> map = new HashMap<>(factories);
         map.put(ChainInput.TYPE, new ChainInputFactory(this));

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/WebhookService.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/WebhookService.java
@@ -44,7 +44,7 @@ import java.util.function.Function;
  * regular "webhook" actions as well as parts of an "email" action with attachments that make HTTP
  * requests.
  */
-public final class WebhookService extends NotificationService<WebhookService.WebhookAccount> {
+public class WebhookService extends NotificationService<WebhookService.WebhookAccount> {
     public static final String NAME = "webhook";
 
     private static final Logger logger = LogManager.getLogger(WebhookService.class);
@@ -68,6 +68,7 @@ public final class WebhookService extends NotificationService<WebhookService.Web
     private final HttpClient httpClient;
     private final boolean additionalTokenEnabled;
 
+    @SuppressWarnings("this-escape")
     public WebhookService(Settings settings, HttpClient httpClient, ClusterSettings clusterSettings) {
         super(NAME, settings, clusterSettings, List.of(), getSecureSettings());
         this.httpClient = httpClient;

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/WebhookService.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/WebhookService.java
@@ -44,7 +44,7 @@ import java.util.function.Function;
  * regular "webhook" actions as well as parts of an "email" action with attachments that make HTTP
  * requests.
  */
-public class WebhookService extends NotificationService<WebhookService.WebhookAccount> {
+public final class WebhookService extends NotificationService<WebhookService.WebhookAccount> {
     public static final String NAME = "webhook";
 
     private static final Logger logger = LogManager.getLogger(WebhookService.class);
@@ -68,7 +68,6 @@ public class WebhookService extends NotificationService<WebhookService.WebhookAc
     private final HttpClient httpClient;
     private final boolean additionalTokenEnabled;
 
-    @SuppressWarnings("this-escape")
     public WebhookService(Settings settings, HttpClient httpClient, ClusterSettings clusterSettings) {
         super(NAME, settings, clusterSettings, List.of(), getSecureSettings());
         this.httpClient = httpClient;

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/email/attachment/ReportingAttachmentParser.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/email/attachment/ReportingAttachmentParser.java
@@ -50,7 +50,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import static org.elasticsearch.core.Strings.format;
 
-public class ReportingAttachmentParser implements EmailAttachmentParser<ReportingAttachment> {
+public final class ReportingAttachmentParser implements EmailAttachmentParser<ReportingAttachment> {
 
     public static final String TYPE = "reporting";
 
@@ -137,7 +137,6 @@ public class ReportingAttachmentParser implements EmailAttachmentParser<Reportin
     private boolean warningEnabled = REPORT_WARNING_ENABLED_SETTING.getDefault(Settings.EMPTY);
     private final Map<String, String> customWarnings = new ConcurrentHashMap<>(1);
 
-    @SuppressWarnings("this-escape")
     public ReportingAttachmentParser(
         Settings settings,
         WebhookService webhookService,

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/jira/JiraService.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/jira/JiraService.java
@@ -24,7 +24,7 @@ import java.util.List;
  *
  * https://www.atlassian.com/software/jira
  */
-public final class JiraService extends NotificationService<JiraAccount> {
+public class JiraService extends NotificationService<JiraAccount> {
 
     private static final Setting<String> SETTING_DEFAULT_ACCOUNT = Setting.simpleString(
         "xpack.notification.jira.default_account",
@@ -64,6 +64,7 @@ public final class JiraService extends NotificationService<JiraAccount> {
 
     private final HttpClient httpClient;
 
+    @SuppressWarnings("this-escape")
     public JiraService(Settings settings, HttpClient httpClient, ClusterSettings clusterSettings) {
         super("jira", settings, clusterSettings, JiraService.getDynamicSettings(), JiraService.getSecureSettings());
         this.httpClient = httpClient;

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/jira/JiraService.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/jira/JiraService.java
@@ -24,7 +24,7 @@ import java.util.List;
  *
  * https://www.atlassian.com/software/jira
  */
-public class JiraService extends NotificationService<JiraAccount> {
+public final class JiraService extends NotificationService<JiraAccount> {
 
     private static final Setting<String> SETTING_DEFAULT_ACCOUNT = Setting.simpleString(
         "xpack.notification.jira.default_account",
@@ -64,7 +64,6 @@ public class JiraService extends NotificationService<JiraAccount> {
 
     private final HttpClient httpClient;
 
-    @SuppressWarnings("this-escape")
     public JiraService(Settings settings, HttpClient httpClient, ClusterSettings clusterSettings) {
         super("jira", settings, clusterSettings, JiraService.getDynamicSettings(), JiraService.getSecureSettings());
         this.httpClient = httpClient;

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/pagerduty/PagerDutyService.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/pagerduty/PagerDutyService.java
@@ -22,7 +22,7 @@ import java.util.List;
 /**
  * A component to store pagerduty credentials.
  */
-public class PagerDutyService extends NotificationService<PagerDutyAccount> {
+public final class PagerDutyService extends NotificationService<PagerDutyAccount> {
 
     private static final Setting<String> SETTING_DEFAULT_ACCOUNT = Setting.simpleString(
         "xpack.notification.pagerduty.default_account",
@@ -44,7 +44,6 @@ public class PagerDutyService extends NotificationService<PagerDutyAccount> {
 
     private final HttpClient httpClient;
 
-    @SuppressWarnings("this-escape")
     public PagerDutyService(Settings settings, HttpClient httpClient, ClusterSettings clusterSettings) {
         super("pagerduty", settings, clusterSettings, PagerDutyService.getDynamicSettings(), PagerDutyService.getSecureSettings());
         this.httpClient = httpClient;

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/pagerduty/PagerDutyService.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/pagerduty/PagerDutyService.java
@@ -22,7 +22,7 @@ import java.util.List;
 /**
  * A component to store pagerduty credentials.
  */
-public final class PagerDutyService extends NotificationService<PagerDutyAccount> {
+public class PagerDutyService extends NotificationService<PagerDutyAccount> {
 
     private static final Setting<String> SETTING_DEFAULT_ACCOUNT = Setting.simpleString(
         "xpack.notification.pagerduty.default_account",
@@ -44,6 +44,7 @@ public final class PagerDutyService extends NotificationService<PagerDutyAccount
 
     private final HttpClient httpClient;
 
+    @SuppressWarnings("this-escape")
     public PagerDutyService(Settings settings, HttpClient httpClient, ClusterSettings clusterSettings) {
         super("pagerduty", settings, clusterSettings, PagerDutyService.getDynamicSettings(), PagerDutyService.getSecureSettings());
         this.httpClient = httpClient;

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/slack/SlackService.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/slack/SlackService.java
@@ -24,7 +24,7 @@ import java.util.List;
 /**
  * A component to store slack credentials.
  */
-public final class SlackService extends NotificationService<SlackAccount> {
+public class SlackService extends NotificationService<SlackAccount> {
 
     private static final Setting<String> SETTING_DEFAULT_ACCOUNT = Setting.simpleString(
         "xpack.notification.slack.default_account",
@@ -48,6 +48,7 @@ public final class SlackService extends NotificationService<SlackAccount> {
 
     private final HttpClient httpClient;
 
+    @SuppressWarnings("this-escape")
     public SlackService(Settings settings, HttpClient httpClient, ClusterSettings clusterSettings) {
         super("slack", settings, clusterSettings, SlackService.getDynamicSettings(), SlackService.getSecureSettings());
         this.httpClient = httpClient;

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/slack/SlackService.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/slack/SlackService.java
@@ -24,7 +24,7 @@ import java.util.List;
 /**
  * A component to store slack credentials.
  */
-public class SlackService extends NotificationService<SlackAccount> {
+public final class SlackService extends NotificationService<SlackAccount> {
 
     private static final Setting<String> SETTING_DEFAULT_ACCOUNT = Setting.simpleString(
         "xpack.notification.slack.default_account",
@@ -48,7 +48,6 @@ public class SlackService extends NotificationService<SlackAccount> {
 
     private final HttpClient httpClient;
 
-    @SuppressWarnings("this-escape")
     public SlackService(Settings settings, HttpClient httpClient, ClusterSettings clusterSettings) {
         super("slack", settings, clusterSettings, SlackService.getDynamicSettings(), SlackService.getSecureSettings());
         this.httpClient = httpClient;

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/trigger/schedule/support/DayTimes.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/trigger/schedule/support/DayTimes.java
@@ -19,7 +19,7 @@ import java.util.List;
 import static org.elasticsearch.xpack.core.watcher.support.Exceptions.illegalArgument;
 import static org.elasticsearch.xpack.watcher.support.Strings.join;
 
-public class DayTimes implements Times {
+public final class DayTimes implements Times {
 
     public static final DayTimes NOON = new DayTimes("noon", new int[] { 12 }, new int[] { 0 });
     public static final DayTimes MIDNIGHT = new DayTimes("midnight", new int[] { 0 }, new int[] { 0 });
@@ -36,12 +36,10 @@ public class DayTimes implements Times {
         this(new int[] { hour }, new int[] { minute });
     }
 
-    @SuppressWarnings("this-escape")
     public DayTimes(int[] hour, int[] minute) {
         this(null, hour, minute);
     }
 
-    @SuppressWarnings("this-escape")
     DayTimes(String time, int[] hour, int[] minute) {
         this.time = time;
         this.hour = hour;

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/trigger/schedule/support/MonthTimes.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/trigger/schedule/support/MonthTimes.java
@@ -22,7 +22,7 @@ import static org.elasticsearch.common.util.set.Sets.newHashSet;
 import static org.elasticsearch.xpack.core.watcher.support.Exceptions.illegalArgument;
 import static org.elasticsearch.xpack.watcher.support.Strings.join;
 
-public class MonthTimes implements Times {
+public final class MonthTimes implements Times {
 
     public static final String LAST = "last_day";
     public static final String FIRST = "first_day";
@@ -37,7 +37,6 @@ public class MonthTimes implements Times {
         this(DEFAULT_DAYS, DEFAULT_TIMES);
     }
 
-    @SuppressWarnings("this-escape")
     public MonthTimes(int[] days, DayTimes[] times) {
         this.days = days.length == 0 ? DEFAULT_DAYS : days;
         Arrays.sort(this.days);

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/trigger/schedule/support/YearTimes.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/trigger/schedule/support/YearTimes.java
@@ -24,7 +24,7 @@ import static org.elasticsearch.common.util.set.Sets.newHashSet;
 import static org.elasticsearch.xpack.core.watcher.support.Exceptions.illegalArgument;
 import static org.elasticsearch.xpack.watcher.support.Strings.join;
 
-public class YearTimes implements Times {
+public final class YearTimes implements Times {
 
     public static final EnumSet<Month> DEFAULT_MONTHS = EnumSet.of(Month.JANUARY);
     public static final int[] DEFAULT_DAYS = new int[] { 1 };
@@ -38,7 +38,6 @@ public class YearTimes implements Times {
         this(DEFAULT_MONTHS, DEFAULT_DAYS, DEFAULT_TIMES);
     }
 
-    @SuppressWarnings("this-escape")
     public YearTimes(EnumSet<Month> months, int[] days, DayTimes[] times) {
         this.months = months.isEmpty() ? DEFAULT_MONTHS : months;
         this.days = days.length == 0 ? DEFAULT_DAYS : days;

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/WatchExecutionContextMockBuilder.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/WatchExecutionContextMockBuilder.java
@@ -22,12 +22,11 @@ import java.util.Map;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class WatchExecutionContextMockBuilder {
+public final class WatchExecutionContextMockBuilder {
 
     private final WatchExecutionContext ctx;
     private final Watch watch;
 
-    @SuppressWarnings("this-escape")
     public WatchExecutionContextMockBuilder(String watchId) {
         ctx = mock(WatchExecutionContext.class);
         watch = mock(Watch.class);

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -122,8 +122,7 @@ public class WildcardFieldMapper extends FieldMapper {
         }
     });
 
-    public static class PunctuationFoldingFilter extends TokenFilter {
-        @SuppressWarnings("this-escape")
+    public static final class PunctuationFoldingFilter extends TokenFilter {
         private final CharTermAttribute termAtt = addAttribute(CharTermAttribute.class);
 
         /**

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -136,7 +136,7 @@ public class WildcardFieldMapper extends FieldMapper {
         }
 
         @Override
-        public final boolean incrementToken() throws IOException {
+        public boolean incrementToken() throws IOException {
             if (input.incrementToken()) {
                 normalize(termAtt.buffer(), 0, termAtt.length());
                 return true;
@@ -586,7 +586,7 @@ public class WildcardFieldMapper extends FieldMapper {
             throw new IllegalStateException("Invalid query type found parsing regex query:" + approxQuery);
         }
 
-        protected void getNgramTokens(Set<String> tokens, String fragment) {
+        private void getNgramTokens(Set<String> tokens, String fragment) {
             if (fragment.equals(TOKEN_START_STRING) || fragment.equals(TOKEN_END_STRING)) {
                 // If a regex is a form of match-all e.g. ".*" we only produce the token start/end markers as search
                 // terms which can be ignored.

--- a/x-pack/qa/security-example-spi-extension/src/main/java/org/elasticsearch/example/realm/CustomRoleMappingRealm.java
+++ b/x-pack/qa/security-example-spi-extension/src/main/java/org/elasticsearch/example/realm/CustomRoleMappingRealm.java
@@ -28,7 +28,7 @@ import java.util.Map;
  * (2) It performs role mapping to determine the roles for the looked-up user
  * (3) It caches the looked-up User objects
  */
-public class CustomRoleMappingRealm extends Realm implements CachingRealm {
+public final class CustomRoleMappingRealm extends Realm implements CachingRealm {
 
     public static final String TYPE = "custom_role_mapping";
 
@@ -38,7 +38,6 @@ public class CustomRoleMappingRealm extends Realm implements CachingRealm {
     private final Cache<String, User> cache;
     private final UserRoleMapper roleMapper;
 
-    @SuppressWarnings("this-escape")
     public CustomRoleMappingRealm(RealmConfig config, UserRoleMapper roleMapper) {
         super(config);
         this.cache = CacheBuilder.<String, User>builder().build();


### PR DESCRIPTION
The "this-escape" compiler warning is intended to alert developers to potential bugs in object initialization due to subclassing. This class of bugs cannot occur when a class is final. Here, we take cases where a class has no implementations but generates a "this-escape" warning, and we make those classes final rather than suppressing the compiler warning.

This makes the remaining suppressions more meaningful, since they now indicate places where we may want to look for initialization bugs.

In a few cases, making a class final meant changing some of its protected fields and methods to private or default accessibility.

Some classes with no implementations are mocked in testing. Since making those classes final would involve non-trivial rewrites of tests, I've left them alone.