### PR TITLE
Unify naming of feature spec implementations

### DIFF
--- a/server/src/main/java/module-info.java
+++ b/server/src/main/java/module-info.java
@@ -405,7 +405,7 @@ module org.elasticsearch.server {
 
     provides org.elasticsearch.features.FeatureSpecification
         with
-            org.elasticsearch.features.FeaturesFeatures,
+            org.elasticsearch.features.FeatureInfrastructureFeatures,
             org.elasticsearch.health.HealthFeatures,
             org.elasticsearch.rest.RestFeatures;
 

--- a/server/src/main/java/module-info.java
+++ b/server/src/main/java/module-info.java
@@ -405,8 +405,8 @@ module org.elasticsearch.server {
 
     provides org.elasticsearch.features.FeatureSpecification
         with
-            org.elasticsearch.features.FeaturesSupportedSpecification,
-            org.elasticsearch.health.HealthFeature,
+            org.elasticsearch.features.FeaturesFeatures,
+            org.elasticsearch.health.HealthFeatures,
             org.elasticsearch.rest.RestFeatures;
 
     uses org.elasticsearch.plugins.internal.SettingsExtension;

--- a/server/src/main/java/org/elasticsearch/features/FeatureInfrastructureFeatures.java
+++ b/server/src/main/java/org/elasticsearch/features/FeatureInfrastructureFeatures.java
@@ -17,7 +17,7 @@ import java.util.Set;
  * Nodes that do not support features won't have this feature in its feature set,
  * so this can be checked without needing to look at the node version.
  */
-public class FeaturesFeatures implements FeatureSpecification {
+public class FeatureInfrastructureFeatures implements FeatureSpecification {
 
     @Override
     public Set<NodeFeature> getFeatures() {

--- a/server/src/main/java/org/elasticsearch/features/FeaturesFeatures.java
+++ b/server/src/main/java/org/elasticsearch/features/FeaturesFeatures.java
@@ -11,6 +11,8 @@ package org.elasticsearch.features;
 import java.util.Set;
 
 /**
+ * This class specifies features for the features functionality itself.
+ * <p>
  * This adds a feature {@code features_supported} indicating that a node supports node features.
  * Nodes that do not support features won't have this feature in its feature set,
  * so this can be checked without needing to look at the node version.

--- a/server/src/main/java/org/elasticsearch/features/FeaturesFeatures.java
+++ b/server/src/main/java/org/elasticsearch/features/FeaturesFeatures.java
@@ -15,7 +15,7 @@ import java.util.Set;
  * Nodes that do not support features won't have this feature in its feature set,
  * so this can be checked without needing to look at the node version.
  */
-public class FeaturesSupportedSpecification implements FeatureSpecification {
+public class FeaturesFeatures implements FeatureSpecification {
 
     @Override
     public Set<NodeFeature> getFeatures() {

--- a/server/src/main/java/org/elasticsearch/health/HealthFeatures.java
+++ b/server/src/main/java/org/elasticsearch/health/HealthFeatures.java
@@ -14,7 +14,7 @@ import org.elasticsearch.features.NodeFeature;
 
 import java.util.Map;
 
-public class HealthFeature implements FeatureSpecification {
+public class HealthFeatures implements FeatureSpecification {
 
     public static final NodeFeature SUPPORTS_HEALTH = new NodeFeature("supports_health");
 

--- a/server/src/main/java/org/elasticsearch/health/metadata/HealthMetadataService.java
+++ b/server/src/main/java/org/elasticsearch/health/metadata/HealthMetadataService.java
@@ -27,7 +27,7 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.gateway.GatewayService;
-import org.elasticsearch.health.HealthFeature;
+import org.elasticsearch.health.HealthFeatures;
 
 import java.util.List;
 import java.util.stream.Stream;
@@ -136,7 +136,7 @@ public class HealthMetadataService {
 
     private boolean canPostClusterStateUpdates(ClusterState state) {
         // Wait until every node in the cluster supports health checks
-        return isMaster && state.clusterRecovered() && featureService.clusterHasFeature(state, HealthFeature.SUPPORTS_HEALTH);
+        return isMaster && state.clusterRecovered() && featureService.clusterHasFeature(state, HealthFeatures.SUPPORTS_HEALTH);
     }
 
     private void updateOnClusterStateChange(ClusterChangedEvent event) {

--- a/server/src/main/java/org/elasticsearch/health/node/LocalHealthMonitor.java
+++ b/server/src/main/java/org/elasticsearch/health/node/LocalHealthMonitor.java
@@ -33,7 +33,7 @@ import org.elasticsearch.common.util.concurrent.RunOnce;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.features.FeatureService;
-import org.elasticsearch.health.HealthFeature;
+import org.elasticsearch.health.HealthFeatures;
 import org.elasticsearch.health.HealthStatus;
 import org.elasticsearch.health.metadata.HealthMetadata;
 import org.elasticsearch.health.node.action.HealthNodeNotDiscoveredException;
@@ -213,7 +213,7 @@ public class LocalHealthMonitor implements ClusterStateListener {
             }
         }
         prerequisitesFulfilled = event.state().clusterRecovered()
-            && featureService.clusterHasFeature(event.state(), HealthFeature.SUPPORTS_HEALTH)
+            && featureService.clusterHasFeature(event.state(), HealthFeatures.SUPPORTS_HEALTH)
             && HealthMetadata.getFromClusterState(event.state()) != null
             && currentHealthNode != null
             && currentMasterNode != null;

--- a/server/src/main/java/org/elasticsearch/health/node/selection/HealthNodeTaskExecutor.java
+++ b/server/src/main/java/org/elasticsearch/health/node/selection/HealthNodeTaskExecutor.java
@@ -22,7 +22,7 @@ import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.features.FeatureService;
-import org.elasticsearch.health.HealthFeature;
+import org.elasticsearch.health.HealthFeatures;
 import org.elasticsearch.persistent.AllocatedPersistentTask;
 import org.elasticsearch.persistent.PersistentTaskParams;
 import org.elasticsearch.persistent.PersistentTaskState;
@@ -156,7 +156,7 @@ public final class HealthNodeTaskExecutor extends PersistentTasksExecutor<Health
     // visible for testing
     void startTask(ClusterChangedEvent event) {
         // Wait until every node in the cluster supports health checks
-        if (event.state().clusterRecovered() && featureService.clusterHasFeature(event.state(), HealthFeature.SUPPORTS_HEALTH)) {
+        if (event.state().clusterRecovered() && featureService.clusterHasFeature(event.state(), HealthFeatures.SUPPORTS_HEALTH)) {
             boolean healthNodeTaskExists = HealthNode.findTask(event.state()) != null;
             boolean isElectedMaster = event.localNodeMaster();
             if (isElectedMaster || healthNodeTaskExists) {

--- a/server/src/main/resources/META-INF/services/org.elasticsearch.features.FeatureSpecification
+++ b/server/src/main/resources/META-INF/services/org.elasticsearch.features.FeatureSpecification
@@ -6,6 +6,6 @@
 # Side Public License, v 1.
 #
 
-org.elasticsearch.features.FeaturesSupportedSpecification
-org.elasticsearch.health.HealthFeature
+org.elasticsearch.features.FeaturesFeatures
+org.elasticsearch.health.HealthFeatures
 org.elasticsearch.rest.RestFeatures

--- a/server/src/main/resources/META-INF/services/org.elasticsearch.features.FeatureSpecification
+++ b/server/src/main/resources/META-INF/services/org.elasticsearch.features.FeatureSpecification
@@ -6,6 +6,6 @@
 # Side Public License, v 1.
 #
 
-org.elasticsearch.features.FeaturesFeatures
+org.elasticsearch.features.FeatureInfrastructureFeatures
 org.elasticsearch.health.HealthFeatures
 org.elasticsearch.rest.RestFeatures

--- a/server/src/test/java/org/elasticsearch/health/node/LocalHealthMonitorTests.java
+++ b/server/src/test/java/org/elasticsearch/health/node/LocalHealthMonitorTests.java
@@ -28,7 +28,7 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.RelativeByteSizeValue;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.features.FeatureService;
-import org.elasticsearch.health.HealthFeature;
+import org.elasticsearch.health.HealthFeatures;
 import org.elasticsearch.health.HealthStatus;
 import org.elasticsearch.health.metadata.HealthMetadata;
 import org.elasticsearch.health.node.selection.HealthNodeExecutorTests;
@@ -124,7 +124,7 @@ public class LocalHealthMonitorTests extends ESTestCase {
 
         client = mock(Client.class);
 
-        featureService = new FeatureService(List.of(new HealthFeature()));
+        featureService = new FeatureService(List.of(new HealthFeatures()));
     }
 
     @SuppressWarnings("unchecked")

--- a/server/src/test/java/org/elasticsearch/health/node/selection/HealthNodeExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/health/node/selection/HealthNodeExecutorTests.java
@@ -21,7 +21,7 @@ import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.features.FeatureService;
-import org.elasticsearch.health.HealthFeature;
+import org.elasticsearch.health.HealthFeatures;
 import org.elasticsearch.persistent.PersistentTaskState;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.persistent.PersistentTasksService;
@@ -75,7 +75,7 @@ public class HealthNodeExecutorTests extends ESTestCase {
         clusterService = createClusterService(threadPool);
         localNodeId = clusterService.localNode().getId();
         persistentTasksService = mock(PersistentTasksService.class);
-        featureService = new FeatureService(List.of(new HealthFeature()));
+        featureService = new FeatureService(List.of(new HealthFeatures()));
         settings = Settings.builder().build();
         clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
     }


### PR DESCRIPTION
Use the same naming convention for feature spec implementations - `<area>Features`