### PR TITLE
[8.11] EQL doc wrong description in query example (#101579)

### DIFF
--- a/docs/reference/eql/syntax.asciidoc
+++ b/docs/reference/eql/syntax.asciidoc
@@ -243,7 +243,7 @@ my_field like  ("Value-*", "VALUE2", "VAL?")              // case-sensitive
 my_field like~ ("value-*", "value2", "val?")              // case-insensitive
 
 my_field regex  ("[vV]alue-[0-9]", "VALUE[^2].?", "VAL3") // case-sensitive
-my_field regex~  ("value-[0-9]", "value[^2].?", "val3")   // case-sensitive
+my_field regex~  ("value-[0-9]", "value[^2].?", "val3")   // case-insensitive
 ----
 
 `in` (case-sensitive)::


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.10` to `8.11`:
 - [EQL doc wrong description in query example (#101579)](https://github.com/elastic/elasticsearch/pull/101579)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)