### PR TITLE
Make LucenePersistedState subclassable again

### DIFF
--- a/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
+++ b/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
@@ -495,7 +495,7 @@ public class GatewayMetaState implements Closeable {
     /**
      * Encapsulates the incremental writing of metadata to a {@link PersistedClusterStateService.Writer}.
      */
-    public static final class LucenePersistedState implements PersistedState {
+    public static class LucenePersistedState implements PersistedState {
 
         private long currentTerm;
         private ClusterState lastAcceptedState;
@@ -505,6 +505,7 @@ public class GatewayMetaState implements Closeable {
         private final AtomicReference<PersistedClusterStateService.Writer> persistenceWriter = new AtomicReference<>();
         private boolean writeNextStateFully;
 
+        @SuppressWarnings("this-escape")
         public LucenePersistedState(
             PersistedClusterStateService persistedClusterStateService,
             long currentTerm,
@@ -525,7 +526,7 @@ public class GatewayMetaState implements Closeable {
             persistenceWriter.set(writer);
         }
 
-        private void maybeWriteInitialState(long currentTerm, ClusterState lastAcceptedState, PersistedClusterStateService.Writer writer)
+        protected void maybeWriteInitialState(long currentTerm, ClusterState lastAcceptedState, PersistedClusterStateService.Writer writer)
             throws IOException {
             try {
                 writer.writeFullStateAndCommit(currentTerm, lastAcceptedState);
@@ -555,7 +556,7 @@ public class GatewayMetaState implements Closeable {
             this.currentTerm = currentTerm;
         }
 
-        private void writeCurrentTermToDisk(long currentTerm) {
+        protected void writeCurrentTermToDisk(long currentTerm) {
             try {
                 if (writeNextStateFully) {
                     getWriterSafe().writeFullStateAndCommit(currentTerm, lastAcceptedState);
@@ -583,7 +584,7 @@ public class GatewayMetaState implements Closeable {
             lastAcceptedState = clusterState;
         }
 
-        private void writeClusterStateToDisk(ClusterState clusterState) {
+        protected void writeClusterStateToDisk(ClusterState clusterState) {
             try {
                 if (writeNextStateFully) {
                     getWriterSafe().writeFullStateAndCommit(currentTerm, clusterState);


### PR DESCRIPTION
In #101699, I overlooked a class that's subclassed in the serverless project. GatewayMetaState.LucenePersistedState can't be final, and some of its methods need to be protected instead of private.