### PR TITLE
Disable weight_matches when kNN query is present

### DIFF
--- a/docs/changelog/101713.yaml
+++ b/docs/changelog/101713.yaml
@@ -1,0 +1,5 @@
+pr: 101713
+summary: Disable `weight_matches` when kNN query is present
+area: Highlighting
+type: bug
+issues: []

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.highlight/10_unified.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.highlight/10_unified.yml
@@ -93,3 +93,50 @@ teardown:
   - match: {hits.hits.0.highlight.text.0: "The <em>quick</em> <em>brown</em> <em>fox</em> is brown."}
   - match: {hits.hits.0.highlight.text\.fvh.0: "The <em>quick</em> <em>brown</em> <em>fox</em> is brown."}
   - match: {hits.hits.0.highlight.text\.postings.0: "The <em>quick</em> <em>brown</em> <em>fox</em> is brown."}
+---
+"Test hybrid search with knn where automatically disables weighted mode":
+  - skip:
+      version: ' - 8.11.99'
+      reason: 'kNN was not correctly skipped until 8.12'
+
+  - do:
+      indices.create:
+        index: test-highlighting-knn
+        body:
+          mappings:
+            "properties":
+              "vectors":
+                "type": "dense_vector"
+                "dims": 2
+                "index": true
+                "similarity": "l2_norm"
+              "text":
+                "type": "text"
+                "fields":
+                  "fvh":
+                    "type": "text"
+                    "term_vector": "with_positions_offsets"
+                  "postings":
+                    "type": "text"
+                    "index_options": "offsets"
+  - do:
+      index:
+        index: test-highlighting-knn
+        id:    "1"
+        body:
+          "text" : "The quick brown fox is brown."
+          "vectors": [1, 2]
+  - do:
+      indices.refresh: {}
+
+  - do:
+      search:
+        index: test-highlighting-knn
+        body: {
+          "query": { "multi_match": { "query": "quick brown fox", "type": "phrase", "fields": [ "text*" ] } },
+          "highlight": { "type": "unified", "fields": { "*": { } } },
+          "knn": { "field": "vectors", "query_vector": [1, 2], "k": 10, "num_candidates": 10 } }
+
+  - match: { hits.hits.0.highlight.text.0: "The <em>quick</em> <em>brown</em> <em>fox</em> is brown." }
+  - match: { hits.hits.0.highlight.text\.fvh.0: "The <em>quick</em> <em>brown</em> <em>fox</em> is brown." }
+  - match: { hits.hits.0.highlight.text\.postings.0: "The <em>quick</em> <em>brown</em> <em>fox</em> is brown." }

--- a/server/src/main/java/org/elasticsearch/lucene/search/uhighlight/CustomUnifiedHighlighter.java
+++ b/server/src/main/java/org/elasticsearch/lucene/search/uhighlight/CustomUnifiedHighlighter.java
@@ -32,6 +32,7 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.search.ESToParentBlockJoinQuery;
 import org.elasticsearch.search.runtime.AbstractScriptFieldQuery;
+import org.elasticsearch.search.vectors.KnnScoreDocQuery;
 
 import java.io.IOException;
 import java.text.BreakIterator;
@@ -248,6 +249,13 @@ public class CustomUnifiedHighlighter extends UnifiedHighlighter {
                  * in order to preserve the compatibility.
                  */
                 if (leafQuery.getClass().getSimpleName().equals("LateParsingQuery")) {
+                    hasUnknownLeaf[0] = true;
+                }
+                /**
+                 * KnnScoreDocQuery requires the same reader that built the docs
+                 * When using {@link HighlightFlag#WEIGHT_MATCHES} different readers are used and isn't supported by this query
+                 */
+                if (leafQuery instanceof KnnScoreDocQuery) {
                     hasUnknownLeaf[0] = true;
                 }
                 super.visitLeaf(query);


### PR DESCRIPTION
8.10 added a new flag called `weight_matches` and we use it by default when highlighting. However, every hybrid search with kNN will fail with cryptic errors. 

This PR disables weight_matches mode when kNN queries are present. Supporting weigh_matches & kNN will take more work.

closes: https://github.com/elastic/elasticsearch/issues/101667