### PR TITLE
Role mapping fallback cache 

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -1018,6 +1018,8 @@ public class Security extends Plugin
 
         reservedRoleMappingAction.set(new ReservedRoleMappingAction(nativeRoleMappingStore));
         systemIndices.getMainIndexManager().onStateRecovered(state -> reservedRoleMappingAction.get().securityIndexRecovered());
+        // How do we wait for role mappings to be available instead of only the security index?
+        systemIndices.getMainIndexManager().onStateRecovered(state -> nativeRoleMappingStore.loadCache());
 
         cacheInvalidatorRegistry.validate();
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/mapper/NativeRoleMappingStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/mapper/NativeRoleMappingStore.java
@@ -363,12 +363,16 @@ public class NativeRoleMappingStore implements UserRoleMapper {
     }
 
     public void onSecurityIndexStateChange(SecurityIndexManager.State previousState, SecurityIndexManager.State currentState) {
-        // TODO figure out correct cache behavior here -- does anything need to happen?
         if (isMoveFromRedToNonRed(previousState, currentState)
             || isIndexDeleted(previousState, currentState)
             || Objects.equals(previousState.indexUUID, currentState.indexUUID) == false
             || previousState.isIndexUpToDate != currentState.isIndexUpToDate) {
             refreshRealms(ActionListener.noop(), null);
+            // TODO is this what we want?
+            if (cache != null) {
+                // re-load cache, yikes...
+                getMappings(ActionListener.noop());
+            }
         }
     }
 


### PR DESCRIPTION
This PR is exploratory and not meant to be merged. 

I'm looking at using a cache to store role mappings in memory, and fall back on this when the security index is not available. 

It's hacky and it's certainly a targeted "work-around". The main challenge is that the cache is per-node, whereas ideally we want an in-memory copy of role mappings on _each_ node.  