### PR TITLE
Disable inter-segment concurrency for composite/terms agg

### DIFF
--- a/docs/changelog/101719.yaml
+++ b/docs/changelog/101719.yaml
@@ -1,0 +1,5 @@
+pr: 101719
+summary: Disable inter-segment concurrency for composite/terms agg
+area: Aggregations
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregationBuilder.java
@@ -302,4 +302,14 @@ public class CompositeAggregationBuilder extends AbstractAggregationBuilder<Comp
     public TransportVersion getMinimalSupportedVersion() {
         return TransportVersions.ZERO;
     }
+
+    @Override
+    public boolean supportsParallelCollection() {
+        for (CompositeValuesSourceBuilder<?> source : sources) {
+            if (source.supportsParallelCollection() == false) {
+                return false;
+            }
+        }
+        return true;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeValuesSourceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeValuesSourceBuilder.java
@@ -325,4 +325,13 @@ public abstract class CompositeValuesSourceBuilder<AB extends CompositeValuesSou
     protected ZoneId timeZone() {
         return null;
     }
+
+    /**
+     * Return false if this composite values source does not support parallel collection.
+     * As a result, a request including a composite aggregation with such source is always executed sequentially despite concurrency is
+     * enabled for the query phase.
+     */
+    public boolean supportsParallelCollection() {
+        return true;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/TermsValuesSourceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/TermsValuesSourceBuilder.java
@@ -215,4 +215,9 @@ public class TermsValuesSourceBuilder extends CompositeValuesSourceBuilder<Terms
         return registry.getAggregator(REGISTRY_KEY, config)
             .apply(config, name, script() != null, format(), missingBucket(), missingOrder(), order());
     }
+
+    @Override
+    public boolean supportsParallelCollection() {
+        return false;
+    }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/AggregatorFactoriesTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/AggregatorFactoriesTests.java
@@ -25,6 +25,9 @@ import org.elasticsearch.index.query.WrapperQueryBuilder;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.composite.DateHistogramValuesSourceBuilder;
+import org.elasticsearch.search.aggregations.bucket.composite.GeoTileGridValuesSourceBuilder;
+import org.elasticsearch.search.aggregations.bucket.composite.HistogramValuesSourceBuilder;
 import org.elasticsearch.search.aggregations.bucket.composite.TermsValuesSourceBuilder;
 import org.elasticsearch.search.aggregations.bucket.filter.FilterAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.nested.NestedAggregationBuilder;
@@ -344,9 +347,30 @@ public class AggregatorFactoriesTests extends ESTestCase {
         {
             AggregatorFactories.Builder builder = new AggregatorFactories.Builder();
             builder.addAggregator(
-                new CompositeAggregationBuilder("composite", Collections.singletonList(new TermsValuesSourceBuilder("name")))
+                new CompositeAggregationBuilder("composite", Collections.singletonList(new GeoTileGridValuesSourceBuilder("name")))
             );
             assertTrue(builder.supportsParallelCollection());
+        }
+        {
+            AggregatorFactories.Builder builder = new AggregatorFactories.Builder();
+            builder.addAggregator(
+                new CompositeAggregationBuilder("composite", Collections.singletonList(new HistogramValuesSourceBuilder("name")))
+            );
+            assertTrue(builder.supportsParallelCollection());
+        }
+        {
+            AggregatorFactories.Builder builder = new AggregatorFactories.Builder();
+            builder.addAggregator(
+                new CompositeAggregationBuilder("composite", Collections.singletonList(new DateHistogramValuesSourceBuilder("name")))
+            );
+            assertTrue(builder.supportsParallelCollection());
+        }
+        {
+            AggregatorFactories.Builder builder = new AggregatorFactories.Builder();
+            builder.addAggregator(
+                new CompositeAggregationBuilder("composite", Collections.singletonList(new TermsValuesSourceBuilder("name")))
+            );
+            assertFalse(builder.supportsParallelCollection());
         }
         {
             AggregatorFactories.Builder builder = new AggregatorFactories.Builder();

--- a/server/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
@@ -34,6 +34,11 @@ import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.AbstractSearchTestCase;
 import org.elasticsearch.search.SearchExtBuilder;
+import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.composite.DateHistogramValuesSourceBuilder;
+import org.elasticsearch.search.aggregations.bucket.composite.GeoTileGridValuesSourceBuilder;
+import org.elasticsearch.search.aggregations.bucket.composite.HistogramValuesSourceBuilder;
+import org.elasticsearch.search.aggregations.bucket.composite.TermsValuesSourceBuilder;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.elasticsearch.search.aggregations.metrics.MaxAggregationBuilder;
 import org.elasticsearch.search.collapse.CollapseBuilder;
@@ -919,6 +924,34 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
         {
             SearchSourceBuilder searchSourceBuilder = newSearchSourceBuilder.get();
             searchSourceBuilder.aggregation(new TermsAggregationBuilder("terms"));
+            assertFalse(searchSourceBuilder.supportsParallelCollection());
+        }
+        {
+            SearchSourceBuilder searchSourceBuilder = newSearchSourceBuilder.get();
+            searchSourceBuilder.aggregation(
+                new CompositeAggregationBuilder("name", Collections.singletonList(new DateHistogramValuesSourceBuilder("name")))
+            );
+            assertTrue(searchSourceBuilder.supportsParallelCollection());
+        }
+        {
+            SearchSourceBuilder searchSourceBuilder = newSearchSourceBuilder.get();
+            searchSourceBuilder.aggregation(
+                new CompositeAggregationBuilder("name", Collections.singletonList(new HistogramValuesSourceBuilder("name")))
+            );
+            assertTrue(searchSourceBuilder.supportsParallelCollection());
+        }
+        {
+            SearchSourceBuilder searchSourceBuilder = newSearchSourceBuilder.get();
+            searchSourceBuilder.aggregation(
+                new CompositeAggregationBuilder("name", Collections.singletonList(new GeoTileGridValuesSourceBuilder("name")))
+            );
+            assertTrue(searchSourceBuilder.supportsParallelCollection());
+        }
+        {
+            SearchSourceBuilder searchSourceBuilder = newSearchSourceBuilder.get();
+            searchSourceBuilder.aggregation(
+                new CompositeAggregationBuilder("name", Collections.singletonList(new TermsValuesSourceBuilder("name")))
+            );
             assertFalse(searchSourceBuilder.supportsParallelCollection());
         }
         {

--- a/server/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
@@ -34,11 +34,6 @@ import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.AbstractSearchTestCase;
 import org.elasticsearch.search.SearchExtBuilder;
-import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregationBuilder;
-import org.elasticsearch.search.aggregations.bucket.composite.DateHistogramValuesSourceBuilder;
-import org.elasticsearch.search.aggregations.bucket.composite.GeoTileGridValuesSourceBuilder;
-import org.elasticsearch.search.aggregations.bucket.composite.HistogramValuesSourceBuilder;
-import org.elasticsearch.search.aggregations.bucket.composite.TermsValuesSourceBuilder;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.elasticsearch.search.aggregations.metrics.MaxAggregationBuilder;
 import org.elasticsearch.search.collapse.CollapseBuilder;
@@ -924,34 +919,6 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
         {
             SearchSourceBuilder searchSourceBuilder = newSearchSourceBuilder.get();
             searchSourceBuilder.aggregation(new TermsAggregationBuilder("terms"));
-            assertFalse(searchSourceBuilder.supportsParallelCollection());
-        }
-        {
-            SearchSourceBuilder searchSourceBuilder = newSearchSourceBuilder.get();
-            searchSourceBuilder.aggregation(
-                new CompositeAggregationBuilder("name", Collections.singletonList(new DateHistogramValuesSourceBuilder("name")))
-            );
-            assertTrue(searchSourceBuilder.supportsParallelCollection());
-        }
-        {
-            SearchSourceBuilder searchSourceBuilder = newSearchSourceBuilder.get();
-            searchSourceBuilder.aggregation(
-                new CompositeAggregationBuilder("name", Collections.singletonList(new HistogramValuesSourceBuilder("name")))
-            );
-            assertTrue(searchSourceBuilder.supportsParallelCollection());
-        }
-        {
-            SearchSourceBuilder searchSourceBuilder = newSearchSourceBuilder.get();
-            searchSourceBuilder.aggregation(
-                new CompositeAggregationBuilder("name", Collections.singletonList(new GeoTileGridValuesSourceBuilder("name")))
-            );
-            assertTrue(searchSourceBuilder.supportsParallelCollection());
-        }
-        {
-            SearchSourceBuilder searchSourceBuilder = newSearchSourceBuilder.get();
-            searchSourceBuilder.aggregation(
-                new CompositeAggregationBuilder("name", Collections.singletonList(new TermsValuesSourceBuilder("name")))
-            );
             assertFalse(searchSourceBuilder.supportsParallelCollection());
         }
         {


### PR DESCRIPTION
We currently disable concurrency for terms aggregation due to precision errors. We should do the same for composite agg when one of the sources is terms, as it is subject to the same precision errors.
