### PR TITLE
Fix listeners in SharedBlobCacheService.readMultiRegions

### DIFF
--- a/docs/changelog/101727.yaml
+++ b/docs/changelog/101727.yaml
@@ -1,0 +1,5 @@
+pr: 101727
+summary: Fix listeners in `SharedBlobCacheService.readMultiRegions`
+area: Distributed
+type: bug
+issues: []

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
@@ -845,16 +845,21 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
                         // nothing to read, skip
                         continue;
                     }
-                    final CacheFileRegion fileRegion = get(cacheKey, length, region);
-                    final long regionStart = getRegionStart(region);
-                    fileRegion.populateAndRead(
-                        mapSubRangeToRegion(rangeToWrite, region),
-                        subRangeToRead,
-                        readerWithOffset(reader, fileRegion, Math.toIntExact(rangeToRead.start() - regionStart)),
-                        writerWithOffset(writer, fileRegion, Math.toIntExact(rangeToWrite.start() - regionStart)),
-                        ioExecutor,
-                        listeners.acquire(i -> bytesRead.updateAndGet(j -> Math.addExact(i, j)))
-                    );
+                    ActionListener<Integer> listener = listeners.acquire(i -> bytesRead.updateAndGet(j -> Math.addExact(i, j)));
+                    try {
+                        final CacheFileRegion fileRegion = get(cacheKey, length, region);
+                        final long regionStart = getRegionStart(region);
+                        fileRegion.populateAndRead(
+                            mapSubRangeToRegion(rangeToWrite, region),
+                            subRangeToRead,
+                            readerWithOffset(reader, fileRegion, Math.toIntExact(rangeToRead.start() - regionStart)),
+                            writerWithOffset(writer, fileRegion, Math.toIntExact(rangeToWrite.start() - regionStart)),
+                            ioExecutor,
+                            listener
+                        );
+                    } catch (Exception e) {
+                        listener.onFailure(e);
+                    }
                 }
             }
             readsComplete.get();

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
@@ -858,6 +858,7 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
                             listener
                         );
                     } catch (Exception e) {
+                        assert e instanceof AlreadyClosedException : e;
                         listener.onFailure(e);
                     }
                 }


### PR DESCRIPTION
`SharedBlobCacheService.CacheFile#readMultiRegions` computes the regions that need to be cached in order to satisfy a read operation. 

When doing so, it retrieves the `CacheFileRegion` to populate and read for every region:
```java
final CacheFileRegion fileRegion = get(cacheKey, length, region);
```

but this method can throw `AlreadyClosedException` if the cache is full. If some regions are asynchronously populated and another region hit the exception, the `readMultiRegions` and `populateAndRead` methods return immediately without waiting for other regions to be fully populated. 

This cause an issue in randomized test execution, when we expect the `populateAndRead` method to be blocking.