### PR TITLE
[7.17] [ci] Don't generate CI artifact for nested builds, tweak build scan data (#101690)

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.build-complete.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-complete.gradle
@@ -9,8 +9,9 @@
 import java.nio.file.Files
 
 String buildNumber = System.getenv('BUILD_NUMBER') ?: System.getenv('BUILDKITE_BUILD_NUMBER')
+Boolean isNested = System.getProperty("scan.tag.NESTED") != null
 
-if (buildNumber) {
+if (buildNumber && isNested == false) {
   def uploadFilePath = "build/${buildNumber}.tar.bz2"
   File uploadFile = file(uploadFilePath)
   project.gradle.buildFinished { result ->

--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -101,8 +101,10 @@ buildScan {
       def jobName = (System.getenv('BUILDKITE_LABEL') ?: '').replaceAll(/[^a-zA-Z0-9_\-]+/, ' ').trim().replaceAll(' ', '_').toLowerCase()
 
       tag 'CI'
-      link 'CI Build', buildKiteUrl
+      link 'CI Build', "${buildKiteUrl}#${System.getenv('BUILDKITE_JOB_ID')}"
       value 'Job Number', System.getenv('BUILDKITE_BUILD_NUMBER')
+      value 'Build ID', System.getenv('BUILDKITE_BUILD_ID')
+      value 'Job ID', System.getenv('BUILDKITE_JOB_ID')
 
       value 'Pipeline', System.getenv('BUILDKITE_PIPELINE_SLUG')
       tag System.getenv('BUILDKITE_PIPELINE_SLUG')


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[ci] Don&#x27;t generate CI artifact for nested builds, tweak build scan data (#101690)](https://github.com/elastic/elasticsearch/pull/101690)

<!--- Backport version: 9.2.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)