### PR TITLE
Unmute FrozenExistenceDeciderIT#testZeroToOne

### DIFF
--- a/x-pack/plugin/autoscaling/build.gradle
+++ b/x-pack/plugin/autoscaling/build.gradle
@@ -20,6 +20,8 @@ dependencies {
   testImplementation project(path: xpackModule('blob-cache'))
   testImplementation project(path: xpackModule('searchable-snapshots'))
   testImplementation project(path: xpackModule('ilm'))
+  testImplementation project(path: xpackModule('slm'))
+  testImplementation project(path: xpackModule('ccr'))
 
   testImplementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson}"
 }

--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/existence/FrozenExistenceDeciderIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/existence/FrozenExistenceDeciderIT.java
@@ -19,6 +19,7 @@ import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.NodeRoles;
 import org.elasticsearch.xpack.autoscaling.AbstractFrozenAutoscalingIntegTestCase;
 import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingCapacity;
+import org.elasticsearch.xpack.ccr.Ccr;
 import org.elasticsearch.xpack.core.ilm.ExplainLifecycleRequest;
 import org.elasticsearch.xpack.core.ilm.ExplainLifecycleResponse;
 import org.elasticsearch.xpack.core.ilm.IndexLifecycleExplainResponse;
@@ -29,6 +30,7 @@ import org.elasticsearch.xpack.core.ilm.SearchableSnapshotAction;
 import org.elasticsearch.xpack.core.ilm.WaitForDataTierStep;
 import org.elasticsearch.xpack.core.ilm.action.ExplainLifecycleAction;
 import org.elasticsearch.xpack.core.ilm.action.PutLifecycleAction;
+import org.elasticsearch.xpack.slm.SnapshotLifecycle;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -72,10 +74,14 @@ public class FrozenExistenceDeciderIT extends AbstractFrozenAutoscalingIntegTest
 
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
-        return List.of(BlobCachePlugin.class, LocalStateAutoscalingAndSearchableSnapshotsAndIndexLifecycle.class);
+        return List.of(
+            BlobCachePlugin.class,
+            LocalStateAutoscalingAndSearchableSnapshotsAndIndexLifecycle.class,
+            SnapshotLifecycle.class,
+            Ccr.class
+        );
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/89082")
     public void testZeroToOne() throws Exception {
         internalCluster().startMasterOnlyNode();
         setupRepoAndPolicy();


### PR DESCRIPTION
It's been muted for so long that now the test needs to adjust dependencies. I ran the adjusted test 1000 times locally without a failure. Let's bring it back and see whether it's still failing on CI

Closes #89082


