### PR TITLE
[8.11] [ci] Migrate branch consistency and protection checks to Buildkite (#101646)

### DIFF
--- a/.buildkite/pipelines/intake.template.yml
+++ b/.buildkite/pipelines/intake.template.yml
@@ -14,7 +14,7 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2004
-      machineType: custom-32-98304
+      machineType: n1-standard-32
       buildDirectory: /dev/shm/bk
   - label: part2
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-task-input-files checkPart2
@@ -22,7 +22,7 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2004
-      machineType: custom-32-98304
+      machineType: n1-standard-32
       buildDirectory: /dev/shm/bk
   - label: part3
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-task-input-files checkPart3
@@ -30,7 +30,7 @@ steps:
     agents:
       provider: gcp
       image: family/elasticsearch-ubuntu-2004
-      machineType: custom-32-98304
+      machineType: n1-standard-32
       buildDirectory: /dev/shm/bk
   - group: bwc-snapshots
     steps:

--- a/.buildkite/pipelines/periodic.template.yml
+++ b/.buildkite/pipelines/periodic.template.yml
@@ -54,7 +54,7 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2004
-          machineType: custom-32-98304
+          machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
         env:
           ES_RUNTIME_JAVA: "{{matrix.ES_RUNTIME_JAVA}}"
@@ -82,7 +82,7 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-ubuntu-2004
-          machineType: custom-32-98304
+          machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
         env:
           ES_RUNTIME_JAVA: "{{matrix.ES_RUNTIME_JAVA}}"
@@ -180,3 +180,13 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: n2-standard-8
       buildDirectory: /dev/shm/bk
+  - label: Check branch consistency
+    command: .ci/scripts/run-gradle.sh branchConsistency
+    timeout_in_minutes: 15
+    agents:
+      provider: gcp
+      image: family/elasticsearch-ubuntu-2004
+      machineType: n2-standard-2
+  - label: Check branch protection rules
+    command: .buildkite/scripts/branch-protection.sh
+    timeout_in_minutes: 5

--- a/.buildkite/pipelines/periodic.yml
+++ b/.buildkite/pipelines/periodic.yml
@@ -1231,3 +1231,13 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: n2-standard-8
       buildDirectory: /dev/shm/bk
+  - label: Check branch consistency
+    command: .ci/scripts/run-gradle.sh branchConsistency
+    timeout_in_minutes: 15
+    agents:
+      provider: gcp
+      image: family/elasticsearch-ubuntu-2004
+      machineType: n2-standard-2
+  - label: Check branch protection rules
+    command: .buildkite/scripts/branch-protection.sh
+    timeout_in_minutes: 5

--- a/.buildkite/scripts/branch-protection.sh
+++ b/.buildkite/scripts/branch-protection.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -euo pipefail
+
+STATUS=$(curl -s "https://api.github.com/repos/elastic/elasticsearch/branches/$BUILDKITE_BRANCH" | jq '.protected')
+echo "Branch $BUILDKITE_BRANCH protection status is: $STATUS"
+if [[ "$STATUS" == "false" ]]; then
+  echo "Development branch $BUILDKITE_BRANCH is not set as protected in GitHub but should be."
+  exit 1
+fi

--- a/.ci/jobs.t/elastic+elasticsearch+branch-consistency.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+branch-consistency.yml
@@ -2,12 +2,12 @@
 - job:
     name: elastic+elasticsearch+%BRANCH%+branch-consistency
     display-name: "elastic / elasticsearch # %BRANCH% - branch consistency"
-    description: Testing of the Elasticsearch %BRANCH% branch version consistency.
-    triggers:
-      - timed: "H 7 * * *"
+    description: "This job has been migrated to Buildkite.\n"
+    disabled: true
+    triggers: []
     builders:
       - inject:
-          properties-file: '.ci/java-versions.properties'
+          properties-file: ".ci/java-versions.properties"
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
       - shell: |

--- a/.ci/jobs.t/elastic+elasticsearch+branch-protection.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+branch-protection.yml
@@ -2,10 +2,10 @@
 - job:
     name: elastic+elasticsearch+%BRANCH%+branch-protection
     display-name: "elastic / elasticsearch # %BRANCH% - branch protection"
-    description: Elasticsearch %BRANCH% branch protection.
+    description: "This job has been migrated to Buildkite.\n"
+    disabled: true
     node: master
-    triggers:
-      - timed: "H 7 * * *"
+    triggers: []
     scm: []
     parameters: []
     builders:

--- a/.ci/scripts/run-gradle.sh
+++ b/.ci/scripts/run-gradle.sh
@@ -31,5 +31,10 @@ if ! uname -a | grep -q MING; then
   export GLIBC_VERSION=$(ldd --version | grep '^ldd' | sed 's/.* \([1-9]\.[0-9]*\).*/\1/')
 fi
 
+# Running on 2-core machines without ramdisk can make this value be 0
+if [[ "$MAX_WORKERS" == "0" ]]; then
+  MAX_WORKERS=1
+fi
+
 set -e
 $GRADLEW -S --max-workers=$MAX_WORKERS $@


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.11`:
 - [[ci] Migrate branch consistency and protection checks to Buildkite (#101646)](https://github.com/elastic/elasticsearch/pull/101646)

<!--- Backport version: 9.2.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)