### PR TITLE
Log shard errors when terms enum endpoint returns partial results.

### DIFF
--- a/server/src/main/java/org/elasticsearch/ExceptionsHelper.java
+++ b/server/src/main/java/org/elasticsearch/ExceptionsHelper.java
@@ -264,8 +264,13 @@ public final class ExceptionsHelper {
 
     /**
      * Deduplicate the failures by exception message and index.
+     * @param failures array to deduplicate
+     * @return deduplicated array; if failures is null or empty, it will be returned without modification
      */
     public static ShardOperationFailedException[] groupBy(ShardOperationFailedException[] failures) {
+        if (failures == null || failures.length == 0) {
+            return failures;
+        }
         List<ShardOperationFailedException> uniqueFailures = new ArrayList<>();
         Set<GroupBy> reasons = new HashSet<>();
         for (ShardOperationFailedException failure : failures) {


### PR DESCRIPTION
Failed terms enum searches already have their exceptions logged by the RestResponse object. 
With partial results, any shard failures are returned in the XContent response to users. 
This commit also logs those errors at WARN level, including stack trace.
