### PR TITLE
[8.10] [ci] Don't run snyk step outside of main dev branches (#101729)

### DIFF
--- a/.buildkite/pipelines/periodic.template.yml
+++ b/.buildkite/pipelines/periodic.template.yml
@@ -180,6 +180,7 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: n2-standard-8
       buildDirectory: /dev/shm/bk
+    if: build.branch == "main" || build.branch =~ /^[0-9]+\.[0-9]+\$/
   - label: Check branch consistency
     command: .ci/scripts/run-gradle.sh branchConsistency
     timeout_in_minutes: 15

--- a/.buildkite/pipelines/periodic.yml
+++ b/.buildkite/pipelines/periodic.yml
@@ -1221,6 +1221,7 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: n2-standard-8
       buildDirectory: /dev/shm/bk
+    if: build.branch == "main" || build.branch =~ /^[0-9]+\.[0-9]+\$/
   - label: Check branch consistency
     command: .ci/scripts/run-gradle.sh branchConsistency
     timeout_in_minutes: 15


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.10`:
 - [[ci] Don&#x27;t run snyk step outside of main dev branches (#101729)](https://github.com/elastic/elasticsearch/pull/101729)

<!--- Backport version: 9.2.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)