### PR TITLE
[8.11] Use separate buildkite annotation context for failed build scans (#101740)

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -131,19 +131,30 @@ buildScan {
         link 'Source', "https://github.com/${repository}/tree/${BuildParams.gitRevision}"
       }
 
-      buildScanPublished { scan ->
-        // Attach build scan link as build metadata
-        // See: https://buildkite.com/docs/pipelines/build-meta-data
-        new ProcessBuilder('buildkite-agent', 'meta-data', 'set', "build-scan-${System.getenv('BUILDKITE_JOB_ID')}", "${scan.buildScanUri}")
-          .start()
-          .waitFor()
+      buildFinished { result ->
+        buildScanPublished { scan ->
+          // Attach build scan link as build metadata
+          // See: https://buildkite.com/docs/pipelines/build-meta-data
+          new ProcessBuilder('buildkite-agent', 'meta-data', 'set', "build-scan-${System.getenv('BUILDKITE_JOB_ID')}", "${scan.buildScanUri}")
+            .start()
+            .waitFor()
 
-        // Add a build annotation
-        // See: https://buildkite.com/docs/agent/v3/cli-annotate
-        def body = """<div class="mb3"><span class="p1 border rounded">${System.getenv('BUILDKITE_LABEL')}</span> :gradle: build ran: <a href="${scan.buildScanUri}"><code>gradle ${gradle.startParameter.taskNames.join(' ')}</code></a></div>"""
-        new ProcessBuilder('buildkite-agent', 'annotate', '--context', 'gradle-build-scans', '--append', '--style', 'info', body)
-          .start()
-          .waitFor()
+          // Add a build annotation
+          // See: https://buildkite.com/docs/agent/v3/cli-annotate
+          def body = """<div class="mb3"><span class="p1 border rounded">${System.getenv('BUILDKITE_LABEL')}</span> :gradle: ${result.failure ? 'failed' : 'successful'} build: <a href="${scan.buildScanUri}"><code>gradle ${gradle.startParameter.taskNames.join(' ')}</code></a></div>"""
+          new ProcessBuilder(
+            'buildkite-agent',
+            'annotate',
+            '--context',
+            result.failure ? 'gradle-build-scans-failed' : 'gradle-build-scans',
+            '--append',
+            '--style',
+            result.failure ? 'error' : 'info',
+            body
+          )
+            .start()
+            .waitFor()
+        }
       }
     } else {
       tag 'LOCAL'


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Use separate buildkite annotation context for failed build scans (#101740)