### PR TITLE
Metrics test: testLockingWhenRegistering wait for threads to join

### DIFF
--- a/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/MeterRegistryConcurrencyTests.java
+++ b/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/MeterRegistryConcurrencyTests.java
@@ -90,7 +90,6 @@ public class MeterRegistryConcurrencyTests extends ESTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/101725")
     public void testLockingWhenRegistering() throws Exception {
         APMMeterRegistry meterRegistrar = new APMMeterRegistry(lockingMeter);
 
@@ -106,12 +105,14 @@ public class MeterRegistryConcurrencyTests extends ESTestCase {
         // assert that a thread is waiting for a lock during long-running registration
         assertBusy(() -> assertThat(setProviderThread.getState(), equalTo(Thread.State.WAITING)));
         // assert that the old lockingMeter is still in place
-        assertBusy(() -> assertThat(meterRegistrar.getMeter(), sameInstance(lockingMeter)));
+        assertThat(meterRegistrar.getMeter(), sameInstance(lockingMeter));
 
         // finish long-running registration
         registerLatch.countDown();
+        // wait for everything to quiesce, registerLatch.countDown() doesn't ensure lock has been released
+        assertBusy(setProviderThread::join);
+        assertBusy(registerThread::join);
         // assert that a meter was overriden
-        assertBusy(() -> assertThat(meterRegistrar.getMeter(), sameInstance(lockingMeter)));
-
+        assertThat(meterRegistrar.getMeter(), sameInstance(noopMeter));
     }
 }

--- a/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/MeterRegistryConcurrencyTests.java
+++ b/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/MeterRegistryConcurrencyTests.java
@@ -110,8 +110,8 @@ public class MeterRegistryConcurrencyTests extends ESTestCase {
         // finish long-running registration
         registerLatch.countDown();
         // wait for everything to quiesce, registerLatch.countDown() doesn't ensure lock has been released
-        assertBusy(setProviderThread::join);
-        assertBusy(registerThread::join);
+        setProviderThread.join();
+        registerThread.join();
         // assert that a meter was overriden
         assertThat(meterRegistrar.getMeter(), sameInstance(noopMeter));
     }


### PR DESCRIPTION
The test was checking for the wrong meter instance, it should be checking for the updated meter, `noopMeter`.

Removed the `assertBusy(() -> assertThat...)` which was hiding the problem.

The goal of the test is that we serialize access to registration and the provider.  A nice way to do this is wait for the contending threads to join (with the added benefit of avoiding thread leaks).  After the threads join, we check that we have the expected state.

Fixes: #101725