### PR TITLE
Move master file watcher to make it available to other modules

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/file/MasterNodeFileWatchingService.java
+++ b/server/src/main/java/org/elasticsearch/common/file/MasterNodeFileWatchingService.java
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-package org.elasticsearch.reservedstate.service;
+package org.elasticsearch.common.file;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -15,7 +15,6 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.file.AbstractFileWatchingService;
 
 import java.io.IOException;
 import java.nio.file.Files;

--- a/server/src/main/java/org/elasticsearch/reservedstate/service/FileSettingsService.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/FileSettingsService.java
@@ -16,6 +16,7 @@ import org.elasticsearch.cluster.ClusterStateListener;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.ReservedStateMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.file.MasterNodeFileWatchingService;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 


### PR DESCRIPTION
This commit moves the new master node file watcher to the o.e.common.file package so that it can be accessible to existing uses of AbstractFileWatchingService.