### PR TITLE
Cleanup some duplication in BestBucketsDeferringCollector

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/BestBucketsDeferringCollector.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/BestBucketsDeferringCollector.java
@@ -259,29 +259,10 @@ public class BestBucketsDeferringCollector extends DeferringBucketCollector {
     public void rewriteBuckets(LongUnaryOperator howToRewrite) {
         List<Entry> newEntries = new ArrayList<>(entries.size());
         for (Entry sourceEntry : entries) {
-            PackedLongValues.Builder newBuckets = PackedLongValues.packedBuilder(PackedInts.DEFAULT);
             PackedLongValues.Builder newDocDeltas = PackedLongValues.packedBuilder(PackedInts.DEFAULT);
             PackedLongValues.Iterator docDeltasItr = sourceEntry.docDeltas.iterator();
 
-            long lastGoodDelta = 0;
-            for (PackedLongValues.Iterator itr = sourceEntry.buckets.iterator(); itr.hasNext();) {
-                long bucket = itr.next();
-                assert docDeltasItr.hasNext();
-                long delta = docDeltasItr.next();
-
-                // Only merge in the ordinal if it hasn't been "removed", signified with -1
-                long ordinal = howToRewrite.applyAsLong(bucket);
-
-                if (ordinal != -1) {
-                    newBuckets.add(ordinal);
-                    newDocDeltas.add(delta + lastGoodDelta);
-                    lastGoodDelta = 0;
-                } else {
-                    // we are skipping this ordinal, which means we need to accumulate the
-                    // doc delta's since the last "good" delta
-                    lastGoodDelta += delta;
-                }
-            }
+            PackedLongValues.Builder newBuckets = merge(howToRewrite, newDocDeltas, docDeltasItr, sourceEntry.buckets);
             // Only create an entry if this segment has buckets after merging
             if (newBuckets.size() > 0) {
                 assert newDocDeltas.size() > 0 : "docDeltas was empty but we had buckets";
@@ -294,33 +275,13 @@ public class BestBucketsDeferringCollector extends DeferringBucketCollector {
         // we need to update the bucket ordinals there too
         if (bucketsBuilder != null && bucketsBuilder.size() > 0) {
             PackedLongValues currentBuckets = bucketsBuilder.build();
-            PackedLongValues.Builder newBuckets = PackedLongValues.packedBuilder(PackedInts.DEFAULT);
             PackedLongValues.Builder newDocDeltas = PackedLongValues.packedBuilder(PackedInts.DEFAULT);
 
             // The current segment's deltas aren't built yet, so build to a temp object
             PackedLongValues currentDeltas = docDeltasBuilder.build();
             PackedLongValues.Iterator docDeltasItr = currentDeltas.iterator();
 
-            long lastGoodDelta = 0;
-            for (PackedLongValues.Iterator itr = currentBuckets.iterator(); itr.hasNext();) {
-                long bucket = itr.next();
-                assert docDeltasItr.hasNext();
-                long delta = docDeltasItr.next();
-                long ordinal = howToRewrite.applyAsLong(bucket);
-
-                // Only merge in the ordinal if it hasn't been "removed", signified with -1
-                if (ordinal != -1) {
-                    newBuckets.add(ordinal);
-                    newDocDeltas.add(delta + lastGoodDelta);
-                    lastGoodDelta = 0;
-                } else {
-                    // we are skipping this ordinal, which means we need to accumulate the
-                    // doc delta's since the last "good" delta.
-                    // The first is skipped because the original deltas are stored as offsets from first doc,
-                    // not offsets from 0
-                    lastGoodDelta += delta;
-                }
-            }
+            PackedLongValues.Builder newBuckets = merge(howToRewrite, newDocDeltas, docDeltasItr, currentBuckets);
             if (newDocDeltas.size() == 0) {
                 // We've decided not to keep *anything* in the current leaf so we should just pitch our state.
                 clearLeaf();
@@ -329,5 +290,35 @@ public class BestBucketsDeferringCollector extends DeferringBucketCollector {
                 bucketsBuilder = newBuckets;
             }
         }
+    }
+
+    private static PackedLongValues.Builder merge(
+        LongUnaryOperator howToRewrite,
+        PackedLongValues.Builder newDocDeltas,
+        PackedLongValues.Iterator docDeltasItr,
+        PackedLongValues currentBuckets
+    ) {
+        PackedLongValues.Builder newBuckets = PackedLongValues.packedBuilder(PackedInts.DEFAULT);
+        long lastGoodDelta = 0;
+        var itr = currentBuckets.iterator();
+        while (itr.hasNext()) {
+            long bucket = itr.next();
+            assert docDeltasItr.hasNext();
+            long delta = docDeltasItr.next();
+
+            // Only merge in the ordinal if it hasn't been "removed", signified with -1
+            long ordinal = howToRewrite.applyAsLong(bucket);
+
+            if (ordinal != -1) {
+                newBuckets.add(ordinal);
+                newDocDeltas.add(delta + lastGoodDelta);
+                lastGoodDelta = 0;
+            } else {
+                // we are skipping this ordinal, which means we need to accumulate the
+                // doc delta's since the last "good" delta
+                lastGoodDelta += delta;
+            }
+        }
+        return newBuckets;
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/BucketsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/BucketsAggregator.java
@@ -28,7 +28,6 @@ import org.elasticsearch.search.sort.SortOrder;
 import java.io.IOException;
 import java.util.AbstractList;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -182,7 +181,7 @@ public abstract class BucketsAggregator extends AggregatorBase {
         InternalAggregations[] result = new InternalAggregations[bucketOrdsToCollect.length];
         for (int ord = 0; ord < bucketOrdsToCollect.length; ord++) {
             final int thisOrd = ord;
-            result[ord] = InternalAggregations.from(new AbstractList<InternalAggregation>() {
+            result[ord] = InternalAggregations.from(new AbstractList<>() {
                 @Override
                 public InternalAggregation get(int index) {
                     return aggregations[index][thisOrd];
@@ -195,23 +194,6 @@ public abstract class BucketsAggregator extends AggregatorBase {
             });
         }
         return result;
-    }
-
-    /**
-     * Build the sub aggregation results for a list of buckets and set them on
-     * the buckets. This is usually used by aggregations that are selective
-     * in which bucket they build. They use some mechanism of selecting a list
-     * of buckets to build use this method to "finish" building the results.
-     * @param buckets the buckets to finish building
-     * @param bucketToOrd how to convert a bucket into an ordinal
-     * @param setAggs how to set the sub-aggregation results on a bucket
-     */
-    protected final <B> void buildSubAggsForBuckets(B[] buckets, ToLongFunction<B> bucketToOrd, BiConsumer<B, InternalAggregations> setAggs)
-        throws IOException {
-        InternalAggregations[] results = buildSubAggsForBuckets(Arrays.stream(buckets).mapToLong(bucketToOrd).toArray());
-        for (int i = 0; i < buckets.length; i++) {
-            setAggs.accept(buckets[i], results[i]);
-        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/InternalSingleBucketAggregation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/InternalSingleBucketAggregation.java
@@ -32,8 +32,8 @@ import java.util.function.Function;
  */
 public abstract class InternalSingleBucketAggregation extends InternalAggregation implements SingleBucketAggregation {
 
-    private long docCount;
-    private InternalAggregations aggregations;
+    private final long docCount;
+    private final InternalAggregations aggregations;
 
     /**
      * Creates a single bucket aggregation.

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/package-info.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/package-info.java
@@ -10,4 +10,3 @@
  * Aggregations module
  */
 package org.elasticsearch.search.aggregations.bucket;
-


### PR DESCRIPTION
Looked into this logic when investigating some memory issues and found a couple small things. Figured it makes sense to clean up the duplication here. Might even make this code run a little better, from compiling a more reasonably sized loop method.

... also removed some dead code and fixed the package file
