### PR TITLE
Remove explicit SearchResponse references from server pipeline aggs

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/pipeline/BucketMetricsPipeLineAggregationTestCase.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/pipeline/BucketMetricsPipeLineAggregationTestCase.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.search.aggregations.pipeline;
 
 import org.elasticsearch.action.index.IndexRequestBuilder;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.XContentHelper;
@@ -37,7 +36,8 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.histogra
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertCheckedResponse;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -127,284 +127,304 @@ abstract class BucketMetricsPipeLineAggregationTestCase<T extends NumericMetrics
     }
 
     public void testDocCountTopLevel() {
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            histogram(histoName).field(SINGLE_VALUED_FIELD_NAME).interval(interval).extendedBounds(minRandomValue, maxRandomValue)
-        ).addAggregation(BucketMetricsPipelineAgg("pipeline_agg", histoName + ">_count")).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                histogram(histoName).field(SINGLE_VALUED_FIELD_NAME).interval(interval).extendedBounds(minRandomValue, maxRandomValue)
+            ).addAggregation(BucketMetricsPipelineAgg("pipeline_agg", histoName + ">_count")),
+            response -> {
+                Histogram histo = response.getAggregations().get(histoName);
+                assertThat(histo, notNullValue());
+                assertThat(histo.getName(), equalTo(histoName));
+                List<? extends Histogram.Bucket> buckets = histo.getBuckets();
+                assertThat(buckets.size(), equalTo(numValueBuckets));
 
-        assertNoFailures(response);
+                for (int i = 0; i < numValueBuckets; ++i) {
+                    Histogram.Bucket bucket = buckets.get(i);
+                    assertThat(bucket, notNullValue());
+                    assertThat(((Number) bucket.getKey()).longValue(), equalTo((long) i * interval));
+                    assertThat(bucket.getDocCount(), equalTo(valueCounts[i]));
+                }
 
-        Histogram histo = response.getAggregations().get(histoName);
-        assertThat(histo, notNullValue());
-        assertThat(histo.getName(), equalTo(histoName));
-        List<? extends Histogram.Bucket> buckets = histo.getBuckets();
-        assertThat(buckets.size(), equalTo(numValueBuckets));
+                T pipelineBucket = response.getAggregations().get("pipeline_agg");
+                assertThat(pipelineBucket, notNullValue());
+                assertThat(pipelineBucket.getName(), equalTo("pipeline_agg"));
 
-        for (int i = 0; i < numValueBuckets; ++i) {
-            Histogram.Bucket bucket = buckets.get(i);
-            assertThat(bucket, notNullValue());
-            assertThat(((Number) bucket.getKey()).longValue(), equalTo((long) i * interval));
-            assertThat(bucket.getDocCount(), equalTo(valueCounts[i]));
-        }
-
-        T pipelineBucket = response.getAggregations().get("pipeline_agg");
-        assertThat(pipelineBucket, notNullValue());
-        assertThat(pipelineBucket.getName(), equalTo("pipeline_agg"));
-
-        assertResult((i) -> buckets.get(i).getDocCount(), (i) -> buckets.get(i).getKeyAsString(), numValueBuckets, pipelineBucket);
+                assertResult((i) -> buckets.get(i).getDocCount(), (i) -> buckets.get(i).getKeyAsString(), numValueBuckets, pipelineBucket);
+            }
+        );
     }
 
     public void testDocCountAsSubAgg() {
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            terms(termsName).field("tag")
-                .order(BucketOrder.key(true))
-                .subAggregation(
-                    histogram(histoName).field(SINGLE_VALUED_FIELD_NAME).interval(interval).extendedBounds(minRandomValue, maxRandomValue)
-                )
-                .subAggregation(BucketMetricsPipelineAgg("pipeline_agg", histoName + ">_count"))
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                terms(termsName).field("tag")
+                    .order(BucketOrder.key(true))
+                    .subAggregation(
+                        histogram(histoName).field(SINGLE_VALUED_FIELD_NAME)
+                            .interval(interval)
+                            .extendedBounds(minRandomValue, maxRandomValue)
+                    )
+                    .subAggregation(BucketMetricsPipelineAgg("pipeline_agg", histoName + ">_count"))
+            ),
+            response -> {
+                Terms terms = response.getAggregations().get(termsName);
+                assertThat(terms, notNullValue());
+                assertThat(terms.getName(), equalTo(termsName));
+                List<? extends Terms.Bucket> termsBuckets = terms.getBuckets();
+                assertThat(termsBuckets.size(), equalTo(interval));
 
-        assertNoFailures(response);
+                for (int i = 0; i < interval; ++i) {
+                    Terms.Bucket termsBucket = termsBuckets.get(i);
+                    assertThat(termsBucket, notNullValue());
+                    assertThat((String) termsBucket.getKey(), equalTo("tag" + (i % interval)));
 
-        Terms terms = response.getAggregations().get(termsName);
-        assertThat(terms, notNullValue());
-        assertThat(terms.getName(), equalTo(termsName));
-        List<? extends Terms.Bucket> termsBuckets = terms.getBuckets();
-        assertThat(termsBuckets.size(), equalTo(interval));
+                    Histogram histo = termsBucket.getAggregations().get(histoName);
+                    assertThat(histo, notNullValue());
+                    assertThat(histo.getName(), equalTo(histoName));
+                    List<? extends Histogram.Bucket> buckets = histo.getBuckets();
 
-        for (int i = 0; i < interval; ++i) {
-            Terms.Bucket termsBucket = termsBuckets.get(i);
-            assertThat(termsBucket, notNullValue());
-            assertThat((String) termsBucket.getKey(), equalTo("tag" + (i % interval)));
+                    for (int j = 0; j < numValueBuckets; ++j) {
+                        Histogram.Bucket bucket = buckets.get(j);
+                        assertThat(bucket, notNullValue());
+                        assertThat(((Number) bucket.getKey()).longValue(), equalTo((long) j * interval));
+                    }
 
-            Histogram histo = termsBucket.getAggregations().get(histoName);
-            assertThat(histo, notNullValue());
-            assertThat(histo.getName(), equalTo(histoName));
-            List<? extends Histogram.Bucket> buckets = histo.getBuckets();
+                    T pipelineBucket = termsBucket.getAggregations().get("pipeline_agg");
+                    assertThat(pipelineBucket, notNullValue());
+                    assertThat(pipelineBucket.getName(), equalTo("pipeline_agg"));
 
-            for (int j = 0; j < numValueBuckets; ++j) {
-                Histogram.Bucket bucket = buckets.get(j);
-                assertThat(bucket, notNullValue());
-                assertThat(((Number) bucket.getKey()).longValue(), equalTo((long) j * interval));
+                    assertResult(
+                        (k) -> buckets.get(k).getDocCount(),
+                        (k) -> buckets.get(k).getKeyAsString(),
+                        numValueBuckets,
+                        pipelineBucket
+                    );
+                }
             }
-
-            T pipelineBucket = termsBucket.getAggregations().get("pipeline_agg");
-            assertThat(pipelineBucket, notNullValue());
-            assertThat(pipelineBucket.getName(), equalTo("pipeline_agg"));
-
-            assertResult((k) -> buckets.get(k).getDocCount(), (k) -> buckets.get(k).getKeyAsString(), numValueBuckets, pipelineBucket);
-        }
+        );
     }
 
     public void testMetricTopLevel() {
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            terms(termsName).field("tag").subAggregation(sum("sum").field(SINGLE_VALUED_FIELD_NAME))
-        ).addAggregation(BucketMetricsPipelineAgg("pipeline_agg", termsName + ">sum")).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(terms(termsName).field("tag").subAggregation(sum("sum").field(SINGLE_VALUED_FIELD_NAME)))
+                .addAggregation(BucketMetricsPipelineAgg("pipeline_agg", termsName + ">sum")),
+            response -> {
+                Terms terms = response.getAggregations().get(termsName);
+                assertThat(terms, notNullValue());
+                assertThat(terms.getName(), equalTo(termsName));
+                List<? extends Terms.Bucket> buckets = terms.getBuckets();
+                assertThat(buckets.size(), equalTo(interval));
 
-        assertNoFailures(response);
+                for (int i = 0; i < interval; ++i) {
+                    Terms.Bucket bucket = buckets.get(i);
+                    assertThat(bucket, notNullValue());
+                    assertThat((String) bucket.getKey(), equalTo("tag" + (i % interval)));
+                    assertThat(bucket.getDocCount(), greaterThan(0L));
+                }
 
-        Terms terms = response.getAggregations().get(termsName);
-        assertThat(terms, notNullValue());
-        assertThat(terms.getName(), equalTo(termsName));
-        List<? extends Terms.Bucket> buckets = terms.getBuckets();
-        assertThat(buckets.size(), equalTo(interval));
+                T pipelineBucket = response.getAggregations().get("pipeline_agg");
+                assertThat(pipelineBucket, notNullValue());
+                assertThat(pipelineBucket.getName(), equalTo("pipeline_agg"));
 
-        for (int i = 0; i < interval; ++i) {
-            Terms.Bucket bucket = buckets.get(i);
-            assertThat(bucket, notNullValue());
-            assertThat((String) bucket.getKey(), equalTo("tag" + (i % interval)));
-            assertThat(bucket.getDocCount(), greaterThan(0L));
-        }
-
-        T pipelineBucket = response.getAggregations().get("pipeline_agg");
-        assertThat(pipelineBucket, notNullValue());
-        assertThat(pipelineBucket.getName(), equalTo("pipeline_agg"));
-
-        IntToDoubleFunction function = (i) -> {
-            Sum sum = buckets.get(i).getAggregations().get("sum");
-            assertThat(sum, notNullValue());
-            return sum.value();
-        };
-        assertResult(function, (i) -> buckets.get(i).getKeyAsString(), interval, pipelineBucket);
+                IntToDoubleFunction function = (i) -> {
+                    Sum sum = buckets.get(i).getAggregations().get("sum");
+                    assertThat(sum, notNullValue());
+                    return sum.value();
+                };
+                assertResult(function, (i) -> buckets.get(i).getKeyAsString(), interval, pipelineBucket);
+            }
+        );
     }
 
     public void testMetricAsSubAgg() {
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            terms(termsName).field("tag")
-                .order(BucketOrder.key(true))
-                .subAggregation(
-                    histogram(histoName).field(SINGLE_VALUED_FIELD_NAME)
-                        .interval(interval)
-                        .extendedBounds(minRandomValue, maxRandomValue)
-                        .subAggregation(sum("sum").field(SINGLE_VALUED_FIELD_NAME))
-                )
-                .subAggregation(BucketMetricsPipelineAgg("pipeline_agg", histoName + ">sum"))
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                terms(termsName).field("tag")
+                    .order(BucketOrder.key(true))
+                    .subAggregation(
+                        histogram(histoName).field(SINGLE_VALUED_FIELD_NAME)
+                            .interval(interval)
+                            .extendedBounds(minRandomValue, maxRandomValue)
+                            .subAggregation(sum("sum").field(SINGLE_VALUED_FIELD_NAME))
+                    )
+                    .subAggregation(BucketMetricsPipelineAgg("pipeline_agg", histoName + ">sum"))
+            ),
+            response -> {
+                Terms terms = response.getAggregations().get(termsName);
+                assertThat(terms, notNullValue());
+                assertThat(terms.getName(), equalTo(termsName));
+                List<? extends Terms.Bucket> termsBuckets = terms.getBuckets();
+                assertThat(termsBuckets.size(), equalTo(interval));
 
-        assertNoFailures(response);
+                for (int i = 0; i < interval; ++i) {
+                    Terms.Bucket termsBucket = termsBuckets.get(i);
+                    assertThat(termsBucket, notNullValue());
+                    assertThat((String) termsBucket.getKey(), equalTo("tag" + (i % interval)));
 
-        Terms terms = response.getAggregations().get(termsName);
-        assertThat(terms, notNullValue());
-        assertThat(terms.getName(), equalTo(termsName));
-        List<? extends Terms.Bucket> termsBuckets = terms.getBuckets();
-        assertThat(termsBuckets.size(), equalTo(interval));
+                    Histogram histo = termsBucket.getAggregations().get(histoName);
+                    assertThat(histo, notNullValue());
+                    assertThat(histo.getName(), equalTo(histoName));
+                    List<? extends Histogram.Bucket> buckets = histo.getBuckets();
 
-        for (int i = 0; i < interval; ++i) {
-            Terms.Bucket termsBucket = termsBuckets.get(i);
-            assertThat(termsBucket, notNullValue());
-            assertThat((String) termsBucket.getKey(), equalTo("tag" + (i % interval)));
+                    List<Histogram.Bucket> notNullBuckets = new ArrayList<>();
+                    for (int j = 0; j < numValueBuckets; ++j) {
+                        Histogram.Bucket bucket = buckets.get(j);
+                        assertThat(bucket, notNullValue());
+                        assertThat(((Number) bucket.getKey()).longValue(), equalTo((long) j * interval));
+                        if (bucket.getDocCount() != 0) {
+                            notNullBuckets.add(bucket);
+                        }
+                    }
 
-            Histogram histo = termsBucket.getAggregations().get(histoName);
-            assertThat(histo, notNullValue());
-            assertThat(histo.getName(), equalTo(histoName));
-            List<? extends Histogram.Bucket> buckets = histo.getBuckets();
+                    T pipelineBucket = termsBucket.getAggregations().get("pipeline_agg");
+                    assertThat(pipelineBucket, notNullValue());
+                    assertThat(pipelineBucket.getName(), equalTo("pipeline_agg"));
 
-            List<Histogram.Bucket> notNullBuckets = new ArrayList<>();
-            for (int j = 0; j < numValueBuckets; ++j) {
-                Histogram.Bucket bucket = buckets.get(j);
-                assertThat(bucket, notNullValue());
-                assertThat(((Number) bucket.getKey()).longValue(), equalTo((long) j * interval));
-                if (bucket.getDocCount() != 0) {
-                    notNullBuckets.add(bucket);
+                    IntToDoubleFunction function = (k) -> {
+                        Sum sum = notNullBuckets.get(k).getAggregations().get("sum");
+                        assertThat(sum, notNullValue());
+                        return sum.value();
+                    };
+                    assertResult(function, (k) -> notNullBuckets.get(k).getKeyAsString(), notNullBuckets.size(), pipelineBucket);
                 }
             }
-
-            T pipelineBucket = termsBucket.getAggregations().get("pipeline_agg");
-            assertThat(pipelineBucket, notNullValue());
-            assertThat(pipelineBucket.getName(), equalTo("pipeline_agg"));
-
-            IntToDoubleFunction function = (k) -> {
-                Sum sum = notNullBuckets.get(k).getAggregations().get("sum");
-                assertThat(sum, notNullValue());
-                return sum.value();
-            };
-            assertResult(function, (k) -> notNullBuckets.get(k).getKeyAsString(), notNullBuckets.size(), pipelineBucket);
-        }
+        );
     }
 
     public void testMetricAsSubAggWithInsertZeros() {
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            terms(termsName).field("tag")
-                .order(BucketOrder.key(true))
-                .subAggregation(
-                    histogram(histoName).field(SINGLE_VALUED_FIELD_NAME)
-                        .interval(interval)
-                        .extendedBounds(minRandomValue, maxRandomValue)
-                        .subAggregation(sum("sum").field(SINGLE_VALUED_FIELD_NAME))
-                )
-                .subAggregation(
-                    BucketMetricsPipelineAgg("pipeline_agg", histoName + ">sum").gapPolicy(BucketHelpers.GapPolicy.INSERT_ZEROS)
-                )
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                terms(termsName).field("tag")
+                    .order(BucketOrder.key(true))
+                    .subAggregation(
+                        histogram(histoName).field(SINGLE_VALUED_FIELD_NAME)
+                            .interval(interval)
+                            .extendedBounds(minRandomValue, maxRandomValue)
+                            .subAggregation(sum("sum").field(SINGLE_VALUED_FIELD_NAME))
+                    )
+                    .subAggregation(
+                        BucketMetricsPipelineAgg("pipeline_agg", histoName + ">sum").gapPolicy(BucketHelpers.GapPolicy.INSERT_ZEROS)
+                    )
+            ),
+            response -> {
+                Terms terms = response.getAggregations().get(termsName);
+                assertThat(terms, notNullValue());
+                assertThat(terms.getName(), equalTo(termsName));
+                List<? extends Terms.Bucket> termsBuckets = terms.getBuckets();
+                assertThat(termsBuckets.size(), equalTo(interval));
 
-        assertNoFailures(response);
+                for (int i = 0; i < interval; ++i) {
+                    Terms.Bucket termsBucket = termsBuckets.get(i);
+                    assertThat(termsBucket, notNullValue());
+                    assertThat((String) termsBucket.getKey(), equalTo("tag" + (i % interval)));
 
-        Terms terms = response.getAggregations().get(termsName);
-        assertThat(terms, notNullValue());
-        assertThat(terms.getName(), equalTo(termsName));
-        List<? extends Terms.Bucket> termsBuckets = terms.getBuckets();
-        assertThat(termsBuckets.size(), equalTo(interval));
+                    Histogram histo = termsBucket.getAggregations().get(histoName);
+                    assertThat(histo, notNullValue());
+                    assertThat(histo.getName(), equalTo(histoName));
+                    List<? extends Histogram.Bucket> buckets = histo.getBuckets();
 
-        for (int i = 0; i < interval; ++i) {
-            Terms.Bucket termsBucket = termsBuckets.get(i);
-            assertThat(termsBucket, notNullValue());
-            assertThat((String) termsBucket.getKey(), equalTo("tag" + (i % interval)));
+                    for (int j = 0; j < numValueBuckets; ++j) {
+                        Histogram.Bucket bucket = buckets.get(j);
+                        assertThat(bucket, notNullValue());
+                        assertThat(((Number) bucket.getKey()).longValue(), equalTo((long) j * interval));
+                    }
 
-            Histogram histo = termsBucket.getAggregations().get(histoName);
-            assertThat(histo, notNullValue());
-            assertThat(histo.getName(), equalTo(histoName));
-            List<? extends Histogram.Bucket> buckets = histo.getBuckets();
+                    T pipelineBucket = termsBucket.getAggregations().get("pipeline_agg");
+                    assertThat(pipelineBucket, notNullValue());
+                    assertThat(pipelineBucket.getName(), equalTo("pipeline_agg"));
 
-            for (int j = 0; j < numValueBuckets; ++j) {
-                Histogram.Bucket bucket = buckets.get(j);
-                assertThat(bucket, notNullValue());
-                assertThat(((Number) bucket.getKey()).longValue(), equalTo((long) j * interval));
+                    IntToDoubleFunction function = (k) -> {
+                        Sum sum = buckets.get(k).getAggregations().get("sum");
+                        assertThat(sum, notNullValue());
+                        return sum.value();
+                    };
+                    assertResult(function, (k) -> buckets.get(k).getKeyAsString(), numValueBuckets, pipelineBucket);
+                }
             }
-
-            T pipelineBucket = termsBucket.getAggregations().get("pipeline_agg");
-            assertThat(pipelineBucket, notNullValue());
-            assertThat(pipelineBucket.getName(), equalTo("pipeline_agg"));
-
-            IntToDoubleFunction function = (k) -> {
-                Sum sum = buckets.get(k).getAggregations().get("sum");
-                assertThat(sum, notNullValue());
-                return sum.value();
-            };
-            assertResult(function, (k) -> buckets.get(k).getKeyAsString(), numValueBuckets, pipelineBucket);
-        }
+        );
     }
 
     public void testNoBuckets() {
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            terms(termsName).field("tag")
-                .includeExclude(new IncludeExclude(null, "tag.*", null, null))
-                .subAggregation(sum("sum").field(SINGLE_VALUED_FIELD_NAME))
-        ).addAggregation(BucketMetricsPipelineAgg("pipeline_agg", termsName + ">sum")).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                terms(termsName).field("tag")
+                    .includeExclude(new IncludeExclude(null, "tag.*", null, null))
+                    .subAggregation(sum("sum").field(SINGLE_VALUED_FIELD_NAME))
+            ).addAggregation(BucketMetricsPipelineAgg("pipeline_agg", termsName + ">sum")),
+            response -> {
+                Terms terms = response.getAggregations().get(termsName);
+                assertThat(terms, notNullValue());
+                assertThat(terms.getName(), equalTo(termsName));
+                List<? extends Terms.Bucket> buckets = terms.getBuckets();
+                assertThat(buckets.size(), equalTo(0));
 
-        assertNoFailures(response);
+                T pipelineBucket = response.getAggregations().get("pipeline_agg");
+                assertThat(pipelineBucket, notNullValue());
+                assertThat(pipelineBucket.getName(), equalTo("pipeline_agg"));
 
-        Terms terms = response.getAggregations().get(termsName);
-        assertThat(terms, notNullValue());
-        assertThat(terms.getName(), equalTo(termsName));
-        List<? extends Terms.Bucket> buckets = terms.getBuckets();
-        assertThat(buckets.size(), equalTo(0));
-
-        T pipelineBucket = response.getAggregations().get("pipeline_agg");
-        assertThat(pipelineBucket, notNullValue());
-        assertThat(pipelineBucket.getName(), equalTo("pipeline_agg"));
-
-        assertResult((k) -> 0.0, (k) -> "", 0, pipelineBucket);
+                assertResult((k) -> 0.0, (k) -> "", 0, pipelineBucket);
+            }
+        );
     }
 
     public void testNested() {
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            terms(termsName).field("tag")
-                .order(BucketOrder.key(true))
-                .subAggregation(
-                    histogram(histoName).field(SINGLE_VALUED_FIELD_NAME).interval(interval).extendedBounds(minRandomValue, maxRandomValue)
-                )
-                .subAggregation(BucketMetricsPipelineAgg("nested_histo_bucket", histoName + ">_count"))
-        ).addAggregation(BucketMetricsPipelineAgg("nested_terms_bucket", termsName + ">nested_histo_bucket." + nestedMetric())).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                terms(termsName).field("tag")
+                    .order(BucketOrder.key(true))
+                    .subAggregation(
+                        histogram(histoName).field(SINGLE_VALUED_FIELD_NAME)
+                            .interval(interval)
+                            .extendedBounds(minRandomValue, maxRandomValue)
+                    )
+                    .subAggregation(BucketMetricsPipelineAgg("nested_histo_bucket", histoName + ">_count"))
+            ).addAggregation(BucketMetricsPipelineAgg("nested_terms_bucket", termsName + ">nested_histo_bucket." + nestedMetric())),
+            response -> {
+                Terms terms = response.getAggregations().get(termsName);
+                assertThat(terms, notNullValue());
+                assertThat(terms.getName(), equalTo(termsName));
+                List<? extends Terms.Bucket> termsBuckets = terms.getBuckets();
+                assertThat(termsBuckets.size(), equalTo(interval));
 
-        assertNoFailures(response);
+                List<T> allBuckets = new ArrayList<>();
+                List<String> nestedTags = new ArrayList<>();
+                for (int i = 0; i < interval; ++i) {
+                    Terms.Bucket termsBucket = termsBuckets.get(i);
+                    assertThat(termsBucket, notNullValue());
+                    assertThat((String) termsBucket.getKey(), equalTo("tag" + (i % interval)));
 
-        Terms terms = response.getAggregations().get(termsName);
-        assertThat(terms, notNullValue());
-        assertThat(terms.getName(), equalTo(termsName));
-        List<? extends Terms.Bucket> termsBuckets = terms.getBuckets();
-        assertThat(termsBuckets.size(), equalTo(interval));
+                    Histogram histo = termsBucket.getAggregations().get(histoName);
+                    assertThat(histo, notNullValue());
+                    assertThat(histo.getName(), equalTo(histoName));
+                    List<? extends Histogram.Bucket> buckets = histo.getBuckets();
 
-        List<T> allBuckets = new ArrayList<>();
-        List<String> nestedTags = new ArrayList<>();
-        for (int i = 0; i < interval; ++i) {
-            Terms.Bucket termsBucket = termsBuckets.get(i);
-            assertThat(termsBucket, notNullValue());
-            assertThat((String) termsBucket.getKey(), equalTo("tag" + (i % interval)));
+                    for (int j = 0; j < numValueBuckets; ++j) {
+                        Histogram.Bucket bucket = buckets.get(j);
+                        assertThat(bucket, notNullValue());
+                        assertThat(((Number) bucket.getKey()).longValue(), equalTo((long) j * interval));
+                    }
 
-            Histogram histo = termsBucket.getAggregations().get(histoName);
-            assertThat(histo, notNullValue());
-            assertThat(histo.getName(), equalTo(histoName));
-            List<? extends Histogram.Bucket> buckets = histo.getBuckets();
+                    T pipelineBucket = termsBucket.getAggregations().get("nested_histo_bucket");
+                    assertThat(pipelineBucket, notNullValue());
+                    assertThat(pipelineBucket.getName(), equalTo("nested_histo_bucket"));
 
-            for (int j = 0; j < numValueBuckets; ++j) {
-                Histogram.Bucket bucket = buckets.get(j);
-                assertThat(bucket, notNullValue());
-                assertThat(((Number) bucket.getKey()).longValue(), equalTo((long) j * interval));
+                    assertResult(
+                        (k) -> buckets.get(k).getDocCount(),
+                        (k) -> buckets.get(k).getKeyAsString(),
+                        numValueBuckets,
+                        pipelineBucket
+                    );
+                    allBuckets.add(pipelineBucket);
+                    nestedTags.add(termsBucket.getKeyAsString());
+                }
+
+                T pipelineBucket = response.getAggregations().get("nested_terms_bucket");
+                assertThat(pipelineBucket, notNullValue());
+                assertThat(pipelineBucket.getName(), equalTo("nested_terms_bucket"));
+
+                assertResult((k) -> getNestedMetric(allBuckets.get(k)), (k) -> nestedTags.get(k), allBuckets.size(), pipelineBucket);
             }
-
-            T pipelineBucket = termsBucket.getAggregations().get("nested_histo_bucket");
-            assertThat(pipelineBucket, notNullValue());
-            assertThat(pipelineBucket.getName(), equalTo("nested_histo_bucket"));
-
-            assertResult((k) -> buckets.get(k).getDocCount(), (k) -> buckets.get(k).getKeyAsString(), numValueBuckets, pipelineBucket);
-            allBuckets.add(pipelineBucket);
-            nestedTags.add(termsBucket.getKeyAsString());
-        }
-
-        T pipelineBucket = response.getAggregations().get("nested_terms_bucket");
-        assertThat(pipelineBucket, notNullValue());
-        assertThat(pipelineBucket.getName(), equalTo("nested_terms_bucket"));
-
-        assertResult((k) -> getNestedMetric(allBuckets.get(k)), (k) -> nestedTags.get(k), allBuckets.size(), pipelineBucket);
+        );
     }
 
     /**
@@ -468,8 +488,9 @@ abstract class BucketMetricsPipeLineAggregationTestCase<T extends NumericMetrics
         groupByLicenseAgg.subAggregation(licensePerDayBuilder);
         groupByLicenseAgg.subAggregation(BucketMetricsPipelineAgg("peak", "licenses_per_day>total_licenses"));
 
-        SearchResponse response = prepareSearch("foo_*").setSize(0).addAggregation(groupByLicenseAgg).get();
-        BytesReference bytes = XContentHelper.toXContent(response, XContentType.JSON, false);
-        XContentHelper.convertToMap(bytes, false, XContentType.JSON);
+        assertCheckedResponse(prepareSearch("foo_*").setSize(0).addAggregation(groupByLicenseAgg), response -> {
+            BytesReference bytes = XContentHelper.toXContent(response, XContentType.JSON, false);
+            XContentHelper.convertToMap(bytes, false, XContentType.JSON);
+        });
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/pipeline/BucketScriptIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/pipeline/BucketScriptIT.java
@@ -11,7 +11,6 @@ package org.elasticsearch.search.aggregations.pipeline;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.script.MockScriptPlugin;
@@ -42,7 +41,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.percenti
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.search.aggregations.PipelineAggregatorBuilders.bucketScript;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
@@ -155,185 +154,189 @@ public class BucketScriptIT extends ESIntegTestCase {
     }
 
     public void testInlineScript() {
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            histogram("histo").field(FIELD_1_NAME)
-                .interval(interval)
-                .subAggregation(sum("field2Sum").field(FIELD_2_NAME))
-                .subAggregation(sum("field3Sum").field(FIELD_3_NAME))
-                .subAggregation(sum("field4Sum").field(FIELD_4_NAME))
-                .subAggregation(
-                    bucketScript(
-                        "seriesArithmetic",
-                        new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "_value0 + _value1 + _value2", Collections.emptyMap()),
-                        "field2Sum",
-                        "field3Sum",
-                        "field4Sum"
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                histogram("histo").field(FIELD_1_NAME)
+                    .interval(interval)
+                    .subAggregation(sum("field2Sum").field(FIELD_2_NAME))
+                    .subAggregation(sum("field3Sum").field(FIELD_3_NAME))
+                    .subAggregation(sum("field4Sum").field(FIELD_4_NAME))
+                    .subAggregation(
+                        bucketScript(
+                            "seriesArithmetic",
+                            new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "_value0 + _value1 + _value2", Collections.emptyMap()),
+                            "field2Sum",
+                            "field3Sum",
+                            "field4Sum"
+                        )
                     )
-                )
-        ).get();
+            ),
+            response -> {
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo, notNullValue());
+                assertThat(histo.getName(), equalTo("histo"));
+                List<? extends Histogram.Bucket> buckets = histo.getBuckets();
 
-        assertNoFailures(response);
-
-        Histogram histo = response.getAggregations().get("histo");
-        assertThat(histo, notNullValue());
-        assertThat(histo.getName(), equalTo("histo"));
-        List<? extends Histogram.Bucket> buckets = histo.getBuckets();
-
-        for (int i = 0; i < buckets.size(); ++i) {
-            Histogram.Bucket bucket = buckets.get(i);
-            if (bucket.getDocCount() == 0) {
-                SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
-                assertThat(seriesArithmetic, nullValue());
-            } else {
-                Sum field2Sum = bucket.getAggregations().get("field2Sum");
-                assertThat(field2Sum, notNullValue());
-                double field2SumValue = field2Sum.value();
-                Sum field3Sum = bucket.getAggregations().get("field3Sum");
-                assertThat(field3Sum, notNullValue());
-                double field3SumValue = field3Sum.value();
-                Sum field4Sum = bucket.getAggregations().get("field4Sum");
-                assertThat(field4Sum, notNullValue());
-                double field4SumValue = field4Sum.value();
-                SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
-                assertThat(seriesArithmetic, notNullValue());
-                double seriesArithmeticValue = seriesArithmetic.value();
-                assertThat(seriesArithmeticValue, equalTo(field2SumValue + field3SumValue + field4SumValue));
+                for (int i = 0; i < buckets.size(); ++i) {
+                    Histogram.Bucket bucket = buckets.get(i);
+                    if (bucket.getDocCount() == 0) {
+                        SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
+                        assertThat(seriesArithmetic, nullValue());
+                    } else {
+                        Sum field2Sum = bucket.getAggregations().get("field2Sum");
+                        assertThat(field2Sum, notNullValue());
+                        double field2SumValue = field2Sum.value();
+                        Sum field3Sum = bucket.getAggregations().get("field3Sum");
+                        assertThat(field3Sum, notNullValue());
+                        double field3SumValue = field3Sum.value();
+                        Sum field4Sum = bucket.getAggregations().get("field4Sum");
+                        assertThat(field4Sum, notNullValue());
+                        double field4SumValue = field4Sum.value();
+                        SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
+                        assertThat(seriesArithmetic, notNullValue());
+                        double seriesArithmeticValue = seriesArithmetic.value();
+                        assertThat(seriesArithmeticValue, equalTo(field2SumValue + field3SumValue + field4SumValue));
+                    }
+                }
             }
-        }
+        );
     }
 
     public void testInlineScript2() {
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            histogram("histo").field(FIELD_1_NAME)
-                .interval(interval)
-                .subAggregation(sum("field2Sum").field(FIELD_2_NAME))
-                .subAggregation(sum("field3Sum").field(FIELD_3_NAME))
-                .subAggregation(sum("field4Sum").field(FIELD_4_NAME))
-                .subAggregation(
-                    bucketScript(
-                        "seriesArithmetic",
-                        new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "_value0 + _value1 / _value2", Collections.emptyMap()),
-                        "field2Sum",
-                        "field3Sum",
-                        "field4Sum"
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                histogram("histo").field(FIELD_1_NAME)
+                    .interval(interval)
+                    .subAggregation(sum("field2Sum").field(FIELD_2_NAME))
+                    .subAggregation(sum("field3Sum").field(FIELD_3_NAME))
+                    .subAggregation(sum("field4Sum").field(FIELD_4_NAME))
+                    .subAggregation(
+                        bucketScript(
+                            "seriesArithmetic",
+                            new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "_value0 + _value1 / _value2", Collections.emptyMap()),
+                            "field2Sum",
+                            "field3Sum",
+                            "field4Sum"
+                        )
                     )
-                )
-        ).get();
+            ),
+            response -> {
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo, notNullValue());
+                assertThat(histo.getName(), equalTo("histo"));
+                List<? extends Histogram.Bucket> buckets = histo.getBuckets();
 
-        assertNoFailures(response);
-
-        Histogram histo = response.getAggregations().get("histo");
-        assertThat(histo, notNullValue());
-        assertThat(histo.getName(), equalTo("histo"));
-        List<? extends Histogram.Bucket> buckets = histo.getBuckets();
-
-        for (int i = 0; i < buckets.size(); ++i) {
-            Histogram.Bucket bucket = buckets.get(i);
-            if (bucket.getDocCount() == 0) {
-                SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
-                assertThat(seriesArithmetic, nullValue());
-            } else {
-                Sum field2Sum = bucket.getAggregations().get("field2Sum");
-                assertThat(field2Sum, notNullValue());
-                double field2SumValue = field2Sum.value();
-                Sum field3Sum = bucket.getAggregations().get("field3Sum");
-                assertThat(field3Sum, notNullValue());
-                double field3SumValue = field3Sum.value();
-                Sum field4Sum = bucket.getAggregations().get("field4Sum");
-                assertThat(field4Sum, notNullValue());
-                double field4SumValue = field4Sum.value();
-                SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
-                assertThat(seriesArithmetic, notNullValue());
-                double seriesArithmeticValue = seriesArithmetic.value();
-                assertThat(seriesArithmeticValue, equalTo(field2SumValue + field3SumValue / field4SumValue));
+                for (int i = 0; i < buckets.size(); ++i) {
+                    Histogram.Bucket bucket = buckets.get(i);
+                    if (bucket.getDocCount() == 0) {
+                        SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
+                        assertThat(seriesArithmetic, nullValue());
+                    } else {
+                        Sum field2Sum = bucket.getAggregations().get("field2Sum");
+                        assertThat(field2Sum, notNullValue());
+                        double field2SumValue = field2Sum.value();
+                        Sum field3Sum = bucket.getAggregations().get("field3Sum");
+                        assertThat(field3Sum, notNullValue());
+                        double field3SumValue = field3Sum.value();
+                        Sum field4Sum = bucket.getAggregations().get("field4Sum");
+                        assertThat(field4Sum, notNullValue());
+                        double field4SumValue = field4Sum.value();
+                        SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
+                        assertThat(seriesArithmetic, notNullValue());
+                        double seriesArithmeticValue = seriesArithmetic.value();
+                        assertThat(seriesArithmeticValue, equalTo(field2SumValue + field3SumValue / field4SumValue));
+                    }
+                }
             }
-        }
+        );
     }
 
     public void testInlineScriptWithDateRange() {
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            dateRange("range").field(FIELD_5_NAME)
-                .addUnboundedFrom(date)
-                .subAggregation(sum("field2Sum").field(FIELD_2_NAME))
-                .subAggregation(sum("field3Sum").field(FIELD_3_NAME))
-                .subAggregation(sum("field4Sum").field(FIELD_4_NAME))
-                .subAggregation(
-                    bucketScript(
-                        "seriesArithmetic",
-                        new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "_value0 + _value1 + _value2", Collections.emptyMap()),
-                        "field2Sum",
-                        "field3Sum",
-                        "field4Sum"
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                dateRange("range").field(FIELD_5_NAME)
+                    .addUnboundedFrom(date)
+                    .subAggregation(sum("field2Sum").field(FIELD_2_NAME))
+                    .subAggregation(sum("field3Sum").field(FIELD_3_NAME))
+                    .subAggregation(sum("field4Sum").field(FIELD_4_NAME))
+                    .subAggregation(
+                        bucketScript(
+                            "seriesArithmetic",
+                            new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "_value0 + _value1 + _value2", Collections.emptyMap()),
+                            "field2Sum",
+                            "field3Sum",
+                            "field4Sum"
+                        )
                     )
-                )
-        ).get();
+            ),
+            response -> {
+                Range range = response.getAggregations().get("range");
+                assertThat(range, notNullValue());
+                assertThat(range.getName(), equalTo("range"));
+                List<? extends Range.Bucket> buckets = range.getBuckets();
 
-        assertNoFailures(response);
-
-        Range range = response.getAggregations().get("range");
-        assertThat(range, notNullValue());
-        assertThat(range.getName(), equalTo("range"));
-        List<? extends Range.Bucket> buckets = range.getBuckets();
-
-        for (int i = 0; i < buckets.size(); ++i) {
-            Range.Bucket bucket = buckets.get(i);
-            if (bucket.getDocCount() == 0) {
-                SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
-                assertThat(seriesArithmetic, nullValue());
-            } else {
-                Sum field2Sum = bucket.getAggregations().get("field2Sum");
-                assertThat(field2Sum, notNullValue());
-                double field2SumValue = field2Sum.value();
-                Sum field3Sum = bucket.getAggregations().get("field3Sum");
-                assertThat(field3Sum, notNullValue());
-                double field3SumValue = field3Sum.value();
-                Sum field4Sum = bucket.getAggregations().get("field4Sum");
-                assertThat(field4Sum, notNullValue());
-                double field4SumValue = field4Sum.value();
-                SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
-                assertThat(seriesArithmetic, notNullValue());
-                double seriesArithmeticValue = seriesArithmetic.value();
-                assertThat(seriesArithmeticValue, equalTo(field2SumValue + field3SumValue + field4SumValue));
+                for (int i = 0; i < buckets.size(); ++i) {
+                    Range.Bucket bucket = buckets.get(i);
+                    if (bucket.getDocCount() == 0) {
+                        SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
+                        assertThat(seriesArithmetic, nullValue());
+                    } else {
+                        Sum field2Sum = bucket.getAggregations().get("field2Sum");
+                        assertThat(field2Sum, notNullValue());
+                        double field2SumValue = field2Sum.value();
+                        Sum field3Sum = bucket.getAggregations().get("field3Sum");
+                        assertThat(field3Sum, notNullValue());
+                        double field3SumValue = field3Sum.value();
+                        Sum field4Sum = bucket.getAggregations().get("field4Sum");
+                        assertThat(field4Sum, notNullValue());
+                        double field4SumValue = field4Sum.value();
+                        SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
+                        assertThat(seriesArithmetic, notNullValue());
+                        double seriesArithmeticValue = seriesArithmetic.value();
+                        assertThat(seriesArithmeticValue, equalTo(field2SumValue + field3SumValue + field4SumValue));
+                    }
+                }
             }
-        }
+        );
     }
 
     public void testInlineScriptSingleVariable() {
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            histogram("histo").field(FIELD_1_NAME)
-                .interval(interval)
-                .subAggregation(sum("field2Sum").field(FIELD_2_NAME))
-                .subAggregation(
-                    bucketScript(
-                        "seriesArithmetic",
-                        new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "_value0", Collections.emptyMap()),
-                        "field2Sum"
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                histogram("histo").field(FIELD_1_NAME)
+                    .interval(interval)
+                    .subAggregation(sum("field2Sum").field(FIELD_2_NAME))
+                    .subAggregation(
+                        bucketScript(
+                            "seriesArithmetic",
+                            new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "_value0", Collections.emptyMap()),
+                            "field2Sum"
+                        )
                     )
-                )
-        ).get();
+            ),
+            response -> {
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo, notNullValue());
+                assertThat(histo.getName(), equalTo("histo"));
+                List<? extends Histogram.Bucket> buckets = histo.getBuckets();
 
-        assertNoFailures(response);
-
-        Histogram histo = response.getAggregations().get("histo");
-        assertThat(histo, notNullValue());
-        assertThat(histo.getName(), equalTo("histo"));
-        List<? extends Histogram.Bucket> buckets = histo.getBuckets();
-
-        for (int i = 0; i < buckets.size(); ++i) {
-            Histogram.Bucket bucket = buckets.get(i);
-            if (bucket.getDocCount() == 0) {
-                SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
-                assertThat(seriesArithmetic, nullValue());
-            } else {
-                Sum field2Sum = bucket.getAggregations().get("field2Sum");
-                assertThat(field2Sum, notNullValue());
-                double field2SumValue = field2Sum.value();
-                SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
-                assertThat(seriesArithmetic, notNullValue());
-                double seriesArithmeticValue = seriesArithmetic.value();
-                assertThat(seriesArithmeticValue, equalTo(field2SumValue));
+                for (int i = 0; i < buckets.size(); ++i) {
+                    Histogram.Bucket bucket = buckets.get(i);
+                    if (bucket.getDocCount() == 0) {
+                        SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
+                        assertThat(seriesArithmetic, nullValue());
+                    } else {
+                        Sum field2Sum = bucket.getAggregations().get("field2Sum");
+                        assertThat(field2Sum, notNullValue());
+                        double field2SumValue = field2Sum.value();
+                        SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
+                        assertThat(seriesArithmetic, notNullValue());
+                        double seriesArithmeticValue = seriesArithmetic.value();
+                        assertThat(seriesArithmeticValue, equalTo(field2SumValue));
+                    }
+                }
             }
-        }
+        );
     }
 
     public void testInlineScriptNamedVars() {
@@ -341,49 +344,50 @@ public class BucketScriptIT extends ESIntegTestCase {
         bucketsPathsMap.put("foo", "field2Sum");
         bucketsPathsMap.put("bar", "field3Sum");
         bucketsPathsMap.put("baz", "field4Sum");
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            histogram("histo").field(FIELD_1_NAME)
-                .interval(interval)
-                .subAggregation(sum("field2Sum").field(FIELD_2_NAME))
-                .subAggregation(sum("field3Sum").field(FIELD_3_NAME))
-                .subAggregation(sum("field4Sum").field(FIELD_4_NAME))
-                .subAggregation(
-                    bucketScript(
-                        "seriesArithmetic",
-                        bucketsPathsMap,
-                        new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "foo + bar + baz", Collections.emptyMap())
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                histogram("histo").field(FIELD_1_NAME)
+                    .interval(interval)
+                    .subAggregation(sum("field2Sum").field(FIELD_2_NAME))
+                    .subAggregation(sum("field3Sum").field(FIELD_3_NAME))
+                    .subAggregation(sum("field4Sum").field(FIELD_4_NAME))
+                    .subAggregation(
+                        bucketScript(
+                            "seriesArithmetic",
+                            bucketsPathsMap,
+                            new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "foo + bar + baz", Collections.emptyMap())
+                        )
                     )
-                )
-        ).get();
+            ),
+            response -> {
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo, notNullValue());
+                assertThat(histo.getName(), equalTo("histo"));
+                List<? extends Histogram.Bucket> buckets = histo.getBuckets();
 
-        assertNoFailures(response);
-
-        Histogram histo = response.getAggregations().get("histo");
-        assertThat(histo, notNullValue());
-        assertThat(histo.getName(), equalTo("histo"));
-        List<? extends Histogram.Bucket> buckets = histo.getBuckets();
-
-        for (int i = 0; i < buckets.size(); ++i) {
-            Histogram.Bucket bucket = buckets.get(i);
-            if (bucket.getDocCount() == 0) {
-                SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
-                assertThat(seriesArithmetic, nullValue());
-            } else {
-                Sum field2Sum = bucket.getAggregations().get("field2Sum");
-                assertThat(field2Sum, notNullValue());
-                double field2SumValue = field2Sum.value();
-                Sum field3Sum = bucket.getAggregations().get("field3Sum");
-                assertThat(field3Sum, notNullValue());
-                double field3SumValue = field3Sum.value();
-                Sum field4Sum = bucket.getAggregations().get("field4Sum");
-                assertThat(field4Sum, notNullValue());
-                double field4SumValue = field4Sum.value();
-                SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
-                assertThat(seriesArithmetic, notNullValue());
-                double seriesArithmeticValue = seriesArithmetic.value();
-                assertThat(seriesArithmeticValue, equalTo(field2SumValue + field3SumValue + field4SumValue));
+                for (int i = 0; i < buckets.size(); ++i) {
+                    Histogram.Bucket bucket = buckets.get(i);
+                    if (bucket.getDocCount() == 0) {
+                        SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
+                        assertThat(seriesArithmetic, nullValue());
+                    } else {
+                        Sum field2Sum = bucket.getAggregations().get("field2Sum");
+                        assertThat(field2Sum, notNullValue());
+                        double field2SumValue = field2Sum.value();
+                        Sum field3Sum = bucket.getAggregations().get("field3Sum");
+                        assertThat(field3Sum, notNullValue());
+                        double field3SumValue = field3Sum.value();
+                        Sum field4Sum = bucket.getAggregations().get("field4Sum");
+                        assertThat(field4Sum, notNullValue());
+                        double field4SumValue = field4Sum.value();
+                        SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
+                        assertThat(seriesArithmetic, notNullValue());
+                        double seriesArithmeticValue = seriesArithmetic.value();
+                        assertThat(seriesArithmeticValue, equalTo(field2SumValue + field3SumValue + field4SumValue));
+                    }
+                }
             }
-        }
+        );
     }
 
     public void testInlineScriptWithParams() {
@@ -392,115 +396,121 @@ public class BucketScriptIT extends ESIntegTestCase {
 
         Script script = new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "(_value0 + _value1 + _value2) * factor", params);
 
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            histogram("histo").field(FIELD_1_NAME)
-                .interval(interval)
-                .subAggregation(sum("field2Sum").field(FIELD_2_NAME))
-                .subAggregation(sum("field3Sum").field(FIELD_3_NAME))
-                .subAggregation(sum("field4Sum").field(FIELD_4_NAME))
-                .subAggregation(bucketScript("seriesArithmetic", script, "field2Sum", "field3Sum", "field4Sum"))
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                histogram("histo").field(FIELD_1_NAME)
+                    .interval(interval)
+                    .subAggregation(sum("field2Sum").field(FIELD_2_NAME))
+                    .subAggregation(sum("field3Sum").field(FIELD_3_NAME))
+                    .subAggregation(sum("field4Sum").field(FIELD_4_NAME))
+                    .subAggregation(bucketScript("seriesArithmetic", script, "field2Sum", "field3Sum", "field4Sum"))
+            ),
+            response -> {
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo, notNullValue());
+                assertThat(histo.getName(), equalTo("histo"));
+                List<? extends Histogram.Bucket> buckets = histo.getBuckets();
 
-        assertNoFailures(response);
-
-        Histogram histo = response.getAggregations().get("histo");
-        assertThat(histo, notNullValue());
-        assertThat(histo.getName(), equalTo("histo"));
-        List<? extends Histogram.Bucket> buckets = histo.getBuckets();
-
-        for (int i = 0; i < buckets.size(); ++i) {
-            Histogram.Bucket bucket = buckets.get(i);
-            if (bucket.getDocCount() == 0) {
-                SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
-                assertThat(seriesArithmetic, nullValue());
-            } else {
-                Sum field2Sum = bucket.getAggregations().get("field2Sum");
-                assertThat(field2Sum, notNullValue());
-                double field2SumValue = field2Sum.value();
-                Sum field3Sum = bucket.getAggregations().get("field3Sum");
-                assertThat(field3Sum, notNullValue());
-                double field3SumValue = field3Sum.value();
-                Sum field4Sum = bucket.getAggregations().get("field4Sum");
-                assertThat(field4Sum, notNullValue());
-                double field4SumValue = field4Sum.value();
-                SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
-                assertThat(seriesArithmetic, notNullValue());
-                double seriesArithmeticValue = seriesArithmetic.value();
-                assertThat(seriesArithmeticValue, equalTo((field2SumValue + field3SumValue + field4SumValue) * 3));
+                for (int i = 0; i < buckets.size(); ++i) {
+                    Histogram.Bucket bucket = buckets.get(i);
+                    if (bucket.getDocCount() == 0) {
+                        SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
+                        assertThat(seriesArithmetic, nullValue());
+                    } else {
+                        Sum field2Sum = bucket.getAggregations().get("field2Sum");
+                        assertThat(field2Sum, notNullValue());
+                        double field2SumValue = field2Sum.value();
+                        Sum field3Sum = bucket.getAggregations().get("field3Sum");
+                        assertThat(field3Sum, notNullValue());
+                        double field3SumValue = field3Sum.value();
+                        Sum field4Sum = bucket.getAggregations().get("field4Sum");
+                        assertThat(field4Sum, notNullValue());
+                        double field4SumValue = field4Sum.value();
+                        SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
+                        assertThat(seriesArithmetic, notNullValue());
+                        double seriesArithmeticValue = seriesArithmetic.value();
+                        assertThat(seriesArithmeticValue, equalTo((field2SumValue + field3SumValue + field4SumValue) * 3));
+                    }
+                }
             }
-        }
+        );
     }
 
     public void testInlineScriptInsertZeros() {
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            histogram("histo").field(FIELD_1_NAME)
-                .interval(interval)
-                .subAggregation(sum("field2Sum").field(FIELD_2_NAME))
-                .subAggregation(sum("field3Sum").field(FIELD_3_NAME))
-                .subAggregation(sum("field4Sum").field(FIELD_4_NAME))
-                .subAggregation(
-                    bucketScript(
-                        "seriesArithmetic",
-                        new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "_value0 + _value1 + _value2", Collections.emptyMap()),
-                        "field2Sum",
-                        "field3Sum",
-                        "field4Sum"
-                    ).gapPolicy(GapPolicy.INSERT_ZEROS)
-                )
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                histogram("histo").field(FIELD_1_NAME)
+                    .interval(interval)
+                    .subAggregation(sum("field2Sum").field(FIELD_2_NAME))
+                    .subAggregation(sum("field3Sum").field(FIELD_3_NAME))
+                    .subAggregation(sum("field4Sum").field(FIELD_4_NAME))
+                    .subAggregation(
+                        bucketScript(
+                            "seriesArithmetic",
+                            new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "_value0 + _value1 + _value2", Collections.emptyMap()),
+                            "field2Sum",
+                            "field3Sum",
+                            "field4Sum"
+                        ).gapPolicy(GapPolicy.INSERT_ZEROS)
+                    )
+            ),
+            response -> {
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo, notNullValue());
+                assertThat(histo.getName(), equalTo("histo"));
+                List<? extends Histogram.Bucket> buckets = histo.getBuckets();
 
-        assertNoFailures(response);
-
-        Histogram histo = response.getAggregations().get("histo");
-        assertThat(histo, notNullValue());
-        assertThat(histo.getName(), equalTo("histo"));
-        List<? extends Histogram.Bucket> buckets = histo.getBuckets();
-
-        for (int i = 0; i < buckets.size(); ++i) {
-            Histogram.Bucket bucket = buckets.get(i);
-            if (bucket.getDocCount() == 0) {
-                SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
-                assertThat(seriesArithmetic, notNullValue());
-                double seriesArithmeticValue = seriesArithmetic.value();
-                assertThat(seriesArithmeticValue, equalTo(0.0));
-            } else {
-                Sum field2Sum = bucket.getAggregations().get("field2Sum");
-                assertThat(field2Sum, notNullValue());
-                double field2SumValue = field2Sum.value();
-                Sum field3Sum = bucket.getAggregations().get("field3Sum");
-                assertThat(field3Sum, notNullValue());
-                double field3SumValue = field3Sum.value();
-                Sum field4Sum = bucket.getAggregations().get("field4Sum");
-                assertThat(field4Sum, notNullValue());
-                double field4SumValue = field4Sum.value();
-                SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
-                assertThat(seriesArithmetic, notNullValue());
-                double seriesArithmeticValue = seriesArithmetic.value();
-                assertThat(seriesArithmeticValue, equalTo(field2SumValue + field3SumValue + field4SumValue));
+                for (int i = 0; i < buckets.size(); ++i) {
+                    Histogram.Bucket bucket = buckets.get(i);
+                    if (bucket.getDocCount() == 0) {
+                        SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
+                        assertThat(seriesArithmetic, notNullValue());
+                        double seriesArithmeticValue = seriesArithmetic.value();
+                        assertThat(seriesArithmeticValue, equalTo(0.0));
+                    } else {
+                        Sum field2Sum = bucket.getAggregations().get("field2Sum");
+                        assertThat(field2Sum, notNullValue());
+                        double field2SumValue = field2Sum.value();
+                        Sum field3Sum = bucket.getAggregations().get("field3Sum");
+                        assertThat(field3Sum, notNullValue());
+                        double field3SumValue = field3Sum.value();
+                        Sum field4Sum = bucket.getAggregations().get("field4Sum");
+                        assertThat(field4Sum, notNullValue());
+                        double field4SumValue = field4Sum.value();
+                        SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
+                        assertThat(seriesArithmetic, notNullValue());
+                        double seriesArithmeticValue = seriesArithmetic.value();
+                        assertThat(seriesArithmeticValue, equalTo(field2SumValue + field3SumValue + field4SumValue));
+                    }
+                }
             }
-        }
+        );
     }
 
     public void testInlineScriptReturnNull() {
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            histogram("histo").field(FIELD_1_NAME)
-                .interval(interval)
-                .subAggregation(
-                    bucketScript("nullField", new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "return null", Collections.emptyMap()))
-                )
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                histogram("histo").field(FIELD_1_NAME)
+                    .interval(interval)
+                    .subAggregation(
+                        bucketScript(
+                            "nullField",
+                            new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "return null", Collections.emptyMap())
+                        )
+                    )
+            ),
+            response -> {
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo, notNullValue());
+                assertThat(histo.getName(), equalTo("histo"));
+                List<? extends Histogram.Bucket> buckets = histo.getBuckets();
 
-        assertNoFailures(response);
-
-        Histogram histo = response.getAggregations().get("histo");
-        assertThat(histo, notNullValue());
-        assertThat(histo.getName(), equalTo("histo"));
-        List<? extends Histogram.Bucket> buckets = histo.getBuckets();
-
-        for (int i = 0; i < buckets.size(); ++i) {
-            Histogram.Bucket bucket = buckets.get(i);
-            assertNull(bucket.getAggregations().get("nullField"));
-        }
+                for (int i = 0; i < buckets.size(); ++i) {
+                    Histogram.Bucket bucket = buckets.get(i);
+                    assertNull(bucket.getAggregations().get("nullField"));
+                }
+            }
+        );
     }
 
     public void testStoredScript() {
@@ -514,125 +524,128 @@ public class BucketScriptIT extends ESIntegTestCase {
                 )
         );
 
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            histogram("histo").field(FIELD_1_NAME)
-                .interval(interval)
-                .subAggregation(sum("field2Sum").field(FIELD_2_NAME))
-                .subAggregation(sum("field3Sum").field(FIELD_3_NAME))
-                .subAggregation(sum("field4Sum").field(FIELD_4_NAME))
-                .subAggregation(
-                    bucketScript(
-                        "seriesArithmetic",
-                        new Script(ScriptType.STORED, null, "my_script", Collections.emptyMap()),
-                        "field2Sum",
-                        "field3Sum",
-                        "field4Sum"
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                histogram("histo").field(FIELD_1_NAME)
+                    .interval(interval)
+                    .subAggregation(sum("field2Sum").field(FIELD_2_NAME))
+                    .subAggregation(sum("field3Sum").field(FIELD_3_NAME))
+                    .subAggregation(sum("field4Sum").field(FIELD_4_NAME))
+                    .subAggregation(
+                        bucketScript(
+                            "seriesArithmetic",
+                            new Script(ScriptType.STORED, null, "my_script", Collections.emptyMap()),
+                            "field2Sum",
+                            "field3Sum",
+                            "field4Sum"
+                        )
                     )
-                )
-        ).get();
+            ),
+            response -> {
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo, notNullValue());
+                assertThat(histo.getName(), equalTo("histo"));
+                List<? extends Histogram.Bucket> buckets = histo.getBuckets();
 
-        assertNoFailures(response);
-
-        Histogram histo = response.getAggregations().get("histo");
-        assertThat(histo, notNullValue());
-        assertThat(histo.getName(), equalTo("histo"));
-        List<? extends Histogram.Bucket> buckets = histo.getBuckets();
-
-        for (int i = 0; i < buckets.size(); ++i) {
-            Histogram.Bucket bucket = buckets.get(i);
-            if (bucket.getDocCount() == 0) {
-                SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
-                assertThat(seriesArithmetic, nullValue());
-            } else {
-                Sum field2Sum = bucket.getAggregations().get("field2Sum");
-                assertThat(field2Sum, notNullValue());
-                double field2SumValue = field2Sum.value();
-                Sum field3Sum = bucket.getAggregations().get("field3Sum");
-                assertThat(field3Sum, notNullValue());
-                double field3SumValue = field3Sum.value();
-                Sum field4Sum = bucket.getAggregations().get("field4Sum");
-                assertThat(field4Sum, notNullValue());
-                double field4SumValue = field4Sum.value();
-                SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
-                assertThat(seriesArithmetic, notNullValue());
-                double seriesArithmeticValue = seriesArithmetic.value();
-                assertThat(seriesArithmeticValue, equalTo(field2SumValue + field3SumValue + field4SumValue));
+                for (int i = 0; i < buckets.size(); ++i) {
+                    Histogram.Bucket bucket = buckets.get(i);
+                    if (bucket.getDocCount() == 0) {
+                        SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
+                        assertThat(seriesArithmetic, nullValue());
+                    } else {
+                        Sum field2Sum = bucket.getAggregations().get("field2Sum");
+                        assertThat(field2Sum, notNullValue());
+                        double field2SumValue = field2Sum.value();
+                        Sum field3Sum = bucket.getAggregations().get("field3Sum");
+                        assertThat(field3Sum, notNullValue());
+                        double field3SumValue = field3Sum.value();
+                        Sum field4Sum = bucket.getAggregations().get("field4Sum");
+                        assertThat(field4Sum, notNullValue());
+                        double field4SumValue = field4Sum.value();
+                        SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
+                        assertThat(seriesArithmetic, notNullValue());
+                        double seriesArithmeticValue = seriesArithmetic.value();
+                        assertThat(seriesArithmeticValue, equalTo(field2SumValue + field3SumValue + field4SumValue));
+                    }
+                }
             }
-        }
+        );
     }
 
     public void testUnmapped() throws Exception {
-        SearchResponse response = prepareSearch("idx_unmapped").addAggregation(
-            histogram("histo").field(FIELD_1_NAME)
-                .interval(interval)
-                .subAggregation(sum("field2Sum").field(FIELD_2_NAME))
-                .subAggregation(sum("field3Sum").field(FIELD_3_NAME))
-                .subAggregation(sum("field4Sum").field(FIELD_4_NAME))
-                .subAggregation(
-                    bucketScript(
-                        "seriesArithmetic",
-                        new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "_value0 + _value1 + _value2", Collections.emptyMap()),
-                        "field2Sum",
-                        "field3Sum",
-                        "field4Sum"
+        assertNoFailuresAndResponse(
+            prepareSearch("idx_unmapped").addAggregation(
+                histogram("histo").field(FIELD_1_NAME)
+                    .interval(interval)
+                    .subAggregation(sum("field2Sum").field(FIELD_2_NAME))
+                    .subAggregation(sum("field3Sum").field(FIELD_3_NAME))
+                    .subAggregation(sum("field4Sum").field(FIELD_4_NAME))
+                    .subAggregation(
+                        bucketScript(
+                            "seriesArithmetic",
+                            new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "_value0 + _value1 + _value2", Collections.emptyMap()),
+                            "field2Sum",
+                            "field3Sum",
+                            "field4Sum"
+                        )
                     )
-                )
-        ).get();
-
-        assertNoFailures(response);
-
-        Histogram deriv = response.getAggregations().get("histo");
-        assertThat(deriv, notNullValue());
-        assertThat(deriv.getName(), equalTo("histo"));
-        assertThat(deriv.getBuckets().size(), equalTo(0));
+            ),
+            response -> {
+                Histogram deriv = response.getAggregations().get("histo");
+                assertThat(deriv, notNullValue());
+                assertThat(deriv.getName(), equalTo("histo"));
+                assertThat(deriv.getBuckets().size(), equalTo(0));
+            }
+        );
     }
 
     public void testPartiallyUnmapped() throws Exception {
-        SearchResponse response = prepareSearch("idx", "idx_unmapped").addAggregation(
-            histogram("histo").field(FIELD_1_NAME)
-                .interval(interval)
-                .subAggregation(sum("field2Sum").field(FIELD_2_NAME))
-                .subAggregation(sum("field3Sum").field(FIELD_3_NAME))
-                .subAggregation(sum("field4Sum").field(FIELD_4_NAME))
-                .subAggregation(
-                    bucketScript(
-                        "seriesArithmetic",
-                        new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "_value0 + _value1 + _value2", Collections.emptyMap()),
-                        "field2Sum",
-                        "field3Sum",
-                        "field4Sum"
+        assertNoFailuresAndResponse(
+            prepareSearch("idx", "idx_unmapped").addAggregation(
+                histogram("histo").field(FIELD_1_NAME)
+                    .interval(interval)
+                    .subAggregation(sum("field2Sum").field(FIELD_2_NAME))
+                    .subAggregation(sum("field3Sum").field(FIELD_3_NAME))
+                    .subAggregation(sum("field4Sum").field(FIELD_4_NAME))
+                    .subAggregation(
+                        bucketScript(
+                            "seriesArithmetic",
+                            new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "_value0 + _value1 + _value2", Collections.emptyMap()),
+                            "field2Sum",
+                            "field3Sum",
+                            "field4Sum"
+                        )
                     )
-                )
-        ).get();
+            ),
+            response -> {
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo, notNullValue());
+                assertThat(histo.getName(), equalTo("histo"));
+                List<? extends Histogram.Bucket> buckets = histo.getBuckets();
 
-        assertNoFailures(response);
-
-        Histogram histo = response.getAggregations().get("histo");
-        assertThat(histo, notNullValue());
-        assertThat(histo.getName(), equalTo("histo"));
-        List<? extends Histogram.Bucket> buckets = histo.getBuckets();
-
-        for (int i = 0; i < buckets.size(); ++i) {
-            Histogram.Bucket bucket = buckets.get(i);
-            if (bucket.getDocCount() == 0) {
-                SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
-                assertThat(seriesArithmetic, nullValue());
-            } else {
-                Sum field2Sum = bucket.getAggregations().get("field2Sum");
-                assertThat(field2Sum, notNullValue());
-                double field2SumValue = field2Sum.value();
-                Sum field3Sum = bucket.getAggregations().get("field3Sum");
-                assertThat(field3Sum, notNullValue());
-                double field3SumValue = field3Sum.value();
-                Sum field4Sum = bucket.getAggregations().get("field4Sum");
-                assertThat(field4Sum, notNullValue());
-                double field4SumValue = field4Sum.value();
-                SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
-                assertThat(seriesArithmetic, notNullValue());
-                double seriesArithmeticValue = seriesArithmetic.value();
-                assertThat(seriesArithmeticValue, equalTo(field2SumValue + field3SumValue + field4SumValue));
+                for (int i = 0; i < buckets.size(); ++i) {
+                    Histogram.Bucket bucket = buckets.get(i);
+                    if (bucket.getDocCount() == 0) {
+                        SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
+                        assertThat(seriesArithmetic, nullValue());
+                    } else {
+                        Sum field2Sum = bucket.getAggregations().get("field2Sum");
+                        assertThat(field2Sum, notNullValue());
+                        double field2SumValue = field2Sum.value();
+                        Sum field3Sum = bucket.getAggregations().get("field3Sum");
+                        assertThat(field3Sum, notNullValue());
+                        double field3SumValue = field3Sum.value();
+                        Sum field4Sum = bucket.getAggregations().get("field4Sum");
+                        assertThat(field4Sum, notNullValue());
+                        double field4SumValue = field4Sum.value();
+                        SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
+                        assertThat(seriesArithmetic, notNullValue());
+                        double seriesArithmeticValue = seriesArithmetic.value();
+                        assertThat(seriesArithmeticValue, equalTo(field2SumValue + field3SumValue + field4SumValue));
+                    }
+                }
             }
-        }
+        );
     }
 
     public void testSingleBucketPathAgg() throws Exception {
@@ -649,35 +662,36 @@ public class BucketScriptIT extends ESIntegTestCase {
             "seriesArithmetic"
         );
 
-        SearchResponse response = prepareSearch("idx", "idx_unmapped").addAggregation(
-            histogram("histo").field(FIELD_1_NAME)
-                .interval(interval)
-                .subAggregation(sum("field2Sum").field(FIELD_2_NAME))
-                .subAggregation(bucketScriptAgg)
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx", "idx_unmapped").addAggregation(
+                histogram("histo").field(FIELD_1_NAME)
+                    .interval(interval)
+                    .subAggregation(sum("field2Sum").field(FIELD_2_NAME))
+                    .subAggregation(bucketScriptAgg)
+            ),
+            response -> {
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo, notNullValue());
+                assertThat(histo.getName(), equalTo("histo"));
+                List<? extends Histogram.Bucket> buckets = histo.getBuckets();
 
-        assertNoFailures(response);
-
-        Histogram histo = response.getAggregations().get("histo");
-        assertThat(histo, notNullValue());
-        assertThat(histo.getName(), equalTo("histo"));
-        List<? extends Histogram.Bucket> buckets = histo.getBuckets();
-
-        for (int i = 0; i < buckets.size(); ++i) {
-            Histogram.Bucket bucket = buckets.get(i);
-            if (bucket.getDocCount() == 0) {
-                SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
-                assertThat(seriesArithmetic, nullValue());
-            } else {
-                Sum field2Sum = bucket.getAggregations().get("field2Sum");
-                assertThat(field2Sum, notNullValue());
-                double field2SumValue = field2Sum.value();
-                SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
-                assertThat(seriesArithmetic, notNullValue());
-                double seriesArithmeticValue = seriesArithmetic.value();
-                assertThat(seriesArithmeticValue, equalTo(field2SumValue));
+                for (int i = 0; i < buckets.size(); ++i) {
+                    Histogram.Bucket bucket = buckets.get(i);
+                    if (bucket.getDocCount() == 0) {
+                        SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
+                        assertThat(seriesArithmetic, nullValue());
+                    } else {
+                        Sum field2Sum = bucket.getAggregations().get("field2Sum");
+                        assertThat(field2Sum, notNullValue());
+                        double field2SumValue = field2Sum.value();
+                        SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
+                        assertThat(seriesArithmetic, notNullValue());
+                        double seriesArithmeticValue = seriesArithmetic.value();
+                        assertThat(seriesArithmeticValue, equalTo(field2SumValue));
+                    }
+                }
             }
-        }
+        );
     }
 
     public void testArrayBucketPathAgg() throws Exception {
@@ -694,43 +708,44 @@ public class BucketScriptIT extends ESIntegTestCase {
             "seriesArithmetic"
         );
 
-        SearchResponse response = prepareSearch("idx", "idx_unmapped").addAggregation(
-            histogram("histo").field(FIELD_1_NAME)
-                .interval(interval)
-                .subAggregation(sum("field2Sum").field(FIELD_2_NAME))
-                .subAggregation(sum("field3Sum").field(FIELD_3_NAME))
-                .subAggregation(sum("field4Sum").field(FIELD_4_NAME))
-                .subAggregation(bucketScriptAgg)
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx", "idx_unmapped").addAggregation(
+                histogram("histo").field(FIELD_1_NAME)
+                    .interval(interval)
+                    .subAggregation(sum("field2Sum").field(FIELD_2_NAME))
+                    .subAggregation(sum("field3Sum").field(FIELD_3_NAME))
+                    .subAggregation(sum("field4Sum").field(FIELD_4_NAME))
+                    .subAggregation(bucketScriptAgg)
+            ),
+            response -> {
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo, notNullValue());
+                assertThat(histo.getName(), equalTo("histo"));
+                List<? extends Histogram.Bucket> buckets = histo.getBuckets();
 
-        assertNoFailures(response);
-
-        Histogram histo = response.getAggregations().get("histo");
-        assertThat(histo, notNullValue());
-        assertThat(histo.getName(), equalTo("histo"));
-        List<? extends Histogram.Bucket> buckets = histo.getBuckets();
-
-        for (int i = 0; i < buckets.size(); ++i) {
-            Histogram.Bucket bucket = buckets.get(i);
-            if (bucket.getDocCount() == 0) {
-                SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
-                assertThat(seriesArithmetic, nullValue());
-            } else {
-                Sum field2Sum = bucket.getAggregations().get("field2Sum");
-                assertThat(field2Sum, notNullValue());
-                double field2SumValue = field2Sum.value();
-                Sum field3Sum = bucket.getAggregations().get("field3Sum");
-                assertThat(field3Sum, notNullValue());
-                double field3SumValue = field3Sum.value();
-                Sum field4Sum = bucket.getAggregations().get("field4Sum");
-                assertThat(field4Sum, notNullValue());
-                double field4SumValue = field4Sum.value();
-                SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
-                assertThat(seriesArithmetic, notNullValue());
-                double seriesArithmeticValue = seriesArithmetic.value();
-                assertThat(seriesArithmeticValue, equalTo(field2SumValue + field3SumValue + field4SumValue));
+                for (int i = 0; i < buckets.size(); ++i) {
+                    Histogram.Bucket bucket = buckets.get(i);
+                    if (bucket.getDocCount() == 0) {
+                        SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
+                        assertThat(seriesArithmetic, nullValue());
+                    } else {
+                        Sum field2Sum = bucket.getAggregations().get("field2Sum");
+                        assertThat(field2Sum, notNullValue());
+                        double field2SumValue = field2Sum.value();
+                        Sum field3Sum = bucket.getAggregations().get("field3Sum");
+                        assertThat(field3Sum, notNullValue());
+                        double field3SumValue = field3Sum.value();
+                        Sum field4Sum = bucket.getAggregations().get("field4Sum");
+                        assertThat(field4Sum, notNullValue());
+                        double field4SumValue = field4Sum.value();
+                        SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
+                        assertThat(seriesArithmetic, notNullValue());
+                        double seriesArithmeticValue = seriesArithmetic.value();
+                        assertThat(seriesArithmeticValue, equalTo(field2SumValue + field3SumValue + field4SumValue));
+                    }
+                }
             }
-        }
+        );
     }
 
     public void testObjectBucketPathAgg() throws Exception {
@@ -751,43 +766,44 @@ public class BucketScriptIT extends ESIntegTestCase {
             "seriesArithmetic"
         );
 
-        SearchResponse response = prepareSearch("idx", "idx_unmapped").addAggregation(
-            histogram("histo").field(FIELD_1_NAME)
-                .interval(interval)
-                .subAggregation(sum("field2Sum").field(FIELD_2_NAME))
-                .subAggregation(sum("field3Sum").field(FIELD_3_NAME))
-                .subAggregation(sum("field4Sum").field(FIELD_4_NAME))
-                .subAggregation(bucketScriptAgg)
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx", "idx_unmapped").addAggregation(
+                histogram("histo").field(FIELD_1_NAME)
+                    .interval(interval)
+                    .subAggregation(sum("field2Sum").field(FIELD_2_NAME))
+                    .subAggregation(sum("field3Sum").field(FIELD_3_NAME))
+                    .subAggregation(sum("field4Sum").field(FIELD_4_NAME))
+                    .subAggregation(bucketScriptAgg)
+            ),
+            response -> {
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo, notNullValue());
+                assertThat(histo.getName(), equalTo("histo"));
+                List<? extends Histogram.Bucket> buckets = histo.getBuckets();
 
-        assertNoFailures(response);
-
-        Histogram histo = response.getAggregations().get("histo");
-        assertThat(histo, notNullValue());
-        assertThat(histo.getName(), equalTo("histo"));
-        List<? extends Histogram.Bucket> buckets = histo.getBuckets();
-
-        for (int i = 0; i < buckets.size(); ++i) {
-            Histogram.Bucket bucket = buckets.get(i);
-            if (bucket.getDocCount() == 0) {
-                SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
-                assertThat(seriesArithmetic, nullValue());
-            } else {
-                Sum field2Sum = bucket.getAggregations().get("field2Sum");
-                assertThat(field2Sum, notNullValue());
-                double field2SumValue = field2Sum.value();
-                Sum field3Sum = bucket.getAggregations().get("field3Sum");
-                assertThat(field3Sum, notNullValue());
-                double field3SumValue = field3Sum.value();
-                Sum field4Sum = bucket.getAggregations().get("field4Sum");
-                assertThat(field4Sum, notNullValue());
-                double field4SumValue = field4Sum.value();
-                SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
-                assertThat(seriesArithmetic, notNullValue());
-                double seriesArithmeticValue = seriesArithmetic.value();
-                assertThat(seriesArithmeticValue, equalTo(field2SumValue + field3SumValue + field4SumValue));
+                for (int i = 0; i < buckets.size(); ++i) {
+                    Histogram.Bucket bucket = buckets.get(i);
+                    if (bucket.getDocCount() == 0) {
+                        SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
+                        assertThat(seriesArithmetic, nullValue());
+                    } else {
+                        Sum field2Sum = bucket.getAggregations().get("field2Sum");
+                        assertThat(field2Sum, notNullValue());
+                        double field2SumValue = field2Sum.value();
+                        Sum field3Sum = bucket.getAggregations().get("field3Sum");
+                        assertThat(field3Sum, notNullValue());
+                        double field3SumValue = field3Sum.value();
+                        Sum field4Sum = bucket.getAggregations().get("field4Sum");
+                        assertThat(field4Sum, notNullValue());
+                        double field4SumValue = field4Sum.value();
+                        SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
+                        assertThat(seriesArithmetic, notNullValue());
+                        double seriesArithmeticValue = seriesArithmetic.value();
+                        assertThat(seriesArithmeticValue, equalTo(field2SumValue + field3SumValue + field4SumValue));
+                    }
+                }
             }
-        }
+        );
     }
 
     public void testInlineScriptWithMultiValueAggregationIllegalBucketsPaths() {
@@ -828,101 +844,105 @@ public class BucketScriptIT extends ESIntegTestCase {
 
     public void testInlineScriptWithMultiValueAggregation() {
         int percentile = 90;
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            histogram("histo").field(FIELD_1_NAME)
-                .interval(interval)
-                .subAggregation(percentiles("field2Percentile").field(FIELD_2_NAME).percentiles(percentile))
-                .subAggregation(percentiles("field3Percentile").field(FIELD_3_NAME).percentiles(percentile))
-                .subAggregation(percentiles("field4Percentile").field(FIELD_4_NAME).percentiles(percentile))
-                .subAggregation(
-                    bucketScript(
-                        "seriesArithmetic",
-                        new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "_value0 + _value1 + _value2", Collections.emptyMap()),
-                        "field2Percentile",
-                        "field3Percentile",
-                        "field4Percentile"
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                histogram("histo").field(FIELD_1_NAME)
+                    .interval(interval)
+                    .subAggregation(percentiles("field2Percentile").field(FIELD_2_NAME).percentiles(percentile))
+                    .subAggregation(percentiles("field3Percentile").field(FIELD_3_NAME).percentiles(percentile))
+                    .subAggregation(percentiles("field4Percentile").field(FIELD_4_NAME).percentiles(percentile))
+                    .subAggregation(
+                        bucketScript(
+                            "seriesArithmetic",
+                            new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "_value0 + _value1 + _value2", Collections.emptyMap()),
+                            "field2Percentile",
+                            "field3Percentile",
+                            "field4Percentile"
+                        )
                     )
-                )
-        ).get();
+            ),
+            response -> {
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo, notNullValue());
+                assertThat(histo.getName(), equalTo("histo"));
+                List<? extends Histogram.Bucket> buckets = histo.getBuckets();
 
-        assertNoFailures(response);
-
-        Histogram histo = response.getAggregations().get("histo");
-        assertThat(histo, notNullValue());
-        assertThat(histo.getName(), equalTo("histo"));
-        List<? extends Histogram.Bucket> buckets = histo.getBuckets();
-
-        for (int i = 0; i < buckets.size(); ++i) {
-            Histogram.Bucket bucket = buckets.get(i);
-            if (bucket.getDocCount() == 0) {
-                SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
-                assertThat(seriesArithmetic, nullValue());
-            } else {
-                Percentiles field2Percentile = bucket.getAggregations().get("field2Percentile");
-                assertThat(field2Percentile, notNullValue());
-                double field2PercentileValue = field2Percentile.value(String.valueOf(percentile));
-                Percentiles field3Percentile = bucket.getAggregations().get("field3Percentile");
-                assertThat(field3Percentile, notNullValue());
-                double field3PercentileValue = field3Percentile.value(String.valueOf(percentile));
-                Percentiles field4Percentile = bucket.getAggregations().get("field4Percentile");
-                assertThat(field4Percentile, notNullValue());
-                double field4PercentileValue = field4Percentile.value(String.valueOf(percentile));
-                SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
-                assertThat(seriesArithmetic, notNullValue());
-                double seriesArithmeticValue = seriesArithmetic.value();
-                assertThat(seriesArithmeticValue, equalTo(field2PercentileValue + field3PercentileValue + field4PercentileValue));
+                for (int i = 0; i < buckets.size(); ++i) {
+                    Histogram.Bucket bucket = buckets.get(i);
+                    if (bucket.getDocCount() == 0) {
+                        SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
+                        assertThat(seriesArithmetic, nullValue());
+                    } else {
+                        Percentiles field2Percentile = bucket.getAggregations().get("field2Percentile");
+                        assertThat(field2Percentile, notNullValue());
+                        double field2PercentileValue = field2Percentile.value(String.valueOf(percentile));
+                        Percentiles field3Percentile = bucket.getAggregations().get("field3Percentile");
+                        assertThat(field3Percentile, notNullValue());
+                        double field3PercentileValue = field3Percentile.value(String.valueOf(percentile));
+                        Percentiles field4Percentile = bucket.getAggregations().get("field4Percentile");
+                        assertThat(field4Percentile, notNullValue());
+                        double field4PercentileValue = field4Percentile.value(String.valueOf(percentile));
+                        SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
+                        assertThat(seriesArithmetic, notNullValue());
+                        double seriesArithmeticValue = seriesArithmetic.value();
+                        assertThat(seriesArithmeticValue, equalTo(field2PercentileValue + field3PercentileValue + field4PercentileValue));
+                    }
+                }
             }
-        }
+        );
     }
 
     public void testInlineScriptWithMultiValueAggregationDifferentBucketsPaths() {
         int percentile10 = 10;
         int percentile50 = 50;
         int percentile90 = 90;
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            histogram("histo").field(FIELD_1_NAME)
-                .interval(interval)
-                .subAggregation(percentiles("field2Percentile").field(FIELD_2_NAME))
-                .subAggregation(percentiles("field3Percentile").field(FIELD_3_NAME).percentiles(percentile10, percentile50, percentile90))
-                .subAggregation(percentiles("field4Percentile").field(FIELD_4_NAME).percentiles(percentile90))
-                .subAggregation(
-                    bucketScript(
-                        "seriesArithmetic",
-                        new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "_value0 + _value1 + _value2", Collections.emptyMap()),
-                        "field2Percentile.10",
-                        "field3Percentile.50",
-                        "field4Percentile"
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                histogram("histo").field(FIELD_1_NAME)
+                    .interval(interval)
+                    .subAggregation(percentiles("field2Percentile").field(FIELD_2_NAME))
+                    .subAggregation(
+                        percentiles("field3Percentile").field(FIELD_3_NAME).percentiles(percentile10, percentile50, percentile90)
                     )
-                )
-        ).get();
+                    .subAggregation(percentiles("field4Percentile").field(FIELD_4_NAME).percentiles(percentile90))
+                    .subAggregation(
+                        bucketScript(
+                            "seriesArithmetic",
+                            new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "_value0 + _value1 + _value2", Collections.emptyMap()),
+                            "field2Percentile.10",
+                            "field3Percentile.50",
+                            "field4Percentile"
+                        )
+                    )
+            ),
+            response -> {
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo, notNullValue());
+                assertThat(histo.getName(), equalTo("histo"));
+                List<? extends Histogram.Bucket> buckets = histo.getBuckets();
 
-        assertNoFailures(response);
-
-        Histogram histo = response.getAggregations().get("histo");
-        assertThat(histo, notNullValue());
-        assertThat(histo.getName(), equalTo("histo"));
-        List<? extends Histogram.Bucket> buckets = histo.getBuckets();
-
-        for (int i = 0; i < buckets.size(); ++i) {
-            Histogram.Bucket bucket = buckets.get(i);
-            if (bucket.getDocCount() == 0) {
-                SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
-                assertThat(seriesArithmetic, nullValue());
-            } else {
-                Percentiles field2Percentile = bucket.getAggregations().get("field2Percentile");
-                assertThat(field2Percentile, notNullValue());
-                double field2PercentileValue = field2Percentile.value(String.valueOf(percentile10));
-                Percentiles field3Percentile = bucket.getAggregations().get("field3Percentile");
-                assertThat(field3Percentile, notNullValue());
-                double field3PercentileValue = field3Percentile.value(String.valueOf(percentile50));
-                Percentiles field4Percentile = bucket.getAggregations().get("field4Percentile");
-                assertThat(field4Percentile, notNullValue());
-                double field4PercentileValue = field4Percentile.value(String.valueOf(percentile90));
-                SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
-                assertThat(seriesArithmetic, notNullValue());
-                double seriesArithmeticValue = seriesArithmetic.value();
-                assertThat(seriesArithmeticValue, equalTo(field2PercentileValue + field3PercentileValue + field4PercentileValue));
+                for (int i = 0; i < buckets.size(); ++i) {
+                    Histogram.Bucket bucket = buckets.get(i);
+                    if (bucket.getDocCount() == 0) {
+                        SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
+                        assertThat(seriesArithmetic, nullValue());
+                    } else {
+                        Percentiles field2Percentile = bucket.getAggregations().get("field2Percentile");
+                        assertThat(field2Percentile, notNullValue());
+                        double field2PercentileValue = field2Percentile.value(String.valueOf(percentile10));
+                        Percentiles field3Percentile = bucket.getAggregations().get("field3Percentile");
+                        assertThat(field3Percentile, notNullValue());
+                        double field3PercentileValue = field3Percentile.value(String.valueOf(percentile50));
+                        Percentiles field4Percentile = bucket.getAggregations().get("field4Percentile");
+                        assertThat(field4Percentile, notNullValue());
+                        double field4PercentileValue = field4Percentile.value(String.valueOf(percentile90));
+                        SimpleValue seriesArithmetic = bucket.getAggregations().get("seriesArithmetic");
+                        assertThat(seriesArithmetic, notNullValue());
+                        double seriesArithmeticValue = seriesArithmetic.value();
+                        assertThat(seriesArithmeticValue, equalTo(field2PercentileValue + field3PercentileValue + field4PercentileValue));
+                    }
+                }
             }
-        }
+        );
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/pipeline/ExtendedStatsBucketIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/pipeline/ExtendedStatsBucketIT.java
@@ -11,7 +11,6 @@ package org.elasticsearch.search.aggregations.pipeline;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.search.aggregations.BucketOrder;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram.Bucket;
@@ -27,6 +26,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.search.aggregations.PipelineAggregatorBuilders.extendedStatsBucket;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.IsNull.notNullValue;
@@ -100,51 +100,54 @@ public class ExtendedStatsBucketIT extends BucketMetricsPipeLineAggregationTestC
      */
     public void testGappyIndexWithSigma() {
         double sigma = randomDoubleBetween(1.0, 6.0, true);
-        SearchResponse response = prepareSearch("idx_gappy").addAggregation(histogram("histo").field(SINGLE_VALUED_FIELD_NAME).interval(1L))
-            .addAggregation(extendedStatsBucket("extended_stats_bucket", "histo>_count").sigma(sigma))
-            .get();
-        assertNoFailures(response);
-        Histogram histo = response.getAggregations().get("histo");
-        assertThat(histo, notNullValue());
-        assertThat(histo.getName(), equalTo("histo"));
-        List<? extends Bucket> buckets = histo.getBuckets();
-        assertThat(buckets.size(), equalTo(6));
+        assertNoFailuresAndResponse(
+            prepareSearch("idx_gappy").addAggregation(histogram("histo").field(SINGLE_VALUED_FIELD_NAME).interval(1L))
+                .addAggregation(extendedStatsBucket("extended_stats_bucket", "histo>_count").sigma(sigma)),
+            response -> {
+                assertNoFailures(response);
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo, notNullValue());
+                assertThat(histo.getName(), equalTo("histo"));
+                List<? extends Bucket> buckets = histo.getBuckets();
+                assertThat(buckets.size(), equalTo(6));
 
-        for (int i = 0; i < 6; ++i) {
-            long expectedDocCount;
-            if (i == 3) {
-                expectedDocCount = 2;
-            } else if (i == 4) {
-                expectedDocCount = 0;
-            } else {
-                expectedDocCount = 1;
+                for (int i = 0; i < 6; ++i) {
+                    long expectedDocCount;
+                    if (i == 3) {
+                        expectedDocCount = 2;
+                    } else if (i == 4) {
+                        expectedDocCount = 0;
+                    } else {
+                        expectedDocCount = 1;
+                    }
+                    Histogram.Bucket bucket = buckets.get(i);
+                    assertThat("i: " + i, bucket, notNullValue());
+                    assertThat("i: " + i, ((Number) bucket.getKey()).longValue(), equalTo((long) i));
+                    assertThat("i: " + i, bucket.getDocCount(), equalTo(expectedDocCount));
+                }
+
+                ExtendedStatsBucket extendedStatsBucketValue = response.getAggregations().get("extended_stats_bucket");
+                long count = 6L;
+                double sum = 1.0 + 1.0 + 1.0 + 2.0 + 0.0 + 1.0;
+                double sumOfSqrs = 1.0 + 1.0 + 1.0 + 4.0 + 0.0 + 1.0;
+                double avg = sum / count;
+                double var = (sumOfSqrs - ((sum * sum) / count)) / count;
+                var = var < 0 ? 0 : var;
+                double stdDev = Math.sqrt(var);
+                assertThat(extendedStatsBucketValue, notNullValue());
+                assertThat(extendedStatsBucketValue.getName(), equalTo("extended_stats_bucket"));
+                assertThat(extendedStatsBucketValue.getMin(), equalTo(0.0));
+                assertThat(extendedStatsBucketValue.getMax(), equalTo(2.0));
+                assertThat(extendedStatsBucketValue.getCount(), equalTo(count));
+                assertThat(extendedStatsBucketValue.getSum(), equalTo(sum));
+                assertThat(extendedStatsBucketValue.getAvg(), equalTo(avg));
+                assertThat(extendedStatsBucketValue.getSumOfSquares(), equalTo(sumOfSqrs));
+                assertThat(extendedStatsBucketValue.getVariance(), equalTo(var));
+                assertThat(extendedStatsBucketValue.getStdDeviation(), equalTo(stdDev));
+                assertThat(extendedStatsBucketValue.getStdDeviationBound(Bounds.LOWER), equalTo(avg - (sigma * stdDev)));
+                assertThat(extendedStatsBucketValue.getStdDeviationBound(Bounds.UPPER), equalTo(avg + (sigma * stdDev)));
             }
-            Histogram.Bucket bucket = buckets.get(i);
-            assertThat("i: " + i, bucket, notNullValue());
-            assertThat("i: " + i, ((Number) bucket.getKey()).longValue(), equalTo((long) i));
-            assertThat("i: " + i, bucket.getDocCount(), equalTo(expectedDocCount));
-        }
-
-        ExtendedStatsBucket extendedStatsBucketValue = response.getAggregations().get("extended_stats_bucket");
-        long count = 6L;
-        double sum = 1.0 + 1.0 + 1.0 + 2.0 + 0.0 + 1.0;
-        double sumOfSqrs = 1.0 + 1.0 + 1.0 + 4.0 + 0.0 + 1.0;
-        double avg = sum / count;
-        double var = (sumOfSqrs - ((sum * sum) / count)) / count;
-        var = var < 0 ? 0 : var;
-        double stdDev = Math.sqrt(var);
-        assertThat(extendedStatsBucketValue, notNullValue());
-        assertThat(extendedStatsBucketValue.getName(), equalTo("extended_stats_bucket"));
-        assertThat(extendedStatsBucketValue.getMin(), equalTo(0.0));
-        assertThat(extendedStatsBucketValue.getMax(), equalTo(2.0));
-        assertThat(extendedStatsBucketValue.getCount(), equalTo(count));
-        assertThat(extendedStatsBucketValue.getSum(), equalTo(sum));
-        assertThat(extendedStatsBucketValue.getAvg(), equalTo(avg));
-        assertThat(extendedStatsBucketValue.getSumOfSquares(), equalTo(sumOfSqrs));
-        assertThat(extendedStatsBucketValue.getVariance(), equalTo(var));
-        assertThat(extendedStatsBucketValue.getStdDeviation(), equalTo(stdDev));
-        assertThat(extendedStatsBucketValue.getStdDeviationBound(Bounds.LOWER), equalTo(avg - (sigma * stdDev)));
-        assertThat(extendedStatsBucketValue.getStdDeviationBound(Bounds.UPPER), equalTo(avg + (sigma * stdDev)));
+        );
     }
 
     public void testBadSigmaAsSubAgg() throws Exception {

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/pipeline/PercentilesBucketIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/pipeline/PercentilesBucketIT.java
@@ -10,7 +10,6 @@ package org.elasticsearch.search.aggregations.pipeline;
 
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.search.aggregations.BucketOrder;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.terms.IncludeExclude;
@@ -28,7 +27,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.histogra
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.search.aggregations.PipelineAggregatorBuilders.percentilesBucket;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.core.IsNull.notNullValue;
@@ -68,62 +67,63 @@ public class PercentilesBucketIT extends BucketMetricsPipeLineAggregationTestCas
     }
 
     public void testMetricTopLevelDefaultPercents() throws Exception {
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            terms(termsName).field("tag").subAggregation(sum("sum").field(SINGLE_VALUED_FIELD_NAME))
-        ).addAggregation(percentilesBucket("percentiles_bucket", termsName + ">sum")).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(terms(termsName).field("tag").subAggregation(sum("sum").field(SINGLE_VALUED_FIELD_NAME)))
+                .addAggregation(percentilesBucket("percentiles_bucket", termsName + ">sum")),
+            response -> {
+                Terms terms = response.getAggregations().get(termsName);
+                assertThat(terms, notNullValue());
+                assertThat(terms.getName(), equalTo(termsName));
+                List<? extends Terms.Bucket> buckets = terms.getBuckets();
+                assertThat(buckets.size(), equalTo(interval));
 
-        assertNoFailures(response);
+                double[] values = new double[interval];
+                for (int i = 0; i < interval; ++i) {
+                    Terms.Bucket bucket = buckets.get(i);
+                    assertThat(bucket, notNullValue());
+                    assertThat((String) bucket.getKey(), equalTo("tag" + (i % interval)));
+                    assertThat(bucket.getDocCount(), greaterThan(0L));
+                    Sum sum = bucket.getAggregations().get("sum");
+                    assertThat(sum, notNullValue());
+                    values[i] = sum.value();
+                }
 
-        Terms terms = response.getAggregations().get(termsName);
-        assertThat(terms, notNullValue());
-        assertThat(terms.getName(), equalTo(termsName));
-        List<? extends Terms.Bucket> buckets = terms.getBuckets();
-        assertThat(buckets.size(), equalTo(interval));
+                Arrays.sort(values);
 
-        double[] values = new double[interval];
-        for (int i = 0; i < interval; ++i) {
-            Terms.Bucket bucket = buckets.get(i);
-            assertThat(bucket, notNullValue());
-            assertThat((String) bucket.getKey(), equalTo("tag" + (i % interval)));
-            assertThat(bucket.getDocCount(), greaterThan(0L));
-            Sum sum = bucket.getAggregations().get("sum");
-            assertThat(sum, notNullValue());
-            values[i] = sum.value();
-        }
-
-        Arrays.sort(values);
-
-        PercentilesBucket percentilesBucketValue = response.getAggregations().get("percentiles_bucket");
-        assertThat(percentilesBucketValue, notNullValue());
-        assertThat(percentilesBucketValue.getName(), equalTo("percentiles_bucket"));
-        assertPercentileBucket(values, percentilesBucketValue);
+                PercentilesBucket percentilesBucketValue = response.getAggregations().get("percentiles_bucket");
+                assertThat(percentilesBucketValue, notNullValue());
+                assertThat(percentilesBucketValue.getName(), equalTo("percentiles_bucket"));
+                assertPercentileBucket(values, percentilesBucketValue);
+            }
+        );
     }
 
     public void testWrongPercents() throws Exception {
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            terms(termsName).field("tag")
-                .includeExclude(new IncludeExclude(null, "tag.*", null, null))
-                .subAggregation(sum("sum").field(SINGLE_VALUED_FIELD_NAME))
-        ).addAggregation(percentilesBucket("percentiles_bucket", termsName + ">sum").setPercents(PERCENTS)).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                terms(termsName).field("tag")
+                    .includeExclude(new IncludeExclude(null, "tag.*", null, null))
+                    .subAggregation(sum("sum").field(SINGLE_VALUED_FIELD_NAME))
+            ).addAggregation(percentilesBucket("percentiles_bucket", termsName + ">sum").setPercents(PERCENTS)),
+            response -> {
+                Terms terms = response.getAggregations().get(termsName);
+                assertThat(terms, notNullValue());
+                assertThat(terms.getName(), equalTo(termsName));
+                List<? extends Terms.Bucket> buckets = terms.getBuckets();
+                assertThat(buckets.size(), equalTo(0));
 
-        assertNoFailures(response);
+                PercentilesBucket percentilesBucketValue = response.getAggregations().get("percentiles_bucket");
+                assertThat(percentilesBucketValue, notNullValue());
+                assertThat(percentilesBucketValue.getName(), equalTo("percentiles_bucket"));
 
-        Terms terms = response.getAggregations().get(termsName);
-        assertThat(terms, notNullValue());
-        assertThat(terms.getName(), equalTo(termsName));
-        List<? extends Terms.Bucket> buckets = terms.getBuckets();
-        assertThat(buckets.size(), equalTo(0));
-
-        PercentilesBucket percentilesBucketValue = response.getAggregations().get("percentiles_bucket");
-        assertThat(percentilesBucketValue, notNullValue());
-        assertThat(percentilesBucketValue.getName(), equalTo("percentiles_bucket"));
-
-        try {
-            percentilesBucketValue.percentile(2.0);
-            fail("2.0 was not a valid percent, should have thrown exception");
-        } catch (IllegalArgumentException exception) {
-            // All good
-        }
+                try {
+                    percentilesBucketValue.percentile(2.0);
+                    fail("2.0 was not a valid percent, should have thrown exception");
+                } catch (IllegalArgumentException exception) {
+                    // All good
+                }
+            }
+        );
     }
 
     public void testBadPercents() throws Exception {
@@ -149,7 +149,6 @@ public class PercentilesBucketIT extends BucketMetricsPipeLineAggregationTestCas
                 throw e;
             }
         }
-
     }
 
     public void testBadPercents_asSubAgg() throws Exception {
@@ -187,62 +186,66 @@ public class PercentilesBucketIT extends BucketMetricsPipeLineAggregationTestCas
 
     public void testNestedWithDecimal() throws Exception {
         double[] percent = { 99.9 };
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            terms(termsName).field("tag")
-                .order(BucketOrder.key(true))
-                .subAggregation(
-                    histogram(histoName).field(SINGLE_VALUED_FIELD_NAME).interval(interval).extendedBounds(minRandomValue, maxRandomValue)
-                )
-                .subAggregation(percentilesBucket("percentile_histo_bucket", histoName + ">_count").setPercents(percent))
-        )
-            .addAggregation(percentilesBucket("percentile_terms_bucket", termsName + ">percentile_histo_bucket[99.9]").setPercents(percent))
-            .get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                terms(termsName).field("tag")
+                    .order(BucketOrder.key(true))
+                    .subAggregation(
+                        histogram(histoName).field(SINGLE_VALUED_FIELD_NAME)
+                            .interval(interval)
+                            .extendedBounds(minRandomValue, maxRandomValue)
+                    )
+                    .subAggregation(percentilesBucket("percentile_histo_bucket", histoName + ">_count").setPercents(percent))
+            )
+                .addAggregation(
+                    percentilesBucket("percentile_terms_bucket", termsName + ">percentile_histo_bucket[99.9]").setPercents(percent)
+                ),
+            response -> {
+                Terms terms = response.getAggregations().get(termsName);
+                assertThat(terms, notNullValue());
+                assertThat(terms.getName(), equalTo(termsName));
+                List<? extends Terms.Bucket> termsBuckets = terms.getBuckets();
+                assertThat(termsBuckets.size(), equalTo(interval));
 
-        assertNoFailures(response);
+                double[] values = new double[termsBuckets.size()];
+                for (int i = 0; i < interval; ++i) {
+                    Terms.Bucket termsBucket = termsBuckets.get(i);
+                    assertThat(termsBucket, notNullValue());
+                    assertThat((String) termsBucket.getKey(), equalTo("tag" + (i % interval)));
 
-        Terms terms = response.getAggregations().get(termsName);
-        assertThat(terms, notNullValue());
-        assertThat(terms.getName(), equalTo(termsName));
-        List<? extends Terms.Bucket> termsBuckets = terms.getBuckets();
-        assertThat(termsBuckets.size(), equalTo(interval));
+                    Histogram histo = termsBucket.getAggregations().get(histoName);
+                    assertThat(histo, notNullValue());
+                    assertThat(histo.getName(), equalTo(histoName));
+                    List<? extends Histogram.Bucket> buckets = histo.getBuckets();
 
-        double[] values = new double[termsBuckets.size()];
-        for (int i = 0; i < interval; ++i) {
-            Terms.Bucket termsBucket = termsBuckets.get(i);
-            assertThat(termsBucket, notNullValue());
-            assertThat((String) termsBucket.getKey(), equalTo("tag" + (i % interval)));
+                    double[] innerValues = new double[numValueBuckets];
+                    for (int j = 0; j < numValueBuckets; ++j) {
+                        Histogram.Bucket bucket = buckets.get(j);
+                        assertThat(bucket, notNullValue());
+                        assertThat(((Number) bucket.getKey()).longValue(), equalTo((long) j * interval));
 
-            Histogram histo = termsBucket.getAggregations().get(histoName);
-            assertThat(histo, notNullValue());
-            assertThat(histo.getName(), equalTo(histoName));
-            List<? extends Histogram.Bucket> buckets = histo.getBuckets();
+                        innerValues[j] = bucket.getDocCount();
+                    }
+                    Arrays.sort(innerValues);
 
-            double[] innerValues = new double[numValueBuckets];
-            for (int j = 0; j < numValueBuckets; ++j) {
-                Histogram.Bucket bucket = buckets.get(j);
-                assertThat(bucket, notNullValue());
-                assertThat(((Number) bucket.getKey()).longValue(), equalTo((long) j * interval));
+                    PercentilesBucket percentilesBucketValue = termsBucket.getAggregations().get("percentile_histo_bucket");
+                    assertThat(percentilesBucketValue, notNullValue());
+                    assertThat(percentilesBucketValue.getName(), equalTo("percentile_histo_bucket"));
+                    assertPercentileBucket(innerValues, percentilesBucketValue);
+                    values[i] = percentilesBucketValue.percentile(99.9);
+                }
 
-                innerValues[j] = bucket.getDocCount();
+                Arrays.sort(values);
+
+                PercentilesBucket percentilesBucketValue = response.getAggregations().get("percentile_terms_bucket");
+                assertThat(percentilesBucketValue, notNullValue());
+                assertThat(percentilesBucketValue.getName(), equalTo("percentile_terms_bucket"));
+                for (Double p : percent) {
+                    double expected = values[(int) ((p / 100) * values.length)];
+                    assertThat(percentilesBucketValue.percentile(p), equalTo(expected));
+                }
             }
-            Arrays.sort(innerValues);
-
-            PercentilesBucket percentilesBucketValue = termsBucket.getAggregations().get("percentile_histo_bucket");
-            assertThat(percentilesBucketValue, notNullValue());
-            assertThat(percentilesBucketValue.getName(), equalTo("percentile_histo_bucket"));
-            assertPercentileBucket(innerValues, percentilesBucketValue);
-            values[i] = percentilesBucketValue.percentile(99.9);
-        }
-
-        Arrays.sort(values);
-
-        PercentilesBucket percentilesBucketValue = response.getAggregations().get("percentile_terms_bucket");
-        assertThat(percentilesBucketValue, notNullValue());
-        assertThat(percentilesBucketValue.getName(), equalTo("percentile_terms_bucket"));
-        for (Double p : percent) {
-            double expected = values[(int) ((p / 100) * values.length)];
-            assertThat(percentilesBucketValue.percentile(p), equalTo(expected));
-        }
+        );
     }
 
     private void assertPercentileBucket(double[] values, PercentilesBucket percentiles) {


### PR DESCRIPTION
Remove explicit SearchResponse references from `org.elasticsearch.search.aggregations.pipeline`