### PR TITLE
Remove explicit SearchResponse references from server metrics aggs (part1)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsIT.java
@@ -7,7 +7,6 @@
  */
 package org.elasticsearch.search.aggregations.metrics;
 
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.script.Script;
@@ -39,6 +38,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -91,310 +91,325 @@ public class ExtendedStatsIT extends AbstractNumericTestCase {
 
     @Override
     public void testEmptyAggregation() throws Exception {
-        SearchResponse searchResponse = prepareSearch("empty_bucket_idx").setQuery(matchAllQuery())
-            .addAggregation(
-                histogram("histo").field("value").interval(1L).minDocCount(0).subAggregation(extendedStats("stats").field("value"))
-            )
-            .get();
+        assertResponse(
+            prepareSearch("empty_bucket_idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    histogram("histo").field("value").interval(1L).minDocCount(0).subAggregation(extendedStats("stats").field("value"))
+                ),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(2L));
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo, notNullValue());
+                Histogram.Bucket bucket = histo.getBuckets().get(1);
+                assertThat(bucket, notNullValue());
 
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(2L));
-        Histogram histo = searchResponse.getAggregations().get("histo");
-        assertThat(histo, notNullValue());
-        Histogram.Bucket bucket = histo.getBuckets().get(1);
-        assertThat(bucket, notNullValue());
-
-        ExtendedStats stats = bucket.getAggregations().get("stats");
-        assertThat(stats, notNullValue());
-        assertThat(stats.getName(), equalTo("stats"));
-        assertThat(stats.getSumOfSquares(), equalTo(0.0));
-        assertThat(stats.getCount(), equalTo(0L));
-        assertThat(stats.getSum(), equalTo(0.0));
-        assertThat(stats.getMin(), equalTo(Double.POSITIVE_INFINITY));
-        assertThat(stats.getMax(), equalTo(Double.NEGATIVE_INFINITY));
-        assertThat(Double.isNaN(stats.getStdDeviation()), is(true));
-        assertThat(Double.isNaN(stats.getStdDeviationPopulation()), is(true));
-        assertThat(Double.isNaN(stats.getStdDeviationSampling()), is(true));
-        assertThat(Double.isNaN(stats.getAvg()), is(true));
-        assertThat(Double.isNaN(stats.getStdDeviationBound(Bounds.UPPER)), is(true));
-        assertThat(Double.isNaN(stats.getStdDeviationBound(Bounds.LOWER)), is(true));
-        assertThat(Double.isNaN(stats.getStdDeviationBound(Bounds.UPPER_POPULATION)), is(true));
-        assertThat(Double.isNaN(stats.getStdDeviationBound(Bounds.LOWER_POPULATION)), is(true));
-        assertThat(Double.isNaN(stats.getStdDeviationBound(Bounds.UPPER_SAMPLING)), is(true));
-        assertThat(Double.isNaN(stats.getStdDeviationBound(Bounds.LOWER_SAMPLING)), is(true));
+                ExtendedStats stats = bucket.getAggregations().get("stats");
+                assertThat(stats, notNullValue());
+                assertThat(stats.getName(), equalTo("stats"));
+                assertThat(stats.getSumOfSquares(), equalTo(0.0));
+                assertThat(stats.getCount(), equalTo(0L));
+                assertThat(stats.getSum(), equalTo(0.0));
+                assertThat(stats.getMin(), equalTo(Double.POSITIVE_INFINITY));
+                assertThat(stats.getMax(), equalTo(Double.NEGATIVE_INFINITY));
+                assertThat(Double.isNaN(stats.getStdDeviation()), is(true));
+                assertThat(Double.isNaN(stats.getStdDeviationPopulation()), is(true));
+                assertThat(Double.isNaN(stats.getStdDeviationSampling()), is(true));
+                assertThat(Double.isNaN(stats.getAvg()), is(true));
+                assertThat(Double.isNaN(stats.getStdDeviationBound(Bounds.UPPER)), is(true));
+                assertThat(Double.isNaN(stats.getStdDeviationBound(Bounds.LOWER)), is(true));
+                assertThat(Double.isNaN(stats.getStdDeviationBound(Bounds.UPPER_POPULATION)), is(true));
+                assertThat(Double.isNaN(stats.getStdDeviationBound(Bounds.LOWER_POPULATION)), is(true));
+                assertThat(Double.isNaN(stats.getStdDeviationBound(Bounds.UPPER_SAMPLING)), is(true));
+                assertThat(Double.isNaN(stats.getStdDeviationBound(Bounds.LOWER_SAMPLING)), is(true));
+            }
+        );
     }
 
     @Override
     public void testUnmapped() throws Exception {
-        SearchResponse searchResponse = prepareSearch("idx_unmapped").setQuery(matchAllQuery())
-            .addAggregation(extendedStats("stats").field("value"))
-            .get();
+        assertResponse(
+            prepareSearch("idx_unmapped").setQuery(matchAllQuery()).addAggregation(extendedStats("stats").field("value")),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(0L));
 
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(0L));
-
-        ExtendedStats stats = searchResponse.getAggregations().get("stats");
-        assertThat(stats, notNullValue());
-        assertThat(stats.getName(), equalTo("stats"));
-        assertThat(stats.getAvg(), equalTo(Double.NaN));
-        assertThat(stats.getMin(), equalTo(Double.POSITIVE_INFINITY));
-        assertThat(stats.getMax(), equalTo(Double.NEGATIVE_INFINITY));
-        assertThat(stats.getSum(), equalTo(0.0));
-        assertThat(stats.getCount(), equalTo(0L));
-        assertThat(stats.getSumOfSquares(), equalTo(0.0));
-        assertThat(stats.getVariance(), equalTo(Double.NaN));
-        assertThat(stats.getVariancePopulation(), equalTo(Double.NaN));
-        assertThat(stats.getVarianceSampling(), equalTo(Double.NaN));
-        assertThat(stats.getStdDeviation(), equalTo(Double.NaN));
-        assertThat(stats.getStdDeviationPopulation(), equalTo(Double.NaN));
-        assertThat(stats.getStdDeviationSampling(), equalTo(Double.NaN));
-        assertThat(Double.isNaN(stats.getStdDeviationBound(Bounds.UPPER)), is(true));
-        assertThat(Double.isNaN(stats.getStdDeviationBound(Bounds.LOWER)), is(true));
-        assertThat(Double.isNaN(stats.getStdDeviationBound(Bounds.UPPER_POPULATION)), is(true));
-        assertThat(Double.isNaN(stats.getStdDeviationBound(Bounds.LOWER_POPULATION)), is(true));
-        assertThat(Double.isNaN(stats.getStdDeviationBound(Bounds.UPPER_SAMPLING)), is(true));
-        assertThat(Double.isNaN(stats.getStdDeviationBound(Bounds.LOWER_SAMPLING)), is(true));
+                ExtendedStats stats = response.getAggregations().get("stats");
+                assertThat(stats, notNullValue());
+                assertThat(stats.getName(), equalTo("stats"));
+                assertThat(stats.getAvg(), equalTo(Double.NaN));
+                assertThat(stats.getMin(), equalTo(Double.POSITIVE_INFINITY));
+                assertThat(stats.getMax(), equalTo(Double.NEGATIVE_INFINITY));
+                assertThat(stats.getSum(), equalTo(0.0));
+                assertThat(stats.getCount(), equalTo(0L));
+                assertThat(stats.getSumOfSquares(), equalTo(0.0));
+                assertThat(stats.getVariance(), equalTo(Double.NaN));
+                assertThat(stats.getVariancePopulation(), equalTo(Double.NaN));
+                assertThat(stats.getVarianceSampling(), equalTo(Double.NaN));
+                assertThat(stats.getStdDeviation(), equalTo(Double.NaN));
+                assertThat(stats.getStdDeviationPopulation(), equalTo(Double.NaN));
+                assertThat(stats.getStdDeviationSampling(), equalTo(Double.NaN));
+                assertThat(Double.isNaN(stats.getStdDeviationBound(Bounds.UPPER)), is(true));
+                assertThat(Double.isNaN(stats.getStdDeviationBound(Bounds.LOWER)), is(true));
+                assertThat(Double.isNaN(stats.getStdDeviationBound(Bounds.UPPER_POPULATION)), is(true));
+                assertThat(Double.isNaN(stats.getStdDeviationBound(Bounds.LOWER_POPULATION)), is(true));
+                assertThat(Double.isNaN(stats.getStdDeviationBound(Bounds.UPPER_SAMPLING)), is(true));
+                assertThat(Double.isNaN(stats.getStdDeviationBound(Bounds.LOWER_SAMPLING)), is(true));
+            }
+        );
     }
 
     public void testPartiallyUnmapped() {
         double sigma = randomDouble() * 5;
-        ExtendedStats s1 = prepareSearch("idx").addAggregation(extendedStats("stats").field("value").sigma(sigma))
-            .get()
-            .getAggregations()
-            .get("stats");
-        ExtendedStats s2 = prepareSearch("idx", "idx_unmapped").addAggregation(extendedStats("stats").field("value").sigma(sigma))
-            .get()
-            .getAggregations()
-            .get("stats");
-        assertEquals(s1.getAvg(), s2.getAvg(), 1e-10);
-        assertEquals(s1.getCount(), s2.getCount());
-        assertEquals(s1.getMin(), s2.getMin(), 0d);
-        assertEquals(s1.getMax(), s2.getMax(), 0d);
-        assertEquals(s1.getStdDeviation(), s2.getStdDeviation(), 1e-10);
-        assertEquals(s1.getStdDeviationPopulation(), s2.getStdDeviationPopulation(), 1e-10);
-        assertEquals(s1.getStdDeviationSampling(), s2.getStdDeviationSampling(), 1e-10);
-        assertEquals(s1.getSumOfSquares(), s2.getSumOfSquares(), 1e-10);
-        assertEquals(s1.getStdDeviationBound(Bounds.LOWER), s2.getStdDeviationBound(Bounds.LOWER), 1e-10);
-        assertEquals(s1.getStdDeviationBound(Bounds.UPPER), s2.getStdDeviationBound(Bounds.UPPER), 1e-10);
-        assertEquals(s1.getStdDeviationBound(Bounds.LOWER_POPULATION), s2.getStdDeviationBound(Bounds.LOWER_POPULATION), 1e-10);
-        assertEquals(s1.getStdDeviationBound(Bounds.UPPER_POPULATION), s2.getStdDeviationBound(Bounds.UPPER_POPULATION), 1e-10);
-        assertEquals(s1.getStdDeviationBound(Bounds.LOWER_SAMPLING), s2.getStdDeviationBound(Bounds.LOWER_SAMPLING), 1e-10);
-        assertEquals(s1.getStdDeviationBound(Bounds.UPPER_SAMPLING), s2.getStdDeviationBound(Bounds.UPPER_SAMPLING), 1e-10);
+        assertResponse(prepareSearch("idx").addAggregation(extendedStats("stats").field("value").sigma(sigma)), response1 -> {
+            ExtendedStats s1 = response1.getAggregations().get("stats");
+            assertResponse(
+                prepareSearch("idx", "idx_unmapped").addAggregation(extendedStats("stats").field("value").sigma(sigma)),
+                response2 -> {
+                    ExtendedStats s2 = response2.getAggregations().get("stats");
+                    assertEquals(s1.getAvg(), s2.getAvg(), 1e-10);
+                    assertEquals(s1.getCount(), s2.getCount());
+                    assertEquals(s1.getMin(), s2.getMin(), 0d);
+                    assertEquals(s1.getMax(), s2.getMax(), 0d);
+                    assertEquals(s1.getStdDeviation(), s2.getStdDeviation(), 1e-10);
+                    assertEquals(s1.getStdDeviationPopulation(), s2.getStdDeviationPopulation(), 1e-10);
+                    assertEquals(s1.getStdDeviationSampling(), s2.getStdDeviationSampling(), 1e-10);
+                    assertEquals(s1.getSumOfSquares(), s2.getSumOfSquares(), 1e-10);
+                    assertEquals(s1.getStdDeviationBound(Bounds.LOWER), s2.getStdDeviationBound(Bounds.LOWER), 1e-10);
+                    assertEquals(s1.getStdDeviationBound(Bounds.UPPER), s2.getStdDeviationBound(Bounds.UPPER), 1e-10);
+                    assertEquals(s1.getStdDeviationBound(Bounds.LOWER_POPULATION), s2.getStdDeviationBound(Bounds.LOWER_POPULATION), 1e-10);
+                    assertEquals(s1.getStdDeviationBound(Bounds.UPPER_POPULATION), s2.getStdDeviationBound(Bounds.UPPER_POPULATION), 1e-10);
+                    assertEquals(s1.getStdDeviationBound(Bounds.LOWER_SAMPLING), s2.getStdDeviationBound(Bounds.LOWER_SAMPLING), 1e-10);
+                    assertEquals(s1.getStdDeviationBound(Bounds.UPPER_SAMPLING), s2.getStdDeviationBound(Bounds.UPPER_SAMPLING), 1e-10);
+                }
+            );
+        });
     }
 
     @Override
     public void testSingleValuedField() throws Exception {
         double sigma = randomDouble() * randomIntBetween(1, 10);
-        SearchResponse searchResponse = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(extendedStats("stats").field("value").sigma(sigma))
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery()).addAggregation(extendedStats("stats").field("value").sigma(sigma)),
+            response -> {
+                assertHitCount(response, 10);
 
-        assertHitCount(searchResponse, 10);
-
-        ExtendedStats stats = searchResponse.getAggregations().get("stats");
-        assertThat(stats, notNullValue());
-        assertThat(stats.getName(), equalTo("stats"));
-        assertThat(stats.getAvg(), equalTo((double) (1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10) / 10));
-        assertThat(stats.getMin(), equalTo(1.0));
-        assertThat(stats.getMax(), equalTo(10.0));
-        assertThat(stats.getSum(), equalTo((double) 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10));
-        assertThat(stats.getCount(), equalTo(10L));
-        assertThat(stats.getSumOfSquares(), equalTo((double) 1 + 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100));
-        assertThat(stats.getVariance(), equalTo(variance(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
-        assertThat(stats.getVariancePopulation(), equalTo(variancePopulation(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
-        assertThat(stats.getVarianceSampling(), equalTo(varianceSampling(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
-        assertThat(stats.getStdDeviation(), equalTo(stdDev(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
-        assertThat(stats.getStdDeviationPopulation(), equalTo(stdDevPopulation(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
-        assertThat(stats.getStdDeviationSampling(), equalTo(stdDevSampling(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
-        checkUpperLowerBounds(stats, sigma);
+                ExtendedStats stats = response.getAggregations().get("stats");
+                assertThat(stats, notNullValue());
+                assertThat(stats.getName(), equalTo("stats"));
+                assertThat(stats.getAvg(), equalTo((double) (1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10) / 10));
+                assertThat(stats.getMin(), equalTo(1.0));
+                assertThat(stats.getMax(), equalTo(10.0));
+                assertThat(stats.getSum(), equalTo((double) 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10));
+                assertThat(stats.getCount(), equalTo(10L));
+                assertThat(stats.getSumOfSquares(), equalTo((double) 1 + 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100));
+                assertThat(stats.getVariance(), equalTo(variance(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
+                assertThat(stats.getVariancePopulation(), equalTo(variancePopulation(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
+                assertThat(stats.getVarianceSampling(), equalTo(varianceSampling(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
+                assertThat(stats.getStdDeviation(), equalTo(stdDev(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
+                assertThat(stats.getStdDeviationPopulation(), equalTo(stdDevPopulation(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
+                assertThat(stats.getStdDeviationSampling(), equalTo(stdDevSampling(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
+                checkUpperLowerBounds(stats, sigma);
+            }
+        );
     }
 
     public void testSingleValuedFieldDefaultSigma() throws Exception {
         // Same as previous test, but uses a default value for sigma
 
-        SearchResponse searchResponse = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(extendedStats("stats").field("value"))
-            .get();
+        assertResponse(prepareSearch("idx").setQuery(matchAllQuery()).addAggregation(extendedStats("stats").field("value")), response -> {
 
-        assertHitCount(searchResponse, 10);
+            assertHitCount(response, 10);
 
-        ExtendedStats stats = searchResponse.getAggregations().get("stats");
-        assertThat(stats, notNullValue());
-        assertThat(stats.getName(), equalTo("stats"));
-        assertThat(stats.getAvg(), equalTo((double) (1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10) / 10));
-        assertThat(stats.getMin(), equalTo(1.0));
-        assertThat(stats.getMax(), equalTo(10.0));
-        assertThat(stats.getSum(), equalTo((double) 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10));
-        assertThat(stats.getCount(), equalTo(10L));
-        assertThat(stats.getSumOfSquares(), equalTo((double) 1 + 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100));
-        assertThat(stats.getVariance(), equalTo(variance(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
-        assertThat(stats.getVariancePopulation(), equalTo(variancePopulation(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
-        assertThat(stats.getVarianceSampling(), equalTo(varianceSampling(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
-        assertThat(stats.getStdDeviation(), equalTo(stdDev(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
-        assertThat(stats.getStdDeviationPopulation(), equalTo(stdDevPopulation(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
-        assertThat(stats.getStdDeviationSampling(), equalTo(stdDevSampling(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
-        checkUpperLowerBounds(stats, 2);
+            ExtendedStats stats = response.getAggregations().get("stats");
+            assertThat(stats, notNullValue());
+            assertThat(stats.getName(), equalTo("stats"));
+            assertThat(stats.getAvg(), equalTo((double) (1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10) / 10));
+            assertThat(stats.getMin(), equalTo(1.0));
+            assertThat(stats.getMax(), equalTo(10.0));
+            assertThat(stats.getSum(), equalTo((double) 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10));
+            assertThat(stats.getCount(), equalTo(10L));
+            assertThat(stats.getSumOfSquares(), equalTo((double) 1 + 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100));
+            assertThat(stats.getVariance(), equalTo(variance(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
+            assertThat(stats.getVariancePopulation(), equalTo(variancePopulation(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
+            assertThat(stats.getVarianceSampling(), equalTo(varianceSampling(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
+            assertThat(stats.getStdDeviation(), equalTo(stdDev(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
+            assertThat(stats.getStdDeviationPopulation(), equalTo(stdDevPopulation(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
+            assertThat(stats.getStdDeviationSampling(), equalTo(stdDevSampling(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
+            checkUpperLowerBounds(stats, 2);
+        });
     }
 
     public void testSingleValuedField_WithFormatter() throws Exception {
         double sigma = randomDouble() * randomIntBetween(1, 10);
-        SearchResponse searchResponse = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(extendedStats("stats").format("0000.0").field("value").sigma(sigma))
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(extendedStats("stats").format("0000.0").field("value").sigma(sigma)),
+            response -> {
+                assertHitCount(response, 10);
 
-        assertHitCount(searchResponse, 10);
-
-        ExtendedStats stats = searchResponse.getAggregations().get("stats");
-        assertThat(stats, notNullValue());
-        assertThat(stats.getName(), equalTo("stats"));
-        assertThat(stats.getAvg(), equalTo((double) (1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10) / 10));
-        assertThat(stats.getAvgAsString(), equalTo("0005.5"));
-        assertThat(stats.getMin(), equalTo(1.0));
-        assertThat(stats.getMinAsString(), equalTo("0001.0"));
-        assertThat(stats.getMax(), equalTo(10.0));
-        assertThat(stats.getMaxAsString(), equalTo("0010.0"));
-        assertThat(stats.getSum(), equalTo((double) 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10));
-        assertThat(stats.getSumAsString(), equalTo("0055.0"));
-        assertThat(stats.getCount(), equalTo(10L));
-        assertThat(stats.getSumOfSquares(), equalTo((double) 1 + 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100));
-        assertThat(stats.getSumOfSquaresAsString(), equalTo("0385.0"));
-        assertThat(stats.getVariance(), equalTo(variance(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
-        assertThat(stats.getVariancePopulation(), equalTo(variancePopulation(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
-        assertThat(stats.getVarianceSampling(), equalTo(varianceSampling(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
-        assertThat(stats.getVarianceAsString(), equalTo("0008.2"));
-        assertThat(stats.getVariancePopulationAsString(), equalTo("0008.2"));
-        assertThat(stats.getVarianceSamplingAsString(), equalTo("0009.2"));
-        assertThat(stats.getStdDeviation(), equalTo(stdDev(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
-        assertThat(stats.getStdDeviationPopulation(), equalTo(stdDevPopulation(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
-        assertThat(stats.getStdDeviationSampling(), equalTo(stdDevSampling(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
-        assertThat(stats.getStdDeviationAsString(), equalTo("0002.9"));
-        assertThat(stats.getStdDeviationPopulationAsString(), equalTo("0002.9"));
-        assertThat(stats.getStdDeviationSamplingAsString(), equalTo("0003.0"));
-        checkUpperLowerBounds(stats, sigma);
+                ExtendedStats stats = response.getAggregations().get("stats");
+                assertThat(stats, notNullValue());
+                assertThat(stats.getName(), equalTo("stats"));
+                assertThat(stats.getAvg(), equalTo((double) (1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10) / 10));
+                assertThat(stats.getAvgAsString(), equalTo("0005.5"));
+                assertThat(stats.getMin(), equalTo(1.0));
+                assertThat(stats.getMinAsString(), equalTo("0001.0"));
+                assertThat(stats.getMax(), equalTo(10.0));
+                assertThat(stats.getMaxAsString(), equalTo("0010.0"));
+                assertThat(stats.getSum(), equalTo((double) 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10));
+                assertThat(stats.getSumAsString(), equalTo("0055.0"));
+                assertThat(stats.getCount(), equalTo(10L));
+                assertThat(stats.getSumOfSquares(), equalTo((double) 1 + 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100));
+                assertThat(stats.getSumOfSquaresAsString(), equalTo("0385.0"));
+                assertThat(stats.getVariance(), equalTo(variance(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
+                assertThat(stats.getVariancePopulation(), equalTo(variancePopulation(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
+                assertThat(stats.getVarianceSampling(), equalTo(varianceSampling(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
+                assertThat(stats.getVarianceAsString(), equalTo("0008.2"));
+                assertThat(stats.getVariancePopulationAsString(), equalTo("0008.2"));
+                assertThat(stats.getVarianceSamplingAsString(), equalTo("0009.2"));
+                assertThat(stats.getStdDeviation(), equalTo(stdDev(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
+                assertThat(stats.getStdDeviationPopulation(), equalTo(stdDevPopulation(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
+                assertThat(stats.getStdDeviationSampling(), equalTo(stdDevSampling(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
+                assertThat(stats.getStdDeviationAsString(), equalTo("0002.9"));
+                assertThat(stats.getStdDeviationPopulationAsString(), equalTo("0002.9"));
+                assertThat(stats.getStdDeviationSamplingAsString(), equalTo("0003.0"));
+                checkUpperLowerBounds(stats, sigma);
+            }
+        );
     }
 
     @Override
     public void testSingleValuedFieldGetProperty() throws Exception {
-        SearchResponse searchResponse = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(global("global").subAggregation(extendedStats("stats").field("value")))
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(global("global").subAggregation(extendedStats("stats").field("value"))),
+            response -> {
+                assertHitCount(response, 10);
 
-        assertHitCount(searchResponse, 10);
+                Global global = response.getAggregations().get("global");
+                assertThat(global, notNullValue());
+                assertThat(global.getName(), equalTo("global"));
+                assertThat(global.getDocCount(), equalTo(10L));
+                assertThat(global.getAggregations(), notNullValue());
+                assertThat(global.getAggregations().asMap().size(), equalTo(1));
 
-        Global global = searchResponse.getAggregations().get("global");
-        assertThat(global, notNullValue());
-        assertThat(global.getName(), equalTo("global"));
-        assertThat(global.getDocCount(), equalTo(10L));
-        assertThat(global.getAggregations(), notNullValue());
-        assertThat(global.getAggregations().asMap().size(), equalTo(1));
-
-        ExtendedStats stats = global.getAggregations().get("stats");
-        assertThat(stats, notNullValue());
-        assertThat(stats.getName(), equalTo("stats"));
-        ExtendedStats statsFromProperty = (ExtendedStats) ((InternalAggregation) global).getProperty("stats");
-        assertThat(statsFromProperty, notNullValue());
-        assertThat(statsFromProperty, sameInstance(stats));
-        double expectedAvgValue = (double) (1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10) / 10;
-        assertThat(stats.getAvg(), equalTo(expectedAvgValue));
-        assertThat((double) ((InternalAggregation) global).getProperty("stats.avg"), equalTo(expectedAvgValue));
-        double expectedMinValue = 1.0;
-        assertThat(stats.getMin(), equalTo(expectedMinValue));
-        assertThat((double) ((InternalAggregation) global).getProperty("stats.min"), equalTo(expectedMinValue));
-        double expectedMaxValue = 10.0;
-        assertThat(stats.getMax(), equalTo(expectedMaxValue));
-        assertThat((double) ((InternalAggregation) global).getProperty("stats.max"), equalTo(expectedMaxValue));
-        double expectedSumValue = 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10;
-        assertThat(stats.getSum(), equalTo(expectedSumValue));
-        assertThat((double) ((InternalAggregation) global).getProperty("stats.sum"), equalTo(expectedSumValue));
-        long expectedCountValue = 10;
-        assertThat(stats.getCount(), equalTo(expectedCountValue));
-        assertThat((double) ((InternalAggregation) global).getProperty("stats.count"), equalTo((double) expectedCountValue));
-        double expectedSumOfSquaresValue = (double) 1 + 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100;
-        assertThat(stats.getSumOfSquares(), equalTo(expectedSumOfSquaresValue));
-        assertThat((double) ((InternalAggregation) global).getProperty("stats.sum_of_squares"), equalTo(expectedSumOfSquaresValue));
-        double expectedVarianceValue = variance(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-        assertThat(stats.getVariance(), equalTo(expectedVarianceValue));
-        assertThat((double) ((InternalAggregation) global).getProperty("stats.variance"), equalTo(expectedVarianceValue));
-        double expectedVariancePopulationValue = variancePopulation(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-        assertThat(stats.getVariancePopulation(), equalTo(expectedVariancePopulationValue));
-        assertThat(
-            (double) ((InternalAggregation) global).getProperty("stats.variance_population"),
-            equalTo(expectedVariancePopulationValue)
-        );
-        double expectedVarianceSamplingValue = varianceSampling(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-        assertThat(stats.getVarianceSampling(), equalTo(expectedVarianceSamplingValue));
-        assertThat((double) ((InternalAggregation) global).getProperty("stats.variance_sampling"), equalTo(expectedVarianceSamplingValue));
-        double expectedStdDevValue = stdDev(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-        assertThat(stats.getStdDeviation(), equalTo(expectedStdDevValue));
-        assertThat((double) ((InternalAggregation) global).getProperty("stats.std_deviation"), equalTo(expectedStdDevValue));
-        double expectedStdDevPopulationValue = stdDevPopulation(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-        assertThat(stats.getStdDeviationPopulation(), equalTo(expectedStdDevValue));
-        assertThat(
-            (double) ((InternalAggregation) global).getProperty("stats.std_deviation_population"),
-            equalTo(expectedStdDevPopulationValue)
-        );
-        double expectedStdDevSamplingValue = stdDevSampling(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-        assertThat(stats.getStdDeviationSampling(), equalTo(expectedStdDevSamplingValue));
-        assertThat(
-            (double) ((InternalAggregation) global).getProperty("stats.std_deviation_sampling"),
-            equalTo(expectedStdDevSamplingValue)
+                ExtendedStats stats = global.getAggregations().get("stats");
+                assertThat(stats, notNullValue());
+                assertThat(stats.getName(), equalTo("stats"));
+                ExtendedStats statsFromProperty = (ExtendedStats) ((InternalAggregation) global).getProperty("stats");
+                assertThat(statsFromProperty, notNullValue());
+                assertThat(statsFromProperty, sameInstance(stats));
+                double expectedAvgValue = (double) (1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10) / 10;
+                assertThat(stats.getAvg(), equalTo(expectedAvgValue));
+                assertThat((double) ((InternalAggregation) global).getProperty("stats.avg"), equalTo(expectedAvgValue));
+                double expectedMinValue = 1.0;
+                assertThat(stats.getMin(), equalTo(expectedMinValue));
+                assertThat((double) ((InternalAggregation) global).getProperty("stats.min"), equalTo(expectedMinValue));
+                double expectedMaxValue = 10.0;
+                assertThat(stats.getMax(), equalTo(expectedMaxValue));
+                assertThat((double) ((InternalAggregation) global).getProperty("stats.max"), equalTo(expectedMaxValue));
+                double expectedSumValue = 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10;
+                assertThat(stats.getSum(), equalTo(expectedSumValue));
+                assertThat((double) ((InternalAggregation) global).getProperty("stats.sum"), equalTo(expectedSumValue));
+                long expectedCountValue = 10;
+                assertThat(stats.getCount(), equalTo(expectedCountValue));
+                assertThat((double) ((InternalAggregation) global).getProperty("stats.count"), equalTo((double) expectedCountValue));
+                double expectedSumOfSquaresValue = (double) 1 + 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100;
+                assertThat(stats.getSumOfSquares(), equalTo(expectedSumOfSquaresValue));
+                assertThat((double) ((InternalAggregation) global).getProperty("stats.sum_of_squares"), equalTo(expectedSumOfSquaresValue));
+                double expectedVarianceValue = variance(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+                assertThat(stats.getVariance(), equalTo(expectedVarianceValue));
+                assertThat((double) ((InternalAggregation) global).getProperty("stats.variance"), equalTo(expectedVarianceValue));
+                double expectedVariancePopulationValue = variancePopulation(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+                assertThat(stats.getVariancePopulation(), equalTo(expectedVariancePopulationValue));
+                assertThat(
+                    (double) ((InternalAggregation) global).getProperty("stats.variance_population"),
+                    equalTo(expectedVariancePopulationValue)
+                );
+                double expectedVarianceSamplingValue = varianceSampling(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+                assertThat(stats.getVarianceSampling(), equalTo(expectedVarianceSamplingValue));
+                assertThat(
+                    (double) ((InternalAggregation) global).getProperty("stats.variance_sampling"),
+                    equalTo(expectedVarianceSamplingValue)
+                );
+                double expectedStdDevValue = stdDev(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+                assertThat(stats.getStdDeviation(), equalTo(expectedStdDevValue));
+                assertThat((double) ((InternalAggregation) global).getProperty("stats.std_deviation"), equalTo(expectedStdDevValue));
+                double expectedStdDevPopulationValue = stdDevPopulation(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+                assertThat(stats.getStdDeviationPopulation(), equalTo(expectedStdDevValue));
+                assertThat(
+                    (double) ((InternalAggregation) global).getProperty("stats.std_deviation_population"),
+                    equalTo(expectedStdDevPopulationValue)
+                );
+                double expectedStdDevSamplingValue = stdDevSampling(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+                assertThat(stats.getStdDeviationSampling(), equalTo(expectedStdDevSamplingValue));
+                assertThat(
+                    (double) ((InternalAggregation) global).getProperty("stats.std_deviation_sampling"),
+                    equalTo(expectedStdDevSamplingValue)
+                );
+            }
         );
     }
 
     @Override
     public void testSingleValuedFieldPartiallyUnmapped() throws Exception {
         double sigma = randomDouble() * randomIntBetween(1, 10);
-        SearchResponse searchResponse = prepareSearch("idx", "idx_unmapped").setQuery(matchAllQuery())
-            .addAggregation(extendedStats("stats").field("value").sigma(sigma))
-            .get();
+        assertResponse(
+            prepareSearch("idx", "idx_unmapped").setQuery(matchAllQuery())
+                .addAggregation(extendedStats("stats").field("value").sigma(sigma)),
+            response -> {
+                assertHitCount(response, 10);
 
-        assertHitCount(searchResponse, 10);
-
-        ExtendedStats stats = searchResponse.getAggregations().get("stats");
-        assertThat(stats, notNullValue());
-        assertThat(stats.getName(), equalTo("stats"));
-        assertThat(stats.getAvg(), equalTo((double) (1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10) / 10));
-        assertThat(stats.getMin(), equalTo(1.0));
-        assertThat(stats.getMax(), equalTo(10.0));
-        assertThat(stats.getSum(), equalTo((double) 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10));
-        assertThat(stats.getCount(), equalTo(10L));
-        assertThat(stats.getSumOfSquares(), equalTo((double) 1 + 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100));
-        assertThat(stats.getVariance(), equalTo(variance(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
-        assertThat(stats.getVariancePopulation(), equalTo(variancePopulation(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
-        assertThat(stats.getVarianceSampling(), equalTo(varianceSampling(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
-        assertThat(stats.getStdDeviation(), equalTo(stdDev(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
-        assertThat(stats.getStdDeviationPopulation(), equalTo(stdDevPopulation(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
-        assertThat(stats.getStdDeviationSampling(), equalTo(stdDevSampling(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
-        checkUpperLowerBounds(stats, sigma);
+                ExtendedStats stats = response.getAggregations().get("stats");
+                assertThat(stats, notNullValue());
+                assertThat(stats.getName(), equalTo("stats"));
+                assertThat(stats.getAvg(), equalTo((double) (1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10) / 10));
+                assertThat(stats.getMin(), equalTo(1.0));
+                assertThat(stats.getMax(), equalTo(10.0));
+                assertThat(stats.getSum(), equalTo((double) 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10));
+                assertThat(stats.getCount(), equalTo(10L));
+                assertThat(stats.getSumOfSquares(), equalTo((double) 1 + 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100));
+                assertThat(stats.getVariance(), equalTo(variance(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
+                assertThat(stats.getVariancePopulation(), equalTo(variancePopulation(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
+                assertThat(stats.getVarianceSampling(), equalTo(varianceSampling(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
+                assertThat(stats.getStdDeviation(), equalTo(stdDev(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
+                assertThat(stats.getStdDeviationPopulation(), equalTo(stdDevPopulation(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
+                assertThat(stats.getStdDeviationSampling(), equalTo(stdDevSampling(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
+                checkUpperLowerBounds(stats, sigma);
+            }
+        );
     }
 
     @Override
     public void testSingleValuedFieldWithValueScript() throws Exception {
         double sigma = randomDouble() * randomIntBetween(1, 10);
-        SearchResponse searchResponse = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                extendedStats("stats").field("value")
-                    .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value + 1", Collections.emptyMap()))
-                    .sigma(sigma)
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    extendedStats("stats").field("value")
+                        .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value + 1", Collections.emptyMap()))
+                        .sigma(sigma)
+                ),
+            response -> {
+                assertHitCount(response, 10);
 
-        assertHitCount(searchResponse, 10);
-
-        ExtendedStats stats = searchResponse.getAggregations().get("stats");
-        assertThat(stats, notNullValue());
-        assertThat(stats.getName(), equalTo("stats"));
-        assertThat(stats.getAvg(), equalTo((double) (2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11) / 10));
-        assertThat(stats.getMin(), equalTo(2.0));
-        assertThat(stats.getMax(), equalTo(11.0));
-        assertThat(stats.getSum(), equalTo((double) 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11));
-        assertThat(stats.getCount(), equalTo(10L));
-        assertThat(stats.getSumOfSquares(), equalTo((double) 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100 + 121));
-        assertThat(stats.getVariance(), equalTo(variance(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
-        assertThat(stats.getVariancePopulation(), equalTo(variancePopulation(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
-        assertThat(stats.getVarianceSampling(), equalTo(varianceSampling(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
-        assertThat(stats.getStdDeviation(), equalTo(stdDev(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
-        assertThat(stats.getStdDeviationPopulation(), equalTo(stdDevPopulation(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
-        assertThat(stats.getStdDeviationSampling(), equalTo(stdDevSampling(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
-        checkUpperLowerBounds(stats, sigma);
+                ExtendedStats stats = response.getAggregations().get("stats");
+                assertThat(stats, notNullValue());
+                assertThat(stats.getName(), equalTo("stats"));
+                assertThat(stats.getAvg(), equalTo((double) (2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11) / 10));
+                assertThat(stats.getMin(), equalTo(2.0));
+                assertThat(stats.getMax(), equalTo(11.0));
+                assertThat(stats.getSum(), equalTo((double) 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11));
+                assertThat(stats.getCount(), equalTo(10L));
+                assertThat(stats.getSumOfSquares(), equalTo((double) 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100 + 121));
+                assertThat(stats.getVariance(), equalTo(variance(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
+                assertThat(stats.getVariancePopulation(), equalTo(variancePopulation(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
+                assertThat(stats.getVarianceSampling(), equalTo(varianceSampling(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
+                assertThat(stats.getStdDeviation(), equalTo(stdDev(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
+                assertThat(stats.getStdDeviationPopulation(), equalTo(stdDevPopulation(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
+                assertThat(stats.getStdDeviationSampling(), equalTo(stdDevSampling(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
+                checkUpperLowerBounds(stats, sigma);
+            }
+        );
     }
 
     @Override
@@ -402,118 +417,139 @@ public class ExtendedStatsIT extends AbstractNumericTestCase {
         Map<String, Object> params = new HashMap<>();
         params.put("inc", 1);
         double sigma = randomDouble() * randomIntBetween(1, 10);
-        SearchResponse searchResponse = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                extendedStats("stats").field("value")
-                    .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value + inc", params))
-                    .sigma(sigma)
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    extendedStats("stats").field("value")
+                        .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value + inc", params))
+                        .sigma(sigma)
+                ),
+            response -> {
+                assertHitCount(response, 10);
 
-        assertHitCount(searchResponse, 10);
-
-        ExtendedStats stats = searchResponse.getAggregations().get("stats");
-        assertThat(stats, notNullValue());
-        assertThat(stats.getName(), equalTo("stats"));
-        assertThat(stats.getAvg(), equalTo((double) (2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11) / 10));
-        assertThat(stats.getMin(), equalTo(2.0));
-        assertThat(stats.getMax(), equalTo(11.0));
-        assertThat(stats.getSum(), equalTo((double) 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11));
-        assertThat(stats.getCount(), equalTo(10L));
-        assertThat(stats.getSumOfSquares(), equalTo((double) 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100 + 121));
-        assertThat(stats.getVariance(), equalTo(variance(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
-        assertThat(stats.getVariancePopulation(), equalTo(variancePopulation(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
-        assertThat(stats.getVarianceSampling(), equalTo(varianceSampling(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
-        assertThat(stats.getStdDeviation(), equalTo(stdDev(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
-        assertThat(stats.getStdDeviationPopulation(), equalTo(stdDevPopulation(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
-        assertThat(stats.getStdDeviationSampling(), equalTo(stdDevSampling(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
-        checkUpperLowerBounds(stats, sigma);
+                ExtendedStats stats = response.getAggregations().get("stats");
+                assertThat(stats, notNullValue());
+                assertThat(stats.getName(), equalTo("stats"));
+                assertThat(stats.getAvg(), equalTo((double) (2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11) / 10));
+                assertThat(stats.getMin(), equalTo(2.0));
+                assertThat(stats.getMax(), equalTo(11.0));
+                assertThat(stats.getSum(), equalTo((double) 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11));
+                assertThat(stats.getCount(), equalTo(10L));
+                assertThat(stats.getSumOfSquares(), equalTo((double) 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100 + 121));
+                assertThat(stats.getVariance(), equalTo(variance(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
+                assertThat(stats.getVariancePopulation(), equalTo(variancePopulation(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
+                assertThat(stats.getVarianceSampling(), equalTo(varianceSampling(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
+                assertThat(stats.getStdDeviation(), equalTo(stdDev(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
+                assertThat(stats.getStdDeviationPopulation(), equalTo(stdDevPopulation(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
+                assertThat(stats.getStdDeviationSampling(), equalTo(stdDevSampling(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
+                checkUpperLowerBounds(stats, sigma);
+            }
+        );
     }
 
     @Override
     public void testMultiValuedField() throws Exception {
         double sigma = randomDouble() * randomIntBetween(1, 10);
-        SearchResponse searchResponse = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(extendedStats("stats").field("values").sigma(sigma))
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery()).addAggregation(extendedStats("stats").field("values").sigma(sigma)),
+            response -> {
 
-        assertHitCount(searchResponse, 10);
+                assertHitCount(response, 10);
 
-        ExtendedStats stats = searchResponse.getAggregations().get("stats");
-        assertThat(stats, notNullValue());
-        assertThat(stats.getName(), equalTo("stats"));
-        assertThat(
-            stats.getAvg(),
-            equalTo((double) (2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12) / 20)
+                ExtendedStats stats = response.getAggregations().get("stats");
+                assertThat(stats, notNullValue());
+                assertThat(stats.getName(), equalTo("stats"));
+                assertThat(
+                    stats.getAvg(),
+                    equalTo((double) (2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12) / 20)
+                );
+                assertThat(stats.getMin(), equalTo(2.0));
+                assertThat(stats.getMax(), equalTo(12.0));
+                assertThat(
+                    stats.getSum(),
+                    equalTo((double) 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12)
+                );
+                assertThat(stats.getCount(), equalTo(20L));
+                assertThat(
+                    stats.getSumOfSquares(),
+                    equalTo((double) 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100 + 121 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100 + 121 + 144)
+                );
+                assertThat(stats.getVariance(), equalTo(variance(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)));
+                assertThat(
+                    stats.getVariancePopulation(),
+                    equalTo(variancePopulation(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12))
+                );
+                assertThat(
+                    stats.getVarianceSampling(),
+                    equalTo(varianceSampling(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12))
+                );
+                assertThat(stats.getStdDeviation(), equalTo(stdDev(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)));
+                assertThat(
+                    stats.getStdDeviationPopulation(),
+                    equalTo(stdDevPopulation(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12))
+                );
+                assertThat(
+                    stats.getStdDeviationSampling(),
+                    equalTo(stdDevSampling(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12))
+                );
+                checkUpperLowerBounds(stats, sigma);
+            }
         );
-        assertThat(stats.getMin(), equalTo(2.0));
-        assertThat(stats.getMax(), equalTo(12.0));
-        assertThat(stats.getSum(), equalTo((double) 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12));
-        assertThat(stats.getCount(), equalTo(20L));
-        assertThat(
-            stats.getSumOfSquares(),
-            equalTo((double) 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100 + 121 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100 + 121 + 144)
-        );
-        assertThat(stats.getVariance(), equalTo(variance(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)));
-        assertThat(
-            stats.getVariancePopulation(),
-            equalTo(variancePopulation(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12))
-        );
-        assertThat(stats.getVarianceSampling(), equalTo(varianceSampling(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)));
-        assertThat(stats.getStdDeviation(), equalTo(stdDev(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)));
-        assertThat(
-            stats.getStdDeviationPopulation(),
-            equalTo(stdDevPopulation(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12))
-        );
-        assertThat(
-            stats.getStdDeviationSampling(),
-            equalTo(stdDevSampling(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12))
-        );
-        checkUpperLowerBounds(stats, sigma);
     }
 
     @Override
     public void testMultiValuedFieldWithValueScript() throws Exception {
         double sigma = randomDouble() * randomIntBetween(1, 10);
-        SearchResponse searchResponse = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                extendedStats("stats").field("values")
-                    .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value - 1", Collections.emptyMap()))
-                    .sigma(sigma)
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    extendedStats("stats").field("values")
+                        .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value - 1", Collections.emptyMap()))
+                        .sigma(sigma)
+                ),
+            response -> {
+                assertHitCount(response, 10);
 
-        assertHitCount(searchResponse, 10);
+                ExtendedStats stats = response.getAggregations().get("stats");
+                assertThat(stats, notNullValue());
+                assertThat(stats.getName(), equalTo("stats"));
+                assertThat(
+                    stats.getAvg(),
+                    equalTo((double) (1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11) / 20)
+                );
+                assertThat(stats.getMin(), equalTo(1.0));
+                assertThat(stats.getMax(), equalTo(11.0));
+                assertThat(
+                    stats.getSum(),
+                    equalTo((double) 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11)
+                );
+                assertThat(stats.getCount(), equalTo(20L));
+                assertThat(
+                    stats.getSumOfSquares(),
+                    equalTo((double) 1 + 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100 + 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100 + 121)
+                );
+                assertThat(stats.getVariance(), equalTo(variance(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
+                assertThat(
+                    stats.getVariancePopulation(),
+                    equalTo(variancePopulation(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11))
+                );
+                assertThat(
+                    stats.getVarianceSampling(),
+                    equalTo(varianceSampling(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11))
+                );
+                assertThat(stats.getStdDeviation(), equalTo(stdDev(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
+                assertThat(
+                    stats.getStdDeviationPopulation(),
+                    equalTo(stdDevPopulation(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11))
+                );
+                assertThat(
+                    stats.getStdDeviationSampling(),
+                    equalTo(stdDevSampling(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11))
+                );
 
-        ExtendedStats stats = searchResponse.getAggregations().get("stats");
-        assertThat(stats, notNullValue());
-        assertThat(stats.getName(), equalTo("stats"));
-        assertThat(
-            stats.getAvg(),
-            equalTo((double) (1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11) / 20)
+                checkUpperLowerBounds(stats, sigma);
+            }
         );
-        assertThat(stats.getMin(), equalTo(1.0));
-        assertThat(stats.getMax(), equalTo(11.0));
-        assertThat(stats.getSum(), equalTo((double) 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11));
-        assertThat(stats.getCount(), equalTo(20L));
-        assertThat(
-            stats.getSumOfSquares(),
-            equalTo((double) 1 + 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100 + 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100 + 121)
-        );
-        assertThat(stats.getVariance(), equalTo(variance(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
-        assertThat(
-            stats.getVariancePopulation(),
-            equalTo(variancePopulation(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11))
-        );
-        assertThat(stats.getVarianceSampling(), equalTo(varianceSampling(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
-        assertThat(stats.getStdDeviation(), equalTo(stdDev(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
-        assertThat(
-            stats.getStdDeviationPopulation(),
-            equalTo(stdDevPopulation(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11))
-        );
-        assertThat(stats.getStdDeviationSampling(), equalTo(stdDevSampling(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
-
-        checkUpperLowerBounds(stats, sigma);
     }
 
     @Override
@@ -521,75 +557,88 @@ public class ExtendedStatsIT extends AbstractNumericTestCase {
         Map<String, Object> params = new HashMap<>();
         params.put("dec", 1);
         double sigma = randomDouble() * randomIntBetween(1, 10);
-        SearchResponse searchResponse = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                extendedStats("stats").field("values")
-                    .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value - dec", params))
-                    .sigma(sigma)
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    extendedStats("stats").field("values")
+                        .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value - dec", params))
+                        .sigma(sigma)
+                ),
+            response -> {
+                assertHitCount(response, 10);
 
-        assertHitCount(searchResponse, 10);
-
-        ExtendedStats stats = searchResponse.getAggregations().get("stats");
-        assertThat(stats, notNullValue());
-        assertThat(stats.getName(), equalTo("stats"));
-        assertThat(
-            stats.getAvg(),
-            equalTo((double) (1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11) / 20)
+                ExtendedStats stats = response.getAggregations().get("stats");
+                assertThat(stats, notNullValue());
+                assertThat(stats.getName(), equalTo("stats"));
+                assertThat(
+                    stats.getAvg(),
+                    equalTo((double) (1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11) / 20)
+                );
+                assertThat(stats.getMin(), equalTo(1.0));
+                assertThat(stats.getMax(), equalTo(11.0));
+                assertThat(
+                    stats.getSum(),
+                    equalTo((double) 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11)
+                );
+                assertThat(stats.getCount(), equalTo(20L));
+                assertThat(
+                    stats.getSumOfSquares(),
+                    equalTo((double) 1 + 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100 + 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100 + 121)
+                );
+                assertThat(stats.getVariance(), equalTo(variance(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
+                assertThat(
+                    stats.getVariancePopulation(),
+                    equalTo(variancePopulation(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11))
+                );
+                assertThat(
+                    stats.getVarianceSampling(),
+                    equalTo(varianceSampling(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11))
+                );
+                assertThat(stats.getStdDeviation(), equalTo(stdDev(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
+                assertThat(
+                    stats.getStdDeviationPopulation(),
+                    equalTo(stdDevPopulation(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11))
+                );
+                assertThat(
+                    stats.getStdDeviationSampling(),
+                    equalTo(stdDevSampling(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11))
+                );
+                checkUpperLowerBounds(stats, sigma);
+            }
         );
-        assertThat(stats.getMin(), equalTo(1.0));
-        assertThat(stats.getMax(), equalTo(11.0));
-        assertThat(stats.getSum(), equalTo((double) 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11));
-        assertThat(stats.getCount(), equalTo(20L));
-        assertThat(
-            stats.getSumOfSquares(),
-            equalTo((double) 1 + 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100 + 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100 + 121)
-        );
-        assertThat(stats.getVariance(), equalTo(variance(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
-        assertThat(
-            stats.getVariancePopulation(),
-            equalTo(variancePopulation(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11))
-        );
-        assertThat(stats.getVarianceSampling(), equalTo(varianceSampling(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
-        assertThat(stats.getStdDeviation(), equalTo(stdDev(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
-        assertThat(
-            stats.getStdDeviationPopulation(),
-            equalTo(stdDevPopulation(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11))
-        );
-        assertThat(stats.getStdDeviationSampling(), equalTo(stdDevSampling(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
-        checkUpperLowerBounds(stats, sigma);
     }
 
     @Override
     public void testScriptSingleValued() throws Exception {
         double sigma = randomDouble() * randomIntBetween(1, 10);
-        SearchResponse searchResponse = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                extendedStats("stats").script(
-                    new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "doc['value'].value", Collections.emptyMap())
-                ).sigma(sigma)
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    extendedStats("stats").script(
+                        new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "doc['value'].value", Collections.emptyMap())
+                    ).sigma(sigma)
+                ),
+            response -> {
+                assertHitCount(response, 10);
 
-        assertHitCount(searchResponse, 10);
-
-        ExtendedStats stats = searchResponse.getAggregations().get("stats");
-        assertThat(stats, notNullValue());
-        assertThat(stats.getName(), equalTo("stats"));
-        assertThat(stats.getAvg(), equalTo((double) (1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10) / 10));
-        assertThat(stats.getMin(), equalTo(1.0));
-        assertThat(stats.getMax(), equalTo(10.0));
-        assertThat(stats.getSum(), equalTo((double) 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10));
-        assertThat(stats.getCount(), equalTo(10L));
-        assertThat(stats.getSumOfSquares(), equalTo((double) 1 + 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100));
-        assertThat(stats.getVariance(), equalTo(variance(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
-        assertThat(stats.getVariancePopulation(), equalTo(variancePopulation(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
-        assertThat(stats.getVarianceSampling(), equalTo(varianceSampling(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
-        assertThat(stats.getStdDeviation(), equalTo(stdDev(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
-        assertThat(stats.getStdDeviationPopulation(), equalTo(stdDevPopulation(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
-        assertThat(stats.getStdDeviationSampling(), equalTo(stdDevSampling(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
-        checkUpperLowerBounds(stats, sigma);
+                ExtendedStats stats = response.getAggregations().get("stats");
+                assertThat(stats, notNullValue());
+                assertThat(stats.getName(), equalTo("stats"));
+                assertThat(stats.getAvg(), equalTo((double) (1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10) / 10));
+                assertThat(stats.getMin(), equalTo(1.0));
+                assertThat(stats.getMax(), equalTo(10.0));
+                assertThat(stats.getSum(), equalTo((double) 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10));
+                assertThat(stats.getCount(), equalTo(10L));
+                assertThat(stats.getSumOfSquares(), equalTo((double) 1 + 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100));
+                assertThat(stats.getVariance(), equalTo(variance(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
+                assertThat(stats.getVariancePopulation(), equalTo(variancePopulation(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
+                assertThat(stats.getVarianceSampling(), equalTo(varianceSampling(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
+                assertThat(stats.getStdDeviation(), equalTo(stdDev(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
+                assertThat(stats.getStdDeviationPopulation(), equalTo(stdDevPopulation(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
+                assertThat(stats.getStdDeviationSampling(), equalTo(stdDevSampling(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)));
+                checkUpperLowerBounds(stats, sigma);
+            }
+        );
     }
 
     @Override
@@ -600,74 +649,83 @@ public class ExtendedStatsIT extends AbstractNumericTestCase {
         Script script = new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "doc['value'].value + inc", params);
 
         double sigma = randomDouble() * randomIntBetween(1, 10);
-        SearchResponse searchResponse = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(extendedStats("stats").script(script).sigma(sigma))
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery()).addAggregation(extendedStats("stats").script(script).sigma(sigma)),
+            response -> {
+                assertHitCount(response, 10);
 
-        assertHitCount(searchResponse, 10);
-
-        ExtendedStats stats = searchResponse.getAggregations().get("stats");
-        assertThat(stats, notNullValue());
-        assertThat(stats.getName(), equalTo("stats"));
-        assertThat(stats.getAvg(), equalTo((double) (2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11) / 10));
-        assertThat(stats.getMin(), equalTo(2.0));
-        assertThat(stats.getMax(), equalTo(11.0));
-        assertThat(stats.getSum(), equalTo((double) 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11));
-        assertThat(stats.getCount(), equalTo(10L));
-        assertThat(stats.getSumOfSquares(), equalTo((double) 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100 + 121));
-        assertThat(stats.getVariance(), equalTo(variance(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
-        assertThat(stats.getVariancePopulation(), equalTo(variancePopulation(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
-        assertThat(stats.getVarianceSampling(), equalTo(varianceSampling(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
-        assertThat(stats.getStdDeviation(), equalTo(stdDev(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
-        assertThat(stats.getStdDeviationPopulation(), equalTo(stdDevPopulation(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
-        assertThat(stats.getStdDeviationSampling(), equalTo(stdDevSampling(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
-        checkUpperLowerBounds(stats, sigma);
+                ExtendedStats stats = response.getAggregations().get("stats");
+                assertThat(stats, notNullValue());
+                assertThat(stats.getName(), equalTo("stats"));
+                assertThat(stats.getAvg(), equalTo((double) (2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11) / 10));
+                assertThat(stats.getMin(), equalTo(2.0));
+                assertThat(stats.getMax(), equalTo(11.0));
+                assertThat(stats.getSum(), equalTo((double) 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11));
+                assertThat(stats.getCount(), equalTo(10L));
+                assertThat(stats.getSumOfSquares(), equalTo((double) 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100 + 121));
+                assertThat(stats.getVariance(), equalTo(variance(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
+                assertThat(stats.getVariancePopulation(), equalTo(variancePopulation(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
+                assertThat(stats.getVarianceSampling(), equalTo(varianceSampling(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
+                assertThat(stats.getStdDeviation(), equalTo(stdDev(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
+                assertThat(stats.getStdDeviationPopulation(), equalTo(stdDevPopulation(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
+                assertThat(stats.getStdDeviationSampling(), equalTo(stdDevSampling(2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
+                checkUpperLowerBounds(stats, sigma);
+            }
+        );
     }
 
     @Override
     public void testScriptMultiValued() throws Exception {
         double sigma = randomDouble() * randomIntBetween(1, 10);
-        SearchResponse searchResponse = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                extendedStats("stats").script(
-                    new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "doc['values']", Collections.emptyMap())
-                ).sigma(sigma)
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    extendedStats("stats").script(
+                        new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "doc['values']", Collections.emptyMap())
+                    ).sigma(sigma)
+                ),
+            response -> {
+                assertHitCount(response, 10);
 
-        assertHitCount(searchResponse, 10);
-
-        ExtendedStats stats = searchResponse.getAggregations().get("stats");
-        assertThat(stats, notNullValue());
-        assertThat(stats.getName(), equalTo("stats"));
-        assertThat(
-            stats.getAvg(),
-            equalTo((double) (2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12) / 20)
+                ExtendedStats stats = response.getAggregations().get("stats");
+                assertThat(stats, notNullValue());
+                assertThat(stats.getName(), equalTo("stats"));
+                assertThat(
+                    stats.getAvg(),
+                    equalTo((double) (2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12) / 20)
+                );
+                assertThat(stats.getMin(), equalTo(2.0));
+                assertThat(stats.getMax(), equalTo(12.0));
+                assertThat(
+                    stats.getSum(),
+                    equalTo((double) 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12)
+                );
+                assertThat(stats.getCount(), equalTo(20L));
+                assertThat(
+                    stats.getSumOfSquares(),
+                    equalTo((double) 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100 + 121 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100 + 121 + 144)
+                );
+                assertThat(stats.getVariance(), equalTo(variance(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)));
+                assertThat(
+                    stats.getVariancePopulation(),
+                    equalTo(variancePopulation(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12))
+                );
+                assertThat(
+                    stats.getVarianceSampling(),
+                    equalTo(varianceSampling(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12))
+                );
+                assertThat(stats.getStdDeviation(), equalTo(stdDev(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)));
+                assertThat(
+                    stats.getStdDeviationPopulation(),
+                    equalTo(stdDevPopulation(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12))
+                );
+                assertThat(
+                    stats.getStdDeviationSampling(),
+                    equalTo(stdDevSampling(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12))
+                );
+                checkUpperLowerBounds(stats, sigma);
+            }
         );
-        assertThat(stats.getMin(), equalTo(2.0));
-        assertThat(stats.getMax(), equalTo(12.0));
-        assertThat(stats.getSum(), equalTo((double) 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 11 + 12));
-        assertThat(stats.getCount(), equalTo(20L));
-        assertThat(
-            stats.getSumOfSquares(),
-            equalTo((double) 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100 + 121 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100 + 121 + 144)
-        );
-        assertThat(stats.getVariance(), equalTo(variance(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)));
-        assertThat(
-            stats.getVariancePopulation(),
-            equalTo(variancePopulation(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12))
-        );
-        assertThat(stats.getVarianceSampling(), equalTo(varianceSampling(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)));
-        assertThat(stats.getStdDeviation(), equalTo(stdDev(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)));
-        assertThat(
-            stats.getStdDeviationPopulation(),
-            equalTo(stdDevPopulation(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12))
-        );
-        assertThat(
-            stats.getStdDeviationSampling(),
-            equalTo(stdDevSampling(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12))
-        );
-        checkUpperLowerBounds(stats, sigma);
     }
 
     @Override
@@ -683,125 +741,147 @@ public class ExtendedStatsIT extends AbstractNumericTestCase {
         );
 
         double sigma = randomDouble() * randomIntBetween(1, 10);
-        SearchResponse searchResponse = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(extendedStats("stats").script(script).sigma(sigma))
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery()).addAggregation(extendedStats("stats").script(script).sigma(sigma)),
+            response -> {
+                assertHitCount(response, 10);
 
-        assertHitCount(searchResponse, 10);
-
-        ExtendedStats stats = searchResponse.getAggregations().get("stats");
-        assertThat(stats, notNullValue());
-        assertThat(stats.getName(), equalTo("stats"));
-        assertThat(stats.getAvg(), equalTo((double) (1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 0 + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9) / 20));
-        assertThat(stats.getMin(), equalTo(0.0));
-        assertThat(stats.getMax(), equalTo(10.0));
-        assertThat(stats.getSum(), equalTo((double) 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 0 + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9));
-        assertThat(stats.getCount(), equalTo(20L));
-        assertThat(
-            stats.getSumOfSquares(),
-            equalTo((double) 1 + 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100 + 0 + 1 + 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81)
+                ExtendedStats stats = response.getAggregations().get("stats");
+                assertThat(stats, notNullValue());
+                assertThat(stats.getName(), equalTo("stats"));
+                assertThat(
+                    stats.getAvg(),
+                    equalTo((double) (1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 0 + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9) / 20)
+                );
+                assertThat(stats.getMin(), equalTo(0.0));
+                assertThat(stats.getMax(), equalTo(10.0));
+                assertThat(
+                    stats.getSum(),
+                    equalTo((double) 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10 + 0 + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9)
+                );
+                assertThat(stats.getCount(), equalTo(20L));
+                assertThat(
+                    stats.getSumOfSquares(),
+                    equalTo((double) 1 + 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81 + 100 + 0 + 1 + 4 + 9 + 16 + 25 + 36 + 49 + 64 + 81)
+                );
+                assertThat(stats.getVariance(), equalTo(variance(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9)));
+                assertThat(
+                    stats.getVariancePopulation(),
+                    equalTo(variancePopulation(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9))
+                );
+                assertThat(
+                    stats.getVarianceSampling(),
+                    equalTo(varianceSampling(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9))
+                );
+                assertThat(stats.getStdDeviation(), equalTo(stdDev(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9)));
+                assertThat(
+                    stats.getStdDeviationPopulation(),
+                    equalTo(stdDevPopulation(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9))
+                );
+                assertThat(
+                    stats.getStdDeviationSampling(),
+                    equalTo(stdDevSampling(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9))
+                );
+                checkUpperLowerBounds(stats, sigma);
+            }
         );
-        assertThat(stats.getVariance(), equalTo(variance(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9)));
-        assertThat(stats.getVariancePopulation(), equalTo(variancePopulation(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9)));
-        assertThat(stats.getVarianceSampling(), equalTo(varianceSampling(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9)));
-        assertThat(stats.getStdDeviation(), equalTo(stdDev(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9)));
-        assertThat(
-            stats.getStdDeviationPopulation(),
-            equalTo(stdDevPopulation(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9))
-        );
-        assertThat(stats.getStdDeviationSampling(), equalTo(stdDevSampling(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9)));
-        checkUpperLowerBounds(stats, sigma);
     }
 
     public void testEmptySubAggregation() {
-        SearchResponse searchResponse = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                terms("value").field("value")
-                    .subAggregation(missing("values").field("values").subAggregation(extendedStats("stats").field("value")))
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    terms("value").field("value")
+                        .subAggregation(missing("values").field("values").subAggregation(extendedStats("stats").field("value")))
+                ),
+            response -> {
+                assertHitCount(response, 10);
 
-        assertHitCount(searchResponse, 10);
+                Terms terms = response.getAggregations().get("value");
+                assertThat(terms, notNullValue());
+                assertThat(terms.getBuckets().size(), equalTo(10));
 
-        Terms terms = searchResponse.getAggregations().get("value");
-        assertThat(terms, notNullValue());
-        assertThat(terms.getBuckets().size(), equalTo(10));
+                for (Terms.Bucket bucket : terms.getBuckets()) {
+                    assertThat(bucket.getDocCount(), equalTo(1L));
 
-        for (Terms.Bucket bucket : terms.getBuckets()) {
-            assertThat(bucket.getDocCount(), equalTo(1L));
+                    Missing missing = bucket.getAggregations().get("values");
+                    assertThat(missing, notNullValue());
+                    assertThat(missing.getDocCount(), equalTo(0L));
 
-            Missing missing = bucket.getAggregations().get("values");
-            assertThat(missing, notNullValue());
-            assertThat(missing.getDocCount(), equalTo(0L));
-
-            ExtendedStats stats = missing.getAggregations().get("stats");
-            assertThat(stats, notNullValue());
-            assertThat(stats.getName(), equalTo("stats"));
-            assertThat(stats.getSumOfSquares(), equalTo(0.0));
-            assertThat(stats.getCount(), equalTo(0L));
-            assertThat(stats.getSum(), equalTo(0.0));
-            assertThat(stats.getMin(), equalTo(Double.POSITIVE_INFINITY));
-            assertThat(stats.getMax(), equalTo(Double.NEGATIVE_INFINITY));
-            assertThat(Double.isNaN(stats.getStdDeviation()), is(true));
-            assertThat(Double.isNaN(stats.getStdDeviationPopulation()), is(true));
-            assertThat(Double.isNaN(stats.getStdDeviationSampling()), is(true));
-            assertThat(Double.isNaN(stats.getAvg()), is(true));
-            assertThat(Double.isNaN(stats.getStdDeviationBound(Bounds.UPPER)), is(true));
-            assertThat(Double.isNaN(stats.getStdDeviationBound(Bounds.LOWER)), is(true));
-            assertThat(Double.isNaN(stats.getStdDeviationBound(Bounds.UPPER_POPULATION)), is(true));
-            assertThat(Double.isNaN(stats.getStdDeviationBound(Bounds.LOWER_POPULATION)), is(true));
-            assertThat(Double.isNaN(stats.getStdDeviationBound(Bounds.UPPER_SAMPLING)), is(true));
-            assertThat(Double.isNaN(stats.getStdDeviationBound(Bounds.LOWER_SAMPLING)), is(true));
-        }
+                    ExtendedStats stats = missing.getAggregations().get("stats");
+                    assertThat(stats, notNullValue());
+                    assertThat(stats.getName(), equalTo("stats"));
+                    assertThat(stats.getSumOfSquares(), equalTo(0.0));
+                    assertThat(stats.getCount(), equalTo(0L));
+                    assertThat(stats.getSum(), equalTo(0.0));
+                    assertThat(stats.getMin(), equalTo(Double.POSITIVE_INFINITY));
+                    assertThat(stats.getMax(), equalTo(Double.NEGATIVE_INFINITY));
+                    assertThat(Double.isNaN(stats.getStdDeviation()), is(true));
+                    assertThat(Double.isNaN(stats.getStdDeviationPopulation()), is(true));
+                    assertThat(Double.isNaN(stats.getStdDeviationSampling()), is(true));
+                    assertThat(Double.isNaN(stats.getAvg()), is(true));
+                    assertThat(Double.isNaN(stats.getStdDeviationBound(Bounds.UPPER)), is(true));
+                    assertThat(Double.isNaN(stats.getStdDeviationBound(Bounds.LOWER)), is(true));
+                    assertThat(Double.isNaN(stats.getStdDeviationBound(Bounds.UPPER_POPULATION)), is(true));
+                    assertThat(Double.isNaN(stats.getStdDeviationBound(Bounds.LOWER_POPULATION)), is(true));
+                    assertThat(Double.isNaN(stats.getStdDeviationBound(Bounds.UPPER_SAMPLING)), is(true));
+                    assertThat(Double.isNaN(stats.getStdDeviationBound(Bounds.LOWER_SAMPLING)), is(true));
+                }
+            }
+        );
     }
 
     @Override
     public void testOrderByEmptyAggregation() throws Exception {
-        SearchResponse searchResponse = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                terms("terms").field("value")
-                    .order(BucketOrder.compound(BucketOrder.aggregation("filter>extendedStats.avg", true)))
-                    .subAggregation(filter("filter", termQuery("value", 100)).subAggregation(extendedStats("extendedStats").field("value")))
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    terms("terms").field("value")
+                        .order(BucketOrder.compound(BucketOrder.aggregation("filter>extendedStats.avg", true)))
+                        .subAggregation(
+                            filter("filter", termQuery("value", 100)).subAggregation(extendedStats("extendedStats").field("value"))
+                        )
+                ),
+            response -> {
+                assertHitCount(response, 10);
 
-        assertHitCount(searchResponse, 10);
+                Terms terms = response.getAggregations().get("terms");
+                assertThat(terms, notNullValue());
+                List<? extends Terms.Bucket> buckets = terms.getBuckets();
+                assertThat(buckets, notNullValue());
+                assertThat(buckets.size(), equalTo(10));
 
-        Terms terms = searchResponse.getAggregations().get("terms");
-        assertThat(terms, notNullValue());
-        List<? extends Terms.Bucket> buckets = terms.getBuckets();
-        assertThat(buckets, notNullValue());
-        assertThat(buckets.size(), equalTo(10));
-
-        for (int i = 0; i < 10; i++) {
-            Terms.Bucket bucket = buckets.get(i);
-            assertThat(bucket, notNullValue());
-            assertThat(bucket.getKeyAsNumber(), equalTo((long) i + 1));
-            assertThat(bucket.getDocCount(), equalTo(1L));
-            Filter filter = bucket.getAggregations().get("filter");
-            assertThat(filter, notNullValue());
-            assertThat(filter.getDocCount(), equalTo(0L));
-            ExtendedStats extendedStats = filter.getAggregations().get("extendedStats");
-            assertThat(extendedStats, notNullValue());
-            assertThat(extendedStats.getMin(), equalTo(Double.POSITIVE_INFINITY));
-            assertThat(extendedStats.getMax(), equalTo(Double.NEGATIVE_INFINITY));
-            assertThat(extendedStats.getAvg(), equalTo(Double.NaN));
-            assertThat(extendedStats.getSum(), equalTo(0.0));
-            assertThat(extendedStats.getCount(), equalTo(0L));
-            assertThat(extendedStats.getStdDeviation(), equalTo(Double.NaN));
-            assertThat(extendedStats.getStdDeviationPopulation(), equalTo(Double.NaN));
-            assertThat(extendedStats.getStdDeviationSampling(), equalTo(Double.NaN));
-            assertThat(extendedStats.getSumOfSquares(), equalTo(0.0));
-            assertThat(extendedStats.getVariance(), equalTo(Double.NaN));
-            assertThat(extendedStats.getVariancePopulation(), equalTo(Double.NaN));
-            assertThat(extendedStats.getVarianceSampling(), equalTo(Double.NaN));
-            assertThat(extendedStats.getStdDeviationBound(Bounds.LOWER), equalTo(Double.NaN));
-            assertThat(extendedStats.getStdDeviationBound(Bounds.UPPER), equalTo(Double.NaN));
-            assertThat(extendedStats.getStdDeviationBound(Bounds.LOWER_POPULATION), equalTo(Double.NaN));
-            assertThat(extendedStats.getStdDeviationBound(Bounds.UPPER_POPULATION), equalTo(Double.NaN));
-            assertThat(extendedStats.getStdDeviationBound(Bounds.LOWER_SAMPLING), equalTo(Double.NaN));
-            assertThat(extendedStats.getStdDeviationBound(Bounds.UPPER_SAMPLING), equalTo(Double.NaN));
-        }
+                for (int i = 0; i < 10; i++) {
+                    Terms.Bucket bucket = buckets.get(i);
+                    assertThat(bucket, notNullValue());
+                    assertThat(bucket.getKeyAsNumber(), equalTo((long) i + 1));
+                    assertThat(bucket.getDocCount(), equalTo(1L));
+                    Filter filter = bucket.getAggregations().get("filter");
+                    assertThat(filter, notNullValue());
+                    assertThat(filter.getDocCount(), equalTo(0L));
+                    ExtendedStats extendedStats = filter.getAggregations().get("extendedStats");
+                    assertThat(extendedStats, notNullValue());
+                    assertThat(extendedStats.getMin(), equalTo(Double.POSITIVE_INFINITY));
+                    assertThat(extendedStats.getMax(), equalTo(Double.NEGATIVE_INFINITY));
+                    assertThat(extendedStats.getAvg(), equalTo(Double.NaN));
+                    assertThat(extendedStats.getSum(), equalTo(0.0));
+                    assertThat(extendedStats.getCount(), equalTo(0L));
+                    assertThat(extendedStats.getStdDeviation(), equalTo(Double.NaN));
+                    assertThat(extendedStats.getStdDeviationPopulation(), equalTo(Double.NaN));
+                    assertThat(extendedStats.getStdDeviationSampling(), equalTo(Double.NaN));
+                    assertThat(extendedStats.getSumOfSquares(), equalTo(0.0));
+                    assertThat(extendedStats.getVariance(), equalTo(Double.NaN));
+                    assertThat(extendedStats.getVariancePopulation(), equalTo(Double.NaN));
+                    assertThat(extendedStats.getVarianceSampling(), equalTo(Double.NaN));
+                    assertThat(extendedStats.getStdDeviationBound(Bounds.LOWER), equalTo(Double.NaN));
+                    assertThat(extendedStats.getStdDeviationBound(Bounds.UPPER), equalTo(Double.NaN));
+                    assertThat(extendedStats.getStdDeviationBound(Bounds.LOWER_POPULATION), equalTo(Double.NaN));
+                    assertThat(extendedStats.getStdDeviationBound(Bounds.UPPER_POPULATION), equalTo(Double.NaN));
+                    assertThat(extendedStats.getStdDeviationBound(Bounds.LOWER_SAMPLING), equalTo(Double.NaN));
+                    assertThat(extendedStats.getStdDeviationBound(Bounds.UPPER_SAMPLING), equalTo(Double.NaN));
+                }
+            }
+        );
     }
 
     private void checkUpperLowerBounds(ExtendedStats stats, double sigma) {
@@ -845,13 +925,13 @@ public class ExtendedStatsIT extends AbstractNumericTestCase {
         );
 
         // Test that a request using a nondeterministic script does not get cached
-        SearchResponse r = prepareSearch("cache_test_idx").setSize(0)
-            .addAggregation(
-                extendedStats("foo").field("d")
-                    .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "Math.random()", Collections.emptyMap()))
-            )
-            .get();
-        assertNoFailures(r);
+        assertNoFailures(
+            prepareSearch("cache_test_idx").setSize(0)
+                .addAggregation(
+                    extendedStats("foo").field("d")
+                        .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "Math.random()", Collections.emptyMap()))
+                )
+        );
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -863,13 +943,13 @@ public class ExtendedStatsIT extends AbstractNumericTestCase {
         );
 
         // Test that a request using a deterministic script gets cached
-        r = prepareSearch("cache_test_idx").setSize(0)
-            .addAggregation(
-                extendedStats("foo").field("d")
-                    .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value + 1", Collections.emptyMap()))
-            )
-            .get();
-        assertNoFailures(r);
+        assertNoFailures(
+            prepareSearch("cache_test_idx").setSize(0)
+                .addAggregation(
+                    extendedStats("foo").field("d")
+                        .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value + 1", Collections.emptyMap()))
+                )
+        );
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -881,8 +961,7 @@ public class ExtendedStatsIT extends AbstractNumericTestCase {
         );
 
         // Ensure that non-scripted requests are cached as normal
-        r = prepareSearch("cache_test_idx").setSize(0).addAggregation(extendedStats("foo").field("d")).get();
-        assertNoFailures(r);
+        assertNoFailures(prepareSearch("cache_test_idx").setSize(0).addAggregation(extendedStats("foo").field("d")));
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -893,5 +972,4 @@ public class ExtendedStatsIT extends AbstractNumericTestCase {
             equalTo(2L)
         );
     }
-
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsIT.java
@@ -8,13 +8,12 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.geo.RandomGeoGenerator;
 
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
@@ -26,45 +25,42 @@ import static org.hamcrest.Matchers.notNullValue;
 public class GeoBoundsIT extends SpatialBoundsAggregationTestBase<GeoPoint> {
 
     public void testSingleValuedFieldNearDateLine() {
-        SearchResponse response = prepareSearch(DATELINE_IDX_NAME).addAggregation(
-            boundsAgg(aggName(), SINGLE_VALUED_FIELD_NAME).wrapLongitude(false)
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch(DATELINE_IDX_NAME).addAggregation(boundsAgg(aggName(), SINGLE_VALUED_FIELD_NAME).wrapLongitude(false)),
+            response -> {
+                GeoPoint geoValuesTopLeft = new GeoPoint(38, -179);
+                GeoPoint geoValuesBottomRight = new GeoPoint(-24, 178);
 
-        assertNoFailures(response);
-
-        GeoPoint geoValuesTopLeft = new GeoPoint(38, -179);
-        GeoPoint geoValuesBottomRight = new GeoPoint(-24, 178);
-
-        GeoBounds geoBounds = response.getAggregations().get(aggName());
-        assertThat(geoBounds, notNullValue());
-        assertThat(geoBounds.getName(), equalTo(aggName()));
-        GeoPoint topLeft = geoBounds.topLeft();
-        GeoPoint bottomRight = geoBounds.bottomRight();
-        assertThat(topLeft.getY(), closeTo(geoValuesTopLeft.getY(), GEOHASH_TOLERANCE));
-        assertThat(topLeft.getX(), closeTo(geoValuesTopLeft.getX(), GEOHASH_TOLERANCE));
-        assertThat(bottomRight.getY(), closeTo(geoValuesBottomRight.getY(), GEOHASH_TOLERANCE));
-        assertThat(bottomRight.getX(), closeTo(geoValuesBottomRight.getX(), GEOHASH_TOLERANCE));
+                GeoBounds geoBounds = response.getAggregations().get(aggName());
+                assertThat(geoBounds, notNullValue());
+                assertThat(geoBounds.getName(), equalTo(aggName()));
+                GeoPoint topLeft = geoBounds.topLeft();
+                GeoPoint bottomRight = geoBounds.bottomRight();
+                assertThat(topLeft.getY(), closeTo(geoValuesTopLeft.getY(), GEOHASH_TOLERANCE));
+                assertThat(topLeft.getX(), closeTo(geoValuesTopLeft.getX(), GEOHASH_TOLERANCE));
+                assertThat(bottomRight.getY(), closeTo(geoValuesBottomRight.getY(), GEOHASH_TOLERANCE));
+                assertThat(bottomRight.getX(), closeTo(geoValuesBottomRight.getX(), GEOHASH_TOLERANCE));
+            }
+        );
     }
 
     public void testSingleValuedFieldNearDateLineWrapLongitude() {
-
         GeoPoint geoValuesTopLeft = new GeoPoint(38, 170);
         GeoPoint geoValuesBottomRight = new GeoPoint(-24, -175);
-        SearchResponse response = prepareSearch(DATELINE_IDX_NAME).addAggregation(
-            boundsAgg(aggName(), SINGLE_VALUED_FIELD_NAME).wrapLongitude(true)
-        ).get();
-
-        assertNoFailures(response);
-
-        GeoBounds geoBounds = response.getAggregations().get(aggName());
-        assertThat(geoBounds, notNullValue());
-        assertThat(geoBounds.getName(), equalTo(aggName()));
-        GeoPoint topLeft = geoBounds.topLeft();
-        GeoPoint bottomRight = geoBounds.bottomRight();
-        assertThat(topLeft.getY(), closeTo(geoValuesTopLeft.getY(), GEOHASH_TOLERANCE));
-        assertThat(topLeft.getX(), closeTo(geoValuesTopLeft.getX(), GEOHASH_TOLERANCE));
-        assertThat(bottomRight.getY(), closeTo(geoValuesBottomRight.getY(), GEOHASH_TOLERANCE));
-        assertThat(bottomRight.getX(), closeTo(geoValuesBottomRight.getX(), GEOHASH_TOLERANCE));
+        assertNoFailuresAndResponse(
+            prepareSearch(DATELINE_IDX_NAME).addAggregation(boundsAgg(aggName(), SINGLE_VALUED_FIELD_NAME).wrapLongitude(true)),
+            response -> {
+                GeoBounds geoBounds = response.getAggregations().get(aggName());
+                assertThat(geoBounds, notNullValue());
+                assertThat(geoBounds.getName(), equalTo(aggName()));
+                GeoPoint topLeft = geoBounds.topLeft();
+                GeoPoint bottomRight = geoBounds.bottomRight();
+                assertThat(topLeft.getY(), closeTo(geoValuesTopLeft.getY(), GEOHASH_TOLERANCE));
+                assertThat(topLeft.getX(), closeTo(geoValuesTopLeft.getX(), GEOHASH_TOLERANCE));
+                assertThat(bottomRight.getY(), closeTo(geoValuesBottomRight.getY(), GEOHASH_TOLERANCE));
+                assertThat(bottomRight.getX(), closeTo(geoValuesBottomRight.getX(), GEOHASH_TOLERANCE));
+            }
+        );
     }
 
     @Override

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidIT.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.search.aggregations.bucket.geogrid.GeoGrid;
@@ -18,7 +17,7 @@ import org.elasticsearch.test.geo.RandomGeoGenerator;
 import java.util.List;
 
 import static org.elasticsearch.search.aggregations.AggregationBuilders.geohashGrid;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 
@@ -29,21 +28,24 @@ import static org.hamcrest.Matchers.notNullValue;
 public class GeoCentroidIT extends CentroidAggregationTestBase {
 
     public void testSingleValueFieldAsSubAggToGeohashGrid() {
-        SearchResponse response = prepareSearch(HIGH_CARD_IDX_NAME).addAggregation(
-            geohashGrid("geoGrid").field(SINGLE_VALUED_FIELD_NAME).subAggregation(centroidAgg(aggName()).field(SINGLE_VALUED_FIELD_NAME))
-        ).get();
-        assertNoFailures(response);
-
-        GeoGrid grid = response.getAggregations().get("geoGrid");
-        assertThat(grid, notNullValue());
-        assertThat(grid.getName(), equalTo("geoGrid"));
-        List<? extends GeoGrid.Bucket> buckets = grid.getBuckets();
-        for (GeoGrid.Bucket cell : buckets) {
-            String geohash = cell.getKeyAsString();
-            SpatialPoint expectedCentroid = expectedCentroidsForGeoHash.get(geohash);
-            GeoCentroid centroidAgg = cell.getAggregations().get(aggName());
-            assertSameCentroid(centroidAgg.centroid(), expectedCentroid);
-        }
+        assertNoFailuresAndResponse(
+            prepareSearch(HIGH_CARD_IDX_NAME).addAggregation(
+                geohashGrid("geoGrid").field(SINGLE_VALUED_FIELD_NAME)
+                    .subAggregation(centroidAgg(aggName()).field(SINGLE_VALUED_FIELD_NAME))
+            ),
+            response -> {
+                GeoGrid grid = response.getAggregations().get("geoGrid");
+                assertThat(grid, notNullValue());
+                assertThat(grid.getName(), equalTo("geoGrid"));
+                List<? extends GeoGrid.Bucket> buckets = grid.getBuckets();
+                for (GeoGrid.Bucket cell : buckets) {
+                    String geohash = cell.getKeyAsString();
+                    SpatialPoint expectedCentroid = expectedCentroidsForGeoHash.get(geohash);
+                    GeoCentroid centroidAgg = cell.getAggregations().get(aggName());
+                    assertSameCentroid(centroidAgg.centroid(), expectedCentroid);
+                }
+            }
+        );
     }
 
     @Override

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/HDRPercentileRanksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/HDRPercentileRanksIT.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.search.aggregations.metrics;
 
 import org.apache.logging.log4j.LogManager;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.script.Script;
@@ -40,6 +39,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
@@ -99,70 +99,76 @@ public class HDRPercentileRanksIT extends AbstractNumericTestCase {
     @Override
     public void testEmptyAggregation() throws Exception {
         int sigDigits = randomSignificantDigits();
-        SearchResponse searchResponse = prepareSearch("empty_bucket_idx").setQuery(matchAllQuery())
-            .addAggregation(
-                histogram("histo").field("value")
-                    .interval(1L)
-                    .minDocCount(0)
-                    .subAggregation(
-                        percentileRanks("percentile_ranks", new double[] { 10, 15 }).field("value")
-                            .method(PercentilesMethod.HDR)
-                            .numberOfSignificantValueDigits(sigDigits)
-                    )
-            )
-            .get();
+        assertResponse(
+            prepareSearch("empty_bucket_idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    histogram("histo").field("value")
+                        .interval(1L)
+                        .minDocCount(0)
+                        .subAggregation(
+                            percentileRanks("percentile_ranks", new double[] { 10, 15 }).field("value")
+                                .method(PercentilesMethod.HDR)
+                                .numberOfSignificantValueDigits(sigDigits)
+                        )
+                ),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(2L));
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo, notNullValue());
+                Histogram.Bucket bucket = histo.getBuckets().get(1);
+                assertThat(bucket, notNullValue());
 
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(2L));
-        Histogram histo = searchResponse.getAggregations().get("histo");
-        assertThat(histo, notNullValue());
-        Histogram.Bucket bucket = histo.getBuckets().get(1);
-        assertThat(bucket, notNullValue());
-
-        PercentileRanks reversePercentiles = bucket.getAggregations().get("percentile_ranks");
-        assertThat(reversePercentiles, notNullValue());
-        assertThat(reversePercentiles.getName(), equalTo("percentile_ranks"));
-        assertThat(reversePercentiles.percent(10), equalTo(Double.NaN));
-        assertThat(reversePercentiles.percent(15), equalTo(Double.NaN));
+                PercentileRanks reversePercentiles = bucket.getAggregations().get("percentile_ranks");
+                assertThat(reversePercentiles, notNullValue());
+                assertThat(reversePercentiles.getName(), equalTo("percentile_ranks"));
+                assertThat(reversePercentiles.percent(10), equalTo(Double.NaN));
+                assertThat(reversePercentiles.percent(15), equalTo(Double.NaN));
+            }
+        );
     }
 
     @Override
     public void testUnmapped() throws Exception {
         int sigDigits = randomSignificantDigits();
-        SearchResponse searchResponse = prepareSearch("idx_unmapped").setQuery(matchAllQuery())
-            .addAggregation(
-                percentileRanks("percentile_ranks", new double[] { 0, 10, 15, 100 }).method(PercentilesMethod.HDR)
-                    .numberOfSignificantValueDigits(sigDigits)
-                    .field("value")
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx_unmapped").setQuery(matchAllQuery())
+                .addAggregation(
+                    percentileRanks("percentile_ranks", new double[] { 0, 10, 15, 100 }).method(PercentilesMethod.HDR)
+                        .numberOfSignificantValueDigits(sigDigits)
+                        .field("value")
+                ),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(0L));
 
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(0L));
-
-        PercentileRanks reversePercentiles = searchResponse.getAggregations().get("percentile_ranks");
-        assertThat(reversePercentiles, notNullValue());
-        assertThat(reversePercentiles.getName(), equalTo("percentile_ranks"));
-        assertThat(reversePercentiles.percent(0), equalTo(Double.NaN));
-        assertThat(reversePercentiles.percent(10), equalTo(Double.NaN));
-        assertThat(reversePercentiles.percent(15), equalTo(Double.NaN));
-        assertThat(reversePercentiles.percent(100), equalTo(Double.NaN));
+                PercentileRanks reversePercentiles = response.getAggregations().get("percentile_ranks");
+                assertThat(reversePercentiles, notNullValue());
+                assertThat(reversePercentiles.getName(), equalTo("percentile_ranks"));
+                assertThat(reversePercentiles.percent(0), equalTo(Double.NaN));
+                assertThat(reversePercentiles.percent(10), equalTo(Double.NaN));
+                assertThat(reversePercentiles.percent(15), equalTo(Double.NaN));
+                assertThat(reversePercentiles.percent(100), equalTo(Double.NaN));
+            }
+        );
     }
 
     @Override
     public void testSingleValuedField() throws Exception {
         int sigDigits = randomSignificantDigits();
         final double[] pcts = randomPercents(minValue, maxValue);
-        SearchResponse searchResponse = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                percentileRanks("percentile_ranks", pcts).method(PercentilesMethod.HDR)
-                    .numberOfSignificantValueDigits(sigDigits)
-                    .field("value")
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    percentileRanks("percentile_ranks", pcts).method(PercentilesMethod.HDR)
+                        .numberOfSignificantValueDigits(sigDigits)
+                        .field("value")
+                ),
+            response -> {
+                assertHitCount(response, 10);
 
-        assertHitCount(searchResponse, 10);
-
-        final PercentileRanks values = searchResponse.getAggregations().get("percentile_ranks");
-        assertConsistent(pcts, values, minValue, maxValue, sigDigits);
+                final PercentileRanks values = response.getAggregations().get("percentile_ranks");
+                assertConsistent(pcts, values, minValue, maxValue, sigDigits);
+            }
+        );
     }
 
     public void testNullValuesField() throws Exception {
@@ -201,84 +207,91 @@ public class HDRPercentileRanksIT extends AbstractNumericTestCase {
     public void testSingleValuedFieldGetProperty() throws Exception {
         int sigDigits = randomSignificantDigits();
         final double[] pcts = randomPercents(minValue, maxValue);
-        SearchResponse searchResponse = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                global("global").subAggregation(
-                    percentileRanks("percentile_ranks", pcts).method(PercentilesMethod.HDR)
-                        .numberOfSignificantValueDigits(sigDigits)
-                        .field("value")
-                )
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    global("global").subAggregation(
+                        percentileRanks("percentile_ranks", pcts).method(PercentilesMethod.HDR)
+                            .numberOfSignificantValueDigits(sigDigits)
+                            .field("value")
+                    )
+                ),
+            response -> {
+                assertHitCount(response, 10);
 
-        assertHitCount(searchResponse, 10);
+                Global global = response.getAggregations().get("global");
+                assertThat(global, notNullValue());
+                assertThat(global.getName(), equalTo("global"));
+                assertThat(global.getDocCount(), equalTo(10L));
+                assertThat(global.getAggregations(), notNullValue());
+                assertThat(global.getAggregations().asMap().size(), equalTo(1));
 
-        Global global = searchResponse.getAggregations().get("global");
-        assertThat(global, notNullValue());
-        assertThat(global.getName(), equalTo("global"));
-        assertThat(global.getDocCount(), equalTo(10L));
-        assertThat(global.getAggregations(), notNullValue());
-        assertThat(global.getAggregations().asMap().size(), equalTo(1));
-
-        PercentileRanks values = global.getAggregations().get("percentile_ranks");
-        assertThat(values, notNullValue());
-        assertThat(values.getName(), equalTo("percentile_ranks"));
-        assertThat(((InternalAggregation) global).getProperty("percentile_ranks"), sameInstance(values));
-
+                PercentileRanks values = global.getAggregations().get("percentile_ranks");
+                assertThat(values, notNullValue());
+                assertThat(values.getName(), equalTo("percentile_ranks"));
+                assertThat(((InternalAggregation) global).getProperty("percentile_ranks"), sameInstance(values));
+            }
+        );
     }
 
     public void testSingleValuedFieldOutsideRange() throws Exception {
         int sigDigits = randomSignificantDigits();
         final double[] pcts = new double[] { minValue - 1, maxValue + 1 };
-        SearchResponse searchResponse = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                percentileRanks("percentile_ranks", pcts).method(PercentilesMethod.HDR)
-                    .numberOfSignificantValueDigits(sigDigits)
-                    .field("value")
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    percentileRanks("percentile_ranks", pcts).method(PercentilesMethod.HDR)
+                        .numberOfSignificantValueDigits(sigDigits)
+                        .field("value")
+                ),
+            response -> {
+                assertHitCount(response, 10);
 
-        assertHitCount(searchResponse, 10);
-
-        final PercentileRanks values = searchResponse.getAggregations().get("percentile_ranks");
-        assertConsistent(pcts, values, minValue, maxValue, sigDigits);
+                final PercentileRanks values = response.getAggregations().get("percentile_ranks");
+                assertConsistent(pcts, values, minValue, maxValue, sigDigits);
+            }
+        );
     }
 
     @Override
     public void testSingleValuedFieldPartiallyUnmapped() throws Exception {
         int sigDigits = randomSignificantDigits();
         final double[] pcts = randomPercents(minValue, maxValue);
-        SearchResponse searchResponse = prepareSearch("idx", "idx_unmapped").setQuery(matchAllQuery())
-            .addAggregation(
-                percentileRanks("percentile_ranks", pcts).method(PercentilesMethod.HDR)
-                    .numberOfSignificantValueDigits(sigDigits)
-                    .field("value")
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx", "idx_unmapped").setQuery(matchAllQuery())
+                .addAggregation(
+                    percentileRanks("percentile_ranks", pcts).method(PercentilesMethod.HDR)
+                        .numberOfSignificantValueDigits(sigDigits)
+                        .field("value")
+                ),
+            response -> {
+                assertHitCount(response, 10);
 
-        assertHitCount(searchResponse, 10);
-
-        final PercentileRanks values = searchResponse.getAggregations().get("percentile_ranks");
-        assertConsistent(pcts, values, minValue, maxValue, sigDigits);
+                final PercentileRanks values = response.getAggregations().get("percentile_ranks");
+                assertConsistent(pcts, values, minValue, maxValue, sigDigits);
+            }
+        );
     }
 
     @Override
     public void testSingleValuedFieldWithValueScript() throws Exception {
         int sigDigits = randomSignificantDigits();
         final double[] pcts = randomPercents(minValue - 1, maxValue - 1);
-        SearchResponse searchResponse = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                percentileRanks("percentile_ranks", pcts).method(PercentilesMethod.HDR)
-                    .numberOfSignificantValueDigits(sigDigits)
-                    .field("value")
-                    .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value - 1", emptyMap()))
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    percentileRanks("percentile_ranks", pcts).method(PercentilesMethod.HDR)
+                        .numberOfSignificantValueDigits(sigDigits)
+                        .field("value")
+                        .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value - 1", emptyMap()))
+                ),
+            response -> {
+                assertHitCount(response, 10);
 
-        assertHitCount(searchResponse, 10);
-
-        final PercentileRanks values = searchResponse.getAggregations().get("percentile_ranks");
-        assertConsistent(pcts, values, minValue - 1, maxValue - 1, sigDigits);
+                final PercentileRanks values = response.getAggregations().get("percentile_ranks");
+                assertConsistent(pcts, values, minValue - 1, maxValue - 1, sigDigits);
+            }
+        );
     }
 
     @Override
@@ -287,74 +300,82 @@ public class HDRPercentileRanksIT extends AbstractNumericTestCase {
         Map<String, Object> params = new HashMap<>();
         params.put("dec", 1);
         final double[] pcts = randomPercents(minValue - 1, maxValue - 1);
-        SearchResponse searchResponse = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                percentileRanks("percentile_ranks", pcts).method(PercentilesMethod.HDR)
-                    .numberOfSignificantValueDigits(sigDigits)
-                    .field("value")
-                    .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value - dec", params))
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    percentileRanks("percentile_ranks", pcts).method(PercentilesMethod.HDR)
+                        .numberOfSignificantValueDigits(sigDigits)
+                        .field("value")
+                        .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value - dec", params))
+                ),
+            response -> {
+                assertHitCount(response, 10);
 
-        assertHitCount(searchResponse, 10);
-
-        final PercentileRanks values = searchResponse.getAggregations().get("percentile_ranks");
-        assertConsistent(pcts, values, minValue - 1, maxValue - 1, sigDigits);
+                final PercentileRanks values = response.getAggregations().get("percentile_ranks");
+                assertConsistent(pcts, values, minValue - 1, maxValue - 1, sigDigits);
+            }
+        );
     }
 
     @Override
     public void testMultiValuedField() throws Exception {
         int sigDigits = randomSignificantDigits();
         final double[] pcts = randomPercents(minValues, maxValues);
-        SearchResponse searchResponse = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                percentileRanks("percentile_ranks", pcts).method(PercentilesMethod.HDR)
-                    .numberOfSignificantValueDigits(sigDigits)
-                    .field("values")
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    percentileRanks("percentile_ranks", pcts).method(PercentilesMethod.HDR)
+                        .numberOfSignificantValueDigits(sigDigits)
+                        .field("values")
+                ),
+            response -> {
+                assertHitCount(response, 10);
 
-        assertHitCount(searchResponse, 10);
-
-        final PercentileRanks values = searchResponse.getAggregations().get("percentile_ranks");
-        assertConsistent(pcts, values, minValues, maxValues, sigDigits);
+                final PercentileRanks values = response.getAggregations().get("percentile_ranks");
+                assertConsistent(pcts, values, minValues, maxValues, sigDigits);
+            }
+        );
     }
 
     @Override
     public void testMultiValuedFieldWithValueScript() throws Exception {
         int sigDigits = randomSignificantDigits();
         final double[] pcts = randomPercents(minValues - 1, maxValues - 1);
-        SearchResponse searchResponse = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                percentileRanks("percentile_ranks", pcts).method(PercentilesMethod.HDR)
-                    .numberOfSignificantValueDigits(sigDigits)
-                    .field("values")
-                    .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value - 1", emptyMap()))
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    percentileRanks("percentile_ranks", pcts).method(PercentilesMethod.HDR)
+                        .numberOfSignificantValueDigits(sigDigits)
+                        .field("values")
+                        .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value - 1", emptyMap()))
+                ),
+            response -> {
+                assertHitCount(response, 10);
 
-        assertHitCount(searchResponse, 10);
-
-        final PercentileRanks values = searchResponse.getAggregations().get("percentile_ranks");
-        assertConsistent(pcts, values, minValues - 1, maxValues - 1, sigDigits);
+                final PercentileRanks values = response.getAggregations().get("percentile_ranks");
+                assertConsistent(pcts, values, minValues - 1, maxValues - 1, sigDigits);
+            }
+        );
     }
 
     public void testMultiValuedFieldWithValueScriptReverse() throws Exception {
         int sigDigits = randomSignificantDigits();
         final double[] pcts = randomPercents(20 - maxValues, 20 - minValues);
-        SearchResponse searchResponse = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                percentileRanks("percentile_ranks", pcts).method(PercentilesMethod.HDR)
-                    .numberOfSignificantValueDigits(sigDigits)
-                    .field("values")
-                    .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "20 - _value", emptyMap()))
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    percentileRanks("percentile_ranks", pcts).method(PercentilesMethod.HDR)
+                        .numberOfSignificantValueDigits(sigDigits)
+                        .field("values")
+                        .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "20 - _value", emptyMap()))
+                ),
+            response -> {
+                assertHitCount(response, 10);
 
-        assertHitCount(searchResponse, 10);
-
-        final PercentileRanks values = searchResponse.getAggregations().get("percentile_ranks");
-        assertConsistent(pcts, values, 20 - maxValues, 20 - minValues, sigDigits);
+                final PercentileRanks values = response.getAggregations().get("percentile_ranks");
+                assertConsistent(pcts, values, 20 - maxValues, 20 - minValues, sigDigits);
+            }
+        );
     }
 
     @Override
@@ -363,37 +384,41 @@ public class HDRPercentileRanksIT extends AbstractNumericTestCase {
         Map<String, Object> params = new HashMap<>();
         params.put("dec", 1);
         final double[] pcts = randomPercents(minValues - 1, maxValues - 1);
-        SearchResponse searchResponse = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                percentileRanks("percentile_ranks", pcts).method(PercentilesMethod.HDR)
-                    .numberOfSignificantValueDigits(sigDigits)
-                    .field("values")
-                    .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value - dec", params))
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    percentileRanks("percentile_ranks", pcts).method(PercentilesMethod.HDR)
+                        .numberOfSignificantValueDigits(sigDigits)
+                        .field("values")
+                        .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value - dec", params))
+                ),
+            response -> {
+                assertHitCount(response, 10);
 
-        assertHitCount(searchResponse, 10);
-
-        final PercentileRanks values = searchResponse.getAggregations().get("percentile_ranks");
-        assertConsistent(pcts, values, minValues - 1, maxValues - 1, sigDigits);
+                final PercentileRanks values = response.getAggregations().get("percentile_ranks");
+                assertConsistent(pcts, values, minValues - 1, maxValues - 1, sigDigits);
+            }
+        );
     }
 
     @Override
     public void testScriptSingleValued() throws Exception {
         int sigDigits = randomSignificantDigits();
         final double[] pcts = randomPercents(minValue, maxValue);
-        SearchResponse searchResponse = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                percentileRanks("percentile_ranks", pcts).method(PercentilesMethod.HDR)
-                    .numberOfSignificantValueDigits(sigDigits)
-                    .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "doc['value'].value", emptyMap()))
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    percentileRanks("percentile_ranks", pcts).method(PercentilesMethod.HDR)
+                        .numberOfSignificantValueDigits(sigDigits)
+                        .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "doc['value'].value", emptyMap()))
+                ),
+            response -> {
+                assertHitCount(response, 10);
 
-        assertHitCount(searchResponse, 10);
-
-        final PercentileRanks values = searchResponse.getAggregations().get("percentile_ranks");
-        assertConsistent(pcts, values, minValue, maxValue, sigDigits);
+                final PercentileRanks values = response.getAggregations().get("percentile_ranks");
+                assertConsistent(pcts, values, minValue, maxValue, sigDigits);
+            }
+        );
     }
 
     @Override
@@ -405,18 +430,20 @@ public class HDRPercentileRanksIT extends AbstractNumericTestCase {
         Script script = new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "doc['value'].value - dec", params);
 
         final double[] pcts = randomPercents(minValue - 1, maxValue - 1);
-        SearchResponse searchResponse = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                percentileRanks("percentile_ranks", pcts).method(PercentilesMethod.HDR)
-                    .numberOfSignificantValueDigits(sigDigits)
-                    .script(script)
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    percentileRanks("percentile_ranks", pcts).method(PercentilesMethod.HDR)
+                        .numberOfSignificantValueDigits(sigDigits)
+                        .script(script)
+                ),
+            response -> {
+                assertHitCount(response, 10);
 
-        assertHitCount(searchResponse, 10);
-
-        final PercentileRanks values = searchResponse.getAggregations().get("percentile_ranks");
-        assertConsistent(pcts, values, minValue - 1, maxValue - 1, sigDigits);
+                final PercentileRanks values = response.getAggregations().get("percentile_ranks");
+                assertConsistent(pcts, values, minValue - 1, maxValue - 1, sigDigits);
+            }
+        );
     }
 
     @Override
@@ -426,18 +453,20 @@ public class HDRPercentileRanksIT extends AbstractNumericTestCase {
 
         Script script = new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "doc['values']", emptyMap());
 
-        SearchResponse searchResponse = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                percentileRanks("percentile_ranks", pcts).method(PercentilesMethod.HDR)
-                    .numberOfSignificantValueDigits(sigDigits)
-                    .script(script)
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    percentileRanks("percentile_ranks", pcts).method(PercentilesMethod.HDR)
+                        .numberOfSignificantValueDigits(sigDigits)
+                        .script(script)
+                ),
+            response -> {
+                assertHitCount(response, 10);
 
-        assertHitCount(searchResponse, 10);
-
-        final PercentileRanks values = searchResponse.getAggregations().get("percentile_ranks");
-        assertConsistent(pcts, values, minValues, maxValues, sigDigits);
+                final PercentileRanks values = response.getAggregations().get("percentile_ranks");
+                assertConsistent(pcts, values, minValues, maxValues, sigDigits);
+            }
+        );
     }
 
     @Override
@@ -446,87 +475,93 @@ public class HDRPercentileRanksIT extends AbstractNumericTestCase {
         Script script = AggregationTestScriptsPlugin.DECREMENT_ALL_VALUES;
 
         final double[] pcts = randomPercents(minValues - 1, maxValues - 1);
-        SearchResponse searchResponse = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                percentileRanks("percentile_ranks", pcts).method(PercentilesMethod.HDR)
-                    .numberOfSignificantValueDigits(sigDigits)
-                    .script(script)
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    percentileRanks("percentile_ranks", pcts).method(PercentilesMethod.HDR)
+                        .numberOfSignificantValueDigits(sigDigits)
+                        .script(script)
+                ),
+            response -> {
+                assertHitCount(response, 10);
 
-        assertHitCount(searchResponse, 10);
-
-        final PercentileRanks values = searchResponse.getAggregations().get("percentile_ranks");
-        assertConsistent(pcts, values, minValues - 1, maxValues - 1, sigDigits);
+                final PercentileRanks values = response.getAggregations().get("percentile_ranks");
+                assertConsistent(pcts, values, minValues - 1, maxValues - 1, sigDigits);
+            }
+        );
     }
 
     public void testOrderBySubAggregation() {
         int sigDigits = randomSignificantDigits();
         boolean asc = randomBoolean();
-        SearchResponse searchResponse = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                histogram("histo").field("value")
-                    .interval(2L)
-                    .subAggregation(
-                        percentileRanks("percentile_ranks", new double[] { 99 }).field("value")
-                            .method(PercentilesMethod.HDR)
-                            .numberOfSignificantValueDigits(sigDigits)
-                    )
-                    .order(BucketOrder.aggregation("percentile_ranks", "99", asc))
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    histogram("histo").field("value")
+                        .interval(2L)
+                        .subAggregation(
+                            percentileRanks("percentile_ranks", new double[] { 99 }).field("value")
+                                .method(PercentilesMethod.HDR)
+                                .numberOfSignificantValueDigits(sigDigits)
+                        )
+                        .order(BucketOrder.aggregation("percentile_ranks", "99", asc))
+                ),
+            response -> {
+                assertHitCount(response, 10);
 
-        assertHitCount(searchResponse, 10);
-
-        Histogram histo = searchResponse.getAggregations().get("histo");
-        double previous = asc ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY;
-        for (Histogram.Bucket bucket : histo.getBuckets()) {
-            PercentileRanks values = bucket.getAggregations().get("percentile_ranks");
-            double p99 = values.percent(99);
-            if (asc) {
-                assertThat(p99, greaterThanOrEqualTo(previous));
-            } else {
-                assertThat(p99, lessThanOrEqualTo(previous));
+                Histogram histo = response.getAggregations().get("histo");
+                double previous = asc ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY;
+                for (Histogram.Bucket bucket : histo.getBuckets()) {
+                    PercentileRanks values = bucket.getAggregations().get("percentile_ranks");
+                    double p99 = values.percent(99);
+                    if (asc) {
+                        assertThat(p99, greaterThanOrEqualTo(previous));
+                    } else {
+                        assertThat(p99, lessThanOrEqualTo(previous));
+                    }
+                    previous = p99;
+                }
             }
-            previous = p99;
-        }
+        );
     }
 
     @Override
     public void testOrderByEmptyAggregation() throws Exception {
-        SearchResponse searchResponse = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                terms("terms").field("value")
-                    .order(BucketOrder.compound(BucketOrder.aggregation("filter>ranks.99", true)))
-                    .subAggregation(
-                        filter("filter", termQuery("value", 100)).subAggregation(
-                            percentileRanks("ranks", new double[] { 99 }).method(PercentilesMethod.HDR).field("value")
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    terms("terms").field("value")
+                        .order(BucketOrder.compound(BucketOrder.aggregation("filter>ranks.99", true)))
+                        .subAggregation(
+                            filter("filter", termQuery("value", 100)).subAggregation(
+                                percentileRanks("ranks", new double[] { 99 }).method(PercentilesMethod.HDR).field("value")
+                            )
                         )
-                    )
-            )
-            .get();
+                ),
+            response -> {
+                assertHitCount(response, 10);
 
-        assertHitCount(searchResponse, 10);
+                Terms terms = response.getAggregations().get("terms");
+                assertThat(terms, notNullValue());
+                List<? extends Terms.Bucket> buckets = terms.getBuckets();
+                assertThat(buckets, notNullValue());
+                assertThat(buckets.size(), equalTo(10));
 
-        Terms terms = searchResponse.getAggregations().get("terms");
-        assertThat(terms, notNullValue());
-        List<? extends Terms.Bucket> buckets = terms.getBuckets();
-        assertThat(buckets, notNullValue());
-        assertThat(buckets.size(), equalTo(10));
+                for (int i = 0; i < 10; i++) {
+                    Terms.Bucket bucket = buckets.get(i);
+                    assertThat(bucket, notNullValue());
+                    assertThat(bucket.getKeyAsNumber(), equalTo((long) i + 1));
+                    assertThat(bucket.getDocCount(), equalTo(1L));
+                    Filter filter = bucket.getAggregations().get("filter");
+                    assertThat(filter, notNullValue());
+                    assertThat(filter.getDocCount(), equalTo(0L));
+                    PercentileRanks ranks = filter.getAggregations().get("ranks");
+                    assertThat(ranks, notNullValue());
+                    assertThat(ranks.percent(99), equalTo(Double.NaN));
 
-        for (int i = 0; i < 10; i++) {
-            Terms.Bucket bucket = buckets.get(i);
-            assertThat(bucket, notNullValue());
-            assertThat(bucket.getKeyAsNumber(), equalTo((long) i + 1));
-            assertThat(bucket.getDocCount(), equalTo(1L));
-            Filter filter = bucket.getAggregations().get("filter");
-            assertThat(filter, notNullValue());
-            assertThat(filter.getDocCount(), equalTo(0L));
-            PercentileRanks ranks = filter.getAggregations().get("ranks");
-            assertThat(ranks, notNullValue());
-            assertThat(ranks.percent(99), equalTo(Double.NaN));
-
-        }
+                }
+            }
+        );
     }
 
     /**
@@ -555,14 +590,14 @@ public class HDRPercentileRanksIT extends AbstractNumericTestCase {
         );
 
         // Test that a request using a nondeterministic script does not get cached
-        SearchResponse r = prepareSearch("cache_test_idx").setSize(0)
-            .addAggregation(
-                percentileRanks("foo", new double[] { 50.0 }).method(PercentilesMethod.HDR)
-                    .field("d")
-                    .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "Math.random()", emptyMap()))
-            )
-            .get();
-        assertNoFailures(r);
+        assertNoFailures(
+            prepareSearch("cache_test_idx").setSize(0)
+                .addAggregation(
+                    percentileRanks("foo", new double[] { 50.0 }).method(PercentilesMethod.HDR)
+                        .field("d")
+                        .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "Math.random()", emptyMap()))
+                )
+        );
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -574,14 +609,14 @@ public class HDRPercentileRanksIT extends AbstractNumericTestCase {
         );
 
         // Test that a request using a deterministic script gets cached
-        r = prepareSearch("cache_test_idx").setSize(0)
-            .addAggregation(
-                percentileRanks("foo", new double[] { 50.0 }).method(PercentilesMethod.HDR)
-                    .field("d")
-                    .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value - 1", emptyMap()))
-            )
-            .get();
-        assertNoFailures(r);
+        assertNoFailures(
+            prepareSearch("cache_test_idx").setSize(0)
+                .addAggregation(
+                    percentileRanks("foo", new double[] { 50.0 }).method(PercentilesMethod.HDR)
+                        .field("d")
+                        .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value - 1", emptyMap()))
+                )
+        );
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -593,10 +628,10 @@ public class HDRPercentileRanksIT extends AbstractNumericTestCase {
         );
 
         // Ensure that non-scripted requests are cached as normal
-        r = prepareSearch("cache_test_idx").setSize(0)
-            .addAggregation(percentileRanks("foo", new double[] { 50.0 }).method(PercentilesMethod.HDR).field("d"))
-            .get();
-        assertNoFailures(r);
+        assertNoFailures(
+            prepareSearch("cache_test_idx").setSize(0)
+                .addAggregation(percentileRanks("foo", new double[] { 50.0 }).method(PercentilesMethod.HDR).field("d"))
+        );
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -607,5 +642,4 @@ public class HDRPercentileRanksIT extends AbstractNumericTestCase {
             equalTo(2L)
         );
     }
-
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/HDRPercentilesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/HDRPercentilesIT.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.search.aggregations.metrics;
 
 import org.apache.logging.log4j.LogManager;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.plugins.Plugin;
@@ -42,6 +41,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -102,143 +102,154 @@ public class HDRPercentilesIT extends AbstractNumericTestCase {
     @Override
     public void testEmptyAggregation() throws Exception {
         int sigDigits = randomSignificantDigits();
-        SearchResponse searchResponse = prepareSearch("empty_bucket_idx").setQuery(matchAllQuery())
-            .addAggregation(
-                histogram("histo").field("value")
-                    .interval(1L)
-                    .minDocCount(0)
-                    .subAggregation(
-                        percentiles("percentiles").field("value")
-                            .numberOfSignificantValueDigits(sigDigits)
-                            .method(PercentilesMethod.HDR)
-                            .percentiles(10, 15)
-                    )
-            )
-            .get();
+        assertResponse(
+            prepareSearch("empty_bucket_idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    histogram("histo").field("value")
+                        .interval(1L)
+                        .minDocCount(0)
+                        .subAggregation(
+                            percentiles("percentiles").field("value")
+                                .numberOfSignificantValueDigits(sigDigits)
+                                .method(PercentilesMethod.HDR)
+                                .percentiles(10, 15)
+                        )
+                ),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(2L));
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo, notNullValue());
+                Histogram.Bucket bucket = histo.getBuckets().get(1);
+                assertThat(bucket, notNullValue());
 
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(2L));
-        Histogram histo = searchResponse.getAggregations().get("histo");
-        assertThat(histo, notNullValue());
-        Histogram.Bucket bucket = histo.getBuckets().get(1);
-        assertThat(bucket, notNullValue());
-
-        Percentiles percentiles = bucket.getAggregations().get("percentiles");
-        assertThat(percentiles, notNullValue());
-        assertThat(percentiles.getName(), equalTo("percentiles"));
-        assertThat(percentiles.percentile(10), equalTo(Double.NaN));
-        assertThat(percentiles.percentile(15), equalTo(Double.NaN));
+                Percentiles percentiles = bucket.getAggregations().get("percentiles");
+                assertThat(percentiles, notNullValue());
+                assertThat(percentiles.getName(), equalTo("percentiles"));
+                assertThat(percentiles.percentile(10), equalTo(Double.NaN));
+                assertThat(percentiles.percentile(15), equalTo(Double.NaN));
+            }
+        );
     }
 
     @Override
     public void testUnmapped() throws Exception {
         int sigDigits = randomSignificantDigits();
-        SearchResponse searchResponse = prepareSearch("idx_unmapped").setQuery(matchAllQuery())
-            .addAggregation(
-                percentiles("percentiles").numberOfSignificantValueDigits(sigDigits)
-                    .method(PercentilesMethod.HDR)
-                    .field("value")
-                    .percentiles(0, 10, 15, 100)
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx_unmapped").setQuery(matchAllQuery())
+                .addAggregation(
+                    percentiles("percentiles").numberOfSignificantValueDigits(sigDigits)
+                        .method(PercentilesMethod.HDR)
+                        .field("value")
+                        .percentiles(0, 10, 15, 100)
+                ),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(0L));
 
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(0L));
-
-        Percentiles percentiles = searchResponse.getAggregations().get("percentiles");
-        assertThat(percentiles, notNullValue());
-        assertThat(percentiles.getName(), equalTo("percentiles"));
-        assertThat(percentiles.percentile(0), equalTo(Double.NaN));
-        assertThat(percentiles.percentile(10), equalTo(Double.NaN));
-        assertThat(percentiles.percentile(15), equalTo(Double.NaN));
-        assertThat(percentiles.percentile(100), equalTo(Double.NaN));
+                Percentiles percentiles = response.getAggregations().get("percentiles");
+                assertThat(percentiles, notNullValue());
+                assertThat(percentiles.getName(), equalTo("percentiles"));
+                assertThat(percentiles.percentile(0), equalTo(Double.NaN));
+                assertThat(percentiles.percentile(10), equalTo(Double.NaN));
+                assertThat(percentiles.percentile(15), equalTo(Double.NaN));
+                assertThat(percentiles.percentile(100), equalTo(Double.NaN));
+            }
+        );
     }
 
     @Override
     public void testSingleValuedField() throws Exception {
         final double[] pcts = randomPercentiles();
         int sigDigits = randomIntBetween(1, 5);
-        SearchResponse searchResponse = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                percentiles("percentiles").numberOfSignificantValueDigits(sigDigits)
-                    .method(PercentilesMethod.HDR)
-                    .field("value")
-                    .percentiles(pcts)
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    percentiles("percentiles").numberOfSignificantValueDigits(sigDigits)
+                        .method(PercentilesMethod.HDR)
+                        .field("value")
+                        .percentiles(pcts)
+                ),
+            response -> {
+                assertHitCount(response, 10);
 
-        assertHitCount(searchResponse, 10);
-
-        final Percentiles percentiles = searchResponse.getAggregations().get("percentiles");
-        assertConsistent(pcts, percentiles, minValue, maxValue, sigDigits);
+                final Percentiles percentiles = response.getAggregations().get("percentiles");
+                assertConsistent(pcts, percentiles, minValue, maxValue, sigDigits);
+            }
+        );
     }
 
     @Override
     public void testSingleValuedFieldGetProperty() throws Exception {
         final double[] pcts = randomPercentiles();
         int sigDigits = randomSignificantDigits();
-        SearchResponse searchResponse = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                global("global").subAggregation(
-                    percentiles("percentiles").numberOfSignificantValueDigits(sigDigits)
-                        .method(PercentilesMethod.HDR)
-                        .field("value")
-                        .percentiles(pcts)
-                )
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    global("global").subAggregation(
+                        percentiles("percentiles").numberOfSignificantValueDigits(sigDigits)
+                            .method(PercentilesMethod.HDR)
+                            .field("value")
+                            .percentiles(pcts)
+                    )
+                ),
+            response -> {
+                assertHitCount(response, 10);
 
-        assertHitCount(searchResponse, 10);
+                Global global = response.getAggregations().get("global");
+                assertThat(global, notNullValue());
+                assertThat(global.getName(), equalTo("global"));
+                assertThat(global.getDocCount(), equalTo(10L));
+                assertThat(global.getAggregations(), notNullValue());
+                assertThat(global.getAggregations().asMap().size(), equalTo(1));
 
-        Global global = searchResponse.getAggregations().get("global");
-        assertThat(global, notNullValue());
-        assertThat(global.getName(), equalTo("global"));
-        assertThat(global.getDocCount(), equalTo(10L));
-        assertThat(global.getAggregations(), notNullValue());
-        assertThat(global.getAggregations().asMap().size(), equalTo(1));
-
-        Percentiles percentiles = global.getAggregations().get("percentiles");
-        assertThat(percentiles, notNullValue());
-        assertThat(percentiles.getName(), equalTo("percentiles"));
-        assertThat(((InternalAggregation) global).getProperty("percentiles"), sameInstance(percentiles));
-
+                Percentiles percentiles = global.getAggregations().get("percentiles");
+                assertThat(percentiles, notNullValue());
+                assertThat(percentiles.getName(), equalTo("percentiles"));
+                assertThat(((InternalAggregation) global).getProperty("percentiles"), sameInstance(percentiles));
+            }
+        );
     }
 
     @Override
     public void testSingleValuedFieldPartiallyUnmapped() throws Exception {
         final double[] pcts = randomPercentiles();
         int sigDigits = randomSignificantDigits();
-        SearchResponse searchResponse = prepareSearch("idx", "idx_unmapped").setQuery(matchAllQuery())
-            .addAggregation(
-                percentiles("percentiles").numberOfSignificantValueDigits(sigDigits)
-                    .method(PercentilesMethod.HDR)
-                    .field("value")
-                    .percentiles(pcts)
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx", "idx_unmapped").setQuery(matchAllQuery())
+                .addAggregation(
+                    percentiles("percentiles").numberOfSignificantValueDigits(sigDigits)
+                        .method(PercentilesMethod.HDR)
+                        .field("value")
+                        .percentiles(pcts)
+                ),
+            response -> {
+                assertHitCount(response, 10);
 
-        assertHitCount(searchResponse, 10);
-
-        final Percentiles percentiles = searchResponse.getAggregations().get("percentiles");
-        assertConsistent(pcts, percentiles, minValue, maxValue, sigDigits);
+                final Percentiles percentiles = response.getAggregations().get("percentiles");
+                assertConsistent(pcts, percentiles, minValue, maxValue, sigDigits);
+            }
+        );
     }
 
     @Override
     public void testSingleValuedFieldWithValueScript() throws Exception {
         final double[] pcts = randomPercentiles();
         int sigDigits = randomSignificantDigits();
-        SearchResponse searchResponse = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                percentiles("percentiles").numberOfSignificantValueDigits(sigDigits)
-                    .method(PercentilesMethod.HDR)
-                    .field("value")
-                    .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value - 1", emptyMap()))
-                    .percentiles(pcts)
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    percentiles("percentiles").numberOfSignificantValueDigits(sigDigits)
+                        .method(PercentilesMethod.HDR)
+                        .field("value")
+                        .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value - 1", emptyMap()))
+                        .percentiles(pcts)
+                ),
+            response -> {
+                assertHitCount(response, 10);
 
-        assertHitCount(searchResponse, 10);
-
-        final Percentiles percentiles = searchResponse.getAggregations().get("percentiles");
-        assertConsistent(pcts, percentiles, minValue - 1, maxValue - 1, sigDigits);
+                final Percentiles percentiles = response.getAggregations().get("percentiles");
+                assertConsistent(pcts, percentiles, minValue - 1, maxValue - 1, sigDigits);
+            }
+        );
     }
 
     @Override
@@ -248,78 +259,86 @@ public class HDRPercentilesIT extends AbstractNumericTestCase {
 
         final double[] pcts = randomPercentiles();
         int sigDigits = randomSignificantDigits();
-        SearchResponse searchResponse = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                percentiles("percentiles").numberOfSignificantValueDigits(sigDigits)
-                    .method(PercentilesMethod.HDR)
-                    .field("value")
-                    .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value - dec", params))
-                    .percentiles(pcts)
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    percentiles("percentiles").numberOfSignificantValueDigits(sigDigits)
+                        .method(PercentilesMethod.HDR)
+                        .field("value")
+                        .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value - dec", params))
+                        .percentiles(pcts)
+                ),
+            response -> {
+                assertHitCount(response, 10);
 
-        assertHitCount(searchResponse, 10);
-
-        final Percentiles percentiles = searchResponse.getAggregations().get("percentiles");
-        assertConsistent(pcts, percentiles, minValue - 1, maxValue - 1, sigDigits);
+                final Percentiles percentiles = response.getAggregations().get("percentiles");
+                assertConsistent(pcts, percentiles, minValue - 1, maxValue - 1, sigDigits);
+            }
+        );
     }
 
     @Override
     public void testMultiValuedField() throws Exception {
         final double[] pcts = randomPercentiles();
         int sigDigits = randomSignificantDigits();
-        SearchResponse searchResponse = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                percentiles("percentiles").numberOfSignificantValueDigits(sigDigits)
-                    .method(PercentilesMethod.HDR)
-                    .field("values")
-                    .percentiles(pcts)
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    percentiles("percentiles").numberOfSignificantValueDigits(sigDigits)
+                        .method(PercentilesMethod.HDR)
+                        .field("values")
+                        .percentiles(pcts)
+                ),
+            response -> {
+                assertHitCount(response, 10);
 
-        assertHitCount(searchResponse, 10);
-
-        final Percentiles percentiles = searchResponse.getAggregations().get("percentiles");
-        assertConsistent(pcts, percentiles, minValues, maxValues, sigDigits);
+                final Percentiles percentiles = response.getAggregations().get("percentiles");
+                assertConsistent(pcts, percentiles, minValues, maxValues, sigDigits);
+            }
+        );
     }
 
     @Override
     public void testMultiValuedFieldWithValueScript() throws Exception {
         final double[] pcts = randomPercentiles();
         int sigDigits = randomSignificantDigits();
-        SearchResponse searchResponse = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                percentiles("percentiles").numberOfSignificantValueDigits(sigDigits)
-                    .method(PercentilesMethod.HDR)
-                    .field("values")
-                    .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value - 1", emptyMap()))
-                    .percentiles(pcts)
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    percentiles("percentiles").numberOfSignificantValueDigits(sigDigits)
+                        .method(PercentilesMethod.HDR)
+                        .field("values")
+                        .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value - 1", emptyMap()))
+                        .percentiles(pcts)
+                ),
+            response -> {
+                assertHitCount(response, 10);
 
-        assertHitCount(searchResponse, 10);
-
-        final Percentiles percentiles = searchResponse.getAggregations().get("percentiles");
-        assertConsistent(pcts, percentiles, minValues - 1, maxValues - 1, sigDigits);
+                final Percentiles percentiles = response.getAggregations().get("percentiles");
+                assertConsistent(pcts, percentiles, minValues - 1, maxValues - 1, sigDigits);
+            }
+        );
     }
 
     public void testMultiValuedFieldWithValueScriptReverse() throws Exception {
         final double[] pcts = randomPercentiles();
         int sigDigits = randomSignificantDigits();
-        SearchResponse searchResponse = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                percentiles("percentiles").numberOfSignificantValueDigits(sigDigits)
-                    .method(PercentilesMethod.HDR)
-                    .field("values")
-                    .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "20 - _value", emptyMap()))
-                    .percentiles(pcts)
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    percentiles("percentiles").numberOfSignificantValueDigits(sigDigits)
+                        .method(PercentilesMethod.HDR)
+                        .field("values")
+                        .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "20 - _value", emptyMap()))
+                        .percentiles(pcts)
+                ),
+            response -> {
+                assertHitCount(response, 10);
 
-        assertHitCount(searchResponse, 10);
-
-        final Percentiles percentiles = searchResponse.getAggregations().get("percentiles");
-        assertConsistent(pcts, percentiles, 20 - maxValues, 20 - minValues, sigDigits);
+                final Percentiles percentiles = response.getAggregations().get("percentiles");
+                assertConsistent(pcts, percentiles, 20 - maxValues, 20 - minValues, sigDigits);
+            }
+        );
     }
 
     @Override
@@ -329,39 +348,43 @@ public class HDRPercentilesIT extends AbstractNumericTestCase {
 
         final double[] pcts = randomPercentiles();
         int sigDigits = randomSignificantDigits();
-        SearchResponse searchResponse = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                percentiles("percentiles").numberOfSignificantValueDigits(sigDigits)
-                    .method(PercentilesMethod.HDR)
-                    .field("values")
-                    .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value - dec", params))
-                    .percentiles(pcts)
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    percentiles("percentiles").numberOfSignificantValueDigits(sigDigits)
+                        .method(PercentilesMethod.HDR)
+                        .field("values")
+                        .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value - dec", params))
+                        .percentiles(pcts)
+                ),
+            response -> {
+                assertHitCount(response, 10);
 
-        assertHitCount(searchResponse, 10);
-
-        final Percentiles percentiles = searchResponse.getAggregations().get("percentiles");
-        assertConsistent(pcts, percentiles, minValues - 1, maxValues - 1, sigDigits);
+                final Percentiles percentiles = response.getAggregations().get("percentiles");
+                assertConsistent(pcts, percentiles, minValues - 1, maxValues - 1, sigDigits);
+            }
+        );
     }
 
     @Override
     public void testScriptSingleValued() throws Exception {
         final double[] pcts = randomPercentiles();
         int sigDigits = randomSignificantDigits();
-        SearchResponse searchResponse = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                percentiles("percentiles").numberOfSignificantValueDigits(sigDigits)
-                    .method(PercentilesMethod.HDR)
-                    .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "doc['value'].value", emptyMap()))
-                    .percentiles(pcts)
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    percentiles("percentiles").numberOfSignificantValueDigits(sigDigits)
+                        .method(PercentilesMethod.HDR)
+                        .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "doc['value'].value", emptyMap()))
+                        .percentiles(pcts)
+                ),
+            response -> {
+                assertHitCount(response, 10);
 
-        assertHitCount(searchResponse, 10);
-
-        final Percentiles percentiles = searchResponse.getAggregations().get("percentiles");
-        assertConsistent(pcts, percentiles, minValue, maxValue, sigDigits);
+                final Percentiles percentiles = response.getAggregations().get("percentiles");
+                assertConsistent(pcts, percentiles, minValue, maxValue, sigDigits);
+            }
+        );
     }
 
     @Override
@@ -373,19 +396,21 @@ public class HDRPercentilesIT extends AbstractNumericTestCase {
 
         final double[] pcts = randomPercentiles();
         int sigDigits = randomSignificantDigits();
-        SearchResponse searchResponse = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                percentiles("percentiles").numberOfSignificantValueDigits(sigDigits)
-                    .method(PercentilesMethod.HDR)
-                    .script(script)
-                    .percentiles(pcts)
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    percentiles("percentiles").numberOfSignificantValueDigits(sigDigits)
+                        .method(PercentilesMethod.HDR)
+                        .script(script)
+                        .percentiles(pcts)
+                ),
+            response -> {
+                assertHitCount(response, 10);
 
-        assertHitCount(searchResponse, 10);
-
-        final Percentiles percentiles = searchResponse.getAggregations().get("percentiles");
-        assertConsistent(pcts, percentiles, minValue - 1, maxValue - 1, sigDigits);
+                final Percentiles percentiles = response.getAggregations().get("percentiles");
+                assertConsistent(pcts, percentiles, minValue - 1, maxValue - 1, sigDigits);
+            }
+        );
     }
 
     @Override
@@ -395,19 +420,21 @@ public class HDRPercentilesIT extends AbstractNumericTestCase {
 
         Script script = new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "doc['values']", emptyMap());
 
-        SearchResponse searchResponse = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                percentiles("percentiles").numberOfSignificantValueDigits(sigDigits)
-                    .method(PercentilesMethod.HDR)
-                    .script(script)
-                    .percentiles(pcts)
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    percentiles("percentiles").numberOfSignificantValueDigits(sigDigits)
+                        .method(PercentilesMethod.HDR)
+                        .script(script)
+                        .percentiles(pcts)
+                ),
+            response -> {
+                assertHitCount(response, 10);
 
-        assertHitCount(searchResponse, 10);
-
-        final Percentiles percentiles = searchResponse.getAggregations().get("percentiles");
-        assertConsistent(pcts, percentiles, minValues, maxValues, sigDigits);
+                final Percentiles percentiles = response.getAggregations().get("percentiles");
+                assertConsistent(pcts, percentiles, minValues, maxValues, sigDigits);
+            }
+        );
     }
 
     @Override
@@ -416,89 +443,96 @@ public class HDRPercentilesIT extends AbstractNumericTestCase {
 
         final double[] pcts = randomPercentiles();
         int sigDigits = randomSignificantDigits();
-        SearchResponse searchResponse = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                percentiles("percentiles").numberOfSignificantValueDigits(sigDigits)
-                    .method(PercentilesMethod.HDR)
-                    .script(script)
-                    .percentiles(pcts)
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    percentiles("percentiles").numberOfSignificantValueDigits(sigDigits)
+                        .method(PercentilesMethod.HDR)
+                        .script(script)
+                        .percentiles(pcts)
+                ),
+            response -> {
+                assertHitCount(response, 10);
 
-        assertHitCount(searchResponse, 10);
+                final Percentiles percentiles = response.getAggregations().get("percentiles");
+                assertConsistent(pcts, percentiles, minValues - 1, maxValues - 1, sigDigits);
 
-        final Percentiles percentiles = searchResponse.getAggregations().get("percentiles");
-        assertConsistent(pcts, percentiles, minValues - 1, maxValues - 1, sigDigits);
+            }
+        );
     }
 
     public void testOrderBySubAggregation() {
         int sigDigits = randomSignificantDigits();
         boolean asc = randomBoolean();
-        SearchResponse searchResponse = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                histogram("histo").field("value")
-                    .interval(2L)
-                    .subAggregation(
-                        percentiles("percentiles").field("value")
-                            .method(PercentilesMethod.HDR)
-                            .numberOfSignificantValueDigits(sigDigits)
-                            .percentiles(99)
-                    )
-                    .order(BucketOrder.aggregation("percentiles", "99", asc))
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    histogram("histo").field("value")
+                        .interval(2L)
+                        .subAggregation(
+                            percentiles("percentiles").field("value")
+                                .method(PercentilesMethod.HDR)
+                                .numberOfSignificantValueDigits(sigDigits)
+                                .percentiles(99)
+                        )
+                        .order(BucketOrder.aggregation("percentiles", "99", asc))
+                ),
+            response -> {
+                assertHitCount(response, 10);
 
-        assertHitCount(searchResponse, 10);
-
-        Histogram histo = searchResponse.getAggregations().get("histo");
-        double previous = asc ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY;
-        for (Histogram.Bucket bucket : histo.getBuckets()) {
-            Percentiles percentiles = bucket.getAggregations().get("percentiles");
-            double p99 = percentiles.percentile(99);
-            if (asc) {
-                assertThat(p99, greaterThanOrEqualTo(previous));
-            } else {
-                assertThat(p99, lessThanOrEqualTo(previous));
+                Histogram histo = response.getAggregations().get("histo");
+                double previous = asc ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY;
+                for (Histogram.Bucket bucket : histo.getBuckets()) {
+                    Percentiles percentiles = bucket.getAggregations().get("percentiles");
+                    double p99 = percentiles.percentile(99);
+                    if (asc) {
+                        assertThat(p99, greaterThanOrEqualTo(previous));
+                    } else {
+                        assertThat(p99, lessThanOrEqualTo(previous));
+                    }
+                    previous = p99;
+                }
             }
-            previous = p99;
-        }
+        );
     }
 
     @Override
     public void testOrderByEmptyAggregation() throws Exception {
-        SearchResponse searchResponse = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                terms("terms").field("value")
-                    .order(BucketOrder.compound(BucketOrder.aggregation("filter>percentiles.99", true)))
-                    .subAggregation(
-                        filter("filter", termQuery("value", 100)).subAggregation(
-                            percentiles("percentiles").method(PercentilesMethod.HDR).field("value")
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    terms("terms").field("value")
+                        .order(BucketOrder.compound(BucketOrder.aggregation("filter>percentiles.99", true)))
+                        .subAggregation(
+                            filter("filter", termQuery("value", 100)).subAggregation(
+                                percentiles("percentiles").method(PercentilesMethod.HDR).field("value")
+                            )
                         )
-                    )
-            )
-            .get();
+                ),
+            response -> {
+                assertHitCount(response, 10);
 
-        assertHitCount(searchResponse, 10);
+                Terms terms = response.getAggregations().get("terms");
+                assertThat(terms, notNullValue());
+                List<? extends Terms.Bucket> buckets = terms.getBuckets();
+                assertThat(buckets, notNullValue());
+                assertThat(buckets.size(), equalTo(10));
 
-        Terms terms = searchResponse.getAggregations().get("terms");
-        assertThat(terms, notNullValue());
-        List<? extends Terms.Bucket> buckets = terms.getBuckets();
-        assertThat(buckets, notNullValue());
-        assertThat(buckets.size(), equalTo(10));
+                for (int i = 0; i < 10; i++) {
+                    Terms.Bucket bucket = buckets.get(i);
+                    assertThat(bucket, notNullValue());
+                    assertThat(bucket.getKeyAsNumber(), equalTo((long) i + 1));
+                    assertThat(bucket.getDocCount(), equalTo(1L));
+                    Filter filter = bucket.getAggregations().get("filter");
+                    assertThat(filter, notNullValue());
+                    assertThat(filter.getDocCount(), equalTo(0L));
+                    Percentiles percentiles = filter.getAggregations().get("percentiles");
+                    assertThat(percentiles, notNullValue());
+                    assertThat(percentiles.percentile(99), equalTo(Double.NaN));
 
-        for (int i = 0; i < 10; i++) {
-            Terms.Bucket bucket = buckets.get(i);
-            assertThat(bucket, notNullValue());
-            assertThat(bucket.getKeyAsNumber(), equalTo((long) i + 1));
-            assertThat(bucket.getDocCount(), equalTo(1L));
-            Filter filter = bucket.getAggregations().get("filter");
-            assertThat(filter, notNullValue());
-            assertThat(filter.getDocCount(), equalTo(0L));
-            Percentiles percentiles = filter.getAggregations().get("percentiles");
-            assertThat(percentiles, notNullValue());
-            assertThat(percentiles.percentile(99), equalTo(Double.NaN));
-
-        }
+                }
+            }
+        );
     }
 
     /**
@@ -527,15 +561,15 @@ public class HDRPercentilesIT extends AbstractNumericTestCase {
         );
 
         // Test that a request using a nondeterministic script does not get cached
-        SearchResponse r = prepareSearch("cache_test_idx").setSize(0)
-            .addAggregation(
-                percentiles("foo").method(PercentilesMethod.HDR)
-                    .field("d")
-                    .percentiles(50.0)
-                    .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "Math.random()", emptyMap()))
-            )
-            .get();
-        assertNoFailures(r);
+        assertNoFailures(
+            prepareSearch("cache_test_idx").setSize(0)
+                .addAggregation(
+                    percentiles("foo").method(PercentilesMethod.HDR)
+                        .field("d")
+                        .percentiles(50.0)
+                        .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "Math.random()", emptyMap()))
+                )
+        );
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -547,15 +581,15 @@ public class HDRPercentilesIT extends AbstractNumericTestCase {
         );
 
         // Test that a request using a deterministic script gets cached
-        r = prepareSearch("cache_test_idx").setSize(0)
-            .addAggregation(
-                percentiles("foo").method(PercentilesMethod.HDR)
-                    .field("d")
-                    .percentiles(50.0)
-                    .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value - 1", emptyMap()))
-            )
-            .get();
-        assertNoFailures(r);
+        assertNoFailures(
+            prepareSearch("cache_test_idx").setSize(0)
+                .addAggregation(
+                    percentiles("foo").method(PercentilesMethod.HDR)
+                        .field("d")
+                        .percentiles(50.0)
+                        .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value - 1", emptyMap()))
+                )
+        );
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -567,10 +601,10 @@ public class HDRPercentilesIT extends AbstractNumericTestCase {
         );
 
         // Ensure that non-scripted requests are cached as normal
-        r = prepareSearch("cache_test_idx").setSize(0)
-            .addAggregation(percentiles("foo").method(PercentilesMethod.HDR).field("d").percentiles(50.0))
-            .get();
-        assertNoFailures(r);
+        assertNoFailures(
+            prepareSearch("cache_test_idx").setSize(0)
+                .addAggregation(percentiles("foo").method(PercentilesMethod.HDR).field("d").percentiles(50.0))
+        );
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -581,5 +615,4 @@ public class HDRPercentilesIT extends AbstractNumericTestCase {
             equalTo(2L)
         );
     }
-
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationIT.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.action.index.IndexRequestBuilder;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.script.Script;
@@ -46,6 +45,7 @@ import static org.elasticsearch.search.aggregations.metrics.MedianAbsoluteDeviat
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -138,21 +138,24 @@ public class MedianAbsoluteDeviationIT extends AbstractNumericTestCase {
 
     @Override
     public void testEmptyAggregation() throws Exception {
-        final SearchResponse response = prepareSearch("empty_bucket_idx").addAggregation(
-            histogram("histogram").field("value").interval(1).minDocCount(0).subAggregation(randomBuilder().field("value"))
-        ).get();
+        assertResponse(
+            prepareSearch("empty_bucket_idx").addAggregation(
+                histogram("histogram").field("value").interval(1).minDocCount(0).subAggregation(randomBuilder().field("value"))
+            ),
+            response -> {
+                assertHitCount(response, 2);
 
-        assertHitCount(response, 2);
+                final Histogram histogram = response.getAggregations().get("histogram");
+                assertThat(histogram, notNullValue());
+                final Histogram.Bucket bucket = histogram.getBuckets().get(1);
+                assertThat(bucket, notNullValue());
 
-        final Histogram histogram = response.getAggregations().get("histogram");
-        assertThat(histogram, notNullValue());
-        final Histogram.Bucket bucket = histogram.getBuckets().get(1);
-        assertThat(bucket, notNullValue());
-
-        final MedianAbsoluteDeviation mad = bucket.getAggregations().get("mad");
-        assertThat(mad, notNullValue());
-        assertThat(mad.getName(), is("mad"));
-        assertThat(mad.getMedianAbsoluteDeviation(), is(Double.NaN));
+                final MedianAbsoluteDeviation mad = bucket.getAggregations().get("mad");
+                assertThat(mad, notNullValue());
+                assertThat(mad.getName(), is("mad"));
+                assertThat(mad.getMedianAbsoluteDeviation(), is(Double.NaN));
+            }
+        );
     }
 
     @Override
@@ -162,68 +165,72 @@ public class MedianAbsoluteDeviationIT extends AbstractNumericTestCase {
 
     @Override
     public void testSingleValuedField() throws Exception {
-        final SearchResponse response = prepareSearch("idx").setQuery(matchAllQuery()).addAggregation(randomBuilder().field("value")).get();
+        assertResponse(prepareSearch("idx").setQuery(matchAllQuery()).addAggregation(randomBuilder().field("value")), response -> {
+            assertHitCount(response, NUMBER_OF_DOCS);
 
-        assertHitCount(response, NUMBER_OF_DOCS);
-
-        final MedianAbsoluteDeviation mad = response.getAggregations().get("mad");
-        assertThat(mad, notNullValue());
-        assertThat(mad.getName(), is("mad"));
-        assertThat(mad.getMedianAbsoluteDeviation(), closeToRelative(singleValueExactMAD));
+            final MedianAbsoluteDeviation mad = response.getAggregations().get("mad");
+            assertThat(mad, notNullValue());
+            assertThat(mad.getName(), is("mad"));
+            assertThat(mad.getMedianAbsoluteDeviation(), closeToRelative(singleValueExactMAD));
+        });
     }
 
     @Override
     public void testSingleValuedFieldGetProperty() throws Exception {
-        final SearchResponse response = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(global("global").subAggregation(randomBuilder().field("value")))
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery()).addAggregation(global("global").subAggregation(randomBuilder().field("value"))),
+            response -> {
+                assertHitCount(response, NUMBER_OF_DOCS);
 
-        assertHitCount(response, NUMBER_OF_DOCS);
+                final Global global = response.getAggregations().get("global");
+                assertThat(global, notNullValue());
+                assertThat(global.getName(), is("global"));
+                assertThat(global.getDocCount(), is((long) NUMBER_OF_DOCS));
+                assertThat(global.getAggregations(), notNullValue());
+                assertThat(global.getAggregations().asMap().entrySet(), hasSize(1));
 
-        final Global global = response.getAggregations().get("global");
-        assertThat(global, notNullValue());
-        assertThat(global.getName(), is("global"));
-        assertThat(global.getDocCount(), is((long) NUMBER_OF_DOCS));
-        assertThat(global.getAggregations(), notNullValue());
-        assertThat(global.getAggregations().asMap().entrySet(), hasSize(1));
-
-        final MedianAbsoluteDeviation mad = global.getAggregations().get("mad");
-        assertThat(mad, notNullValue());
-        assertThat(mad.getName(), is("mad"));
-        assertThat(((InternalAggregation) global).getProperty("mad"), sameInstance(mad));
+                final MedianAbsoluteDeviation mad = global.getAggregations().get("mad");
+                assertThat(mad, notNullValue());
+                assertThat(mad.getName(), is("mad"));
+                assertThat(((InternalAggregation) global).getProperty("mad"), sameInstance(mad));
+            }
+        );
     }
 
     @Override
     public void testSingleValuedFieldPartiallyUnmapped() throws Exception {
-        final SearchResponse response = prepareSearch("idx", "idx_unmapped").setQuery(matchAllQuery())
-            .addAggregation(randomBuilder().field("value"))
-            .get();
+        assertResponse(
+            prepareSearch("idx", "idx_unmapped").setQuery(matchAllQuery()).addAggregation(randomBuilder().field("value")),
+            response -> {
+                assertHitCount(response, NUMBER_OF_DOCS);
 
-        assertHitCount(response, NUMBER_OF_DOCS);
-
-        final MedianAbsoluteDeviation mad = response.getAggregations().get("mad");
-        assertThat(mad, notNullValue());
-        assertThat(mad.getName(), is("mad"));
-        assertThat(mad.getMedianAbsoluteDeviation(), closeToRelative(singleValueExactMAD));
+                final MedianAbsoluteDeviation mad = response.getAggregations().get("mad");
+                assertThat(mad, notNullValue());
+                assertThat(mad.getName(), is("mad"));
+                assertThat(mad.getMedianAbsoluteDeviation(), closeToRelative(singleValueExactMAD));
+            }
+        );
     }
 
     @Override
     public void testSingleValuedFieldWithValueScript() throws Exception {
-        final SearchResponse response = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                randomBuilder().field("value")
-                    .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value + 1", Collections.emptyMap()))
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    randomBuilder().field("value")
+                        .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value + 1", Collections.emptyMap()))
+                ),
+            response -> {
+                assertHitCount(response, NUMBER_OF_DOCS);
 
-        assertHitCount(response, NUMBER_OF_DOCS);
+                final MedianAbsoluteDeviation mad = response.getAggregations().get("mad");
+                assertThat(mad, notNullValue());
+                assertThat(mad.getName(), is("mad"));
 
-        final MedianAbsoluteDeviation mad = response.getAggregations().get("mad");
-        assertThat(mad, notNullValue());
-        assertThat(mad.getName(), is("mad"));
-
-        final double fromIncrementedSampleMAD = calculateMAD(Arrays.stream(singleValueSample).map(point -> point + 1).toArray());
-        assertThat(mad.getMedianAbsoluteDeviation(), closeToRelative(fromIncrementedSampleMAD));
+                final double fromIncrementedSampleMAD = calculateMAD(Arrays.stream(singleValueSample).map(point -> point + 1).toArray());
+                assertThat(mad.getMedianAbsoluteDeviation(), closeToRelative(fromIncrementedSampleMAD));
+            }
+        );
     }
 
     @Override
@@ -231,53 +238,55 @@ public class MedianAbsoluteDeviationIT extends AbstractNumericTestCase {
         final Map<String, Object> params = new HashMap<>();
         params.put("inc", 1);
 
-        final SearchResponse response = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                randomBuilder().field("value")
-                    .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value + inc", params))
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    randomBuilder().field("value")
+                        .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value + inc", params))
+                ),
+            response -> {
+                assertHitCount(response, NUMBER_OF_DOCS);
 
-        assertHitCount(response, NUMBER_OF_DOCS);
+                final MedianAbsoluteDeviation mad = response.getAggregations().get("mad");
+                assertThat(mad, notNullValue());
+                assertThat(mad.getName(), is("mad"));
 
-        final MedianAbsoluteDeviation mad = response.getAggregations().get("mad");
-        assertThat(mad, notNullValue());
-        assertThat(mad.getName(), is("mad"));
-
-        final double fromIncrementedSampleMAD = calculateMAD(Arrays.stream(singleValueSample).map(point -> point + 1).toArray());
-        assertThat(mad.getMedianAbsoluteDeviation(), closeToRelative(fromIncrementedSampleMAD));
+                final double fromIncrementedSampleMAD = calculateMAD(Arrays.stream(singleValueSample).map(point -> point + 1).toArray());
+                assertThat(mad.getMedianAbsoluteDeviation(), closeToRelative(fromIncrementedSampleMAD));
+            }
+        );
     }
 
     @Override
     public void testMultiValuedField() throws Exception {
-        final SearchResponse response = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(randomBuilder().field("values"))
-            .get();
+        assertResponse(prepareSearch("idx").setQuery(matchAllQuery()).addAggregation(randomBuilder().field("values")), response -> {
+            assertHitCount(response, NUMBER_OF_DOCS);
 
-        assertHitCount(response, NUMBER_OF_DOCS);
-
-        final MedianAbsoluteDeviation mad = response.getAggregations().get("mad");
-        assertThat(mad, notNullValue());
-        assertThat(mad.getName(), is("mad"));
-        assertThat(mad.getMedianAbsoluteDeviation(), closeToRelative(multiValueExactMAD));
+            final MedianAbsoluteDeviation mad = response.getAggregations().get("mad");
+            assertThat(mad, notNullValue());
+            assertThat(mad.getName(), is("mad"));
+            assertThat(mad.getMedianAbsoluteDeviation(), closeToRelative(multiValueExactMAD));
+        });
     }
 
     @Override
     public void testMultiValuedFieldWithValueScript() throws Exception {
-        final SearchResponse response = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                randomBuilder().field("values")
-                    .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value + 1", Collections.emptyMap()))
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    randomBuilder().field("values")
+                        .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value + 1", Collections.emptyMap()))
+                ),
+            response -> {
+                assertHitCount(response, NUMBER_OF_DOCS);
 
-        assertHitCount(response, NUMBER_OF_DOCS);
+                final MedianAbsoluteDeviation mad = response.getAggregations().get("mad");
+                assertThat(mad, notNullValue());
 
-        final MedianAbsoluteDeviation mad = response.getAggregations().get("mad");
-        assertThat(mad, notNullValue());
-
-        final double fromIncrementedSampleMAD = calculateMAD(Arrays.stream(multiValueSample).map(point -> point + 1).toArray());
-        assertThat(mad.getMedianAbsoluteDeviation(), closeToRelative(fromIncrementedSampleMAD));
+                final double fromIncrementedSampleMAD = calculateMAD(Arrays.stream(multiValueSample).map(point -> point + 1).toArray());
+                assertThat(mad.getMedianAbsoluteDeviation(), closeToRelative(fromIncrementedSampleMAD));
+            }
+        );
     }
 
     @Override
@@ -285,38 +294,42 @@ public class MedianAbsoluteDeviationIT extends AbstractNumericTestCase {
         final Map<String, Object> params = new HashMap<>();
         params.put("inc", 1);
 
-        final SearchResponse response = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                randomBuilder().field("values")
-                    .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value + inc", params))
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    randomBuilder().field("values")
+                        .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value + inc", params))
+                ),
+            response -> {
+                assertHitCount(response, NUMBER_OF_DOCS);
 
-        assertHitCount(response, NUMBER_OF_DOCS);
+                final MedianAbsoluteDeviation mad = response.getAggregations().get("mad");
+                assertThat(mad, notNullValue());
 
-        final MedianAbsoluteDeviation mad = response.getAggregations().get("mad");
-        assertThat(mad, notNullValue());
-
-        final double fromIncrementedSampleMAD = calculateMAD(Arrays.stream(multiValueSample).map(point -> point + 1).toArray());
-        assertThat(mad.getMedianAbsoluteDeviation(), closeToRelative(fromIncrementedSampleMAD));
+                final double fromIncrementedSampleMAD = calculateMAD(Arrays.stream(multiValueSample).map(point -> point + 1).toArray());
+                assertThat(mad.getMedianAbsoluteDeviation(), closeToRelative(fromIncrementedSampleMAD));
+            }
+        );
     }
 
     @Override
     public void testScriptSingleValued() throws Exception {
-        final SearchResponse response = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                randomBuilder().script(
-                    new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "doc['value'].value", Collections.emptyMap())
-                )
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    randomBuilder().script(
+                        new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "doc['value'].value", Collections.emptyMap())
+                    )
+                ),
+            response -> {
+                assertHitCount(response, NUMBER_OF_DOCS);
 
-        assertHitCount(response, NUMBER_OF_DOCS);
-
-        final MedianAbsoluteDeviation mad = response.getAggregations().get("mad");
-        assertThat(mad, notNullValue());
-        assertThat(mad.getName(), is("mad"));
-        assertThat(mad.getMedianAbsoluteDeviation(), closeToRelative(singleValueExactMAD));
+                final MedianAbsoluteDeviation mad = response.getAggregations().get("mad");
+                assertThat(mad, notNullValue());
+                assertThat(mad.getName(), is("mad"));
+                assertThat(mad.getMedianAbsoluteDeviation(), closeToRelative(singleValueExactMAD));
+            }
+        );
     }
 
     @Override
@@ -324,38 +337,44 @@ public class MedianAbsoluteDeviationIT extends AbstractNumericTestCase {
         final Map<String, Object> params = new HashMap<>();
         params.put("inc", 1);
 
-        final SearchResponse response = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                randomBuilder().script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "doc['value'].value + inc", params))
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    randomBuilder().script(
+                        new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "doc['value'].value + inc", params)
+                    )
+                ),
+            response -> {
+                assertHitCount(response, NUMBER_OF_DOCS);
 
-        assertHitCount(response, NUMBER_OF_DOCS);
+                final MedianAbsoluteDeviation mad = response.getAggregations().get("mad");
+                assertThat(mad, notNullValue());
+                assertThat(mad.getName(), is("mad"));
 
-        final MedianAbsoluteDeviation mad = response.getAggregations().get("mad");
-        assertThat(mad, notNullValue());
-        assertThat(mad.getName(), is("mad"));
-
-        final double fromIncrementedSampleMAD = calculateMAD(Arrays.stream(singleValueSample).map(point -> point + 1).toArray());
-        assertThat(mad.getMedianAbsoluteDeviation(), closeToRelative(fromIncrementedSampleMAD));
+                final double fromIncrementedSampleMAD = calculateMAD(Arrays.stream(singleValueSample).map(point -> point + 1).toArray());
+                assertThat(mad.getMedianAbsoluteDeviation(), closeToRelative(fromIncrementedSampleMAD));
+            }
+        );
     }
 
     @Override
     public void testScriptMultiValued() throws Exception {
-        final SearchResponse response = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                randomBuilder().script(
-                    new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "doc['values']", Collections.emptyMap())
-                )
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    randomBuilder().script(
+                        new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "doc['values']", Collections.emptyMap())
+                    )
+                ),
+            response -> {
+                assertHitCount(response, NUMBER_OF_DOCS);
 
-        assertHitCount(response, NUMBER_OF_DOCS);
-
-        final MedianAbsoluteDeviation mad = response.getAggregations().get("mad");
-        assertThat(mad, notNullValue());
-        assertThat(mad.getName(), is("mad"));
-        assertThat(mad.getMedianAbsoluteDeviation(), closeToRelative(multiValueExactMAD));
+                final MedianAbsoluteDeviation mad = response.getAggregations().get("mad");
+                assertThat(mad, notNullValue());
+                assertThat(mad.getName(), is("mad"));
+                assertThat(mad.getMedianAbsoluteDeviation(), closeToRelative(multiValueExactMAD));
+            }
+        );
     }
 
     @Override
@@ -363,107 +382,112 @@ public class MedianAbsoluteDeviationIT extends AbstractNumericTestCase {
         final Map<String, Object> params = new HashMap<>();
         params.put("inc", 1);
 
-        final SearchResponse response = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                randomBuilder().script(
-                    new Script(
-                        ScriptType.INLINE,
-                        AggregationTestScriptsPlugin.NAME,
-                        "[ doc['value'].value, doc['value'].value + inc ]",
-                        params
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    randomBuilder().script(
+                        new Script(
+                            ScriptType.INLINE,
+                            AggregationTestScriptsPlugin.NAME,
+                            "[ doc['value'].value, doc['value'].value + inc ]",
+                            params
+                        )
                     )
-                )
-            )
-            .get();
+                ),
+            response -> {
+                assertHitCount(response, NUMBER_OF_DOCS);
 
-        assertHitCount(response, NUMBER_OF_DOCS);
+                final MedianAbsoluteDeviation mad = response.getAggregations().get("mad");
+                assertThat(mad, notNullValue());
+                assertThat(mad.getName(), is("mad"));
 
-        final MedianAbsoluteDeviation mad = response.getAggregations().get("mad");
-        assertThat(mad, notNullValue());
-        assertThat(mad.getName(), is("mad"));
-
-        final double fromIncrementedSampleMAD = calculateMAD(
-            Arrays.stream(singleValueSample).flatMap(point -> LongStream.of(point, point + 1)).toArray()
+                final double fromIncrementedSampleMAD = calculateMAD(
+                    Arrays.stream(singleValueSample).flatMap(point -> LongStream.of(point, point + 1)).toArray()
+                );
+                assertThat(mad.getMedianAbsoluteDeviation(), closeToRelative(fromIncrementedSampleMAD));
+            }
         );
-        assertThat(mad.getMedianAbsoluteDeviation(), closeToRelative(fromIncrementedSampleMAD));
     }
 
     public void testAsSubAggregation() throws Exception {
         final int rangeBoundary = (MAX_SAMPLE_VALUE + MIN_SAMPLE_VALUE) / 2;
-        final SearchResponse response = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                range("range").field("value")
-                    .addRange(MIN_SAMPLE_VALUE, rangeBoundary)
-                    .addRange(rangeBoundary, MAX_SAMPLE_VALUE)
-                    .subAggregation(randomBuilder().field("value"))
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    range("range").field("value")
+                        .addRange(MIN_SAMPLE_VALUE, rangeBoundary)
+                        .addRange(rangeBoundary, MAX_SAMPLE_VALUE)
+                        .subAggregation(randomBuilder().field("value"))
+                ),
+            response -> {
+                assertHitCount(response, NUMBER_OF_DOCS);
 
-        assertHitCount(response, NUMBER_OF_DOCS);
+                final long[] lowerBucketSample = Arrays.stream(singleValueSample)
+                    .filter(point -> point >= MIN_SAMPLE_VALUE && point < rangeBoundary)
+                    .toArray();
+                final long[] upperBucketSample = Arrays.stream(singleValueSample)
+                    .filter(point -> point >= rangeBoundary && point < MAX_SAMPLE_VALUE)
+                    .toArray();
 
-        final long[] lowerBucketSample = Arrays.stream(singleValueSample)
-            .filter(point -> point >= MIN_SAMPLE_VALUE && point < rangeBoundary)
-            .toArray();
-        final long[] upperBucketSample = Arrays.stream(singleValueSample)
-            .filter(point -> point >= rangeBoundary && point < MAX_SAMPLE_VALUE)
-            .toArray();
+                final Range range = response.getAggregations().get("range");
+                assertThat(range, notNullValue());
+                List<? extends Range.Bucket> buckets = range.getBuckets();
+                assertThat(buckets, notNullValue());
+                assertThat(buckets, hasSize(2));
 
-        final Range range = response.getAggregations().get("range");
-        assertThat(range, notNullValue());
-        List<? extends Range.Bucket> buckets = range.getBuckets();
-        assertThat(buckets, notNullValue());
-        assertThat(buckets, hasSize(2));
+                final Range.Bucket lowerBucket = buckets.get(0);
+                assertThat(lowerBucket, notNullValue());
 
-        final Range.Bucket lowerBucket = buckets.get(0);
-        assertThat(lowerBucket, notNullValue());
+                final MedianAbsoluteDeviation lowerBucketMAD = lowerBucket.getAggregations().get("mad");
+                assertThat(lowerBucketMAD, notNullValue());
+                assertThat(lowerBucketMAD.getMedianAbsoluteDeviation(), closeToRelative(calculateMAD(lowerBucketSample)));
 
-        final MedianAbsoluteDeviation lowerBucketMAD = lowerBucket.getAggregations().get("mad");
-        assertThat(lowerBucketMAD, notNullValue());
-        assertThat(lowerBucketMAD.getMedianAbsoluteDeviation(), closeToRelative(calculateMAD(lowerBucketSample)));
+                final Range.Bucket upperBucket = buckets.get(1);
+                assertThat(upperBucket, notNullValue());
 
-        final Range.Bucket upperBucket = buckets.get(1);
-        assertThat(upperBucket, notNullValue());
-
-        final MedianAbsoluteDeviation upperBucketMAD = upperBucket.getAggregations().get("mad");
-        assertThat(upperBucketMAD, notNullValue());
-        assertThat(upperBucketMAD.getMedianAbsoluteDeviation(), closeToRelative(calculateMAD(upperBucketSample)));
-
+                final MedianAbsoluteDeviation upperBucketMAD = upperBucket.getAggregations().get("mad");
+                assertThat(upperBucketMAD, notNullValue());
+                assertThat(upperBucketMAD.getMedianAbsoluteDeviation(), closeToRelative(calculateMAD(upperBucketSample)));
+            }
+        );
     }
 
     @Override
     public void testOrderByEmptyAggregation() throws Exception {
         final int numberOfBuckets = 10;
-        final SearchResponse response = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                terms("terms").field("value")
-                    .size(numberOfBuckets)
-                    .order(BucketOrder.compound(BucketOrder.aggregation("filter>mad", true)))
-                    .subAggregation(
-                        filter("filter", termQuery("value", MAX_SAMPLE_VALUE + 1)).subAggregation(randomBuilder().field("value"))
-                    )
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    terms("terms").field("value")
+                        .size(numberOfBuckets)
+                        .order(BucketOrder.compound(BucketOrder.aggregation("filter>mad", true)))
+                        .subAggregation(
+                            filter("filter", termQuery("value", MAX_SAMPLE_VALUE + 1)).subAggregation(randomBuilder().field("value"))
+                        )
+                ),
+            response -> {
+                assertHitCount(response, NUMBER_OF_DOCS);
 
-        assertHitCount(response, NUMBER_OF_DOCS);
+                final Terms terms = response.getAggregations().get("terms");
+                assertThat(terms, notNullValue());
+                List<? extends Terms.Bucket> buckets = terms.getBuckets();
+                assertThat(buckets, notNullValue());
+                assertThat(buckets, hasSize(numberOfBuckets));
 
-        final Terms terms = response.getAggregations().get("terms");
-        assertThat(terms, notNullValue());
-        List<? extends Terms.Bucket> buckets = terms.getBuckets();
-        assertThat(buckets, notNullValue());
-        assertThat(buckets, hasSize(numberOfBuckets));
+                for (int i = 0; i < numberOfBuckets; i++) {
+                    Terms.Bucket bucket = buckets.get(i);
+                    assertThat(bucket, notNullValue());
 
-        for (int i = 0; i < numberOfBuckets; i++) {
-            Terms.Bucket bucket = buckets.get(i);
-            assertThat(bucket, notNullValue());
+                    Filter filter = bucket.getAggregations().get("filter");
+                    assertThat(filter, notNullValue());
+                    assertThat(filter.getDocCount(), equalTo(0L));
 
-            Filter filter = bucket.getAggregations().get("filter");
-            assertThat(filter, notNullValue());
-            assertThat(filter.getDocCount(), equalTo(0L));
-
-            MedianAbsoluteDeviation mad = filter.getAggregations().get("mad");
-            assertThat(mad, notNullValue());
-            assertThat(mad.getMedianAbsoluteDeviation(), equalTo(Double.NaN));
-        }
+                    MedianAbsoluteDeviation mad = filter.getAggregations().get("mad");
+                    assertThat(mad, notNullValue());
+                    assertThat(mad.getMedianAbsoluteDeviation(), equalTo(Double.NaN));
+                }
+            }
+        );
     }
 
     /**
@@ -493,13 +517,13 @@ public class MedianAbsoluteDeviationIT extends AbstractNumericTestCase {
         );
 
         // Test that a request using a nondeterministic script does not get cached
-        SearchResponse r = prepareSearch("cache_test_idx").setSize(0)
-            .addAggregation(
-                randomBuilder().field("d")
-                    .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "Math.random()", emptyMap()))
-            )
-            .get();
-        assertNoFailures(r);
+        assertNoFailures(
+            prepareSearch("cache_test_idx").setSize(0)
+                .addAggregation(
+                    randomBuilder().field("d")
+                        .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "Math.random()", emptyMap()))
+                )
+        );
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -511,13 +535,13 @@ public class MedianAbsoluteDeviationIT extends AbstractNumericTestCase {
         );
 
         // Test that a request using a deterministic script gets cached
-        r = prepareSearch("cache_test_idx").setSize(0)
-            .addAggregation(
-                randomBuilder().field("d")
-                    .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value - 1", emptyMap()))
-            )
-            .get();
-        assertNoFailures(r);
+        assertNoFailures(
+            prepareSearch("cache_test_idx").setSize(0)
+                .addAggregation(
+                    randomBuilder().field("d")
+                        .script(new Script(ScriptType.INLINE, AggregationTestScriptsPlugin.NAME, "_value - 1", emptyMap()))
+                )
+        );
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -529,8 +553,7 @@ public class MedianAbsoluteDeviationIT extends AbstractNumericTestCase {
         );
 
         // Ensure that non-scripted requests are cached as normal
-        r = prepareSearch("cache_test_idx").setSize(0).addAggregation(randomBuilder().field("d")).get();
-        assertNoFailures(r);
+        assertNoFailures(prepareSearch("cache_test_idx").setSize(0).addAggregation(randomBuilder().field("d")));
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricIT.java
@@ -11,7 +11,6 @@ package org.elasticsearch.search.aggregations.metrics;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchRequestBuilder;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
@@ -50,6 +49,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.histogra
 import static org.elasticsearch.search.aggregations.AggregationBuilders.scriptedMetric;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
@@ -359,37 +359,39 @@ public class ScriptedMetricIT extends ESIntegTestCase {
         Script combineScript = new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "no-op aggregation", Collections.emptyMap());
         Script reduceScript = new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "no-op list aggregation", Collections.emptyMap());
 
-        SearchResponse response = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(scriptedMetric("scripted").mapScript(mapScript).combineScript(combineScript).reduceScript(reduceScript))
-            .get();
-        assertNoFailures(response);
-        assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(scriptedMetric("scripted").mapScript(mapScript).combineScript(combineScript).reduceScript(reduceScript)),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
 
-        Aggregation aggregation = response.getAggregations().get("scripted");
-        assertThat(aggregation, notNullValue());
-        assertThat(aggregation, instanceOf(ScriptedMetric.class));
-        ScriptedMetric scriptedMetricAggregation = (ScriptedMetric) aggregation;
-        assertThat(scriptedMetricAggregation.getName(), equalTo("scripted"));
-        assertThat(scriptedMetricAggregation.aggregation(), notNullValue());
-        assertThat(scriptedMetricAggregation.aggregation(), instanceOf(ArrayList.class));
-        List<?> aggregationList = (List<?>) scriptedMetricAggregation.aggregation();
-        assertThat(aggregationList.size(), equalTo(getNumShards("idx").numPrimaries));
-        int numShardsRun = 0;
-        for (Object object : aggregationList) {
-            assertThat(object, notNullValue());
-            assertThat(object, instanceOf(Map.class));
-            Map<?, ?> map = (Map<?, ?>) object;
-            assertThat(map.size(), lessThanOrEqualTo(1));
-            if (map.size() == 1) {
-                assertThat(map.get("count"), notNullValue());
-                assertThat(map.get("count"), instanceOf(Number.class));
-                assertThat(map.get("count"), equalTo(1));
-                numShardsRun++;
+                Aggregation aggregation = response.getAggregations().get("scripted");
+                assertThat(aggregation, notNullValue());
+                assertThat(aggregation, instanceOf(ScriptedMetric.class));
+                ScriptedMetric scriptedMetricAggregation = (ScriptedMetric) aggregation;
+                assertThat(scriptedMetricAggregation.getName(), equalTo("scripted"));
+                assertThat(scriptedMetricAggregation.aggregation(), notNullValue());
+                assertThat(scriptedMetricAggregation.aggregation(), instanceOf(ArrayList.class));
+                List<?> aggregationList = (List<?>) scriptedMetricAggregation.aggregation();
+                assertThat(aggregationList.size(), equalTo(getNumShards("idx").numPrimaries));
+                int numShardsRun = 0;
+                for (Object object : aggregationList) {
+                    assertThat(object, notNullValue());
+                    assertThat(object, instanceOf(Map.class));
+                    Map<?, ?> map = (Map<?, ?>) object;
+                    assertThat(map.size(), lessThanOrEqualTo(1));
+                    if (map.size() == 1) {
+                        assertThat(map.get("count"), notNullValue());
+                        assertThat(map.get("count"), instanceOf(Number.class));
+                        assertThat(map.get("count"), equalTo(1));
+                        numShardsRun++;
+                    }
+                }
+                // We don't know how many shards will have documents but we need to make
+                // sure that at least one shard ran the map script
+                assertThat(numShardsRun, greaterThan(0));
             }
-        }
-        // We don't know how many shards will have documents but we need to make
-        // sure that at least one shard ran the map script
-        assertThat(numShardsRun, greaterThan(0));
+        );
     }
 
     public void testMapWithParams() {
@@ -401,45 +403,47 @@ public class ScriptedMetricIT extends ESIntegTestCase {
         Script combineScript = new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "no-op aggregation", Collections.emptyMap());
         Script reduceScript = new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "no-op list aggregation", Collections.emptyMap());
 
-        SearchResponse response = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                scriptedMetric("scripted").params(aggregationParams)
-                    .mapScript(mapScript)
-                    .combineScript(combineScript)
-                    .reduceScript(reduceScript)
-            )
-            .get();
-        assertNoFailures(response);
-        assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    scriptedMetric("scripted").params(aggregationParams)
+                        .mapScript(mapScript)
+                        .combineScript(combineScript)
+                        .reduceScript(reduceScript)
+                ),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
 
-        Aggregation aggregation = response.getAggregations().get("scripted");
-        assertThat(aggregation, notNullValue());
-        assertThat(aggregation, instanceOf(ScriptedMetric.class));
-        ScriptedMetric scriptedMetricAggregation = (ScriptedMetric) aggregation;
-        assertThat(scriptedMetricAggregation.getName(), equalTo("scripted"));
-        assertThat(scriptedMetricAggregation.aggregation(), notNullValue());
-        assertThat(scriptedMetricAggregation.aggregation(), instanceOf(ArrayList.class));
-        List<?> aggregationList = (List<?>) scriptedMetricAggregation.aggregation();
-        assertThat(aggregationList.size(), equalTo(getNumShards("idx").numPrimaries));
-        int numShardsRun = 0;
-        for (Object object : aggregationList) {
-            assertThat(object, notNullValue());
-            assertThat(object, instanceOf(Map.class));
-            Map<?, ?> map = (Map<?, ?>) object;
-            for (Map.Entry<?, ?> entry : map.entrySet()) {
-                assertThat(entry, notNullValue());
-                assertThat(entry.getKey(), notNullValue());
-                assertThat(entry.getKey(), instanceOf(String.class));
-                assertThat(entry.getValue(), notNullValue());
-                assertThat(entry.getValue(), instanceOf(Number.class));
-                String stringValue = (String) entry.getKey();
-                assertThat(stringValue, equalTo("12"));
-                Number numberValue = (Number) entry.getValue();
-                assertThat(numberValue, equalTo(1));
-                numShardsRun++;
+                Aggregation aggregation = response.getAggregations().get("scripted");
+                assertThat(aggregation, notNullValue());
+                assertThat(aggregation, instanceOf(ScriptedMetric.class));
+                ScriptedMetric scriptedMetricAggregation = (ScriptedMetric) aggregation;
+                assertThat(scriptedMetricAggregation.getName(), equalTo("scripted"));
+                assertThat(scriptedMetricAggregation.aggregation(), notNullValue());
+                assertThat(scriptedMetricAggregation.aggregation(), instanceOf(ArrayList.class));
+                List<?> aggregationList = (List<?>) scriptedMetricAggregation.aggregation();
+                assertThat(aggregationList.size(), equalTo(getNumShards("idx").numPrimaries));
+                int numShardsRun = 0;
+                for (Object object : aggregationList) {
+                    assertThat(object, notNullValue());
+                    assertThat(object, instanceOf(Map.class));
+                    Map<?, ?> map = (Map<?, ?>) object;
+                    for (Map.Entry<?, ?> entry : map.entrySet()) {
+                        assertThat(entry, notNullValue());
+                        assertThat(entry.getKey(), notNullValue());
+                        assertThat(entry.getKey(), instanceOf(String.class));
+                        assertThat(entry.getValue(), notNullValue());
+                        assertThat(entry.getValue(), instanceOf(Number.class));
+                        String stringValue = (String) entry.getKey();
+                        assertThat(stringValue, equalTo("12"));
+                        Number numberValue = (Number) entry.getValue();
+                        assertThat(numberValue, equalTo(1));
+                        numShardsRun++;
+                    }
+                }
+                assertThat(numShardsRun, greaterThan(0));
             }
-        }
-        assertThat(numShardsRun, greaterThan(0));
+        );
     }
 
     public void testInitMutatesParams() {
@@ -449,47 +453,56 @@ public class ScriptedMetricIT extends ESIntegTestCase {
         Map<String, Object> params = new HashMap<>();
         params.put("vars", varsMap);
 
-        SearchResponse response = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                scriptedMetric("scripted").params(params)
-                    .initScript(new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "vars.multiplier = 3", Collections.emptyMap()))
-                    .mapScript(
-                        new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "state.list.add(vars.multiplier)", Collections.emptyMap())
-                    )
-                    .combineScript(new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "no-op aggregation", Collections.emptyMap()))
-                    .reduceScript(new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "no-op list aggregation", Collections.emptyMap()))
-            )
-            .get();
-        assertNoFailures(response);
-        assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    scriptedMetric("scripted").params(params)
+                        .initScript(new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "vars.multiplier = 3", Collections.emptyMap()))
+                        .mapScript(
+                            new Script(
+                                ScriptType.INLINE,
+                                CustomScriptPlugin.NAME,
+                                "state.list.add(vars.multiplier)",
+                                Collections.emptyMap()
+                            )
+                        )
+                        .combineScript(new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "no-op aggregation", Collections.emptyMap()))
+                        .reduceScript(
+                            new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "no-op list aggregation", Collections.emptyMap())
+                        )
+                ),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
 
-        Aggregation aggregation = response.getAggregations().get("scripted");
-        assertThat(aggregation, notNullValue());
-        assertThat(aggregation, instanceOf(ScriptedMetric.class));
-        ScriptedMetric scriptedMetricAggregation = (ScriptedMetric) aggregation;
-        assertThat(scriptedMetricAggregation.getName(), equalTo("scripted"));
-        assertThat(scriptedMetricAggregation.aggregation(), notNullValue());
-        assertThat(scriptedMetricAggregation.aggregation(), instanceOf(ArrayList.class));
-        List<?> aggregationList = (List<?>) scriptedMetricAggregation.aggregation();
-        assertThat(aggregationList.size(), equalTo(getNumShards("idx").numPrimaries));
-        long totalCount = 0;
-        for (Object object : aggregationList) {
-            assertThat(object, notNullValue());
-            assertThat(object, instanceOf(HashMap.class));
-            @SuppressWarnings("unchecked")
-            Map<String, Object> map = (Map<String, Object>) object;
-            assertThat(map, hasKey("list"));
-            assertThat(map.get("list"), instanceOf(List.class));
-            List<?> list = (List<?>) map.get("list");
-            for (Object o : list) {
-                assertThat(o, notNullValue());
-                assertThat(o, instanceOf(Number.class));
-                Number numberValue = (Number) o;
-                assertThat(numberValue, equalTo(3));
-                totalCount += numberValue.longValue();
+                Aggregation aggregation = response.getAggregations().get("scripted");
+                assertThat(aggregation, notNullValue());
+                assertThat(aggregation, instanceOf(ScriptedMetric.class));
+                ScriptedMetric scriptedMetricAggregation = (ScriptedMetric) aggregation;
+                assertThat(scriptedMetricAggregation.getName(), equalTo("scripted"));
+                assertThat(scriptedMetricAggregation.aggregation(), notNullValue());
+                assertThat(scriptedMetricAggregation.aggregation(), instanceOf(ArrayList.class));
+                List<?> aggregationList = (List<?>) scriptedMetricAggregation.aggregation();
+                assertThat(aggregationList.size(), equalTo(getNumShards("idx").numPrimaries));
+                long totalCount = 0;
+                for (Object object : aggregationList) {
+                    assertThat(object, notNullValue());
+                    assertThat(object, instanceOf(HashMap.class));
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> map = (Map<String, Object>) object;
+                    assertThat(map, hasKey("list"));
+                    assertThat(map.get("list"), instanceOf(List.class));
+                    List<?> list = (List<?>) map.get("list");
+                    for (Object o : list) {
+                        assertThat(o, notNullValue());
+                        assertThat(o, instanceOf(Number.class));
+                        Number numberValue = (Number) o;
+                        assertThat(numberValue, equalTo(3));
+                        totalCount += numberValue.longValue();
+                    }
+                }
+                assertThat(totalCount, equalTo(numDocs * 3));
             }
-        }
-        assertThat(totalCount, equalTo(numDocs * 3));
+        );
     }
 
     public void testMapCombineWithParams() {
@@ -508,40 +521,42 @@ public class ScriptedMetricIT extends ESIntegTestCase {
         );
         Script reduceScript = new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "no-op list aggregation", Collections.emptyMap());
 
-        SearchResponse response = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                scriptedMetric("scripted").params(params).mapScript(mapScript).combineScript(combineScript).reduceScript(reduceScript)
-            )
-            .get();
-        assertNoFailures(response);
-        assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    scriptedMetric("scripted").params(params).mapScript(mapScript).combineScript(combineScript).reduceScript(reduceScript)
+                ),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
 
-        Aggregation aggregation = response.getAggregations().get("scripted");
-        assertThat(aggregation, notNullValue());
-        assertThat(aggregation, instanceOf(ScriptedMetric.class));
-        ScriptedMetric scriptedMetricAggregation = (ScriptedMetric) aggregation;
-        assertThat(scriptedMetricAggregation.getName(), equalTo("scripted"));
-        assertThat(scriptedMetricAggregation.aggregation(), notNullValue());
-        assertThat(scriptedMetricAggregation.aggregation(), instanceOf(ArrayList.class));
-        List<?> aggregationList = (List<?>) scriptedMetricAggregation.aggregation();
-        assertThat(aggregationList.size(), equalTo(getNumShards("idx").numPrimaries));
-        long totalCount = 0;
-        for (Object object : aggregationList) {
-            assertThat(object, notNullValue());
-            assertThat(object, instanceOf(List.class));
-            List<?> list = (List<?>) object;
-            for (Object o : list) {
-                assertThat(o, notNullValue());
-                assertThat(o, instanceOf(Number.class));
-                Number numberValue = (Number) o;
-                // A particular shard may not have any documents stored on it so
-                // we have to assume the lower bound may be 0. The check at the
-                // bottom of the test method will make sure the count is correct
-                assertThat(numberValue.longValue(), allOf(greaterThanOrEqualTo(0L), lessThanOrEqualTo(numDocs)));
-                totalCount += numberValue.longValue();
+                Aggregation aggregation = response.getAggregations().get("scripted");
+                assertThat(aggregation, notNullValue());
+                assertThat(aggregation, instanceOf(ScriptedMetric.class));
+                ScriptedMetric scriptedMetricAggregation = (ScriptedMetric) aggregation;
+                assertThat(scriptedMetricAggregation.getName(), equalTo("scripted"));
+                assertThat(scriptedMetricAggregation.aggregation(), notNullValue());
+                assertThat(scriptedMetricAggregation.aggregation(), instanceOf(ArrayList.class));
+                List<?> aggregationList = (List<?>) scriptedMetricAggregation.aggregation();
+                assertThat(aggregationList.size(), equalTo(getNumShards("idx").numPrimaries));
+                long totalCount = 0;
+                for (Object object : aggregationList) {
+                    assertThat(object, notNullValue());
+                    assertThat(object, instanceOf(List.class));
+                    List<?> list = (List<?>) object;
+                    for (Object o : list) {
+                        assertThat(o, notNullValue());
+                        assertThat(o, instanceOf(Number.class));
+                        Number numberValue = (Number) o;
+                        // A particular shard may not have any documents stored on it so
+                        // we have to assume the lower bound may be 0. The check at the
+                        // bottom of the test method will make sure the count is correct
+                        assertThat(numberValue.longValue(), allOf(greaterThanOrEqualTo(0L), lessThanOrEqualTo(numDocs)));
+                        totalCount += numberValue.longValue();
+                    }
+                }
+                assertThat(totalCount, equalTo(numDocs));
             }
-        }
-        assertThat(totalCount, equalTo(numDocs));
+        );
     }
 
     public void testInitMapCombineWithParams() {
@@ -566,44 +581,46 @@ public class ScriptedMetricIT extends ESIntegTestCase {
         );
         Script reduceScript = new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "no-op list aggregation", Collections.emptyMap());
 
-        SearchResponse response = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                scriptedMetric("scripted").params(params)
-                    .initScript(initScript)
-                    .mapScript(mapScript)
-                    .combineScript(combineScript)
-                    .reduceScript(reduceScript)
-            )
-            .get();
-        assertNoFailures(response);
-        assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    scriptedMetric("scripted").params(params)
+                        .initScript(initScript)
+                        .mapScript(mapScript)
+                        .combineScript(combineScript)
+                        .reduceScript(reduceScript)
+                ),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
 
-        Aggregation aggregation = response.getAggregations().get("scripted");
-        assertThat(aggregation, notNullValue());
-        assertThat(aggregation, instanceOf(ScriptedMetric.class));
-        ScriptedMetric scriptedMetricAggregation = (ScriptedMetric) aggregation;
-        assertThat(scriptedMetricAggregation.getName(), equalTo("scripted"));
-        assertThat(scriptedMetricAggregation.aggregation(), notNullValue());
-        assertThat(scriptedMetricAggregation.aggregation(), instanceOf(ArrayList.class));
-        List<?> aggregationList = (List<?>) scriptedMetricAggregation.aggregation();
-        assertThat(aggregationList.size(), equalTo(getNumShards("idx").numPrimaries));
-        long totalCount = 0;
-        for (Object object : aggregationList) {
-            assertThat(object, notNullValue());
-            assertThat(object, instanceOf(List.class));
-            List<?> list = (List<?>) object;
-            for (Object o : list) {
-                assertThat(o, notNullValue());
-                assertThat(o, instanceOf(Number.class));
-                Number numberValue = (Number) o;
-                // A particular shard may not have any documents stored on it so
-                // we have to assume the lower bound may be 0. The check at the
-                // bottom of the test method will make sure the count is correct
-                assertThat(numberValue.longValue(), allOf(greaterThanOrEqualTo(0L), lessThanOrEqualTo(numDocs * 3)));
-                totalCount += numberValue.longValue();
+                Aggregation aggregation = response.getAggregations().get("scripted");
+                assertThat(aggregation, notNullValue());
+                assertThat(aggregation, instanceOf(ScriptedMetric.class));
+                ScriptedMetric scriptedMetricAggregation = (ScriptedMetric) aggregation;
+                assertThat(scriptedMetricAggregation.getName(), equalTo("scripted"));
+                assertThat(scriptedMetricAggregation.aggregation(), notNullValue());
+                assertThat(scriptedMetricAggregation.aggregation(), instanceOf(ArrayList.class));
+                List<?> aggregationList = (List<?>) scriptedMetricAggregation.aggregation();
+                assertThat(aggregationList.size(), equalTo(getNumShards("idx").numPrimaries));
+                long totalCount = 0;
+                for (Object object : aggregationList) {
+                    assertThat(object, notNullValue());
+                    assertThat(object, instanceOf(List.class));
+                    List<?> list = (List<?>) object;
+                    for (Object o : list) {
+                        assertThat(o, notNullValue());
+                        assertThat(o, instanceOf(Number.class));
+                        Number numberValue = (Number) o;
+                        // A particular shard may not have any documents stored on it so
+                        // we have to assume the lower bound may be 0. The check at the
+                        // bottom of the test method will make sure the count is correct
+                        assertThat(numberValue.longValue(), allOf(greaterThanOrEqualTo(0L), lessThanOrEqualTo(numDocs * 3)));
+                        totalCount += numberValue.longValue();
+                    }
+                }
+                assertThat(totalCount, equalTo(numDocs * 3));
             }
-        }
-        assertThat(totalCount, equalTo(numDocs * 3));
+        );
     }
 
     public void testInitMapCombineReduceWithParams() {
@@ -633,31 +650,33 @@ public class ScriptedMetricIT extends ESIntegTestCase {
             Collections.emptyMap()
         );
 
-        SearchResponse response = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                scriptedMetric("scripted").params(params)
-                    .initScript(initScript)
-                    .mapScript(mapScript)
-                    .combineScript(combineScript)
-                    .reduceScript(reduceScript)
-            )
-            .get();
-        assertNoFailures(response);
-        assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    scriptedMetric("scripted").params(params)
+                        .initScript(initScript)
+                        .mapScript(mapScript)
+                        .combineScript(combineScript)
+                        .reduceScript(reduceScript)
+                ),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
 
-        Aggregation aggregation = response.getAggregations().get("scripted");
-        assertThat(aggregation, notNullValue());
-        assertThat(aggregation, instanceOf(ScriptedMetric.class));
-        ScriptedMetric scriptedMetricAggregation = (ScriptedMetric) aggregation;
-        assertThat(scriptedMetricAggregation.getName(), equalTo("scripted"));
-        assertThat(scriptedMetricAggregation.aggregation(), notNullValue());
-        assertThat(scriptedMetricAggregation.aggregation(), instanceOf(ArrayList.class));
-        List<?> aggregationList = (List<?>) scriptedMetricAggregation.aggregation();
-        assertThat(aggregationList.size(), equalTo(1));
-        Object object = aggregationList.get(0);
-        assertThat(object, notNullValue());
-        assertThat(object, instanceOf(Number.class));
-        assertThat(((Number) object).longValue(), equalTo(numDocs * 3));
+                Aggregation aggregation = response.getAggregations().get("scripted");
+                assertThat(aggregation, notNullValue());
+                assertThat(aggregation, instanceOf(ScriptedMetric.class));
+                ScriptedMetric scriptedMetricAggregation = (ScriptedMetric) aggregation;
+                assertThat(scriptedMetricAggregation.getName(), equalTo("scripted"));
+                assertThat(scriptedMetricAggregation.aggregation(), notNullValue());
+                assertThat(scriptedMetricAggregation.aggregation(), instanceOf(ArrayList.class));
+                List<?> aggregationList = (List<?>) scriptedMetricAggregation.aggregation();
+                assertThat(aggregationList.size(), equalTo(1));
+                Object object = aggregationList.get(0);
+                assertThat(object, notNullValue());
+                assertThat(object, instanceOf(Number.class));
+                assertThat(((Number) object).longValue(), equalTo(numDocs * 3));
+            }
+        );
     }
 
     @SuppressWarnings("rawtypes")
@@ -688,42 +707,43 @@ public class ScriptedMetricIT extends ESIntegTestCase {
             Collections.emptyMap()
         );
 
-        SearchResponse searchResponse = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                global("global").subAggregation(
-                    scriptedMetric("scripted").params(params)
-                        .initScript(initScript)
-                        .mapScript(mapScript)
-                        .combineScript(combineScript)
-                        .reduceScript(reduceScript)
-                )
-            )
-            .get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    global("global").subAggregation(
+                        scriptedMetric("scripted").params(params)
+                            .initScript(initScript)
+                            .mapScript(mapScript)
+                            .combineScript(combineScript)
+                            .reduceScript(reduceScript)
+                    )
+                ),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
 
-        assertNoFailures(searchResponse);
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(numDocs));
+                Global global = response.getAggregations().get("global");
+                assertThat(global, notNullValue());
+                assertThat(global.getName(), equalTo("global"));
+                assertThat(global.getDocCount(), equalTo(numDocs));
+                assertThat(global.getAggregations(), notNullValue());
+                assertThat(global.getAggregations().asMap().size(), equalTo(1));
 
-        Global global = searchResponse.getAggregations().get("global");
-        assertThat(global, notNullValue());
-        assertThat(global.getName(), equalTo("global"));
-        assertThat(global.getDocCount(), equalTo(numDocs));
-        assertThat(global.getAggregations(), notNullValue());
-        assertThat(global.getAggregations().asMap().size(), equalTo(1));
-
-        ScriptedMetric scriptedMetricAggregation = global.getAggregations().get("scripted");
-        assertThat(scriptedMetricAggregation, notNullValue());
-        assertThat(scriptedMetricAggregation.getName(), equalTo("scripted"));
-        assertThat(scriptedMetricAggregation.aggregation(), notNullValue());
-        assertThat(scriptedMetricAggregation.aggregation(), instanceOf(ArrayList.class));
-        List<?> aggregationList = (List<?>) scriptedMetricAggregation.aggregation();
-        assertThat(aggregationList.size(), equalTo(1));
-        Object object = aggregationList.get(0);
-        assertThat(object, notNullValue());
-        assertThat(object, instanceOf(Number.class));
-        assertThat(((Number) object).longValue(), equalTo(numDocs * 3));
-        assertThat(((InternalAggregation) global).getProperty("scripted"), sameInstance(scriptedMetricAggregation));
-        assertThat((List) ((InternalAggregation) global).getProperty("scripted.value"), sameInstance(aggregationList));
-        assertThat((List) ((InternalAggregation) scriptedMetricAggregation).getProperty("value"), sameInstance(aggregationList));
+                ScriptedMetric scriptedMetricAggregation = global.getAggregations().get("scripted");
+                assertThat(scriptedMetricAggregation, notNullValue());
+                assertThat(scriptedMetricAggregation.getName(), equalTo("scripted"));
+                assertThat(scriptedMetricAggregation.aggregation(), notNullValue());
+                assertThat(scriptedMetricAggregation.aggregation(), instanceOf(ArrayList.class));
+                List<?> aggregationList = (List<?>) scriptedMetricAggregation.aggregation();
+                assertThat(aggregationList.size(), equalTo(1));
+                Object object = aggregationList.get(0);
+                assertThat(object, notNullValue());
+                assertThat(object, instanceOf(Number.class));
+                assertThat(((Number) object).longValue(), equalTo(numDocs * 3));
+                assertThat(((InternalAggregation) global).getProperty("scripted"), sameInstance(scriptedMetricAggregation));
+                assertThat((List) ((InternalAggregation) global).getProperty("scripted.value"), sameInstance(aggregationList));
+                assertThat((List) ((InternalAggregation) scriptedMetricAggregation).getProperty("value"), sameInstance(aggregationList));
+            }
+        );
     }
 
     public void testMapCombineReduceWithParams() {
@@ -752,27 +772,29 @@ public class ScriptedMetricIT extends ESIntegTestCase {
             Collections.emptyMap()
         );
 
-        SearchResponse response = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                scriptedMetric("scripted").params(params).mapScript(mapScript).combineScript(combineScript).reduceScript(reduceScript)
-            )
-            .get();
-        assertNoFailures(response);
-        assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    scriptedMetric("scripted").params(params).mapScript(mapScript).combineScript(combineScript).reduceScript(reduceScript)
+                ),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
 
-        Aggregation aggregation = response.getAggregations().get("scripted");
-        assertThat(aggregation, notNullValue());
-        assertThat(aggregation, instanceOf(ScriptedMetric.class));
-        ScriptedMetric scriptedMetricAggregation = (ScriptedMetric) aggregation;
-        assertThat(scriptedMetricAggregation.getName(), equalTo("scripted"));
-        assertThat(scriptedMetricAggregation.aggregation(), notNullValue());
-        assertThat(scriptedMetricAggregation.aggregation(), instanceOf(ArrayList.class));
-        List<?> aggregationList = (List<?>) scriptedMetricAggregation.aggregation();
-        assertThat(aggregationList.size(), equalTo(1));
-        Object object = aggregationList.get(0);
-        assertThat(object, notNullValue());
-        assertThat(object, instanceOf(Number.class));
-        assertThat(((Number) object).longValue(), equalTo(numDocs));
+                Aggregation aggregation = response.getAggregations().get("scripted");
+                assertThat(aggregation, notNullValue());
+                assertThat(aggregation, instanceOf(ScriptedMetric.class));
+                ScriptedMetric scriptedMetricAggregation = (ScriptedMetric) aggregation;
+                assertThat(scriptedMetricAggregation.getName(), equalTo("scripted"));
+                assertThat(scriptedMetricAggregation.aggregation(), notNullValue());
+                assertThat(scriptedMetricAggregation.aggregation(), instanceOf(ArrayList.class));
+                List<?> aggregationList = (List<?>) scriptedMetricAggregation.aggregation();
+                assertThat(aggregationList.size(), equalTo(1));
+                Object object = aggregationList.get(0);
+                assertThat(object, notNullValue());
+                assertThat(object, instanceOf(Number.class));
+                assertThat(((Number) object).longValue(), equalTo(numDocs));
+            }
+        );
     }
 
     public void testInitMapReduceWithParams() {
@@ -797,31 +819,33 @@ public class ScriptedMetricIT extends ESIntegTestCase {
             Collections.emptyMap()
         );
 
-        SearchResponse response = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                scriptedMetric("scripted").params(params)
-                    .initScript(initScript)
-                    .mapScript(mapScript)
-                    .combineScript(combineScript)
-                    .reduceScript(reduceScript)
-            )
-            .get();
-        assertNoFailures(response);
-        assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    scriptedMetric("scripted").params(params)
+                        .initScript(initScript)
+                        .mapScript(mapScript)
+                        .combineScript(combineScript)
+                        .reduceScript(reduceScript)
+                ),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
 
-        Aggregation aggregation = response.getAggregations().get("scripted");
-        assertThat(aggregation, notNullValue());
-        assertThat(aggregation, instanceOf(ScriptedMetric.class));
-        ScriptedMetric scriptedMetricAggregation = (ScriptedMetric) aggregation;
-        assertThat(scriptedMetricAggregation.getName(), equalTo("scripted"));
-        assertThat(scriptedMetricAggregation.aggregation(), notNullValue());
-        assertThat(scriptedMetricAggregation.aggregation(), instanceOf(ArrayList.class));
-        List<?> aggregationList = (List<?>) scriptedMetricAggregation.aggregation();
-        assertThat(aggregationList.size(), equalTo(1));
-        Object object = aggregationList.get(0);
-        assertThat(object, notNullValue());
-        assertThat(object, instanceOf(Number.class));
-        assertThat(((Number) object).longValue(), equalTo(numDocs * 3));
+                Aggregation aggregation = response.getAggregations().get("scripted");
+                assertThat(aggregation, notNullValue());
+                assertThat(aggregation, instanceOf(ScriptedMetric.class));
+                ScriptedMetric scriptedMetricAggregation = (ScriptedMetric) aggregation;
+                assertThat(scriptedMetricAggregation.getName(), equalTo("scripted"));
+                assertThat(scriptedMetricAggregation.aggregation(), notNullValue());
+                assertThat(scriptedMetricAggregation.aggregation(), instanceOf(ArrayList.class));
+                List<?> aggregationList = (List<?>) scriptedMetricAggregation.aggregation();
+                assertThat(aggregationList.size(), equalTo(1));
+                Object object = aggregationList.get(0);
+                assertThat(object, notNullValue());
+                assertThat(object, instanceOf(Number.class));
+                assertThat(((Number) object).longValue(), equalTo(numDocs * 3));
+            }
+        );
     }
 
     public void testMapReduceWithParams() {
@@ -844,27 +868,29 @@ public class ScriptedMetricIT extends ESIntegTestCase {
             Collections.emptyMap()
         );
 
-        SearchResponse response = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                scriptedMetric("scripted").params(params).mapScript(mapScript).combineScript(combineScript).reduceScript(reduceScript)
-            )
-            .get();
-        assertNoFailures(response);
-        assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    scriptedMetric("scripted").params(params).mapScript(mapScript).combineScript(combineScript).reduceScript(reduceScript)
+                ),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
 
-        Aggregation aggregation = response.getAggregations().get("scripted");
-        assertThat(aggregation, notNullValue());
-        assertThat(aggregation, instanceOf(ScriptedMetric.class));
-        ScriptedMetric scriptedMetricAggregation = (ScriptedMetric) aggregation;
-        assertThat(scriptedMetricAggregation.getName(), equalTo("scripted"));
-        assertThat(scriptedMetricAggregation.aggregation(), notNullValue());
-        assertThat(scriptedMetricAggregation.aggregation(), instanceOf(ArrayList.class));
-        List<?> aggregationList = (List<?>) scriptedMetricAggregation.aggregation();
-        assertThat(aggregationList.size(), equalTo(1));
-        Object object = aggregationList.get(0);
-        assertThat(object, notNullValue());
-        assertThat(object, instanceOf(Number.class));
-        assertThat(((Number) object).longValue(), equalTo(numDocs));
+                Aggregation aggregation = response.getAggregations().get("scripted");
+                assertThat(aggregation, notNullValue());
+                assertThat(aggregation, instanceOf(ScriptedMetric.class));
+                ScriptedMetric scriptedMetricAggregation = (ScriptedMetric) aggregation;
+                assertThat(scriptedMetricAggregation.getName(), equalTo("scripted"));
+                assertThat(scriptedMetricAggregation.aggregation(), notNullValue());
+                assertThat(scriptedMetricAggregation.aggregation(), instanceOf(ArrayList.class));
+                List<?> aggregationList = (List<?>) scriptedMetricAggregation.aggregation();
+                assertThat(aggregationList.size(), equalTo(1));
+                Object object = aggregationList.get(0);
+                assertThat(object, notNullValue());
+                assertThat(object, instanceOf(Number.class));
+                assertThat(((Number) object).longValue(), equalTo(numDocs));
+            }
+        );
     }
 
     public void testInitMapCombineReduceWithParamsAndReduceParams() {
@@ -897,31 +923,33 @@ public class ScriptedMetricIT extends ESIntegTestCase {
             reduceParams
         );
 
-        SearchResponse response = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                scriptedMetric("scripted").params(params)
-                    .initScript(initScript)
-                    .mapScript(mapScript)
-                    .combineScript(combineScript)
-                    .reduceScript(reduceScript)
-            )
-            .get();
-        assertNoFailures(response);
-        assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    scriptedMetric("scripted").params(params)
+                        .initScript(initScript)
+                        .mapScript(mapScript)
+                        .combineScript(combineScript)
+                        .reduceScript(reduceScript)
+                ),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
 
-        Aggregation aggregation = response.getAggregations().get("scripted");
-        assertThat(aggregation, notNullValue());
-        assertThat(aggregation, instanceOf(ScriptedMetric.class));
-        ScriptedMetric scriptedMetricAggregation = (ScriptedMetric) aggregation;
-        assertThat(scriptedMetricAggregation.getName(), equalTo("scripted"));
-        assertThat(scriptedMetricAggregation.aggregation(), notNullValue());
-        assertThat(scriptedMetricAggregation.aggregation(), instanceOf(ArrayList.class));
-        List<?> aggregationList = (List<?>) scriptedMetricAggregation.aggregation();
-        assertThat(aggregationList.size(), equalTo(1));
-        Object object = aggregationList.get(0);
-        assertThat(object, notNullValue());
-        assertThat(object, instanceOf(Number.class));
-        assertThat(((Number) object).longValue(), equalTo(numDocs * 12));
+                Aggregation aggregation = response.getAggregations().get("scripted");
+                assertThat(aggregation, notNullValue());
+                assertThat(aggregation, instanceOf(ScriptedMetric.class));
+                ScriptedMetric scriptedMetricAggregation = (ScriptedMetric) aggregation;
+                assertThat(scriptedMetricAggregation.getName(), equalTo("scripted"));
+                assertThat(scriptedMetricAggregation.aggregation(), notNullValue());
+                assertThat(scriptedMetricAggregation.aggregation(), instanceOf(ArrayList.class));
+                List<?> aggregationList = (List<?>) scriptedMetricAggregation.aggregation();
+                assertThat(aggregationList.size(), equalTo(1));
+                Object object = aggregationList.get(0);
+                assertThat(object, notNullValue());
+                assertThat(object, instanceOf(Number.class));
+                assertThat(((Number) object).longValue(), equalTo(numDocs * 12));
+            }
+        );
     }
 
     public void testInitMapCombineReduceWithParamsStored() {
@@ -931,31 +959,33 @@ public class ScriptedMetricIT extends ESIntegTestCase {
         Map<String, Object> params = new HashMap<>();
         params.put("vars", varsMap);
 
-        SearchResponse response = prepareSearch("idx").setQuery(matchAllQuery())
-            .addAggregation(
-                scriptedMetric("scripted").params(params)
-                    .initScript(new Script(ScriptType.STORED, null, "initScript_stored", Collections.emptyMap()))
-                    .mapScript(new Script(ScriptType.STORED, null, "mapScript_stored", Collections.emptyMap()))
-                    .combineScript(new Script(ScriptType.STORED, null, "combineScript_stored", Collections.emptyMap()))
-                    .reduceScript(new Script(ScriptType.STORED, null, "reduceScript_stored", Collections.emptyMap()))
-            )
-            .get();
-        assertNoFailures(response);
-        assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    scriptedMetric("scripted").params(params)
+                        .initScript(new Script(ScriptType.STORED, null, "initScript_stored", Collections.emptyMap()))
+                        .mapScript(new Script(ScriptType.STORED, null, "mapScript_stored", Collections.emptyMap()))
+                        .combineScript(new Script(ScriptType.STORED, null, "combineScript_stored", Collections.emptyMap()))
+                        .reduceScript(new Script(ScriptType.STORED, null, "reduceScript_stored", Collections.emptyMap()))
+                ),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
 
-        Aggregation aggregation = response.getAggregations().get("scripted");
-        assertThat(aggregation, notNullValue());
-        assertThat(aggregation, instanceOf(ScriptedMetric.class));
-        ScriptedMetric scriptedMetricAggregation = (ScriptedMetric) aggregation;
-        assertThat(scriptedMetricAggregation.getName(), equalTo("scripted"));
-        assertThat(scriptedMetricAggregation.aggregation(), notNullValue());
-        assertThat(scriptedMetricAggregation.aggregation(), instanceOf(ArrayList.class));
-        List<?> aggregationList = (List<?>) scriptedMetricAggregation.aggregation();
-        assertThat(aggregationList.size(), equalTo(1));
-        Object object = aggregationList.get(0);
-        assertThat(object, notNullValue());
-        assertThat(object, instanceOf(Number.class));
-        assertThat(((Number) object).longValue(), equalTo(numDocs * 3));
+                Aggregation aggregation = response.getAggregations().get("scripted");
+                assertThat(aggregation, notNullValue());
+                assertThat(aggregation, instanceOf(ScriptedMetric.class));
+                ScriptedMetric scriptedMetricAggregation = (ScriptedMetric) aggregation;
+                assertThat(scriptedMetricAggregation.getName(), equalTo("scripted"));
+                assertThat(scriptedMetricAggregation.aggregation(), notNullValue());
+                assertThat(scriptedMetricAggregation.aggregation(), instanceOf(ArrayList.class));
+                List<?> aggregationList = (List<?>) scriptedMetricAggregation.aggregation();
+                assertThat(aggregationList.size(), equalTo(1));
+                Object object = aggregationList.get(0);
+                assertThat(object, notNullValue());
+                assertThat(object, instanceOf(Number.class));
+                assertThat(((Number) object).longValue(), equalTo(numDocs * 3));
+            }
+        );
     }
 
     public void testInitMapCombineReduceWithParamsAsSubAgg() {
@@ -985,49 +1015,51 @@ public class ScriptedMetricIT extends ESIntegTestCase {
             Collections.emptyMap()
         );
 
-        SearchResponse response = prepareSearch("idx").setQuery(matchAllQuery())
-            .setSize(1000)
-            .addAggregation(
-                histogram("histo").field("l_value")
-                    .interval(1)
-                    .subAggregation(
-                        scriptedMetric("scripted").params(params)
-                            .initScript(initScript)
-                            .mapScript(mapScript)
-                            .combineScript(combineScript)
-                            .reduceScript(reduceScript)
-                    )
-            )
-            .get();
-        assertNoFailures(response);
-        assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
-        Aggregation aggregation = response.getAggregations().get("histo");
-        assertThat(aggregation, notNullValue());
-        assertThat(aggregation, instanceOf(Histogram.class));
-        Histogram histoAgg = (Histogram) aggregation;
-        assertThat(histoAgg.getName(), equalTo("histo"));
-        List<? extends Bucket> buckets = histoAgg.getBuckets();
-        assertThat(buckets, notNullValue());
-        for (Bucket b : buckets) {
-            assertThat(b, notNullValue());
-            assertThat(b.getDocCount(), equalTo(1L));
-            Aggregations subAggs = b.getAggregations();
-            assertThat(subAggs, notNullValue());
-            assertThat(subAggs.asList().size(), equalTo(1));
-            Aggregation subAgg = subAggs.get("scripted");
-            assertThat(subAgg, notNullValue());
-            assertThat(subAgg, instanceOf(ScriptedMetric.class));
-            ScriptedMetric scriptedMetricAggregation = (ScriptedMetric) subAgg;
-            assertThat(scriptedMetricAggregation.getName(), equalTo("scripted"));
-            assertThat(scriptedMetricAggregation.aggregation(), notNullValue());
-            assertThat(scriptedMetricAggregation.aggregation(), instanceOf(ArrayList.class));
-            List<?> aggregationList = (List<?>) scriptedMetricAggregation.aggregation();
-            assertThat(aggregationList.size(), equalTo(1));
-            Object object = aggregationList.get(0);
-            assertThat(object, notNullValue());
-            assertThat(object, instanceOf(Number.class));
-            assertThat(((Number) object).longValue(), equalTo(3L));
-        }
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").setQuery(matchAllQuery())
+                .setSize(1000)
+                .addAggregation(
+                    histogram("histo").field("l_value")
+                        .interval(1)
+                        .subAggregation(
+                            scriptedMetric("scripted").params(params)
+                                .initScript(initScript)
+                                .mapScript(mapScript)
+                                .combineScript(combineScript)
+                                .reduceScript(reduceScript)
+                        )
+                ),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(numDocs));
+                Aggregation aggregation = response.getAggregations().get("histo");
+                assertThat(aggregation, notNullValue());
+                assertThat(aggregation, instanceOf(Histogram.class));
+                Histogram histoAgg = (Histogram) aggregation;
+                assertThat(histoAgg.getName(), equalTo("histo"));
+                List<? extends Bucket> buckets = histoAgg.getBuckets();
+                assertThat(buckets, notNullValue());
+                for (Bucket b : buckets) {
+                    assertThat(b, notNullValue());
+                    assertThat(b.getDocCount(), equalTo(1L));
+                    Aggregations subAggs = b.getAggregations();
+                    assertThat(subAggs, notNullValue());
+                    assertThat(subAggs.asList().size(), equalTo(1));
+                    Aggregation subAgg = subAggs.get("scripted");
+                    assertThat(subAgg, notNullValue());
+                    assertThat(subAgg, instanceOf(ScriptedMetric.class));
+                    ScriptedMetric scriptedMetricAggregation = (ScriptedMetric) subAgg;
+                    assertThat(scriptedMetricAggregation.getName(), equalTo("scripted"));
+                    assertThat(scriptedMetricAggregation.aggregation(), notNullValue());
+                    assertThat(scriptedMetricAggregation.aggregation(), instanceOf(ArrayList.class));
+                    List<?> aggregationList = (List<?>) scriptedMetricAggregation.aggregation();
+                    assertThat(aggregationList.size(), equalTo(1));
+                    Object object = aggregationList.get(0);
+                    assertThat(object, notNullValue());
+                    assertThat(object, instanceOf(Number.class));
+                    assertThat(((Number) object).longValue(), equalTo(3L));
+                }
+            }
+        );
     }
 
     public void testEmptyAggregation() throws Exception {
@@ -1057,36 +1089,38 @@ public class ScriptedMetricIT extends ESIntegTestCase {
             Collections.emptyMap()
         );
 
-        SearchResponse searchResponse = prepareSearch("empty_bucket_idx").setQuery(matchAllQuery())
-            .addAggregation(
-                histogram("histo").field("value")
-                    .interval(1L)
-                    .minDocCount(0)
-                    .subAggregation(
-                        scriptedMetric("scripted").params(params)
-                            .initScript(initScript)
-                            .mapScript(mapScript)
-                            .combineScript(combineScript)
-                            .reduceScript(reduceScript)
-                    )
-            )
-            .get();
+        assertNoFailuresAndResponse(
+            prepareSearch("empty_bucket_idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    histogram("histo").field("value")
+                        .interval(1L)
+                        .minDocCount(0)
+                        .subAggregation(
+                            scriptedMetric("scripted").params(params)
+                                .initScript(initScript)
+                                .mapScript(mapScript)
+                                .combineScript(combineScript)
+                                .reduceScript(reduceScript)
+                        )
+                ),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(2L));
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo, notNullValue());
+                Histogram.Bucket bucket = histo.getBuckets().get(1);
+                assertThat(bucket, notNullValue());
 
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(2L));
-        Histogram histo = searchResponse.getAggregations().get("histo");
-        assertThat(histo, notNullValue());
-        Histogram.Bucket bucket = histo.getBuckets().get(1);
-        assertThat(bucket, notNullValue());
-
-        ScriptedMetric scriptedMetric = bucket.getAggregations().get("scripted");
-        assertThat(scriptedMetric, notNullValue());
-        assertThat(scriptedMetric.getName(), equalTo("scripted"));
-        assertThat(scriptedMetric.aggregation(), notNullValue());
-        assertThat(scriptedMetric.aggregation(), instanceOf(List.class));
-        @SuppressWarnings("unchecked") // We'll just get a ClassCastException a couple lines down if we're wrong, its ok.
-        List<Integer> aggregationResult = (List<Integer>) scriptedMetric.aggregation();
-        assertThat(aggregationResult.size(), equalTo(1));
-        assertThat(aggregationResult.get(0), equalTo(0));
+                ScriptedMetric scriptedMetric = bucket.getAggregations().get("scripted");
+                assertThat(scriptedMetric, notNullValue());
+                assertThat(scriptedMetric.getName(), equalTo("scripted"));
+                assertThat(scriptedMetric.aggregation(), notNullValue());
+                assertThat(scriptedMetric.aggregation(), instanceOf(List.class));
+                @SuppressWarnings("unchecked") // We'll just get a ClassCastException a couple lines down if we're wrong, its ok.
+                List<Integer> aggregationResult = (List<Integer>) scriptedMetric.aggregation();
+                assertThat(aggregationResult.size(), equalTo(1));
+                assertThat(aggregationResult.get(0), equalTo(0));
+            }
+        );
     }
 
     /**
@@ -1129,12 +1163,15 @@ public class ScriptedMetricIT extends ESIntegTestCase {
         );
 
         // Test that a non-deterministic init script causes the result to not be cached
-        SearchResponse r = prepareSearch("cache_test_idx").setSize(0)
-            .addAggregation(
-                scriptedMetric("foo").initScript(ndInitScript).mapScript(mapScript).combineScript(combineScript).reduceScript(reduceScript)
-            )
-            .get();
-        assertNoFailures(r);
+        assertNoFailures(
+            prepareSearch("cache_test_idx").setSize(0)
+                .addAggregation(
+                    scriptedMetric("foo").initScript(ndInitScript)
+                        .mapScript(mapScript)
+                        .combineScript(combineScript)
+                        .reduceScript(reduceScript)
+                )
+        );
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -1146,10 +1183,10 @@ public class ScriptedMetricIT extends ESIntegTestCase {
         );
 
         // Test that a non-deterministic map script causes the result to not be cached
-        r = prepareSearch("cache_test_idx").setSize(0)
-            .addAggregation(scriptedMetric("foo").mapScript(ndMapScript).combineScript(combineScript).reduceScript(reduceScript))
-            .get();
-        assertNoFailures(r);
+        assertNoFailures(
+            prepareSearch("cache_test_idx").setSize(0)
+                .addAggregation(scriptedMetric("foo").mapScript(ndMapScript).combineScript(combineScript).reduceScript(reduceScript))
+        );
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -1161,10 +1198,10 @@ public class ScriptedMetricIT extends ESIntegTestCase {
         );
 
         // Test that a non-deterministic combine script causes the result to not be cached
-        r = prepareSearch("cache_test_idx").setSize(0)
-            .addAggregation(scriptedMetric("foo").mapScript(mapScript).combineScript(ndRandom).reduceScript(reduceScript))
-            .get();
-        assertNoFailures(r);
+        assertNoFailures(
+            prepareSearch("cache_test_idx").setSize(0)
+                .addAggregation(scriptedMetric("foo").mapScript(mapScript).combineScript(ndRandom).reduceScript(reduceScript))
+        );
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -1176,10 +1213,10 @@ public class ScriptedMetricIT extends ESIntegTestCase {
         );
 
         // NOTE: random reduce scripts don't hit the query shard context (they are done on the coordinator) and so can be cached.
-        r = prepareSearch("cache_test_idx").setSize(0)
-            .addAggregation(scriptedMetric("foo").mapScript(mapScript).combineScript(combineScript).reduceScript(ndRandom))
-            .get();
-        assertNoFailures(r);
+        assertNoFailures(
+            prepareSearch("cache_test_idx").setSize(0)
+                .addAggregation(scriptedMetric("foo").mapScript(mapScript).combineScript(combineScript).reduceScript(ndRandom))
+        );
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -1191,10 +1228,10 @@ public class ScriptedMetricIT extends ESIntegTestCase {
         );
 
         // Test that all deterministic scripts cause the request to be cached
-        r = prepareSearch("cache_test_idx").setSize(0)
-            .addAggregation(scriptedMetric("foo").mapScript(mapScript).combineScript(combineScript).reduceScript(reduceScript))
-            .get();
-        assertNoFailures(r);
+        assertNoFailures(
+            prepareSearch("cache_test_idx").setSize(0)
+                .addAggregation(scriptedMetric("foo").mapScript(mapScript).combineScript(combineScript).reduceScript(reduceScript))
+        );
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),


### PR DESCRIPTION
Remove explicit references from `org.elasticsearch.search.aggregations.metrics`