### PR TITLE
Don't update system index mappings in mixed clusters

### DIFF
--- a/docs/changelog/101778.yaml
+++ b/docs/changelog/101778.yaml
@@ -1,0 +1,6 @@
+pr: 101778
+summary: Don't update system index mappings in mixed clusters
+area: Infra/Core
+type: bug
+issues:
+ - 99778

--- a/docs/changelog/101778.yaml
+++ b/docs/changelog/101778.yaml
@@ -3,4 +3,5 @@ summary: Don't update system index mappings in mixed clusters
 area: Infra/Core
 type: bug
 issues:
+ - 101331
  - 99778

--- a/qa/rolling-upgrade-legacy/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
+++ b/qa/rolling-upgrade-legacy/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.upgrades;
 
 import org.apache.http.util.EntityUtils;
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.Request;
@@ -54,7 +53,6 @@ import static org.hamcrest.Matchers.oneOf;
 /**
  * In depth testing of the recovery mechanism during a rolling restart.
  */
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/99778")
 public class RecoveryIT extends AbstractRollingTestCase {
 
     private static String CLUSTER_NAME = System.getProperty("tests.clustername");

--- a/server/src/main/java/org/elasticsearch/indices/SystemIndexMappingUpdateService.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndexMappingUpdateService.java
@@ -97,8 +97,6 @@ public class SystemIndexMappingUpdateService implements ClusterStateListener {
             return;
         }
 
-        assert state.hasMixedSystemIndexVersions() == false : "Version equality should imply system index mapping version equality";
-
         if (isUpgradeInProgress.compareAndSet(false, true)) {
             // Use a RefCountingRunnable so that we only release the lock once all upgrade attempts have succeeded or failed.
             // The failures are logged in upgradeIndexMetadata(), so we don't actually care about them here.

--- a/server/src/main/java/org/elasticsearch/indices/SystemIndexMappingUpdateService.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndexMappingUpdateService.java
@@ -92,7 +92,8 @@ public class SystemIndexMappingUpdateService implements ClusterStateListener {
         }
 
         // if we're in a mixed-version cluster, exit
-        if (state.hasMixedSystemIndexVersions()) {
+        if (state.nodes().getMaxNodeVersion().after(state.nodes().getSmallestNonClientNodeVersion())) {
+            assert state.hasMixedSystemIndexVersions() == false : "Version equality should imply system index mapping version equality";
             logger.debug("Skipping system indices up-to-date check as cluster has mixed versions");
             return;
         }

--- a/server/src/main/java/org/elasticsearch/indices/SystemIndexMappingUpdateService.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndexMappingUpdateService.java
@@ -93,10 +93,11 @@ public class SystemIndexMappingUpdateService implements ClusterStateListener {
 
         // if we're in a mixed-version cluster, exit
         if (state.nodes().getMaxNodeVersion().after(state.nodes().getSmallestNonClientNodeVersion())) {
-            assert state.hasMixedSystemIndexVersions() == false : "Version equality should imply system index mapping version equality";
             logger.debug("Skipping system indices up-to-date check as cluster has mixed versions");
             return;
         }
+
+        assert state.hasMixedSystemIndexVersions() == false : "Version equality should imply system index mapping version equality";
 
         if (isUpgradeInProgress.compareAndSet(false, true)) {
             // Use a RefCountingRunnable so that we only release the lock once all upgrade attempts have succeeded or failed.


### PR DESCRIPTION
#99668 seems to have introduced a bug where SystemIndexMappingUpdateService updates system index mappings even in mixed clusters. This PR restores the old version-based check in order to be sure that there's no update until the cluster is fully upgraded.

I plan to work on a fix for the non-version check on a feature branch.

Fixes #99778
Fixes #101331