### PR TITLE
Add static factoryNumber in SnifferThreadFactory

### DIFF
--- a/client/sniffer/src/main/java/org/elasticsearch/client/sniff/Sniffer.java
+++ b/client/sniffer/src/main/java/org/elasticsearch/client/sniff/Sniffer.java
@@ -52,6 +52,7 @@ public class Sniffer implements Closeable {
 
     private static final Log logger = LogFactory.getLog(Sniffer.class);
     private static final String SNIFFER_THREAD_NAME = "es_rest_client_sniffer";
+    private static final AtomicInteger factoryNumber = new AtomicInteger(1);
 
     private final NodesSniffer nodesSniffer;
     private final RestClient restClient;
@@ -293,6 +294,7 @@ public class Sniffer implements Closeable {
 
     static class SnifferThreadFactory implements ThreadFactory {
         private final AtomicInteger threadNumber = new AtomicInteger(1);
+        private final int curFactoryNumber;
         private final String namePrefix;
         private final ThreadFactory originalThreadFactory;
 
@@ -304,6 +306,7 @@ public class Sniffer implements Closeable {
                     return Executors.defaultThreadFactory();
                 }
             });
+            curFactoryNumber = factoryNumber.getAndIncrement();
         }
 
         @Override
@@ -312,7 +315,7 @@ public class Sniffer implements Closeable {
                 @Override
                 public Thread run() {
                     Thread t = originalThreadFactory.newThread(r);
-                    t.setName(namePrefix + "[T#" + threadNumber.getAndIncrement() + "]");
+                    t.setName(namePrefix + "[F#"+ curFactoryNumber + ",T#" + threadNumber.getAndIncrement() + "]");
                     t.setDaemon(true);
                     return t;
                 }


### PR DESCRIPTION
related issue https://github.com/elastic/elasticsearch/issues/78271

Motivation:
// SnifferThreadFactory 1
es_rest_client_sniffer[T1],
es_rest_client_sniffer[T2],
es_rest_client_sniffer[T3] ..

// SnifferThreadFactory 2
es_rest_client_sniffer[T1],
es_rest_client_sniffer[T2],
es_rest_client_sniffer[T3] .. // same thread name with Factory 1
On https://github.com/elastic/elasticsearch/issues/78271, we found that sniffer's thread name can be duplicated over multiple SnifferThreadFactory, cause they only have threadNumber to set thread name
Modification:
// SnifferThreadFactory 1
es_rest_client_sniffer[F1,T1],
es_rest_client_sniffer[F1,T2],
es_rest_client_sniffer[F1,T3] ..

// SnifferThreadFactory 2
es_rest_client_sniffer[F2,T1],
es_rest_client_sniffer[F2,T2],
es_rest_client_sniffer[F2,T3] ..
Add factoryNumber on SnifferThreadFactory to set different thread name that created from different factory
Result:
Now SnifferThreadFactory has each factoryNum so thread name is all different and easy to distinguish
Close https://github.com/elastic/elasticsearch/issues/78271