### PR TITLE
[8.11] Don't update system index mappings in mixed clusters (#101778)

### DIFF
--- a/docs/changelog/101778.yaml
+++ b/docs/changelog/101778.yaml
@@ -1,0 +1,7 @@
+pr: 101778
+summary: Don't update system index mappings in mixed clusters
+area: Infra/Core
+type: bug
+issues:
+ - 101331
+ - 99778

--- a/qa/rolling-upgrade-legacy/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
+++ b/qa/rolling-upgrade-legacy/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.upgrades;
 
 import org.apache.http.util.EntityUtils;
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.Request;
@@ -53,7 +52,6 @@ import static org.hamcrest.Matchers.oneOf;
 /**
  * In depth testing of the recovery mechanism during a rolling restart.
  */
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/99778")
 public class RecoveryIT extends AbstractRollingTestCase {
 
     private static String CLUSTER_NAME = System.getProperty("tests.clustername");

--- a/server/src/main/java/org/elasticsearch/indices/SystemIndexMappingUpdateService.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndexMappingUpdateService.java
@@ -92,7 +92,7 @@ public class SystemIndexMappingUpdateService implements ClusterStateListener {
         }
 
         // if we're in a mixed-version cluster, exit
-        if (state.hasMixedSystemIndexVersions()) {
+        if (state.nodes().getMaxNodeVersion().after(state.nodes().getSmallestNonClientNodeVersion())) {
             logger.debug("Skipping system indices up-to-date check as cluster has mixed versions");
             return;
         }


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Don't update system index mappings in mixed clusters (#101778)