### PR TITLE
Run TransportGetAliasesAction on local node

### DIFF
--- a/docs/changelog/101815.yaml
+++ b/docs/changelog/101815.yaml
@@ -1,0 +1,5 @@
+pr: 101815
+summary: Run `TransportGetAliasesAction` on local node
+area: Indices APIs
+type: enhancement
+issues: []

--- a/qa/smoke-test-http/src/javaRestTest/java/org/elasticsearch/http/RestActionCancellationIT.java
+++ b/qa/smoke-test-http/src/javaRestTest/java/org/elasticsearch/http/RestActionCancellationIT.java
@@ -11,6 +11,7 @@ package org.elasticsearch.http;
 import org.apache.http.client.methods.HttpGet;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthAction;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateAction;
+import org.elasticsearch.action.admin.indices.alias.get.GetAliasesAction;
 import org.elasticsearch.action.admin.indices.recovery.RecoveryAction;
 import org.elasticsearch.action.support.CancellableActionTestPlugin;
 import org.elasticsearch.action.support.PlainActionFuture;
@@ -47,6 +48,14 @@ public class RestActionCancellationIT extends HttpSmokeTestCase {
 
     public void testClusterStateRestCancellation() throws Exception {
         runRestActionCancellationTest(new Request(HttpGet.METHOD_NAME, "/_cluster/state"), ClusterStateAction.NAME);
+    }
+
+    public void testGetAliasesCancellation() throws Exception {
+        runRestActionCancellationTest(new Request("GET", "/_alias"), GetAliasesAction.NAME);
+    }
+
+    public void testCatAliasesCancellation() throws Exception {
+        runRestActionCancellationTest(new Request("GET", "/_cat/aliases"), GetAliasesAction.NAME);
     }
 
     private void runRestActionCancellationTest(Request request, String actionName) throws Exception {

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cat.aliases/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cat.aliases/10_basic.yml
@@ -496,3 +496,16 @@
                 test_alias \s+ test_index\n
                 my_alias \s+ test_index\n
             $/
+
+---
+"Deprecated local parameter":
+  - skip:
+      version: "- 8.11.99"
+      features: ["warnings"]
+      reason: verifying deprecation warnings from 8.12.0 onwards
+
+  - do:
+      cat.aliases:
+        local: true
+      warnings:
+        - "the [?local=true] query parameter to cat-aliases requests has no effect and will be removed in a future version"

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.exists_alias/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.exists_alias/10_basic.yml
@@ -37,9 +37,14 @@
 
 ---
 "Test indices.exists_alias with local flag":
+  - skip:
+      features: ["allowed_warnings"]
+
   - do:
       indices.exists_alias:
         name: test_alias
         local: true
+      allowed_warnings:
+        - "the [?local=true] query parameter to get-aliases requests has no effect and will be removed in a future version"
 
   - is_false: ''

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_alias/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_alias/10_basic.yml
@@ -291,10 +291,14 @@ setup:
 
 ---
 "Get alias with local flag":
+  - skip:
+      features: ["allowed_warnings"]
 
   - do:
       indices.get_alias:
         local: true
+      allowed_warnings:
+        - "the [?local=true] query parameter to get-aliases requests has no effect and will be removed in a future version"
 
   - is_true: test_index
 
@@ -325,3 +329,17 @@ setup:
 
   - is_true: test_index
   - is_false: test_index_2
+
+
+---
+"Deprecated local parameter":
+  - skip:
+      version: "- 8.11.99"
+      features: ["warnings"]
+      reason: verifying deprecation warnings from 8.12.0 onwards
+
+  - do:
+      indices.get_alias:
+        local: true
+      warnings:
+        - "the [?local=true] query parameter to get-aliases requests has no effect and will be removed in a future version"

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesAction.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.action.admin.indices.alias.get;
 
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.common.io.stream.Writeable;
 
 public class GetAliasesAction extends ActionType<GetAliasesResponse> {
 
@@ -16,6 +17,6 @@ public class GetAliasesAction extends ActionType<GetAliasesResponse> {
     public static final String NAME = "indices:admin/aliases/get";
 
     private GetAliasesAction() {
-        super(NAME, GetAliasesResponse::new);
+        super(NAME, Writeable.Reader.localOnly());
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesResponse.java
@@ -11,7 +11,6 @@ package org.elasticsearch.action.admin.indices.alias.get;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.cluster.metadata.DataStreamAlias;
-import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
@@ -29,12 +28,6 @@ public class GetAliasesResponse extends ActionResponse {
         this.dataStreamAliases = dataStreamAliases;
     }
 
-    public GetAliasesResponse(StreamInput in) throws IOException {
-        super(in);
-        aliases = in.readImmutableOpenMap(StreamInput::readString, i -> i.readCollectionAsList(AliasMetadata::new));
-        dataStreamAliases = in.readMap(in1 -> in1.readCollectionAsList(DataStreamAlias::new));
-    }
-
     public Map<String, List<AliasMetadata>> getAliases() {
         return aliases;
     }
@@ -43,6 +36,10 @@ public class GetAliasesResponse extends ActionResponse {
         return dataStreamAliases;
     }
 
+    /**
+     * NB prior to 8.12 get-aliases was a TransportMasterNodeReadAction so for BwC we must remain able to write these responses until we no
+     * longer need to support {@link org.elasticsearch.TransportVersions#CLUSTER_FEATURES_ADDED} and earlier.
+     */
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeMap(aliases, StreamOutput::writeCollection);

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesAction.java
@@ -9,7 +9,7 @@ package org.elasticsearch.action.admin.indices.alias.get;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.master.TransportMasterNodeReadAction;
+import org.elasticsearch.action.support.TransportLocalClusterStateAction;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
@@ -26,6 +26,7 @@ import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.indices.SystemIndices;
 import org.elasticsearch.indices.SystemIndices.SystemIndexAccessLevel;
+import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -38,32 +39,37 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 
-public class TransportGetAliasesAction extends TransportMasterNodeReadAction<GetAliasesRequest, GetAliasesResponse> {
+/**
+ * NB prior to 8.12 this was a TransportMasterNodeReadAction so for BwC it must be registered with the TransportService (i.e. a
+ * HandledTransportAction) until we no longer need to support {@link org.elasticsearch.TransportVersions#CLUSTER_FEATURES_ADDED} and
+ * earlier.
+ */
+public class TransportGetAliasesAction extends TransportLocalClusterStateAction<GetAliasesRequest, GetAliasesResponse> {
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(TransportGetAliasesAction.class);
 
+    private final IndexNameExpressionResolver indexNameExpressionResolver;
     private final SystemIndices systemIndices;
+    private final ThreadContext threadContext;
 
     @Inject
     public TransportGetAliasesAction(
         TransportService transportService,
-        ClusterService clusterService,
-        ThreadPool threadPool,
         ActionFilters actionFilters,
+        ClusterService clusterService,
         IndexNameExpressionResolver indexNameExpressionResolver,
         SystemIndices systemIndices
     ) {
         super(
             GetAliasesAction.NAME,
-            transportService,
             clusterService,
-            threadPool,
+            transportService,
             actionFilters,
             GetAliasesRequest::new,
-            indexNameExpressionResolver,
-            GetAliasesResponse::new,
-            threadPool.executor(ThreadPool.Names.MANAGEMENT)
+            clusterService.threadPool().executor(ThreadPool.Names.MANAGEMENT)
         );
+        this.indexNameExpressionResolver = indexNameExpressionResolver;
         this.systemIndices = systemIndices;
+        this.threadContext = clusterService.threadPool().getThreadContext();
     }
 
     @Override
@@ -77,15 +83,22 @@ public class TransportGetAliasesAction extends TransportMasterNodeReadAction<Get
     }
 
     @Override
-    protected void masterOperation(Task task, GetAliasesRequest request, ClusterState state, ActionListener<GetAliasesResponse> listener) {
+    protected void localClusterStateOperation(
+        Task task,
+        GetAliasesRequest request,
+        ClusterState state,
+        ActionListener<GetAliasesResponse> listener
+    ) {
         assert Transports.assertNotTransportThread("no need to avoid the context switch and may be expensive if there are many aliases");
+        final var cancellableTask = (CancellableTask) task;
         // resolve all concrete indices upfront and warn/error later
         final String[] concreteIndices = indexNameExpressionResolver.concreteIndexNamesWithSystemIndexAccess(state, request);
         final SystemIndexAccessLevel systemIndexAccessLevel = indexNameExpressionResolver.getSystemIndexAccessLevel();
         Map<String, List<AliasMetadata>> aliases = state.metadata().findAliases(request.aliases(), concreteIndices);
+        cancellableTask.ensureNotCancelled();
         listener.onResponse(
             new GetAliasesResponse(
-                postProcess(request, concreteIndices, aliases, state, systemIndexAccessLevel, threadPool.getThreadContext(), systemIndices),
+                postProcess(request, concreteIndices, aliases, state, systemIndexAccessLevel, threadContext, systemIndices),
                 postProcess(indexNameExpressionResolver, request, state)
             )
         );
@@ -122,7 +135,7 @@ public class TransportGetAliasesAction extends TransportMasterNodeReadAction<Get
         }
         final Map<String, List<AliasMetadata>> finalResponse = Collections.unmodifiableMap(mapBuilder);
         if (systemIndexAccessLevel != SystemIndexAccessLevel.ALL) {
-            checkSystemIndexAccess(request, systemIndices, state, finalResponse, systemIndexAccessLevel, threadContext);
+            checkSystemIndexAccess(systemIndices, state, finalResponse, systemIndexAccessLevel, threadContext);
         }
         return finalResponse;
     }
@@ -151,7 +164,6 @@ public class TransportGetAliasesAction extends TransportMasterNodeReadAction<Get
     }
 
     private static void checkSystemIndexAccess(
-        GetAliasesRequest request,
         SystemIndices systemIndices,
         ClusterState state,
         Map<String, List<AliasMetadata>> aliasesMap,

--- a/server/src/main/java/org/elasticsearch/action/support/TransportLocalClusterStateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/TransportLocalClusterStateAction.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.support;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.ActionRunnable;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.transport.TransportService;
+
+import java.util.concurrent.Executor;
+
+/**
+ * Analogue of {@link org.elasticsearch.action.support.master.TransportMasterNodeReadAction} except that it runs on the local node rather
+ * than delegating to the master.
+ */
+public abstract class TransportLocalClusterStateAction<Request extends ActionRequest, Response extends ActionResponse> extends
+    HandledTransportAction<Request, Response> {
+
+    protected final ClusterService clusterService;
+    protected final Executor executor;
+
+    protected TransportLocalClusterStateAction(
+        String actionName,
+        ClusterService clusterService,
+        TransportService transportService,
+        ActionFilters actionFilters,
+        Writeable.Reader<Request> requestReader,
+        Executor executor
+    ) {
+        // TODO replace DIRECT_EXECUTOR_SERVICE when removing workaround for https://github.com/elastic/elasticsearch/issues/97916
+        super(actionName, transportService, actionFilters, requestReader, EsExecutors.DIRECT_EXECUTOR_SERVICE);
+        this.clusterService = clusterService;
+        this.executor = executor;
+    }
+
+    protected abstract ClusterBlockException checkBlock(Request request, ClusterState state);
+
+    @Override
+    protected final void doExecute(Task task, Request request, ActionListener<Response> listener) {
+        final var state = clusterService.state();
+        final var clusterBlockException = checkBlock(request, state);
+        if (clusterBlockException != null) {
+            throw clusterBlockException;
+        }
+
+        // Workaround for https://github.com/elastic/elasticsearch/issues/97916 - TODO remove this when we can
+        executor.execute(ActionRunnable.wrap(listener, l -> localClusterStateOperation(task, request, state, l)));
+    }
+
+    protected abstract void localClusterStateOperation(Task task, Request request, ClusterState state, ActionListener<Response> listener)
+        throws Exception;
+}

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetAliasesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetAliasesAction.java
@@ -20,6 +20,7 @@ import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestResponse;
@@ -208,13 +209,16 @@ public class RestGetAliasesAction extends BaseRestHandler {
         getAliasesRequest.indicesOptions(IndicesOptions.fromRequest(request, getAliasesRequest.indicesOptions()));
 
         if (request.hasParam("local")) {
-            DEPRECATION_LOGGER.critical(
-                DeprecationCategory.API,
-                "get-aliases-local",
-                "the [?local={}] query parameter to get-aliases requests has no effect and will be removed in a future version",
-                // consume the param for the message
-                request.paramAsBoolean("local", false)
-            );
+            // consume this param just for validation
+            final var localParam = request.paramAsBoolean("local", false);
+            if (request.getRestApiVersion() != RestApiVersion.V_7) {
+                DEPRECATION_LOGGER.critical(
+                    DeprecationCategory.API,
+                    "get-aliases-local",
+                    "the [?local={}] query parameter to get-aliases requests has no effect and will be removed in a future version",
+                    localParam
+                );
+            }
         }
 
         // we may want to move this logic to TransportGetAliasesAction but it is based on the original provided aliases, which will

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestAliasAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestAliasAction.java
@@ -14,10 +14,13 @@ import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.Table;
+import org.elasticsearch.common.logging.DeprecationCategory;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.Scope;
 import org.elasticsearch.rest.ServerlessScope;
+import org.elasticsearch.rest.action.RestCancellableNodeClient;
 import org.elasticsearch.rest.action.RestResponseListener;
 
 import java.util.List;
@@ -27,6 +30,8 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
 
 @ServerlessScope(Scope.PUBLIC)
 public class RestAliasAction extends AbstractCatAction {
+
+    private static final DeprecationLogger DEPRECATION_LOGGER = DeprecationLogger.getLogger(RestAliasAction.class);
 
     @Override
     public List<Route> routes() {
@@ -49,15 +54,26 @@ public class RestAliasAction extends AbstractCatAction {
             ? new GetAliasesRequest(Strings.commaDelimitedListToStringArray(request.param("alias")))
             : new GetAliasesRequest();
         getAliasesRequest.indicesOptions(IndicesOptions.fromRequest(request, getAliasesRequest.indicesOptions()));
-        getAliasesRequest.local(request.paramAsBoolean("local", getAliasesRequest.local()));
 
-        return channel -> client.admin().indices().getAliases(getAliasesRequest, new RestResponseListener<GetAliasesResponse>(channel) {
-            @Override
-            public RestResponse buildResponse(GetAliasesResponse response) throws Exception {
-                Table tab = buildTable(request, response);
-                return RestTable.buildResponse(tab, channel);
-            }
-        });
+        if (request.hasParam("local")) {
+            DEPRECATION_LOGGER.critical(
+                DeprecationCategory.API,
+                "cat-aliases-local",
+                "the [?local={}] query parameter to cat-aliases requests has no effect and will be removed in a future version",
+                // consume the param for the message
+                request.paramAsBoolean("local", false)
+            );
+        }
+
+        return channel -> new RestCancellableNodeClient(client, request.getHttpChannel()).admin()
+            .indices()
+            .getAliases(getAliasesRequest, new RestResponseListener<>(channel) {
+                @Override
+                public RestResponse buildResponse(GetAliasesResponse response) throws Exception {
+                    Table tab = buildTable(request, response);
+                    return RestTable.buildResponse(tab, channel);
+                }
+            });
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestAliasAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestAliasAction.java
@@ -16,6 +16,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.Table;
 import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.Scope;
@@ -56,13 +57,16 @@ public class RestAliasAction extends AbstractCatAction {
         getAliasesRequest.indicesOptions(IndicesOptions.fromRequest(request, getAliasesRequest.indicesOptions()));
 
         if (request.hasParam("local")) {
-            DEPRECATION_LOGGER.critical(
-                DeprecationCategory.API,
-                "cat-aliases-local",
-                "the [?local={}] query parameter to cat-aliases requests has no effect and will be removed in a future version",
-                // consume the param for the message
-                request.paramAsBoolean("local", false)
-            );
+            // consume this param just for validation
+            final var localParam = request.paramAsBoolean("local", false);
+            if (request.getRestApiVersion() != RestApiVersion.V_7) {
+                DEPRECATION_LOGGER.critical(
+                    DeprecationCategory.API,
+                    "cat-aliases-local",
+                    "the [?local={}] query parameter to cat-aliases requests has no effect and will be removed in a future version",
+                    localParam
+                );
+            }
         }
 
         return channel -> new RestCancellableNodeClient(client, request.getHttpChannel()).admin()

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/index/IndexResolver.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/index/IndexResolver.java
@@ -651,8 +651,7 @@ public class IndexResolver {
     }
 
     private static GetAliasesRequest createGetAliasesRequest(FieldCapabilitiesResponse response, boolean includeFrozen) {
-        return new GetAliasesRequest().local(true)
-            .aliases("*")
+        return new GetAliasesRequest().aliases("*")
             .indices(response.getIndices())
             .indicesOptions(includeFrozen ? FIELD_CAPS_FROZEN_INDICES_OPTIONS : FIELD_CAPS_INDICES_OPTIONS);
     }


### PR DESCRIPTION
This action is a pure function of the cluster state, it can run on any
node. Moreover it can be fairly expensive if there are a lot of aliases
so running it on the master can be quite harmful to the cluster.
Finally, it needs to be cancellable to avoid doing unnecessary work
after a client failure or timeout.

Relates #101805