### PR TITLE
[DOCS] Add Elastic Security bullet to 8.11 'What's new'

### DIFF
--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -51,6 +51,7 @@ These compute capabilities enable ES|QL to simplify user workflows in several ke
 * Use ES|QL across Kibana in Discover, Kibana Lens, and Elastic Solutions, giving you seamless workflows.
   You will be able to visualize ES|QL queries, share them with teams on dashboards or as queries,
   and use queries to create custom alerts.
+* In {security-guide}/whats-new.html[{elastic-sec}], use {esql} to investigate events in Timeline and create detection rules. Use the AI Assistant to write queries, or answer questions about the {esql} query language.
 
 [role="screenshot"]
 image:images/esql/esql_kibana_discover_logs.png[ES|QL usage in Kibana Discover for Analysing Proxy Logs]

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -51,7 +51,7 @@ These compute capabilities enable ES|QL to simplify user workflows in several ke
 * Use ES|QL across Kibana in Discover, Kibana Lens, and Elastic Solutions, giving you seamless workflows.
   You will be able to visualize ES|QL queries, share them with teams on dashboards or as queries,
   and use queries to create custom alerts.
-* In {security-guide}/whats-new.html[{elastic-sec}], use {esql} to investigate events in Timeline and create detection rules. Use the AI Assistant to write queries, or answer questions about the {esql} query language.
+* In {security-guide}/whats-new.html[{elastic-sec}], create an {esql} rule and use {esql} to investigate events in Timeline. Use the AI Assistant to write queries, or answer questions about the {esql} query language.
 
 [role="screenshot"]
 image:images/esql/esql_kibana_discover_logs.png[ES|QL usage in Kibana Discover for Analysing Proxy Logs]


### PR DESCRIPTION
Adds a bullet to the Elasticsearch 8.11 "What's new" about ES|QL capabilities in Elastic Security, with a link to the Elastic Security "What's new" docs.