### PR TITLE
Make enforceYamlTestConvention cc compatible

### DIFF
--- a/rest-api-spec/build.gradle
+++ b/rest-api-spec/build.gradle
@@ -228,8 +228,9 @@ tasks.named("yamlRestTestV7CompatTransform").configure { task ->
 }
 
 tasks.register('enforceYamlTestConvention').configure {
+  def tree = fileTree('src/main/resources/rest-api-spec/test')
   doLast {
-    if (fileTree('src/main/resources/rest-api-spec/test').files) {
+    if (tree.files) {
       throw new GradleException("There are YAML tests in src/main source set. These should be moved to src/yamlRestTest.")
     }
   }

--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -177,16 +177,18 @@ tasks.named("yamlRestTestV7CompatTransform").configure { task ->
 }
 
 tasks.register('enforceApiSpecsConvention').configure {
+  def mainApiSpecs = fileTree('src/test/resources/rest-api-spec/api')
   doLast {
-    if (fileTree('src/test/resources/rest-api-spec/api').files) {
+    if (mainApiSpecs.files) {
       throw new GradleException("There are REST specs in src/test source set. These should be moved to the :rest-api-spec project.")
     }
   }
 }
 
 tasks.register('enforceYamlTestConvention').configure {
+  def mainYamlFiles = fileTree('src/test/resources/rest-api-spec/test')
   doLast {
-    if (fileTree('src/test/resources/rest-api-spec/test').files) {
+    if (mainYamlFiles.files) {
       throw new GradleException("There are YAML tests in src/test source set. These should be moved to src/yamlRestTest.")
     }
   }


### PR DESCRIPTION
fixes enforceYamlTestConvention configuration cache compatibility not referencing project object from task action


related to #57918