### PR TITLE
Fix snippet task cc incompatibilities

### DIFF
--- a/build-tools-internal/src/main/groovy/org/elasticsearch/gradle/internal/doc/DocsTestPlugin.groovy
+++ b/build-tools-internal/src/main/groovy/org/elasticsearch/gradle/internal/doc/DocsTestPlugin.groovy
@@ -12,6 +12,7 @@ import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.test.rest.CopyRestApiTask
 import org.elasticsearch.gradle.internal.test.rest.CopyRestTestsTask
+import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.file.Directory
@@ -61,16 +62,24 @@ class DocsTestPlugin implements Plugin<Project> {
             group 'Docs'
             description 'List each snippet'
             defaultSubstitutions = commonDefaultSubstitutions
-            perSnippet { println(it.toString()) }
+            perSnippet = new Action<SnippetsTask.Snippet>() {
+                @Override
+                void execute(SnippetsTask.Snippet snippet) {
+                    println(snippet.toString())
+                }
+            }
         }
         project.tasks.register('listConsoleCandidates', SnippetsTask) {
             group 'Docs'
             description
             'List snippets that probably should be marked // CONSOLE'
             defaultSubstitutions = commonDefaultSubstitutions
-            perSnippet {
-                if (RestTestsFromSnippetsTask.isConsoleCandidate(it)) {
-                    println(it.toString())
+            perSnippet = new Action<SnippetsTask.Snippet>() {
+                @Override
+                void execute(SnippetsTask.Snippet snippet) {
+                    if (RestTestsFromSnippetsTask.isConsoleCandidate(it)) {
+                        println(it.toString())
+                    }
                 }
             }
         }
@@ -80,7 +89,7 @@ class DocsTestPlugin implements Plugin<Project> {
             defaultSubstitutions = commonDefaultSubstitutions
             testRoot.convention(restRootDir)
             doFirst {
-                fileOperations.delete(restRootDir)
+                getFileOperations().delete(testRoot.get())
             }
         }
 

--- a/build-tools-internal/src/main/groovy/org/elasticsearch/gradle/internal/doc/SnippetsTask.groovy
+++ b/build-tools-internal/src/main/groovy/org/elasticsearch/gradle/internal/doc/SnippetsTask.groovy
@@ -11,8 +11,9 @@ package org.elasticsearch.gradle.internal.doc
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.JsonToken
 
+import org.gradle.api.Action;
 import org.gradle.api.DefaultTask
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.file.ConfigurableFileTree
@@ -44,7 +45,7 @@ class SnippetsTask extends DefaultTask {
      * instance of Snippet.
      */
     @Internal
-    Closure perSnippet
+    Action<Snippet> perSnippet
 
     /**
      * The docs to scan. Defaults to every file in the directory exception the
@@ -134,7 +135,7 @@ class SnippetsTask extends DefaultTask {
                         + "After substitutions and munging, the json looks like:\n" + quoted, e);
                     }
                 }
-                perSnippet(snippet)
+                perSnippet.execute(snippet)
                 snippet = null
             }
             file.eachLine('UTF-8') { String line, int lineNumber ->


### PR DESCRIPTION
Addresses some Gradle configuration cache issues related to https://github.com/elastic/elasticsearch/issues/57918