### PR TITLE
[DOCS] Explain ES|QL CASE behavior with even no. arguments

### DIFF
--- a/docs/reference/esql/functions/case.asciidoc
+++ b/docs/reference/esql/functions/case.asciidoc
@@ -27,7 +27,8 @@ Accepts pairs of conditions and values. The function returns the value that
 belongs to the first condition that evaluates to `true`.
 
 If the number of arguments is odd, the last argument is the default value which
-is returned when no condition matches.
+is returned when no condition matches. If the number of arguments is even, and
+no condition matches, the function returns `null`.
 
 *Example*
 


### PR DESCRIPTION
Explains that if the number of arguments is even, and no condition matches, the CASE function returns `null`.

Closes https://github.com/elastic/elasticsearch/issues/99479