### PR TITLE
[DOCS] Default and max limits are now dynamic settings

### DIFF
--- a/docs/reference/esql/esql-limitations.asciidoc
+++ b/docs/reference/esql/esql-limitations.asciidoc
@@ -10,20 +10,8 @@
 === Result set size limit
 
 By default, an {esql} query returns up to 500 rows. You can increase the number
-of rows up to 10,000 using the <<esql-limit>> command. Queries do not return
-more than 10,000 rows, regardless of the `LIMIT` command's value.
-
-This limit only applies to the number of rows that are retrieved by the query
-and displayed in Discover. Queries and aggregations run on the full data set.
-
-To overcome this limitation:
-
-* Reduce the result set size by modifying the query to only return relevant
-data. Use <<esql-where>> to select a smaller subset of the data.
-* Shift any post-query processing to the query itself. You can use the {esql}
-<<esql-stats-by>> command to aggregate data in the query.
-* Increase the limit with the `esql.query.result_truncation_max_size` static
-cluster setting.
+of rows up to 10,000 using the <<esql-limit>> command.
+include::processing-commands/limit.asciidoc[tag=limitation]
 
 [discrete]
 [[esql-supported-types]]

--- a/docs/reference/esql/processing-commands/limit.asciidoc
+++ b/docs/reference/esql/processing-commands/limit.asciidoc
@@ -17,11 +17,27 @@ The maximum number of rows to return.
 *Description*
 
 The `LIMIT` processing command enables you to limit the number of rows that are
-returned. If not specified, `LIMIT` defaults to `500`.
+returned.
+// tag::limitation[]
+Queries do not return more than 10,000 rows, regardless of the `LIMIT` command's
+value.
 
-A query does not return more than 10,000 rows, regardless of the `LIMIT` value.
-You can change this with the `esql.query.result_truncation_max_size` static
-cluster setting.
+This limit only applies to the number of rows that are retrieved by the query
+and displayed in Discover. Queries and aggregations run on the full data set.
+
+To overcome this limitation:
+
+* Reduce the result set size by modifying the query to only return relevant
+data. Use <<esql-where>> to select a smaller subset of the data.
+* Shift any post-query processing to the query itself. You can use the {esql}
+<<esql-stats-by>> command to aggregate data in the query.
+
+The default and maximum limits can be changed using these dynamic cluster
+settings:
+
+* `esql.query.result_truncation_default_size`
+* `esql.query.result_truncation_max_size`
+// end::limitation[]
 
 *Example*
 

--- a/docs/reference/esql/processing-commands/limit.asciidoc
+++ b/docs/reference/esql/processing-commands/limit.asciidoc
@@ -22,8 +22,8 @@ returned.
 Queries do not return more than 10,000 rows, regardless of the `LIMIT` command's
 value.
 
-This limit only applies to the number of rows that are retrieved by the query
-and displayed in Discover. Queries and aggregations run on the full data set.
+This limit only applies to the number of rows that are retrieved by the query.
+Queries and aggregations run on the full data set.
 
 To overcome this limitation:
 


### PR DESCRIPTION
The default and max limits are now dynamic settings (`esql.query.result_truncation_default_size` and `esql.query.result_truncation_max_size`). This updates the docs accordingly.