### PR TITLE
Separate NoOpClient and ThreadPool lifecycles

### DIFF
--- a/docs/changelog/101835.yaml
+++ b/docs/changelog/101835.yaml
@@ -1,0 +1,5 @@
+pr: 101835
+summary: Separate `NoOpClient` and `ThreadPool` lifecycles
+area: Infra/Transport API
+type: tech debt
+issues: []

--- a/docs/changelog/101835.yaml
+++ b/docs/changelog/101835.yaml
@@ -1,5 +1,0 @@
-pr: 101835
-summary: Separate `NoOpClient` and `ThreadPool` lifecycles
-area: Infra/Transport API
-type: tech debt
-issues: []

--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleServiceTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleServiceTests.java
@@ -126,7 +126,6 @@ public class DataStreamLifecycleServiceTests extends ESTestCase {
     private ThreadPool threadPool;
     private DataStreamLifecycleService dataStreamLifecycleService;
     private List<TransportRequest> clientSeenRequests;
-    private Client client;
     private DoExecuteDelegate clientDelegate;
     private ClusterService clusterService;
 
@@ -145,7 +144,7 @@ public class DataStreamLifecycleServiceTests extends ESTestCase {
         Clock clock = Clock.fixed(Instant.ofEpochMilli(now), ZoneId.of(randomFrom(ZoneId.getAvailableZoneIds())));
         clientSeenRequests = new CopyOnWriteArrayList<>();
 
-        client = getTransportRequestsRecordingClient();
+        final Client client = getTransportRequestsRecordingClient();
         AllocationService allocationService = new AllocationService(
             new AllocationDeciders(
                 new HashSet<>(
@@ -178,7 +177,6 @@ public class DataStreamLifecycleServiceTests extends ESTestCase {
         dataStreamLifecycleService.close();
         clusterService.close();
         threadPool.shutdownNow();
-        client.close();
     }
 
     public void testOperationsExecutedOnce() {
@@ -1499,7 +1497,7 @@ public class DataStreamLifecycleServiceTests extends ESTestCase {
      * (it does not even notify the listener), but tests can provide an implementation of clientDelegate to provide any needed behavior.
      */
     private Client getTransportRequestsRecordingClient() {
-        return new NoOpClient(getTestName()) {
+        return new NoOpClient(threadPool) {
             @Override
             protected <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
                 ActionType<Response> action,

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/AsyncBulkByScrollActionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/AsyncBulkByScrollActionTests.java
@@ -126,6 +126,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
     private PlainActionFuture<BulkByScrollResponse> listener;
     private String scrollId;
     private ThreadPool threadPool;
+    private ThreadPool clientThreadPool;
     private TaskManager taskManager;
     private BulkByScrollTask testTask;
     private WorkerBulkByScrollTaskState worker;
@@ -154,16 +155,18 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
     }
 
     private void setupClient(ThreadPool threadPool) {
-        if (client != null) {
-            client.close();
+        if (clientThreadPool != null) {
+            terminate(clientThreadPool);
         }
+        clientThreadPool = threadPool;
         client = new MyMockClient(new NoOpClient(threadPool));
         client.threadPool().getThreadContext().putHeader(expectedHeaders);
     }
 
     @After
     public void tearDownAndVerifyCommonStuff() throws Exception {
-        client.close();
+        terminate(clientThreadPool);
+        clientThreadPool = null;
         terminate(threadPool);
     }
 

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequestBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequestBuilderTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Strings;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.client.NoOpClient;
+import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentType;
@@ -28,19 +29,21 @@ public class CreateIndexRequestBuilderTests extends ESTestCase {
 
     private static final String KEY = "my.settings.key";
     private static final String VALUE = "my.settings.value";
+    private TestThreadPool threadPool;
     private NoOpClient testClient;
 
     @Override
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        this.testClient = new NoOpClient(getTestName());
+        this.threadPool = createThreadPool();
+        this.testClient = new NoOpClient(threadPool);
     }
 
     @Override
     @After
     public void tearDown() throws Exception {
-        this.testClient.close();
+        this.threadPool.close();
         super.tearDown();
     }
 

--- a/server/src/test/java/org/elasticsearch/action/bulk/Retry2Tests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/Retry2Tests.java
@@ -18,6 +18,8 @@ import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.client.NoOpClient;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.After;
 import org.junit.Before;
 
@@ -39,6 +41,7 @@ import static org.hamcrest.Matchers.nullValue;
 public class Retry2Tests extends ESTestCase {
     private static final int CALLS_TO_FAIL = 5;
 
+    private TestThreadPool threadPool;
     private MockBulkClient bulkClient;
     /**
      * Headers that are expected to be sent with all bulk requests.
@@ -49,7 +52,8 @@ public class Retry2Tests extends ESTestCase {
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        this.bulkClient = new MockBulkClient(getTestName(), CALLS_TO_FAIL);
+        this.threadPool = createThreadPool();
+        this.bulkClient = new MockBulkClient(threadPool, CALLS_TO_FAIL);
         // Stash some random headers so we can assert that we preserve them
         bulkClient.threadPool().getThreadContext().stashContext();
         expectedHeaders.clear();
@@ -60,8 +64,8 @@ public class Retry2Tests extends ESTestCase {
     @Override
     @After
     public void tearDown() throws Exception {
+        this.threadPool.close();
         super.tearDown();
-        this.bulkClient.close();
     }
 
     private BulkRequest createBulkRequest() {
@@ -267,8 +271,8 @@ public class Retry2Tests extends ESTestCase {
     private class MockBulkClient extends NoOpClient {
         private int numberOfCallsToFail;
 
-        private MockBulkClient(String testName, int numberOfCallsToFail) {
-            super(testName);
+        private MockBulkClient(ThreadPool threadPool, int numberOfCallsToFail) {
+            super(threadPool);
             this.numberOfCallsToFail = numberOfCallsToFail;
         }
 

--- a/server/src/test/java/org/elasticsearch/action/bulk/RetryTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/RetryTests.java
@@ -18,6 +18,8 @@ import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.client.NoOpClient;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.After;
 import org.junit.Before;
 
@@ -36,6 +38,7 @@ public class RetryTests extends ESTestCase {
     private static final TimeValue DELAY = TimeValue.timeValueMillis(1L);
     private static final int CALLS_TO_FAIL = 5;
 
+    private TestThreadPool threadPool;
     private MockBulkClient bulkClient;
     /**
      * Headers that are expected to be sent with all bulk requests.
@@ -46,7 +49,8 @@ public class RetryTests extends ESTestCase {
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        this.bulkClient = new MockBulkClient(getTestName(), CALLS_TO_FAIL);
+        this.threadPool = createThreadPool();
+        this.bulkClient = new MockBulkClient(threadPool, CALLS_TO_FAIL);
         // Stash some random headers so we can assert that we preserve them
         bulkClient.threadPool().getThreadContext().stashContext();
         expectedHeaders.clear();
@@ -57,8 +61,8 @@ public class RetryTests extends ESTestCase {
     @Override
     @After
     public void tearDown() throws Exception {
+        this.threadPool.close();
         super.tearDown();
-        this.bulkClient.close();
     }
 
     private BulkRequest createBulkRequest() {
@@ -195,8 +199,8 @@ public class RetryTests extends ESTestCase {
     private class MockBulkClient extends NoOpClient {
         private int numberOfCallsToFail;
 
-        private MockBulkClient(String testName, int numberOfCallsToFail) {
-            super(testName);
+        private MockBulkClient(ThreadPool threadPool, int numberOfCallsToFail) {
+            super(threadPool);
             this.numberOfCallsToFail = numberOfCallsToFail;
         }
 

--- a/server/src/test/java/org/elasticsearch/action/index/IndexRequestBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/action/index/IndexRequestBuilderTests.java
@@ -11,6 +11,7 @@ package org.elasticsearch.action.index;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.client.NoOpClient;
+import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentType;
@@ -24,19 +25,21 @@ import java.util.Map;
 public class IndexRequestBuilderTests extends ESTestCase {
 
     private static final String EXPECTED_SOURCE = "{\"SomeKey\":\"SomeValue\"}";
+    private TestThreadPool threadPool;
     private NoOpClient testClient;
 
     @Override
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        this.testClient = new NoOpClient(getTestName());
+        this.threadPool = createThreadPool();
+        this.testClient = new NoOpClient(threadPool);
     }
 
     @Override
     @After
     public void tearDown() throws Exception {
-        this.testClient.close();
+        this.threadPool.close();
         super.tearDown();
     }
 

--- a/server/src/test/java/org/elasticsearch/action/synonyms/PutSynonymRuleActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/synonyms/PutSynonymRuleActionTests.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.action.synonyms;
 
-import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.synonyms.RestPutSynonymRuleAction;
 import org.elasticsearch.test.ESTestCase;
@@ -27,7 +26,8 @@ public class PutSynonymRuleActionTests extends ESTestCase {
             .build();
 
         FakeRestChannel channel = new FakeRestChannel(request, false, 0);
-        try (NodeClient nodeClient = new NoOpNodeClient(this.getTestName())) {
+        try (var threadPool = createThreadPool()) {
+            final var nodeClient = new NoOpNodeClient(threadPool);
             expectThrows(IllegalArgumentException.class, () -> action.handleRequest(request, channel, nodeClient));
         }
     }

--- a/server/src/test/java/org/elasticsearch/action/synonyms/PutSynonymsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/synonyms/PutSynonymsActionTests.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.action.synonyms;
 
-import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.synonyms.RestPutSynonymsAction;
 import org.elasticsearch.test.ESTestCase;
@@ -27,7 +26,8 @@ public class PutSynonymsActionTests extends ESTestCase {
             .build();
 
         FakeRestChannel channel = new FakeRestChannel(request, false, 0);
-        try (NodeClient nodeClient = new NoOpNodeClient(this.getTestName())) {
+        try (var threadPool = createThreadPool()) {
+            final var nodeClient = new NoOpNodeClient(threadPool);
             expectThrows(IllegalArgumentException.class, () -> action.handleRequest(request, channel, nodeClient));
         }
     }

--- a/server/src/test/java/org/elasticsearch/client/internal/OriginSettingClientTests.java
+++ b/server/src/test/java/org/elasticsearch/client/internal/OriginSettingClientTests.java
@@ -24,23 +24,24 @@ public class OriginSettingClientTests extends ESTestCase {
     public void testSetsParentId() {
         String origin = randomAlphaOfLength(7);
 
-        /*
-         * This mock will do nothing but verify that origin is set in the
-         * thread context before executing the action.
-         */
-        NoOpClient mock = new NoOpClient(getTestName()) {
-            @Override
-            protected <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
-                ActionType<Response> action,
-                Request request,
-                ActionListener<Response> listener
-            ) {
-                assertEquals(origin, threadPool().getThreadContext().getTransient(ThreadContext.ACTION_ORIGIN_TRANSIENT_NAME));
-                super.doExecute(action, request, listener);
-            }
-        };
+        try (var threadPool = createThreadPool()) {
+            /*
+             * This mock will do nothing but verify that origin is set in the
+             * thread context before executing the action.
+             */
+            final var mock = new NoOpClient(threadPool) {
+                @Override
+                protected <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
+                    ActionType<Response> action,
+                    Request request,
+                    ActionListener<Response> listener
+                ) {
+                    assertEquals(origin, threadPool().getThreadContext().getTransient(ThreadContext.ACTION_ORIGIN_TRANSIENT_NAME));
+                    super.doExecute(action, request, listener);
+                }
+            };
 
-        try (OriginSettingClient client = new OriginSettingClient(mock, origin)) {
+            final var client = new OriginSettingClient(mock, origin);
             // All of these should have the origin set
             client.bulk(new BulkRequest());
             client.search(new SearchRequest());

--- a/server/src/test/java/org/elasticsearch/client/internal/ParentTaskAssigningClientTests.java
+++ b/server/src/test/java/org/elasticsearch/client/internal/ParentTaskAssigningClientTests.java
@@ -23,19 +23,21 @@ public class ParentTaskAssigningClientTests extends ESTestCase {
     public void testSetsParentId() {
         TaskId[] parentTaskId = new TaskId[] { new TaskId(randomAlphaOfLength(3), randomLong()) };
 
-        // This mock will do nothing but verify that parentTaskId is set on all requests sent to it.
-        NoOpClient mock = new NoOpClient(getTestName()) {
-            @Override
-            protected <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
-                ActionType<Response> action,
-                Request request,
-                ActionListener<Response> listener
-            ) {
-                assertEquals(parentTaskId[0], request.getParentTask());
-                super.doExecute(action, request, listener);
-            }
-        };
-        try (ParentTaskAssigningClient client = new ParentTaskAssigningClient(mock, parentTaskId[0])) {
+        try (var threadPool = createThreadPool()) {
+            // This mock will do nothing but verify that parentTaskId is set on all requests sent to it.
+            final var mock = new NoOpClient(threadPool) {
+                @Override
+                protected <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
+                    ActionType<Response> action,
+                    Request request,
+                    ActionListener<Response> listener
+                ) {
+                    assertEquals(parentTaskId[0], request.getParentTask());
+                    super.doExecute(action, request, listener);
+                }
+            };
+
+            final var client = new ParentTaskAssigningClient(mock, parentTaskId[0]);
             assertEquals(parentTaskId[0], client.getParentTask());
 
             // All of these should have the parentTaskId set

--- a/server/src/test/java/org/elasticsearch/rest/RestControllerTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/RestControllerTests.java
@@ -39,6 +39,7 @@ import org.elasticsearch.telemetry.tracing.Tracer;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.client.NoOpNodeClient;
 import org.elasticsearch.test.rest.FakeRestRequest;
+import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.transport.BytesRefRecycler;
 import org.elasticsearch.usage.UsageService;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
@@ -87,6 +88,7 @@ public class RestControllerTests extends ESTestCase {
     private RestController restController;
     private HierarchyCircuitBreakerService circuitBreakerService;
     private UsageService usageService;
+    private TestThreadPool threadPool;
     private NodeClient client;
     private Tracer tracer;
     private List<RestRequest.Method> methodList;
@@ -107,7 +109,8 @@ public class RestControllerTests extends ESTestCase {
         inFlightRequestsBreaker = circuitBreakerService.getBreaker(CircuitBreaker.IN_FLIGHT_REQUESTS);
 
         HttpServerTransport httpServerTransport = new TestHttpServerTransport();
-        client = new NoOpNodeClient(this.getTestName());
+        threadPool = createThreadPool();
+        client = new NoOpNodeClient(threadPool);
         tracer = mock(Tracer.class);
         restController = new RestController(null, client, circuitBreakerService, usageService, tracer);
         restController.registerHandler(
@@ -126,7 +129,7 @@ public class RestControllerTests extends ESTestCase {
 
     @After
     public void teardown() throws IOException {
-        IOUtils.close(client);
+        IOUtils.close(threadPool);
     }
 
     public void testApplyProductSpecificResponseHeaders() {

--- a/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestAnalyzeActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestAnalyzeActionTests.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.rest.action.admin.indices;
 
 import org.elasticsearch.action.admin.indices.analyze.AnalyzeAction;
-import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.index.analysis.NameOrDefinition;
 import org.elasticsearch.rest.RestRequest;
@@ -95,7 +94,8 @@ public class RestAnalyzeActionTests extends ESTestCase {
             new BytesArray("{invalid_json}"),
             XContentType.JSON
         ).build();
-        try (NodeClient client = new NoOpNodeClient(this.getClass().getSimpleName())) {
+        try (var threadPool = createThreadPool()) {
+            final var client = new NoOpNodeClient(threadPool);
             var e = expectThrows(XContentParseException.class, () -> action.handleRequest(request, null, client));
             assertThat(e.getMessage(), containsString("expecting double-quote"));
         }

--- a/server/src/test/java/org/elasticsearch/rest/action/cat/RestCatComponentTemplateActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/cat/RestCatComponentTemplateActionTests.java
@@ -28,6 +28,7 @@ import org.elasticsearch.test.client.NoOpNodeClient;
 import org.elasticsearch.test.rest.FakeRestChannel;
 import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.test.rest.RestActionTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -78,7 +79,8 @@ public class RestCatComponentTemplateActionTests extends RestActionTestCase {
         FakeRestChannel channel = new FakeRestChannel(getCatComponentTemplateRequest, true, 0);
 
         // execute action
-        try (NoOpNodeClient nodeClient = buildNodeClient()) {
+        try (var threadPool = createThreadPool()) {
+            final var nodeClient = buildNodeClient(threadPool);
             action.handleRequest(getCatComponentTemplateRequest, channel, nodeClient);
         }
 
@@ -96,7 +98,8 @@ public class RestCatComponentTemplateActionTests extends RestActionTestCase {
         FakeRestChannel channel = new FakeRestChannel(getCatComponentTemplateRequest, true, 0);
 
         // execute action
-        try (NoOpNodeClient nodeClient = buildNodeClient()) {
+        try (var threadPool = createThreadPool()) {
+            final var nodeClient = buildNodeClient(threadPool);
             action.handleRequest(getCatComponentTemplateRequest, channel, nodeClient);
         }
 
@@ -106,10 +109,10 @@ public class RestCatComponentTemplateActionTests extends RestActionTestCase {
         assertThat(channel.capturedResponse().content().utf8ToString(), emptyString());
     }
 
-    private NoOpNodeClient buildNodeClient() {
+    private NoOpNodeClient buildNodeClient(ThreadPool threadPool) {
         ClusterStateResponse clusterStateResponse = new ClusterStateResponse(clusterName, clusterState, false);
 
-        return new NoOpNodeClient(getTestName()) {
+        return new NoOpNodeClient(threadPool) {
             @Override
             @SuppressWarnings("unchecked")
             public <Request extends ActionRequest, Response extends ActionResponse> void doExecute(

--- a/server/src/test/java/org/elasticsearch/rest/action/cat/RestTasksActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/cat/RestTasksActionTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.client.NoOpNodeClient;
 import org.elasticsearch.test.rest.FakeRestChannel;
 import org.elasticsearch.test.rest.FakeRestRequest;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 
 import java.util.List;
@@ -33,7 +34,8 @@ public class RestTasksActionTests extends ESTestCase {
             Map.of("parent_task_id", "the node:3", "nodes", "node1,node2", "actions", "*")
         ).build();
         FakeRestChannel fakeRestChannel = new FakeRestChannel(fakeRestRequest, false, 1);
-        try (NoOpNodeClient nodeClient = buildNodeClient()) {
+        try (var threadPool = createThreadPool()) {
+            final var nodeClient = buildNodeClient(threadPool);
             action.handleRequest(fakeRestRequest, fakeRestChannel, nodeClient);
         }
 
@@ -41,8 +43,8 @@ public class RestTasksActionTests extends ESTestCase {
         assertThat(fakeRestChannel.responses().get(), is(1));
     }
 
-    private NoOpNodeClient buildNodeClient() {
-        return new NoOpNodeClient(getTestName()) {
+    private NoOpNodeClient buildNodeClient(ThreadPool threadPool) {
+        return new NoOpNodeClient(threadPool) {
             @Override
             @SuppressWarnings("unchecked")
             public <Request extends ActionRequest, Response extends ActionResponse> void doExecute(

--- a/server/src/test/java/org/elasticsearch/usage/UsageServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/usage/UsageServiceTests.java
@@ -95,7 +95,8 @@ public class UsageServiceTests extends ESTestCase {
         usageService.addRestHandler(handlerD);
         usageService.addRestHandler(handlerE);
         usageService.addRestHandler(handlerF);
-        try (NodeClient client = new NoOpNodeClient(this.getClass().getSimpleName() + "TestClient")) {
+        try (var threadPool = createThreadPool()) {
+            final var client = new NoOpNodeClient(threadPool);
             handlerA.handleRequest(restRequest, null, client);
             handlerB.handleRequest(restRequest, null, client);
             handlerA.handleRequest(restRequest, null, client);

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractQueryVectorBuilderTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractQueryVectorBuilderTestCase.java
@@ -23,6 +23,7 @@ import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.search.vectors.KnnSearchBuilder;
 import org.elasticsearch.search.vectors.QueryVectorBuilder;
 import org.elasticsearch.test.client.NoOpClient;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.junit.Before;
 
@@ -114,7 +115,8 @@ public abstract class AbstractQueryVectorBuilderTestCase<T extends QueryVectorBu
                 KnnSearchBuilder::new,
                 TransportVersion.current()
             );
-            try (NoOpClient client = new AssertingClient(expected, queryVectorBuilder)) {
+            try (var threadPool = createThreadPool()) {
+                final var client = new AssertingClient(threadPool, expected, queryVectorBuilder);
                 QueryRewriteContext context = new QueryRewriteContext(null, client, null);
                 PlainActionFuture<KnnSearchBuilder> future = new PlainActionFuture<>();
                 Rewriteable.rewriteAndFetch(randomFrom(serialized, searchBuilder), context, future);
@@ -128,7 +130,8 @@ public abstract class AbstractQueryVectorBuilderTestCase<T extends QueryVectorBu
     public final void testVectorFetch() throws Exception {
         float[] expected = randomVector(randomIntBetween(10, 1024));
         T queryVectorBuilder = createTestInstance(expected);
-        try (NoOpClient client = new AssertingClient(expected, queryVectorBuilder)) {
+        try (var threadPool = createThreadPool()) {
+            final var client = new AssertingClient(threadPool, expected, queryVectorBuilder);
             PlainActionFuture<float[]> future = new PlainActionFuture<>();
             queryVectorBuilder.buildVector(client, future);
             assertThat(future.get(), equalTo(expected));
@@ -163,8 +166,8 @@ public abstract class AbstractQueryVectorBuilderTestCase<T extends QueryVectorBu
         private final float[] array;
         private final T queryVectorBuilder;
 
-        AssertingClient(float[] array, T queryVectorBuilder) {
-            super("query_vector_builder_tests");
+        AssertingClient(ThreadPool threadPool, float[] array, T queryVectorBuilder) {
+            super(threadPool);
             this.array = array;
             this.queryVectorBuilder = queryVectorBuilder;
         }

--- a/test/framework/src/main/java/org/elasticsearch/test/client/NoOpClient.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/client/NoOpClient.java
@@ -8,17 +8,13 @@
 
 package org.elasticsearch.test.client;
 
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.client.internal.support.AbstractClient;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
-
-import java.util.concurrent.TimeUnit;
 
 /**
  * Client that always responds with {@code null} to every request. Override {@link #doExecute(ActionType, ActionRequest, ActionListener)}
@@ -34,13 +30,6 @@ public class NoOpClient extends AbstractClient {
         super(Settings.EMPTY, threadPool);
     }
 
-    /**
-     * Create a new {@link TestThreadPool} for this client. This {@linkplain TestThreadPool} is terminated on {@link #close()}.
-     */
-    public NoOpClient(String testName) {
-        super(Settings.EMPTY, new TestThreadPool(testName));
-    }
-
     @Override
     protected <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
         ActionType<Response> action,
@@ -51,11 +40,5 @@ public class NoOpClient extends AbstractClient {
     }
 
     @Override
-    public void close() {
-        try {
-            ThreadPool.terminate(threadPool(), 10, TimeUnit.SECONDS);
-        } catch (Exception e) {
-            throw new ElasticsearchException(e.getMessage(), e);
-        }
-    }
+    public void close() {}
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/client/NoOpNodeClient.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/client/NoOpNodeClient.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.test.client;
 
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
@@ -20,14 +19,12 @@ import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskManager;
-import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.RemoteClusterService;
 import org.elasticsearch.transport.Transport;
 
 import java.util.Map;
 import java.util.concurrent.Executor;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 
@@ -46,13 +43,6 @@ public class NoOpNodeClient extends NodeClient {
      */
     public NoOpNodeClient(ThreadPool threadPool) {
         super(Settings.EMPTY, threadPool);
-    }
-
-    /**
-     * Create a new {@link TestThreadPool} for this client. This {@linkplain TestThreadPool} is terminated on {@link #close()}.
-     */
-    public NoOpNodeClient(String testName) {
-        super(Settings.EMPTY, new TestThreadPool(testName));
     }
 
     @Override
@@ -96,18 +86,5 @@ public class NoOpNodeClient extends NodeClient {
     @Override
     public Client getRemoteClusterClient(String clusterAlias, Executor responseExecutor) {
         return null;
-    }
-
-    @Override
-    public void close() {
-        try {
-            ThreadPool.terminate(threadPool(), 10, TimeUnit.SECONDS);
-        } catch (Exception e) {
-            throw new ElasticsearchException(e.getMessage(), e);
-        }
-    }
-
-    public long getExecutionCount() {
-        return executionCount.get();
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/RestActionTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/RestActionTestCase.java
@@ -20,6 +20,8 @@ import org.elasticsearch.tasks.Task;
 import org.elasticsearch.telemetry.tracing.Tracer;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.client.NoOpNodeClient;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.usage.UsageService;
 import org.junit.After;
 import org.junit.Before;
@@ -35,17 +37,19 @@ import java.util.function.BiFunction;
  */
 public abstract class RestActionTestCase extends ESTestCase {
     private RestController controller;
+    private TestThreadPool threadPool;
     protected VerifyingClient verifyingClient;
 
     @Before
     public void setUpController() {
-        verifyingClient = new VerifyingClient(this.getTestName());
+        threadPool = createThreadPool();
+        verifyingClient = new VerifyingClient(threadPool);
         controller = new RestController(null, verifyingClient, new NoneCircuitBreakerService(), new UsageService(), Tracer.NOOP);
     }
 
     @After
     public void tearDownController() {
-        verifyingClient.close();
+        threadPool.close();
     }
 
     /**
@@ -78,8 +82,8 @@ public abstract class RestActionTestCase extends ESTestCase {
         AtomicReference<BiFunction<ActionType<?>, ActionRequest, ActionResponse>> executeVerifier = new AtomicReference<>();
         AtomicReference<BiFunction<ActionType<?>, ActionRequest, ActionResponse>> executeLocallyVerifier = new AtomicReference<>();
 
-        public VerifyingClient(String testName) {
-            super(testName);
+        public VerifyingClient(ThreadPool threadPool) {
+            super(threadPool);
             reset();
         }
 

--- a/test/framework/src/main/java/org/elasticsearch/threadpool/TestThreadPool.java
+++ b/test/framework/src/main/java/org/elasticsearch/threadpool/TestThreadPool.java
@@ -10,14 +10,16 @@ package org.elasticsearch.threadpool;
 
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.core.Releasable;
 import org.elasticsearch.node.Node;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
-public class TestThreadPool extends ThreadPool {
+public class TestThreadPool extends ThreadPool implements Releasable {
 
     private final CountDownLatch blockingLatch = new CountDownLatch(1);
     private volatile boolean returnRejectingExecutor = false;
@@ -97,5 +99,10 @@ public class TestThreadPool extends ThreadPool {
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Override
+    public void close() {
+        ThreadPool.terminate(this, 10, TimeUnit.SECONDS);
     }
 }

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/nodeinfo/AutoscalingNodesInfoServiceTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/nodeinfo/AutoscalingNodesInfoServiceTests.java
@@ -42,6 +42,8 @@ import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.monitor.os.OsInfo;
 import org.elasticsearch.monitor.os.OsStats;
 import org.elasticsearch.test.client.NoOpClient;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.autoscaling.AutoscalingMetadata;
 import org.elasticsearch.xpack.autoscaling.AutoscalingTestCase;
 import org.elasticsearch.xpack.autoscaling.policy.AutoscalingPolicy;
@@ -73,6 +75,7 @@ import static org.mockito.Mockito.when;
 
 public class AutoscalingNodesInfoServiceTests extends AutoscalingTestCase {
 
+    private TestThreadPool threadPool;
     private NodeStatsClient client;
     private AutoscalingNodeInfoService service;
     private TimeValue fetchTimeout;
@@ -83,7 +86,8 @@ public class AutoscalingNodesInfoServiceTests extends AutoscalingTestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        client = new NodeStatsClient();
+        threadPool = createThreadPool();
+        client = new NodeStatsClient(threadPool);
         final ClusterService clusterService = mock(ClusterService.class);
         Settings settings;
         if (randomBoolean()) {
@@ -105,8 +109,8 @@ public class AutoscalingNodesInfoServiceTests extends AutoscalingTestCase {
     @After
     @Override
     public void tearDown() throws Exception {
+        threadPool.close();
         super.tearDown();
-        client.close();
     }
 
     public void testAddRemoveNode() {
@@ -470,8 +474,8 @@ public class AutoscalingNodesInfoServiceTests extends AutoscalingTestCase {
         private BiConsumer<NodesStatsRequest, ActionListener<NodesStatsResponse>> responderStats;
         private BiConsumer<NodesInfoRequest, ActionListener<NodesInfoResponse>> responderInfo;
 
-        private NodeStatsClient() {
-            super(getTestName());
+        private NodeStatsClient(ThreadPool threadPool) {
+            super(threadPool);
         }
 
         public void respondInfo(NodesInfoResponse response, Runnable whileFetching) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/validation/SourceDestValidatorTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/validation/SourceDestValidatorTests.java
@@ -95,6 +95,7 @@ public class SourceDestValidatorTests extends ESTestCase {
         REMOTE_SOURCE_VALIDATION
     );
 
+    private TestThreadPool clientThreadPool;
     private Client clientWithBasicLicense;
     private Client clientWithExpiredBasicLicense;
     private Client clientWithPlatinumLicense;
@@ -154,8 +155,8 @@ public class SourceDestValidatorTests extends ESTestCase {
         private final String license;
         private final LicenseStatus licenseStatus;
 
-        MockClientLicenseCheck(String testName, String license, LicenseStatus licenseStatus) {
-            super(testName);
+        MockClientLicenseCheck(ThreadPool threadPool, String license, LicenseStatus licenseStatus) {
+            super(threadPool);
             this.license = license;
             this.licenseStatus = licenseStatus;
         }
@@ -187,21 +188,19 @@ public class SourceDestValidatorTests extends ESTestCase {
 
     @Before
     public void setupComponents() {
-        clientWithBasicLicense = new MockClientLicenseCheck(getTestName(), "basic", LicenseStatus.ACTIVE);
-        clientWithExpiredBasicLicense = new MockClientLicenseCheck(getTestName(), "basic", LicenseStatus.EXPIRED);
+        clientThreadPool = createThreadPool();
+        clientWithBasicLicense = new MockClientLicenseCheck(clientThreadPool, "basic", LicenseStatus.ACTIVE);
+        clientWithExpiredBasicLicense = new MockClientLicenseCheck(clientThreadPool, "basic", LicenseStatus.EXPIRED);
         LicensedFeature.Momentary feature = LicensedFeature.momentary(null, "feature", License.OperationMode.BASIC);
         platinumFeature = LicensedFeature.momentary(null, "platinum-feature", License.OperationMode.PLATINUM);
         remoteClusterLicenseCheckerBasic = new RemoteClusterLicenseChecker(clientWithBasicLicense, feature);
-        clientWithPlatinumLicense = new MockClientLicenseCheck(getTestName(), "platinum", LicenseStatus.ACTIVE);
-        clientWithTrialLicense = new MockClientLicenseCheck(getTestName(), "trial", LicenseStatus.ACTIVE);
+        clientWithPlatinumLicense = new MockClientLicenseCheck(clientThreadPool, "platinum", LicenseStatus.ACTIVE);
+        clientWithTrialLicense = new MockClientLicenseCheck(clientThreadPool, "trial", LicenseStatus.ACTIVE);
     }
 
     @After
     public void closeComponents() throws Exception {
-        clientWithBasicLicense.close();
-        clientWithExpiredBasicLicense.close();
-        clientWithPlatinumLicense.close();
-        clientWithTrialLicense.close();
+        clientThreadPool.close();
         ThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS);
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CleanupShrinkIndexStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CleanupShrinkIndexStepTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.cluster.metadata.LifecycleExecutionState;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.test.client.NoOpClient;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.ilm.Step.StepKey;
 
 import java.util.Map;
@@ -100,7 +101,8 @@ public class CleanupShrinkIndexStepTests extends AbstractStepTestCase<CleanupShr
             .metadata(Metadata.builder().put(indexMetadata, true).build())
             .build();
 
-        try (NoOpClient client = getDeleteIndexRequestAssertingClient(shrinkIndexName)) {
+        try (var threadPool = createThreadPool()) {
+            final var client = getDeleteIndexRequestAssertingClient(threadPool, shrinkIndexName);
             CleanupShrinkIndexStep step = new CleanupShrinkIndexStep(randomStepKey(), randomStepKey(), client);
             step.performAction(indexMetadata, clusterState, null, ActionListener.noop());
         }
@@ -126,14 +128,15 @@ public class CleanupShrinkIndexStepTests extends AbstractStepTestCase<CleanupShr
             .metadata(Metadata.builder().put(shrunkIndexMetadata, true).build())
             .build();
 
-        try (NoOpClient client = getFailingIfCalledClient()) {
+        try (var threadPool = createThreadPool()) {
+            final var client = getFailingIfCalledClient(threadPool);
             CleanupShrinkIndexStep step = new CleanupShrinkIndexStep(randomStepKey(), randomStepKey(), client);
             step.performAction(shrunkIndexMetadata, clusterState, null, ActionListener.noop());
         }
     }
 
-    private NoOpClient getDeleteIndexRequestAssertingClient(String shrinkIndexName) {
-        return new NoOpClient(getTestName()) {
+    private NoOpClient getDeleteIndexRequestAssertingClient(ThreadPool threadPool, String shrinkIndexName) {
+        return new NoOpClient(threadPool) {
             @Override
             protected <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
                 ActionType<Response> action,
@@ -147,8 +150,8 @@ public class CleanupShrinkIndexStepTests extends AbstractStepTestCase<CleanupShr
         };
     }
 
-    private NoOpClient getFailingIfCalledClient() {
-        return new NoOpClient(getTestName()) {
+    private NoOpClient getFailingIfCalledClient(ThreadPool threadPool) {
+        return new NoOpClient(threadPool) {
             @Override
             protected <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
                 ActionType<Response> action,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CreateSnapshotStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/CreateSnapshotStepTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.snapshots.SnapshotNameAlreadyInUseException;
 import org.elasticsearch.test.client.NoOpClient;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.ilm.Step.StepKey;
 
 import java.util.HashMap;
@@ -132,7 +133,8 @@ public class CreateSnapshotStepTests extends AbstractStepTestCase<CreateSnapshot
             .metadata(Metadata.builder().put(indexMetadata, true).build())
             .build();
 
-        try (NoOpClient client = getCreateSnapshotRequestAssertingClient(repository, snapshotName, indexName)) {
+        try (var threadPool = createThreadPool()) {
+            final var client = getCreateSnapshotRequestAssertingClient(threadPool, repository, snapshotName, indexName);
             CreateSnapshotStep step = new CreateSnapshotStep(randomStepKey(), randomStepKey(), randomStepKey(), client);
             step.performAction(indexMetadata, clusterState, null, ActionListener.noop());
         }
@@ -158,7 +160,8 @@ public class CreateSnapshotStepTests extends AbstractStepTestCase<CreateSnapshot
             .metadata(Metadata.builder().put(indexMetadata, true).build())
             .build();
         {
-            try (NoOpClient client = new NoOpClient(getTestName())) {
+            try (var threadPool = createThreadPool()) {
+                final var client = new NoOpClient(threadPool);
                 StepKey nextKeyOnComplete = randomStepKey();
                 StepKey nextKeyOnIncomplete = randomStepKey();
                 CreateSnapshotStep completeStep = new CreateSnapshotStep(randomStepKey(), nextKeyOnComplete, nextKeyOnIncomplete, client) {
@@ -173,7 +176,8 @@ public class CreateSnapshotStepTests extends AbstractStepTestCase<CreateSnapshot
         }
 
         {
-            try (NoOpClient client = new NoOpClient(getTestName())) {
+            try (var threadPool = createThreadPool()) {
+                final var client = new NoOpClient(threadPool);
                 StepKey nextKeyOnComplete = randomStepKey();
                 StepKey nextKeyOnIncomplete = randomStepKey();
                 CreateSnapshotStep incompleteStep = new CreateSnapshotStep(
@@ -193,7 +197,8 @@ public class CreateSnapshotStepTests extends AbstractStepTestCase<CreateSnapshot
         }
 
         {
-            try (NoOpClient client = new NoOpClient(getTestName())) {
+            try (var threadPool = createThreadPool()) {
+                final var client = new NoOpClient(threadPool);
                 StepKey nextKeyOnComplete = randomStepKey();
                 StepKey nextKeyOnIncomplete = randomStepKey();
                 CreateSnapshotStep doubleInvocationStep = new CreateSnapshotStep(
@@ -213,8 +218,13 @@ public class CreateSnapshotStepTests extends AbstractStepTestCase<CreateSnapshot
         }
     }
 
-    private NoOpClient getCreateSnapshotRequestAssertingClient(String expectedRepoName, String expectedSnapshotName, String indexName) {
-        return new NoOpClient(getTestName()) {
+    private NoOpClient getCreateSnapshotRequestAssertingClient(
+        ThreadPool threadPool,
+        String expectedRepoName,
+        String expectedSnapshotName,
+        String indexName
+    ) {
+        return new NoOpClient(threadPool) {
             @Override
             protected <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
                 ActionType<Response> action,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/DownsampleStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/DownsampleStepTests.java
@@ -251,7 +251,8 @@ public class DownsampleStepTests extends AbstractStepTestCase<DownsampleStep> {
             .metadata(Metadata.builder().put(sourceIndexMetadata, true).build())
             .build();
         {
-            try (NoOpClient client = new NoOpClient(getTestName())) {
+            try (var threadPool = createThreadPool()) {
+                final var client = new NoOpClient(threadPool);
                 StepKey nextKey = randomStepKey();
                 DateHistogramInterval fixedInterval = ConfigTestHelpers.randomInterval();
                 TimeValue timeout = DownsampleAction.DEFAULT_WAIT_TIMEOUT;
@@ -265,7 +266,8 @@ public class DownsampleStepTests extends AbstractStepTestCase<DownsampleStep> {
             }
         }
         {
-            try (NoOpClient client = new NoOpClient(getTestName())) {
+            try (var threadPool = createThreadPool()) {
+                final var client = new NoOpClient(threadPool);
                 StepKey nextKey = randomStepKey();
                 DateHistogramInterval fixedInterval = ConfigTestHelpers.randomInterval();
                 TimeValue timeout = DownsampleAction.DEFAULT_WAIT_TIMEOUT;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SwapAliasesAndDeleteSourceIndexStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SwapAliasesAndDeleteSourceIndexStepTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.cluster.metadata.LifecycleExecutionState;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.test.client.NoOpClient;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.ilm.Step.StepKey;
 
 import java.util.Arrays;
@@ -103,7 +104,8 @@ public class SwapAliasesAndDeleteSourceIndexStepTests extends AbstractStepTestCa
                 .isHidden(isHidden)
         );
 
-        try (NoOpClient client = getIndicesAliasAssertingClient(expectedAliasActions)) {
+        try (var threadPool = createThreadPool()) {
+            final var client = getIndicesAliasAssertingClient(threadPool, expectedAliasActions);
             SwapAliasesAndDeleteSourceIndexStep step = new SwapAliasesAndDeleteSourceIndexStep(
                 randomStepKey(),
                 randomStepKey(),
@@ -124,8 +126,8 @@ public class SwapAliasesAndDeleteSourceIndexStepTests extends AbstractStepTestCa
         }
     }
 
-    private NoOpClient getIndicesAliasAssertingClient(List<AliasActions> expectedAliasActions) {
-        return new NoOpClient(getTestName()) {
+    private NoOpClient getIndicesAliasAssertingClient(ThreadPool threadPool, List<AliasActions> expectedAliasActions) {
+        return new NoOpClient(threadPool) {
             @Override
             protected <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
                 ActionType<Response> action,

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/AbstractRestEnterpriseSearchActionTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/AbstractRestEnterpriseSearchActionTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.application;
 
-import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
@@ -28,7 +27,8 @@ public abstract class AbstractRestEnterpriseSearchActionTests extends ESTestCase
 
         final FakeRestChannel channel = new FakeRestChannel(request, true, 1);
 
-        try (NodeClient nodeClient = new NoOpNodeClient(this.getTestName())) {
+        try (var threadPool = createThreadPool()) {
+            final var nodeClient = new NoOpNodeClient(threadPool);
             action.handleRequest(request, channel, nodeClient);
         }
         assertThat(channel.capturedResponse(), notNullValue());

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/EnterpriseSearchBaseRestHandlerTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/EnterpriseSearchBaseRestHandlerTests.java
@@ -59,7 +59,8 @@ public class EnterpriseSearchBaseRestHandlerTests extends ESTestCase {
         FakeRestRequest fakeRestRequest = new FakeRestRequest();
         FakeRestChannel fakeRestChannel = new FakeRestChannel(fakeRestRequest, randomBoolean(), licensedFeature ? 0 : 1);
 
-        try (NodeClient client = new NoOpNodeClient(this.getTestName())) {
+        try (var threadPool = createThreadPool()) {
+            final var client = new NoOpNodeClient(threadPool);
             assertFalse(consumerCalled.get());
             verifyNoMoreInteractions(licenseState);
             handler.handleRequest(fakeRestRequest, fakeRestChannel, client);

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/sample/CircuitBreakerTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/sample/CircuitBreakerTests.java
@@ -34,6 +34,7 @@ import org.elasticsearch.search.aggregations.bucket.composite.InternalComposite;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.client.NoOpClient;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.eql.EqlTestUtils;
 import org.elasticsearch.xpack.eql.analysis.PostAnalyzer;
 import org.elasticsearch.xpack.eql.analysis.PreAnalyzer;
@@ -103,8 +104,9 @@ public class CircuitBreakerTests extends ESTestCase {
                 Collections.singletonList(EqlTestUtils.circuitBreakerSettings(Settings.EMPTY)),
                 new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
             );
-            ESMockClient esClient = new ESMockClient(service.getBreaker(CIRCUIT_BREAKER_NAME));
+            var threadPool = createThreadPool()
         ) {
+            final var esClient = new ESMockClient(threadPool, service.getBreaker(CIRCUIT_BREAKER_NAME));
             CircuitBreaker eqlCircuitBreaker = service.getBreaker(CIRCUIT_BREAKER_NAME);
             IndexResolver indexResolver = new IndexResolver(esClient, "cluster", DefaultDataTypeRegistry.INSTANCE, () -> emptySet());
             EqlSession eqlSession = new EqlSession(
@@ -190,8 +192,8 @@ public class CircuitBreakerTests extends ESTestCase {
         protected final CircuitBreaker circuitBreaker;
         private final String pitId = "test_pit_id";
 
-        ESMockClient(CircuitBreaker circuitBreaker) {
-            super(getTestName());
+        ESMockClient(ThreadPool threadPool, CircuitBreaker circuitBreaker) {
+            super(threadPool);
             this.circuitBreaker = circuitBreaker;
         }
 

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/sequence/PITFailureTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/sequence/PITFailureTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.client.NoOpClient;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.async.AsyncExecutionId;
 import org.elasticsearch.xpack.eql.action.EqlSearchAction;
 import org.elasticsearch.xpack.eql.action.EqlSearchTask;
@@ -67,7 +68,8 @@ public class PITFailureTests extends ESTestCase {
     private final List<HitExtractor> keyExtractors = emptyList();
 
     public void testHandlingPitFailure() {
-        try (ESMockClient esClient = new ESMockClient();) {
+        try (var threadPool = createThreadPool()) {
+            final var esClient = new ESMockClient(threadPool);
 
             EqlConfiguration eqlConfiguration = new EqlConfiguration(
                 new String[] { "test" },
@@ -146,8 +148,8 @@ public class PITFailureTests extends ESTestCase {
      */
     private class ESMockClient extends NoOpClient {
 
-        ESMockClient() {
-            super(getTestName());
+        ESMockClient(ThreadPool threadPool) {
+            super(threadPool);
         }
 
         @SuppressWarnings("unchecked")

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleTransitionTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleTransitionTests.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.ilm;
 
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -592,7 +591,8 @@ public class IndexLifecycleTransitionTests extends ESTestCase {
 
         IndexMetadata meta = buildIndexMetadata("my-policy", executionState);
 
-        try (Client client = new NoOpClient(getTestName())) {
+        try (var threadPool = createThreadPool()) {
+            final var client = new NoOpClient(threadPool);
             Step.StepKey currentStepKey = new Step.StepKey("hot", RolloverAction.NAME, WaitForRolloverReadyStep.NAME);
             Step.StepKey nextStepKey = new Step.StepKey("hot", RolloverAction.NAME, RolloverStep.NAME);
             Step currentStep = new WaitForRolloverReadyStep(
@@ -648,7 +648,8 @@ public class IndexLifecycleTransitionTests extends ESTestCase {
 
         IndexMetadata meta = buildIndexMetadata("my-policy", executionState);
 
-        try (Client client = new NoOpClient(getTestName())) {
+        try (var threadPool = createThreadPool()) {
+            final var client = new NoOpClient(threadPool);
             Step.StepKey currentStepKey = new Step.StepKey("warm", MigrateAction.NAME, DataTierMigrationRoutedStep.NAME);
             Step.StepKey nextStepKey = new Step.StepKey("warm", PhaseCompleteStep.NAME, PhaseCompleteStep.NAME);
 
@@ -708,7 +709,8 @@ public class IndexLifecycleTransitionTests extends ESTestCase {
 
         IndexMetadata meta = buildIndexMetadata("my-policy", executionState);
 
-        try (Client client = new NoOpClient(getTestName())) {
+        try (var threadPool = createThreadPool()) {
+            final var client = new NoOpClient(threadPool);
             Step.StepKey currentStepKey = new Step.StepKey("warm", MigrateAction.NAME, MigrateAction.NAME);
             Step.StepKey nextStepKey = new Step.StepKey("warm", MigrateAction.NAME, DataTierMigrationRoutedStep.NAME);
 
@@ -1198,7 +1200,8 @@ public class IndexLifecycleTransitionTests extends ESTestCase {
                 2L
             );
 
-            try (Client client = new NoOpClient(getTestName())) {
+            try (var threadPool = createThreadPool()) {
+                final var client = new NoOpClient(threadPool);
                 LifecycleExecutionState newState = moveStateToNextActionAndUpdateCachedPhase(
                     meta,
                     meta.getLifecycleExecutionState(),
@@ -1235,7 +1238,8 @@ public class IndexLifecycleTransitionTests extends ESTestCase {
                 2L
             );
 
-            try (Client client = new NoOpClient(getTestName())) {
+            try (var threadPool = createThreadPool()) {
+                final var client = new NoOpClient(threadPool);
                 LifecycleExecutionState newState = moveStateToNextActionAndUpdateCachedPhase(
                     meta,
                     meta.getLifecycleExecutionState(),

--- a/x-pack/plugin/logstash/src/test/java/org/elasticsearch/xpack/logstash/action/TransportDeletePipelineActionTests.java
+++ b/x-pack/plugin/logstash/src/test/java/org/elasticsearch/xpack/logstash/action/TransportDeletePipelineActionTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.test.client.NoOpClient;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.RemoteTransportException;
 import org.elasticsearch.transport.TransportService;
 
@@ -27,7 +28,8 @@ import static org.mockito.Mockito.mock;
 public class TransportDeletePipelineActionTests extends ESTestCase {
 
     public void testDeletePipelineWithMissingIndex() throws Exception {
-        try (Client client = getFailureClient(new IndexNotFoundException("missing .logstash"))) {
+        try (var threadPool = createThreadPool()) {
+            final var client = getFailureClient(threadPool, new IndexNotFoundException("missing .logstash"));
             TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
             final TransportDeletePipelineAction action = new TransportDeletePipelineAction(
                 transportService,
@@ -41,8 +43,8 @@ public class TransportDeletePipelineActionTests extends ESTestCase {
         }
     }
 
-    private Client getFailureClient(Exception e) {
-        return new NoOpClient(getTestName()) {
+    private Client getFailureClient(ThreadPool threadPool, Exception e) {
+        return new NoOpClient(threadPool) {
             @Override
             protected <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
                 ActionType<Response> action,

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelProviderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelProviderTests.java
@@ -22,6 +22,7 @@ import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.client.NoOpClient;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.core.action.util.PageParams;
 import org.elasticsearch.xpack.core.ml.action.GetTrainedModelsAction;
@@ -346,7 +347,8 @@ public class TrainedModelProviderTests extends ESTestCase {
     }
 
     public void testStoreTrainedModelConfigCallsClientExecuteWithOperationCreate() {
-        try (var client = createMockClient()) {
+        try (var threadPool = createThreadPool()) {
+            final var client = createMockClient(threadPool);
             var config = TrainedModelConfigTests.createTestInstance("modelId").build();
             var trainedModelProvider = new TrainedModelProvider(client, xContentRegistry());
             var future = new PlainActionFuture<Boolean>();
@@ -357,7 +359,8 @@ public class TrainedModelProviderTests extends ESTestCase {
     }
 
     public void testStoreTrainedModelConfigCallsClientExecuteWithOperationCreateWhenAllowOverwriteIsFalse() {
-        try (var client = createMockClient()) {
+        try (var threadPool = createThreadPool()) {
+            final var client = createMockClient(threadPool);
             var config = TrainedModelConfigTests.createTestInstance("modelId").build();
             var trainedModelProvider = new TrainedModelProvider(client, xContentRegistry());
             var future = new PlainActionFuture<Boolean>();
@@ -368,7 +371,8 @@ public class TrainedModelProviderTests extends ESTestCase {
     }
 
     public void testStoreTrainedModelConfigCallsClientExecuteWithOperationIndex() {
-        try (var client = createMockClient()) {
+        try (var threadPool = createThreadPool()) {
+            final var client = createMockClient(threadPool);
             var config = TrainedModelConfigTests.createTestInstance("modelId").build();
             var trainedModelProvider = new TrainedModelProvider(client, xContentRegistry());
             var future = new PlainActionFuture<Boolean>();
@@ -379,7 +383,8 @@ public class TrainedModelProviderTests extends ESTestCase {
     }
 
     public void testStoreTrainedModelWithDefinitionCallsClientExecuteWithOperationCreate() throws IOException {
-        try (var client = createMockClient()) {
+        try (var threadPool = createThreadPool()) {
+            final var client = createMockClient(threadPool);
             var config = createTrainedModelConfigWithDefinition("modelId");
             var trainedModelProvider = new TrainedModelProvider(client, xContentRegistry());
             var future = new PlainActionFuture<Boolean>();
@@ -390,7 +395,8 @@ public class TrainedModelProviderTests extends ESTestCase {
     }
 
     public void testStoreTrainedModelWithDefinitionCallsClientExecuteWithOperationCreateWhenAllowOverwriteIsFalse() throws IOException {
-        try (var client = createMockClient()) {
+        try (var threadPool = createThreadPool()) {
+            final var client = createMockClient(threadPool);
             var config = createTrainedModelConfigWithDefinition("modelId");
             var trainedModelProvider = new TrainedModelProvider(client, xContentRegistry());
             var future = new PlainActionFuture<Boolean>();
@@ -401,7 +407,8 @@ public class TrainedModelProviderTests extends ESTestCase {
     }
 
     public void testStoreTrainedModelWithDefinitionCallsClientExecuteWithOperationIndex() throws IOException {
-        try (var client = createMockClient()) {
+        try (var threadPool = createThreadPool()) {
+            final var client = createMockClient(threadPool);
             var config = createTrainedModelConfigWithDefinition("modelId");
             var trainedModelProvider = new TrainedModelProvider(client, xContentRegistry());
             var future = new PlainActionFuture<Boolean>();
@@ -412,7 +419,8 @@ public class TrainedModelProviderTests extends ESTestCase {
     }
 
     public void testStoreTrainedModelDefinitionDocCallsClientExecuteWithOperationCreate() {
-        try (var client = createMockClient()) {
+        try (var threadPool = createThreadPool()) {
+            final var client = createMockClient(threadPool);
             var config = TrainedModelDefinitionDocTests.createDefinitionDocInstance();
             var trainedModelProvider = new TrainedModelProvider(client, xContentRegistry());
             var future = new PlainActionFuture<Void>();
@@ -423,7 +431,8 @@ public class TrainedModelProviderTests extends ESTestCase {
     }
 
     public void testStoreTrainedModelDefinitionDocCallsClientExecuteWithOperationCreateWhenAllowOverwriteIsFalse() {
-        try (var client = createMockClient()) {
+        try (var threadPool = createThreadPool()) {
+            final var client = createMockClient(threadPool);
             var config = TrainedModelDefinitionDocTests.createDefinitionDocInstance();
             var trainedModelProvider = new TrainedModelProvider(client, xContentRegistry());
             var future = new PlainActionFuture<Void>();
@@ -434,7 +443,8 @@ public class TrainedModelProviderTests extends ESTestCase {
     }
 
     public void testStoreTrainedModelDefinitionDocCallsClientExecuteWithOperationIndex() {
-        try (var client = createMockClient()) {
+        try (var threadPool = createThreadPool()) {
+            final var client = createMockClient(threadPool);
             var config = TrainedModelDefinitionDocTests.createDefinitionDocInstance();
             var trainedModelProvider = new TrainedModelProvider(client, xContentRegistry());
             var future = new PlainActionFuture<Void>();
@@ -445,7 +455,8 @@ public class TrainedModelProviderTests extends ESTestCase {
     }
 
     public void testStoreTrainedModelVocabularyCallsClientExecuteWithOperationCreate() {
-        try (var client = createMockClient()) {
+        try (var threadPool = createThreadPool()) {
+            final var client = createMockClient(threadPool);
             var vocab = createVocabulary();
             var trainedModelProvider = new TrainedModelProvider(client, xContentRegistry());
             var future = new PlainActionFuture<Void>();
@@ -456,7 +467,8 @@ public class TrainedModelProviderTests extends ESTestCase {
     }
 
     public void testStoreTrainedModelVocabularyCallsClientExecuteWithOperationCreateWhenAllowOverwritingIsFalse() {
-        try (var client = createMockClient()) {
+        try (var threadPool = createThreadPool()) {
+            final var client = createMockClient(threadPool);
             var vocab = createVocabulary();
             var trainedModelProvider = new TrainedModelProvider(client, xContentRegistry());
             var future = new PlainActionFuture<Void>();
@@ -467,7 +479,8 @@ public class TrainedModelProviderTests extends ESTestCase {
     }
 
     public void testStoreTrainedModelVocabularyCallsClientExecuteWithOperationIndex() {
-        try (var client = createMockClient()) {
+        try (var threadPool = createThreadPool()) {
+            final var client = createMockClient(threadPool);
             var vocab = createVocabulary();
             var trainedModelProvider = new TrainedModelProvider(client, xContentRegistry());
             var future = new PlainActionFuture<Void>();
@@ -478,7 +491,8 @@ public class TrainedModelProviderTests extends ESTestCase {
     }
 
     public void testStoreTrainedModelMetadataCallsClientExecuteWithOperationCreate() {
-        try (var client = createMockClient()) {
+        try (var threadPool = createThreadPool()) {
+            final var client = createMockClient(threadPool);
             var metadata = TrainedModelMetadataTests.randomInstance();
             var trainedModelProvider = new TrainedModelProvider(client, xContentRegistry());
             var future = new PlainActionFuture<Void>();
@@ -489,7 +503,8 @@ public class TrainedModelProviderTests extends ESTestCase {
     }
 
     public void testStoreTrainedModelMetadataCallsClientExecuteWithOperationCreateWhenAllowOverwritingIsFalse() {
-        try (var client = createMockClient()) {
+        try (var threadPool = createThreadPool()) {
+            final var client = createMockClient(threadPool);
             var metadata = TrainedModelMetadataTests.randomInstance();
             var trainedModelProvider = new TrainedModelProvider(client, xContentRegistry());
             var future = new PlainActionFuture<Void>();
@@ -500,7 +515,8 @@ public class TrainedModelProviderTests extends ESTestCase {
     }
 
     public void testStoreTrainedModelMetadataCallsClientExecuteWithOperationIndex() {
-        try (var client = createMockClient()) {
+        try (var threadPool = createThreadPool()) {
+            final var client = createMockClient(threadPool);
             var metadata = TrainedModelMetadataTests.randomInstance();
             var trainedModelProvider = new TrainedModelProvider(client, xContentRegistry());
             var future = new PlainActionFuture<Void>();
@@ -520,10 +536,8 @@ public class TrainedModelProviderTests extends ESTestCase {
         return TrainedModelConfigTests.createTestInstance(modelId).setDefinitionFromBytes(bytes).build();
     }
 
-    private Client createMockClient() {
-        var noOpClient = new NoOpClient(getTestName());
-
-        return spy(noOpClient);
+    private Client createMockClient(ThreadPool threadPool) {
+        return spy(new NoOpClient(threadPool));
     }
 
     private void assertThatIndexRequestHasOperation(Client client, DocWriteRequest.OpType operation) {

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/local/LocalExporterTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/local/LocalExporterTests.java
@@ -51,7 +51,8 @@ public class LocalExporterTests extends ESTestCase {
         final Exporter.Config config = new Exporter.Config("name", "type", Settings.EMPTY, clusterService, licenseState);
         final CleanerService cleanerService = mock(CleanerService.class);
         final MonitoringMigrationCoordinator migrationCoordinator = new MonitoringMigrationCoordinator();
-        try (Client client = new NoOpClient(getTestName())) {
+        try (var threadPool = createThreadPool()) {
+            final var client = new NoOpClient(threadPool);
             final LocalExporter exporter = new LocalExporter(config, client, migrationCoordinator, cleanerService);
 
             final TimeValue retention = TimeValue.timeValueDays(randomIntBetween(1, 90));

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupJobTaskTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupJobTaskTests.java
@@ -64,7 +64,7 @@ public class RollupJobTaskTests extends ESTestCase {
     private ThreadPool pool;
 
     @Before
-    public void createThreadPool() {
+    public void createSuiteThreadPool() {
         pool = new TestThreadPool("test");
     }
 
@@ -291,7 +291,8 @@ public class RollupJobTaskTests extends ESTestCase {
 
         final CountDownLatch block = new CountDownLatch(1);
         final CountDownLatch unblock = new CountDownLatch(1);
-        try (NoOpClient client = getEmptySearchResponseClient(block, unblock)) {
+        try (var threadPool = createThreadPool()) {
+            final var client = getEmptySearchResponseClient(threadPool, block, unblock);
             SchedulerEngine schedulerEngine = mock(SchedulerEngine.class);
 
             AtomicInteger counter = new AtomicInteger(0);
@@ -949,7 +950,8 @@ public class RollupJobTaskTests extends ESTestCase {
         RollupJob job = new RollupJob(ConfigTestHelpers.randomRollupJobConfig(random()), Collections.emptyMap());
         final CountDownLatch block = new CountDownLatch(1);
         final CountDownLatch unblock = new CountDownLatch(1);
-        try (NoOpClient client = getEmptySearchResponseClient(block, unblock)) {
+        try (var threadPool = createThreadPool()) {
+            final var client = getEmptySearchResponseClient(threadPool, block, unblock);
             SchedulerEngine schedulerEngine = mock(SchedulerEngine.class);
 
             AtomicInteger counter = new AtomicInteger(0);
@@ -1118,8 +1120,8 @@ public class RollupJobTaskTests extends ESTestCase {
         }
     }
 
-    private NoOpClient getEmptySearchResponseClient(CountDownLatch unblock, CountDownLatch block) {
-        return new NoOpClient(getTestName()) {
+    private NoOpClient getEmptySearchResponseClient(ThreadPool threadPool, CountDownLatch unblock, CountDownLatch block) {
+        return new NoOpClient(threadPool) {
             @SuppressWarnings("unchecked")
             @Override
             protected <Request extends ActionRequest, Response extends ActionResponse> void doExecute(

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/role/PutRoleBuilderTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/role/PutRoleBuilderTests.java
@@ -7,7 +7,6 @@
 package org.elasticsearch.xpack.security.action.role;
 
 import org.elasticsearch.ElasticsearchParseException;
-import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.client.NoOpClient;
@@ -26,7 +25,8 @@ public class PutRoleBuilderTests extends ESTestCase {
         Path path = getDataPath("roles2xformat.json");
         byte[] bytes = Files.readAllBytes(path);
         String roleString = new String(bytes, Charset.defaultCharset());
-        try (Client client = new NoOpClient("testBWCFieldPermissions")) {
+        try (var threadPool = createThreadPool()) {
+            final var client = new NoOpClient(threadPool);
             ElasticsearchParseException e = expectThrows(
                 ElasticsearchParseException.class,
                 () -> new PutRoleRequestBuilder(client).source("role1", new BytesArray(roleString), XContentType.JSON)

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/NativePrivilegeStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/NativePrivilegeStoreTests.java
@@ -38,7 +38,6 @@ import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.test.ClusterServiceUtils;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.client.NoOpClient;
-import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentType;
@@ -108,7 +107,8 @@ public class NativePrivilegeStoreTests extends ESTestCase {
     public void setup() {
         requests = new ArrayList<>();
         listener = new AtomicReference<>();
-        client = new NoOpClient(getTestName()) {
+        threadPool = createThreadPool();
+        client = new NoOpClient(threadPool) {
             @Override
             @SuppressWarnings("unchecked")
             protected <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
@@ -144,7 +144,6 @@ public class NativePrivilegeStoreTests extends ESTestCase {
         }).when(securityIndex).checkIndexVersionThenExecute(anyConsumer(), any(Runnable.class));
         cacheInvalidatorRegistry = new CacheInvalidatorRegistry();
 
-        threadPool = new TestThreadPool(getTestName());
         final ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
         clusterService = ClusterServiceUtils.createClusterService(threadPool, clusterSettings);
         allowExpensiveQueries = randomBoolean();
@@ -159,7 +158,6 @@ public class NativePrivilegeStoreTests extends ESTestCase {
 
     @After
     public void cleanup() {
-        client.close();
         terminate(threadPool);
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/SecurityBaseRestHandlerTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/SecurityBaseRestHandlerTests.java
@@ -60,7 +60,8 @@ public class SecurityBaseRestHandlerTests extends ESTestCase {
         FakeRestRequest fakeRestRequest = new FakeRestRequest();
         FakeRestChannel fakeRestChannel = new FakeRestChannel(fakeRestRequest, randomBoolean(), securityEnabled ? 0 : 1);
 
-        try (NodeClient client = new NoOpNodeClient(this.getTestName())) {
+        try (var threadPool = createThreadPool()) {
+            final var client = new NoOpNodeClient(threadPool);
             assertFalse(consumerCalled.get());
             verifyNoMoreInteractions(licenseState);
             handler.handleRequest(fakeRestRequest, fakeRestChannel, client);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/apikey/ApiKeyBaseRestHandlerTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/apikey/ApiKeyBaseRestHandlerTests.java
@@ -58,7 +58,8 @@ public class ApiKeyBaseRestHandlerTests extends ESTestCase {
         final var fakeRestRequest = new FakeRestRequest();
         final var fakeRestChannel = new FakeRestChannel(fakeRestRequest, randomBoolean(), requiredSettingsEnabled ? 0 : 1);
 
-        try (NodeClient client = new NoOpNodeClient(this.getTestName())) {
+        try (var threadPool = createThreadPool()) {
+            final var client = new NoOpNodeClient(threadPool);
             assertFalse(consumerCalled.get());
             handler.handleRequest(fakeRestRequest, fakeRestChannel, client);
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/role/RestPutRoleActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/role/RestPutRoleActionTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.security.rest.action.role;
 
-import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.license.License;
@@ -42,7 +41,8 @@ public class RestPutRoleActionTests extends ESTestCase {
             .build();
         final FakeRestChannel channel = new FakeRestChannel(request, true, 1);
 
-        try (NodeClient nodeClient = new NoOpNodeClient(this.getTestName())) {
+        try (var threadPool = createThreadPool()) {
+            final var nodeClient = new NoOpNodeClient(threadPool);
             action.handleRequest(request, channel, nodeClient);
         }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/user/RestGetUserPrivilegesActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/user/RestGetUserPrivilegesActionTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.security.rest.action.user;
 
-import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.Settings;
@@ -55,7 +54,8 @@ public class RestGetUserPrivilegesActionTests extends ESTestCase {
         );
         final FakeRestRequest request = new FakeRestRequest();
         final FakeRestChannel channel = new FakeRestChannel(request, true, 1);
-        try (NodeClient nodeClient = new NoOpNodeClient(this.getTestName())) {
+        try (var threadPool = createThreadPool()) {
+            final var nodeClient = new NoOpNodeClient(threadPool);
             action.handleRequest(request, channel, nodeClient);
         }
         assertThat(channel.capturedResponse(), notNullValue());

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/user/RestHasPrivilegesActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/user/RestHasPrivilegesActionTests.java
@@ -7,7 +7,6 @@
 package org.elasticsearch.xpack.security.rest.action.user;
 
 import org.elasticsearch.ElasticsearchSecurityException;
-import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.license.License;
@@ -43,10 +42,8 @@ public class RestHasPrivilegesActionTests extends ESTestCase {
     public void testBodyConsumed() throws Exception {
         final XPackLicenseState licenseState = mock(XPackLicenseState.class);
         final RestHasPrivilegesAction action = new RestHasPrivilegesAction(Settings.EMPTY, mock(SecurityContext.class), licenseState);
-        try (
-            XContentBuilder bodyBuilder = JsonXContent.contentBuilder().startObject().endObject();
-            NodeClient client = new NoOpNodeClient(this.getTestName())
-        ) {
+        try (XContentBuilder bodyBuilder = JsonXContent.contentBuilder().startObject().endObject(); var threadPool = createThreadPool()) {
+            final var client = new NoOpNodeClient(threadPool);
             final RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withPath("/_security/user/_has_privileges/")
                 .withContent(new BytesArray(bodyBuilder.toString()), XContentType.JSON)
                 .build();
@@ -68,10 +65,8 @@ public class RestHasPrivilegesActionTests extends ESTestCase {
             mock(SecurityContext.class),
             licenseState
         );
-        try (
-            XContentBuilder bodyBuilder = JsonXContent.contentBuilder().startObject().endObject();
-            NodeClient client = new NoOpNodeClient(this.getTestName())
-        ) {
+        try (XContentBuilder bodyBuilder = JsonXContent.contentBuilder().startObject().endObject(); var threadPool = createThreadPool()) {
+            final var client = new NoOpNodeClient(threadPool);
             final RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withPath("/_security/user/_has_privileges/")
                 .withContent(new BytesArray(bodyBuilder.toString()), XContentType.JSON)
                 .build();

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/user/RestPutUserActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/user/RestPutUserActionTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.security.rest.action.user;
 
-import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.license.License;
@@ -42,7 +41,8 @@ public class RestPutUserActionTests extends ESTestCase {
             .build();
         final FakeRestChannel channel = new FakeRestChannel(request, true, 1);
 
-        try (NodeClient nodeClient = new NoOpNodeClient(this.getTestName())) {
+        try (var threadPool = createThreadPool()) {
+            final var nodeClient = new NoOpNodeClient(threadPool);
             action.handleRequest(request, channel, nodeClient);
         }
 

--- a/x-pack/plugin/slm/src/test/java/org/elasticsearch/xpack/slm/SnapshotRetentionTaskTests.java
+++ b/x-pack/plugin/slm/src/test/java/org/elasticsearch/xpack/slm/SnapshotRetentionTaskTests.java
@@ -135,9 +135,9 @@ public class SnapshotRetentionTaskTests extends ESTestCase {
         );
         try (
             ClusterService clusterService = ClusterServiceUtils.createClusterService(threadPool, settings);
-            Client noOpClient = new NoOpClient("slm-test")
+            var clientThreadPool = createThreadPool()
         ) {
-
+            final var noOpClient = new NoOpClient(clientThreadPool);
             final String policyId = "policy";
             final String repoId = "repo";
             SnapshotLifecyclePolicy policy = new SnapshotLifecyclePolicy(
@@ -232,7 +232,9 @@ public class SnapshotRetentionTaskTests extends ESTestCase {
         final String repoId = "repo";
         try (
             ClusterService clusterService = ClusterServiceUtils.createClusterService(threadPool, settings);
-            Client noOpClient = new NoOpClient("slm-test") {
+            var clientThreadPool = createThreadPool()
+        ) {
+            final var noOpClient = new NoOpClient(clientThreadPool) {
 
                 @Override
                 @SuppressWarnings("unchecked")
@@ -248,8 +250,7 @@ public class SnapshotRetentionTaskTests extends ESTestCase {
                         super.doExecute(action, request, listener);
                     }
                 }
-            }
-        ) {
+            };
             SnapshotLifecyclePolicy policy = new SnapshotLifecyclePolicy(
                 policyId,
                 "snap",
@@ -307,8 +308,9 @@ public class SnapshotRetentionTaskTests extends ESTestCase {
         );
         try (
             ClusterService clusterService = ClusterServiceUtils.createClusterService(threadPool, settings);
-            Client noOpClient = new NoOpClient("slm-test") {
-
+            var clientThreadPool = createThreadPool()
+        ) {
+            final var noOpClient = new NoOpClient(clientThreadPool) {
                 @Override
                 @SuppressWarnings("unchecked")
                 protected <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
@@ -323,8 +325,7 @@ public class SnapshotRetentionTaskTests extends ESTestCase {
                         super.doExecute(action, request, listener);
                     }
                 }
-            }
-        ) {
+            };
             final String policyId = "policy";
             final String repoId = "repo";
             SnapshotLifecyclePolicy policy = new SnapshotLifecyclePolicy(
@@ -393,8 +394,9 @@ public class SnapshotRetentionTaskTests extends ESTestCase {
         );
         try (
             ClusterService clusterService = ClusterServiceUtils.createClusterService(threadPool, settings);
-            Client noOpClient = new NoOpClient("slm-test")
+            var clientThreadPool = createThreadPool()
         ) {
+            final var noOpClient = new NoOpClient(clientThreadPool);
             final String policyId = "policy";
             final String repoId = "repo";
             SnapshotLifecyclePolicy policy = new SnapshotLifecyclePolicy(
@@ -449,8 +451,9 @@ public class SnapshotRetentionTaskTests extends ESTestCase {
         );
         try (
             ClusterService clusterService = ClusterServiceUtils.createClusterService(threadPool, settings);
-            Client noOpClient = new NoOpClient("slm-test")
+            var clientThreadPool = createThreadPool()
         ) {
+            final var noOpClient = new NoOpClient(clientThreadPool);
             final String policyId = "policy";
             final String repoId = "repo";
             SnapshotLifecyclePolicy policy = new SnapshotLifecyclePolicy(

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransformPrivilegeCheckerTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransformPrivilegeCheckerTests.java
@@ -23,7 +23,6 @@ import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.indices.TestIndexNameExpressionResolver;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.client.NoOpClient;
-import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.security.SecurityContext;
 import org.elasticsearch.xpack.core.security.action.user.HasPrivilegesRequest;
@@ -93,8 +92,8 @@ public class TransformPrivilegeCheckerTests extends ESTestCase {
         if (client != null) {
             client.close();
         }
-        client = new MyMockClient(getTestName());
-        threadPool = new TestThreadPool("transform_privilege_checker_tests");
+        threadPool = createThreadPool();
+        client = new MyMockClient(threadPool);
         securityContext = new SecurityContext(Settings.EMPTY, threadPool.getThreadContext()) {
             public User getUser() {
                 return new User(USER_NAME);
@@ -404,8 +403,8 @@ public class TransformPrivilegeCheckerTests extends ESTestCase {
             emptyMap()
         );
 
-        MyMockClient(String testName) {
-            super(testName);
+        MyMockClient(ThreadPool threadPool) {
+            super(threadPool);
         }
 
         @SuppressWarnings("unchecked")

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexerTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexerTests.java
@@ -127,7 +127,8 @@ public class ClientTransformIndexerTests extends ESTestCase {
             new SettingsConfig.Builder().setUsePit(true).build()
         ).build();
 
-        try (PitMockClient client = new PitMockClient(getTestName(), true)) {
+        try (var threadPool = createThreadPool()) {
+            final var client = new PitMockClient(threadPool, true);
             MockClientTransformIndexer indexer = new MockClientTransformIndexer(
                 mock(ThreadPool.class),
                 new TransformServices(
@@ -220,7 +221,8 @@ public class ClientTransformIndexerTests extends ESTestCase {
             new SettingsConfig.Builder().setUsePit(true).build()
         ).build();
 
-        try (PitMockClient client = new PitMockClient(getTestName(), false)) {
+        try (var threadPool = createThreadPool()) {
+            final var client = new PitMockClient(threadPool, false);
             MockClientTransformIndexer indexer = new MockClientTransformIndexer(
                 mock(ThreadPool.class),
                 new TransformServices(
@@ -296,7 +298,8 @@ public class ClientTransformIndexerTests extends ESTestCase {
         TransformConfig config = TransformConfigTests.randomTransformConfig();
         boolean pitEnabled = config.getSettings().getUsePit() == null || config.getSettings().getUsePit();
 
-        try (PitMockClient client = new PitMockClient(getTestName(), true)) {
+        try (var threadPool = createThreadPool()) {
+            final var client = new PitMockClient(threadPool, true);
             MockClientTransformIndexer indexer = new MockClientTransformIndexer(
                 mock(ThreadPool.class),
                 new TransformServices(
@@ -359,7 +362,8 @@ public class ClientTransformIndexerTests extends ESTestCase {
             .build();
         boolean pitEnabled = config.getSettings().getUsePit() == null || config.getSettings().getUsePit();
 
-        try (PitMockClient client = new PitMockClient(getTestName(), true)) {
+        try (var threadPool = createThreadPool()) {
+            final var client = new PitMockClient(threadPool, true);
             MockClientTransformIndexer indexer = new MockClientTransformIndexer(
                 mock(ThreadPool.class),
                 new TransformServices(
@@ -413,7 +417,8 @@ public class ClientTransformIndexerTests extends ESTestCase {
 
     public void testHandlePitIndexNotFound() throws InterruptedException {
         // simulate a deleted index due to ILM
-        try (PitMockClient client = new PitMockClient(getTestName(), true)) {
+        try (var threadPool = createThreadPool()) {
+            final var client = new PitMockClient(threadPool, true);
             ClientTransformIndexer indexer = createTestIndexer(new ParentTaskAssigningClient(client, new TaskId("dummy-node:123456")));
             SearchRequest searchRequest = new SearchRequest("deleted-index");
             searchRequest.source().pointInTimeBuilder(new PointInTimeBuilder("the_pit_id"));
@@ -425,7 +430,8 @@ public class ClientTransformIndexerTests extends ESTestCase {
         }
 
         // simulate a deleted index that is essential, search must fail (after a retry without pit)
-        try (PitMockClient client = new PitMockClient(getTestName(), true)) {
+        try (var threadPool = createThreadPool()) {
+            final var client = new PitMockClient(threadPool, true);
             ClientTransformIndexer indexer = createTestIndexer(new ParentTaskAssigningClient(client, new TaskId("dummy-node:123456")));
             SearchRequest searchRequest = new SearchRequest("essential-deleted-index");
             searchRequest.source().pointInTimeBuilder(new PointInTimeBuilder("the_pit_id"));
@@ -483,8 +489,8 @@ public class ClientTransformIndexerTests extends ESTestCase {
         private final boolean pitSupported;
         private AtomicLong pitContextCounter = new AtomicLong();
 
-        PitMockClient(String testName, boolean pitSupported) {
-            super(testName);
+        PitMockClient(ThreadPool threadPool, boolean pitSupported) {
+            super(threadPool);
             this.pitSupported = pitSupported;
         }
 

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerFailureHandlingTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerFailureHandlingTests.java
@@ -35,7 +35,6 @@ import org.elasticsearch.search.profile.SearchProfileResults;
 import org.elasticsearch.search.suggest.Suggest;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.client.NoOpClient;
-import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.common.notifications.Level;
 import org.elasticsearch.xpack.core.indexing.IndexerState;
@@ -274,13 +273,12 @@ public class TransformIndexerFailureHandlingTests extends ESTestCase {
 
     @Before
     public void setUpMocks() {
-        client = new NoOpClient(getTestName());
-        threadPool = new TestThreadPool(getTestName());
+        threadPool = createThreadPool();
+        client = new NoOpClient(threadPool);
     }
 
     @After
     public void tearDownClient() {
-        client.close();
         ThreadPool.terminate(threadPool, 30, TimeUnit.SECONDS);
     }
 

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerFailureOnStatePersistenceTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerFailureOnStatePersistenceTests.java
@@ -10,7 +10,6 @@ package org.elasticsearch.xpack.transform.transforms;
 import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.LatchedActionListener;
-import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.ParentTaskAssigningClient;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Tuple;
@@ -209,7 +208,8 @@ public class TransformIndexerFailureOnStatePersistenceTests extends ESTestCase {
                 ? new VersionConflictEngineException(new ShardId("index", "indexUUID", 42), "some_id", 45L, 44L, 43L, 42L)
                 : new ElasticsearchTimeoutException("timeout");
             TransformConfigManager configManager = new FailingToPutStoredDocTransformConfigManager(Set.of(0, 1, 2, 3), exceptionToThrow);
-            try (Client client = new NoOpClient(getTestName())) {
+            try (var threadPool = createThreadPool()) {
+                final var client = new NoOpClient(threadPool);
 
                 MockClientTransformIndexer indexer = new MockClientTransformIndexer(
                     mock(ThreadPool.class),
@@ -292,7 +292,8 @@ public class TransformIndexerFailureOnStatePersistenceTests extends ESTestCase {
                 ? new VersionConflictEngineException(new ShardId("index", "indexUUID", 42), "some_id", 45L, 44L, 43L, 42L)
                 : new ElasticsearchTimeoutException("timeout");
             TransformConfigManager configManager = new FailingToPutStoredDocTransformConfigManager(Set.of(0, 2, 3, 4), exceptionToThrow);
-            try (Client client = new NoOpClient(getTestName())) {
+            try (var threadPool = createThreadPool()) {
+                final var client = new NoOpClient(threadPool);
                 MockClientTransformIndexer indexer = new MockClientTransformIndexer(
                     mock(ThreadPool.class),
                     new TransformServices(
@@ -422,7 +423,8 @@ public class TransformIndexerFailureOnStatePersistenceTests extends ESTestCase {
         TransformContext context = new TransformContext(state.get(), null, 0, contextListener);
         TransformConfigManager configManager = new SeqNoCheckingTransformConfigManager();
 
-        try (Client client = new NoOpClient(getTestName())) {
+        try (var threadPool = createThreadPool()) {
+            final var client = new NoOpClient(threadPool);
             MockClientTransformIndexer indexer = new MockClientTransformIndexer(
                 mock(ThreadPool.class),
                 new TransformServices(

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerStateTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerStateTests.java
@@ -351,13 +351,12 @@ public class TransformIndexerStateTests extends ESTestCase {
     public void setUpMocks() {
         auditor = MockTransformAuditor.createMockAuditor();
         transformConfigManager = new InMemoryTransformConfigManager();
-        client = new NoOpClient(getTestName());
         threadPool = new TestThreadPool(ThreadPool.Names.GENERIC);
+        client = new NoOpClient(threadPool);
     }
 
     @After
     public void tearDownClient() {
-        client.close();
         ThreadPool.terminate(threadPool, 30, TimeUnit.SECONDS);
     }
 

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerTests.java
@@ -280,13 +280,12 @@ public class TransformIndexerTests extends ESTestCase {
     public void setUpMocks() {
         auditor = MockTransformAuditor.createMockAuditor();
         transformConfigManager = new InMemoryTransformConfigManager();
-        client = new NoOpClient(getTestName());
         threadPool = new TestThreadPool(ThreadPool.Names.GENERIC);
+        client = new NoOpClient(threadPool);
     }
 
     @After
     public void tearDownClient() {
-        client.close();
         ThreadPool.terminate(threadPool, 30, TimeUnit.SECONDS);
     }
 

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformTaskTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformTaskTests.java
@@ -29,6 +29,7 @@ import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.tasks.TaskManager;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.client.NoOpClient;
+import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.indexing.IndexerState;
 import org.elasticsearch.xpack.core.transform.TransformConfigVersion;
@@ -69,19 +70,21 @@ import static org.mockito.Mockito.when;
 
 public class TransformTaskTests extends ESTestCase {
 
+    private TestThreadPool threadPool;
     private Client client;
 
     @Before
     public void setupClient() {
-        if (client != null) {
-            client.close();
+        if (threadPool != null) {
+            threadPool.close();
         }
-        client = new NoOpClient(getTestName());
+        threadPool = createThreadPool();
+        client = new NoOpClient(threadPool);
     }
 
     @After
     public void tearDownClient() {
-        client.close();
+        threadPool.close();
     }
 
     // see https://github.com/elastic/elasticsearch/issues/48957

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationSchemaAndResultTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationSchemaAndResultTests.java
@@ -25,6 +25,8 @@ import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.metrics.Percentile;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.client.NoOpClient;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.transform.transforms.pivot.AggregationConfig;
 import org.elasticsearch.xpack.core.transform.transforms.pivot.GroupConfig;
 import org.elasticsearch.xpack.core.transform.transforms.pivot.GroupConfigTests;
@@ -48,25 +50,27 @@ import static org.mockito.Mockito.when;
 
 public class AggregationSchemaAndResultTests extends ESTestCase {
 
+    private TestThreadPool threadPool;
     private Client client;
 
     @Before
     public void setupClient() {
-        if (client != null) {
-            client.close();
+        if (threadPool != null) {
+            threadPool.close();
         }
-        client = new MyMockClient(getTestName());
+        threadPool = createThreadPool();
+        client = new MyMockClient(threadPool);
     }
 
     @After
     public void tearDownClient() {
-        client.close();
+        threadPool.close();
     }
 
     private class MyMockClient extends NoOpClient {
 
-        MyMockClient(String testName) {
-            super(testName);
+        MyMockClient(ThreadPool threadPool) {
+            super(threadPool);
         }
 
         @SuppressWarnings("unchecked")

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/PivotTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/PivotTests.java
@@ -30,6 +30,8 @@ import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregation;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.client.NoOpClient;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
@@ -82,6 +84,7 @@ import static org.mockito.Mockito.when;
 public class PivotTests extends ESTestCase {
 
     private NamedXContentRegistry namedXContentRegistry;
+    private TestThreadPool threadPool;
     private Client client;
 
     // exclude aggregations from the analytics module as we don't have parser for it here
@@ -102,15 +105,16 @@ public class PivotTests extends ESTestCase {
 
     @Before
     public void setupClient() {
-        if (client != null) {
-            client.close();
+        if (threadPool != null) {
+            threadPool.close();
         }
-        client = new MyMockClient(getTestName());
+        threadPool = createThreadPool();
+        client = new MyMockClient(threadPool);
     }
 
     @After
     public void tearDownClient() {
-        client.close();
+        threadPool.close();
     }
 
     @Override
@@ -279,17 +283,17 @@ public class PivotTests extends ESTestCase {
         final AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
         final AtomicReference<List<Map<String, Object>>> responseHolder = new AtomicReference<>();
 
-        Client emptyAggregationClient = new MyMockClientWithEmptyAggregation("empty aggregation test for preview");
-        pivot.preview(emptyAggregationClient, null, new HashMap<>(), new SourceConfig("test"), null, 1, ActionListener.wrap(r -> {
-            responseHolder.set(r);
-            latch.countDown();
-        }, e -> {
-            exceptionHolder.set(e);
-            latch.countDown();
-        }));
-        assertTrue(latch.await(100, TimeUnit.MILLISECONDS));
-        emptyAggregationClient.close();
-
+        try (var threadPool = createThreadPool()) {
+            final var emptyAggregationClient = new MyMockClientWithEmptyAggregation(threadPool);
+            pivot.preview(emptyAggregationClient, null, new HashMap<>(), new SourceConfig("test"), null, 1, ActionListener.wrap(r -> {
+                responseHolder.set(r);
+                latch.countDown();
+            }, e -> {
+                exceptionHolder.set(e);
+                latch.countDown();
+            }));
+            assertTrue(latch.await(100, TimeUnit.MILLISECONDS));
+        }
         assertThat(exceptionHolder.get(), is(nullValue()));
         assertThat(responseHolder.get(), is(empty()));
     }
@@ -306,16 +310,17 @@ public class PivotTests extends ESTestCase {
         final AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
         final AtomicReference<List<Map<String, Object>>> responseHolder = new AtomicReference<>();
 
-        Client compositeAggregationClient = new MyMockClientWithCompositeAggregation("composite aggregation test for preview");
-        pivot.preview(compositeAggregationClient, null, new HashMap<>(), new SourceConfig("test"), null, 1, ActionListener.wrap(r -> {
-            responseHolder.set(r);
-            latch.countDown();
-        }, e -> {
-            exceptionHolder.set(e);
-            latch.countDown();
-        }));
-        assertTrue(latch.await(100, TimeUnit.MILLISECONDS));
-        compositeAggregationClient.close();
+        try (var threadPool = createThreadPool()) {
+            final var compositeAggregationClient = new MyMockClientWithCompositeAggregation(threadPool);
+            pivot.preview(compositeAggregationClient, null, new HashMap<>(), new SourceConfig("test"), null, 1, ActionListener.wrap(r -> {
+                responseHolder.set(r);
+                latch.countDown();
+            }, e -> {
+                exceptionHolder.set(e);
+                latch.countDown();
+            }));
+            assertTrue(latch.await(100, TimeUnit.MILLISECONDS));
+        }
 
         assertThat(exceptionHolder.get(), is(nullValue()));
         assertThat(responseHolder.get(), is(empty()));
@@ -328,8 +333,8 @@ public class PivotTests extends ESTestCase {
     }
 
     private class MyMockClient extends NoOpClient {
-        MyMockClient(String testName) {
-            super(testName);
+        MyMockClient(ThreadPool threadPool) {
+            super(threadPool);
         }
 
         @SuppressWarnings("unchecked")
@@ -383,8 +388,8 @@ public class PivotTests extends ESTestCase {
     }
 
     private class MyMockClientWithEmptyAggregation extends NoOpClient {
-        MyMockClientWithEmptyAggregation(String testName) {
-            super(testName);
+        MyMockClientWithEmptyAggregation(ThreadPool threadPool) {
+            super(threadPool);
         }
 
         @SuppressWarnings("unchecked")
@@ -401,8 +406,8 @@ public class PivotTests extends ESTestCase {
     }
 
     private class MyMockClientWithCompositeAggregation extends NoOpClient {
-        MyMockClientWithCompositeAggregation(String testName) {
-            super(testName);
+        MyMockClientWithCompositeAggregation(ThreadPool threadPool) {
+            super(threadPool);
         }
 
         @SuppressWarnings("unchecked")

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/SchemaUtilTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/SchemaUtilTests.java
@@ -16,10 +16,10 @@ import org.elasticsearch.action.fieldcaps.FieldCapabilities;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesRequest;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse;
 import org.elasticsearch.action.support.ActionTestUtils;
-import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.client.NoOpClient;
+import org.elasticsearch.threadpool.ThreadPool;
 
 import java.math.BigInteger;
 import java.util.Collections;
@@ -96,7 +96,8 @@ public class SchemaUtilTests extends ESTestCase {
     }
 
     public void testGetSourceFieldMappings() throws InterruptedException {
-        try (Client client = new FieldCapsMockClient(getTestName())) {
+        try (var threadPool = createThreadPool()) {
+            final var client = new FieldCapsMockClient(threadPool);
             // fields is null
             this.<Map<String, String>>assertAsync(
                 listener -> SchemaUtil.getSourceFieldMappings(
@@ -188,7 +189,8 @@ public class SchemaUtilTests extends ESTestCase {
                 put("field-3", singletonMap("type", "boolean"));
             }
         };
-        try (Client client = new FieldCapsMockClient(getTestName())) {
+        try (var threadPool = createThreadPool()) {
+            final var client = new FieldCapsMockClient(threadPool);
             this.<Map<String, String>>assertAsync(
                 listener -> SchemaUtil.getSourceFieldMappings(
                     client,
@@ -210,8 +212,8 @@ public class SchemaUtilTests extends ESTestCase {
     }
 
     private static class FieldCapsMockClient extends NoOpClient {
-        FieldCapsMockClient(String testName) {
-            super(testName);
+        FieldCapsMockClient(ThreadPool threadPool) {
+            super(threadPool);
         }
 
         @SuppressWarnings("unchecked")


### PR DESCRIPTION
Since the removal of the transport client there are no _real_ clients
with their own threadpools, but in tests we still have `NoOpClient` and
`NoOpNodeClient` which sometimes implicitly create a threadpool, and
terminate their threadpools on close too (even if the threadpool is
owned by the caller). This commit detaches the lifecycle of the client
from the lifecycle of its threadpool, moving the threadpool creation and
termination up into the caller.