### PR TITLE
[8.11] [DOCS] Add Enterprise Search content to docs landing page (#101797)

### DIFF
--- a/docs/reference/landing-page.asciidoc
+++ b/docs/reference/landing-page.asciidoc
@@ -105,6 +105,9 @@
     <li>
       <a href="troubleshooting.html">Troubleshooting</a>
     </li>
+    <li>
+      <a href="https://www.elastic.co/guide/en/enterprise-search/current/start.html">Enterprise Search server</a>
+    </li>
   </ul>
 </div>
 
@@ -118,6 +121,12 @@
   <ul class="ul-col-md-2 ul-col-1">
     <li>
       <a href="https://www.elastic.co/guide/en/cloud/current/ec-cloud-ingest-data.html">Adding data to Elasticsearch</a>
+    </li>
+    <li>
+      <a href="https://www.elastic.co/guide/en/enterprise-search/current/connectors.html">Connectors</a>
+    </li>
+    <li>
+      <a href="https://www.elastic.co/guide/en/enterprise-search/current/crawler.html">Web crawler</a>
     </li>
     <li>
       <a href="data-streams.html">Data streams</a>
@@ -144,6 +153,12 @@
     </li>
     <li>
       Query data with <a href="query-dsl.html">the Query DSL</a>, <a href="esql.html">ES|QL</a>, <a href="eql.html">EQL</a>, or <a href="xpack-sql.html">SQL</a>
+    </li>
+    <li>
+      <a href="search-application-overview.html">Search applications</a>
+    </li>
+    <li>
+      <a href="behavioral-analytics-overview.html">Search analytics</a>
     </li>
     <li>
       <a href="search-aggregations.html">Aggregations</a>
@@ -207,7 +222,7 @@
 
 <div class="row my-4">
   <div class="col-md-4 col-12 mb-2">
-    <a class="no-text-decoration" href="https://www.elastic.co/guide/en/enterprise-search/current/start.html">
+    <a class="no-text-decoration" href="https://www.elastic.co/search-labs">
       <div class="card h-100">
         <h4 class="mt-3">
           <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/blt11200907c1c033aa/634d9da119d8652169cf9b2b/enterprise-search-logo-color-32px.png');"></span>


### PR DESCRIPTION
Backports the following commits to 8.11:
 - [DOCS] Add Enterprise Search content to docs landing page (#101797)