### PR TITLE
[DOCS] Mark 'ignore_throttled' deprecated in all docs

### DIFF
--- a/docs/reference/indices/resolve.asciidoc
+++ b/docs/reference/indices/resolve.asciidoc
@@ -88,9 +88,11 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=allow-no-indices]
 +
 Defaults to `true`.
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=ignore_throttled]
+`ignore_throttled`::
+(Optional, Boolean) If `true`, concrete, expanded or aliased indices are
+ignored when frozen. Defaults to `false`.
 +
-Defaults to `false`.
+deprecated:[7.16.0]
 
 [[resolve-index-api-example]]
 ==== {api-examples-title}

--- a/docs/reference/ml/anomaly-detection/apis/put-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-datafeed.asciidoc
@@ -66,8 +66,6 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 Defaults to `open`.
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=ignore_throttled]
-+
-deprecated:[7.16.0]
 
 `ignore_unavailable`::
 (Optional, Boolean) If `true`, unavailable indices (missing or closed) are

--- a/docs/reference/ml/anomaly-detection/apis/update-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/update-datafeed.asciidoc
@@ -55,8 +55,6 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 Defaults to `open`.
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=ignore_throttled]
-+
-deprecated:[7.16.0]
 
 `ignore_unavailable`::
 (Optional, Boolean) If `true`, unavailable indices (missing or closed) are

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -438,6 +438,8 @@ tag::ignore_throttled[]
 `ignore_throttled`::
 (Optional, Boolean) If `true`, concrete, expanded or aliased indices are
 ignored when frozen. Defaults to `true`.
++
+deprecated:[7.16.0]
 end::ignore_throttled[]
 
 tag::index-ignore-unavailable[]

--- a/docs/reference/search/multi-search.asciidoc
+++ b/docs/reference/search/multi-search.asciidoc
@@ -84,10 +84,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 +
 Defaults to `open`.
 
-`ignore_throttled`::
-(Optional, Boolean)
-If `true`, concrete, expanded or aliased indices are ignored when frozen.
-Defaults to `true`.
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=ignore_throttled]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 

--- a/docs/reference/search/search-template-api.asciidoc
+++ b/docs/reference/search/search-template-api.asciidoc
@@ -92,9 +92,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=expand-wildcards]
 (Optional, Boolean) If `true`, the response includes additional details about
 score computation as part of a hit. Defaults to `false`.
 
-`ignore_throttled`::
-(Optional, Boolean) If `true`, specified concrete, expanded, or aliased indices
-are not included in the response when throttled. Defaults to `true`.
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=ignore_throttled]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 

--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -109,9 +109,7 @@ By default, you cannot page through more than 10,000 hits using the `from` and
 `size` parameters. To page through more hits, use the
 <<search-after,`search_after`>> parameter.
 
-`ignore_throttled`::
-(Optional, Boolean) If `true`, concrete, expanded or aliased indices will be
-ignored when frozen. Defaults to `true`.
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=ignore_throttled]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 


### PR DESCRIPTION
The `ignore_throttled` parameter was deprecated in 7.16 (https://github.com/elastic/elasticsearch/pull/77479), but not documented as such consistently. This PR fixes that.

I've also changed most occurrences in the docs to use a common definition from `docs/reference/rest-api/common-parms.asciidoc`, with the exception of the resolve index API, which has a different default value for this parameter.

Closes https://github.com/elastic/elasticsearch/issues/101348