### PR TITLE
[DOCS] Disabling _source field

### DIFF
--- a/docs/reference/mapping/fields/source-field.asciidoc
+++ b/docs/reference/mapping/fields/source-field.asciidoc
@@ -43,6 +43,8 @@ available then a number of features are not supported:
 * The <<docs-update,`update`>>, <<docs-update-by-query,`update_by_query`>>,
 and <<docs-reindex,`reindex`>> APIs.
 
+* In the {kib} link:{kibana-ref}/discover.html[Discover] application, field data will not be displayed. 
+
 * On the fly <<highlighting,highlighting>>.
 
 * The ability to reindex from one Elasticsearch index to another, either


### PR DESCRIPTION
Disabling the `_source` field results in Kibana Discover not displaying any field data. This bullet point had been added to the ['Think before disabling the _source field'](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-source-field.html#disable-source-field) section.

Relates to: [#100416](https://github.com/elastic/kibana/issues/100416)