### PR TITLE
Log errors from search endpoints when partial results (200 OK) are returned

### DIFF
--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/TransportMultiSearchTemplateAction.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/TransportMultiSearchTemplateAction.java
@@ -8,8 +8,6 @@
 
 package org.elasticsearch.script.mustache;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.MultiSearchRequest;
@@ -35,8 +33,6 @@ import static org.elasticsearch.script.mustache.TransportSearchTemplateAction.co
 import static org.elasticsearch.search.SearchService.SEARCH_PARTIAL_RESULTS_LOGGER;
 
 public class TransportMultiSearchTemplateAction extends HandledTransportAction<MultiSearchTemplateRequest, MultiSearchTemplateResponse> {
-
-    private static final Logger logger = LogManager.getLogger(TransportMultiSearchTemplateAction.class);
 
     private final ScriptService scriptService;
     private final NamedXContentRegistry xContentRegistry;

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
@@ -61,6 +61,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.action.search.TransportSearchHelper.checkCCSVersionCompatibility;
+import static org.elasticsearch.search.SearchService.SEARCH_PARTIAL_RESULTS_LOGGER;
 
 public class TransportFieldCapabilitiesAction extends HandledTransportAction<FieldCapabilitiesRequest, FieldCapabilitiesResponse> {
     public static final String ACTION_NODE_NAME = FieldCapabilitiesAction.NAME + "[n]";
@@ -331,7 +332,7 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
         // These failures have already been deduplicated, before this method was called.
         for (FieldCapabilitiesFailure failure : failures) {
             if (shouldLogException(failure.getException())) {
-                LOGGER.warn(
+                SEARCH_PARTIAL_RESULTS_LOGGER.warn(
                     "Field caps partial-results Exception for indices " + Arrays.toString(failure.getIndices()),
                     failure.getException()
                 );

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
@@ -332,7 +332,7 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
         // These failures have already been deduplicated, before this method was called.
         for (FieldCapabilitiesFailure failure : failures) {
             if (shouldLogException(failure.getException())) {
-                SEARCH_PARTIAL_RESULTS_LOGGER.warn(
+                SEARCH_PARTIAL_RESULTS_LOGGER.debug(
                     "Field caps partial-results Exception for indices " + Arrays.toString(failure.getIndices()),
                     failure.getException()
                 );

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchScrollAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchScrollAction.java
@@ -8,8 +8,6 @@
 
 package org.elasticsearch.action.search;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
@@ -25,7 +23,6 @@ import static org.elasticsearch.action.search.TransportSearchHelper.parseScrollI
 import static org.elasticsearch.search.SearchService.SEARCH_PARTIAL_RESULTS_LOGGER;
 
 public class TransportSearchScrollAction extends HandledTransportAction<SearchScrollRequest, SearchResponse> {
-    private static final Logger logger = LogManager.getLogger(TransportSearchScrollAction.class);
     private final ClusterService clusterService;
     private final SearchTransportService searchTransportService;
 

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -150,6 +150,9 @@ import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
 public class SearchService extends AbstractLifecycleComponent implements IndexEventListener {
     private static final Logger logger = LogManager.getLogger(SearchService.class);
 
+    // common named logger for logger errors in search/aggs endpoints that return partial results (200 OK)
+    public static final Logger SEARCH_PARTIAL_RESULTS_LOGGER = LogManager.getLogger("search.partial-results.errors");
+
     // we can have 5 minutes here, since we make sure to clean with search requests and when shard/index closes
     public static final Setting<TimeValue> DEFAULT_KEEPALIVE_SETTING = Setting.positiveTimeSetting(
         "search.default_keep_alive",

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -151,7 +151,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
     private static final Logger logger = LogManager.getLogger(SearchService.class);
 
     // common named logger for logger errors in search/aggs endpoints that return partial results (200 OK)
-    public static final Logger SEARCH_PARTIAL_RESULTS_LOGGER = LogManager.getLogger("search.partial-results.errors");
+    public static final Logger SEARCH_PARTIAL_RESULTS_LOGGER = LogManager.getLogger("search.partial.errors");
 
     // we can have 5 minutes here, since we make sure to clean with search requests and when shard/index closes
     public static final Setting<TimeValue> DEFAULT_KEEPALIVE_SETTING = Setting.positiveTimeSetting(


### PR DESCRIPTION
A new common named "search.partial-results.errors" logger is added to the SearchService that search and aggs endpoints can leverage to log the errors (usually shard failures) that occur when searches return partial results. These errors are typically included in the response to the end user but not logged, so admins have no record of these as they occur.

The partial-results logger logs at DEBUG level to avoid increasing log sizes for users that don't want it. Since there is one single named logger for these logs changing the log4j configs to debug level for this logger is an easy way to toggle these logs on/off.
