### PR TITLE
Set ActiveProcessorCount when node.processors is set

### DIFF
--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/JvmOptionsParser.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/JvmOptionsParser.java
@@ -137,7 +137,7 @@ final class JvmOptionsParser {
         );
         substitutedJvmOptions.addAll(machineDependentHeap.determineHeapSettings(config, substitutedJvmOptions));
         final List<String> ergonomicJvmOptions = JvmErgonomics.choose(substitutedJvmOptions);
-        final List<String> systemJvmOptions = SystemJvmOptions.systemJvmOptions();
+        final List<String> systemJvmOptions = SystemJvmOptions.systemJvmOptions(args.nodeSettings());
 
         final List<String> apmOptions = APMJvmOptions.apmJvmOptions(args.nodeSettings(), args.secrets(), args.logsDir(), tmpDir);
 

--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/SystemJvmOptions.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/SystemJvmOptions.java
@@ -8,13 +8,16 @@
 
 package org.elasticsearch.server.cli;
 
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 final class SystemJvmOptions {
 
-    static List<String> systemJvmOptions() {
+    static List<String> systemJvmOptions(Settings nodeSettings) {
         return Stream.of(
             /*
              * Cache ttl in seconds for positive DNS lookups noting that this overrides the JDK security property networkaddress.cache.ttl;
@@ -61,7 +64,8 @@ final class SystemJvmOptions {
              * explore alternatives. See org.elasticsearch.xpack.searchablesnapshots.preallocate.Preallocate.
              */
             "--add-opens=java.base/java.io=org.elasticsearch.preallocate",
-            maybeOverrideDockerCgroup()
+            maybeOverrideDockerCgroup(),
+            maybeSetActiveProcessorCount(nodeSettings)
         ).filter(e -> e.isEmpty() == false).collect(Collectors.toList());
     }
 
@@ -82,6 +86,18 @@ final class SystemJvmOptions {
     private static String maybeOverrideDockerCgroup() {
         if ("docker".equals(System.getProperty("es.distribution.type"))) {
             return "-Des.cgroups.hierarchy.override=/";
+        }
+        return "";
+    }
+
+    /*
+     * node.processors determines thread pool sizes for Elasticsearch. When it
+     * is set, we need to also tell the JVM to respect a different value
+     */
+    private static String maybeSetActiveProcessorCount(Settings nodeSettings) {
+        if (EsExecutors.NODE_PROCESSORS_SETTING.exists(nodeSettings)) {
+            int allocated = EsExecutors.allocatedProcessors(nodeSettings);
+            return "-XX:ActiveProcessorCount=" + allocated;
         }
         return "";
     }

--- a/distribution/tools/server-cli/src/test/java/org/elasticsearch/server/cli/JvmOptionsParserTests.java
+++ b/distribution/tools/server-cli/src/test/java/org/elasticsearch/server/cli/JvmOptionsParserTests.java
@@ -8,9 +8,6 @@
 
 package org.elasticsearch.server.cli;
 
-import org.elasticsearch.bootstrap.ServerArgs;
-import org.elasticsearch.common.settings.MockSecureSettings;
-import org.elasticsearch.common.settings.SecureSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.Strings;

--- a/distribution/tools/server-cli/src/test/java/org/elasticsearch/server/cli/JvmOptionsParserTests.java
+++ b/distribution/tools/server-cli/src/test/java/org/elasticsearch/server/cli/JvmOptionsParserTests.java
@@ -8,6 +8,9 @@
 
 package org.elasticsearch.server.cli;
 
+import org.elasticsearch.bootstrap.ServerArgs;
+import org.elasticsearch.common.settings.MockSecureSettings;
+import org.elasticsearch.common.settings.SecureSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.Strings;
@@ -361,7 +364,7 @@ public class JvmOptionsParserTests extends ESTestCase {
         }
         {
             // check rounding
-            Settings nodeSettings = Settings.builder().put(EsExecutors.NODE_PROCESSORS_SETTING.getKey(), 0.5).build();
+            Settings nodeSettings = Settings.builder().put(EsExecutors.NODE_PROCESSORS_SETTING.getKey(), 0.2).build();
             final List<String> jvmOptions = SystemJvmOptions.systemJvmOptions(nodeSettings);
             assertThat(jvmOptions, hasItem("-XX:ActiveProcessorCount=1"));
         }

--- a/distribution/tools/server-cli/src/test/java/org/elasticsearch/server/cli/JvmOptionsParserTests.java
+++ b/distribution/tools/server-cli/src/test/java/org/elasticsearch/server/cli/JvmOptionsParserTests.java
@@ -8,6 +8,8 @@
 
 package org.elasticsearch.server.cli;
 
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.Strings;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.ESTestCase.WithoutSecurityManager;
@@ -28,10 +30,13 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
 
 @WithoutSecurityManager
 public class JvmOptionsParserTests extends ESTestCase {
@@ -344,4 +349,27 @@ public class JvmOptionsParserTests extends ESTestCase {
         assertThat(seenInvalidLines, equalTo(invalidLines));
     }
 
+    public void testNodeProcessorsActiveCount() {
+        {
+            final List<String> jvmOptions = SystemJvmOptions.systemJvmOptions(Settings.EMPTY);
+            assertThat(jvmOptions, not(hasItem(containsString("-XX:ActiveProcessorCount="))));
+        }
+        {
+            Settings nodeSettings = Settings.builder().put(EsExecutors.NODE_PROCESSORS_SETTING.getKey(), 1).build();
+            final List<String> jvmOptions = SystemJvmOptions.systemJvmOptions(nodeSettings);
+            assertThat(jvmOptions, hasItem("-XX:ActiveProcessorCount=1"));
+        }
+        {
+            // check rounding
+            Settings nodeSettings = Settings.builder().put(EsExecutors.NODE_PROCESSORS_SETTING.getKey(), 0.5).build();
+            final List<String> jvmOptions = SystemJvmOptions.systemJvmOptions(nodeSettings);
+            assertThat(jvmOptions, hasItem("-XX:ActiveProcessorCount=1"));
+        }
+        {
+            // check validation
+            Settings nodeSettings = Settings.builder().put(EsExecutors.NODE_PROCESSORS_SETTING.getKey(), 10000).build();
+            var e = expectThrows(IllegalArgumentException.class, () -> SystemJvmOptions.systemJvmOptions(nodeSettings));
+            assertThat(e.getMessage(), containsString("setting [node.processors] must be <="));
+        }
+    }
 }

--- a/docs/changelog/101846.yaml
+++ b/docs/changelog/101846.yaml
@@ -1,0 +1,5 @@
+pr: 101846
+summary: Set `ActiveProcessorCount` when `node.processors` is set
+area: Infra/CLI
+type: enhancement
+issues: []


### PR DESCRIPTION
node.processors determines the size of Elasticsearch threadpools. This commit sets the JDK flag -XX:ActiveProcessorCount when node.processors is set so that the JDK similarly sizes its threadpools accordingly.

relates #100244