### PR TITLE
[8.11] [ci] Migrate pull requests to running in Buildkite (#101843)

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -11,10 +11,7 @@
       "set_commit_status": false,
       "build_on_commit": true,
       "build_on_comment": true,
-      "trigger_comment_regex": "buildkite\\W+elasticsearch-ci.+",
-      "labels": [
-        "buildkite-opt-in"
-      ],
+      "trigger_comment_regex": "run\\W+elasticsearch-ci.+",
       "cancel_intermediate_builds": true,
       "cancel_intermediate_builds_on_comment": false
     },

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+build-benchmark-part1.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+build-benchmark-part1.yml
@@ -23,7 +23,8 @@
           org-list:
             - elastic
           allow-whitelist-orgs-as-admins: true
-          trigger-phrase: '.*run\W+elasticsearch-ci/build-bench.*'
+          only-trigger-phrase: true
+          trigger-phrase: '.*run\W+jenkins\W+elasticsearch-ci/build-bench.*'
           github-hooks: true
           status-context: elasticsearch-ci/build-benchmark-part1
           cancel-builds-on-update: true
@@ -32,21 +33,17 @@
           excluded-regions:
             - ^docs/.*
             - ^x-pack/docs/.*
-          white-list-labels:
-            - 'build-benchmark'
-          black-list-labels:
-            - 'buildkite-opt-in'
     builders:
       - inject:
-          properties-file: '.ci/java-versions.properties'
+          properties-file: ".ci/java-versions.properties"
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
             JAVA8_HOME=$HOME/.java/java8
             JAVA11_HOME=$HOME/.java/java11
       - shell: |
-         #!/usr/local/bin/runbld --redirect-stderr
-         $WORKSPACE/.ci/scripts/run-gradle.sh :build-tools-internal:bootstrapPerformanceTests
-         $WORKSPACE/.ci/scripts/install-gradle-profiler.sh
-         $WORKSPACE/.ci/scripts/run-gradle-profiler.sh --benchmark --scenario-file build-tools-internal/build/performanceTests/elasticsearch-build-benchmark-part1.scenarios --project-dir . --output-dir profile-out
-         mkdir $WORKSPACE/build
-         tar -czf $WORKSPACE/build/${BUILD_NUMBER}.tar.bz2 profile-out
+          #!/usr/local/bin/runbld --redirect-stderr
+          $WORKSPACE/.ci/scripts/run-gradle.sh :build-tools-internal:bootstrapPerformanceTests
+          $WORKSPACE/.ci/scripts/install-gradle-profiler.sh
+          $WORKSPACE/.ci/scripts/run-gradle-profiler.sh --benchmark --scenario-file build-tools-internal/build/performanceTests/elasticsearch-build-benchmark-part1.scenarios --project-dir . --output-dir profile-out
+          mkdir $WORKSPACE/build
+          tar -czf $WORKSPACE/build/${BUILD_NUMBER}.tar.bz2 profile-out

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+build-benchmark-part2.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+build-benchmark-part2.yml
@@ -23,7 +23,8 @@
           org-list:
             - elastic
           allow-whitelist-orgs-as-admins: true
-          trigger-phrase: '.*run\W+elasticsearch-ci/build-bench.*'
+          only-trigger-phrase: true
+          trigger-phrase: '.*run\W+jenkins\W+elasticsearch-ci/build-bench.*'
           github-hooks: true
           status-context: elasticsearch-ci/build-benchmark-part2
           cancel-builds-on-update: true
@@ -32,21 +33,17 @@
           excluded-regions:
             - ^docs/.*
             - ^x-pack/docs/.*
-          white-list-labels:
-            - 'build-benchmark'
-          black-list-labels:
-            - 'buildkite-opt-in'
     builders:
       - inject:
-          properties-file: '.ci/java-versions.properties'
+          properties-file: ".ci/java-versions.properties"
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
             JAVA8_HOME=$HOME/.java/java8
             JAVA11_HOME=$HOME/.java/java11
       - shell: |
-         #!/usr/local/bin/runbld --redirect-stderr
-         $WORKSPACE/.ci/scripts/run-gradle.sh :build-tools-internal:bootstrapPerformanceTests
-         $WORKSPACE/.ci/scripts/install-gradle-profiler.sh
-         $WORKSPACE/.ci/scripts/run-gradle-profiler.sh --benchmark --scenario-file build-tools-internal/build/performanceTests/elasticsearch-build-benchmark-part2.scenarios --project-dir . --output-dir profile-out
-         mkdir $WORKSPACE/build
-         tar -czf $WORKSPACE/build/${BUILD_NUMBER}.tar.bz2 profile-out
+          #!/usr/local/bin/runbld --redirect-stderr
+          $WORKSPACE/.ci/scripts/run-gradle.sh :build-tools-internal:bootstrapPerformanceTests
+          $WORKSPACE/.ci/scripts/install-gradle-profiler.sh
+          $WORKSPACE/.ci/scripts/run-gradle-profiler.sh --benchmark --scenario-file build-tools-internal/build/performanceTests/elasticsearch-build-benchmark-part2.scenarios --project-dir . --output-dir profile-out
+          mkdir $WORKSPACE/build
+          tar -czf $WORKSPACE/build/${BUILD_NUMBER}.tar.bz2 profile-out

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+bwc-snapshots-windows.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+bwc-snapshots-windows.yml
@@ -16,7 +16,8 @@
           org-list:
             - elastic
           allow-whitelist-orgs-as-admins: true
-          trigger-phrase: '.*run\W+elasticsearch-ci/bwc-snapshots-windows.*'
+          only-trigger-phrase: true
+          trigger-phrase: '.*run\W+jenkins\W+elasticsearch-ci/bwc-snapshots-windows.*'
           github-hooks: true
           status-context: elasticsearch-ci/bwc-snapshots-windows
           cancel-builds-on-update: true
@@ -25,11 +26,6 @@
           excluded-regions:
             - ^docs/.*
             - ^x-pack/docs/.*
-          white-list-labels:
-            - 'test-windows'
-          black-list-labels:
-            - '>test-mute'
-            - 'buildkite-opt-in'
     axes:
       - axis:
           type: slave
@@ -42,7 +38,7 @@
           name: "BWC_VERSION"
     builders:
       - inject:
-          properties-file: '.ci/java-versions.properties'
+          properties-file: ".ci/java-versions.properties"
           properties-content: |
             JAVA_HOME=$USERPROFILE\\.java\\$ES_BUILD_JAVA
             JAVA11_HOME=$USERPROFILE\\.java\\java11

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+bwc-snapshots.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+bwc-snapshots.yml
@@ -16,17 +16,14 @@
           org-list:
             - elastic
           allow-whitelist-orgs-as-admins: true
-          trigger-phrase: '.*run\W+elasticsearch-ci/bwc.*'
+          only-trigger-phrase: true
+          trigger-phrase: '.*run\W+jenkins\W+elasticsearch-ci/bwc.*'
           github-hooks: true
           status-context: elasticsearch-ci/bwc
           cancel-builds-on-update: true
           excluded-regions:
             - ^docs/.*
             - ^x-pack/docs/.*
-          black-list-labels:
-            - '>test-mute'
-            - 'test-full-bwc'
-            - 'buildkite-opt-in'
     axes:
       - axis:
           type: slave
@@ -39,7 +36,7 @@
           name: "BWC_VERSION"
     builders:
       - inject:
-          properties-file: '.ci/java-versions.properties'
+          properties-file: ".ci/java-versions.properties"
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
             JAVA8_HOME=$HOME/.java/java8

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+cloud-deploy.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+cloud-deploy.yml
@@ -15,7 +15,8 @@
           org-list:
             - elastic
           allow-whitelist-orgs-as-admins: true
-          trigger-phrase: '.*run\W+elasticsearch-ci/cloud-deploy.*'
+          only-trigger-phrase: true
+          trigger-phrase: '.*run\W+jenkins\W+elasticsearch-ci/cloud-deploy.*'
           github-hooks: true
           status-context: elasticsearch-ci/cloud-deploy
           cancel-builds-on-update: true
@@ -24,13 +25,9 @@
           excluded-regions:
             - ^docs/.*
             - ^x-pack/docs/.*
-          white-list-labels:
-            - 'cloud-deploy'
-          black-list-labels:
-            - 'buildkite-opt-in'
     builders:
       - inject:
-          properties-file: '.ci/java-versions.properties'
+          properties-file: ".ci/java-versions.properties"
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
       - shell: |

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+docs-check.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+docs-check.yml
@@ -14,19 +14,17 @@
           org-list:
             - elastic
           allow-whitelist-orgs-as-admins: true
-          trigger-phrase: '.*run\W+elasticsearch-ci/docs-check.*'
+          only-trigger-phrase: true
+          trigger-phrase: '.*run\W+jenkins\W+elasticsearch-ci/docs-check.*'
           github-hooks: true
           status-context: elasticsearch-ci/docs-check
           cancel-builds-on-update: true
           included-regions:
             - ^docs/.*
             - ^x-pack/docs/.*
-          black-list-labels:
-            - '>test-mute'
-            - 'buildkite-opt-in'
     builders:
       - inject:
-          properties-file: '.ci/java-versions.properties'
+          properties-file: ".ci/java-versions.properties"
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
             JAVA8_HOME=$HOME/.java/java8

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+eql-correctness.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+eql-correctness.yml
@@ -14,7 +14,8 @@
           org-list:
             - elastic
           allow-whitelist-orgs-as-admins: true
-          trigger-phrase: '.*run\W+elasticsearch-ci/eql-correctness.*'
+          only-trigger-phrase: true
+          trigger-phrase: '.*run\W+jenkins\W+elasticsearch-ci/eql-correctness.*'
           github-hooks: true
           status-context: elasticsearch-ci/eql-correctness
           cancel-builds-on-update: true
@@ -23,12 +24,9 @@
           excluded-regions:
             - ^docs/.*
             - ^x-pack/docs/.*
-          black-list-labels:
-            - '>test-mute'
-            - 'buildkite-opt-in'
     builders:
       - inject:
-          properties-file: '.ci/java-versions.properties'
+          properties-file: ".ci/java-versions.properties"
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
       - shell: |

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+example-plugins.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+example-plugins.yml
@@ -14,7 +14,8 @@
           org-list:
             - elastic
           allow-whitelist-orgs-as-admins: true
-          trigger-phrase: '.*run\W+elasticsearch-ci/example-plugins.*'
+          only-trigger-phrase: true
+          trigger-phrase: '.*run\W+jenkins\W+elasticsearch-ci/example-plugins.*'
           github-hooks: true
           status-context: elasticsearch-ci/example-plugins
           cancel-builds-on-update: true
@@ -23,11 +24,9 @@
             - build-tools/.*
             - build-tools-internal/.*
             - plugins/examples/.*
-          black-list-labels:
-            - 'buildkite-opt-in'
     builders:
       - inject:
-          properties-file: '.ci/java-versions.properties'
+          properties-file: ".ci/java-versions.properties"
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
             JAVA8_HOME=$HOME/.java/java8

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+full-bwc.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+full-bwc.yml
@@ -16,18 +16,14 @@
           org-list:
             - elastic
           allow-whitelist-orgs-as-admins: true
-          trigger-phrase: '.*run\W+elasticsearch-ci/full-bwc.*'
+          only-trigger-phrase: true
+          trigger-phrase: '.*run\W+jenkins\W+elasticsearch-ci/full-bwc.*'
           github-hooks: true
           status-context: elasticsearch-ci/full-bwc
           cancel-builds-on-update: true
           excluded-regions:
             - ^docs/.*
             - ^x-pack/docs/.*
-          white-list-labels:
-            - 'test-full-bwc'
-          black-list-labels:
-            - '>test-mute'
-            - 'buildkite-opt-in'
     axes:
       - axis:
           type: slave
@@ -40,7 +36,7 @@
           name: "BWC_VERSION"
     builders:
       - inject:
-          properties-file: '.ci/java-versions.properties'
+          properties-file: ".ci/java-versions.properties"
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
             JAVA8_HOME=$HOME/.java/java8

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-unix-sample.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-unix-sample.yml
@@ -15,7 +15,8 @@
           org-list:
             - elastic
           allow-whitelist-orgs-as-admins: true
-          trigger-phrase: '.*run\W+elasticsearch-ci/packaging-tests-unix-sample.*'
+          only-trigger-phrase: true
+          trigger-phrase: '.*run\W+jenkins\W+elasticsearch-ci/packaging-tests-unix-sample.*'
           github-hooks: true
           status-context: elasticsearch-ci/packaging-tests-unix-sample
           cancel-builds-on-update: true
@@ -24,10 +25,6 @@
           excluded-regions:
             - ^docs/.*
             - ^x-pack/docs/.*
-          black-list-labels:
-            - ">test-mute"
-            - ":Delivery/Packaging"
-            - "buildkite-opt-in"
     axes:
       - axis:
           type: label-expression

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-unix.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-unix.yml
@@ -15,7 +15,8 @@
           org-list:
             - elastic
           allow-whitelist-orgs-as-admins: true
-          trigger-phrase: '.*run\W+elasticsearch-ci/packaging-tests-unix.*'
+          only-trigger-phrase: true
+          trigger-phrase: '.*run\W+jenkins\W+elasticsearch-ci/packaging-tests-unix.*'
           github-hooks: true
           status-context: elasticsearch-ci/packaging-tests-unix
           cancel-builds-on-update: true
@@ -24,11 +25,6 @@
           excluded-regions:
             - ^docs/.*
             - ^x-pack/docs/.*
-          white-list-labels:
-            - ":Delivery/Packaging"
-          black-list-labels:
-            - ">test-mute"
-            - "buildkite-opt-in"
     axes:
       - axis:
           type: label-expression

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-windows-nojdk.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-windows-nojdk.yml
@@ -17,7 +17,8 @@
           org-list:
             - elastic
           allow-whitelist-orgs-as-admins: true
-          trigger-phrase: '.*run\W+elasticsearch-ci/packaging-tests-windows.*'
+          only-trigger-phrase: true
+          trigger-phrase: '.*run\W+jenkins\W+elasticsearch-ci/packaging-tests-windows.*'
           github-hooks: true
           status-context: elasticsearch-ci/packaging-tests-windows
           cancel-builds-on-update: true
@@ -28,11 +29,6 @@
           excluded-regions:
             - ^docs/.*
             - ^x-pack/docs/.*
-          white-list-labels:
-            - ':Delivery/Packaging'
-          black-list-labels:
-            - '>test-mute'
-            - 'buildkite-opt-in'
     axes:
       - axis:
           type: label-expression
@@ -46,11 +42,11 @@
           type: user-defined
           name: PACKAGING_TASK
           values:
-            - 'default-windows-archive'
-            - 'default-windows-archive-no-jdk'
+            - "default-windows-archive"
+            - "default-windows-archive-no-jdk"
     builders:
       - inject:
-          properties-file: '.ci/java-versions.properties'
+          properties-file: ".ci/java-versions.properties"
           properties-content: |
             JAVA_HOME=$USERPROFILE\\.java\\$ES_BUILD_JAVA
       - batch: |

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-windows-sample-nojdk.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-windows-sample-nojdk.yml
@@ -17,7 +17,8 @@
           org-list:
             - elastic
           allow-whitelist-orgs-as-admins: true
-          trigger-phrase: '.*run\W+elasticsearch-ci/packaging-tests-windows-sample.*'
+          only-trigger-phrase: true
+          trigger-phrase: '.*run\W+jenkins\W+elasticsearch-ci/packaging-tests-windows-sample.*'
           github-hooks: true
           status-context: elasticsearch-ci/packaging-tests-windows-sample
           cancel-builds-on-update: true
@@ -28,10 +29,6 @@
           excluded-regions:
             - ^docs/.*
             - ^x-pack/docs/.*
-          black-list-labels:
-            - '>test-mute'
-            - ':Delivery/Packaging'
-            - 'buildkite-opt-in'
     axes:
       - axis:
           type: label-expression
@@ -42,11 +39,11 @@
           type: user-defined
           name: PACKAGING_TASK
           values:
-            - 'default-windows-archive'
-            - 'default-windows-archive-no-jdk'
+            - "default-windows-archive"
+            - "default-windows-archive-no-jdk"
     builders:
       - inject:
-          properties-file: '.ci/java-versions.properties'
+          properties-file: ".ci/java-versions.properties"
           properties-content: |
             JAVA_HOME=$USERPROFILE\\.java\\$ES_BUILD_JAVA
       - batch: |

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-windows-sample.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-windows-sample.yml
@@ -17,7 +17,8 @@
           org-list:
             - elastic
           allow-whitelist-orgs-as-admins: true
-          trigger-phrase: '.*run\W+elasticsearch-ci/packaging-tests-windows-sample.*'
+          only-trigger-phrase: true
+          trigger-phrase: '.*run\W+jenkins\W+elasticsearch-ci/packaging-tests-windows-sample.*'
           github-hooks: true
           status-context: elasticsearch-ci/packaging-tests-windows-sample
           cancel-builds-on-update: true
@@ -27,10 +28,6 @@
           excluded-regions:
             - ^docs/.*
             - ^x-pack/docs/.*
-          black-list-labels:
-            - '>test-mute'
-            - ':Delivery/Packaging'
-            - 'buildkite-opt-in'
     axes:
       - axis:
           type: label-expression
@@ -41,10 +38,10 @@
           type: user-defined
           name: PACKAGING_TASK
           values:
-            - 'default-windows-archive'
+            - "default-windows-archive"
     builders:
       - inject:
-          properties-file: '.ci/java-versions.properties'
+          properties-file: ".ci/java-versions.properties"
           properties-content: |
             JAVA_HOME=$USERPROFILE\\.java\\$ES_BUILD_JAVA
       - batch: |

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-windows.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-windows.yml
@@ -17,7 +17,8 @@
           org-list:
             - elastic
           allow-whitelist-orgs-as-admins: true
-          trigger-phrase: '.*run\W+elasticsearch-ci/packaging-tests-windows.*'
+          only-trigger-phrase: true
+          trigger-phrase: '.*run\W+jenkins\W+elasticsearch-ci/packaging-tests-windows.*'
           github-hooks: true
           status-context: elasticsearch-ci/packaging-tests-windows
           cancel-builds-on-update: true
@@ -28,11 +29,6 @@
           excluded-regions:
             - ^docs/.*
             - ^x-pack/docs/.*
-          white-list-labels:
-            - ':Delivery/Packaging'
-          black-list-labels:
-            - '>test-mute'
-            - 'buildkite-opt-in'
     axes:
       - axis:
           type: label-expression
@@ -46,10 +42,10 @@
           type: user-defined
           name: PACKAGING_TASK
           values:
-            - 'default-windows-archive'
+            - "default-windows-archive"
     builders:
       - inject:
-          properties-file: '.ci/java-versions.properties'
+          properties-file: ".ci/java-versions.properties"
           properties-content: |
             JAVA_HOME=$USERPROFILE\\.java\\$ES_BUILD_JAVA
       - batch: |

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-upgrade-tests.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-upgrade-tests.yml
@@ -16,7 +16,8 @@
           org-list:
             - elastic
           allow-whitelist-orgs-as-admins: true
-          trigger-phrase: '.*run\W+elasticsearch-ci/packaging-upgrade-tests.*'
+          only-trigger-phrase: true
+          trigger-phrase: '.*run\W+jenkins\W+elasticsearch-ci/packaging-upgrade-tests.*'
           github-hooks: true
           status-context: elasticsearch-ci/packaging-upgrade-tests
           cancel-builds-on-update: true
@@ -25,11 +26,6 @@
           excluded-regions:
             - ^docs/.*
             - ^x-pack/docs/.*
-          white-list-labels:
-            - ":Delivery/Packaging"
-          black-list-labels:
-            - ">test-mute"
-            - "buildkite-opt-in"
     axes:
       - axis:
           type: label-expression

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+part-1-fips.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+part-1-fips.yml
@@ -14,7 +14,8 @@
           org-list:
             - elastic
           allow-whitelist-orgs-as-admins: true
-          trigger-phrase: '.*run\W+elasticsearch-ci/part-1-fips.*'
+          only-trigger-phrase: true
+          trigger-phrase: '.*run\W+jenkins\W+elasticsearch-ci/part-1-fips.*'
           github-hooks: true
           status-context: elasticsearch-ci/part-1-fips
           cancel-builds-on-update: true
@@ -23,15 +24,10 @@
           excluded-regions:
             - ^docs/.*
             - ^x-pack/docs/.*
-          white-list-labels:
-            - 'Team:Security'
-          black-list-labels:
-            - '>test-mute'
-            - 'buildkite-opt-in'
     builders:
       - inject:
           # Use FIPS-specific Java versions
-          properties-file: '.ci/java-versions-fips.properties'
+          properties-file: ".ci/java-versions-fips.properties"
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
             JAVA16_HOME=$HOME/.java/openjdk16

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+part-1-windows.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+part-1-windows.yml
@@ -15,7 +15,8 @@
           org-list:
             - elastic
           allow-whitelist-orgs-as-admins: true
-          trigger-phrase: '.*run\W+elasticsearch-ci/part-1-windows.*'
+          only-trigger-phrase: true
+          trigger-phrase: '.*run\W+jenkins\W+elasticsearch-ci/part-1-windows.*'
           github-hooks: true
           status-context: elasticsearch-ci/part-1-windows
           cancel-builds-on-update: true
@@ -24,14 +25,9 @@
           excluded-regions:
             - ^docs/.*
             - ^x-pack/docs/.*
-          white-list-labels:
-            - 'test-windows'
-          black-list-labels:
-            - '>test-mute'
-            - 'buildkite-opt-in'
     builders:
       - inject:
-          properties-file: '.ci/java-versions.properties'
+          properties-file: ".ci/java-versions.properties"
           properties-content: |
             JAVA_HOME=$USERPROFILE\\.java\\$ES_BUILD_JAVA
             JAVA11_HOME=$USERPROFILE\\.java\\java11

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+part-2-fips.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+part-2-fips.yml
@@ -14,7 +14,8 @@
           org-list:
             - elastic
           allow-whitelist-orgs-as-admins: true
-          trigger-phrase: '.*run\W+elasticsearch-ci/part-2-fips.*'
+          only-trigger-phrase: true
+          trigger-phrase: '.*run\W+jenkins\W+elasticsearch-ci/part-2-fips.*'
           github-hooks: true
           status-context: elasticsearch-ci/part-2-fips
           cancel-builds-on-update: true
@@ -23,15 +24,10 @@
           excluded-regions:
             - ^docs/.*
             - ^x-pack/docs/.*
-          white-list-labels:
-            - 'Team:Security'
-          black-list-labels:
-            - '>test-mute'
-            - 'buildkite-opt-in'
     builders:
       - inject:
           # Use FIPS-specific Java versions
-          properties-file: '.ci/java-versions-fips.properties'
+          properties-file: ".ci/java-versions-fips.properties"
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
             JAVA16_HOME=$HOME/.java/openjdk16

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+part-2-windows.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+part-2-windows.yml
@@ -15,7 +15,8 @@
           org-list:
             - elastic
           allow-whitelist-orgs-as-admins: true
-          trigger-phrase: '.*run\W+elasticsearch-ci/part-2-windows.*'
+          only-trigger-phrase: true
+          trigger-phrase: '.*run\W+jenkins\W+elasticsearch-ci/part-2-windows.*'
           github-hooks: true
           status-context: elasticsearch-ci/part-2-windows
           cancel-builds-on-update: true
@@ -24,14 +25,9 @@
           excluded-regions:
             - ^docs/.*
             - ^x-pack/docs/.*
-          white-list-labels:
-            - 'test-windows'
-          black-list-labels:
-            - '>test-mute'
-            - 'buildkite-opt-in'
     builders:
       - inject:
-          properties-file: '.ci/java-versions.properties'
+          properties-file: ".ci/java-versions.properties"
           properties-content: |
             JAVA_HOME=$USERPROFILE\\.java\\$ES_BUILD_JAVA
             JAVA11_HOME=$USERPROFILE\\.java\\java11

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+part-3-fips.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+part-3-fips.yml
@@ -14,7 +14,8 @@
           org-list:
             - elastic
           allow-whitelist-orgs-as-admins: true
-          trigger-phrase: '.*run\W+elasticsearch-ci/part-3-fips.*'
+          only-trigger-phrase: true
+          trigger-phrase: '.*run\W+jenkins\W+elasticsearch-ci/part-3-fips.*'
           github-hooks: true
           status-context: elasticsearch-ci/part-3-fips
           cancel-builds-on-update: true
@@ -24,15 +25,10 @@
           excluded-regions:
             - ^docs/.*
             - ^x-pack/docs/.*
-          white-list-labels:
-            - 'Team:Security'
-          black-list-labels:
-            - '>test-mute'
-            - 'buildkite-opt-in'
     builders:
       - inject:
           # Use FIPS-specific Java versions
-          properties-file: '.ci/java-versions-fips.properties'
+          properties-file: ".ci/java-versions-fips.properties"
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
             JAVA16_HOME=$HOME/.java/openjdk16

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+part-3-windows.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+part-3-windows.yml
@@ -15,7 +15,8 @@
           org-list:
             - elastic
           allow-whitelist-orgs-as-admins: true
-          trigger-phrase: '.*run\W+elasticsearch-ci/part-3-windows.*'
+          only-trigger-phrase: true
+          trigger-phrase: '.*run\W+jenkins\W+elasticsearch-ci/part-3-windows.*'
           github-hooks: true
           status-context: elasticsearch-ci/part-3-windows
           cancel-builds-on-update: true
@@ -25,14 +26,9 @@
           excluded-regions:
             - ^docs/.*
             - ^x-pack/docs/.*
-          white-list-labels:
-            - 'test-windows'
-          black-list-labels:
-            - '>test-mute'
-            - 'buildkite-opt-in'
     builders:
       - inject:
-          properties-file: '.ci/java-versions.properties'
+          properties-file: ".ci/java-versions.properties"
           properties-content: |
             JAVA_HOME=$USERPROFILE\\.java\\$ES_BUILD_JAVA
             JAVA11_HOME=$USERPROFILE\\.java\\java11

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+part-3.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+part-3.yml
@@ -14,22 +14,20 @@
           org-list:
             - elastic
           allow-whitelist-orgs-as-admins: true
-          trigger-phrase: '.*run\W+elasticsearch-ci/part-3.*'
+          only-trigger-phrase: true
+          trigger-phrase: '.*run\W+jenkins\W+elasticsearch-ci/part-3.*'
           github-hooks: true
           status-context: elasticsearch-ci/part-3
           cancel-builds-on-update: true
           excluded-regions:
             - ^docs/.*
             - ^x-pack/docs/.*
-          black-list-labels:
-            - '>test-mute'
-            - 'buildkite-opt-in'
           black-list-target-branches:
             - 6.8
             - 7.17
     builders:
       - inject:
-          properties-file: '.ci/java-versions.properties'
+          properties-file: ".ci/java-versions.properties"
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
             JAVA8_HOME=$HOME/.java/java8

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+precommit.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+precommit.yml
@@ -14,17 +14,14 @@
           org-list:
             - elastic
           allow-whitelist-orgs-as-admins: true
-          trigger-phrase: '.*run\W+elasticsearch-ci/precommit.*'
+          only-trigger-phrase: true
+          trigger-phrase: '.*run\W+jenkins\W+elasticsearch-ci/precommit.*'
           github-hooks: true
           status-context: elasticsearch-ci/precommit
           cancel-builds-on-update: true
-          white-list-labels:
-            - '>test-mute'
-          black-list-labels:
-            - 'buildkite-opt-in'
     builders:
       - inject:
-          properties-file: '.ci/java-versions.properties'
+          properties-file: ".ci/java-versions.properties"
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
             JAVA8_HOME=$HOME/.java/java8

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+release-tests.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+release-tests.yml
@@ -16,23 +16,20 @@
           org-list:
             - elastic
           allow-whitelist-orgs-as-admins: true
-          trigger-phrase: '.*run\W+elasticsearch-ci/release-tests.*'
+          only-trigger-phrase: true
+          trigger-phrase: '.*run\W+jenkins\W+elasticsearch-ci/release-tests.*'
           github-hooks: true
           status-context: elasticsearch-ci/release-tests
           cancel-builds-on-update: true
           excluded-regions:
             - ^docs/.*
             - ^x-pack/docs/.*
-          white-list-labels:
-            - 'test-release'
-          black-list-labels:
-            - 'buildkite-opt-in'
           black-list-target-branches:
             - 7.15
             - 6.8
     builders:
       - inject:
-          properties-file: '.ci/java-versions.properties'
+          properties-file: ".ci/java-versions.properties"
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
             JAVA8_HOME=$HOME/.java/java8

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+rest-compatibility.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+rest-compatibility.yml
@@ -14,7 +14,8 @@
           org-list:
             - elastic
           allow-whitelist-orgs-as-admins: true
-          trigger-phrase: '.*run\W+elasticsearch-ci/rest-compatibility.*'
+          only-trigger-phrase: true
+          trigger-phrase: '.*run\W+jenkins\W+elasticsearch-ci/rest-compatibility.*'
           github-hooks: true
           status-context: elasticsearch-ci/rest-compatibility
           cancel-builds-on-update: true
@@ -26,12 +27,9 @@
           excluded-regions:
             - ^docs/.*
             - ^x-pack/docs/.*
-          black-list-labels:
-            - '>test-mute'
-            - 'buildkite-opt-in'
     builders:
       - inject:
-          properties-file: '.ci/java-versions.properties'
+          properties-file: ".ci/java-versions.properties"
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
             JAVA8_HOME=$HOME/.java/java8

--- a/.ci/templates.t/pull-request-gradle-unix.yml
+++ b/.ci/templates.t/pull-request-gradle-unix.yml
@@ -14,19 +14,17 @@
           org-list:
             - elastic
           allow-whitelist-orgs-as-admins: true
-          trigger-phrase: '.*run\W+elasticsearch-ci/{pr-job}.*'
+          only-trigger-phrase: true
+          trigger-phrase: '.*run\W+jenkins\W+elasticsearch-ci/{pr-job}.*'
           github-hooks: true
           status-context: elasticsearch-ci/{pr-job}
           cancel-builds-on-update: true
           excluded-regions:
             - ^docs/.*
             - ^x-pack/docs/.*
-          black-list-labels:
-            - '>test-mute'
-            - 'buildkite-opt-in'
     builders:
       - inject:
-          properties-file: '.ci/java-versions.properties'
+          properties-file: ".ci/java-versions.properties"
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
             JAVA8_HOME=$HOME/.java/java8


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.11`:
 - [[ci] Migrate pull requests to running in Buildkite (#101843)](https://github.com/elastic/elasticsearch/pull/101843)

<!--- Backport version: 9.2.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)