### PR TITLE
Remove Releasable interface from clients

### DIFF
--- a/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/PredicateTokenScriptFilterTests.java
+++ b/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/PredicateTokenScriptFilterTests.java
@@ -98,9 +98,6 @@ public class PredicateTokenScriptFilterTests extends ESTokenStreamTestCase {
         }
 
         @Override
-        public void close() {}
-
-        @Override
         protected <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
             ActionType<Response> action,
             Request request,

--- a/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/ScriptedConditionTokenFilterTests.java
+++ b/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/ScriptedConditionTokenFilterTests.java
@@ -98,9 +98,6 @@ public class ScriptedConditionTokenFilterTests extends ESTokenStreamTestCase {
         }
 
         @Override
-        public void close() {}
-
-        @Override
         protected <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
             ActionType<Response> action,
             Request request,

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ClientScrollableHitSourceTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ClientScrollableHitSourceTests.java
@@ -267,9 +267,6 @@ public class ClientScrollableHitSourceTests extends ESTestCase {
             ((ExecuteRequest<Request, Response>) executeRequest).validateRequest(action, validator);
         }
 
-        @Override
-        public void close() {}
-
         public synchronized void awaitOperation() throws InterruptedException {
             if (executeRequest == null) {
                 wait(10000);

--- a/server/src/main/java/org/elasticsearch/client/internal/Client.java
+++ b/server/src/main/java/org/elasticsearch/client/internal/Client.java
@@ -55,7 +55,6 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Nullable;
-import org.elasticsearch.core.Releasable;
 
 import java.util.Map;
 import java.util.concurrent.Executor;
@@ -71,7 +70,7 @@ import java.util.concurrent.Executor;
  *
  * @see org.elasticsearch.node.Node#client()
  */
-public interface Client extends ElasticsearchClient, Releasable {
+public interface Client extends ElasticsearchClient {
 
     // Note: This setting is registered only for bwc. The value is never read.
     Setting<String> CLIENT_TYPE_SETTING_S = new Setting<>("client.type", "node", (s) -> {

--- a/server/src/main/java/org/elasticsearch/client/internal/FilterClient.java
+++ b/server/src/main/java/org/elasticsearch/client/internal/FilterClient.java
@@ -46,11 +46,6 @@ public abstract class FilterClient extends AbstractClient {
     }
 
     @Override
-    public void close() {
-        in().close();
-    }
-
-    @Override
     protected <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
         ActionType<Response> action,
         Request request,

--- a/server/src/main/java/org/elasticsearch/client/internal/node/NodeClient.java
+++ b/server/src/main/java/org/elasticsearch/client/internal/node/NodeClient.java
@@ -76,11 +76,6 @@ public class NodeClient extends AbstractClient {
     }
 
     @Override
-    public void close() {
-        // nothing really to do
-    }
-
-    @Override
     public <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
         ActionType<Response> action,
         Request request,

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -43,7 +43,6 @@ import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.core.Assertions;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.PathUtils;
-import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.env.Environment;
@@ -508,8 +507,6 @@ public class Node implements Closeable {
         toClose.add(injector.getInstance(SnapshotsService.class));
         toClose.add(injector.getInstance(SnapshotShardsService.class));
         toClose.add(injector.getInstance(RepositoriesService.class));
-        toClose.add(() -> stopWatch.stop().start("client"));
-        Releasables.close(injector.getInstance(Client.class));
         toClose.add(() -> stopWatch.stop().start("indices_cluster"));
         toClose.add(injector.getInstance(IndicesClusterStateService.class));
         toClose.add(() -> stopWatch.stop().start("indices"));

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterAwareClient.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterAwareClient.java
@@ -85,11 +85,6 @@ final class RemoteClusterAwareClient extends AbstractClient {
     }
 
     @Override
-    public void close() {
-        // do nothing
-    }
-
-    @Override
     public Client getRemoteClusterClient(String remoteClusterAlias, Executor responseExecutor) {
         return remoteClusterService.getRemoteClusterClient(threadPool(), remoteClusterAlias, responseExecutor);
     }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/remote/RemoteClusterNodesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/remote/RemoteClusterNodesActionTests.java
@@ -123,9 +123,6 @@ public class RemoteClusterNodesActionTests extends ESTestCase {
                     );
                     listener.onResponse((Response) nodesInfoResponse);
                 }
-
-                @Override
-                public void close() {}
             }
         );
 
@@ -201,9 +198,6 @@ public class RemoteClusterNodesActionTests extends ESTestCase {
                     assertThat(asInstanceOf(NodesInfoRequest.class, request).requestedMetrics(), empty());
                     listener.onResponse((Response) nodesInfoResponse);
                 }
-
-                @Override
-                public void close() {}
             }
         );
 

--- a/server/src/test/java/org/elasticsearch/client/internal/AbstractClientHeadersTestCase.java
+++ b/server/src/test/java/org/elasticsearch/client/internal/AbstractClientHeadersTestCase.java
@@ -83,7 +83,6 @@ public abstract class AbstractClientHeadersTestCase extends ESTestCase {
     @Override
     public void tearDown() throws Exception {
         super.tearDown();
-        client.close();
         terminate(threadPool);
     }
 

--- a/server/src/test/java/org/elasticsearch/health/HealthPeriodicLoggerTests.java
+++ b/server/src/test/java/org/elasticsearch/health/HealthPeriodicLoggerTests.java
@@ -92,7 +92,6 @@ public class HealthPeriodicLoggerTests extends ESTestCase {
             testHealthPeriodicLogger.close();
         }
         threadPool.shutdownNow();
-        client.close();
     }
 
     public void testConvertToLoggedFields() {

--- a/server/src/test/java/org/elasticsearch/rest/BaseRestHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/BaseRestHandlerTests.java
@@ -47,7 +47,6 @@ public class BaseRestHandlerTests extends ESTestCase {
     public void tearDown() throws Exception {
         super.tearDown();
         threadPool.shutdown();
-        mockClient.close();
     }
 
     public void testOneUnconsumedParameters() throws Exception {

--- a/server/src/test/java/org/elasticsearch/rest/action/RestCancellableNodeClientTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/RestCancellableNodeClientTests.java
@@ -64,30 +64,29 @@ public class RestCancellableNodeClientTests extends ESTestCase {
      * associated with its corresponding channel. Either way, we need to make sure that no tasks are left in the map.
      */
     public void testCompletedTasks() throws Exception {
-        try (TestClient testClient = new TestClient(Settings.EMPTY, threadPool, false)) {
-            int initialHttpChannels = RestCancellableNodeClient.getNumChannels();
-            int totalSearches = 0;
-            List<Future<?>> futures = new ArrayList<>();
-            int numChannels = randomIntBetween(1, 30);
-            for (int i = 0; i < numChannels; i++) {
-                int numTasks = randomIntBetween(1, 30);
-                TestHttpChannel channel = new TestHttpChannel();
-                totalSearches += numTasks;
-                for (int j = 0; j < numTasks; j++) {
-                    PlainActionFuture<SearchResponse> actionFuture = new PlainActionFuture<>();
-                    RestCancellableNodeClient client = new RestCancellableNodeClient(testClient, channel);
-                    threadPool.generic().submit(() -> client.execute(SearchAction.INSTANCE, new SearchRequest(), actionFuture));
-                    futures.add(actionFuture);
-                }
+        final var testClient = new TestClient(Settings.EMPTY, threadPool, false);
+        int initialHttpChannels = RestCancellableNodeClient.getNumChannels();
+        int totalSearches = 0;
+        List<Future<?>> futures = new ArrayList<>();
+        int numChannels = randomIntBetween(1, 30);
+        for (int i = 0; i < numChannels; i++) {
+            int numTasks = randomIntBetween(1, 30);
+            TestHttpChannel channel = new TestHttpChannel();
+            totalSearches += numTasks;
+            for (int j = 0; j < numTasks; j++) {
+                PlainActionFuture<SearchResponse> actionFuture = new PlainActionFuture<>();
+                RestCancellableNodeClient client = new RestCancellableNodeClient(testClient, channel);
+                threadPool.generic().submit(() -> client.execute(SearchAction.INSTANCE, new SearchRequest(), actionFuture));
+                futures.add(actionFuture);
             }
-            for (Future<?> future : futures) {
-                future.get();
-            }
-            // no channels get closed in this test, hence we expect as many channels as we created in the map
-            assertEquals(initialHttpChannels + numChannels, RestCancellableNodeClient.getNumChannels());
-            assertEquals(0, RestCancellableNodeClient.getNumTasks());
-            assertEquals(totalSearches, testClient.searchRequests.get());
         }
+        for (Future<?> future : futures) {
+            future.get();
+        }
+        // no channels get closed in this test, hence we expect as many channels as we created in the map
+        assertEquals(initialHttpChannels + numChannels, RestCancellableNodeClient.getNumChannels());
+        assertEquals(0, RestCancellableNodeClient.getNumTasks());
+        assertEquals(totalSearches, testClient.searchRequests.get());
     }
 
     /**
@@ -95,30 +94,29 @@ public class RestCancellableNodeClientTests extends ESTestCase {
      * removed and all of its corresponding tasks get cancelled.
      */
     public void testCancelledTasks() throws Exception {
-        try (TestClient nodeClient = new TestClient(Settings.EMPTY, threadPool, true)) {
-            int initialHttpChannels = RestCancellableNodeClient.getNumChannels();
-            int numChannels = randomIntBetween(1, 30);
-            int totalSearches = 0;
-            List<TestHttpChannel> channels = new ArrayList<>(numChannels);
-            for (int i = 0; i < numChannels; i++) {
-                TestHttpChannel channel = new TestHttpChannel();
-                channels.add(channel);
-                int numTasks = randomIntBetween(1, 30);
-                totalSearches += numTasks;
-                RestCancellableNodeClient client = new RestCancellableNodeClient(nodeClient, channel);
-                for (int j = 0; j < numTasks; j++) {
-                    client.execute(SearchAction.INSTANCE, new SearchRequest(), null);
-                }
-                assertEquals(numTasks, RestCancellableNodeClient.getNumTasks(channel));
+        final var nodeClient = new TestClient(Settings.EMPTY, threadPool, true);
+        int initialHttpChannels = RestCancellableNodeClient.getNumChannels();
+        int numChannels = randomIntBetween(1, 30);
+        int totalSearches = 0;
+        List<TestHttpChannel> channels = new ArrayList<>(numChannels);
+        for (int i = 0; i < numChannels; i++) {
+            TestHttpChannel channel = new TestHttpChannel();
+            channels.add(channel);
+            int numTasks = randomIntBetween(1, 30);
+            totalSearches += numTasks;
+            RestCancellableNodeClient client = new RestCancellableNodeClient(nodeClient, channel);
+            for (int j = 0; j < numTasks; j++) {
+                client.execute(SearchAction.INSTANCE, new SearchRequest(), null);
             }
-            assertEquals(initialHttpChannels + numChannels, RestCancellableNodeClient.getNumChannels());
-            for (TestHttpChannel channel : channels) {
-                channel.awaitClose();
-            }
-            assertEquals(initialHttpChannels, RestCancellableNodeClient.getNumChannels());
-            assertEquals(totalSearches, nodeClient.searchRequests.get());
-            assertEquals(totalSearches, nodeClient.cancelledTasks.size());
+            assertEquals(numTasks, RestCancellableNodeClient.getNumTasks(channel));
         }
+        assertEquals(initialHttpChannels + numChannels, RestCancellableNodeClient.getNumChannels());
+        for (TestHttpChannel channel : channels) {
+            channel.awaitClose();
+        }
+        assertEquals(initialHttpChannels, RestCancellableNodeClient.getNumChannels());
+        assertEquals(totalSearches, nodeClient.searchRequests.get());
+        assertEquals(totalSearches, nodeClient.cancelledTasks.size());
     }
 
     /**
@@ -128,26 +126,25 @@ public class RestCancellableNodeClientTests extends ESTestCase {
      * the newly added listener will be invoked at registration time.
      */
     public void testChannelAlreadyClosed() {
-        try (TestClient testClient = new TestClient(Settings.EMPTY, threadPool, true)) {
-            int initialHttpChannels = RestCancellableNodeClient.getNumChannels();
-            int numChannels = randomIntBetween(1, 30);
-            int totalSearches = 0;
-            for (int i = 0; i < numChannels; i++) {
-                TestHttpChannel channel = new TestHttpChannel();
-                // no need to wait here, there will be no close listener registered, nothing to wait for.
-                channel.close();
-                int numTasks = randomIntBetween(1, 5);
-                totalSearches += numTasks;
-                RestCancellableNodeClient client = new RestCancellableNodeClient(testClient, channel);
-                for (int j = 0; j < numTasks; j++) {
-                    // here the channel will be first registered, then straight-away removed from the map as the close listener is invoked
-                    client.execute(SearchAction.INSTANCE, new SearchRequest(), null);
-                }
+        final var testClient = new TestClient(Settings.EMPTY, threadPool, true);
+        int initialHttpChannels = RestCancellableNodeClient.getNumChannels();
+        int numChannels = randomIntBetween(1, 30);
+        int totalSearches = 0;
+        for (int i = 0; i < numChannels; i++) {
+            TestHttpChannel channel = new TestHttpChannel();
+            // no need to wait here, there will be no close listener registered, nothing to wait for.
+            channel.close();
+            int numTasks = randomIntBetween(1, 5);
+            totalSearches += numTasks;
+            RestCancellableNodeClient client = new RestCancellableNodeClient(testClient, channel);
+            for (int j = 0; j < numTasks; j++) {
+                // here the channel will be first registered, then straight-away removed from the map as the close listener is invoked
+                client.execute(SearchAction.INSTANCE, new SearchRequest(), null);
             }
-            assertEquals(initialHttpChannels, RestCancellableNodeClient.getNumChannels());
-            assertEquals(totalSearches, testClient.searchRequests.get());
-            assertEquals(totalSearches, testClient.cancelledTasks.size());
         }
+        assertEquals(initialHttpChannels, RestCancellableNodeClient.getNumChannels());
+        assertEquals(totalSearches, testClient.searchRequests.get());
+        assertEquals(totalSearches, testClient.cancelledTasks.size());
     }
 
     private static class TestClient extends NodeClient {

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterAwareClientTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterAwareClientTests.java
@@ -85,39 +85,36 @@ public class RemoteClusterAwareClientTests extends ESTestCase {
                 service.start();
                 service.acceptIncomingRequests();
 
-                try (
-                    RemoteClusterAwareClient client = new RemoteClusterAwareClient(
-                        Settings.EMPTY,
-                        threadPool,
-                        service,
-                        "cluster1",
-                        threadPool.executor(TEST_THREAD_POOL_NAME),
-                        randomBoolean()
-                    )
-                ) {
-                    SearchShardsRequest searchShardsRequest = new SearchShardsRequest(
-                        new String[] { "test-index" },
-                        IndicesOptions.strictExpandOpen(),
-                        new MatchAllQueryBuilder(),
-                        null,
-                        null,
-                        randomBoolean(),
-                        null
-                    );
-                    final SearchShardsResponse searchShardsResponse = PlainActionFuture.get(
-                        future -> client.execute(
-                            SearchShardsAction.INSTANCE,
-                            searchShardsRequest,
-                            ActionListener.runBefore(
-                                future,
-                                () -> assertTrue(Thread.currentThread().getName().contains('[' + TEST_THREAD_POOL_NAME + ']'))
-                            )
-                        ),
-                        10,
-                        TimeUnit.SECONDS
-                    );
-                    assertThat(searchShardsResponse.getNodes(), equalTo(knownNodes));
-                }
+                final var client = new RemoteClusterAwareClient(
+                    Settings.EMPTY,
+                    threadPool,
+                    service,
+                    "cluster1",
+                    threadPool.executor(TEST_THREAD_POOL_NAME),
+                    randomBoolean()
+                );
+                SearchShardsRequest searchShardsRequest = new SearchShardsRequest(
+                    new String[] { "test-index" },
+                    IndicesOptions.strictExpandOpen(),
+                    new MatchAllQueryBuilder(),
+                    null,
+                    null,
+                    randomBoolean(),
+                    null
+                );
+                final SearchShardsResponse searchShardsResponse = PlainActionFuture.get(
+                    future -> client.execute(
+                        SearchShardsAction.INSTANCE,
+                        searchShardsRequest,
+                        ActionListener.runBefore(
+                            future,
+                            () -> assertTrue(Thread.currentThread().getName().contains('[' + TEST_THREAD_POOL_NAME + ']'))
+                        )
+                    ),
+                    10,
+                    TimeUnit.SECONDS
+                );
+                assertThat(searchShardsResponse.getNodes(), equalTo(knownNodes));
             }
         }
     }
@@ -145,46 +142,44 @@ public class RemoteClusterAwareClientTests extends ESTestCase {
                 service.start();
                 service.acceptIncomingRequests();
 
-                try (
-                    RemoteClusterAwareClient client = new RemoteClusterAwareClient(
-                        Settings.EMPTY,
-                        threadPool,
-                        service,
-                        "cluster1",
-                        EsExecutors.DIRECT_EXECUTOR_SERVICE,
-                        randomBoolean()
-                    )
-                ) {
-                    int numThreads = 10;
-                    ExecutorService executorService = Executors.newFixedThreadPool(numThreads);
-                    for (int i = 0; i < numThreads; i++) {
-                        final String threadId = Integer.toString(i);
-                        PlainActionFuture<SearchShardsResponse> future = new PlainActionFuture<>();
-                        executorService.submit(() -> {
-                            ThreadContext threadContext = seedTransport.threadPool.getThreadContext();
-                            threadContext.putHeader("threadId", threadId);
-                            var searchShardsRequest = new SearchShardsRequest(
-                                new String[] { "test-index" },
-                                IndicesOptions.strictExpandOpen(),
-                                new MatchAllQueryBuilder(),
-                                null,
-                                null,
-                                randomBoolean(),
-                                null
-                            );
-                            client.execute(
-                                SearchShardsAction.INSTANCE,
-                                searchShardsRequest,
-                                ActionListener.runBefore(
-                                    future,
-                                    () -> assertThat(seedTransport.threadPool.getThreadContext().getHeader("threadId"), equalTo(threadId))
-                                )
-                            );
-                            assertThat(future.actionGet().getNodes(), equalTo(knownNodes));
-                        });
-                    }
-                    ThreadPool.terminate(executorService, 5, TimeUnit.SECONDS);
+                final var client = new RemoteClusterAwareClient(
+                    Settings.EMPTY,
+                    threadPool,
+                    service,
+                    "cluster1",
+                    EsExecutors.DIRECT_EXECUTOR_SERVICE,
+                    randomBoolean()
+                );
+
+                int numThreads = 10;
+                ExecutorService executorService = Executors.newFixedThreadPool(numThreads);
+                for (int i = 0; i < numThreads; i++) {
+                    final String threadId = Integer.toString(i);
+                    PlainActionFuture<SearchShardsResponse> future = new PlainActionFuture<>();
+                    executorService.submit(() -> {
+                        ThreadContext threadContext = seedTransport.threadPool.getThreadContext();
+                        threadContext.putHeader("threadId", threadId);
+                        var searchShardsRequest = new SearchShardsRequest(
+                            new String[] { "test-index" },
+                            IndicesOptions.strictExpandOpen(),
+                            new MatchAllQueryBuilder(),
+                            null,
+                            null,
+                            randomBoolean(),
+                            null
+                        );
+                        client.execute(
+                            SearchShardsAction.INSTANCE,
+                            searchShardsRequest,
+                            ActionListener.runBefore(
+                                future,
+                                () -> assertThat(seedTransport.threadPool.getThreadContext().getHeader("threadId"), equalTo(threadId))
+                            )
+                        );
+                        assertThat(future.actionGet().getNodes(), equalTo(knownNodes));
+                    });
                 }
+                ThreadPool.terminate(executorService, 5, TimeUnit.SECONDS);
             }
         }
     }

--- a/test/framework/src/main/java/org/elasticsearch/test/ExternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ExternalTestCluster.java
@@ -135,14 +135,14 @@ public final class ExternalTestCluster extends TestCluster {
             logger.info("Setup ExternalTestCluster [{}] made of [{}] nodes", nodeInfos.getClusterName().value(), size());
         } catch (NodeValidationException e) {
             try {
-                IOUtils.close(wrappedClient, mockNode);
+                IOUtils.close(mockNode);
             } catch (IOException e1) {
                 e.addSuppressed(e1);
             }
             throw new ElasticsearchException(e);
         } catch (Exception e) {
             try {
-                IOUtils.close(wrappedClient, mockNode);
+                IOUtils.close(mockNode);
             } catch (IOException e1) {
                 e.addSuppressed(e1);
             }
@@ -182,7 +182,7 @@ public final class ExternalTestCluster extends TestCluster {
 
     @Override
     public void close() throws IOException {
-        IOUtils.close(client, node);
+        IOUtils.close(node);
     }
 
     @Override

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -64,7 +64,6 @@ import org.elasticsearch.common.util.concurrent.FutureUtils;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.Nullable;
-import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
@@ -977,7 +976,6 @@ public final class InternalTestCluster extends TestCluster {
 
         void resetClient() {
             if (closed.get() == false) {
-                Releasables.close(nodeClient);
                 nodeClient = null;
             }
         }

--- a/test/framework/src/main/java/org/elasticsearch/test/client/NoOpClient.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/client/NoOpClient.java
@@ -23,9 +23,7 @@ import org.elasticsearch.threadpool.ThreadPool;
  * See also {@link NoOpNodeClient} if you need to mock a {@link org.elasticsearch.client.internal.node.NodeClient}.
  */
 public class NoOpClient extends AbstractClient {
-    /**
-     * Build with {@link ThreadPool}. This {@linkplain ThreadPool} is terminated on {@link #close()}.
-     */
+
     public NoOpClient(ThreadPool threadPool) {
         super(Settings.EMPTY, threadPool);
     }
@@ -38,7 +36,4 @@ public class NoOpClient extends AbstractClient {
     ) {
         listener.onResponse(null);
     }
-
-    @Override
-    public void close() {}
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/client/NoOpNodeClient.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/client/NoOpNodeClient.java
@@ -38,9 +38,6 @@ public class NoOpNodeClient extends NodeClient {
 
     private final AtomicLong executionCount = new AtomicLong(0);
 
-    /**
-     * Build with {@link ThreadPool}. This {@linkplain ThreadPool} is terminated on {@link #close()}.
-     */
     public NoOpNodeClient(ThreadPool threadPool) {
         super(Settings.EMPTY, threadPool);
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicySecurityClient.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicySecurityClient.java
@@ -40,12 +40,6 @@ public class LifecyclePolicySecurityClient extends AbstractClient {
     }
 
     @Override
-    public void close() {
-        // Doesn't close the wrapped client since this client object is shared
-        // among multiple instances
-    }
-
-    @Override
     protected <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
         ActionType<Response> action,
         Request request,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicyClientTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicyClientTests.java
@@ -56,15 +56,8 @@ public class LifecyclePolicyClientTests extends ESTestCase {
 
         SearchRequest request = new SearchRequest("foo");
 
-        try (
-            LifecyclePolicySecurityClient policyClient = new LifecyclePolicySecurityClient(
-                client,
-                ClientHelper.INDEX_LIFECYCLE_ORIGIN,
-                Collections.emptyMap()
-            )
-        ) {
-            policyClient.execute(SearchAction.INSTANCE, request, listener);
-        }
+        final var policyClient = new LifecyclePolicySecurityClient(client, ClientHelper.INDEX_LIFECYCLE_ORIGIN, Collections.emptyMap());
+        policyClient.execute(SearchAction.INSTANCE, request, listener);
 
         latch.await();
     }
@@ -95,15 +88,8 @@ public class LifecyclePolicyClientTests extends ESTestCase {
         headers.put("foo", "foo");
         headers.put("bar", "bar");
 
-        try (
-            LifecyclePolicySecurityClient policyClient = new LifecyclePolicySecurityClient(
-                client,
-                ClientHelper.INDEX_LIFECYCLE_ORIGIN,
-                headers
-            )
-        ) {
-            policyClient.execute(SearchAction.INSTANCE, request, listener);
-        }
+        final var policyClient = new LifecyclePolicySecurityClient(client, ClientHelper.INDEX_LIFECYCLE_ORIGIN, headers);
+        policyClient.execute(SearchAction.INSTANCE, request, listener);
 
         latch.await();
     }
@@ -136,15 +122,8 @@ public class LifecyclePolicyClientTests extends ESTestCase {
         headers.put("es-security-runas-user", "foo");
         headers.put("_xpack_security_authentication", "bar");
 
-        try (
-            LifecyclePolicySecurityClient policyClient = new LifecyclePolicySecurityClient(
-                client,
-                ClientHelper.INDEX_LIFECYCLE_ORIGIN,
-                headers
-            )
-        ) {
-            policyClient.execute(SearchAction.INSTANCE, request, listener);
-        }
+        final var policyClient = new LifecyclePolicySecurityClient(client, ClientHelper.INDEX_LIFECYCLE_ORIGIN, headers);
+        policyClient.execute(SearchAction.INSTANCE, request, listener);
 
         latch.await();
     }

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunnerTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunnerTests.java
@@ -131,7 +131,6 @@ public class IndexLifecycleRunnerTests extends ESTestCase {
     @After
     public void shutdown() {
         historyStore.close();
-        noopClient.close();
         threadPool.shutdownNow();
     }
 

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/history/ILMHistoryStoreTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/history/ILMHistoryStoreTests.java
@@ -93,7 +93,6 @@ public class ILMHistoryStoreTests extends ESTestCase {
     public void setdown() {
         historyStore.close();
         clusterService.close();
-        client.close();
         threadPool.shutdownNow();
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/apikey/RestCreateApiKeyActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/apikey/RestCreateApiKeyActionTests.java
@@ -86,7 +86,7 @@ public class RestCreateApiKeyActionTests extends ESTestCase {
             Instant.now().plus(Duration.ofHours(5))
         );
 
-        try (NodeClient client = new NodeClient(Settings.EMPTY, threadPool) {
+        final var client = new NodeClient(Settings.EMPTY, threadPool) {
             @Override
             public <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
                 ActionType<Response> action,
@@ -103,17 +103,15 @@ public class RestCreateApiKeyActionTests extends ESTestCase {
                     listener.onFailure(new ElasticsearchSecurityException("encountered an error while creating API key"));
                 }
             }
-        }) {
-            final RestCreateApiKeyAction restCreateApiKeyAction = new RestCreateApiKeyAction(Settings.EMPTY, mockLicenseState);
-            restCreateApiKeyAction.handleRequest(restRequest, restChannel, client);
+        };
+        final RestCreateApiKeyAction restCreateApiKeyAction = new RestCreateApiKeyAction(Settings.EMPTY, mockLicenseState);
+        restCreateApiKeyAction.handleRequest(restRequest, restChannel, client);
 
-            final RestResponse restResponse = responseSetOnce.get();
-            assertNotNull(restResponse);
-            assertThat(
-                CreateApiKeyResponse.fromXContent(createParser(XContentType.JSON.xContent(), restResponse.content())),
-                equalTo(expected)
-            );
-        }
+        final RestResponse restResponse = responseSetOnce.get();
+        assertNotNull(restResponse);
+        assertThat(
+            CreateApiKeyResponse.fromXContent(createParser(XContentType.JSON.xContent(), restResponse.content())),
+            equalTo(expected)
+        );
     }
-
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/apikey/RestGetApiKeyActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/apikey/RestGetApiKeyActionTests.java
@@ -122,7 +122,7 @@ public class RestGetApiKeyActionTests extends ESTestCase {
             )
         );
 
-        try (NodeClient client = new NodeClient(Settings.EMPTY, threadPool) {
+        final var client = new NodeClient(Settings.EMPTY, threadPool) {
             @SuppressWarnings("unchecked")
             @Override
             public <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
@@ -149,44 +149,37 @@ public class RestGetApiKeyActionTests extends ESTestCase {
                     listener.onFailure(new ElasticsearchSecurityException("encountered an error while creating API key"));
                 }
             }
-        }) {
-            final RestGetApiKeyAction restGetApiKeyAction = new RestGetApiKeyAction(Settings.EMPTY, mockLicenseState);
+        };
+        final RestGetApiKeyAction restGetApiKeyAction = new RestGetApiKeyAction(Settings.EMPTY, mockLicenseState);
 
-            restGetApiKeyAction.handleRequest(restRequest, restChannel, client);
+        restGetApiKeyAction.handleRequest(restRequest, restChannel, client);
 
-            final RestResponse restResponse = responseSetOnce.get();
-            assertNotNull(restResponse);
+        final RestResponse restResponse = responseSetOnce.get();
+        assertNotNull(restResponse);
+        assertThat(restResponse.status(), (replyEmptyResponse && params.get("id") != null) ? is(RestStatus.NOT_FOUND) : is(RestStatus.OK));
+        final GetApiKeyResponse actual = GetApiKeyResponse.fromXContent(createParser(XContentType.JSON.xContent(), restResponse.content()));
+        if (replyEmptyResponse) {
+            assertThat(actual.getApiKeyInfos().length, is(0));
+        } else {
             assertThat(
-                restResponse.status(),
-                (replyEmptyResponse && params.get("id") != null) ? is(RestStatus.NOT_FOUND) : is(RestStatus.OK)
-            );
-            final GetApiKeyResponse actual = GetApiKeyResponse.fromXContent(
-                createParser(XContentType.JSON.xContent(), restResponse.content())
-            );
-            if (replyEmptyResponse) {
-                assertThat(actual.getApiKeyInfos().length, is(0));
-            } else {
-                assertThat(
-                    actual.getApiKeyInfos(),
-                    arrayContaining(
-                        new ApiKey(
-                            "api-key-name-1",
-                            "api-key-id-1",
-                            type,
-                            creation,
-                            expiration,
-                            false,
-                            "user-x",
-                            "realm-1",
-                            metadata,
-                            roleDescriptors,
-                            limitedByRoleDescriptors
-                        )
+                actual.getApiKeyInfos(),
+                arrayContaining(
+                    new ApiKey(
+                        "api-key-name-1",
+                        "api-key-id-1",
+                        type,
+                        creation,
+                        expiration,
+                        false,
+                        "user-x",
+                        "realm-1",
+                        metadata,
+                        roleDescriptors,
+                        limitedByRoleDescriptors
                     )
-                );
-            }
+                )
+            );
         }
-
     }
 
     public void testGetApiKeyOwnedByCurrentAuthenticatedUser() throws Exception {
@@ -253,7 +246,7 @@ public class RestGetApiKeyActionTests extends ESTestCase {
         final GetApiKeyResponse getApiKeyResponseExpectedWhenOwnerFlagIsTrue = new GetApiKeyResponse(Collections.singletonList(apiKey1));
         final GetApiKeyResponse getApiKeyResponseExpectedWhenOwnerFlagIsFalse = new GetApiKeyResponse(List.of(apiKey1, apiKey2));
 
-        try (NodeClient client = new NodeClient(Settings.EMPTY, threadPool) {
+        final var client = new NodeClient(Settings.EMPTY, threadPool) {
             @SuppressWarnings("unchecked")
             @Override
             public <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
@@ -274,24 +267,21 @@ public class RestGetApiKeyActionTests extends ESTestCase {
                     listener.onResponse((Response) getApiKeyResponseExpectedWhenOwnerFlagIsFalse);
                 }
             }
-        }) {
-            final RestGetApiKeyAction restGetApiKeyAction = new RestGetApiKeyAction(Settings.EMPTY, mockLicenseState);
+        };
+        final RestGetApiKeyAction restGetApiKeyAction = new RestGetApiKeyAction(Settings.EMPTY, mockLicenseState);
 
-            restGetApiKeyAction.handleRequest(restRequest, restChannel, client);
+        restGetApiKeyAction.handleRequest(restRequest, restChannel, client);
 
-            final RestResponse restResponse = responseSetOnce.get();
-            assertNotNull(restResponse);
-            assertThat(restResponse.status(), is(RestStatus.OK));
-            final GetApiKeyResponse actual = GetApiKeyResponse.fromXContent(
-                createParser(XContentType.JSON.xContent(), restResponse.content())
-            );
-            if (isGetRequestForOwnedKeysOnly) {
-                assertThat(actual.getApiKeyInfos().length, is(1));
-                assertThat(actual.getApiKeyInfos(), arrayContaining(apiKey1));
-            } else {
-                assertThat(actual.getApiKeyInfos().length, is(2));
-                assertThat(actual.getApiKeyInfos(), arrayContaining(apiKey1, apiKey2));
-            }
+        final RestResponse restResponse = responseSetOnce.get();
+        assertNotNull(restResponse);
+        assertThat(restResponse.status(), is(RestStatus.OK));
+        final GetApiKeyResponse actual = GetApiKeyResponse.fromXContent(createParser(XContentType.JSON.xContent(), restResponse.content()));
+        if (isGetRequestForOwnedKeysOnly) {
+            assertThat(actual.getApiKeyInfos().length, is(1));
+            assertThat(actual.getApiKeyInfos(), arrayContaining(apiKey1));
+        } else {
+            assertThat(actual.getApiKeyInfos().length, is(2));
+            assertThat(actual.getApiKeyInfos(), arrayContaining(apiKey1, apiKey2));
         }
     }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/apikey/RestInvalidateApiKeyActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/apikey/RestInvalidateApiKeyActionTests.java
@@ -88,7 +88,7 @@ public class RestInvalidateApiKeyActionTests extends ESTestCase {
             null
         );
 
-        try (NodeClient client = new NodeClient(Settings.EMPTY, threadPool) {
+        final var client = new NodeClient(Settings.EMPTY, threadPool) {
             @Override
             @SuppressWarnings("unchecked")
             public <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
@@ -112,24 +112,19 @@ public class RestInvalidateApiKeyActionTests extends ESTestCase {
                     listener.onFailure(new ElasticsearchSecurityException("encountered an error while creating API key"));
                 }
             }
-        }) {
-            final RestInvalidateApiKeyAction restInvalidateApiKeyAction = new RestInvalidateApiKeyAction(Settings.EMPTY, mockLicenseState);
+        };
+        final RestInvalidateApiKeyAction restInvalidateApiKeyAction = new RestInvalidateApiKeyAction(Settings.EMPTY, mockLicenseState);
 
-            restInvalidateApiKeyAction.handleRequest(restRequest, restChannel, client);
+        restInvalidateApiKeyAction.handleRequest(restRequest, restChannel, client);
 
-            final RestResponse restResponse = responseSetOnce.get();
-            assertNotNull(restResponse);
-            final InvalidateApiKeyResponse actual = InvalidateApiKeyResponse.fromXContent(
-                createParser(XContentType.JSON.xContent(), restResponse.content())
-            );
-            assertThat(actual.getInvalidatedApiKeys(), equalTo(invalidateApiKeyResponseExpected.getInvalidatedApiKeys()));
-            assertThat(
-                actual.getPreviouslyInvalidatedApiKeys(),
-                equalTo(invalidateApiKeyResponseExpected.getPreviouslyInvalidatedApiKeys())
-            );
-            assertThat(actual.getErrors(), equalTo(invalidateApiKeyResponseExpected.getErrors()));
-        }
-
+        final RestResponse restResponse = responseSetOnce.get();
+        assertNotNull(restResponse);
+        final InvalidateApiKeyResponse actual = InvalidateApiKeyResponse.fromXContent(
+            createParser(XContentType.JSON.xContent(), restResponse.content())
+        );
+        assertThat(actual.getInvalidatedApiKeys(), equalTo(invalidateApiKeyResponseExpected.getInvalidatedApiKeys()));
+        assertThat(actual.getPreviouslyInvalidatedApiKeys(), equalTo(invalidateApiKeyResponseExpected.getPreviouslyInvalidatedApiKeys()));
+        assertThat(actual.getErrors(), equalTo(invalidateApiKeyResponseExpected.getErrors()));
     }
 
     public void testInvalidateApiKeyOwnedByCurrentAuthenticatedUser() throws Exception {
@@ -165,7 +160,7 @@ public class RestInvalidateApiKeyActionTests extends ESTestCase {
             null
         );
 
-        try (NodeClient client = new NodeClient(Settings.EMPTY, threadPool) {
+        final var client = new NodeClient(Settings.EMPTY, threadPool) {
             @SuppressWarnings("unchecked")
             @Override
             public <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
@@ -186,25 +181,23 @@ public class RestInvalidateApiKeyActionTests extends ESTestCase {
                     listener.onResponse((Response) invalidateApiKeyResponseExpectedWhenOwnerFlagIsFalse);
                 }
             }
-        }) {
-            final RestInvalidateApiKeyAction restInvalidateApiKeyAction = new RestInvalidateApiKeyAction(Settings.EMPTY, mockLicenseState);
+        };
+        final RestInvalidateApiKeyAction restInvalidateApiKeyAction = new RestInvalidateApiKeyAction(Settings.EMPTY, mockLicenseState);
 
-            restInvalidateApiKeyAction.handleRequest(restRequest, restChannel, client);
+        restInvalidateApiKeyAction.handleRequest(restRequest, restChannel, client);
 
-            final RestResponse restResponse = responseSetOnce.get();
-            assertNotNull(restResponse);
-            assertThat(restResponse.status(), is(RestStatus.OK));
-            final InvalidateApiKeyResponse actual = InvalidateApiKeyResponse.fromXContent(
-                createParser(XContentType.JSON.xContent(), restResponse.content())
-            );
-            if (isInvalidateRequestForOwnedKeysOnly) {
-                assertThat(actual.getInvalidatedApiKeys().size(), is(1));
-                assertThat(actual.getInvalidatedApiKeys(), containsInAnyOrder("api-key-id-1"));
-            } else {
-                assertThat(actual.getInvalidatedApiKeys().size(), is(2));
-                assertThat(actual.getInvalidatedApiKeys(), containsInAnyOrder("api-key-id-1", "api-key-id-2"));
-            }
+        final RestResponse restResponse = responseSetOnce.get();
+        assertNotNull(restResponse);
+        assertThat(restResponse.status(), is(RestStatus.OK));
+        final InvalidateApiKeyResponse actual = InvalidateApiKeyResponse.fromXContent(
+            createParser(XContentType.JSON.xContent(), restResponse.content())
+        );
+        if (isInvalidateRequestForOwnedKeysOnly) {
+            assertThat(actual.getInvalidatedApiKeys().size(), is(1));
+            assertThat(actual.getInvalidatedApiKeys(), containsInAnyOrder("api-key-id-1"));
+        } else {
+            assertThat(actual.getInvalidatedApiKeys().size(), is(2));
+            assertThat(actual.getInvalidatedApiKeys(), containsInAnyOrder("api-key-id-1", "api-key-id-2"));
         }
-
     }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/apikey/RestQueryApiKeyActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/apikey/RestQueryApiKeyActionTests.java
@@ -102,7 +102,7 @@ public class RestQueryApiKeyActionTests extends ESTestCase {
             }
         };
 
-        try (NodeClient client = new NodeClient(Settings.EMPTY, threadPool) {
+        final var client = new NodeClient(Settings.EMPTY, threadPool) {
             @SuppressWarnings("unchecked")
             @Override
             public <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
@@ -127,10 +127,9 @@ public class RestQueryApiKeyActionTests extends ESTestCase {
                 assertThat(((PrefixQueryBuilder) shouldQueryBuilder).fieldName(), equalTo("metadata.environ"));
                 listener.onResponse((Response) new QueryApiKeyResponse(0, List.of()));
             }
-        }) {
-            final RestQueryApiKeyAction restQueryApiKeyAction = new RestQueryApiKeyAction(Settings.EMPTY, mockLicenseState);
-            restQueryApiKeyAction.handleRequest(restRequest, restChannel, client);
-        }
+        };
+        final RestQueryApiKeyAction restQueryApiKeyAction = new RestQueryApiKeyAction(Settings.EMPTY, mockLicenseState);
+        restQueryApiKeyAction.handleRequest(restRequest, restChannel, client);
 
         assertNotNull(responseSetOnce.get());
     }
@@ -160,7 +159,7 @@ public class RestQueryApiKeyActionTests extends ESTestCase {
             }
         };
 
-        try (NodeClient client = new NodeClient(Settings.EMPTY, threadPool) {
+        final var client = new NodeClient(Settings.EMPTY, threadPool) {
             @SuppressWarnings("unchecked")
             @Override
             public <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
@@ -192,10 +191,10 @@ public class RestQueryApiKeyActionTests extends ESTestCase {
 
                 listener.onResponse((Response) new QueryApiKeyResponse(0, List.of()));
             }
-        }) {
-            final RestQueryApiKeyAction restQueryApiKeyAction = new RestQueryApiKeyAction(Settings.EMPTY, mockLicenseState);
-            restQueryApiKeyAction.handleRequest(restRequest, restChannel, client);
-        }
+        };
+
+        final RestQueryApiKeyAction restQueryApiKeyAction = new RestQueryApiKeyAction(Settings.EMPTY, mockLicenseState);
+        restQueryApiKeyAction.handleRequest(restRequest, restChannel, client);
 
         assertNotNull(responseSetOnce.get());
     }

--- a/x-pack/plugin/slm/src/test/java/org/elasticsearch/xpack/slm/SnapshotLifecycleTaskTests.java
+++ b/x-pack/plugin/slm/src/test/java/org/elasticsearch/xpack/slm/SnapshotLifecycleTaskTests.java
@@ -106,13 +106,11 @@ public class SnapshotLifecycleTaskTests extends ESTestCase {
             Settings.EMPTY,
             Sets.union(ClusterSettings.BUILT_IN_CLUSTER_SETTINGS, Set.of(SLM_HISTORY_INDEX_ENABLED_SETTING))
         );
-        try (
-            ClusterService clusterService = ClusterServiceUtils.createClusterService(state, threadPool, settings);
+        try (ClusterService clusterService = ClusterServiceUtils.createClusterService(state, threadPool, settings)) {
             VerifyingClient client = new VerifyingClient(threadPool, (a, r, l) -> {
                 fail("should not have tried to take a snapshot");
                 return null;
-            })
-        ) {
+            });
             SnapshotHistoryStore historyStore = new VerifyingHistoryStore(
                 null,
                 clusterService,
@@ -173,8 +171,7 @@ public class SnapshotLifecycleTaskTests extends ESTestCase {
 
         final AtomicBoolean clientCalled = new AtomicBoolean(false);
         final SetOnce<String> snapshotName = new SetOnce<>();
-        try (
-            ClusterService clusterService = ClusterServiceUtils.createClusterService(state, threadPool, settings);
+        try (ClusterService clusterService = ClusterServiceUtils.createClusterService(state, threadPool, settings)) {
             // This verifying client will verify that we correctly invoked
             // client.admin().createSnapshot(...) with the appropriate
             // request. It also returns a mock real response
@@ -202,8 +199,7 @@ public class SnapshotLifecycleTaskTests extends ESTestCase {
                     fail("failed to parse snapshot response");
                     return null;
                 }
-            })
-        ) {
+            });
             final AtomicBoolean historyStoreCalled = new AtomicBoolean(false);
             SnapshotHistoryStore historyStore = new VerifyingHistoryStore(null, clusterService, item -> {
                 assertFalse(historyStoreCalled.getAndSet(true));
@@ -247,8 +243,7 @@ public class SnapshotLifecycleTaskTests extends ESTestCase {
         );
         final AtomicBoolean clientCalled = new AtomicBoolean(false);
         final SetOnce<String> snapshotName = new SetOnce<>();
-        try (
-            ClusterService clusterService = ClusterServiceUtils.createClusterService(state, threadPool, settings);
+        try (ClusterService clusterService = ClusterServiceUtils.createClusterService(state, threadPool, settings)) {
             VerifyingClient client = new VerifyingClient(threadPool, (action, request, listener) -> {
                 assertFalse(clientCalled.getAndSet(true));
                 assertThat(action, instanceOf(CreateSnapshotAction.class));
@@ -285,8 +280,8 @@ public class SnapshotLifecycleTaskTests extends ESTestCase {
                         Collections.emptyMap()
                     )
                 );
-            })
-        ) {
+            });
+
             final AtomicBoolean historyStoreCalled = new AtomicBoolean(false);
             SnapshotHistoryStore historyStore = new VerifyingHistoryStore(null, clusterService, item -> {
                 assertFalse(historyStoreCalled.getAndSet(true));

--- a/x-pack/plugin/slm/src/test/java/org/elasticsearch/xpack/slm/history/SnapshotHistoryStoreTests.java
+++ b/x-pack/plugin/slm/src/test/java/org/elasticsearch/xpack/slm/history/SnapshotHistoryStoreTests.java
@@ -68,7 +68,6 @@ public class SnapshotHistoryStoreTests extends ESTestCase {
     public void tearDown() throws Exception {
         super.tearDown();
         clusterService.stop();
-        client.close();
         threadPool.shutdownNow();
     }
 

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransformPrivilegeCheckerTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransformPrivilegeCheckerTests.java
@@ -89,9 +89,6 @@ public class TransformPrivilegeCheckerTests extends ESTestCase {
 
     @Before
     public void setupClient() {
-        if (client != null) {
-            client.close();
-        }
         threadPool = createThreadPool();
         client = new MyMockClient(threadPool);
         securityContext = new SecurityContext(Settings.EMPTY, threadPool.getThreadContext()) {
@@ -103,7 +100,6 @@ public class TransformPrivilegeCheckerTests extends ESTestCase {
 
     @After
     public void tearDownClient() {
-        client.close();
         threadPool.shutdown();
     }
 


### PR DESCRIPTION
No `Client` implementations hold any resources, so they don't need to be
`Releasable`. This commit removes the unnecessary interface. As well as
removing the dead code, this change means that IDEs no longer warn about
calling `ESIntegTestCase#client()` outside of a try-with-resources
block.