### PR TITLE
Add a historical feature for shutdown api general availability in 7.15

### DIFF
--- a/x-pack/plugin/shutdown/src/main/java/module-info.java
+++ b/x-pack/plugin/shutdown/src/main/java/module-info.java
@@ -14,4 +14,6 @@ module org.elasticsearch.shutdown {
     requires org.apache.logging.log4j;
 
     exports org.elasticsearch.xpack.shutdown;
+
+    provides org.elasticsearch.features.FeatureSpecification with org.elasticsearch.xpack.shutdown.ShutdownFeatures;
 }

--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/ShutdownFeatures.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/ShutdownFeatures.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.shutdown;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.features.FeatureSpecification;
+import org.elasticsearch.features.NodeFeature;
+
+import java.util.Map;
+
+/**
+ * This class specifies features exposed by the Shutdown plugin.
+ */
+public class ShutdownFeatures implements FeatureSpecification {
+
+    @Override
+    public Map<NodeFeature, Version> getHistoricalFeatures() {
+        return Map.of(ShutdownPlugin.SHUTDOWN_API_SUPPORTED, Version.V_7_15_0);
+    }
+}

--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/ShutdownPlugin.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/ShutdownPlugin.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsFilter;
+import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.rest.RestController;
@@ -27,6 +28,12 @@ import java.util.List;
 import java.util.function.Supplier;
 
 public class ShutdownPlugin extends Plugin implements ActionPlugin {
+
+    /**
+     * A feature indicating that a node supports the shutdown API.
+     */
+    public static final NodeFeature SHUTDOWN_API_SUPPORTED = new NodeFeature("shutdown.api_supported");
+
     @Override
     public Collection<?> createComponents(PluginServices services) {
 

--- a/x-pack/plugin/shutdown/src/main/resources/META-INF/services/org.elasticsearch.features.FeatureSpecification
+++ b/x-pack/plugin/shutdown/src/main/resources/META-INF/services/org.elasticsearch.features.FeatureSpecification
@@ -1,0 +1,8 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+#
+
+org.elasticsearch.xpack.shutdown.ShutdownFeatures


### PR DESCRIPTION
This PR introduces a `FeatureSpecification` class for Shutdown API, with an historical feature linked to the version in which it became GA.
The feature is not used internally by the plugin itself, but it is needed in integration tests (`ESRestTestCase.java` and derived classes): integration and rest tests perform cleanup operations on the test cluster between tests to avoid leakage and dependencies between them. In this case, if any nodes are registered for shutdown, the test framework will remove their metadata. 
In order to do so safely, the test framework needs to know if the cluster under test exposes such API or not (this is especially needed for BwC tests).

A PR to use this feature in `ESRestTestCase.java` will follow.