### PR TITLE
Add a historical feature for the state reset fallback fix added in 8.7

### DIFF
--- a/x-pack/plugin/ml/src/main/java/module-info.java
+++ b/x-pack/plugin/ml/src/main/java/module-info.java
@@ -33,6 +33,7 @@ module org.elasticsearch.ml {
 
     provides org.elasticsearch.painless.spi.PainlessExtension with org.elasticsearch.xpack.ml.MachineLearningPainlessExtension;
     provides org.elasticsearch.xpack.autoscaling.AutoscalingExtension with org.elasticsearch.xpack.ml.autoscaling.MlAutoscalingExtension;
+    provides org.elasticsearch.features.FeatureSpecification with org.elasticsearch.xpack.ml.MlFeatures;
 
     exports org.elasticsearch.xpack.ml;
     exports org.elasticsearch.xpack.ml.action;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -44,6 +44,7 @@ import org.elasticsearch.common.unit.Processors;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.env.Environment;
+import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.index.analysis.CharFilterFactory;
 import org.elasticsearch.index.analysis.TokenizerFactory;
 import org.elasticsearch.index.query.QueryBuilder;
@@ -484,6 +485,8 @@ public class MachineLearning extends Plugin
     public static final String UTILITY_THREAD_POOL_NAME = NAME + "_utility";
 
     public static final String TRAINED_MODEL_CIRCUIT_BREAKER_NAME = "model_inference";
+
+    public static final NodeFeature STATE_RESET_FALLBACK_ON_DISABLED = new NodeFeature("ml.state_reset_fallback_on_disabled");
 
     private static final long DEFAULT_MODEL_CIRCUIT_BREAKER_LIMIT = (long) ((0.50) * JvmInfo.jvmInfo().getMem().getHeapMax().getBytes());
     private static final double DEFAULT_MODEL_CIRCUIT_BREAKER_OVERHEAD = 1.0D;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlFeatures.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlFeatures.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.features.FeatureSpecification;
+import org.elasticsearch.features.NodeFeature;
+
+import java.util.Map;
+
+/**
+ * This class specifies source code features exposed by the Shutdown plugin.
+ */
+public class MlFeatures implements FeatureSpecification {
+    @Override
+    public Map<NodeFeature, Version> getHistoricalFeatures() {
+        return Map.of(MachineLearning.STATE_RESET_FALLBACK_ON_DISABLED, Version.V_8_7_0);
+    }
+}

--- a/x-pack/plugin/ml/src/main/resources/META-INF/services/org.elasticsearch.features.FeatureSpecification
+++ b/x-pack/plugin/ml/src/main/resources/META-INF/services/org.elasticsearch.features.FeatureSpecification
@@ -1,0 +1,8 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+#
+
+org.elasticsearch.xpack.ml.MlFeatures


### PR DESCRIPTION
This PR introduces a `FeatureSpecification` class for the ML plugin, with a historical feature needed by integration tests.

The feature is not used internally by the plugin itself, but it is needed in integration tests (`ESRestTestCase.java` and derived). Integration tests preforms some cleanup the test cluster between tests and avoid leakage and dependencies between them; in this case, resetting the state of system indices by calling `_features/reset`.
Before 8.7, calling this API when the plugin is disabled would result in errors. A fix was published with 8.7 (https://github.com/elastic/elasticsearch/pull/94130). 
The rest tests and integration tests need to know if they can safely call it on the cluster under test exposes (for BwC tests).

A PR to use it in `ESRestTestCase.java` and derived tests (including update of `MlPluginDisabledIT.java`) will follow.
