### PR TITLE
Add a historical feature for SearchableSnapshots general availability in 7.8

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/module-info.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/module-info.java
@@ -19,4 +19,6 @@ module org.elasticsearch.searchablesnapshots {
 
     exports org.elasticsearch.xpack.searchablesnapshots.action.cache to org.elasticsearch.server;
     exports org.elasticsearch.xpack.searchablesnapshots.action to org.elasticsearch.server;
+
+    provides org.elasticsearch.features.FeatureSpecification with org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsFeatures;
 }

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshots.java
@@ -40,6 +40,7 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.engine.EngineFactory;
@@ -244,6 +245,8 @@ public class SearchableSnapshots extends Plugin implements IndexStorePlugin, Eng
      */
     public static final String DATA_TIERS_CACHE_INDEX_PREFERENCE = String.join(",", DataTier.DATA_CONTENT, DataTier.DATA_HOT);
     private static final int SEARCHABLE_SNAPSHOTS_INDEX_MAPPINGS_VERSION = 1;
+
+    public static NodeFeature SEARCHABLE_SNAPSHOTS_SUPPORTED = new NodeFeature("searchable-snapshots.supported");
 
     private volatile Supplier<RepositoriesService> repositoriesServiceSupplier;
     private final SetOnce<BlobStoreCacheService> blobStoreCacheService = new SetOnce<>();

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsFeatures.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsFeatures.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.searchablesnapshots;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.features.FeatureSpecification;
+import org.elasticsearch.features.NodeFeature;
+
+import java.util.Map;
+
+public class SearchableSnapshotsFeatures implements FeatureSpecification {
+
+    @Override
+    public Map<NodeFeature, Version> getHistoricalFeatures() {
+        return Map.of(SearchableSnapshots.SEARCHABLE_SNAPSHOTS_SUPPORTED, Version.V_7_8_0);
+    }
+}

--- a/x-pack/plugin/searchable-snapshots/src/main/resources/META-INF/services/org.elasticsearch.features.FeatureSpecification
+++ b/x-pack/plugin/searchable-snapshots/src/main/resources/META-INF/services/org.elasticsearch.features.FeatureSpecification
@@ -1,0 +1,8 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+#
+
+org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshotsFeatures


### PR DESCRIPTION
This PR introduces a `FeatureSpecification` class for SearchableSnapshots, with an historical feature linked to the version in which it became GA.
The feature is not used internally by the plugin itself, but it is needed in integration tests (`ESRestTestCase.java` and derived classes): integration and rest tests perform cleanup operations on the test cluster between tests to avoid leakage and dependencies between them. In this case the test framework will clean up searchable snapshots indices before deleting snapshots and repositories.
In order to do so safely, the test framework needs to know if the cluster under test has this capability or not (this is especially needed for BwC tests).

A PR to use this feature in `ESRestTestCase.java` will follow.