### PR TITLE
Enable configuration cache feature preview

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -18,6 +18,8 @@ plugins {
   id 'elasticsearch.java-toolchain'
 }
 
+enableFeaturePreview "STABLE_CONFIGURATION_CACHE"
+
 rootProject.name = "elasticsearch"
 
 dependencyResolutionManagement {


### PR DESCRIPTION
As preparation for full configuration cache compatibility, this flag enables some additional strictness required
for configuration cache and this will emit a deprecation warning. This ensures
we do not add incompatibilities.

The additional checks include:
- not registering build services
- using the Project object at execution time
- using task extensions and conventions at execution time
- using shared build service without Task.usesService