### PR TITLE
Fix forbidden apis checks ignoring signaturefiles

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/CheckForbiddenApisTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/CheckForbiddenApisTask.java
@@ -377,6 +377,7 @@ public abstract class CheckForbiddenApisTask extends DefaultTask implements Patt
             parameters.getTargetCompatibility().set(getTargetCompatibility());
             parameters.getIgnoreFailures().set(getIgnoreFailures());
             parameters.getSuccessMarker().set(getSuccessMarker());
+            parameters.getSignaturesFiles().from(getSignaturesFiles());
         });
     }
 

--- a/modules/repository-s3/src/test/java/org/elasticsearch/repositories/s3/CustomWebIdentityTokenCredentialsProviderTests.java
+++ b/modules/repository-s3/src/test/java/org/elasticsearch/repositories/s3/CustomWebIdentityTokenCredentialsProviderTests.java
@@ -44,7 +44,7 @@ public class CustomWebIdentityTokenCredentialsProviderTests extends ESTestCase {
     private static final String ROLE_NAME = "aws-sdk-java-1651084775908";
 
     private static Environment getEnvironment() throws IOException {
-        Path configDirectory = Files.createTempDirectory("web-identity-token-test");
+        Path configDirectory = createTempDir("web-identity-token-test");
         Files.createDirectory(configDirectory.resolve("repository-s3"));
         Files.writeString(configDirectory.resolve("repository-s3/aws-web-identity-token-file"), "YXdzLXdlYi1pZGVudGl0eS10b2tlbi1maWxl");
         Environment environment = Mockito.mock(Environment.class);


### PR DESCRIPTION
@arteam exposed an issue with our forbidden api checks when back porting #101705.
This provides a fix for the forbidden apis checks and a fix for one forbidden api call that sneaked in