### PR TITLE
[DOCS] Add CCS to ES|QL limitations

### DIFF
--- a/docs/reference/esql/esql-limitations.asciidoc
+++ b/docs/reference/esql/esql-limitations.asciidoc
@@ -113,6 +113,12 @@ you query, and query `keyword` sub-fields instead of `text` fields.
 {esql} does not support querying time series data streams (TSDS).
 
 [discrete]
+[[esql-limitations-ccs]]
+=== {ccs-cap} is not supported
+
+{esql} does not support {ccs}.
+
+[discrete]
 [[esql-limitations-date-math]]
 === Date math limitations
 


### PR DESCRIPTION
Lists cross-cluster search as not supported on the ES|QL limitations page.