### PR TITLE
Update docs for v8.11.0 release

### DIFF
--- a/docs/reference/release-notes/8.11.0.asciidoc
+++ b/docs/reference/release-notes/8.11.0.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-8.11.0]]
 == {es} version 8.11.0
 
-coming[8.11.0]
-
 Also see <<breaking-changes-8.11,Breaking changes in 8.11>>.
 
 [[breaking-8.11.0]]

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -1,8 +1,6 @@
 [[release-highlights]]
 == What's new in {minor-version}
 
-coming::[{minor-version}]
-
 Here are the highlights of what's new and improved in {es} {minor-version}!
 ifeval::["{release-state}"!="unreleased"]
 For detailed information about this release, see the <<es-release-notes>> and


### PR DESCRIPTION
This removes the `coming` tag from the release notes and highlights