### PR TITLE
[Docs] Remove Functionbeat from 'How monitoring works' page

### DIFF
--- a/docs/reference/monitoring/how-monitoring-works.asciidoc
+++ b/docs/reference/monitoring/how-monitoring-works.asciidoc
@@ -34,7 +34,6 @@ collection methods, you should migrate to using {agent} or {metricbeat}.
 * Monitoring {beats}:
 ** {auditbeat-ref}/monitoring.html[{auditbeat}]
 ** {filebeat-ref}/monitoring.html[{filebeat}]
-** {functionbeat-ref}/monitoring.html[{functionbeat}]
 ** {heartbeat-ref}/monitoring.html[{heartbeat}]
 ** {metricbeat-ref}/monitoring.html[{metricbeat}]
 ** {packetbeat-ref}/monitoring.html[{packetbeat}]


### PR DESCRIPTION
This removes the Functionbeat entry from the [How monitoring works](https://www.elastic.co/guide/en/elasticsearch/reference/current/how-monitoring-works.html) page. This is part of deprecating the Functionbeat docs in favour of Elastic Serverless Forwarder.

Rel: https://github.com/elastic/ingest-docs/issues/608

---

![screen](https://github.com/elastic/elasticsearch/assets/41695641/aa72e358-6b09-4c1e-9951-5afb69b8b5fa)
