### PR TITLE
[8.11] Remove Functionbeat from 'How monitoring works' page (#101889)

### DIFF
--- a/docs/reference/monitoring/how-monitoring-works.asciidoc
+++ b/docs/reference/monitoring/how-monitoring-works.asciidoc
@@ -34,7 +34,6 @@ collection methods, you should migrate to using {agent} or {metricbeat}.
 * Monitoring {beats}:
 ** {auditbeat-ref}/monitoring.html[{auditbeat}]
 ** {filebeat-ref}/monitoring.html[{filebeat}]
-** {functionbeat-ref}/monitoring.html[{functionbeat}]
 ** {heartbeat-ref}/monitoring.html[{heartbeat}]
 ** {metricbeat-ref}/monitoring.html[{metricbeat}]
 ** {packetbeat-ref}/monitoring.html[{packetbeat}]


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Remove Functionbeat from 'How monitoring works' page (#101889)