### PR TITLE
Dry up AsyncTaskIndexService memory management and fix inefficient circuit breaker use

### DIFF
--- a/docs/changelog/101892.yaml
+++ b/docs/changelog/101892.yaml
@@ -1,0 +1,6 @@
+pr: 101892
+summary: Dry up `AsyncTaskIndexService` memory management and fix inefficient circuit
+  breaker use
+area: Search
+type: bug
+issues: []


### PR DESCRIPTION
This does two things. For one, this dries up a couple of spots where we were allocating the buffers for "base64ed" search responses. This sets up future improvements to the memory use of this functionality (and generally makes the memory usage easier to follow IMO).

But also, one fix is already made in the error handling in `updateResponse`. With this change we directly release buffers when this method fails instead of waiting for the subsequent persistence of the exception to complete. This was a serious bug when the expection to be persisted was a circuit breaker exception because we would need yet more bytes from the `BigArrays` instance that's already at capacity, to be able to release the bytes that we acquired up until the breaker exception.
