### PR TITLE
Fix 8.11 migrate doc

### DIFF
--- a/docs/reference/migration/migrate_8_11.asciidoc
+++ b/docs/reference/migration/migrate_8_11.asciidoc
@@ -9,8 +9,6 @@ your application to {es} 8.11.
 
 See also <<release-highlights>> and <<es-release-notes>>.
 
-coming::[8.11.0]
-
 
 [discrete]
 [[breaking-changes-8.11]]


### PR DESCRIPTION
This removes a `coming` tag that was missed in the first `8.11.0` docs PR