### PR TITLE
[ML] Fix serverless downscale decision when HA prevents it

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingResourceTracker.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingResourceTracker.java
@@ -270,11 +270,13 @@ public final class MlAutoscalingResourceTracker {
         // - modelMemory on nodes is available
         // - no jobs wait for assignment
         // - the total memory usage is less than memory usage after taking away 1 node
+        // - the current number of nodes is greater than the minimum number of nodes
         if (perNodeMemoryInBytes > 0
             && perNodeAvailableModelMemoryInBytes > 0
             && extraModelMemoryInBytes == 0
             && extraProcessors == 0
             && modelMemoryBytesSum <= perNodeMemoryInBytes * (numberMlNodes - 1)
+            && minNodes < numberMlNodes
             && (perNodeModelMemoryInBytes.size() < numberMlNodes // a node has no assigned jobs
                 || checkIfOneNodeCouldBeRemoved(
                     perNodeModelMemoryInBytes,


### PR DESCRIPTION
In serverless we require up to 3 nodes to be in the cluster when models have more than one allocation. This is to ensure that models can remain allocated during rolling restarts.

This PR fixes a bug where the downscaling code was not taking this policy into account and was suggesting a downscale when models would fit on fewer nodes, but not with the desired level of high availability.