### PR TITLE
Make Legacy test cluster infrastructure configuration cache compatible

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/fixtures/AbstractRestResourcesFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/fixtures/AbstractRestResourcesFuncTest.groovy
@@ -31,7 +31,8 @@ abstract class AbstractRestResourcesFuncTest extends AbstractGradleFuncTest {
         }
         """
 
-        subProject(":distribution:archives:integ-test-zip") << "configurations { extracted }"
+        subProject(":distribution:archives:integ-test-zip") << "configurations.create('extracted') \n"
+        subProject(":distribution:archives:integ-test-zip") << "configurations.create('default')\n"
     }
 
     void setupRestResources(List<String> apis, List<String> tests = [], List<String> xpackTests = []) {

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/fixtures/AbstractRestResourcesFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/fixtures/AbstractRestResourcesFuncTest.groovy
@@ -31,7 +31,7 @@ abstract class AbstractRestResourcesFuncTest extends AbstractGradleFuncTest {
         }
         """
 
-        subProject(":distribution:archives:integ-test-zip") << "configurations.create('extracted') \n"
+        subProject(":distribution:archives:integ-test-zip") << "configurations.create('extracted')\n"
         subProject(":distribution:archives:integ-test-zip") << "configurations.create('default')\n"
     }
 

--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/test/rest/LegacyYamlRestTestPluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/test/rest/LegacyYamlRestTestPluginFuncTest.groovy
@@ -24,8 +24,6 @@ class LegacyYamlRestTestPluginFuncTest extends AbstractRestResourcesFuncTest {
 
     def "yamlRestTest does nothing when there are no tests"() {
         given:
-        // RestIntegTestTask not cc compatible due to
-        configurationCacheCompatible = false
         buildFile << """
         plugins {
           id 'elasticsearch.legacy-yaml-rest-test'
@@ -43,8 +41,6 @@ class LegacyYamlRestTestPluginFuncTest extends AbstractRestResourcesFuncTest {
 
     def "yamlRestTest executes and copies api and tests to correct source set"() {
         given:
-        // RestIntegTestTask not cc compatible due to
-        configurationCacheCompatible = false
         internalBuild()
         buildFile << """
             apply plugin: 'elasticsearch.legacy-yaml-rest-test'
@@ -56,9 +52,10 @@ class LegacyYamlRestTestPluginFuncTest extends AbstractRestResourcesFuncTest {
             // can't actually spin up test cluster from this test
            tasks.withType(Test).configureEach{ enabled = false }
 
+           def clazzpath = sourceSets.yamlRestTest.runtimeClasspath
            tasks.register("printYamlRestTestClasspath").configure {
                doLast {
-                   println sourceSets.yamlRestTest.runtimeClasspath.asPath
+                   println clazzpath.asPath
                }
            }
         """

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BaseInternalPluginBuildPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BaseInternalPluginBuildPlugin.java
@@ -74,13 +74,12 @@ public class BaseInternalPluginBuildPlugin implements Plugin<Project> {
                 }
             });
 
+        boolean isModule = GradleUtils.isModuleProject(project.getPath());
+        boolean isXPackModule = isModule && project.getPath().startsWith(":x-pack");
+        if (isModule == false || isXPackModule) {
+            addNoticeGeneration(project, extension);
+        }
         project.afterEvaluate(p -> {
-            boolean isModule = GradleUtils.isModuleProject(p.getPath());
-            boolean isXPackModule = isModule && p.getPath().startsWith(":x-pack");
-            if (isModule == false || isXPackModule) {
-                addNoticeGeneration(p, extension);
-            }
-
             @SuppressWarnings("unchecked")
             NamedDomainObjectContainer<ElasticsearchCluster> testClusters = (NamedDomainObjectContainer<ElasticsearchCluster>) project
                 .getExtensions()

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/NoticeTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/NoticeTask.java
@@ -16,11 +16,11 @@ import org.gradle.api.file.FileTree;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.internal.file.FileOperations;
-import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.PathSensitive;
@@ -43,7 +43,7 @@ import static org.apache.commons.io.FileUtils.readFileToString;
  * A task to create a notice file which includes dependencies' notices.
  */
 @CacheableTask
-public class NoticeTask extends DefaultTask {
+public abstract class NoticeTask extends DefaultTask {
 
     @InputFile
     @PathSensitive(PathSensitivity.RELATIVE)
@@ -57,19 +57,17 @@ public class NoticeTask extends DefaultTask {
     /**
      * Directories to include notices from
      */
-    private final ListProperty<File> licensesDirs;
+    @Internal
+    abstract ListProperty<File> getLicenseDirs();
 
     private final FileOperations fileOperations;
-    private ObjectFactory objectFactory;
 
     @Inject
-    public NoticeTask(BuildLayout buildLayout, ProjectLayout projectLayout, FileOperations fileOperations, ObjectFactory objectFactory) {
-        this.objectFactory = objectFactory;
+    public NoticeTask(BuildLayout buildLayout, ProjectLayout projectLayout, FileOperations fileOperations) {
         this.fileOperations = fileOperations;
         setDescription("Create a notice file from dependencies");
         // Default licenses directory is ${projectDir}/licenses (if it exists)
-        licensesDirs = objectFactory.listProperty(File.class);
-        licensesDirs.add(projectLayout.getProjectDirectory().dir("licenses").getAsFile());
+        getLicenseDirs().add(projectLayout.getProjectDirectory().dir("licenses").getAsFile());
         inputFile = new File(buildLayout.getRootDirectory(), "NOTICE.txt");
         outputFile = projectLayout.getBuildDirectory().dir("notices/" + getName()).get().file("NOTICE.txt").getAsFile();
     }
@@ -78,7 +76,7 @@ public class NoticeTask extends DefaultTask {
      * Add notices from the specified directory.
      */
     public void licensesDir(File licensesDir) {
-        licensesDirs.add(licensesDir);
+        getLicenseDirs().add(licensesDir);
     }
 
     public void source(Object source) {
@@ -185,7 +183,7 @@ public class NoticeTask extends DefaultTask {
     }
 
     private List<File> existingLicenseDirs() {
-        return licensesDirs.get().stream().filter(d -> d.exists()).collect(Collectors.toList());
+        return getLicenseDirs().get().stream().filter(d -> d.exists()).collect(Collectors.toList());
     }
 
     @InputFiles

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/LegacyRestTestBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/LegacyRestTestBasePlugin.java
@@ -29,10 +29,7 @@ import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.specs.NotSpec;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.Sync;
-import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.bundling.Zip;
-
-import java.util.Collections;
 
 import javax.inject.Inject;
 
@@ -131,11 +128,7 @@ public class LegacyRestTestBasePlugin implements Plugin<Project> {
     }
 
     private void configureCacheability(StandaloneRestIntegTestTask testTask) {
-        TaskContainer tasks = project.getTasks();
-        Spec<Task> taskSpec = t -> tasks.withType(StandaloneRestIntegTestTask.class)
-            .stream()
-            .filter(task -> task != testTask)
-            .anyMatch(task -> Collections.disjoint(task.getClusters(), testTask.getClusters()) == false);
+        Spec<Task> taskSpec = task -> testTask.getClusters().stream().anyMatch(testTask.getRegistery().get()::isReusedCluster);
         testTask.getOutputs()
             .doNotCacheIf(
                 "Caching disabled for this task since it uses a cluster shared by other tasks",

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/LegacyRestTestBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/LegacyRestTestBasePlugin.java
@@ -128,7 +128,7 @@ public class LegacyRestTestBasePlugin implements Plugin<Project> {
     }
 
     private void configureCacheability(StandaloneRestIntegTestTask testTask) {
-        Spec<Task> taskSpec = task -> testTask.getClusters().stream().anyMatch(testTask.getRegistery().get()::isReusedCluster);
+        Spec<Task> taskSpec = task -> testTask.getClusters().stream().anyMatch(ElasticsearchCluster::isShared);
         testTask.getOutputs()
             .doNotCacheIf(
                 "Caching disabled for this task since it uses a cluster shared by other tasks",

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/TestWithSslPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/TestWithSslPlugin.java
@@ -85,7 +85,7 @@ public class TestWithSslPlugin implements Plugin<Project> {
             NamedDomainObjectContainer<ElasticsearchCluster> clusters = (NamedDomainObjectContainer<ElasticsearchCluster>) project
                 .getExtensions()
                 .getByName(TestClustersPlugin.EXTENSION_NAME);
-            clusters.all(c -> {
+            clusters.configureEach(c -> {
                 if (BuildParams.isInFipsJvm()) {
                     c.setting("xpack.security.transport.ssl.key", "test-node.key");
                     c.keystore("xpack.security.transport.ssl.secure_key_passphrase", "test-node-key-password");

--- a/build-tools/src/integTest/groovy/org/elasticsearch/gradle/TestClustersPluginFuncTest.groovy
+++ b/build-tools/src/integTest/groovy/org/elasticsearch/gradle/TestClustersPluginFuncTest.groovy
@@ -166,7 +166,7 @@ class TestClustersPluginFuncTest extends AbstractGradleFuncTest {
 
         then:
         result.output.contains("Task ':myTask' is not up-to-date because:\n" +
-                "  Input property 'clusters.myCluster\$0.nodes.\$0.$propertyName'")
+                "  Input property 'clusters.myCluster\$0.$propertyName'")
         result.output.contains("elasticsearch-keystore script executed!")
         assertEsOutputContains("myCluster", "Starting Elasticsearch process")
         assertEsOutputContains("myCluster", "Stopping node")

--- a/build-tools/src/main/java/org/elasticsearch/gradle/DistributionDownloadPlugin.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/DistributionDownloadPlugin.java
@@ -79,6 +79,7 @@ public class DistributionDownloadPlugin implements Plugin<Project> {
     }
 
     private void setupDistributionContainer(Project project, Property<Boolean> dockerAvailable) {
+
         distributionsContainer = project.container(ElasticsearchDistribution.class, name -> {
             Configuration fileConfiguration = project.getConfigurations().create(DISTRO_CONFIG_PREFIX + name);
             Configuration extractedConfiguration = project.getConfigurations().create(DISTRO_EXTRACTED_CONFIG_PREFIX + name);

--- a/build-tools/src/main/java/org/elasticsearch/gradle/ElasticsearchDistribution.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/ElasticsearchDistribution.java
@@ -55,7 +55,7 @@ public class ElasticsearchDistribution implements Buildable, Iterable<File> {
     private final Property<Boolean> failIfUnavailable;
     private final Property<Boolean> preferArchive;
     private final ConfigurableFileCollection extracted;
-    private Action<ElasticsearchDistribution> distributionFinalizer;
+    private transient Action<ElasticsearchDistribution> distributionFinalizer;
     private boolean frozen = false;
 
     ElasticsearchDistribution(

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchCluster.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchCluster.java
@@ -84,6 +84,20 @@ public class ElasticsearchCluster implements TestClusterConfiguration, Named {
 
     private final ConfigurableFileCollection pluginAndModuleConfiguration;
 
+    private boolean shared = false;
+
+    /**
+     * this cluster si marked as shared across TestClusterAware tasks
+     * */
+    @Internal
+    public boolean isShared() {
+        return shared;
+    }
+
+    protected void setShared(boolean shared) {
+        this.shared = shared;
+    }
+
     public ElasticsearchCluster(
         String path,
         String clusterName,

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchCluster.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchCluster.java
@@ -144,7 +144,6 @@ public class ElasticsearchCluster implements TestClusterConfiguration, Named {
         this.shared = shared;
     }
 
-
     @Classpath
     public FileCollection getInstalledClasspath() {
         return pluginAndModuleConfiguration.getAsFileTree().filter(f -> f.getName().endsWith(".jar"));

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchCluster.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchCluster.java
@@ -86,18 +86,6 @@ public class ElasticsearchCluster implements TestClusterConfiguration, Named {
 
     private boolean shared = false;
 
-    /**
-     * this cluster si marked as shared across TestClusterAware tasks
-     * */
-    @Internal
-    public boolean isShared() {
-        return shared;
-    }
-
-    protected void setShared(boolean shared) {
-        this.shared = shared;
-    }
-
     public ElasticsearchCluster(
         String path,
         String clusterName,
@@ -143,6 +131,19 @@ public class ElasticsearchCluster implements TestClusterConfiguration, Named {
 
         addWaitForClusterHealth();
     }
+
+    /**
+     * this cluster si marked as shared across TestClusterAware tasks
+     * */
+    @Internal
+    public boolean isShared() {
+        return shared;
+    }
+
+    protected void setShared(boolean shared) {
+        this.shared = shared;
+    }
+
 
     @Classpath
     public FileCollection getInstalledClasspath() {

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchCluster.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchCluster.java
@@ -74,7 +74,7 @@ public class ElasticsearchCluster implements TestClusterConfiguration, Named {
     private final FileOperations fileOperations;
     private final File workingDirBase;
     private final LinkedHashMap<String, Predicate<TestClusterConfiguration>> waitConditions = new LinkedHashMap<>();
-    private final Project project;
+    transient private final Project project;
     private final Provider<ReaperService> reaper;
     private final FileSystemOperations fileSystemOperations;
     private final ArchiveOperations archiveOperations;
@@ -119,6 +119,7 @@ public class ElasticsearchCluster implements TestClusterConfiguration, Named {
                 safeName(clusterName),
                 path,
                 clusterName + "-0",
+                project,
                 reaper,
                 fileSystemOperations,
                 archiveOperations,
@@ -163,6 +164,7 @@ public class ElasticsearchCluster implements TestClusterConfiguration, Named {
                     safeName(clusterName),
                     path,
                     clusterName + "-" + i,
+                    project,
                     reaper,
                     fileSystemOperations,
                     archiveOperations,
@@ -660,7 +662,4 @@ public class ElasticsearchCluster implements TestClusterConfiguration, Named {
         return "cluster{" + path + ":" + clusterName + "}";
     }
 
-    public void finalizeConfiguration() {
-        nodes.forEach(n -> n.finalizeConfiguration(project));
-    }
 }

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -163,7 +163,7 @@ public class ElasticsearchNode implements TestClusterConfiguration {
     private int currentDistro = 0;
     private TestDistribution testDistribution;
     private volatile Process esProcess;
-    private Function<String, String> nameCustomization = Function.identity();
+    private Function<String, String> nameCustomization = s -> s;
     private boolean isWorkingDirConfigured = false;
     private String httpPort = "0";
     private String transportPort = "0";

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -26,7 +26,6 @@ import org.gradle.api.Action;
 import org.gradle.api.Named;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Project;
-import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.file.ArchiveOperations;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileSystemOperations;
@@ -134,7 +133,6 @@ public class ElasticsearchNode implements TestClusterConfiguration {
     private final Path workingDir;
 
     private final LinkedHashMap<String, Predicate<TestClusterConfiguration>> waitConditions = new LinkedHashMap<>();
-    private final Map<String, Configuration> pluginAndModuleConfigurations = new HashMap<>();
     private final List<Provider<File>> plugins = new ArrayList<>();
     private final List<Provider<File>> modules = new ArrayList<>();
     private final LazyPropertyMap<String, CharSequence> settings = new LazyPropertyMap<>("Settings", this);
@@ -279,7 +277,6 @@ public class ElasticsearchNode implements TestClusterConfiguration {
             setDistributionType(distribution, testDistribution);
         }
     }
-
     private void setDistributionType(ElasticsearchDistribution distribution, TestDistribution testDistribution) {
         if (testDistribution == TestDistribution.INTEG_TEST) {
             distribution.setType(ElasticsearchDistributionTypes.INTEG_TEST_ZIP);
@@ -291,16 +288,9 @@ public class ElasticsearchNode implements TestClusterConfiguration {
         }
     }
 
-    // package protected so only TestClustersAware can access
-    @Internal
-    Collection<Configuration> getPluginAndModuleConfigurations() {
-        return pluginAndModuleConfigurations.values();
-    }
-
     @Override
     public void plugin(Provider<RegularFile> plugin) {
         checkFrozen();
-        //
         this.plugins.add(plugin.map(RegularFile::getAsFile));
     }
 
@@ -316,7 +306,6 @@ public class ElasticsearchNode implements TestClusterConfiguration {
     @Override
     public void module(Provider<RegularFile> module) {
         checkFrozen();
-        //registerExtractedConfig(module);
         this.modules.add(module.map(RegularFile::getAsFile));
     }
 

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -295,11 +295,11 @@ public class ElasticsearchNode implements TestClusterConfiguration {
 
     @Override
     public void plugin(String pluginProjectPath) {
-        throw new IllegalStateException("Not Supported API");
+        throw new UnsupportedOperationException("Not Supported API");
     }
 
     public void plugin(TaskProvider<Zip> plugin) {
-        throw new IllegalStateException("Not Supported API");
+        throw new UnsupportedOperationException("Not Supported API");
     }
 
     @Override

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/StandaloneRestIntegTestTask.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/StandaloneRestIntegTestTask.java
@@ -70,13 +70,9 @@ public abstract class StandaloneRestIntegTestTask extends Test implements TestCl
     @Internal
     public List<ResourceLock> getSharedResources() {
         List<ResourceLock> locks = new ArrayList<>(super.getSharedResources());
-        System.out.println("locks.size() = " + getName() + " -- " + locks.size());
         BuildServiceRegistryInternal serviceRegistry = getServices().get(BuildServiceRegistryInternal.class);
         BuildServiceProvider<?, ?> serviceProvider = serviceRegistry.consume(THROTTLE_SERVICE_NAME, TestClustersThrottle.class);
-        System.out.println("locks.size() 2 = " + getName() + " -- " + super.getSharedResources().size());
-
         SharedResource resource = serviceRegistry.forService(serviceProvider);
-        System.out.println("resource.getMaxUsages() = " + getName() + " -- " + resource.getMaxUsages());
         int nodeCount = clusters.stream().mapToInt(cluster -> cluster.getNodes().size()).sum();
         if (nodeCount > 0) {
             for (int i = 0; i < Math.min(nodeCount, resource.getMaxUsages()); i++) {

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/StandaloneRestIntegTestTask.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/StandaloneRestIntegTestTask.java
@@ -88,6 +88,7 @@ public abstract class StandaloneRestIntegTestTask extends Test implements TestCl
 
     @Override
     public void beforeStart() {
+        getTasksService().get().register(this);
         if (debugServer) {
             enableDebug();
         }

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/StandaloneRestIntegTestTask.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/StandaloneRestIntegTestTask.java
@@ -70,9 +70,13 @@ public abstract class StandaloneRestIntegTestTask extends Test implements TestCl
     @Internal
     public List<ResourceLock> getSharedResources() {
         List<ResourceLock> locks = new ArrayList<>(super.getSharedResources());
+        System.out.println("locks.size() = " + getName() + " -- " + locks.size());
         BuildServiceRegistryInternal serviceRegistry = getServices().get(BuildServiceRegistryInternal.class);
         BuildServiceProvider<?, ?> serviceProvider = serviceRegistry.consume(THROTTLE_SERVICE_NAME, TestClustersThrottle.class);
+        System.out.println("locks.size() 2 = " + getName() + " -- " + super.getSharedResources().size());
+
         SharedResource resource = serviceRegistry.forService(serviceProvider);
+        System.out.println("resource.getMaxUsages() = " + getName() + " -- " + resource.getMaxUsages());
         int nodeCount = clusters.stream().mapToInt(cluster -> cluster.getNodes().size()).sum();
         if (nodeCount > 0) {
             for (int i = 0; i < Math.min(nodeCount, resource.getMaxUsages()); i++) {

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersAware.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersAware.java
@@ -16,6 +16,7 @@ import org.gradle.api.tasks.Nested;
 import java.util.Collection;
 
 import static org.elasticsearch.gradle.testclusters.TestClustersPlugin.REGISTRY_SERVICE_NAME;
+import static org.elasticsearch.gradle.testclusters.TestClustersPlugin.TEST_CLUSTER_TASKS_SERVICE;
 
 public interface TestClustersAware extends Task {
 
@@ -24,6 +25,9 @@ public interface TestClustersAware extends Task {
 
     @ServiceReference(REGISTRY_SERVICE_NAME)
     Property<TestClustersRegistry> getRegistery();
+
+    @ServiceReference(TEST_CLUSTER_TASKS_SERVICE)
+    Property<TestClustersPlugin.TaskEventsService> getTasksService();
 
     default void useCluster(ElasticsearchCluster cluster) {
         if (cluster.getPath().equals(getProject().getPath()) == false) {
@@ -40,7 +44,9 @@ public interface TestClustersAware extends Task {
         useCluster(cluster.get());
     }
 
-    default void beforeStart() {}
+    default void beforeStart() {
+        getTasksService().get().register(this);
+    }
 
     default void enableDebug() {
         int debugPort = 5007;

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersAware.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersAware.java
@@ -32,9 +32,8 @@ public interface TestClustersAware extends Task {
             throw new TestClustersException("Task " + getPath() + " can't use test cluster from" + " another project " + cluster);
         }
 
-        cluster.getNodes()
-            .all(node -> node.getDistributions().forEach(distro -> dependsOn(getProject().provider(() -> distro.maybeFreeze()))));
-        cluster.getNodes().all(node -> dependsOn((Callable<Collection<Configuration>>) node::getPluginAndModuleConfigurations));
+        cluster.getNodes().all(node -> node.getDistributions().forEach(distro -> dependsOn(getProject().provider(() -> distro.maybeFreeze()))));
+        dependsOn(cluster.getPluginAndModuleConfigurations());
         getClusters().add(cluster);
     }
 

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersAware.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersAware.java
@@ -8,14 +8,12 @@
 package org.elasticsearch.gradle.testclusters;
 
 import org.gradle.api.Task;
-import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.services.ServiceReference;
 import org.gradle.api.tasks.Nested;
 
 import java.util.Collection;
-import java.util.concurrent.Callable;
 
 import static org.elasticsearch.gradle.testclusters.TestClustersPlugin.REGISTRY_SERVICE_NAME;
 
@@ -32,7 +30,8 @@ public interface TestClustersAware extends Task {
             throw new TestClustersException("Task " + getPath() + " can't use test cluster from" + " another project " + cluster);
         }
 
-        cluster.getNodes().all(node -> node.getDistributions().forEach(distro -> dependsOn(getProject().provider(() -> distro.maybeFreeze()))));
+        cluster.getNodes()
+            .all(node -> node.getDistributions().forEach(distro -> dependsOn(getProject().provider(() -> distro.maybeFreeze()))));
         dependsOn(cluster.getPluginAndModuleConfigurations());
         getClusters().add(cluster);
     }

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
@@ -221,6 +221,9 @@ public class TestClustersPlugin implements Plugin<Project> {
                     .map(task -> (TestClustersAware) task)
                     .forEach(awareTask -> {
                         testClusterTasksService.get().register(awareTask.getPath(), awareTask);
+
+                        Set<ElasticsearchCluster> runningClusters = registry.getRunningClusters();
+
                         awareTask.doFirst(task -> {
                             awareTask.beforeStart();
                             awareTask.getClusters().forEach(awareTask.getRegistery().get()::maybeStartCluster);

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
@@ -109,7 +109,7 @@ public class TestClustersPlugin implements Plugin<Project> {
         project.getGradle().getSharedServices().registerIfAbsent(REGISTRY_SERVICE_NAME, TestClustersRegistry.class, noop());
 
         // register throttle so we only run at most max-workers/2 nodes concurrently
-        project.getGradle()
+        Provider<TestClustersThrottle> testClustersThrottleProvider = project.getGradle()
             .getSharedServices()
             .registerIfAbsent(
                 THROTTLE_SERVICE_NAME,
@@ -117,7 +117,7 @@ public class TestClustersPlugin implements Plugin<Project> {
                 spec -> spec.getMaxParallelUsages().set(Math.max(1, project.getGradle().getStartParameter().getMaxWorkerCount() / 2))
             );
 
-        // register cluster hooks
+        project.getTasks().withType(TestClustersAware.class).configureEach(task -> { task.usesService(testClustersThrottleProvider); });
         project.getRootProject().getPluginManager().apply(TestClustersHookPlugin.class);
     }
 

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
@@ -37,7 +37,6 @@ import org.gradle.tooling.events.task.TaskFinishEvent;
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Function;
 
 import javax.inject.Inject;
@@ -222,9 +221,6 @@ public class TestClustersPlugin implements Plugin<Project> {
                     .map(task -> (TestClustersAware) task)
                     .forEach(awareTask -> {
                         testClusterTasksService.get().register(awareTask.getPath(), awareTask);
-
-                        Set<ElasticsearchCluster> runningClusters = registry.getRunningClusters();
-
                         awareTask.doFirst(task -> {
                             awareTask.beforeStart();
                             awareTask.getClusters().forEach(awareTask.getRegistery().get()::maybeStartCluster);
@@ -232,14 +228,6 @@ public class TestClustersPlugin implements Plugin<Project> {
                     });
             });
         }
-    }
-
-    public static void maybeStartCluster(ElasticsearchCluster cluster, Set<ElasticsearchCluster> runningClusters) {
-        if (runningClusters.contains(cluster)) {
-            return;
-        }
-        runningClusters.add(cluster);
-        cluster.start();
     }
 
     static public abstract class TaskEventsService implements BuildService<BuildServiceParameters.None>, OperationCompletionListener {

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
@@ -104,13 +104,6 @@ public class TestClustersPlugin implements Plugin<Project> {
         // enable the DSL to describe clusters
         NamedDomainObjectContainer<ElasticsearchCluster> container = createTestClustersContainerExtension(project, reaperServiceProvider);
 
-        project.afterEvaluate(new Action<Project>() {
-            @Override
-            public void execute(Project project) {
-                container.configureEach(cluster -> cluster.finalizeConfiguration());
-            }
-        });
-
         // provide a task to be able to list defined clusters.
         createListClustersTask(project, container);
 

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
@@ -183,10 +183,9 @@ public class TestClustersPlugin implements Plugin<Project> {
         @Inject
         public abstract BuildEventsListenerRegistry getEventsListenerRegistry();
 
+        @SuppressWarnings("checkstyle:RedundantModifier")
         @Inject
-        public TestClustersHookPlugin() {
-
-        }
+        public TestClustersHookPlugin() {}
 
         public void apply(Project project) {
             if (project != project.getRootProject()) {
@@ -202,7 +201,6 @@ public class TestClustersPlugin implements Plugin<Project> {
                 .registerIfAbsent(TEST_CLUSTER_TASKS_SERVICE, TaskEventsService.class, spec -> {});
 
             TestClustersRegistry registry = registryProvider.get();
-
             // When we know what tasks will run, we claim the clusters of those task to differentiate between clusters
             // that are defined in the build script and the ones that will actually be used in this invocation of gradle
             // we use this information to determine when the last task that required the cluster executed so that we can
@@ -260,7 +258,7 @@ public class TestClustersPlugin implements Plugin<Project> {
         }
 
         public void registry(TestClustersRegistry registry) {
-            registryProvider = registry;
+            this.registryProvider = registry;
         }
 
         @Override

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
@@ -12,7 +12,6 @@ import org.elasticsearch.gradle.ReaperPlugin;
 import org.elasticsearch.gradle.ReaperService;
 import org.elasticsearch.gradle.Version;
 import org.elasticsearch.gradle.util.GradleUtils;
-import org.gradle.api.Action;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
@@ -56,6 +56,7 @@ public class TestClustersPlugin implements Plugin<Project> {
     private static final String LIST_TASK_NAME = "listTestClusters";
     public static final String REGISTRY_SERVICE_NAME = "testClustersRegistry";
     private static final Logger logger = Logging.getLogger(TestClustersPlugin.class);
+    public static final String TEST_CLUSTER_TASKS_SERVICE = "testClusterTasksService";
     private final ProviderFactory providerFactory;
     private Provider<File> runtimeJavaProvider;
     private Function<Version, Boolean> isReleasedVersion = v -> true;
@@ -198,7 +199,7 @@ public class TestClustersPlugin implements Plugin<Project> {
 
             Provider<TaskEventsService> testClusterTasksService = project.getGradle()
                 .getSharedServices()
-                .registerIfAbsent("testClusterTasksService", TaskEventsService.class, spec -> {});
+                .registerIfAbsent(TEST_CLUSTER_TASKS_SERVICE, TaskEventsService.class, spec -> {});
 
             TestClustersRegistry registry = registryProvider.get();
 
@@ -240,7 +241,6 @@ public class TestClustersPlugin implements Plugin<Project> {
                     .filter(task -> task instanceof TestClustersAware)
                     .map(task -> (TestClustersAware) task)
                     .forEach(awareTask -> {
-                        testClusterTasksService.get().register(awareTask.getPath(), awareTask);
                         awareTask.doFirst(task -> {
                             awareTask.beforeStart();
                             awareTask.getClusters().forEach(awareTask.getRegistery().get()::maybeStartCluster);
@@ -255,8 +255,9 @@ public class TestClustersPlugin implements Plugin<Project> {
         Map<String, TestClustersAware> tasksMap = new HashMap<>();
         private TestClustersRegistry registryProvider;
 
-        public void register(String path, TestClustersAware task) {
-            tasksMap.put(path, task);
+        public void register(TestClustersAware task) {
+            System.out.println("TaskEventsService.register " + task.getPath());
+            tasksMap.put(task.getPath(), task);
         }
 
         public void registry(TestClustersRegistry registry) {

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
@@ -256,7 +256,6 @@ public class TestClustersPlugin implements Plugin<Project> {
         private TestClustersRegistry registryProvider;
 
         public void register(TestClustersAware task) {
-            System.out.println("TaskEventsService.register " + task.getPath());
             tasksMap.put(task.getPath(), task);
         }
 

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersPlugin.java
@@ -12,6 +12,7 @@ import org.elasticsearch.gradle.ReaperPlugin;
 import org.elasticsearch.gradle.ReaperService;
 import org.elasticsearch.gradle.Version;
 import org.elasticsearch.gradle.util.GradleUtils;
+import org.gradle.api.Action;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -103,6 +104,13 @@ public class TestClustersPlugin implements Plugin<Project> {
         // enable the DSL to describe clusters
         NamedDomainObjectContainer<ElasticsearchCluster> container = createTestClustersContainerExtension(project, reaperServiceProvider);
 
+        project.afterEvaluate(new Action<Project>() {
+            @Override
+            public void execute(Project project) {
+                container.configureEach(cluster -> cluster.finalizeConfiguration());
+            }
+        });
+
         // provide a task to be able to list defined clusters.
         createListClustersTask(project, container);
 
@@ -157,7 +165,6 @@ public class TestClustersPlugin implements Plugin<Project> {
                 (Task t) -> container.forEach(cluster -> logger.lifecycle("   * {}: {}", cluster.getName(), cluster.getNumberOfNodes()))
             );
         });
-
     }
 
     static abstract class TestClustersHookPlugin implements Plugin<Project> {
@@ -165,7 +172,9 @@ public class TestClustersPlugin implements Plugin<Project> {
         public abstract BuildEventsListenerRegistry getEventsListenerRegistry();
 
         @Inject
-        public TestClustersHookPlugin() {}
+        public TestClustersHookPlugin() {
+
+        }
 
         public void apply(Project project) {
             if (project != project.getRootProject()) {

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersRegistry.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersRegistry.java
@@ -24,7 +24,6 @@ public abstract class TestClustersRegistry implements BuildService<BuildServiceP
     private final Map<ElasticsearchCluster, Integer> claimsInventory = new HashMap<>();
     private final Set<ElasticsearchCluster> runningClusters = new HashSet<>();
 
-
     public Set<ElasticsearchCluster> getRunningClusters() {
         return runningClusters;
     }

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersRegistry.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersRegistry.java
@@ -67,6 +67,7 @@ public abstract class TestClustersRegistry implements BuildService<BuildServiceP
             }
         } else {
             int currentClaims = claimsInventory.getOrDefault(cluster, 0) - 1;
+            System.out.println("currentClaims = " + currentClaims);
             claimsInventory.put(cluster, currentClaims);
 
             if (currentClaims <= 0 && runningClusters.contains(cluster)) {

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersRegistry.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersRegistry.java
@@ -34,7 +34,7 @@ public abstract class TestClustersRegistry implements BuildService<BuildServiceP
     }
 
     public boolean isReusedCluster(ElasticsearchCluster cluster) {
-        return claimCount.get(cluster) > 1;
+        return claimCount.getOrDefault(cluster, 0) > 0;
     }
 
     public void maybeStartCluster(ElasticsearchCluster cluster) {

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersRegistry.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersRegistry.java
@@ -23,18 +23,15 @@ public abstract class TestClustersRegistry implements BuildService<BuildServiceP
     private final Boolean allowClusterToSurvive = Boolean.valueOf(System.getProperty(TESTCLUSTERS_INSPECT_FAILURE, "false"));
     private final Map<ElasticsearchCluster, Integer> claimsInventory = new HashMap<>();
 
-    private final Map<ElasticsearchCluster, Integer> claimCount = new HashMap<>();
-
     private final Set<ElasticsearchCluster> runningClusters = new HashSet<>();
 
     public void claimCluster(ElasticsearchCluster cluster) {
         cluster.freeze();
-        claimsInventory.put(cluster, claimsInventory.getOrDefault(cluster, 0) + 1);
-        claimCount.put(cluster, claimCount.getOrDefault(cluster, 0) + 1);
-    }
-
-    public boolean isReusedCluster(ElasticsearchCluster cluster) {
-        return claimCount.getOrDefault(cluster, 0) > 0;
+        int claim = claimsInventory.getOrDefault(cluster, 0) + 1;
+        claimsInventory.put(cluster, claim);
+        if (claim > 1) {
+            cluster.setShared(true);
+        }
     }
 
     public void maybeStartCluster(ElasticsearchCluster cluster) {

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersRegistry.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersRegistry.java
@@ -67,9 +67,7 @@ public abstract class TestClustersRegistry implements BuildService<BuildServiceP
             }
         } else {
             int currentClaims = claimsInventory.getOrDefault(cluster, 0) - 1;
-            System.out.println("currentClaims = " + currentClaims);
             claimsInventory.put(cluster, currentClaims);
-
             if (currentClaims <= 0 && runningClusters.contains(cluster)) {
                 cluster.stop(false);
                 runningClusters.remove(cluster);

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersRegistry.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersRegistry.java
@@ -24,17 +24,14 @@ public abstract class TestClustersRegistry implements BuildService<BuildServiceP
     private final Map<ElasticsearchCluster, Integer> claimsInventory = new HashMap<>();
     private final Set<ElasticsearchCluster> runningClusters = new HashSet<>();
 
+
+    public Set<ElasticsearchCluster> getRunningClusters() {
+        return runningClusters;
+    }
+
     public void claimCluster(ElasticsearchCluster cluster) {
         cluster.freeze();
         claimsInventory.put(cluster, claimsInventory.getOrDefault(cluster, 0) + 1);
-    }
-
-    public void maybeStartCluster(ElasticsearchCluster cluster) {
-        if (runningClusters.contains(cluster)) {
-            return;
-        }
-        runningClusters.add(cluster);
-        cluster.start();
     }
 
     public void stopCluster(ElasticsearchCluster cluster, boolean taskFailed) {

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersThrottle.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/TestClustersThrottle.java
@@ -10,4 +10,6 @@ package org.elasticsearch.gradle.testclusters;
 import org.gradle.api.services.BuildService;
 import org.gradle.api.services.BuildServiceParameters;
 
-public abstract class TestClustersThrottle implements BuildService<BuildServiceParameters.None> {}
+public abstract class TestClustersThrottle implements BuildService<BuildServiceParameters.None> {
+
+}

--- a/qa/rolling-upgrade/build.gradle
+++ b/qa/rolling-upgrade/build.gradle
@@ -9,7 +9,6 @@
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
-apply plugin: 'elasticsearch.internal-testclusters'
 apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.internal-test-artifact-base'
 apply plugin: 'elasticsearch.bwc-test'

--- a/x-pack/plugin/ml/build.gradle
+++ b/x-pack/plugin/ml/build.gradle
@@ -119,15 +119,12 @@ tasks.register("extractNativeLicenses", Copy) {
   }
   include 'platform/licenses/**'
 }
-project.afterEvaluate {
-  // Add an extra licenses directory to the combined notices
-  tasks.named('generateNotice').configure {
-    dependsOn "extractNativeLicenses"
-    licensesDir new File("${project.buildDir}/extractedNativeLicenses/platform/licenses")
-    outputs.upToDateWhen {
-      extractNativeLicenses.didWork
-    }
-  }
+
+// Add an extra licenses directory to the combined notices
+tasks.named('generateNotice').configure {
+  dependsOn "extractNativeLicenses"
+  inputs.dir("${project.buildDir}/extractedNativeLicenses/platform/licenses")
+  licensesDir new File("${project.buildDir}/extractedNativeLicenses/platform/licenses")
 }
 
 tasks.named("dependencyLicenses").configure {
@@ -135,4 +132,3 @@ tasks.named("dependencyLicenses").configure {
 }
 
 addQaCheckDependencies(project)
-

--- a/x-pack/plugin/ml/build.gradle
+++ b/x-pack/plugin/ml/build.gradle
@@ -124,7 +124,7 @@ tasks.register("extractNativeLicenses", Copy) {
 tasks.named('generateNotice').configure {
   dependsOn "extractNativeLicenses"
   inputs.dir("${project.buildDir}/extractedNativeLicenses/platform/licenses")
-  licensesDir new File("${project.buildDir}/extractedNativeLicenses/platform/licenses")
+  licenseDirs.add(tasks.named("extractNativeLicenses").map {new File(it.destinationDir, "platform/licenses") })
 }
 
 tasks.named("dependencyLicenses").configure {

--- a/x-pack/plugin/sql/qa/jdbc/build.gradle
+++ b/x-pack/plugin/sql/qa/jdbc/build.gradle
@@ -74,7 +74,7 @@ subprojects {
     // Compatibility testing for JDBC driver started with version 7.9.0
     BuildParams.bwcVersions.allIndexCompatible.findAll({ it.onOrAfter(Version.fromString("7.9.0")) && it != VersionProperties.elasticsearchVersion }).each { bwcVersion ->
       def baseName = "v${bwcVersion}"
-      def cluster = testClusters.maybeCreate(baseName)
+      def cluster = testClusters.register(baseName)
 
       UnreleasedVersionInfo unreleasedVersion = BuildParams.bwcVersions.unreleasedInfo(bwcVersion)
       Configuration driverConfiguration = configurations.create("jdbcDriver${baseName}") {
@@ -97,7 +97,7 @@ subprojects {
 
       final String bwcVersionString = bwcVersion.toString()
       tasks.register(bwcTaskName(bwcVersion), StandaloneRestIntegTestTask) {
-          useCluster cluster
+          useCluster cluster.get()
           classpath = sourceSets.javaRestTest.runtimeClasspath + driverConfiguration
           testClassesDirs = sourceSets.javaRestTest.output.classesDirs
           systemProperty 'jdbc.driver.version', bwcVersionString

--- a/x-pack/plugin/sql/qa/jdbc/build.gradle
+++ b/x-pack/plugin/sql/qa/jdbc/build.gradle
@@ -97,7 +97,7 @@ subprojects {
 
       final String bwcVersionString = bwcVersion.toString()
       tasks.register(bwcTaskName(bwcVersion), StandaloneRestIntegTestTask) {
-          useCluster cluster.get()
+          useCluster cluster
           classpath = sourceSets.javaRestTest.runtimeClasspath + driverConfiguration
           testClassesDirs = sourceSets.javaRestTest.output.classesDirs
           systemProperty 'jdbc.driver.version', bwcVersionString

--- a/x-pack/plugin/sql/qa/jdbc/build.gradle
+++ b/x-pack/plugin/sql/qa/jdbc/build.gradle
@@ -101,7 +101,7 @@ subprojects {
           classpath = sourceSets.javaRestTest.runtimeClasspath + driverConfiguration
           testClassesDirs = sourceSets.javaRestTest.output.classesDirs
           systemProperty 'jdbc.driver.version', bwcVersionString
-          nonInputProperties.systemProperty('tests.rest.cluster', "${-> cluster.allHttpSocketURI.join(",")}")
+          nonInputProperties.systemProperty('tests.rest.cluster', "${-> cluster.get().allHttpSocketURI.join(",")}")
           nonInputProperties.systemProperty('tests.clustername', baseName)
       }
     }


### PR DESCRIPTION
- Made some minor optimisations on the way
- Do not allow node specific module or plugin configuration in test cluster setup