### PR TITLE
[DOCS] Update SVG reference for starts_with ESQL docs

### DIFF
--- a/docs/reference/esql/functions/starts_with.asciidoc
+++ b/docs/reference/esql/functions/starts_with.asciidoc
@@ -2,7 +2,7 @@
 [[esql-starts_with]]
 === `STARTS_WITH`
 [.text-center]
-image::esql/functions/signature/ends_with.svg[Embedded,opts=inline]
+image::esql/functions/signature/starts_with.svg[Embedded,opts=inline]
 
 Returns a boolean that indicates whether a keyword string starts with another
 string:


### PR DESCRIPTION
Docs use the `ENDS_WITH` SVG for the `STARTS_WITH function, this change should point to the right picture.

<img width="825" alt="image" src="https://github.com/elastic/elasticsearch/assets/52658645/139a4bba-c1fa-4952-9bf3-9065aea87d36">
