### PR TITLE
[8.11] Referenced the svgs of starts_with and trim in asciidoc for consistency. (#100834)

### DIFF
--- a/docs/reference/esql/functions/starts_with.asciidoc
+++ b/docs/reference/esql/functions/starts_with.asciidoc
@@ -1,6 +1,9 @@
 [discrete]
 [[esql-starts_with]]
 === `STARTS_WITH`
+[.text-center]
+image::esql/functions/signature/ends_with.svg[Embedded,opts=inline]
+
 Returns a boolean that indicates whether a keyword string starts with another
 string:
 
@@ -12,3 +15,7 @@ include::{esql-specs}/docs.csv-spec[tag=startsWith]
 |===
 include::{esql-specs}/docs.csv-spec[tag=startsWith-result]
 |===
+
+Supported types:
+
+include::types/starts_with.asciidoc[]

--- a/docs/reference/esql/functions/trim.asciidoc
+++ b/docs/reference/esql/functions/trim.asciidoc
@@ -1,6 +1,9 @@
 [discrete]
 [[esql-trim]]
 === `TRIM`
+[.text-center]
+image::esql/functions/signature/trim.svg[Embedded,opts=inline]
+
 Removes leading and trailing whitespaces from strings.
 
 [source.merge.styled,esql]
@@ -11,3 +14,7 @@ include::{esql-specs}/string.csv-spec[tag=trim]
 |===
 include::{esql-specs}/string.csv-spec[tag=trim-result]
 |===
+
+Supported types:
+
+include::types/trim.asciidoc[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.11`:
 - [Referenced the svgs of starts_with and trim in asciidoc for consistency. (#100834)](https://github.com/elastic/elasticsearch/pull/100834)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)