### PR TITLE
[8.11] Update SVG reference for starts_with ESQL docs (#101909)

### DIFF
--- a/docs/reference/esql/functions/starts_with.asciidoc
+++ b/docs/reference/esql/functions/starts_with.asciidoc
@@ -2,7 +2,7 @@
 [[esql-starts_with]]
 === `STARTS_WITH`
 [.text-center]
-image::esql/functions/signature/ends_with.svg[Embedded,opts=inline]
+image::esql/functions/signature/starts_with.svg[Embedded,opts=inline]
 
 Returns a boolean that indicates whether a keyword string starts with another
 string:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.11`:
 - [Update SVG reference for starts_with ESQL docs (#101909)](https://github.com/elastic/elasticsearch/pull/101909)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)