### PR TITLE
Add inference counts by model to the machine learning usage stats.

### DIFF
--- a/docs/changelog/101915.yaml
+++ b/docs/changelog/101915.yaml
@@ -1,0 +1,5 @@
+pr: 101915
+summary: Add inference counts by model to the machine learning usage stats
+area: Machine Learning
+type: enhancement
+issues: []

--- a/docs/reference/rest-api/usage.asciidoc
+++ b/docs/reference/rest-api/usage.asciidoc
@@ -183,7 +183,7 @@ GET /_xpack/usage
           "avg": 0.0,
           "max": 0.0
         },
-        "inference_counts_by_model": {},
+        "stats_by_model": {},
         "model_sizes_bytes": {
           "total": 0.0,
           "min": 0.0,

--- a/docs/reference/rest-api/usage.asciidoc
+++ b/docs/reference/rest-api/usage.asciidoc
@@ -183,6 +183,7 @@ GET /_xpack/usage
           "avg": 0.0,
           "max": 0.0
         },
+        "inference_counts_by_model": {},
         "model_sizes_bytes": {
           "total": 0.0,
           "min": 0.0,

--- a/docs/reference/rest-api/usage.asciidoc
+++ b/docs/reference/rest-api/usage.asciidoc
@@ -183,7 +183,7 @@ GET /_xpack/usage
           "avg": 0.0,
           "max": 0.0
         },
-        "stats_by_model": {},
+        "stats_by_model": [],
         "model_sizes_bytes": {
           "total": 0.0,
           "min": 0.0,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/support/xcontent/XContentSource.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/support/xcontent/XContentSource.java
@@ -109,17 +109,6 @@ public class XContentSource implements ToXContent {
         return (T) ObjectPath.eval(path, data());
     }
 
-    /**
-     * Extracts a value identified by the given path in the source.
-     *
-     * @param path the path segments to the requested value
-     * @return The extracted value or {@code null} if no value is associated with the given path
-     */
-    @SuppressWarnings("unchecked")
-    public <T> T getValue(String[] path) {
-        return (T) ObjectPath.eval(path, data());
-    }
-
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         // EMPTY is safe here because we never use namedObject

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/support/xcontent/XContentSource.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/support/xcontent/XContentSource.java
@@ -109,6 +109,17 @@ public class XContentSource implements ToXContent {
         return (T) ObjectPath.eval(path, data());
     }
 
+    /**
+     * Extracts a value identified by the given path in the source.
+     *
+     * @param path the path segments to the requested value
+     * @return The extracted value or {@code null} if no value is associated with the given path
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T getValue(String[] path) {
+        return (T) ObjectPath.eval(path, data());
+    }
+
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         // EMPTY is safe here because we never use namedObject

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearningUsageTransportAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearningUsageTransportAction.java
@@ -57,7 +57,6 @@ import org.elasticsearch.xpack.ml.job.JobManagerHolder;
 
 import java.time.Instant;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -490,10 +489,7 @@ public class MachineLearningUsageTransportAction extends XPackUsageFeatureTransp
                 "inference_counts",
                 nodeDistribution.asMap(),
                 "stats_by_model",
-                statsByModel.values()
-                    .stream()
-                    .map(ModelStats::asMap)
-                    .collect(Collectors.toList())
+                statsByModel.values().stream().map(ModelStats::asMap).collect(Collectors.toList())
             )
         );
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearningUsageTransportAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearningUsageTransportAction.java
@@ -430,7 +430,8 @@ public class MachineLearningUsageTransportAction extends XPackUsageFeatureTransp
                 nodeDistribution.add(nodeInferenceCount);
                 // If the model ID starts with a dot, it's an internal model, and the stats should be
                 // reported separately. If not, it's a third party model, whose stats are aggregated.
-                String modelId = deploymentStats.getModelId().startsWith(".") ? deploymentStats.getModelId() : "other";
+                // The leading dot is stripped, because it's inconvenient to handle it downstream.
+                String modelId = deploymentStats.getModelId().startsWith(".") ? deploymentStats.getModelId().substring(1) : "other";
                 nodeDistributionByModel.computeIfAbsent(modelId, key -> new StatsAccumulator()).add(nodeInferenceCount);
             }
         }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningInfoTransportActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningInfoTransportActionTests.java
@@ -336,29 +336,29 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
             assertThat(source.getValue("inference.ingest_processors._all.num_failures.sum"), equalTo(1500));
             assertThat(source.getValue("inference.ingest_processors._all.num_failures.min"), equalTo(100));
             assertThat(source.getValue("inference.ingest_processors._all.num_failures.max"), equalTo(500));
-            assertThat(source.getValue("inference.deployments.count"), equalTo(3));
+            assertThat(source.getValue("inference.deployments.count"), equalTo(2));
             assertThat(source.getValue("inference.deployments.inference_counts.total"), equalTo(12.0));
             assertThat(source.getValue("inference.deployments.inference_counts.min"), equalTo(3.0));
             assertThat(source.getValue("inference.deployments.inference_counts.max"), equalTo(5.0));
             assertThat(source.getValue("inference.deployments.inference_counts.avg"), equalTo(4.0));
-            assertThat(source.getValue("inference.deployments.stats_by_model.1.model_id"), equalTo("model_3"));
-            assertThat(source.getValue("inference.deployments.stats_by_model.1.task_type"), equalTo("ner"));
-            assertThat(source.getValue("inference.deployments.stats_by_model.1.last_access"), equalTo(lastAccess(3).toString()));
-            assertThat(source.getValue("inference.deployments.stats_by_model.1.inference_counts.total"), equalTo(3.0));
-            assertThat(source.getValue("inference.deployments.stats_by_model.1.inference_counts.min"), equalTo(3.0));
-            assertThat(source.getValue("inference.deployments.stats_by_model.1.inference_counts.max"), equalTo(3.0));
-            assertThat(source.getValue("inference.deployments.stats_by_model.1.inference_counts.avg"), equalTo(3.0));
-            assertThat(source.getValue("inference.deployments.stats_by_model.2.model_id"), equalTo("model_4"));
-            assertThat(source.getValue("inference.deployments.stats_by_model.2.task_type"), equalTo("text_expansion"));
-            assertThat(source.getValue("inference.deployments.stats_by_model.2.last_access"), equalTo(lastAccess(44).toString()));
-            assertThat(source.getValue("inference.deployments.stats_by_model.2.inference_counts.total"), equalTo(9.0));
-            assertThat(source.getValue("inference.deployments.stats_by_model.2.inference_counts.min"), equalTo(4.0));
-            assertThat(source.getValue("inference.deployments.stats_by_model.2.inference_counts.max"), equalTo(5.0));
-            assertThat(source.getValue("inference.deployments.stats_by_model.2.inference_counts.avg"), equalTo(4.5));
-            assertThat(source.getValue("inference.deployments.model_sizes_bytes.total"), equalTo(1500.0));
-            assertThat(source.getValue("inference.deployments.model_sizes_bytes.min"), equalTo(200.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.0.model_id"), equalTo("model_3"));
+            assertThat(source.getValue("inference.deployments.stats_by_model.0.task_type"), equalTo("ner"));
+            assertThat(source.getValue("inference.deployments.stats_by_model.0.last_access"), equalTo(lastAccess(3).toString()));
+            assertThat(source.getValue("inference.deployments.stats_by_model.0.inference_counts.total"), equalTo(3.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.0.inference_counts.min"), equalTo(3.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.0.inference_counts.max"), equalTo(3.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.0.inference_counts.avg"), equalTo(3.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.1.model_id"), equalTo("model_4"));
+            assertThat(source.getValue("inference.deployments.stats_by_model.1.task_type"), equalTo("text_expansion"));
+            assertThat(source.getValue("inference.deployments.stats_by_model.1.last_access"), equalTo(lastAccess(44).toString()));
+            assertThat(source.getValue("inference.deployments.stats_by_model.1.inference_counts.total"), equalTo(9.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.1.inference_counts.min"), equalTo(4.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.1.inference_counts.max"), equalTo(5.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.1.inference_counts.avg"), equalTo(4.5));
+            assertThat(source.getValue("inference.deployments.model_sizes_bytes.total"), equalTo(1300.0));
+            assertThat(source.getValue("inference.deployments.model_sizes_bytes.min"), equalTo(300.0));
             assertThat(source.getValue("inference.deployments.model_sizes_bytes.max"), equalTo(1000.0));
-            assertThat(source.getValue("inference.deployments.model_sizes_bytes.avg"), equalTo(500.0));
+            assertThat(source.getValue("inference.deployments.model_sizes_bytes.avg"), equalTo(650.0));
             assertThat(source.getValue("inference.deployments.time_ms.avg"), closeTo(44.0, 1e-10));
         }
     }
@@ -434,29 +434,29 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
             assertThat(source.getValue("inference.ingest_processors._all.num_failures.sum"), equalTo(1500));
             assertThat(source.getValue("inference.ingest_processors._all.num_failures.min"), equalTo(100));
             assertThat(source.getValue("inference.ingest_processors._all.num_failures.max"), equalTo(500));
-            assertThat(source.getValue("inference.deployments.count"), equalTo(3));
+            assertThat(source.getValue("inference.deployments.count"), equalTo(2));
             assertThat(source.getValue("inference.deployments.inference_counts.total"), equalTo(12.0));
             assertThat(source.getValue("inference.deployments.inference_counts.min"), equalTo(3.0));
             assertThat(source.getValue("inference.deployments.inference_counts.max"), equalTo(5.0));
             assertThat(source.getValue("inference.deployments.inference_counts.avg"), equalTo(4.0));
-            assertThat(source.getValue("inference.deployments.stats_by_model.1.model_id"), equalTo("model_3"));
-            assertThat(source.getValue("inference.deployments.stats_by_model.1.task_type"), equalTo("ner"));
-            assertThat(source.getValue("inference.deployments.stats_by_model.1.last_access"), equalTo(lastAccess(3).toString()));
-            assertThat(source.getValue("inference.deployments.stats_by_model.1.inference_counts.total"), equalTo(3.0));
-            assertThat(source.getValue("inference.deployments.stats_by_model.1.inference_counts.min"), equalTo(3.0));
-            assertThat(source.getValue("inference.deployments.stats_by_model.1.inference_counts.max"), equalTo(3.0));
-            assertThat(source.getValue("inference.deployments.stats_by_model.1.inference_counts.avg"), equalTo(3.0));
-            assertThat(source.getValue("inference.deployments.stats_by_model.2.model_id"), equalTo("model_4"));
-            assertThat(source.getValue("inference.deployments.stats_by_model.2.task_type"), equalTo("text_expansion"));
-            assertThat(source.getValue("inference.deployments.stats_by_model.2.last_access"), equalTo(lastAccess(44).toString()));
-            assertThat(source.getValue("inference.deployments.stats_by_model.2.inference_counts.total"), equalTo(9.0));
-            assertThat(source.getValue("inference.deployments.stats_by_model.2.inference_counts.min"), equalTo(4.0));
-            assertThat(source.getValue("inference.deployments.stats_by_model.2.inference_counts.max"), equalTo(5.0));
-            assertThat(source.getValue("inference.deployments.stats_by_model.2.inference_counts.avg"), equalTo(4.5));
-            assertThat(source.getValue("inference.deployments.model_sizes_bytes.total"), equalTo(1500.0));
-            assertThat(source.getValue("inference.deployments.model_sizes_bytes.min"), equalTo(200.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.0.model_id"), equalTo("model_3"));
+            assertThat(source.getValue("inference.deployments.stats_by_model.0.task_type"), equalTo("ner"));
+            assertThat(source.getValue("inference.deployments.stats_by_model.0.last_access"), equalTo(lastAccess(3).toString()));
+            assertThat(source.getValue("inference.deployments.stats_by_model.0.inference_counts.total"), equalTo(3.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.0.inference_counts.min"), equalTo(3.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.0.inference_counts.max"), equalTo(3.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.0.inference_counts.avg"), equalTo(3.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.1.model_id"), equalTo("model_4"));
+            assertThat(source.getValue("inference.deployments.stats_by_model.1.task_type"), equalTo("text_expansion"));
+            assertThat(source.getValue("inference.deployments.stats_by_model.1.last_access"), equalTo(lastAccess(44).toString()));
+            assertThat(source.getValue("inference.deployments.stats_by_model.1.inference_counts.total"), equalTo(9.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.1.inference_counts.min"), equalTo(4.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.1.inference_counts.max"), equalTo(5.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.1.inference_counts.avg"), equalTo(4.5));
+            assertThat(source.getValue("inference.deployments.model_sizes_bytes.total"), equalTo(1300.0));
+            assertThat(source.getValue("inference.deployments.model_sizes_bytes.min"), equalTo(300.0));
             assertThat(source.getValue("inference.deployments.model_sizes_bytes.max"), equalTo(1000.0));
-            assertThat(source.getValue("inference.deployments.model_sizes_bytes.avg"), equalTo(500.0));
+            assertThat(source.getValue("inference.deployments.model_sizes_bytes.avg"), equalTo(650.0));
             assertThat(source.getValue("inference.deployments.time_ms.avg"), closeTo(44.0, 1e-10));
         }
     }
@@ -980,17 +980,7 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
                             ),
                             2,
                             null,
-                            new AssignmentStats(
-                                "deployment_2",
-                                "model_2",
-                                2,
-                                2,
-                                1000,
-                                ByteSizeValue.ofBytes(1000),
-                                Instant.now(),
-                                List.of(),
-                                Priority.NORMAL
-                            ).setState(AssignmentState.STARTED).setAllocationStatus(new AllocationStatus(2, 2))
+                            null
                         ),
                         new GetTrainedModelsStatsAction.Response.TrainedModelStats(
                             trainedModel3.getModelId(),

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningInfoTransportActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningInfoTransportActionTests.java
@@ -340,14 +340,20 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
             assertThat(source.getValue("inference.deployments.inference_counts.min"), equalTo(1.0));
             assertThat(source.getValue("inference.deployments.inference_counts.max"), equalTo(5.0));
             assertThat(source.getValue("inference.deployments.inference_counts.avg"), equalTo(3.0));
-            assertThat(source.getValue("inference.deployments.inference_counts_by_model.internal_model_3.total"), equalTo(5.0));
-            assertThat(source.getValue("inference.deployments.inference_counts_by_model.internal_model_3.min"), equalTo(5.0));
-            assertThat(source.getValue("inference.deployments.inference_counts_by_model.internal_model_3.max"), equalTo(5.0));
-            assertThat(source.getValue("inference.deployments.inference_counts_by_model.internal_model_3.avg"), equalTo(5.0));
-            assertThat(source.getValue("inference.deployments.inference_counts_by_model.other.total"), equalTo(4.0));
-            assertThat(source.getValue("inference.deployments.inference_counts_by_model.other.min"), equalTo(1.0));
-            assertThat(source.getValue("inference.deployments.inference_counts_by_model.other.max"), equalTo(3.0));
-            assertThat(source.getValue("inference.deployments.inference_counts_by_model.other.avg"), equalTo(2.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.internal_model_3.task_type"), equalTo("ner"));
+            assertThat(source.getValue("inference.deployments.stats_by_model.internal_model_3.last_access"),
+                equalTo(lastAccess(3).toString()));
+            assertThat(source.getValue("inference.deployments.stats_by_model.internal_model_3.inference_counts.total"), equalTo(5.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.internal_model_3.inference_counts.min"), equalTo(5.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.internal_model_3.inference_counts.max"), equalTo(5.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.internal_model_3.inference_counts.avg"), equalTo(5.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.other.task_type"), equalTo("regression"));
+            assertThat(source.getValue("inference.deployments.stats_by_model.other.last_access"),
+                equalTo(lastAccess(4).toString()));
+            assertThat(source.getValue("inference.deployments.stats_by_model.other.inference_counts.total"), equalTo(4.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.other.inference_counts.min"), equalTo(1.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.other.inference_counts.max"), equalTo(3.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.other.inference_counts.avg"), equalTo(2.0));
             assertThat(source.getValue("inference.deployments.model_sizes_bytes.total"), equalTo(1500.0));
             assertThat(source.getValue("inference.deployments.model_sizes_bytes.min"), equalTo(200.0));
             assertThat(source.getValue("inference.deployments.model_sizes_bytes.max"), equalTo(1000.0));
@@ -432,14 +438,20 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
             assertThat(source.getValue("inference.deployments.inference_counts.min"), equalTo(1.0));
             assertThat(source.getValue("inference.deployments.inference_counts.max"), equalTo(5.0));
             assertThat(source.getValue("inference.deployments.inference_counts.avg"), equalTo(3.0));
-            assertThat(source.getValue("inference.deployments.inference_counts_by_model.internal_model_3.total"), equalTo(5.0));
-            assertThat(source.getValue("inference.deployments.inference_counts_by_model.internal_model_3.min"), equalTo(5.0));
-            assertThat(source.getValue("inference.deployments.inference_counts_by_model.internal_model_3.max"), equalTo(5.0));
-            assertThat(source.getValue("inference.deployments.inference_counts_by_model.internal_model_3.avg"), equalTo(5.0));
-            assertThat(source.getValue("inference.deployments.inference_counts_by_model.other.total"), equalTo(4.0));
-            assertThat(source.getValue("inference.deployments.inference_counts_by_model.other.min"), equalTo(1.0));
-            assertThat(source.getValue("inference.deployments.inference_counts_by_model.other.max"), equalTo(3.0));
-            assertThat(source.getValue("inference.deployments.inference_counts_by_model.other.avg"), equalTo(2.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.internal_model_3.task_type"), equalTo("ner"));
+            assertThat(source.getValue("inference.deployments.stats_by_model.internal_model_3.last_access"),
+                equalTo(lastAccess(3).toString()));
+            assertThat(source.getValue("inference.deployments.stats_by_model.internal_model_3.inference_counts.total"), equalTo(5.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.internal_model_3.inference_counts.min"), equalTo(5.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.internal_model_3.inference_counts.max"), equalTo(5.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.internal_model_3.inference_counts.avg"), equalTo(5.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.other.task_type"), equalTo("regression"));
+            assertThat(source.getValue("inference.deployments.stats_by_model.other.last_access"),
+                equalTo(lastAccess(4).toString()));
+            assertThat(source.getValue("inference.deployments.stats_by_model.other.inference_counts.total"), equalTo(4.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.other.inference_counts.min"), equalTo(1.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.other.inference_counts.max"), equalTo(3.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.other.inference_counts.avg"), equalTo(2.0));
             assertThat(source.getValue("inference.deployments.model_sizes_bytes.total"), equalTo(1500.0));
             assertThat(source.getValue("inference.deployments.model_sizes_bytes.min"), equalTo(200.0));
             assertThat(source.getValue("inference.deployments.model_sizes_bytes.max"), equalTo(1000.0));
@@ -891,24 +903,24 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
             expectedDfaCountByAnalysis.put(analysisName, ++analysisCount);
         });
 
-        TrainedModelConfig trainedModel1 = TrainedModelConfigTests.createTestInstance("model_1")
+        TrainedModelConfig trainedModel1 = TrainedModelConfigTests.createTestInstance(".internal_model_1")
             .setModelSize(100)
             .setEstimatedOperations(200)
             .setMetadata(Collections.singletonMap("analytics_config", "anything"))
             .setInferenceConfig(ClassificationConfig.EMPTY_PARAMS)
             .build();
-        TrainedModelConfig trainedModel2 = TrainedModelConfigTests.createTestInstance("model_2")
+        TrainedModelConfig trainedModel2 = TrainedModelConfigTests.createTestInstance("third_party_model_2")
             .setModelSize(200)
             .setEstimatedOperations(400)
             .setMetadata(Collections.singletonMap("analytics_config", "anything"))
             .setInferenceConfig(RegressionConfig.EMPTY_PARAMS)
             .build();
-        TrainedModelConfig trainedModel3 = TrainedModelConfigTests.createTestInstance("model_3")
+        TrainedModelConfig trainedModel3 = TrainedModelConfigTests.createTestInstance(".internal_model_3")
             .setModelSize(300)
             .setEstimatedOperations(600)
             .setInferenceConfig(new NerConfig(null, null, null, null))
             .build();
-        TrainedModelConfig trainedModel4 = TrainedModelConfigTests.createTestInstance("model_4")
+        TrainedModelConfig trainedModel4 = TrainedModelConfigTests.createTestInstance("third_party_model_4")
             .setTags(Collections.singletonList("prepackaged"))
             .setModelSize(1000)
             .setEstimatedOperations(2000)
@@ -985,7 +997,7 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
                                         1L,
                                         2,
                                         3,
-                                        Instant.now(),
+                                        lastAccess(2),
                                         Instant.now(),
                                         randomIntBetween(1, 16),
                                         randomIntBetween(1, 16),
@@ -1036,7 +1048,7 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
                                         3L,
                                         2,
                                         3,
-                                        Instant.now(),
+                                        lastAccess(3),
                                         Instant.now(),
                                         randomIntBetween(1, 16),
                                         randomIntBetween(1, 16),
@@ -1087,7 +1099,7 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
                                         1L,
                                         2,
                                         3,
-                                        Instant.now(),
+                                        lastAccess(4),
                                         Instant.now(),
                                         randomIntBetween(1, 16),
                                         randomIntBetween(1, 16),
@@ -1107,5 +1119,9 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
             )
         );
         return expectedDfaCountByAnalysis;
+    }
+
+    private static Instant lastAccess(int i) {
+        return Instant.ofEpochSecond(1_000_000_000 + i);
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningInfoTransportActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningInfoTransportActionTests.java
@@ -340,14 +340,10 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
             assertThat(source.getValue("inference.deployments.inference_counts.min"), equalTo(1.0));
             assertThat(source.getValue("inference.deployments.inference_counts.max"), equalTo(5.0));
             assertThat(source.getValue("inference.deployments.inference_counts.avg"), equalTo(3.0));
-            assertThat(source.getValue(new String[]{"inference", "deployments", "inference_counts_by_model", ".internal_model_3", "total"}),
-                equalTo(5.0));
-            assertThat(source.getValue(new String[]{"inference", "deployments", "inference_counts_by_model", ".internal_model_3", "min"}),
-                equalTo(5.0));
-            assertThat(source.getValue(new String[]{"inference", "deployments", "inference_counts_by_model", ".internal_model_3", "max"}),
-                equalTo(5.0));
-            assertThat(source.getValue(new String[]{"inference", "deployments", "inference_counts_by_model", ".internal_model_3", "avg"}),
-                equalTo(5.0));
+            assertThat(source.getValue("inference.deployments.inference_counts_by_model.internal_model_3.total"), equalTo(5.0));
+            assertThat(source.getValue("inference.deployments.inference_counts_by_model.internal_model_3.min"), equalTo(5.0));
+            assertThat(source.getValue("inference.deployments.inference_counts_by_model.internal_model_3.max"), equalTo(5.0));
+            assertThat(source.getValue("inference.deployments.inference_counts_by_model.internal_model_3.avg"), equalTo(5.0));
             assertThat(source.getValue("inference.deployments.inference_counts_by_model.other.total"), equalTo(4.0));
             assertThat(source.getValue("inference.deployments.inference_counts_by_model.other.min"), equalTo(1.0));
             assertThat(source.getValue("inference.deployments.inference_counts_by_model.other.max"), equalTo(3.0));
@@ -436,14 +432,10 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
             assertThat(source.getValue("inference.deployments.inference_counts.min"), equalTo(1.0));
             assertThat(source.getValue("inference.deployments.inference_counts.max"), equalTo(5.0));
             assertThat(source.getValue("inference.deployments.inference_counts.avg"), equalTo(3.0));
-            assertThat(source.getValue(new String[]{"inference", "deployments", "inference_counts_by_model", ".internal_model_3", "total"}),
-                equalTo(5.0));
-            assertThat(source.getValue(new String[]{"inference", "deployments", "inference_counts_by_model", ".internal_model_3", "min"}),
-                equalTo(5.0));
-            assertThat(source.getValue(new String[]{"inference", "deployments", "inference_counts_by_model", ".internal_model_3", "max"}),
-                equalTo(5.0));
-            assertThat(source.getValue(new String[]{"inference", "deployments", "inference_counts_by_model", ".internal_model_3", "avg"}),
-                equalTo(5.0));
+            assertThat(source.getValue("inference.deployments.inference_counts_by_model.internal_model_3.total"), equalTo(5.0));
+            assertThat(source.getValue("inference.deployments.inference_counts_by_model.internal_model_3.min"), equalTo(5.0));
+            assertThat(source.getValue("inference.deployments.inference_counts_by_model.internal_model_3.max"), equalTo(5.0));
+            assertThat(source.getValue("inference.deployments.inference_counts_by_model.internal_model_3.avg"), equalTo(5.0));
             assertThat(source.getValue("inference.deployments.inference_counts_by_model.other.total"), equalTo(4.0));
             assertThat(source.getValue("inference.deployments.inference_counts_by_model.other.min"), equalTo(1.0));
             assertThat(source.getValue("inference.deployments.inference_counts_by_model.other.max"), equalTo(3.0));

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningInfoTransportActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningInfoTransportActionTests.java
@@ -335,16 +335,27 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
             assertThat(source.getValue("inference.ingest_processors._all.num_failures.sum"), equalTo(1500));
             assertThat(source.getValue("inference.ingest_processors._all.num_failures.min"), equalTo(100));
             assertThat(source.getValue("inference.ingest_processors._all.num_failures.max"), equalTo(500));
-            assertThat(source.getValue("inference.deployments.count"), equalTo(2));
+            assertThat(source.getValue("inference.deployments.count"), equalTo(3));
             assertThat(source.getValue("inference.deployments.inference_counts.total"), equalTo(9.0));
-            assertThat(source.getValue("inference.deployments.inference_counts.min"), equalTo(4.0));
-            assertThat(source.getValue("inference.deployments.inference_counts.total"), equalTo(9.0));
+            assertThat(source.getValue("inference.deployments.inference_counts.min"), equalTo(1.0));
             assertThat(source.getValue("inference.deployments.inference_counts.max"), equalTo(5.0));
-            assertThat(source.getValue("inference.deployments.inference_counts.avg"), equalTo(4.5));
-            assertThat(source.getValue("inference.deployments.model_sizes_bytes.total"), equalTo(1300.0));
-            assertThat(source.getValue("inference.deployments.model_sizes_bytes.min"), equalTo(300.0));
+            assertThat(source.getValue("inference.deployments.inference_counts.avg"), equalTo(3.0));
+            assertThat(source.getValue(new String[]{"inference", "deployments", "inference_counts_by_model", ".internal_model_3", "total"}),
+                equalTo(5.0));
+            assertThat(source.getValue(new String[]{"inference", "deployments", "inference_counts_by_model", ".internal_model_3", "min"}),
+                equalTo(5.0));
+            assertThat(source.getValue(new String[]{"inference", "deployments", "inference_counts_by_model", ".internal_model_3", "max"}),
+                equalTo(5.0));
+            assertThat(source.getValue(new String[]{"inference", "deployments", "inference_counts_by_model", ".internal_model_3", "avg"}),
+                equalTo(5.0));
+            assertThat(source.getValue("inference.deployments.inference_counts_by_model.other.total"), equalTo(4.0));
+            assertThat(source.getValue("inference.deployments.inference_counts_by_model.other.min"), equalTo(1.0));
+            assertThat(source.getValue("inference.deployments.inference_counts_by_model.other.max"), equalTo(3.0));
+            assertThat(source.getValue("inference.deployments.inference_counts_by_model.other.avg"), equalTo(2.0));
+            assertThat(source.getValue("inference.deployments.model_sizes_bytes.total"), equalTo(1500.0));
+            assertThat(source.getValue("inference.deployments.model_sizes_bytes.min"), equalTo(200.0));
             assertThat(source.getValue("inference.deployments.model_sizes_bytes.max"), equalTo(1000.0));
-            assertThat(source.getValue("inference.deployments.model_sizes_bytes.avg"), equalTo(650.0));
+            assertThat(source.getValue("inference.deployments.model_sizes_bytes.avg"), equalTo(500.0));
             assertThat(source.getValue("inference.deployments.time_ms.avg"), closeTo(45.55555555555556, 1e-10));
         }
     }
@@ -420,16 +431,27 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
             assertThat(source.getValue("inference.ingest_processors._all.num_failures.sum"), equalTo(1500));
             assertThat(source.getValue("inference.ingest_processors._all.num_failures.min"), equalTo(100));
             assertThat(source.getValue("inference.ingest_processors._all.num_failures.max"), equalTo(500));
-            assertThat(source.getValue("inference.deployments.count"), equalTo(2));
+            assertThat(source.getValue("inference.deployments.count"), equalTo(3));
             assertThat(source.getValue("inference.deployments.inference_counts.total"), equalTo(9.0));
-            assertThat(source.getValue("inference.deployments.inference_counts.min"), equalTo(4.0));
-            assertThat(source.getValue("inference.deployments.inference_counts.total"), equalTo(9.0));
+            assertThat(source.getValue("inference.deployments.inference_counts.min"), equalTo(1.0));
             assertThat(source.getValue("inference.deployments.inference_counts.max"), equalTo(5.0));
-            assertThat(source.getValue("inference.deployments.inference_counts.avg"), equalTo(4.5));
-            assertThat(source.getValue("inference.deployments.model_sizes_bytes.total"), equalTo(1300.0));
-            assertThat(source.getValue("inference.deployments.model_sizes_bytes.min"), equalTo(300.0));
+            assertThat(source.getValue("inference.deployments.inference_counts.avg"), equalTo(3.0));
+            assertThat(source.getValue(new String[]{"inference", "deployments", "inference_counts_by_model", ".internal_model_3", "total"}),
+                equalTo(5.0));
+            assertThat(source.getValue(new String[]{"inference", "deployments", "inference_counts_by_model", ".internal_model_3", "min"}),
+                equalTo(5.0));
+            assertThat(source.getValue(new String[]{"inference", "deployments", "inference_counts_by_model", ".internal_model_3", "max"}),
+                equalTo(5.0));
+            assertThat(source.getValue(new String[]{"inference", "deployments", "inference_counts_by_model", ".internal_model_3", "avg"}),
+                equalTo(5.0));
+            assertThat(source.getValue("inference.deployments.inference_counts_by_model.other.total"), equalTo(4.0));
+            assertThat(source.getValue("inference.deployments.inference_counts_by_model.other.min"), equalTo(1.0));
+            assertThat(source.getValue("inference.deployments.inference_counts_by_model.other.max"), equalTo(3.0));
+            assertThat(source.getValue("inference.deployments.inference_counts_by_model.other.avg"), equalTo(2.0));
+            assertThat(source.getValue("inference.deployments.model_sizes_bytes.total"), equalTo(1500.0));
+            assertThat(source.getValue("inference.deployments.model_sizes_bytes.min"), equalTo(200.0));
             assertThat(source.getValue("inference.deployments.model_sizes_bytes.max"), equalTo(1000.0));
-            assertThat(source.getValue("inference.deployments.model_sizes_bytes.avg"), equalTo(650.0));
+            assertThat(source.getValue("inference.deployments.model_sizes_bytes.avg"), equalTo(500.0));
             assertThat(source.getValue("inference.deployments.time_ms.avg"), closeTo(45.55555555555556, 1e-10));
         }
     }
@@ -952,7 +974,37 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
                             ),
                             2,
                             null,
-                            null
+                            new AssignmentStats(
+                                "deployment_2",
+                                "third_party_model_2",
+                                2,
+                                2,
+                                1000,
+                                ByteSizeValue.ofBytes(1000),
+                                Instant.now(),
+                                List.of(
+                                    AssignmentStats.NodeStats.forStartedState(
+                                        DiscoveryNodeUtils.create("baz", new TransportAddress(TransportAddress.META_ADDRESS, 3)),
+                                        3,
+                                        50.0,
+                                        50.0,
+                                        0,
+                                        1,
+                                        1L,
+                                        2,
+                                        3,
+                                        Instant.now(),
+                                        Instant.now(),
+                                        randomIntBetween(1, 16),
+                                        randomIntBetween(1, 16),
+                                        2L,
+                                        4L,
+                                        34.0,
+                                        1L
+                                    )
+                                ),
+                                Priority.NORMAL
+                            ).setState(AssignmentState.STARTED).setAllocationStatus(new AllocationStatus(2, 2))
                         ),
                         new GetTrainedModelsStatsAction.Response.TrainedModelStats(
                             trainedModel3.getModelId(),
@@ -975,13 +1027,33 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
                             null,
                             new AssignmentStats(
                                 "deployment_3",
-                                "model_3",
+                                ".internal_model_3",
                                 null,
                                 null,
                                 null,
                                 null,
                                 Instant.now(),
-                                List.of(),
+                                List.of(
+                                    AssignmentStats.NodeStats.forStartedState(
+                                        DiscoveryNodeUtils.create("foo", new TransportAddress(TransportAddress.META_ADDRESS, 2)),
+                                        5,
+                                        42.0,
+                                        42.0,
+                                        0,
+                                        1,
+                                        3L,
+                                        2,
+                                        3,
+                                        Instant.now(),
+                                        Instant.now(),
+                                        randomIntBetween(1, 16),
+                                        randomIntBetween(1, 16),
+                                        1L,
+                                        2L,
+                                        33.0,
+                                        1L
+                                    )
+                                ),
                                 Priority.NORMAL
                             ).setState(AssignmentState.STOPPING)
                         ),
@@ -1006,7 +1078,7 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
                             null,
                             new AssignmentStats(
                                 "deployment_4",
-                                "model_4",
+                                "third_party_model_4",
                                 2,
                                 2,
                                 1000,
@@ -1014,27 +1086,8 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
                                 Instant.now(),
                                 List.of(
                                     AssignmentStats.NodeStats.forStartedState(
-                                        DiscoveryNodeUtils.create("foo", new TransportAddress(TransportAddress.META_ADDRESS, 2)),
-                                        5,
-                                        42.0,
-                                        42.0,
-                                        0,
-                                        1,
-                                        3L,
-                                        2,
-                                        3,
-                                        Instant.now(),
-                                        Instant.now(),
-                                        randomIntBetween(1, 16),
-                                        randomIntBetween(1, 16),
-                                        1L,
-                                        2L,
-                                        33.0,
-                                        1L
-                                    ),
-                                    AssignmentStats.NodeStats.forStartedState(
                                         DiscoveryNodeUtils.create("bar", new TransportAddress(TransportAddress.META_ADDRESS, 3)),
-                                        4,
+                                        1,
                                         50.0,
                                         50.0,
                                         0,

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningInfoTransportActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningInfoTransportActionTests.java
@@ -61,6 +61,7 @@ import org.elasticsearch.xpack.core.ml.inference.assignment.Priority;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ClassificationConfig;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.NerConfig;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.RegressionConfig;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TextExpansionConfig;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TrainedModelSizeStats;
 import org.elasticsearch.xpack.core.ml.job.config.AnalysisConfig;
 import org.elasticsearch.xpack.core.ml.job.config.DataDescription;
@@ -336,29 +337,29 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
             assertThat(source.getValue("inference.ingest_processors._all.num_failures.min"), equalTo(100));
             assertThat(source.getValue("inference.ingest_processors._all.num_failures.max"), equalTo(500));
             assertThat(source.getValue("inference.deployments.count"), equalTo(3));
-            assertThat(source.getValue("inference.deployments.inference_counts.total"), equalTo(9.0));
-            assertThat(source.getValue("inference.deployments.inference_counts.min"), equalTo(1.0));
+            assertThat(source.getValue("inference.deployments.inference_counts.total"), equalTo(12.0));
+            assertThat(source.getValue("inference.deployments.inference_counts.min"), equalTo(3.0));
             assertThat(source.getValue("inference.deployments.inference_counts.max"), equalTo(5.0));
-            assertThat(source.getValue("inference.deployments.inference_counts.avg"), equalTo(3.0));
-            assertThat(source.getValue("inference.deployments.stats_by_model.internal_model_3.task_type"), equalTo("ner"));
-            assertThat(source.getValue("inference.deployments.stats_by_model.internal_model_3.last_access"),
-                equalTo(lastAccess(3).toString()));
-            assertThat(source.getValue("inference.deployments.stats_by_model.internal_model_3.inference_counts.total"), equalTo(5.0));
-            assertThat(source.getValue("inference.deployments.stats_by_model.internal_model_3.inference_counts.min"), equalTo(5.0));
-            assertThat(source.getValue("inference.deployments.stats_by_model.internal_model_3.inference_counts.max"), equalTo(5.0));
-            assertThat(source.getValue("inference.deployments.stats_by_model.internal_model_3.inference_counts.avg"), equalTo(5.0));
-            assertThat(source.getValue("inference.deployments.stats_by_model.other.task_type"), equalTo("regression"));
-            assertThat(source.getValue("inference.deployments.stats_by_model.other.last_access"),
-                equalTo(lastAccess(4).toString()));
-            assertThat(source.getValue("inference.deployments.stats_by_model.other.inference_counts.total"), equalTo(4.0));
-            assertThat(source.getValue("inference.deployments.stats_by_model.other.inference_counts.min"), equalTo(1.0));
-            assertThat(source.getValue("inference.deployments.stats_by_model.other.inference_counts.max"), equalTo(3.0));
-            assertThat(source.getValue("inference.deployments.stats_by_model.other.inference_counts.avg"), equalTo(2.0));
+            assertThat(source.getValue("inference.deployments.inference_counts.avg"), equalTo(4.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.1.model_id"), equalTo("model_3"));
+            assertThat(source.getValue("inference.deployments.stats_by_model.1.task_type"), equalTo("ner"));
+            assertThat(source.getValue("inference.deployments.stats_by_model.1.last_access"), equalTo(lastAccess(3).toString()));
+            assertThat(source.getValue("inference.deployments.stats_by_model.1.inference_counts.total"), equalTo(3.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.1.inference_counts.min"), equalTo(3.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.1.inference_counts.max"), equalTo(3.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.1.inference_counts.avg"), equalTo(3.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.2.model_id"), equalTo("model_4"));
+            assertThat(source.getValue("inference.deployments.stats_by_model.2.task_type"), equalTo("text_expansion"));
+            assertThat(source.getValue("inference.deployments.stats_by_model.2.last_access"), equalTo(lastAccess(44).toString()));
+            assertThat(source.getValue("inference.deployments.stats_by_model.2.inference_counts.total"), equalTo(9.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.2.inference_counts.min"), equalTo(4.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.2.inference_counts.max"), equalTo(5.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.2.inference_counts.avg"), equalTo(4.5));
             assertThat(source.getValue("inference.deployments.model_sizes_bytes.total"), equalTo(1500.0));
             assertThat(source.getValue("inference.deployments.model_sizes_bytes.min"), equalTo(200.0));
             assertThat(source.getValue("inference.deployments.model_sizes_bytes.max"), equalTo(1000.0));
             assertThat(source.getValue("inference.deployments.model_sizes_bytes.avg"), equalTo(500.0));
-            assertThat(source.getValue("inference.deployments.time_ms.avg"), closeTo(45.55555555555556, 1e-10));
+            assertThat(source.getValue("inference.deployments.time_ms.avg"), closeTo(44.0, 1e-10));
         }
     }
 
@@ -434,29 +435,29 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
             assertThat(source.getValue("inference.ingest_processors._all.num_failures.min"), equalTo(100));
             assertThat(source.getValue("inference.ingest_processors._all.num_failures.max"), equalTo(500));
             assertThat(source.getValue("inference.deployments.count"), equalTo(3));
-            assertThat(source.getValue("inference.deployments.inference_counts.total"), equalTo(9.0));
-            assertThat(source.getValue("inference.deployments.inference_counts.min"), equalTo(1.0));
+            assertThat(source.getValue("inference.deployments.inference_counts.total"), equalTo(12.0));
+            assertThat(source.getValue("inference.deployments.inference_counts.min"), equalTo(3.0));
             assertThat(source.getValue("inference.deployments.inference_counts.max"), equalTo(5.0));
-            assertThat(source.getValue("inference.deployments.inference_counts.avg"), equalTo(3.0));
-            assertThat(source.getValue("inference.deployments.stats_by_model.internal_model_3.task_type"), equalTo("ner"));
-            assertThat(source.getValue("inference.deployments.stats_by_model.internal_model_3.last_access"),
-                equalTo(lastAccess(3).toString()));
-            assertThat(source.getValue("inference.deployments.stats_by_model.internal_model_3.inference_counts.total"), equalTo(5.0));
-            assertThat(source.getValue("inference.deployments.stats_by_model.internal_model_3.inference_counts.min"), equalTo(5.0));
-            assertThat(source.getValue("inference.deployments.stats_by_model.internal_model_3.inference_counts.max"), equalTo(5.0));
-            assertThat(source.getValue("inference.deployments.stats_by_model.internal_model_3.inference_counts.avg"), equalTo(5.0));
-            assertThat(source.getValue("inference.deployments.stats_by_model.other.task_type"), equalTo("regression"));
-            assertThat(source.getValue("inference.deployments.stats_by_model.other.last_access"),
-                equalTo(lastAccess(4).toString()));
-            assertThat(source.getValue("inference.deployments.stats_by_model.other.inference_counts.total"), equalTo(4.0));
-            assertThat(source.getValue("inference.deployments.stats_by_model.other.inference_counts.min"), equalTo(1.0));
-            assertThat(source.getValue("inference.deployments.stats_by_model.other.inference_counts.max"), equalTo(3.0));
-            assertThat(source.getValue("inference.deployments.stats_by_model.other.inference_counts.avg"), equalTo(2.0));
+            assertThat(source.getValue("inference.deployments.inference_counts.avg"), equalTo(4.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.1.model_id"), equalTo("model_3"));
+            assertThat(source.getValue("inference.deployments.stats_by_model.1.task_type"), equalTo("ner"));
+            assertThat(source.getValue("inference.deployments.stats_by_model.1.last_access"), equalTo(lastAccess(3).toString()));
+            assertThat(source.getValue("inference.deployments.stats_by_model.1.inference_counts.total"), equalTo(3.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.1.inference_counts.min"), equalTo(3.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.1.inference_counts.max"), equalTo(3.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.1.inference_counts.avg"), equalTo(3.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.2.model_id"), equalTo("model_4"));
+            assertThat(source.getValue("inference.deployments.stats_by_model.2.task_type"), equalTo("text_expansion"));
+            assertThat(source.getValue("inference.deployments.stats_by_model.2.last_access"), equalTo(lastAccess(44).toString()));
+            assertThat(source.getValue("inference.deployments.stats_by_model.2.inference_counts.total"), equalTo(9.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.2.inference_counts.min"), equalTo(4.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.2.inference_counts.max"), equalTo(5.0));
+            assertThat(source.getValue("inference.deployments.stats_by_model.2.inference_counts.avg"), equalTo(4.5));
             assertThat(source.getValue("inference.deployments.model_sizes_bytes.total"), equalTo(1500.0));
             assertThat(source.getValue("inference.deployments.model_sizes_bytes.min"), equalTo(200.0));
             assertThat(source.getValue("inference.deployments.model_sizes_bytes.max"), equalTo(1000.0));
             assertThat(source.getValue("inference.deployments.model_sizes_bytes.avg"), equalTo(500.0));
-            assertThat(source.getValue("inference.deployments.time_ms.avg"), closeTo(45.55555555555556, 1e-10));
+            assertThat(source.getValue("inference.deployments.time_ms.avg"), closeTo(44.0, 1e-10));
         }
     }
 
@@ -903,27 +904,28 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
             expectedDfaCountByAnalysis.put(analysisName, ++analysisCount);
         });
 
-        TrainedModelConfig trainedModel1 = TrainedModelConfigTests.createTestInstance(".internal_model_1")
+        TrainedModelConfig trainedModel1 = TrainedModelConfigTests.createTestInstance("model_1")
             .setModelSize(100)
             .setEstimatedOperations(200)
             .setMetadata(Collections.singletonMap("analytics_config", "anything"))
             .setInferenceConfig(ClassificationConfig.EMPTY_PARAMS)
             .build();
-        TrainedModelConfig trainedModel2 = TrainedModelConfigTests.createTestInstance("third_party_model_2")
+        TrainedModelConfig trainedModel2 = TrainedModelConfigTests.createTestInstance("model_2")
             .setModelSize(200)
             .setEstimatedOperations(400)
             .setMetadata(Collections.singletonMap("analytics_config", "anything"))
             .setInferenceConfig(RegressionConfig.EMPTY_PARAMS)
             .build();
-        TrainedModelConfig trainedModel3 = TrainedModelConfigTests.createTestInstance(".internal_model_3")
+        TrainedModelConfig trainedModel3 = TrainedModelConfigTests.createTestInstance("model_3")
             .setModelSize(300)
             .setEstimatedOperations(600)
             .setInferenceConfig(new NerConfig(null, null, null, null))
             .build();
-        TrainedModelConfig trainedModel4 = TrainedModelConfigTests.createTestInstance("third_party_model_4")
+        TrainedModelConfig trainedModel4 = TrainedModelConfigTests.createTestInstance("model_4")
             .setTags(Collections.singletonList("prepackaged"))
             .setModelSize(1000)
             .setEstimatedOperations(2000)
+            .setInferenceConfig(new TextExpansionConfig(null, null, null))
             .build();
         givenTrainedModels(Arrays.asList(trainedModel1, trainedModel2, trainedModel3, trainedModel4));
 
@@ -980,33 +982,13 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
                             null,
                             new AssignmentStats(
                                 "deployment_2",
-                                "third_party_model_2",
+                                "model_2",
                                 2,
                                 2,
                                 1000,
                                 ByteSizeValue.ofBytes(1000),
                                 Instant.now(),
-                                List.of(
-                                    AssignmentStats.NodeStats.forStartedState(
-                                        DiscoveryNodeUtils.create("baz", new TransportAddress(TransportAddress.META_ADDRESS, 3)),
-                                        3,
-                                        50.0,
-                                        50.0,
-                                        0,
-                                        1,
-                                        1L,
-                                        2,
-                                        3,
-                                        lastAccess(2),
-                                        Instant.now(),
-                                        randomIntBetween(1, 16),
-                                        randomIntBetween(1, 16),
-                                        2L,
-                                        4L,
-                                        34.0,
-                                        1L
-                                    )
-                                ),
+                                List.of(),
                                 Priority.NORMAL
                             ).setState(AssignmentState.STARTED).setAllocationStatus(new AllocationStatus(2, 2))
                         ),
@@ -1031,7 +1013,7 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
                             null,
                             new AssignmentStats(
                                 "deployment_3",
-                                ".internal_model_3",
+                                "model_3",
                                 null,
                                 null,
                                 null,
@@ -1040,9 +1022,9 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
                                 List.of(
                                     AssignmentStats.NodeStats.forStartedState(
                                         DiscoveryNodeUtils.create("foo", new TransportAddress(TransportAddress.META_ADDRESS, 2)),
-                                        5,
-                                        42.0,
-                                        42.0,
+                                        3,
+                                        41.0,
+                                        41.0,
                                         0,
                                         1,
                                         3L,
@@ -1082,7 +1064,7 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
                             null,
                             new AssignmentStats(
                                 "deployment_4",
-                                "third_party_model_4",
+                                "model_4",
                                 2,
                                 2,
                                 1000,
@@ -1090,8 +1072,27 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
                                 Instant.now(),
                                 List.of(
                                     AssignmentStats.NodeStats.forStartedState(
-                                        DiscoveryNodeUtils.create("bar", new TransportAddress(TransportAddress.META_ADDRESS, 3)),
+                                        DiscoveryNodeUtils.create("foo", new TransportAddress(TransportAddress.META_ADDRESS, 2)),
+                                        5,
+                                        41.0,
+                                        41.0,
+                                        0,
                                         1,
+                                        3L,
+                                        2,
+                                        3,
+                                        lastAccess(4),
+                                        Instant.now(),
+                                        randomIntBetween(1, 16),
+                                        randomIntBetween(1, 16),
+                                        1L,
+                                        2L,
+                                        33.0,
+                                        1L
+                                    ),
+                                    AssignmentStats.NodeStats.forStartedState(
+                                        DiscoveryNodeUtils.create("bar", new TransportAddress(TransportAddress.META_ADDRESS, 3)),
+                                        4,
                                         50.0,
                                         50.0,
                                         0,
@@ -1099,7 +1100,7 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
                                         1L,
                                         2,
                                         3,
-                                        lastAccess(4),
+                                        lastAccess(44),
                                         Instant.now(),
                                         randomIntBetween(1, 16),
                                         randomIntBetween(1, 16),


### PR DESCRIPTION
See: https://github.com/elastic/ml-team/issues/1010

This PR adds a section `stats_by_model` to `ml.inference.deployments`, like:
```
      "deployments" : {
        "count" : 1,
        "time_ms" : {
          "avg" : 33.0
        },
        "stats_by_model" : [
          {
            "last_access" : "2023-11-10T07:47:18.926Z",
            "inference_counts" : {
              "total" : 3.0,
              "min" : 3.0,
              "avg" : 3.0,
              "max" : 3.0
            },
            "model_id" : ".elser_model_2",
            "task_type" : "text_expansion"
          }
        ],
        "inference_counts" : {
          "total" : 3.0,
          "min" : 3.0,
          "avg" : 3.0,
          "max" : 3.0
        },
        "model_sizes_bytes" : {
          "total" : 4.38123914E8,
          "min" : 4.38123914E8,
          "avg" : 4.38123914E8,
          "max" : 4.38123914E8
        }
      }
```