### PR TITLE
Metrics for jvm threads and open file descriptor

### DIFF
--- a/docs/changelog/101916.yaml
+++ b/docs/changelog/101916.yaml
@@ -1,0 +1,5 @@
+pr: 101916
+summary: Metrics from jvm threads and open file descriptor
+area: Search
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/monitor/MonitorMetrics.java
+++ b/server/src/main/java/org/elasticsearch/monitor/MonitorMetrics.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.monitor;
+
+import org.elasticsearch.monitor.jvm.JvmService;
+import org.elasticsearch.monitor.process.ProcessService;
+import org.elasticsearch.telemetry.metric.LongGauge;
+import org.elasticsearch.telemetry.metric.MeterRegistry;
+
+public class MonitorMetrics {
+    private final LongGauge threadsGauge;
+    private final LongGauge openFileDescriptorGauge;
+
+    public MonitorMetrics(MeterRegistry meterRegistry, JvmService jvmService, ProcessService processService) {
+        this(
+            meterRegistry.registerLongGauge(
+                "elasticsearch.jvm.threads",
+                "The number of threads in the JVM",
+                "threads",
+                jvmService.threadsCountSupplier()
+            ),
+            meterRegistry.registerLongGauge(
+                "elasticsearch.process.open_file_descriptors",
+                "The number of open file descriptors for the Elasticsearch process",
+                "files",
+                processService.openFileDescriptorSupplier()
+            )
+        );
+    }
+
+    MonitorMetrics(LongGauge threadsGauge, LongGauge openFileDescriptorGauge) {
+        this.threadsGauge = threadsGauge;
+        this.openFileDescriptorGauge = openFileDescriptorGauge;
+    }
+
+    public LongGauge getThreadsGauge() {
+        return threadsGauge;
+    }
+
+    public LongGauge getOpenFileDescriptorGauge() {
+        return openFileDescriptorGauge;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/monitor/MonitorService.java
+++ b/server/src/main/java/org/elasticsearch/monitor/MonitorService.java
@@ -16,6 +16,7 @@ import org.elasticsearch.monitor.jvm.JvmGcMonitorService;
 import org.elasticsearch.monitor.jvm.JvmService;
 import org.elasticsearch.monitor.os.OsService;
 import org.elasticsearch.monitor.process.ProcessService;
+import org.elasticsearch.telemetry.metric.MeterRegistry;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.io.IOException;
@@ -27,13 +28,16 @@ public class MonitorService extends AbstractLifecycleComponent {
     private final ProcessService processService;
     private final JvmService jvmService;
     private final FsService fsService;
+    private final MonitorMetrics monitorMetrics;
 
-    public MonitorService(Settings settings, NodeEnvironment nodeEnvironment, ThreadPool threadPool) throws IOException {
+    public MonitorService(Settings settings, NodeEnvironment nodeEnvironment, ThreadPool threadPool, MeterRegistry meterRegistry)
+        throws IOException {
         this.jvmGcMonitorService = new JvmGcMonitorService(settings, threadPool);
         this.osService = new OsService(settings);
         this.processService = new ProcessService(settings);
         this.jvmService = new JvmService(settings);
         this.fsService = new FsService(settings, nodeEnvironment);
+        this.monitorMetrics = new MonitorMetrics(meterRegistry, this.jvmService, this.processService);
     }
 
     public OsService osService() {
@@ -46,6 +50,10 @@ public class MonitorService extends AbstractLifecycleComponent {
 
     public JvmService jvmService() {
         return this.jvmService;
+    }
+
+    public MonitorMetrics monitorMetrics() {
+        return this.monitorMetrics;
     }
 
     public FsService fsService() {

--- a/server/src/main/java/org/elasticsearch/monitor/jvm/JvmService.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/JvmService.java
@@ -16,6 +16,10 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.SingleObjectCache;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.node.ReportingService;
+import org.elasticsearch.telemetry.metric.LongWithAttributes;
+
+import java.util.Map;
+import java.util.function.Supplier;
 
 public class JvmService implements ReportingService<JvmInfo> {
 
@@ -46,6 +50,10 @@ public class JvmService implements ReportingService<JvmInfo> {
 
     public JvmStats stats() {
         return jvmStatsCache.getOrRefresh();
+    }
+
+    public Supplier<LongWithAttributes> threadsCountSupplier() {
+        return () -> new LongWithAttributes(jvmStatsCache.getOrRefresh().getThreads().getCount(), Map.of());
     }
 
     private class JvmStatsCache extends SingleObjectCache<JvmStats> {

--- a/server/src/main/java/org/elasticsearch/monitor/jvm/JvmService.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/JvmService.java
@@ -53,7 +53,7 @@ public class JvmService implements ReportingService<JvmInfo> {
     }
 
     public Supplier<LongWithAttributes> threadsCountSupplier() {
-        return () -> new LongWithAttributes(jvmStatsCache.getOrRefresh().getThreads().getCount(), Map.of());
+        return () -> new LongWithAttributes(stats().getThreads().getCount(), Map.of());
     }
 
     private class JvmStatsCache extends SingleObjectCache<JvmStats> {

--- a/server/src/main/java/org/elasticsearch/monitor/process/ProcessService.java
+++ b/server/src/main/java/org/elasticsearch/monitor/process/ProcessService.java
@@ -16,6 +16,10 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.SingleObjectCache;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.node.ReportingService;
+import org.elasticsearch.telemetry.metric.LongWithAttributes;
+
+import java.util.Map;
+import java.util.function.Supplier;
 
 public final class ProcessService implements ReportingService<ProcessInfo> {
 
@@ -45,6 +49,10 @@ public final class ProcessService implements ReportingService<ProcessInfo> {
 
     public ProcessStats stats() {
         return processStatsCache.getOrRefresh();
+    }
+
+    public Supplier<LongWithAttributes> openFileDescriptorSupplier() {
+        return () -> new LongWithAttributes(stats().getOpenFileDescriptors(), Map.of());
     }
 
     private static class ProcessStatsCache extends SingleObjectCache<ProcessStats> {

--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -605,7 +605,12 @@ class NodeConstruction {
         final ExecutorSelector executorSelector = systemIndices.getExecutorSelector();
 
         ModulesBuilder modules = new ModulesBuilder();
-        final MonitorService monitorService = new MonitorService(settings, nodeEnvironment, threadPool);
+        final MonitorService monitorService = new MonitorService(
+            settings,
+            nodeEnvironment,
+            threadPool,
+            telemetryProvider.getMeterRegistry()
+        );
         final FsHealthService fsHealthService = new FsHealthService(
             settings,
             clusterService.getClusterSettings(),


### PR DESCRIPTION
Added metrics: `elasticsearch.jvm.threads` and `elasticsearch.process.open_file_descriptors`. Both metrics where available in node stats API under `jvm.threads.count` and `process.open_file_descriptors` but not scraped by Metricbeat.
For both metrics we used `LongGauge` since we want to record non-additive long values.
In `JvmService` and in `ProcessService` we created a supplier function to be used as a callback to update the gauge and in the callback we use the SingleObjectCache implementation (`JvmStatsCache` and `ProcessStatsCache`) to getOrRefresh the current count.
The class `MonitorMetrics` uses the same pattern used in https://github.com/elastic/elasticsearch/pull/101577 
