### PR TITLE
[DOCS] Adds AI assistant functionality to Using ES|QL page

### DIFF
--- a/docs/reference/esql/esql-using.asciidoc
+++ b/docs/reference/esql/esql-using.asciidoc
@@ -9,7 +9,7 @@ Using {esql} in {kib} to query and aggregate your data, create visualizations,
 and set up alerts.
 
 <<esql-elastic-security>>::
-Using {esql} in {elastic-sec} to investigate events in Timeline and create
+Using {esql} in {elastic-sec} to investigate events in Timeline, create
 detection rules, and build {esql} queries using Elastic AI Assistant. 
 
 <<esql-task-management>>::

--- a/docs/reference/esql/esql-using.asciidoc
+++ b/docs/reference/esql/esql-using.asciidoc
@@ -10,7 +10,7 @@ and set up alerts.
 
 <<esql-elastic-security>>::
 Using {esql} in {elastic-sec} to investigate events in Timeline and create
-detection rules.
+detection rules, and build {esql} queries using Elastic AI Assistant. 
 
 <<esql-task-management>>::
 Using the <<tasks,task management API>> to list and cancel {esql} queries.


### PR DESCRIPTION
Adds AI assistant functionality to the [Using ES|QL](https://www.elastic.co/guide/en/elasticsearch/reference/current/esql-using.html) page.