### PR TITLE
[8.11] [DOCS] Adds AI assistant functionality to Using ES|QL page (#101918)

### DIFF
--- a/docs/reference/esql/esql-using.asciidoc
+++ b/docs/reference/esql/esql-using.asciidoc
@@ -9,8 +9,8 @@ Using {esql} in {kib} to query and aggregate your data, create visualizations,
 and set up alerts.
 
 <<esql-elastic-security>>::
-Using {esql} in {elastic-sec} to investigate events in Timeline and create
-detection rules.
+Using {esql} in {elastic-sec} to investigate events in Timeline, create
+detection rules, and build {esql} queries using Elastic AI Assistant. 
 
 <<esql-task-management>>::
 Using the <<tasks,task management API>> to list and cancel {esql} queries.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.11`:
 - [[DOCS] Adds AI assistant functionality to Using ES|QL page (#101918)](https://github.com/elastic/elasticsearch/pull/101918)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)