### PR TITLE
[8.11] Dry up AsyncTaskIndexService memory management and fix inefficient circuit breaker use (#101892)

### DIFF
--- a/docs/changelog/101892.yaml
+++ b/docs/changelog/101892.yaml
@@ -1,0 +1,6 @@
+pr: 101892
+summary: Dry up `AsyncTaskIndexService` memory management and fix inefficient circuit
+  breaker use
+area: Search
+type: bug
+issues: []


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Dry up AsyncTaskIndexService memory management and fix inefficient circuit breaker use (#101892)