### PR TITLE
[8.11] Mute failing test in SearchQueryThenFetchAsyncActionTests (#101933)

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncActionTests.java
@@ -237,6 +237,7 @@ public class SearchQueryThenFetchAsyncActionTests extends ESTestCase {
         assertThat(((FieldDoc) phase.sortedTopDocs().scoreDocs()[0]).fields[0], equalTo(0));
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/101932")
     public void testMinimumVersionSameAsNewVersion() throws Exception {
         Version newVersion = Version.CURRENT;
         Version oldVersion = VersionUtils.randomVersionBetween(
@@ -354,6 +355,7 @@ public class SearchQueryThenFetchAsyncActionTests extends ESTestCase {
         );
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/101932")
     public void testMinimumVersionSameAsOldVersion() throws Exception {
         Version newVersion = Version.CURRENT;
         Version oldVersion = VersionUtils.randomVersionBetween(
@@ -500,6 +502,7 @@ public class SearchQueryThenFetchAsyncActionTests extends ESTestCase {
         assertThat(phase.totalHits().relation, equalTo(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO));
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/101932")
     public void testMinimumVersionShardDuringPhaseExecution() throws Exception {
         Version newVersion = Version.CURRENT;
         Version oldVersion = VersionUtils.randomVersionBetween(


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Mute failing test in SearchQueryThenFetchAsyncActionTests (#101933)