### PR TITLE
Derive expected shard size from forecast field

### DIFF
--- a/docs/changelog/101950.yaml
+++ b/docs/changelog/101950.yaml
@@ -1,0 +1,5 @@
+pr: 101950
+summary: Derive expected shard size from forecast field
+area: Allocation
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/cluster/routing/ExpectedShardSizeEstimator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/ExpectedShardSizeEstimator.java
@@ -51,7 +51,10 @@ public class ExpectedShardSizeEstimator {
         } else if (shard.unassigned() && shard.recoverySource().getType() == RecoverySource.Type.SNAPSHOT) {
             return snapshotShardSizeInfo.getShardSize(shard, defaultValue);
         } else {
-            return clusterInfo.getShardSize(shard, defaultValue);
+            return Math.max(
+                indexMetadata.getForecastedShardSizeInBytes().orElse(defaultValue),
+                clusterInfo.getShardSize(shard, defaultValue)
+            );
         }
     }
 


### PR DESCRIPTION
This change derives expected shard size from data stream shard size forecast allowing it to proactively allocate shard that is expected to grow to the node with enough disk space to avoid future relocations.
