### PR TITLE
[8.11] Fail listener on exception in TcpTransport#openConnection (#101907)

### DIFF
--- a/docs/changelog/101907.yaml
+++ b/docs/changelog/101907.yaml
@@ -1,0 +1,6 @@
+pr: 101907
+summary: Fail listener on exception in `TcpTransport#openConnection`
+area: Network
+type: bug
+issues:
+ - 100510


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Fail listener on exception in TcpTransport#openConnection (#101907)