### PR TITLE
[ML] Skip multi-deployment test in single processor tests

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlAssignmentPlannerUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlAssignmentPlannerUpgradeIT.java
@@ -30,6 +30,10 @@ import static org.hamcrest.Matchers.hasSize;
 
 public class MlAssignmentPlannerUpgradeIT extends AbstractUpgradeTestCase {
 
+    private static final boolean IS_SINGLE_PROCESSOR_TEST = Boolean.parseBoolean(
+        System.getProperty("tests.configure_test_clusters_with_one_processor", "false")
+    );
+
     private Logger logger = LogManager.getLogger(MlAssignmentPlannerUpgradeIT.class);
 
     // See PyTorchModelIT for how this model was created
@@ -61,9 +65,9 @@ public class MlAssignmentPlannerUpgradeIT extends AbstractUpgradeTestCase {
         RAW_MODEL_SIZE = Base64.getDecoder().decode(BASE_64_ENCODED_MODEL).length;
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/101926")
     public void testMlAssignmentPlannerUpgrade() throws Exception {
         assumeTrue("NLP model deployments added in 8.0", isOriginalClusterVersionAtLeast(Version.V_8_0_0));
+        assumeFalse("This test deploys multiple models which cannot be accommodated on a single processor", IS_SINGLE_PROCESSOR_TEST);
 
         logger.info("Starting testMlAssignmentPlannerUpgrade, model size {}", RAW_MODEL_SIZE);
 


### PR DESCRIPTION
`MlAssignmentPlannerUpgradeIT` creates 2 model deployments, the second will fail in single processor tests due to insufficient CPUs to run the deployment. The fix here is to skip the test when running on a single CPU.

An alternative option considered was to use low priority deployments but this functionality was added in v8.6 and the upgrade tests run from v8.0. 

Note in the same test suite the test `MLModelDeploymentsUpgradeIT` also creates a model deployment. That test is not skipped for single processor tests so there is coverage of upgrades on a single processor.

Closes #101926 

