### PR TITLE
Only export APM plugin from apm module

### DIFF
--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/APMMeterRegistry.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/APMMeterRegistry.java
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-package org.elasticsearch.telemetry.apm;
+package org.elasticsearch.telemetry.apm.internal;
 
 import io.opentelemetry.api.metrics.Meter;
 

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/APMMeterService.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/APMMeterService.java
@@ -15,7 +15,6 @@ import io.opentelemetry.api.metrics.Meter;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.telemetry.apm.APMMeterRegistry;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/APMTelemetryProvider.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/APMTelemetryProvider.java
@@ -10,7 +10,6 @@ package org.elasticsearch.telemetry.apm.internal;
 
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.telemetry.TelemetryProvider;
-import org.elasticsearch.telemetry.apm.APMMeterRegistry;
 import org.elasticsearch.telemetry.apm.internal.tracing.APMTracer;
 
 public class APMTelemetryProvider implements TelemetryProvider {

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/AbstractInstrument.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/AbstractInstrument.java
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-package org.elasticsearch.telemetry.apm;
+package org.elasticsearch.telemetry.apm.internal;
 
 import io.opentelemetry.api.metrics.Meter;
 

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/metrics/DoubleCounterAdapter.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/metrics/DoubleCounterAdapter.java
@@ -11,7 +11,7 @@ package org.elasticsearch.telemetry.apm.internal.metrics;
 import io.opentelemetry.api.metrics.DoubleCounter;
 import io.opentelemetry.api.metrics.Meter;
 
-import org.elasticsearch.telemetry.apm.AbstractInstrument;
+import org.elasticsearch.telemetry.apm.internal.AbstractInstrument;
 
 import java.util.Map;
 import java.util.Objects;

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/metrics/DoubleGaugeAdapter.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/metrics/DoubleGaugeAdapter.java
@@ -12,7 +12,7 @@ import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.ObservableDoubleGauge;
 
 import org.elasticsearch.common.util.concurrent.ReleasableLock;
-import org.elasticsearch.telemetry.apm.AbstractInstrument;
+import org.elasticsearch.telemetry.apm.internal.AbstractInstrument;
 import org.elasticsearch.telemetry.metric.DoubleWithAttributes;
 
 import java.util.Objects;

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/metrics/DoubleHistogramAdapter.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/metrics/DoubleHistogramAdapter.java
@@ -11,7 +11,7 @@ package org.elasticsearch.telemetry.apm.internal.metrics;
 import io.opentelemetry.api.metrics.DoubleHistogram;
 import io.opentelemetry.api.metrics.Meter;
 
-import org.elasticsearch.telemetry.apm.AbstractInstrument;
+import org.elasticsearch.telemetry.apm.internal.AbstractInstrument;
 
 import java.util.Map;
 import java.util.Objects;

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/metrics/DoubleUpDownCounterAdapter.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/metrics/DoubleUpDownCounterAdapter.java
@@ -11,7 +11,7 @@ package org.elasticsearch.telemetry.apm.internal.metrics;
 import io.opentelemetry.api.metrics.DoubleUpDownCounter;
 import io.opentelemetry.api.metrics.Meter;
 
-import org.elasticsearch.telemetry.apm.AbstractInstrument;
+import org.elasticsearch.telemetry.apm.internal.AbstractInstrument;
 
 import java.util.Map;
 import java.util.Objects;

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/metrics/LongCounterAdapter.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/metrics/LongCounterAdapter.java
@@ -11,7 +11,7 @@ package org.elasticsearch.telemetry.apm.internal.metrics;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.Meter;
 
-import org.elasticsearch.telemetry.apm.AbstractInstrument;
+import org.elasticsearch.telemetry.apm.internal.AbstractInstrument;
 
 import java.util.Map;
 import java.util.Objects;

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/metrics/LongGaugeAdapter.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/metrics/LongGaugeAdapter.java
@@ -12,7 +12,7 @@ import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.ObservableLongGauge;
 
 import org.elasticsearch.common.util.concurrent.ReleasableLock;
-import org.elasticsearch.telemetry.apm.AbstractInstrument;
+import org.elasticsearch.telemetry.apm.internal.AbstractInstrument;
 import org.elasticsearch.telemetry.metric.LongWithAttributes;
 
 import java.util.Objects;

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/metrics/LongHistogramAdapter.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/metrics/LongHistogramAdapter.java
@@ -11,7 +11,7 @@ package org.elasticsearch.telemetry.apm.internal.metrics;
 import io.opentelemetry.api.metrics.LongHistogram;
 import io.opentelemetry.api.metrics.Meter;
 
-import org.elasticsearch.telemetry.apm.AbstractInstrument;
+import org.elasticsearch.telemetry.apm.internal.AbstractInstrument;
 
 import java.util.Map;
 import java.util.Objects;

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/metrics/LongUpDownCounterAdapter.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/metrics/LongUpDownCounterAdapter.java
@@ -11,7 +11,7 @@ package org.elasticsearch.telemetry.apm.internal.metrics;
 import io.opentelemetry.api.metrics.LongUpDownCounter;
 import io.opentelemetry.api.metrics.Meter;
 
-import org.elasticsearch.telemetry.apm.AbstractInstrument;
+import org.elasticsearch.telemetry.apm.internal.AbstractInstrument;
 
 import java.util.Map;
 import java.util.Objects;

--- a/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/MeterRegistryConcurrencyTests.java
+++ b/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/MeterRegistryConcurrencyTests.java
@@ -19,6 +19,7 @@ import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.ObservableLongCounter;
 import io.opentelemetry.api.metrics.ObservableLongMeasurement;
 
+import org.elasticsearch.telemetry.apm.internal.APMMeterRegistry;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.concurrent.CountDownLatch;

--- a/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/internal/APMMeterRegistryTests.java
+++ b/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/internal/APMMeterRegistryTests.java
@@ -6,12 +6,13 @@
  * Side Public License, v 1.
  */
 
-package org.elasticsearch.telemetry.apm;
+package org.elasticsearch.telemetry.apm.internal;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.metrics.Meter;
 
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.telemetry.apm.RecordingOtelMeter;
 import org.elasticsearch.telemetry.apm.internal.APMAgentSettings;
 import org.elasticsearch.telemetry.apm.internal.APMMeterService;
 import org.elasticsearch.telemetry.apm.internal.TestAPMMeterService;

--- a/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/internal/MeterRegistryConcurrencyTests.java
+++ b/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/internal/MeterRegistryConcurrencyTests.java
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-package org.elasticsearch.telemetry.apm;
+package org.elasticsearch.telemetry.apm.internal;
 
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.metrics.DoubleCounterBuilder;

--- a/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/internal/metrics/GaugeAdapterTests.java
+++ b/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/internal/metrics/GaugeAdapterTests.java
@@ -9,7 +9,7 @@
 package org.elasticsearch.telemetry.apm.internal.metrics;
 
 import org.elasticsearch.telemetry.Measurement;
-import org.elasticsearch.telemetry.apm.APMMeterRegistry;
+import org.elasticsearch.telemetry.apm.internal.APMMeterRegistry;
 import org.elasticsearch.telemetry.apm.RecordingOtelMeter;
 import org.elasticsearch.telemetry.metric.DoubleGauge;
 import org.elasticsearch.telemetry.metric.DoubleWithAttributes;


### PR DESCRIPTION
the implementation classes don't have to be on an exported package from the apm module.
The only class that should be created by server is `APM.java`