### PR TITLE
Fix incorrect dynamic mapping for non-numeric-value arrays #101965

### DIFF
--- a/docs/changelog/101967.yaml
+++ b/docs/changelog/101967.yaml
@@ -1,0 +1,5 @@
+pr: 101967
+summary: "Fix incorrect dynamic mapping for non-numeric-value arrays #101965"
+area: Mapping
+type: bug
+issues: []

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/60_dense_vector_dynamic_mapping.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/60_dense_vector_dynamic_mapping.yml
@@ -2,7 +2,38 @@ setup:
   - skip:
       version: ' - 8.10.99'
       reason: 'Dynamic mapping of floats to dense_vector was added in 8.11'
+---
+"Fields indexed as strings won't be transformed into dense_vector":
+  - skip:
+      # TODO adjust after backport
+      version: ' - 8.11.99'
+      reason: 'Dynamic mapping of things other than numbers is fixed in 8.12'
+  - do:
+      index:
+        index: strings-are-not-floats
+        refresh: true
+        body:
+          obviously_string: ["foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo",
+                           "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo",
+                           "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo",
+                           "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo",
+                           "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo",
+                           "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo",
+                           "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo",
+                           "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo",
+                           "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo",
+                           "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo",
+                           "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo",
+                           "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo",
+                           "foo", "foo", "foo", "foo", "foo", "foo", "foo", "foo"]
+  - do:
+      cluster.health:
+        wait_for_events: languid
+  - do:
+      indices.get_mapping:
+        index: strings-are-not-floats
 
+  - match: { strings-are-not-floats.mappings.properties.obviously_string.type: text }
 ---
 "Fields with float arrays below the threshold still map as float":
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -613,9 +613,12 @@ public final class DocumentParser {
                 || context.isCopyToField(fullFieldName)
                 || mappers.size() < MIN_DIMS_FOR_DYNAMIC_FLOAT_MAPPING
                 || mappers.size() > MAX_DIMS_COUNT
-                || mappers.stream().anyMatch(m -> m instanceof NumberFieldMapper.Builder == false)
+                // Anything that is NOT a number or anything that IS a number but not mapped to `float` should NOT be mapped to dense_vector
                 || mappers.stream()
-                    .allMatch(m -> m instanceof NumberFieldMapper.Builder nb && nb.type != NumberFieldMapper.NumberType.FLOAT)) {
+                    .anyMatch(
+                        m -> m instanceof NumberFieldMapper.Builder == false
+                            || ((NumberFieldMapper.Builder) m).type != NumberFieldMapper.NumberType.FLOAT
+                    )) {
                 return;
             }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -613,6 +613,7 @@ public final class DocumentParser {
                 || context.isCopyToField(fullFieldName)
                 || mappers.size() < MIN_DIMS_FOR_DYNAMIC_FLOAT_MAPPING
                 || mappers.size() > MAX_DIMS_COUNT
+                || mappers.stream().anyMatch(m -> m instanceof NumberFieldMapper.Builder == false)
                 || mappers.stream()
                     .allMatch(m -> m instanceof NumberFieldMapper.Builder nb && nb.type != NumberFieldMapper.NumberType.FLOAT)) {
                 return;

--- a/server/src/test/java/org/elasticsearch/index/mapper/DynamicMappingTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DynamicMappingTests.java
@@ -21,6 +21,7 @@ import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.stream.Stream;
 
 import static org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.MAX_DIMS_COUNT;
 import static org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.MIN_DIMS_FOR_DYNAMIC_FLOAT_MAPPING;
@@ -990,5 +991,16 @@ public class DynamicMappingTests extends MapperServiceTestCase {
         assertNotNull(update);
         ObjectMapper parent = (ObjectMapper) update.getRoot().getMapper("parent_object");
         assertThat(((FieldMapper) parent.getMapper("mapsToDenseVector")).fieldType().typeName(), equalTo("dense_vector"));
+    }
+
+    public void testStringArraysAreText() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(topMapping(b -> b.field("numeric_detection", true)));
+        BytesReference source = BytesReference.bytes(
+            XContentFactory.jsonBuilder().startObject().field("mapsToString", Stream.generate(() -> "foo").limit(129).toArray()).endObject()
+        );
+        ParsedDocument parsedDocument = mapper.parse(new SourceToParse("id", source, XContentType.JSON));
+        Mapping update = parsedDocument.dynamicMappingsUpdate();
+        assertNotNull(update);
+        assertThat(((FieldMapper) update.getRoot().getMapper("mapsToString")).fieldType().typeName(), equalTo("text"));
     }
 }


### PR DESCRIPTION
After https://github.com/elastic/elasticsearch/pull/98512 we incorrectly attempt to map an array of any single value type to dense_vector.

Instead, we should validate that ALL mappers are numeric and that ALL of them are `float`.

closes: https://github.com/elastic/elasticsearch/issues/101965