### PR TITLE
Added content-type to inference APIs

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.inference.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.inference.json
@@ -7,7 +7,8 @@
     "stability":"experimental",
     "visibility":"public",
     "headers":{
-      "accept": [ "application/json"]
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
     },
     "url":{
       "paths":[

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_model.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.put_model.json
@@ -7,7 +7,8 @@
     "stability":"experimental",
     "visibility":"public",
     "headers":{
-      "accept": [ "application/json"]
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
     },
     "url":{
       "paths":[


### PR DESCRIPTION
The `Content-Type` is missing for the `inference.inference` and inference.put_model` APIs in the specification.