### PR TITLE
[ML] Fix inference timeout from the Inference Ingest Processor

### DIFF
--- a/docs/changelog/101971.yaml
+++ b/docs/changelog/101971.yaml
@@ -1,0 +1,5 @@
+pr: 101971
+summary: Fix inference timeout from the Inference Ingest Processor
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/InferModelActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/InferModelActionRequestTests.java
@@ -54,12 +54,15 @@ public class InferModelActionRequestTests extends AbstractBWCWireSerializationTe
                 randomAlphaOfLength(10),
                 Stream.generate(InferModelActionRequestTests::randomMap).limit(randomInt(10)).collect(Collectors.toList()),
                 randomInferenceConfigUpdate(),
-                randomBoolean()
+                randomBoolean(),
+                TimeValue.timeValueMillis(randomLongBetween(1, 2048))
             )
             : Request.forTextInput(
                 randomAlphaOfLength(10),
                 randomInferenceConfigUpdate(),
-                Arrays.asList(generateRandomStringArray(3, 5, false))
+                Arrays.asList(generateRandomStringArray(3, 5, false)),
+                randomBoolean(),
+                TimeValue.timeValueMillis(randomLongBetween(1, 2048))
             );
 
         request.setHighPriority(randomBoolean());
@@ -114,7 +117,6 @@ public class InferModelActionRequestTests extends AbstractBWCWireSerializationTe
 
         var r = new Request(modelId, update, objectsToInfer, textInput, timeout, previouslyLicensed);
         r.setHighPriority(highPriority);
-        r.setInferenceTimeout(timeout);
         return r;
     }
 

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/license/MachineLearningLicensingIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/license/MachineLearningLicensingIT.java
@@ -669,8 +669,9 @@ public class MachineLearningLicensingIT extends BaseMlIntegTestCase {
                 modelId,
                 Collections.singletonList(Collections.emptyMap()),
                 RegressionConfigUpdate.EMPTY_PARAMS,
-                false
-            ).setInferenceTimeout(TimeValue.timeValueSeconds(5)),
+                false,
+                TimeValue.timeValueSeconds(5)
+            ),
             inferModelSuccess
         );
         InferModelAction.Response response = inferModelSuccess.actionGet();
@@ -690,8 +691,9 @@ public class MachineLearningLicensingIT extends BaseMlIntegTestCase {
                     modelId,
                     Collections.singletonList(Collections.emptyMap()),
                     RegressionConfigUpdate.EMPTY_PARAMS,
-                    false
-                ).setInferenceTimeout(TimeValue.timeValueSeconds(5))
+                    false,
+                    TimeValue.timeValueSeconds(5)
+                )
             ).actionGet();
         });
         assertThat(e.status(), is(RestStatus.FORBIDDEN));
@@ -706,8 +708,9 @@ public class MachineLearningLicensingIT extends BaseMlIntegTestCase {
                 modelId,
                 Collections.singletonList(Collections.emptyMap()),
                 RegressionConfigUpdate.EMPTY_PARAMS,
-                true
-            ).setInferenceTimeout(TimeValue.timeValueSeconds(5)),
+                true,
+                TimeValue.timeValueSeconds(5)
+            ),
             inferModelSuccess
         );
         response = inferModelSuccess.actionGet();
@@ -726,8 +729,9 @@ public class MachineLearningLicensingIT extends BaseMlIntegTestCase {
                 modelId,
                 Collections.singletonList(Collections.emptyMap()),
                 RegressionConfigUpdate.EMPTY_PARAMS,
-                false
-            ).setInferenceTimeout(TimeValue.timeValueSeconds(5)),
+                false,
+                TimeValue.timeValueSeconds(5)
+            ),
             listener
         );
         assertThat(listener.actionGet().getInferenceResults(), is(not(empty())));

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/ModelInferenceActionIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/ModelInferenceActionIT.java
@@ -175,7 +175,8 @@ public class ModelInferenceActionIT extends MlSingleNodeTestCase {
             modelId1,
             toInfer,
             RegressionConfigUpdate.EMPTY_PARAMS,
-            true
+            true,
+            InferModelAction.Request.DEFAULT_TIMEOUT_FOR_INGEST
         );
         InferModelAction.Response response = client().execute(InferModelAction.INSTANCE, request).actionGet();
         assertThat(
@@ -183,7 +184,13 @@ public class ModelInferenceActionIT extends MlSingleNodeTestCase {
             contains(1.3, 1.25)
         );
 
-        request = InferModelAction.Request.forIngestDocs(modelId1, toInfer2, RegressionConfigUpdate.EMPTY_PARAMS, true);
+        request = InferModelAction.Request.forIngestDocs(
+            modelId1,
+            toInfer2,
+            RegressionConfigUpdate.EMPTY_PARAMS,
+            true,
+            InferModelAction.Request.DEFAULT_TIMEOUT_FOR_INGEST
+        );
         response = client().execute(InferModelAction.INSTANCE, request).actionGet();
         assertThat(
             response.getInferenceResults().stream().map(i -> ((SingleValueInferenceResults) i).value()).collect(Collectors.toList()),
@@ -191,7 +198,13 @@ public class ModelInferenceActionIT extends MlSingleNodeTestCase {
         );
 
         // Test classification
-        request = InferModelAction.Request.forIngestDocs(modelId2, toInfer, ClassificationConfigUpdate.EMPTY_PARAMS, true);
+        request = InferModelAction.Request.forIngestDocs(
+            modelId2,
+            toInfer,
+            ClassificationConfigUpdate.EMPTY_PARAMS,
+            true,
+            InferModelAction.Request.DEFAULT_TIMEOUT_FOR_INGEST
+        );
         response = client().execute(InferModelAction.INSTANCE, request).actionGet();
         assertThat(
             response.getInferenceResults()
@@ -206,7 +219,8 @@ public class ModelInferenceActionIT extends MlSingleNodeTestCase {
             modelId2,
             toInfer,
             new ClassificationConfigUpdate(2, null, null, null, null),
-            true
+            true,
+            InferModelAction.Request.DEFAULT_TIMEOUT_FOR_INGEST
         );
         response = client().execute(InferModelAction.INSTANCE, request).actionGet();
 
@@ -234,7 +248,8 @@ public class ModelInferenceActionIT extends MlSingleNodeTestCase {
             modelId2,
             toInfer2,
             new ClassificationConfigUpdate(1, null, null, null, null),
-            true
+            true,
+            InferModelAction.Request.DEFAULT_TIMEOUT_FOR_INGEST
         );
         response = client().execute(InferModelAction.INSTANCE, request).actionGet();
 
@@ -338,7 +353,8 @@ public class ModelInferenceActionIT extends MlSingleNodeTestCase {
             modelId,
             toInfer,
             ClassificationConfigUpdate.EMPTY_PARAMS,
-            true
+            true,
+            InferModelAction.Request.DEFAULT_TIMEOUT_FOR_INGEST
         );
         InferModelAction.Response response = client().execute(InferModelAction.INSTANCE, request).actionGet();
         assertThat(
@@ -349,7 +365,13 @@ public class ModelInferenceActionIT extends MlSingleNodeTestCase {
             contains("option_0", "option_2")
         );
 
-        request = InferModelAction.Request.forIngestDocs(modelId, toInfer2, ClassificationConfigUpdate.EMPTY_PARAMS, true);
+        request = InferModelAction.Request.forIngestDocs(
+            modelId,
+            toInfer2,
+            ClassificationConfigUpdate.EMPTY_PARAMS,
+            true,
+            InferModelAction.Request.DEFAULT_TIMEOUT_FOR_INGEST
+        );
         response = client().execute(InferModelAction.INSTANCE, request).actionGet();
         assertThat(
             response.getInferenceResults()
@@ -360,7 +382,13 @@ public class ModelInferenceActionIT extends MlSingleNodeTestCase {
         );
 
         // Get top classes
-        request = InferModelAction.Request.forIngestDocs(modelId, toInfer, new ClassificationConfigUpdate(3, null, null, null, null), true);
+        request = InferModelAction.Request.forIngestDocs(
+            modelId,
+            toInfer,
+            new ClassificationConfigUpdate(3, null, null, null, null),
+            true,
+            InferModelAction.Request.DEFAULT_TIMEOUT_FOR_INGEST
+        );
         response = client().execute(InferModelAction.INSTANCE, request).actionGet();
 
         ClassificationInferenceResults classificationInferenceResults = (ClassificationInferenceResults) response.getInferenceResults()
@@ -382,7 +410,8 @@ public class ModelInferenceActionIT extends MlSingleNodeTestCase {
             model,
             Collections.emptyList(),
             RegressionConfigUpdate.EMPTY_PARAMS,
-            true
+            true,
+            InferModelAction.Request.DEFAULT_TIMEOUT_FOR_INGEST
         );
         try {
             client().execute(InferModelAction.INSTANCE, request).actionGet();
@@ -428,7 +457,8 @@ public class ModelInferenceActionIT extends MlSingleNodeTestCase {
             modelId,
             toInferMissingField,
             RegressionConfigUpdate.EMPTY_PARAMS,
-            true
+            true,
+            InferModelAction.Request.DEFAULT_TIMEOUT_FOR_INGEST
         );
         try {
             InferenceResults result = client().execute(InferModelAction.INSTANCE, request).actionGet().getInferenceResults().get(0);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessor.java
@@ -245,7 +245,13 @@ public class InferenceProcessor extends AbstractProcessor {
                     }
                 }
             }
-            return InferModelAction.Request.forTextInput(modelId, inferenceConfig, requestInputs);
+            return InferModelAction.Request.forTextInput(
+                modelId,
+                inferenceConfig,
+                requestInputs,
+                previouslyLicensed,
+                InferModelAction.Request.DEFAULT_TIMEOUT_FOR_INGEST
+            );
         } else {
             Map<String, Object> fields = new HashMap<>(ingestDocument.getSourceAndMetadata());
             // Add ingestMetadata as previous processors might have added metadata from which we are predicting (see: foreach processor)
@@ -254,7 +260,13 @@ public class InferenceProcessor extends AbstractProcessor {
             }
 
             LocalModel.mapFieldsIfNecessary(fields, fieldMap);
-            return InferModelAction.Request.forIngestDocs(modelId, List.of(fields), inferenceConfig, previouslyLicensed);
+            return InferModelAction.Request.forIngestDocs(
+                modelId,
+                List.of(fields),
+                inferenceConfig,
+                previouslyLicensed,
+                InferModelAction.Request.DEFAULT_TIMEOUT_FOR_INGEST
+            );
         }
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/queries/TextExpansionQueryBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/queries/TextExpansionQueryBuilder.java
@@ -126,7 +126,9 @@ public class TextExpansionQueryBuilder extends AbstractQueryBuilder<TextExpansio
         InferModelAction.Request inferRequest = InferModelAction.Request.forTextInput(
             modelId,
             TextExpansionConfigUpdate.EMPTY_UPDATE,
-            List.of(modelText)
+            List.of(modelText),
+            false,
+            InferModelAction.Request.DEFAULT_TIMEOUT_FOR_API
         );
         inferRequest.setHighPriority(true);
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/vectors/TextEmbeddingQueryVectorBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/vectors/TextEmbeddingQueryVectorBuilder.java
@@ -95,7 +95,9 @@ public class TextEmbeddingQueryVectorBuilder implements QueryVectorBuilder {
         InferModelAction.Request inferRequest = InferModelAction.Request.forTextInput(
             modelId,
             TextEmbeddingConfigUpdate.EMPTY_INSTANCE,
-            List.of(modelText)
+            List.of(modelText),
+            false,
+            InferModelAction.Request.DEFAULT_TIMEOUT_FOR_API
         );
         inferRequest.setHighPriority(true);
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessorTests.java
@@ -303,14 +303,19 @@ public class InferenceProcessorTests extends ESTestCase {
         };
         IngestDocument document = TestIngestDocument.ofIngestWithNullableVersion(source, new HashMap<>());
 
-        assertThat(processor.buildRequest(document).getObjectsToInfer().get(0), equalTo(source));
+        var request = processor.buildRequest(document);
+        assertThat(request.getObjectsToInfer().get(0), equalTo(source));
+        assertEquals(InferModelAction.Request.DEFAULT_TIMEOUT_FOR_INGEST, request.getInferenceTimeout());
 
         Map<String, Object> ingestMetadata = Collections.singletonMap("_value", 3);
         document = TestIngestDocument.ofIngestWithNullableVersion(source, ingestMetadata);
 
         Map<String, Object> expected = new HashMap<>(source);
         expected.put("_ingest", ingestMetadata);
-        assertThat(processor.buildRequest(document).getObjectsToInfer().get(0), equalTo(expected));
+
+        request = processor.buildRequest(document);
+        assertThat(request.getObjectsToInfer().get(0), equalTo(expected));
+        assertEquals(InferModelAction.Request.DEFAULT_TIMEOUT_FOR_INGEST, request.getInferenceTimeout());
     }
 
     public void testGenerateWithMapping() {
@@ -346,14 +351,18 @@ public class InferenceProcessorTests extends ESTestCase {
         expectedMap.put("categorical", "foo");
         expectedMap.put("new_categorical", "foo");
         expectedMap.put("un_touched", "bar");
-        assertThat(processor.buildRequest(document).getObjectsToInfer().get(0), equalTo(expectedMap));
+        var request = processor.buildRequest(document);
+        assertThat(request.getObjectsToInfer().get(0), equalTo(expectedMap));
+        assertEquals(InferModelAction.Request.DEFAULT_TIMEOUT_FOR_INGEST, request.getInferenceTimeout());
 
         Map<String, Object> ingestMetadata = Collections.singletonMap("_value", "baz");
         document = TestIngestDocument.ofIngestWithNullableVersion(source, ingestMetadata);
         expectedMap = new HashMap<>(expectedMap);
         expectedMap.put("metafield", "baz");
         expectedMap.put("_ingest", ingestMetadata);
-        assertThat(processor.buildRequest(document).getObjectsToInfer().get(0), equalTo(expectedMap));
+        request = processor.buildRequest(document);
+        assertThat(request.getObjectsToInfer().get(0), equalTo(expectedMap));
+        assertEquals(InferModelAction.Request.DEFAULT_TIMEOUT_FOR_INGEST, request.getInferenceTimeout());
     }
 
     public void testGenerateWithMappingNestedFields() {
@@ -597,6 +606,7 @@ public class InferenceProcessorTests extends ESTestCase {
         assertTrue(request.getObjectsToInfer().isEmpty());
         var requestInputs = request.getTextInput();
         assertThat(requestInputs, contains("body_text", "title_text"));
+        assertEquals(InferModelAction.Request.DEFAULT_TIMEOUT_FOR_INGEST, request.getInferenceTimeout());
     }
 
     public void testBuildRequestWithInputFields_WrongType() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/queries/TextExpansionQueryBuilderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/queries/TextExpansionQueryBuilderTests.java
@@ -77,6 +77,7 @@ public class TextExpansionQueryBuilderTests extends AbstractQueryTestCase<TextEx
     @Override
     protected Object simulateMethod(Method method, Object[] args) {
         InferModelAction.Request request = (InferModelAction.Request) args[1];
+        assertEquals(InferModelAction.Request.DEFAULT_TIMEOUT_FOR_API, request.getInferenceTimeout());
 
         // Randomisation cannot be used here as {@code #doAssertLuceneQuery}
         // asserts that 2 rewritten queries are the same

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/vectors/TextEmbeddingQueryVectorBuilderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/vectors/TextEmbeddingQueryVectorBuilderTests.java
@@ -38,6 +38,7 @@ public class TextEmbeddingQueryVectorBuilderTests extends AbstractQueryVectorBui
         assertThat(inferRequest.getTextInput(), hasSize(1));
         assertEquals(builder.getModelText(), inferRequest.getTextInput().get(0));
         assertEquals(builder.getModelId(), inferRequest.getId());
+        assertEquals(InferModelAction.Request.DEFAULT_TIMEOUT_FOR_API, inferRequest.getInferenceTimeout());
     }
 
     public ActionResponse createResponse(float[] array, TextEmbeddingQueryVectorBuilder builder) {


### PR DESCRIPTION
When using the Inference ingest processor with the [input_output](https://www.elastic.co/guide/en/elasticsearch/reference/current/inference-processor.html#inference-processor) configuration option added in 8.11 inference requests may timeout after 10 seconds with the message:

```
timeout [10s] waiting for inference result
```

Inference requests made at ingest should have a long timeout as large numbers of requests can queue up when ingesting documents. An error introduced when adding the `input_output` option meant that a default value of 10 seconds is used instead of the maximum timeout. This change makes timeout a parameter that must be explicitly added and adds tests to check the correct timeout is used. 

This only applies when using the `input_output` option, the work around is to use the `target_field` and `field_map` options to configure the ingest processor or use smaller batch sizes in bulk upload or reindex. 