### PR TITLE
[8.11] Don't apply IntelliJ illegal module dependency inspection to test code (#101977)

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -2,12 +2,13 @@
   <profile version="1.0">
     <option name="myName" value="Project Default" />
     <inspection_tool class="GroovyPointlessBoolean" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="IllegalDependencyOnInternalPackage" enabled="true" level="ERROR" enabled_by_default="false">
+      <scope name="Production" level="ERROR" enabled="false" />
+      <scope name="Production minus fixtures" level="ERROR" enabled="true" />
+    </inspection_tool>
     <inspection_tool class="PointlessBooleanExpression" enabled="false" level="WARNING" enabled_by_default="false">
       <option name="m_ignoreExpressionsContainingConstants" value="true" />
     </inspection_tool>
     <inspection_tool class="jol" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="IllegalDependencyOnInternalPackage" enabled="true" level="ERROR" enabled_by_default="false">
-      <scope name="Production" level="ERROR" enabled="true" />
-    </inspection_tool>
   </profile>
 </component>

--- a/.idea/scopes/Production_minus_fixtures.xml
+++ b/.idea/scopes/Production_minus_fixtures.xml
@@ -1,0 +1,3 @@
+<component name="DependencyValidationManager">
+  <scope name="Production minus fixtures" pattern="src:*..*&amp;&amp;!file[elasticsearch.test*]:*//*" />
+</component>


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Don't apply IntelliJ illegal module dependency inspection to test code (#101977)