### PR TITLE
Add message field to HealthPeriodicLogger and S3RequestRetryStats

### DIFF
--- a/docs/changelog/101989.yaml
+++ b/docs/changelog/101989.yaml
@@ -1,5 +1,5 @@
 pr: 101989
-summary: Add message field to `HealthPeriodicLogger` output
+summary: Add message field to `HealthPeriodicLogger` and `S3RequestRetryStats`
 area: Health
 type: enhancement
 issues: []

--- a/docs/changelog/101989.yaml
+++ b/docs/changelog/101989.yaml
@@ -1,0 +1,5 @@
+pr: 101989
+summary: Add message field to `HealthPeriodicLogger` output
+area: Health
+type: enhancement
+issues: []

--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RequestRetryStats.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RequestRetryStats.java
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicLongArray;
  * This class emit aws s3 metrics as logs until we have a proper apm integration
  */
 public class S3RequestRetryStats {
+    public static final String MESSAGE_FIELD = "message";
 
     private static final Logger logger = LogManager.getLogger(S3RequestRetryStats.class);
 
@@ -65,7 +66,8 @@ public class S3RequestRetryStats {
 
     public void emitMetrics() {
         if (logger.isDebugEnabled()) {
-            var metrics = Maps.<String, Object>newMapWithExpectedSize(3);
+            var metrics = Maps.<String, Object>newMapWithExpectedSize(4);
+            metrics.put(MESSAGE_FIELD, "S3 Request Retry Stats");
             metrics.put("elasticsearch.metrics.s3.requests", requests.get());
             metrics.put("elasticsearch.metrics.s3.exceptions", exceptions.get());
             metrics.put("elasticsearch.metrics.s3.throttles", throttles.get());

--- a/server/src/main/java/org/elasticsearch/health/HealthPeriodicLogger.java
+++ b/server/src/main/java/org/elasticsearch/health/HealthPeriodicLogger.java
@@ -41,6 +41,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public class HealthPeriodicLogger implements ClusterStateListener, Closeable, SchedulerEngine.Listener {
     public static final String HEALTH_FIELD_PREFIX = "elasticsearch.health";
+    public static final String MESSAGE_FIELD = "message";
 
     public static final Setting<TimeValue> POLL_INTERVAL_SETTING = Setting.timeSetting(
         "health.periodic_logger.poll_interval",
@@ -193,6 +194,7 @@ public class HealthPeriodicLogger implements ClusterStateListener, Closeable, Sc
         // overall status
         final HealthStatus status = HealthStatus.merge(indicatorResults.stream().map(HealthIndicatorResult::status));
         result.put(String.format(Locale.ROOT, "%s.overall.status", HEALTH_FIELD_PREFIX), status.xContentValue());
+        result.put(MESSAGE_FIELD, String.format(Locale.ROOT, "health=%s", status.xContentValue()));
 
         // top-level status for each indicator
         indicatorResults.forEach((indicatorResult) -> {

--- a/server/src/test/java/org/elasticsearch/health/HealthPeriodicLoggerTests.java
+++ b/server/src/test/java/org/elasticsearch/health/HealthPeriodicLoggerTests.java
@@ -100,7 +100,8 @@ public class HealthPeriodicLoggerTests extends ESTestCase {
 
         Map<String, Object> loggerResults = HealthPeriodicLogger.convertToLoggedFields(results);
 
-        assertThat(loggerResults.size(), equalTo(results.size() + 1));
+        // verify that the number of fields is the number of indicators + 2 (for overall and for message)
+        assertThat(loggerResults.size(), equalTo(results.size() + 2));
 
         // test indicator status
         assertThat(loggerResults.get(makeHealthStatusString("network_latency")), equalTo("green"));
@@ -109,6 +110,12 @@ public class HealthPeriodicLoggerTests extends ESTestCase {
 
         // test calculated overall status
         assertThat(loggerResults.get(makeHealthStatusString("overall")), equalTo(overallStatus.xContentValue()));
+
+        // test calculated message
+        assertThat(
+            loggerResults.get(HealthPeriodicLogger.MESSAGE_FIELD),
+            equalTo(String.format(Locale.ROOT, "health=%s", overallStatus.xContentValue()))
+        );
 
         // test empty results
         {


### PR DESCRIPTION
This adds the `message` field to the logged output of `HealthPeriodicLogger`. Downstream log parsing components sometimes require this field.