### PR TITLE
CCS should fail fast when a cluster that cannot be skipped is unavailable

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -164,6 +164,7 @@ public class TransportVersions {
     public static final TransportVersion UPDATE_NON_DYNAMIC_SETTINGS_ADDED = def(8_533_00_0);
     public static final TransportVersion REPO_ANALYSIS_REGISTER_OP_COUNT_ADDED = def(8_534_00_0);
     public static final TransportVersion ML_TRAINED_MODEL_PREFIX_STRINGS_ADDED = def(8_535_00_0);
+    public static final TransportVersion THROWING_QUERY_BUILDER_SLEEPS_ADDED = def(8_536_00_0);
     /*
      * STOP! READ THIS FIRST! No, really,
      *        ____ _____ ___  ____  _        ____  _____    _    ____    _____ _   _ ___ ____    _____ ___ ____  ____ _____ _

--- a/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
@@ -8,8 +8,6 @@
 
 package org.elasticsearch.action.search;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionResponse;
@@ -62,7 +60,6 @@ import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpect
  */
 public class SearchResponse extends ActionResponse implements ChunkedToXContentObject {
 
-    private static final Logger logger = LogManager.getLogger(SearchResponse.class);
     private static final ParseField SCROLL_ID = new ParseField("_scroll_id");
     private static final ParseField POINT_IN_TIME_ID = new ParseField("pit_id");
     private static final ParseField TOOK = new ParseField("took");
@@ -692,22 +689,16 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
          * Changes the status of any Cluster objects with RUNNING status to CANCELLED.
          */
         public void notifySearchCancelled() {
-            assert clusterInfo != null : "ClusterInfo map should never be null";
-
             for (Cluster cluster : clusterInfo.values()) {
                 if (cluster.getStatus() == Cluster.Status.RUNNING) {
-                    logger.warn("JJJ YYY DEBUG 1");
                     swapCluster(cluster.getClusterAlias(), (k, v) -> {
                         if (v.getStatus() == Cluster.Status.RUNNING) {
-                            logger.warn("JJJ YYY DEBUG 2");
                             return new Cluster.Builder(v).setStatus(Cluster.Status.CANCELLED).build();
                         } else {
-                            logger.warn("JJJ YYY DEBUG 3");
                             return v;
                         }
                     });
                 }
-                logger.warn("JJJ YYY Clusters.notifySearchCancelled: cluster status AFTER: " + cluster.getStatus()); // FIXME - remove
             }
         }
 

--- a/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
@@ -696,15 +696,18 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
 
             for (Cluster cluster : clusterInfo.values()) {
                 if (cluster.getStatus() == Cluster.Status.RUNNING) {
+                    logger.warn("JJJ YYY DEBUG 1");
                     swapCluster(cluster.getClusterAlias(), (k, v) -> {
                         if (v.getStatus() == Cluster.Status.RUNNING) {
+                            logger.warn("JJJ YYY DEBUG 2");
                             return new Cluster.Builder(v).setStatus(Cluster.Status.CANCELLED).build();
                         } else {
+                            logger.warn("JJJ YYY DEBUG 3");
                             return v;
                         }
                     });
                 }
-                logger.warn("JJJ Clusters.notifySearchCancelled: cluster status AFTER: " + cluster.getStatus()); // FIXME - remove
+                logger.warn("JJJ YYY Clusters.notifySearchCancelled: cluster status AFTER: " + cluster.getStatus()); // FIXME - remove
             }
         }
 

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -94,7 +94,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -1424,7 +1424,6 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
         private final AtomicReference<Exception> exceptions;
         protected final SearchResponse.Clusters clusters;
         private final ActionListener<FinalResponse> originalListener;
-        private final AtomicBoolean originalListenerOnFailureCalled = new AtomicBoolean(false);
 
         /**
          * Used by both minimize_roundtrips true and false
@@ -1505,14 +1504,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                     }
                     originalListener.onResponse(response);
                 } else {
-                    // only call onFailure on the originalListener once
-                    // as that listener expects it to occur only when the search has finished
-                    // when we fail fast to do cancellations, we'll have late arriving errors
-                    // (usually TaskCancelledExceptions) that should just be ignored
-                    boolean alreadyCalled = originalListenerOnFailureCalled.getAndSet(true);
-                    if (alreadyCalled == false) {
-                        originalListener.onFailure(exceptions.get());
-                    }
+                    originalListener.onFailure(exceptions.get());
                 }
             }
         }

--- a/server/src/main/java/org/elasticsearch/transport/RemoteTransportException.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteTransportException.java
@@ -21,8 +21,23 @@ import java.net.InetSocketAddress;
  */
 public class RemoteTransportException extends ActionTransportException implements ElasticsearchWrapperException {
 
+    private String clusterAlias;
+    private boolean fatalForCCS; // if true, indicates that a cross-cluster search should be marked as failed
+
     public RemoteTransportException(String msg, Throwable cause) {
         super(msg, null, null, cause);
+    }
+
+    /**
+     * @param msg error message
+     * @param clusterAlias alias of remote cluster the error occurred on
+     * @param fatalForCCS whether this error is "fatal" for a cross-cluster search (will cause the whole search to fail)
+     * @param cause underlying cause
+     */
+    public RemoteTransportException(String msg, String clusterAlias, boolean fatalForCCS, Throwable cause) {
+        super(msg, null, null, cause);
+        this.clusterAlias = clusterAlias;
+        this.fatalForCCS = fatalForCCS;
     }
 
     public RemoteTransportException(String name, TransportAddress address, String action, Throwable cause) {
@@ -35,6 +50,14 @@ public class RemoteTransportException extends ActionTransportException implement
 
     public RemoteTransportException(StreamInput in) throws IOException {
         super(in);
+    }
+
+    public String getClusterAlias() {
+        return clusterAlias;
+    }
+
+    public boolean isFatalForCCS() {
+        return fatalForCCS;
     }
 
     @Override

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AbstractCrossClusterAsyncSearchTestCase.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AbstractCrossClusterAsyncSearchTestCase.java
@@ -1,0 +1,306 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.search;
+
+import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksResponse;
+import org.elasticsearch.action.search.SearchAction;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.IndexModule;
+import org.elasticsearch.index.shard.SearchOperationListener;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.plugins.SearchPlugin;
+import org.elasticsearch.search.internal.LegacyReaderContext;
+import org.elasticsearch.search.internal.ReaderContext;
+import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.search.query.SlowRunningQueryBuilder;
+import org.elasticsearch.search.query.ThrowingQueryBuilder;
+import org.elasticsearch.tasks.TaskInfo;
+import org.elasticsearch.test.AbstractMultiClustersTestCase;
+import org.elasticsearch.test.InternalTestCluster;
+import org.elasticsearch.transport.RemoteClusterAware;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.async.AsyncResultsIndexPlugin;
+import org.elasticsearch.xpack.core.LocalStateCompositeXPackPlugin;
+import org.elasticsearch.xpack.core.async.DeleteAsyncResultAction;
+import org.elasticsearch.xpack.core.async.DeleteAsyncResultRequest;
+import org.elasticsearch.xpack.core.async.GetAsyncResultRequest;
+import org.elasticsearch.xpack.core.async.GetAsyncStatusRequest;
+import org.elasticsearch.xpack.core.search.action.AsyncSearchResponse;
+import org.elasticsearch.xpack.core.search.action.AsyncStatusResponse;
+import org.elasticsearch.xpack.core.search.action.GetAsyncSearchAction;
+import org.elasticsearch.xpack.core.search.action.GetAsyncStatusAction;
+import org.elasticsearch.xpack.core.search.action.SubmitAsyncSearchAction;
+import org.elasticsearch.xpack.core.search.action.SubmitAsyncSearchRequest;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
+
+public class AbstractCrossClusterAsyncSearchTestCase extends AbstractMultiClustersTestCase {
+    static final String REMOTE_CLUSTER = "cluster_a";
+    static final long EARLIEST_TIMESTAMP = 1691348810000L;
+    static final long LATEST_TIMESTAMP = 1691348820000L;
+
+    @Override
+    protected Collection<String> remoteClusterAlias() {
+        return List.of(REMOTE_CLUSTER);
+    }
+
+    @Override
+    protected boolean reuseClusters() {
+        return false;
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins(String clusterAlias) {
+        List<Class<? extends Plugin>> plugs = Arrays.asList(
+            CrossClusterAsyncSearchIT.SearchListenerPlugin.class,
+            AsyncSearch.class,
+            AsyncResultsIndexPlugin.class,
+            LocalStateCompositeXPackPlugin.class,
+            TestQueryBuilderPlugin.class
+        );
+        return Stream.concat(super.nodePlugins(clusterAlias).stream(), plugs.stream()).collect(Collectors.toList());
+    }
+
+    public static class TestQueryBuilderPlugin extends Plugin implements SearchPlugin {
+        public TestQueryBuilderPlugin() {}
+
+        @Override
+        public List<QuerySpec<?>> getQueries() {
+            QuerySpec<SlowRunningQueryBuilder> slowRunningSpec = new QuerySpec<>(
+                SlowRunningQueryBuilder.NAME,
+                SlowRunningQueryBuilder::new,
+                p -> {
+                    throw new IllegalStateException("not implemented");
+                }
+            );
+            QuerySpec<ThrowingQueryBuilder> throwingSpec = new QuerySpec<>(ThrowingQueryBuilder.NAME, ThrowingQueryBuilder::new, p -> {
+                throw new IllegalStateException("not implemented");
+            });
+
+            return List.of(slowRunningSpec, throwingSpec);
+        }
+    }
+
+    protected AsyncSearchResponse submitAsyncSearch(SubmitAsyncSearchRequest request) throws ExecutionException, InterruptedException {
+        return client(LOCAL_CLUSTER).execute(SubmitAsyncSearchAction.INSTANCE, request).get();
+    }
+
+    protected AsyncSearchResponse getAsyncSearch(String id) throws ExecutionException, InterruptedException {
+        return client(LOCAL_CLUSTER).execute(GetAsyncSearchAction.INSTANCE, new GetAsyncResultRequest(id)).get();
+    }
+
+    protected AsyncStatusResponse getAsyncStatus(String id) throws ExecutionException, InterruptedException {
+        return client(LOCAL_CLUSTER).execute(GetAsyncStatusAction.INSTANCE, new GetAsyncStatusRequest(id)).get();
+    }
+
+    protected AcknowledgedResponse deleteAsyncSearch(String id) throws ExecutionException, InterruptedException {
+        return client().execute(DeleteAsyncResultAction.INSTANCE, new DeleteAsyncResultRequest(id)).get();
+    }
+
+    protected Map<String, Object> setupTwoClusters() {
+        String localIndex = "demo";
+        int numShardsLocal = randomIntBetween(2, 12);
+        Settings localSettings = indexSettings(numShardsLocal, randomIntBetween(0, 1)).build();
+        assertAcked(
+            client(LOCAL_CLUSTER).admin()
+                .indices()
+                .prepareCreate(localIndex)
+                .setSettings(localSettings)
+                .setMapping("@timestamp", "type=date", "f", "type=text")
+        );
+        indexDocs(client(LOCAL_CLUSTER), localIndex);
+
+        String remoteIndex = "prod";
+        int numShardsRemote = randomIntBetween(2, 12);
+        final InternalTestCluster remoteCluster = cluster(REMOTE_CLUSTER);
+        remoteCluster.ensureAtLeastNumDataNodes(randomIntBetween(1, 3));
+        final Settings.Builder remoteSettings = Settings.builder();
+        remoteSettings.put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, numShardsRemote);
+        remoteSettings.put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, randomIntBetween(0, 1));
+
+        assertAcked(
+            client(REMOTE_CLUSTER).admin()
+                .indices()
+                .prepareCreate(remoteIndex)
+                .setSettings(Settings.builder().put(remoteSettings.build()))
+                .setMapping("@timestamp", "type=date", "f", "type=text")
+        );
+        assertFalse(
+            client(REMOTE_CLUSTER).admin()
+                .cluster()
+                .prepareHealth(remoteIndex)
+                .setWaitForYellowStatus()
+                .setTimeout(TimeValue.timeValueSeconds(10))
+                .get()
+                .isTimedOut()
+        );
+        indexDocs(client(REMOTE_CLUSTER), remoteIndex);
+
+        String skipUnavailableKey = Strings.format("cluster.remote.%s.skip_unavailable", REMOTE_CLUSTER);
+        Setting<?> skipUnavailableSetting = cluster(REMOTE_CLUSTER).clusterService().getClusterSettings().get(skipUnavailableKey);
+        boolean skipUnavailable = (boolean) cluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY).clusterService()
+            .getClusterSettings()
+            .get(skipUnavailableSetting);
+
+        Map<String, Object> clusterInfo = new HashMap<>();
+        clusterInfo.put("local.num_shards", numShardsLocal);
+        clusterInfo.put("local.index", localIndex);
+        clusterInfo.put("remote.num_shards", numShardsRemote);
+        clusterInfo.put("remote.index", remoteIndex);
+        clusterInfo.put("remote.skip_unavailable", skipUnavailable);
+        return clusterInfo;
+    }
+
+    private static int indexDocs(Client client, String index) {
+        int numDocs = between(500, 1200);
+        for (int i = 0; i < numDocs; i++) {
+            long ts = EARLIEST_TIMESTAMP + i;
+            if (i == numDocs - 1) {
+                ts = LATEST_TIMESTAMP;
+            }
+            client.prepareIndex(index).setSource("f", "v", "@timestamp", ts).get();
+        }
+        client.admin().indices().prepareRefresh(index).get();
+        return numDocs;
+    }
+
+    void waitForSearchTasksToFinish() throws Exception {
+        assertBusy(() -> {
+            ListTasksResponse listTasksResponse = client(LOCAL_CLUSTER).admin()
+                .cluster()
+                .prepareListTasks()
+                .setActions(SearchAction.INSTANCE.name())
+                .get();
+            List<TaskInfo> tasks = listTasksResponse.getTasks();
+            assertThat(tasks.size(), equalTo(0));
+
+            ListTasksResponse remoteTasksResponse = client(REMOTE_CLUSTER).admin()
+                .cluster()
+                .prepareListTasks()
+                .setActions(SearchAction.INSTANCE.name())
+                .get();
+            List<TaskInfo> remoteTasks = remoteTasksResponse.getTasks();
+            assertThat(remoteTasks.size(), equalTo(0));
+        });
+
+        assertBusy(() -> {
+            final Iterable<TransportService> transportServices = cluster(REMOTE_CLUSTER).getInstances(TransportService.class);
+            for (TransportService transportService : transportServices) {
+                assertThat(transportService.getTaskManager().getBannedTaskIds(), Matchers.empty());
+            }
+        });
+    }
+
+    @Before
+    public void resetSearchListenerPlugin() throws Exception {
+        SearchListenerPlugin.reset();
+    }
+
+    public static class SearchListenerPlugin extends Plugin {
+        private static final AtomicReference<CountDownLatch> startedLatch = new AtomicReference<>();
+        private static final AtomicReference<CountDownLatch> queryLatch = new AtomicReference<>();
+        private static final AtomicReference<CountDownLatch> failedQueryLatch = new AtomicReference<>();
+
+        /**
+         * For tests that cannot use SearchListenerPlugin, ensure all latches are unset to
+         * avoid test problems around searches of the .async-search index
+         */
+        static void negate() {
+            if (startedLatch.get() != null) {
+                startedLatch.get().countDown();
+            }
+            if (queryLatch.get() != null) {
+                queryLatch.get().countDown();
+            }
+            if (failedQueryLatch.get() != null) {
+                failedQueryLatch.get().countDown();
+            }
+        }
+
+        static void reset() {
+            startedLatch.set(new CountDownLatch(1));
+            failedQueryLatch.set(new CountDownLatch(1));
+        }
+
+        static void blockQueryPhase() {
+            queryLatch.set(new CountDownLatch(1));
+        }
+
+        static void allowQueryPhase() {
+            final CountDownLatch latch = queryLatch.get();
+            if (latch != null) {
+                latch.countDown();
+            }
+        }
+
+        static void waitSearchStarted() throws InterruptedException {
+            assertTrue(startedLatch.get().await(60, TimeUnit.SECONDS));
+        }
+
+        static void waitQueryFailure() throws Exception {
+            assertTrue(failedQueryLatch.get().await(60, TimeUnit.SECONDS));
+        }
+
+        @Override
+        public void onIndexModule(IndexModule indexModule) {
+            indexModule.addSearchOperationListener(new SearchOperationListener() {
+                @Override
+                public void onNewReaderContext(ReaderContext readerContext) {
+                    assertThat(readerContext, not(instanceOf(LegacyReaderContext.class)));
+                }
+
+                @Override
+                public void onPreQueryPhase(SearchContext searchContext) {
+                    startedLatch.get().countDown();
+                    final CountDownLatch latch = queryLatch.get();
+                    if (latch != null) {
+                        try {
+                            assertTrue(latch.await(60, TimeUnit.SECONDS));
+                        } catch (InterruptedException e) {
+                            throw new AssertionError(e);
+                        }
+                    }
+                }
+
+                @Override
+                public void onFailedQueryPhase(SearchContext searchContext) {
+                    // only count failed queries that have a timeout set (to be sure we are listening for our test query)
+                    if (searchContext.timeout().millis() > -1) {
+                        if (failedQueryLatch.get().getCount() > 0) {
+                            failedQueryLatch.get().countDown();
+                        }
+                    }
+                }
+            });
+            super.onIndexModule(indexModule);
+        }
+    }
+}

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AbstractCrossClusterAsyncSearchTestCaseIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AbstractCrossClusterAsyncSearchTestCaseIT.java
@@ -62,7 +62,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 
-public class AbstractCrossClusterAsyncSearchTestCase extends AbstractMultiClustersTestCase {
+public class AbstractCrossClusterAsyncSearchTestCaseIT extends AbstractMultiClustersTestCase {
     static final String REMOTE_CLUSTER = "cluster_a";
     static final long EARLIEST_TIMESTAMP = 1691348810000L;
     static final long LATEST_TIMESTAMP = 1691348820000L;

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CrossClusterAsyncSearchIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CrossClusterAsyncSearchIT.java
@@ -52,7 +52,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.matchesRegex;
 
-public class CrossClusterAsyncSearchIT extends AbstractCrossClusterAsyncSearchTestCase {
+public class CrossClusterAsyncSearchIT extends AbstractCrossClusterAsyncSearchTestCaseIT {
 
     @Override
     protected Map<String, Boolean> skipUnavailableForRemoteClusters() {

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/FailFastCrossClusterAsyncSearchIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/FailFastCrossClusterAsyncSearchIT.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.search;
+
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.ShardSearchFailure;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.query.ThrowingQueryBuilder;
+import org.elasticsearch.transport.RemoteClusterAware;
+import org.elasticsearch.xpack.core.search.action.AsyncSearchResponse;
+import org.elasticsearch.xpack.core.search.action.AsyncStatusResponse;
+import org.elasticsearch.xpack.core.search.action.SubmitAsyncSearchRequest;
+
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Tests for cross-cluster search where a remote cluster marked with skip_unavailable=false
+ * fails, the other searches are cancelled in order to fail-fast the overall search query.
+ */
+public class FailFastCrossClusterAsyncSearchIT extends AbstractCrossClusterAsyncSearchTestCase {
+
+    @Override
+    protected Map<String, Boolean> skipUnavailableForRemoteClusters() {
+        return Map.of(REMOTE_CLUSTER, false);
+    }
+
+    public void testClusterDetailsAfterCCSCancelledDueToFailFast() throws Exception {
+        Map<String, Object> testClusterInfo = setupTwoClusters();
+        String localIndex = (String) testClusterInfo.get("local.index");
+        String remoteIndex = (String) testClusterInfo.get("remote.index");
+        boolean skipUnavailable = (Boolean) testClusterInfo.get("remote.skip_unavailable");
+
+        assertFalse("This test should be set up for remotes to always have skip_unavailable=false", skipUnavailable);
+
+        SearchListenerPlugin.blockQueryPhase();
+
+        SubmitAsyncSearchRequest request = new SubmitAsyncSearchRequest(localIndex, REMOTE_CLUSTER + ":" + remoteIndex);
+        request.setCcsMinimizeRoundtrips(true);
+        request.setWaitForCompletionTimeout(TimeValue.timeValueMillis(1));
+        request.setKeepOnCompletion(true);
+
+        ThrowingQueryBuilder queryBuilder = new ThrowingQueryBuilder.Builder(randomLong()).setExceptionForIndex(
+            remoteIndex,
+            new IllegalStateException("index corrupted")
+        ).setSleepForIndex(localIndex, 500).build();
+        request.getSearchRequest().source(new SearchSourceBuilder().query(queryBuilder).size(10));
+
+        AsyncSearchResponse response = submitAsyncSearch(request);
+        assertNotNull(response.getSearchResponse());
+        assertTrue(response.isRunning());
+        {
+            SearchResponse.Clusters clusters = response.getSearchResponse().getClusters();
+            assertThat(clusters.getTotal(), equalTo(2));
+            assertTrue("search cluster results should be marked as partial", clusters.hasPartialResults());
+
+            SearchResponse.Cluster localClusterSearchInfo = clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
+            assertNotNull(localClusterSearchInfo);
+            assertThat(localClusterSearchInfo.getStatus(), equalTo(SearchResponse.Cluster.Status.RUNNING));
+
+            SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER);
+            assertNotNull(remoteClusterSearchInfo);
+            assertThat(localClusterSearchInfo.getStatus(), equalTo(SearchResponse.Cluster.Status.RUNNING));
+        }
+
+        SearchListenerPlugin.waitSearchStarted();
+        SearchListenerPlugin.allowQueryPhase();
+        waitForSearchTasksToFinish();
+
+        // there is a slight race condition in this test due to how the ThrowingQueryBuilder works - the
+        // local cluster is sleeping a short while to allow the remote cluster to fail first. Most of the
+        // time this results in a CANCELLED status, but if the local cluster does finish before the remote
+        // cluster fails, it will have SUCCESS status instead. The asserts below are set up to handle this
+        // so the test should never fail due to this race condition.
+        SearchResponse.Cluster.Status localClusterExpectedStatus = SearchResponse.Cluster.Status.CANCELLED;
+
+        {
+            AsyncSearchResponse finishedResponse = getAsyncSearch(response.getId());
+            assertTrue(finishedResponse.isPartial());
+
+            SearchResponse.Clusters clusters = finishedResponse.getSearchResponse().getClusters();
+            assertThat(clusters.getTotal(), equalTo(2));
+
+            if (clusters.getClusterStateCount(SearchResponse.Cluster.Status.SUCCESSFUL) == 1) {
+                localClusterExpectedStatus = SearchResponse.Cluster.Status.SUCCESSFUL;
+                assertThat(clusters.getClusterStateCount(SearchResponse.Cluster.Status.RUNNING), equalTo(0));
+                assertThat(clusters.getClusterStateCount(SearchResponse.Cluster.Status.PARTIAL), equalTo(0));
+            } else {
+                assertThat(clusters.getClusterStateCount(SearchResponse.Cluster.Status.SUCCESSFUL), equalTo(0));
+            }
+            assertThat(clusters.getClusterStateCount(SearchResponse.Cluster.Status.SKIPPED), equalTo(0));
+            assertThat(clusters.getClusterStateCount(SearchResponse.Cluster.Status.FAILED), equalTo(1));
+
+            SearchResponse.Cluster localClusterSearchInfo = clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
+            assertNotNull(localClusterSearchInfo);
+            assertThat(localClusterSearchInfo.getStatus(), equalTo(localClusterExpectedStatus));
+
+            SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER);
+            assertNotNull(remoteClusterSearchInfo);
+            assertThat(remoteClusterSearchInfo.getStatus(), equalTo(SearchResponse.Cluster.Status.FAILED));
+            assertNull(remoteClusterSearchInfo.getTotalShards());
+            assertNull(remoteClusterSearchInfo.getSuccessfulShards());
+            assertNull(remoteClusterSearchInfo.getSkippedShards());
+            assertNull(remoteClusterSearchInfo.getFailedShards());
+            assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(1));
+            assertNull(remoteClusterSearchInfo.getTook());
+            assertFalse(remoteClusterSearchInfo.isTimedOut());
+            ShardSearchFailure remoteShardSearchFailure = remoteClusterSearchInfo.getFailures().get(0);
+            assertTrue("should have 'index corrupted' in reason", remoteShardSearchFailure.reason().contains("index corrupted"));
+        }
+
+        // check that the async_search/status response includes the same cluster details
+        {
+            AsyncStatusResponse statusResponse = getAsyncStatus(response.getId());
+            assertTrue(statusResponse.isPartial());
+
+            SearchResponse.Clusters clusters = statusResponse.getClusters();
+            assertThat(clusters.getTotal(), equalTo(2));
+            assertThat(clusters.getClusterStateCount(SearchResponse.Cluster.Status.FAILED), equalTo(1));
+
+            SearchResponse.Cluster localClusterSearchInfo = clusters.getCluster(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
+            assertNotNull(localClusterSearchInfo);
+            assertThat(localClusterSearchInfo.getStatus(), equalTo(localClusterExpectedStatus));
+
+            SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER);
+            assertNotNull(remoteClusterSearchInfo);
+            assertThat(remoteClusterSearchInfo.getStatus(), equalTo(SearchResponse.Cluster.Status.FAILED));
+            assertNull(remoteClusterSearchInfo.getTotalShards());
+            assertNull(remoteClusterSearchInfo.getFailedShards());
+            assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(1));
+            assertNull(remoteClusterSearchInfo.getTook());
+            assertFalse(remoteClusterSearchInfo.isTimedOut());
+            ShardSearchFailure remoteShardSearchFailure = remoteClusterSearchInfo.getFailures().get(0);
+            assertTrue("should have 'index corrupted' in reason", remoteShardSearchFailure.reason().contains("index corrupted"));
+        }
+    }
+}

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/FailFastCrossClusterAsyncSearchIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/FailFastCrossClusterAsyncSearchIT.java
@@ -25,7 +25,7 @@ import static org.hamcrest.Matchers.equalTo;
  * Tests for cross-cluster search where a remote cluster marked with skip_unavailable=false
  * fails, the other searches are cancelled in order to fail-fast the overall search query.
  */
-public class FailFastCrossClusterAsyncSearchIT extends AbstractCrossClusterAsyncSearchTestCase {
+public class FailFastCrossClusterAsyncSearchIT extends AbstractCrossClusterAsyncSearchTestCaseIT {
 
     @Override
     protected Map<String, Boolean> skipUnavailableForRemoteClusters() {

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/AsyncSearchTask.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/AsyncSearchTask.java
@@ -74,6 +74,8 @@ final class AsyncSearchTask extends SearchTask implements AsyncTask {
 
     private volatile long expirationTimeMillis;
     private final AtomicBoolean isCancelling = new AtomicBoolean(false);
+    // set to true if the search is being exited early (e.g., due to fatal error)
+    private final AtomicBoolean earlyExitInvoked = new AtomicBoolean(false);
 
     private final AtomicReference<MutableSearchResponse> searchResponse = new AtomicReference<>();
 
@@ -491,25 +493,35 @@ final class AsyncSearchTask extends SearchTask implements AsyncTask {
         @Override
         public void onResponse(SearchResponse response) {
             searchResponse.get().updateFinalResponse(response, ccsMinimizeRoundtrips);
+            logger.warn("JJJ XXX: AsyncSearchTask onResponse - earlyExitInvoked already:? " + earlyExitInvoked.get());
             executeCompletionListeners();
         }
 
         @Override
         public void onFailure(Exception exc) {
+            logger.warn("JJJ: AsyncSearchTask onFailure called with : " + exc.getClass()); /// MP FIXME - remove
             // if the failure occurred before calling onListShards
             searchResponse.compareAndSet(null, new MutableSearchResponse(-1, -1, null, threadPool.getThreadContext()));
 
             boolean failImmediately = (exc instanceof RemoteTransportException rte && rte.isFatalForCCS());
+            if (failImmediately) {
+                boolean alreadyInvoked = earlyExitInvoked.getAndSet(true);
+                logger.warn("JJJ XXX: AsyncSearchTask onFailure - earlyExitInvoked already:? " + alreadyInvoked);
+                if (alreadyInvoked) {
+                    logger.warn("JJJ XXX: AsyncSearchTask onFailure - RETURNING EARLY");
+                    // ignore late arriving errors (usually from remote clusters in a CCS) if we are exiting early
+                    return;
+                }
+                if (isCancelled() == false) {
+                    cancelTask(() -> {}, "fatal error has occurred in a cross-cluster search - cancelling the search");
+                    logger.warn("JJJ: BINGOx!! =========== ++++++++++++++ CANCELLED CANCELLED +++++");
+                }
+            }
             searchResponse.get()
                 .updateWithFailure(
                     new ElasticsearchStatusException("error while executing search", ExceptionsHelper.status(exc), exc),
                     failImmediately
                 );
-
-            if (failImmediately && isCancelled() == false) {
-                cancelTask(() -> {}, "fatal error has occurred in a cross-cluster search - cancelling the search");
-                logger.warn("JJJ: BINGO!! =========== ++++++++++++++ CANCELLED CANCELLED +++++");
-            }
 
             executeInitListeners();
             executeCompletionListeners();

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/AsyncSearchTask.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/AsyncSearchTask.java
@@ -496,6 +496,7 @@ final class AsyncSearchTask extends SearchTask implements AsyncTask {
 
         @Override
         public void onFailure(Exception exc) {
+            System.err.println("XXX AsyncSearchTask onFailure called with: " + exc.getClass());
             // if the failure occurred before calling onListShards
             searchResponse.compareAndSet(null, new MutableSearchResponse(-1, -1, null, threadPool.getThreadContext()));
 
@@ -508,6 +509,7 @@ final class AsyncSearchTask extends SearchTask implements AsyncTask {
             if (failImmediately && isCancelled() == false) {
                 cancelTask(() -> {}, "fatal error has occurred in a cross-cluster search - cancelling the search");
                 logger.warn("JJJy: BINGO!! =========== ++++++++++++++ CANCELLED CANCELLED +++++");  /// MP FIXME - remove
+                System.err.println("XXX AsyncSearchTasK BINGO - CANCELLED");
             }
             executeInitListeners();
             executeCompletionListeners();

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/AsyncSearchTask.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/AsyncSearchTask.java
@@ -6,8 +6,6 @@
  */
 package org.elasticsearch.xpack.search;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchStatusException;
@@ -56,7 +54,6 @@ import static java.util.Collections.singletonList;
  * Task that tracks the progress of a currently running {@link SearchRequest}.
  */
 final class AsyncSearchTask extends SearchTask implements AsyncTask {
-    private static final Logger logger = LogManager.getLogger(AsyncSearchTask.class);
     private final AsyncExecutionId searchId;
     private final Client client;
     private final ThreadPool threadPool;
@@ -496,7 +493,6 @@ final class AsyncSearchTask extends SearchTask implements AsyncTask {
 
         @Override
         public void onFailure(Exception exc) {
-            System.err.println("XXX AsyncSearchTask onFailure called with: " + exc.getClass());
             // if the failure occurred before calling onListShards
             searchResponse.compareAndSet(null, new MutableSearchResponse(-1, -1, null, threadPool.getThreadContext()));
 
@@ -508,8 +504,6 @@ final class AsyncSearchTask extends SearchTask implements AsyncTask {
                 );
             if (failImmediately && isCancelled() == false) {
                 cancelTask(() -> {}, "fatal error has occurred in a cross-cluster search - cancelling the search");
-                logger.warn("JJJy: BINGO!! =========== ++++++++++++++ CANCELLED CANCELLED +++++");  /// MP FIXME - remove
-                System.err.println("XXX AsyncSearchTasK BINGO - CANCELLED");
             }
             executeInitListeners();
             executeCompletionListeners();

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/MutableSearchResponse.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/MutableSearchResponse.java
@@ -6,6 +6,8 @@
  */
 package org.elasticsearch.xpack.search;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
@@ -36,6 +38,7 @@ import static org.elasticsearch.xpack.core.async.AsyncTaskIndexService.restoreRe
  * run concurrently to 1 and ensures that we pause the search progress when an {@link AsyncSearchResponse} is built.
  */
 class MutableSearchResponse {
+    private static final Logger logger = LogManager.getLogger(MutableSearchResponse.class);
     private static final TotalHits EMPTY_TOTAL_HITS = new TotalHits(0L, TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO);
     private final int totalShards;
     private final int skippedShards;
@@ -134,7 +137,7 @@ class MutableSearchResponse {
      * Updates the response with a fatal failure. This method preserves the partial response
      * received from previous updates
      */
-    synchronized void updateWithFailure(ElasticsearchException exc) {
+    synchronized void updateWithFailure(ElasticsearchException exc, boolean failImmediately) {
         failIfFrozen();
         // copy the response headers from the current context
         this.responseHeaders = threadContext.getResponseHeaders();
@@ -143,6 +146,10 @@ class MutableSearchResponse {
         this.isPartial = true;
         this.failure = exc;
         this.frozen = true;
+        if (failImmediately && clusters != null) {  // TODO: can we remove the clusters != null check?
+            logger.warn("JJJ MutableSearchResponse updateWithFailure: notifySearchCancelled");
+            clusters.notifySearchCancelled();
+        }
     }
 
     /**

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/MutableSearchResponse.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/MutableSearchResponse.java
@@ -160,7 +160,6 @@ class MutableSearchResponse {
         if (failImmediately) {
             earlyExitInvoked = true;
             clusters.notifySearchCancelled();
-            System.err.println("XXX MSR.updateWithFailure FAIL_IMMEDIATELY = notifySearchCancelled");
         }
     }
 

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/MutableSearchResponse.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/MutableSearchResponse.java
@@ -160,6 +160,7 @@ class MutableSearchResponse {
         if (failImmediately) {
             earlyExitInvoked = true;
             clusters.notifySearchCancelled();
+            System.err.println("XXX MSR.updateWithFailure FAIL_IMMEDIATELY = notifySearchCancelled");
         }
     }
 


### PR DESCRIPTION
For CCS with minimize_roundtrips=true, when one of the remote clusters in scope for the search is down (or goes down during the query) and that cluster is not marked with skip_unavailable=true, the search will fail (as expected) but it will not fail fast. Instead, it has to wait for all the other remote cluster searches to finish before it fails the search.

This commit changes that behavior for minimize_roundtrips=true. Once a fatal error is detected, the remaining searches will be cancelled and the search will end as quickly as possible.

A "fatal error" here means that a cluster that cannot be skipped either has lost connection (e.g, node_disconnected) or searches on all shards of that cluster fail.