### PR TITLE
Fix SearchCancellationIT failures (#101777)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/SearchCancellationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/SearchCancellationIT.java
@@ -32,7 +32,6 @@ import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.test.AbstractSearchCancellationTestCase;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.junit.annotations.TestIssueLogging;
 import org.elasticsearch.transport.TransportService;
 
 import java.util.ArrayList;
@@ -231,11 +230,10 @@ public class SearchCancellationIT extends AbstractSearchCancellationTestCase {
         }
     }
 
-    @TestIssueLogging(
-        value = "org.elasticsearch.action.search:TRACE,org.elasticsearch.search:TRACE," + "org.elasticsearch.tasks:TRACE",
-        issueUrl = "https://github.com/elastic/elasticsearch/issues/99929"
-    )
     public void testCancelFailedSearchWhenPartialResultDisallowed() throws Exception {
+        // Have at least two nodes so that we have parallel execution of two request guaranteed even if max concurrent requests per node
+        // are limited to 1
+        internalCluster().ensureAtLeastNumDataNodes(2);
         int numberOfShards = between(2, 5);
         createIndex("test", numberOfShards, 0);
         indexTestData();


### PR DESCRIPTION
We need at least two data nodes in this test, otherwise we are not guaranteed to get two concurrently executing shard query requests because max concurrency could be 1.

closes #101739 #99929

backport of #101777