### PR TITLE
Fix disk usage computation during desired balance calculation

### DIFF
--- a/docs/changelog/102013.yaml
+++ b/docs/changelog/102013.yaml
@@ -1,0 +1,5 @@
+pr: 102013
+summary: Fix disk usage computation during desired balance calculation
+area: Allocation
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/cluster/DiskUsage.java
+++ b/server/src/main/java/org/elasticsearch/cluster/DiskUsage.java
@@ -33,6 +33,10 @@ public record DiskUsage(String nodeId, String nodeName, String path, long totalB
 
     private static final Logger logger = LogManager.getLogger(DiskUsage.class);
 
+    public DiskUsage(String nodeId, String path, long totalBytes, long freeBytes) {
+        this(nodeId, nodeId, path, totalBytes, freeBytes);
+    }
+
     public DiskUsage(StreamInput in) throws IOException {
         this(in.readString(), in.readString(), in.readString(), in.readVLong(), in.readVLong());
     }

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputerTests.java
@@ -1037,7 +1037,7 @@ public class DesiredBalanceComputerTests extends ESAllocationTestCase {
             Map.ofEntries(
                 Map.entry(new ShardId(indexMetadata1.getIndex(), 0), new ShardAssignment(Set.of("node-1"), 1, 0, 0)),
                 Map.entry(new ShardId(indexMetadata1.getIndex(), 1), new ShardAssignment(Set.of("node-2"), 1, 0, 0)),
-                Map.entry(new ShardId(indexMetadata2.getIndex(), 2), new ShardAssignment(Set.of("node-1"), 1, 0, 0))
+                Map.entry(new ShardId(indexMetadata2.getIndex(), 0), new ShardAssignment(Set.of("node-1"), 1, 0, 0))
             )
         );
 
@@ -1104,7 +1104,7 @@ public class DesiredBalanceComputerTests extends ESAllocationTestCase {
             Map.ofEntries(
                 Map.entry(new ShardId(indexMetadata1.getIndex(), 0), new ShardAssignment(Set.of("node-1"), 1, 0, 0)),
                 Map.entry(new ShardId(indexMetadata1.getIndex(), 1), new ShardAssignment(Set.of("node-2"), 1, 0, 0)),
-                Map.entry(new ShardId(indexMetadata2.getIndex(), 2), new ShardAssignment(Set.of("node-1"), 1, 0, 0))
+                Map.entry(new ShardId(indexMetadata2.getIndex(), 0), new ShardAssignment(Set.of("node-1"), 1, 0, 0))
             )
         );
 
@@ -1171,7 +1171,7 @@ public class DesiredBalanceComputerTests extends ESAllocationTestCase {
             Map.ofEntries(
                 Map.entry(new ShardId(indexMetadata1.getIndex(), 0), new ShardAssignment(Set.of("node-1"), 1, 0, 0)),
                 Map.entry(new ShardId(indexMetadata1.getIndex(), 1), new ShardAssignment(Set.of("node-2"), 1, 0, 0)),
-                Map.entry(new ShardId(indexMetadata2.getIndex(), 2), new ShardAssignment(Set.of("node-1"), 1, 0, 0))
+                Map.entry(new ShardId(indexMetadata2.getIndex(), 0), new ShardAssignment(Set.of("node-1"), 1, 0, 0))
             )
         );
 
@@ -1238,7 +1238,7 @@ public class DesiredBalanceComputerTests extends ESAllocationTestCase {
             Map.ofEntries(
                 Map.entry(new ShardId(indexMetadata1.getIndex(), 0), new ShardAssignment(Set.of("node-1"), 1, 0, 0)),
                 Map.entry(new ShardId(indexMetadata1.getIndex(), 1), new ShardAssignment(Set.of("node-2"), 1, 0, 0)),
-                Map.entry(new ShardId(indexMetadata2.getIndex(), 2), new ShardAssignment(Set.of("node-1"), 1, 0, 0))
+                Map.entry(new ShardId(indexMetadata2.getIndex(), 0), new ShardAssignment(Set.of("node-1"), 1, 0, 0))
             )
         );
 


### PR DESCRIPTION
There are set of bugs in disk usage computation in cases when previous desired balance is partially reconciled while receiving a new computation call. This change is fixing them

Related to #91386

(This is still wip, I am looking for a best alternative to fix it)
