### PR TITLE
Retrieve stacktrace events from a custom index

### DIFF
--- a/docs/changelog/102020.yaml
+++ b/docs/changelog/102020.yaml
@@ -1,0 +1,5 @@
+pr: 102020
+summary: Retrieve stacktrace events from a custom index
+area: Application
+type: enhancement
+issues: []

--- a/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/GetFlameGraphActionIT.java
+++ b/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/GetFlameGraphActionIT.java
@@ -9,13 +9,13 @@ package org.elasticsearch.xpack.profiling;
 
 public class GetFlameGraphActionIT extends ProfilingTestCase {
     public void testGetStackTracesUnfiltered() throws Exception {
-        GetStackTracesRequest request = new GetStackTracesRequest(10, null);
+        GetStackTracesRequest request = new GetStackTracesRequest(10, null, null, null);
         GetFlamegraphResponse response = client().execute(GetFlamegraphAction.INSTANCE, request).get();
         // only spot-check top level properties - detailed tests are done in unit tests
-        assertEquals(231, response.getSize());
+        assertEquals(297, response.getSize());
         assertEquals(1.0d, response.getSamplingRate(), 0.001d);
         assertEquals(60, response.getSelfCPU());
-        assertEquals(1204, response.getTotalCPU());
+        assertEquals(1956, response.getTotalCPU());
         assertEquals(40, response.getTotalSamples());
     }
 }

--- a/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/ProfilingTestCase.java
+++ b/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/ProfilingTestCase.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.profiling;
 import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
 import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsResponse;
+import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.common.network.NetworkModule;
@@ -30,6 +31,7 @@ import org.junit.After;
 import org.junit.Before;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -68,7 +70,22 @@ public abstract class ProfilingTestCase extends ESIntegTestCase {
         return false; // enable http
     }
 
-    private void indexDoc(String index, String id, Map<String, Object> source) {
+    protected final byte[] read(String resource) throws IOException {
+        return ProfilingTestCase.class.getClassLoader().getResourceAsStream(resource).readAllBytes();
+    }
+
+    protected final void createIndex(String name, String bodyFileName) throws Exception {
+        CreateIndexResponse response = client().admin()
+            .indices()
+            .prepareCreate(name)
+            .setSource(read(bodyFileName), XContentType.JSON)
+            .execute()
+            .get();
+        assertTrue("Creation of [" + name + "] is not acknowledged.", response.isAcknowledged());
+        assertTrue("Shards for [" + name + "] are not acknowledged.", response.isShardsAcknowledged());
+    }
+
+    protected final void indexDoc(String index, String id, Map<String, Object> source) {
         DocWriteResponse indexResponse = client().prepareIndex(index).setId(id).setSource(source).setCreate(true).get();
         assertEquals(RestStatus.CREATED, indexResponse.status());
     }
@@ -80,18 +97,10 @@ public abstract class ProfilingTestCase extends ESIntegTestCase {
         return true;
     }
 
-    protected void waitForIndices() throws Exception {
+    protected void waitForIndices(Collection<String> indices) throws Exception {
         assertBusy(() -> {
             ClusterState state = clusterAdmin().prepareState().get().getState();
-            assertTrue(
-                "Timed out waiting for the indices to be created",
-                state.metadata()
-                    .indices()
-                    .keySet()
-                    .containsAll(
-                        ProfilingIndexManager.PROFILING_INDICES.stream().map(ProfilingIndexManager.ProfilingIndex::toString).toList()
-                    )
-            );
+            assertTrue("Timed out waiting for indices to be created", state.metadata().indices().keySet().containsAll(indices));
         });
     }
 
@@ -100,10 +109,6 @@ public abstract class ProfilingTestCase extends ESIntegTestCase {
         request.persistentSettings(Settings.builder().put(ProfilingPlugin.PROFILING_TEMPLATES_ENABLED.getKey(), newValue).build());
         ClusterUpdateSettingsResponse response = clusterAdmin().updateSettings(request).actionGet();
         assertTrue("Update of profiling templates enabled setting is not acknowledged", response.isAcknowledged());
-    }
-
-    protected final byte[] read(String resource) throws IOException {
-        return ProfilingTestCase.class.getClassLoader().getResourceAsStream(resource).readAllBytes();
     }
 
     protected final void bulkIndex(String file) throws Exception {
@@ -117,15 +122,22 @@ public abstract class ProfilingTestCase extends ESIntegTestCase {
         if (requiresDataSetup() == false) {
             return;
         }
+        final String apmTestIndex = "apm-test-001";
         // only enable index management while setting up indices to avoid interfering with the rest of the test infrastructure
         updateProfilingTemplatesEnabled(true);
-        waitForIndices();
-        ensureGreen();
+        createIndex(apmTestIndex, "indices/apm-test.json");
+        List<String> allIndices = new ArrayList<>(
+            ProfilingIndexManager.PROFILING_INDICES.stream().map(ProfilingIndexManager.ProfilingIndex::toString).toList()
+        );
+        allIndices.add(apmTestIndex);
+        waitForIndices(allIndices);
+        ensureGreen(allIndices.toArray(new String[0]));
 
         bulkIndex("data/profiling-events-all.ndjson");
         bulkIndex("data/profiling-stacktraces.ndjson");
         bulkIndex("data/profiling-stackframes.ndjson");
         bulkIndex("data/profiling-executables.ndjson");
+        bulkIndex("data/apm-test.ndjson");
 
         refresh();
     }

--- a/x-pack/plugin/profiling/src/internalClusterTest/resources/data/apm-test.ndjson
+++ b/x-pack/plugin/profiling/src/internalClusterTest/resources/data/apm-test.ndjson
@@ -1,0 +1,2 @@
+{"create": {"_index": "apm-test-001"}}
+{"@timestamp": "1698624000", "transaction.name":  "encodeSha1", "transaction.profiler_stack_trace_ids": "Ce77w10WeIDow3kd1jowlA"}

--- a/x-pack/plugin/profiling/src/internalClusterTest/resources/indices/apm-test.json
+++ b/x-pack/plugin/profiling/src/internalClusterTest/resources/indices/apm-test.json
@@ -1,0 +1,24 @@
+{
+  "settings": {
+    "index" : {
+      "number_of_replicas" : 0
+    }
+  },
+  "mappings": {
+    "_doc": {
+      "dynamic": "false",
+      "date_detection": false,
+      "properties": {
+        "@timestamp": {
+          "type": "date"
+        },
+        "transaction.profiler_stack_trace_ids": {
+          "type": "keyword"
+        },
+        "transaction.name": {
+          "type": "keyword"
+        }
+      }
+    }
+  }
+}

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetFlamegraphResponse.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetFlamegraphResponse.java
@@ -23,8 +23,8 @@ import java.util.Map;
 public class GetFlamegraphResponse extends ActionResponse implements ChunkedToXContentObject {
     private final int size;
     private final double samplingRate;
-    private final int selfCPU;
-    private final int totalCPU;
+    private final long selfCPU;
+    private final long totalCPU;
     private final long totalSamples;
     private final List<Map<String, Integer>> edges;
     private final List<String> fileIds;
@@ -36,8 +36,8 @@ public class GetFlamegraphResponse extends ActionResponse implements ChunkedToXC
     private final List<Integer> functionOffsets;
     private final List<String> sourceFileNames;
     private final List<Integer> sourceLines;
-    private final List<Integer> countInclusive;
-    private final List<Integer> countExclusive;
+    private final List<Long> countInclusive;
+    private final List<Long> countExclusive;
 
     public GetFlamegraphResponse(StreamInput in) throws IOException {
         this.size = in.readInt();
@@ -52,10 +52,10 @@ public class GetFlamegraphResponse extends ActionResponse implements ChunkedToXC
         this.functionOffsets = in.readCollectionAsList(StreamInput::readInt);
         this.sourceFileNames = in.readCollectionAsList(StreamInput::readString);
         this.sourceLines = in.readCollectionAsList(StreamInput::readInt);
-        this.countInclusive = in.readCollectionAsList(StreamInput::readInt);
-        this.countExclusive = in.readCollectionAsList(StreamInput::readInt);
-        this.selfCPU = in.readInt();
-        this.totalCPU = in.readInt();
+        this.countInclusive = in.readCollectionAsList(StreamInput::readLong);
+        this.countExclusive = in.readCollectionAsList(StreamInput::readLong);
+        this.selfCPU = in.readLong();
+        this.totalCPU = in.readLong();
         this.totalSamples = in.readLong();
     }
 
@@ -72,10 +72,10 @@ public class GetFlamegraphResponse extends ActionResponse implements ChunkedToXC
         List<Integer> functionOffsets,
         List<String> sourceFileNames,
         List<Integer> sourceLines,
-        List<Integer> countInclusive,
-        List<Integer> countExclusive,
-        int selfCPU,
-        int totalCPU,
+        List<Long> countInclusive,
+        List<Long> countExclusive,
+        long selfCPU,
+        long totalCPU,
         long totalSamples
     ) {
         this.size = size;
@@ -111,10 +111,10 @@ public class GetFlamegraphResponse extends ActionResponse implements ChunkedToXC
         out.writeCollection(this.functionOffsets, StreamOutput::writeInt);
         out.writeCollection(this.sourceFileNames, StreamOutput::writeString);
         out.writeCollection(this.sourceLines, StreamOutput::writeInt);
-        out.writeCollection(this.countInclusive, StreamOutput::writeInt);
-        out.writeCollection(this.countExclusive, StreamOutput::writeInt);
-        out.writeInt(this.selfCPU);
-        out.writeInt(this.totalCPU);
+        out.writeCollection(this.countInclusive, StreamOutput::writeLong);
+        out.writeCollection(this.countExclusive, StreamOutput::writeLong);
+        out.writeLong(this.selfCPU);
+        out.writeLong(this.totalCPU);
         out.writeLong(this.totalSamples);
     }
 
@@ -126,11 +126,11 @@ public class GetFlamegraphResponse extends ActionResponse implements ChunkedToXC
         return samplingRate;
     }
 
-    public List<Integer> getCountInclusive() {
+    public List<Long> getCountInclusive() {
         return countInclusive;
     }
 
-    public List<Integer> getCountExclusive() {
+    public List<Long> getCountExclusive() {
         return countExclusive;
     }
 
@@ -174,11 +174,11 @@ public class GetFlamegraphResponse extends ActionResponse implements ChunkedToXC
         return sourceLines;
     }
 
-    public int getSelfCPU() {
+    public long getSelfCPU() {
         return selfCPU;
     }
 
-    public int getTotalCPU() {
+    public long getTotalCPU() {
         return totalCPU;
     }
 

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetStackTracesResponse.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetStackTracesResponse.java
@@ -30,7 +30,7 @@ public class GetStackTracesResponse extends ActionResponse implements ChunkedToX
     @Nullable
     private final Map<String, String> executables;
     @Nullable
-    private final Map<String, Integer> stackTraceEvents;
+    private final Map<String, Long> stackTraceEvents;
     private final int totalFrames;
     private final double samplingRate;
     private final long totalSamples;
@@ -57,7 +57,7 @@ public class GetStackTracesResponse extends ActionResponse implements ChunkedToX
             )
             : null;
         this.executables = in.readBoolean() ? in.readMap(StreamInput::readString) : null;
-        this.stackTraceEvents = in.readBoolean() ? in.readMap(StreamInput::readInt) : null;
+        this.stackTraceEvents = in.readBoolean() ? in.readMap(StreamInput::readLong) : null;
         this.totalFrames = in.readInt();
         this.samplingRate = in.readDouble();
         this.totalSamples = in.readLong();
@@ -67,7 +67,7 @@ public class GetStackTracesResponse extends ActionResponse implements ChunkedToX
         Map<String, StackTrace> stackTraces,
         Map<String, StackFrame> stackFrames,
         Map<String, String> executables,
-        Map<String, Integer> stackTraceEvents,
+        Map<String, Long> stackTraceEvents,
         int totalFrames,
         double samplingRate,
         long totalSamples
@@ -113,7 +113,7 @@ public class GetStackTracesResponse extends ActionResponse implements ChunkedToX
         }
         if (stackTraceEvents != null) {
             out.writeBoolean(true);
-            out.writeMap(stackTraceEvents, StreamOutput::writeInt);
+            out.writeMap(stackTraceEvents, StreamOutput::writeLong);
         } else {
             out.writeBoolean(false);
         }
@@ -134,7 +134,7 @@ public class GetStackTracesResponse extends ActionResponse implements ChunkedToX
         return executables;
     }
 
-    public Map<String, Integer> getStackTraceEvents() {
+    public Map<String, Long> getStackTraceEvents() {
         return stackTraceEvents;
     }
 

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetFlamegraphAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetFlamegraphAction.java
@@ -79,7 +79,7 @@ public class TransportGetFlamegraphAction extends HandledTransportAction<GetStac
         for (Map.Entry<String, StackTrace> st : sortedStacktraces.entrySet()) {
             String stackTraceId = st.getKey();
             StackTrace stackTrace = st.getValue();
-            int samples = response.getStackTraceEvents().getOrDefault(stackTraceId, 0);
+            long samples = response.getStackTraceEvents().getOrDefault(stackTraceId, 0L);
             builder.setCurrentNode(0);
             builder.addSamplesInclusive(0, samples);
             builder.addSamplesExclusive(0, 0);
@@ -129,8 +129,8 @@ public class TransportGetFlamegraphAction extends HandledTransportAction<GetStac
     private static class FlamegraphBuilder {
         private int currentNode = 0;
         private int size = 0;
-        private int selfCPU;
-        private int totalCPU;
+        private long selfCPU;
+        private long totalCPU;
         private final long totalSamples;
         // Map: FrameGroupId -> NodeId
         private final List<Map<String, Integer>> edges;
@@ -143,8 +143,8 @@ public class TransportGetFlamegraphAction extends HandledTransportAction<GetStac
         private final List<Integer> functionOffsets;
         private final List<String> sourceFileNames;
         private final List<Integer> sourceLines;
-        private final List<Integer> countInclusive;
-        private final List<Integer> countExclusive;
+        private final List<Long> countInclusive;
+        private final List<Long> countExclusive;
         private final double samplingRate;
 
         FlamegraphBuilder(long totalSamples, int frames, double samplingRate) {
@@ -180,7 +180,7 @@ public class TransportGetFlamegraphAction extends HandledTransportAction<GetStac
             int functionOffset,
             String sourceFileName,
             int sourceLine,
-            int samples,
+            long samples,
             String frameGroupId
         ) {
             int node = this.size;
@@ -196,7 +196,7 @@ public class TransportGetFlamegraphAction extends HandledTransportAction<GetStac
             this.sourceLines.add(sourceLine);
             this.countInclusive.add(samples);
             this.totalCPU += samples;
-            this.countExclusive.add(0);
+            this.countExclusive.add(0L);
             if (frameGroupId != null) {
                 this.edges.get(currentNode).put(frameGroupId, node);
             }
@@ -216,14 +216,14 @@ public class TransportGetFlamegraphAction extends HandledTransportAction<GetStac
             return this.edges.get(currentNode).get(frameGroupId);
         }
 
-        public void addSamplesInclusive(int nodeId, int sampleCount) {
-            Integer priorSampleCount = this.countInclusive.get(nodeId);
+        public void addSamplesInclusive(int nodeId, long sampleCount) {
+            Long priorSampleCount = this.countInclusive.get(nodeId);
             this.countInclusive.set(nodeId, priorSampleCount + sampleCount);
             this.totalCPU += sampleCount;
         }
 
-        public void addSamplesExclusive(int nodeId, int sampleCount) {
-            Integer priorSampleCount = this.countExclusive.get(nodeId);
+        public void addSamplesExclusive(int nodeId, long sampleCount) {
+            Long priorSampleCount = this.countExclusive.get(nodeId);
             this.countExclusive.set(nodeId, priorSampleCount + sampleCount);
             this.selfCPU += sampleCount;
         }

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStackTracesAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStackTracesAction.java
@@ -192,11 +192,11 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
             )
             .execute(handleEventsGroupedByStackTrace(client, responseBuilder, submitListener, searchResponse -> {
                 StringTerms stacktraces = searchResponse.getAggregations().get("group_by");
-                Map<String, Long> stackTraceEvents = new TreeMap<>();
+                Map<String, Long> countPerStackTrace = new TreeMap<>();
                 for (StringTerms.Bucket bucket : stacktraces.getBuckets()) {
-                    stackTraceEvents.put(bucket.getKeyAsString(), bucket.getDocCount());
+                    countPerStackTrace.put(bucket.getKeyAsString(), bucket.getDocCount());
                 }
-                return stackTraceEvents;
+                return countPerStackTrace;
             }));
     }
 

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStackTracesAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStackTracesAction.java
@@ -11,6 +11,7 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.get.MultiGetItemResponse;
 import org.elasticsearch.action.get.MultiGetResponse;
+import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.action.support.ThreadedActionListener;
@@ -51,6 +52,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 
 public class TransportGetStackTracesAction extends HandledTransportAction<GetStackTracesRequest, GetStackTracesResponse> {
     private static final Logger log = LogManager.getLogger(TransportGetStackTracesAction.class);
@@ -126,8 +128,20 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
     @Override
     protected void doExecute(Task submitTask, GetStackTracesRequest request, ActionListener<GetStackTracesResponse> submitListener) {
         licenseChecker.requireSupportedLicense();
-        StopWatch watch = new StopWatch("getResampledIndex");
         Client client = new ParentTaskAssigningClient(this.nodeClient, transportService.getLocalNode(), submitTask);
+        if (request.getIndices() == null) {
+            searchProfilingEvents(request, submitListener, client);
+        } else {
+            searchGenericEvents(request, submitListener, client);
+        }
+    }
+
+    private void searchProfilingEvents(
+        GetStackTracesRequest request,
+        ActionListener<GetStackTracesResponse> submitListener,
+        Client client
+    ) {
+        StopWatch watch = new StopWatch("getResampledIndex");
         EventsIndex mediumDownsampled = EventsIndex.MEDIUM_DOWNSAMPLED;
         client.prepareSearch(mediumDownsampled.getName())
             .setSize(0)
@@ -143,8 +157,8 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
                     mediumDownsampled,
                     resampledIndex
                 );
-                log.debug(() -> watch.report());
-                searchEventGroupByStackTrace(client, request, resampledIndex, submitListener);
+                log.debug(watch::report);
+                searchEventGroupedByStackTrace(client, request, resampledIndex, submitListener);
             }, e -> {
                 // All profiling-events data streams are created lazily. In a relatively empty cluster it can happen that there are so few
                 // data that we need to resort to the "full" events stream. As this is an edge case we'd rather fail instead of prematurely
@@ -153,22 +167,47 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
                     String missingIndex = ((IndexNotFoundException) e).getIndex().getName();
                     EventsIndex fullIndex = EventsIndex.FULL_INDEX;
                     log.debug("Index [{}] does not exist. Using [{}] instead.", missingIndex, fullIndex.getName());
-                    searchEventGroupByStackTrace(client, request, fullIndex, submitListener);
+                    searchEventGroupedByStackTrace(client, request, fullIndex, submitListener);
                 } else {
                     submitListener.onFailure(e);
                 }
             }));
     }
 
-    private void searchEventGroupByStackTrace(
+    private void searchGenericEvents(GetStackTracesRequest request, ActionListener<GetStackTracesResponse> submitListener, Client client) {
+        GetStackTracesResponseBuilder responseBuilder = new GetStackTracesResponseBuilder();
+        responseBuilder.setSamplingRate(1.0d);
+        client.prepareSearch(request.indices())
+            .setTrackTotalHits(false)
+            .setSize(0)
+            .setQuery(request.getQuery())
+            .addAggregation(new MinAggregationBuilder("min_time").field("@timestamp"))
+            .addAggregation(new MaxAggregationBuilder("max_time").field("@timestamp"))
+            .addAggregation(
+                // TODO: Replace this with a CountedTermsAggregationBuilder when #101826 is merged.
+                new TermsAggregationBuilder("group_by")
+                    // 'size' should be max 100k, but might be slightly more. Better be on the safe side.
+                    .size(150_000)
+                    .field(request.getStackTraceIds())
+            )
+            .execute(handleEventsGroupedByStackTrace(client, responseBuilder, submitListener, searchResponse -> {
+                StringTerms stacktraces = searchResponse.getAggregations().get("group_by");
+                Map<String, Long> stackTraceEvents = new TreeMap<>();
+                for (StringTerms.Bucket bucket : stacktraces.getBuckets()) {
+                    stackTraceEvents.put(bucket.getKeyAsString(), bucket.getDocCount());
+                }
+                return stackTraceEvents;
+            }));
+    }
+
+    private void searchEventGroupedByStackTrace(
         Client client,
         GetStackTracesRequest request,
         EventsIndex eventsIndex,
         ActionListener<GetStackTracesResponse> submitListener
     ) {
-        StopWatch watch = new StopWatch("searchEventGroupByStackTrace");
         GetStackTracesResponseBuilder responseBuilder = new GetStackTracesResponseBuilder();
-        responseBuilder.setSampleRate(eventsIndex.getSampleRate());
+        responseBuilder.setSamplingRate(eventsIndex.getSampleRate());
         client.prepareSearch(eventsIndex.getName())
             .setTrackTotalHits(false)
             .setSize(0)
@@ -186,54 +225,71 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
                     .subAggregation(new SumAggregationBuilder("count").field("Stacktrace.count"))
             )
             .addAggregation(new SumAggregationBuilder("total_count").field("Stacktrace.count"))
-            .execute(ActionListener.wrap(searchResponse -> {
-                Min minTimeAgg = searchResponse.getAggregations().get("min_time");
-                Max maxTimeAgg = searchResponse.getAggregations().get("max_time");
-                long minTime = Math.round(minTimeAgg.value());
-                long maxTime = Math.round(maxTimeAgg.value());
+            .execute(handleEventsGroupedByStackTrace(client, responseBuilder, submitListener, searchResponse -> {
+                StringTerms stacktraces = searchResponse.getAggregations().get("group_by");
                 Sum totalCountAgg = searchResponse.getAggregations().get("total_count");
                 long totalCount = Math.round(totalCountAgg.value());
-                Resampler resampler = new Resampler(request, eventsIndex.getSampleRate(), totalCount);
-                StringTerms stacktraces = searchResponse.getAggregations().get("group_by");
+                Resampler resampler = new Resampler(request, responseBuilder.getSamplingRate(), totalCount);
                 // sort items lexicographically to access Lucene's term dictionary more efficiently when issuing an mget request.
                 // The term dictionary is lexicographically sorted and using the same order reduces the number of page faults
                 // needed to load it.
                 long totalFinalCount = 0;
-                Map<String, Integer> stackTraceEvents = new TreeMap<>();
+                Map<String, Long> stackTraceEvents = new TreeMap<>();
                 for (StringTerms.Bucket bucket : stacktraces.getBuckets()) {
                     Sum count = bucket.getAggregations().get("count");
                     int finalCount = resampler.adjustSampleCount((int) count.value());
                     totalFinalCount += finalCount;
                     if (finalCount > 0) {
-                        stackTraceEvents.put(bucket.getKeyAsString(), finalCount);
+                        stackTraceEvents.put(bucket.getKeyAsString(), (long) finalCount);
                     }
                 }
                 responseBuilder.setTotalSamples(totalFinalCount);
                 log.debug(
                     "Found [{}] stacktrace events, resampled with sample rate [{}] to [{}] events ([{}] unique stack traces).",
                     totalCount,
-                    eventsIndex.getSampleRate(),
+                    responseBuilder.getSamplingRate(),
                     totalFinalCount,
                     stackTraceEvents.size()
                 );
-                log.debug(() -> watch.report());
-                if (stackTraceEvents.isEmpty() == false) {
-                    responseBuilder.setStart(Instant.ofEpochMilli(minTime));
-                    responseBuilder.setEnd(Instant.ofEpochMilli(maxTime));
-                    responseBuilder.setStackTraceEvents(stackTraceEvents);
-                    retrieveStackTraces(client, responseBuilder, submitListener);
-                } else {
-                    submitListener.onResponse(responseBuilder.build());
-                }
-            }, e -> {
-                // Data streams are created lazily; if even the "full" index does not exist no data have been indexed yet.
-                if (e instanceof IndexNotFoundException) {
-                    log.debug("Index [{}] does not exist. Returning empty response.", ((IndexNotFoundException) e).getIndex());
-                    submitListener.onResponse(responseBuilder.build());
-                } else {
-                    submitListener.onFailure(e);
-                }
+                return stackTraceEvents;
             }));
+    }
+
+    private ActionListener<SearchResponse> handleEventsGroupedByStackTrace(
+        Client client,
+        GetStackTracesResponseBuilder responseBuilder,
+        ActionListener<GetStackTracesResponse> submitListener,
+        Function<SearchResponse, Map<String, Long>> stacktraceCollector
+    ) {
+        StopWatch watch = new StopWatch("eventsGroupedByStackTrace");
+        return ActionListener.wrap(searchResponse -> {
+            Min minTimeAgg = searchResponse.getAggregations().get("min_time");
+            Max maxTimeAgg = searchResponse.getAggregations().get("max_time");
+            long minTime = Math.round(minTimeAgg.value());
+            long maxTime = Math.round(maxTimeAgg.value());
+
+            Map<String, Long> stackTraceEvents = stacktraceCollector.apply(searchResponse);
+
+            log.debug(watch::report);
+            if (stackTraceEvents.isEmpty() == false) {
+                long totalSamples = stackTraceEvents.values().stream().mapToLong(v -> v).sum();
+                responseBuilder.setTotalSamples(totalSamples);
+                responseBuilder.setStart(Instant.ofEpochMilli(minTime));
+                responseBuilder.setEnd(Instant.ofEpochMilli(maxTime));
+                responseBuilder.setStackTraceEvents(stackTraceEvents);
+                retrieveStackTraces(client, responseBuilder, submitListener);
+            } else {
+                submitListener.onResponse(responseBuilder.build());
+            }
+        }, e -> {
+            // Data streams are created lazily; if even the "full" index does not exist no data have been indexed yet.
+            if (e instanceof IndexNotFoundException) {
+                log.debug("Index [{}] does not exist. Returning empty response.", ((IndexNotFoundException) e).getIndex());
+                submitListener.onResponse(responseBuilder.build());
+            } else {
+                submitListener.onFailure(e);
+            }
+        });
     }
 
     private void retrieveStackTraces(
@@ -334,7 +390,7 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
                     stackFrameIds.size(),
                     executableIds.size()
                 );
-                log.debug(() -> watch.report());
+                log.debug(watch::report);
                 retrieveStackTraceDetails(
                     clusterState,
                     client,
@@ -479,7 +535,7 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
                 builder.setExecutables(executables);
                 builder.setStackFrames(stackFrames);
                 log.debug("retrieveStackTraceDetails found [{}] stack frames, [{}] executables.", stackFrames.size(), executables.size());
-                log.debug(() -> watch.report());
+                log.debug(watch::report);
                 submitListener.onResponse(builder.build());
             }
         }
@@ -501,7 +557,7 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
         private int totalFrames;
         private Map<String, StackFrame> stackFrames;
         private Map<String, String> executables;
-        private Map<String, Integer> stackTraceEvents;
+        private Map<String, Long> stackTraceEvents;
         private double samplingRate;
         private long totalSamples;
 
@@ -537,16 +593,20 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
             this.executables = executables;
         }
 
-        public void setStackTraceEvents(Map<String, Integer> stackTraceEvents) {
+        public void setStackTraceEvents(Map<String, Long> stackTraceEvents) {
             this.stackTraceEvents = stackTraceEvents;
         }
 
-        public Map<String, Integer> getStackTraceEvents() {
+        public Map<String, Long> getStackTraceEvents() {
             return stackTraceEvents;
         }
 
-        public void setSampleRate(double rate) {
+        public void setSamplingRate(double rate) {
             this.samplingRate = rate;
+        }
+
+        public double getSamplingRate() {
+            return samplingRate;
         }
 
         public void setTotalSamples(long totalSamples) {

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/GetStackTracesResponseTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/GetStackTracesResponseTests.java
@@ -42,8 +42,8 @@ public class GetStackTracesResponseTests extends AbstractWireSerializingTestCase
             )
         );
         Map<String, String> executables = randomNullable(Map.of("QCCDqjSg3bMK1C4YRK6Tiw", "libc.so.6"));
-        int totalSamples = randomIntBetween(1, 200);
-        Map<String, Integer> stackTraceEvents = randomNullable(Map.of(randomAlphaOfLength(12), totalSamples));
+        long totalSamples = randomLongBetween(1L, 200L);
+        Map<String, Long> stackTraceEvents = randomNullable(Map.of(randomAlphaOfLength(12), totalSamples));
 
         return new GetStackTracesResponse(stackTraces, stackFrames, executables, stackTraceEvents, totalFrames, 1.0, totalSamples);
     }

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/ResamplerTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/ResamplerTests.java
@@ -30,7 +30,7 @@ public class ResamplerTests extends ESTestCase {
         int requestedSamples = 20_000;
         int actualTotalSamples = 10_000;
 
-        GetStackTracesRequest request = new GetStackTracesRequest(requestedSamples, null);
+        GetStackTracesRequest request = new GetStackTracesRequest(requestedSamples, null, null, null);
         request.setAdjustSampleCount(false);
 
         Resampler resampler = createResampler(request, sampleRate, actualTotalSamples);
@@ -45,7 +45,7 @@ public class ResamplerTests extends ESTestCase {
         int requestedSamples = 20_000;
         int actualTotalSamples = 10_000;
 
-        GetStackTracesRequest request = new GetStackTracesRequest(requestedSamples, null);
+        GetStackTracesRequest request = new GetStackTracesRequest(requestedSamples, null, null, null);
         request.setAdjustSampleCount(true);
 
         Resampler resampler = createResampler(request, sampleRate, actualTotalSamples);
@@ -60,7 +60,7 @@ public class ResamplerTests extends ESTestCase {
         int requestedSamples = 20_000;
         int actualTotalSamples = 40_000;
 
-        GetStackTracesRequest request = new GetStackTracesRequest(requestedSamples, null);
+        GetStackTracesRequest request = new GetStackTracesRequest(requestedSamples, null, null, null);
         request.setAdjustSampleCount(false);
 
         Resampler resampler = createResampler(request, sampleRate, actualTotalSamples);
@@ -79,8 +79,10 @@ public class ResamplerTests extends ESTestCase {
         GetStackTracesRequest request = new GetStackTracesRequest(
             requestedSamples,
             new BoolQueryBuilder().filter(
-                new RangeQueryBuilder("@timestamp").lt("2023-10-19 15:33:00").gte("2023-10-19 15:31:52").format("yyyy-MM-dd HH:mm:ss")
-            )
+                new RangeQueryBuilder("@timestamp").lt("2023-10-19 15:33:00").gte("2023-09-20 15:31:52").format("yyyy-MM-dd HH:mm:ss")
+            ),
+            null,
+            null
         );
 
         request.setAdjustSampleCount(false);
@@ -96,7 +98,7 @@ public class ResamplerTests extends ESTestCase {
         int requestedSamples = 20_000;
         int actualTotalSamples = 40_000;
 
-        GetStackTracesRequest request = new GetStackTracesRequest(requestedSamples, null);
+        GetStackTracesRequest request = new GetStackTracesRequest(requestedSamples, null, null, null);
         request.setAdjustSampleCount(true);
 
         Resampler resampler = createResampler(request, sampleRate, actualTotalSamples);

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/TransportGetFlamegraphActionTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/TransportGetFlamegraphActionTests.java
@@ -46,7 +46,7 @@ public class TransportGetFlamegraphActionTests extends ESTestCase {
             ),
             Map.of(),
             Map.of("fr28zxcZ2UDasxYuu6dV-w", "containerd"),
-            Map.of("2buqP1GpF-TXYmL4USW8gA", 1),
+            Map.of("2buqP1GpF-TXYmL4USW8gA", 1L),
             9,
             1.0d,
             1
@@ -55,8 +55,8 @@ public class TransportGetFlamegraphActionTests extends ESTestCase {
         assertNotNull(response);
         assertEquals(10, response.getSize());
         assertEquals(1.0d, response.getSamplingRate(), 0.001d);
-        assertEquals(List.of(1, 1, 1, 1, 1, 1, 1, 1, 1, 1), response.getCountInclusive());
-        assertEquals(List.of(0, 0, 0, 0, 0, 0, 0, 0, 0, 1), response.getCountExclusive());
+        assertEquals(List.of(1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L), response.getCountInclusive());
+        assertEquals(List.of(0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 1L), response.getCountExclusive());
         assertEquals(
             List.of(
                 Map.of("174640828", 1),
@@ -112,8 +112,8 @@ public class TransportGetFlamegraphActionTests extends ESTestCase {
         assertEquals(List.of(0, 0, 0, 0, 0, 0, 0, 0, 0, 0), response.getFunctionOffsets());
         assertEquals(List.of("", "", "", "", "", "", "", "", "", ""), response.getSourceFileNames());
         assertEquals(List.of(0, 0, 0, 0, 0, 0, 0, 0, 0, 0), response.getSourceLines());
-        assertEquals(1, response.getSelfCPU());
-        assertEquals(10, response.getTotalCPU());
+        assertEquals(1L, response.getSelfCPU());
+        assertEquals(10L, response.getTotalCPU());
         assertEquals(1L, response.getTotalSamples());
 
     }
@@ -124,8 +124,8 @@ public class TransportGetFlamegraphActionTests extends ESTestCase {
         assertNotNull(response);
         assertEquals(1, response.getSize());
         assertEquals(1.0d, response.getSamplingRate(), 0.001d);
-        assertEquals(List.of(0), response.getCountInclusive());
-        assertEquals(List.of(0), response.getCountExclusive());
+        assertEquals(List.of(0L), response.getCountInclusive());
+        assertEquals(List.of(0L), response.getCountExclusive());
         assertEquals(List.of(Map.of()), response.getEdges());
         assertEquals(List.of(""), response.getFileIds());
         assertEquals(List.of(0), response.getFrameTypes());
@@ -136,8 +136,8 @@ public class TransportGetFlamegraphActionTests extends ESTestCase {
         assertEquals(List.of(0), response.getFunctionOffsets());
         assertEquals(List.of(""), response.getSourceFileNames());
         assertEquals(List.of(0), response.getSourceLines());
-        assertEquals(0, response.getSelfCPU());
-        assertEquals(0, response.getTotalCPU());
+        assertEquals(0L, response.getSelfCPU());
+        assertEquals(0L, response.getTotalCPU());
         assertEquals(0L, response.getTotalSamples());
     }
 }


### PR DESCRIPTION
With this commit we add two new request (body) parameters for the profiling stacktrace API that allow to customize the index as well as the property that is used to retrieve stacktrace events.