### PR TITLE
[ML] Remove all SearchResponse direct references from tests

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
@@ -372,6 +372,18 @@ public class ElasticsearchAssertions {
         }
     }
 
+    public static void assertCheckedResponse(
+        ActionFuture<SearchResponse> responseFuture,
+        CheckedConsumer<SearchResponse, IOException> consumer
+    ) throws IOException, ExecutionException, InterruptedException {
+        var res = responseFuture.get();
+        try {
+            consumer.accept(res);
+        } finally {
+            res.decRef();
+        }
+    }
+
     public static void assertNoFailures(SearchResponse searchResponse) {
         assertThat(
             "Unexpected ShardFailures: " + Arrays.toString(searchResponse.getShardFailures()),

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/CategorizationIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/CategorizationIT.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.ml.integration;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.index.IndexRequest;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.core.Strings;
 import org.elasticsearch.core.TimeValue;
@@ -43,6 +42,8 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertCheckedResponse;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -303,13 +304,16 @@ public class CategorizationIT extends MlNativeAutodetectIntegTestCase {
         // before closing the job to prove that it was persisted in the background at the
         // end of lookback rather than when the job was closed.
         assertBusy(() -> {
-            SearchResponse stateDocsResponse = prepareSearch(AnomalyDetectorsIndex.jobStateIndexPattern()).setQuery(
-                QueryBuilders.idsQuery().addIds(CategorizerState.documentId(job.getId(), 1))
-            ).get();
-
-            SearchHit[] hits = stateDocsResponse.getHits().getHits();
-            assertThat(hits, arrayWithSize(1));
-            assertThat(hits[0].getSourceAsMap(), hasKey("compressed"));
+            assertResponse(
+                prepareSearch(AnomalyDetectorsIndex.jobStateIndexPattern()).setQuery(
+                    QueryBuilders.idsQuery().addIds(CategorizerState.documentId(job.getId(), 1))
+                ),
+                stateDocsResponse -> {
+                    SearchHit[] hits = stateDocsResponse.getHits().getHits();
+                    assertThat(hits, arrayWithSize(1));
+                    assertThat(hits[0].getSourceAsMap(), hasKey("compressed"));
+                }
+            );
         }, 30, TimeUnit.SECONDS);
 
         stopDatafeed(datafeedId);
@@ -553,26 +557,28 @@ public class CategorizationIT extends MlNativeAutodetectIntegTestCase {
     }
 
     private List<CategorizerStats> getCategorizerStats(String jobId) throws IOException {
-
-        SearchResponse searchResponse = prepareSearch(AnomalyDetectorsIndex.jobResultsAliasedName(jobId)).setQuery(
-            QueryBuilders.boolQuery()
-                .filter(QueryBuilders.termQuery(Result.RESULT_TYPE.getPreferredName(), CategorizerStats.RESULT_TYPE_VALUE))
-                .filter(QueryBuilders.termQuery(Job.ID.getPreferredName(), jobId))
-        ).setSize(1000).get();
-
         List<CategorizerStats> stats = new ArrayList<>();
-        for (SearchHit hit : searchResponse.getHits().getHits()) {
-            try (
-                XContentParser parser = XContentFactory.xContent(XContentType.JSON)
-                    .createParser(
-                        NamedXContentRegistry.EMPTY,
-                        DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
-                        hit.getSourceRef().streamInput()
-                    )
-            ) {
-                stats.add(CategorizerStats.LENIENT_PARSER.apply(parser, null).build());
+        assertCheckedResponse(
+            prepareSearch(AnomalyDetectorsIndex.jobResultsAliasedName(jobId)).setQuery(
+                QueryBuilders.boolQuery()
+                    .filter(QueryBuilders.termQuery(Result.RESULT_TYPE.getPreferredName(), CategorizerStats.RESULT_TYPE_VALUE))
+                    .filter(QueryBuilders.termQuery(Job.ID.getPreferredName(), jobId))
+            ).setSize(1000),
+            searchResponse -> {
+                for (SearchHit hit : searchResponse.getHits().getHits()) {
+                    try (
+                        XContentParser parser = XContentFactory.xContent(XContentType.JSON)
+                            .createParser(
+                                NamedXContentRegistry.EMPTY,
+                                DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                                hit.getSourceRef().streamInput()
+                            )
+                    ) {
+                        stats.add(CategorizerStats.LENIENT_PARSER.apply(parser, null).build());
+                    }
+                }
             }
-        }
+        );
         return stats;
     }
 }

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ClassificationIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ClassificationIT.java
@@ -15,7 +15,6 @@ import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.index.IndexRequest;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
@@ -57,6 +56,8 @@ import java.util.Map;
 import java.util.Set;
 
 import static java.util.stream.Collectors.toList;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.elasticsearch.xpack.core.ml.MlTasks.AWAITING_UPGRADE;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -145,20 +146,21 @@ public class ClassificationIT extends MlNativeDataFrameAnalyticsIntegTestCase {
         waitUntilAnalyticsIsStopped(jobId);
 
         client().admin().indices().refresh(new RefreshRequest(destIndex));
-        SearchResponse sourceData = prepareSearch(sourceIndex).setTrackTotalHits(true).setSize(1000).get();
-        for (SearchHit hit : sourceData.getHits()) {
-            Map<String, Object> destDoc = getDestDoc(config, hit);
-            Map<String, Object> resultsObject = getFieldValue(destDoc, "ml");
-            assertThat(getFieldValue(resultsObject, predictedClassField), is(in(KEYWORD_FIELD_VALUES)));
-            assertThat(getFieldValue(resultsObject, "is_training"), is(destDoc.containsKey(KEYWORD_FIELD)));
-            assertTopClasses(resultsObject, 2, KEYWORD_FIELD, KEYWORD_FIELD_VALUES);
-            @SuppressWarnings("unchecked")
-            List<Map<String, Object>> importanceArray = (List<Map<String, Object>>) resultsObject.get("feature_importance");
-            assertThat(importanceArray, hasSize(greaterThan(0)));
-        }
+        assertResponse(prepareSearch(sourceIndex).setTrackTotalHits(true).setSize(1000), sourceData -> {
+            for (SearchHit hit : sourceData.getHits()) {
+                Map<String, Object> destDoc = getDestDoc(config, hit);
+                Map<String, Object> resultsObject = getFieldValue(destDoc, "ml");
+                assertThat(getFieldValue(resultsObject, predictedClassField), is(in(KEYWORD_FIELD_VALUES)));
+                assertThat(getFieldValue(resultsObject, "is_training"), is(destDoc.containsKey(KEYWORD_FIELD)));
+                assertTopClasses(resultsObject, 2, KEYWORD_FIELD, KEYWORD_FIELD_VALUES);
+                @SuppressWarnings("unchecked")
+                List<Map<String, Object>> importanceArray = (List<Map<String, Object>>) resultsObject.get("feature_importance");
+                assertThat(importanceArray, hasSize(greaterThan(0)));
+            }
+        });
 
         assertProgressComplete(jobId);
-        assertThat(searchStoredProgress(jobId).getHits().getTotalHits().value, equalTo(1L));
+        assertStoredProgressHits(jobId, 1);
         assertModelStatePersisted(stateDocId());
         assertExactlyOneInferenceModelPersisted(jobId);
         assertMlResultsFieldMappings(destIndex, predictedClassField, "keyword");
@@ -210,20 +212,21 @@ public class ClassificationIT extends MlNativeDataFrameAnalyticsIntegTestCase {
         waitUntilAnalyticsIsStopped(jobId);
 
         client().admin().indices().refresh(new RefreshRequest(destIndex));
-        SearchResponse sourceData = prepareSearch(sourceIndex).setTrackTotalHits(true).setSize(1000).get();
-        for (SearchHit hit : sourceData.getHits()) {
-            Map<String, Object> destDoc = getDestDoc(config, hit);
-            Map<String, Object> resultsObject = getFieldValue(destDoc, "ml");
-            assertThat(getFieldValue(resultsObject, predictedClassField), is(in(KEYWORD_FIELD_VALUES)));
-            assertThat(getFieldValue(resultsObject, "is_training"), is(destDoc.containsKey(KEYWORD_FIELD)));
-            assertTopClasses(resultsObject, 2, KEYWORD_FIELD, KEYWORD_FIELD_VALUES);
-            @SuppressWarnings("unchecked")
-            List<Map<String, Object>> importanceArray = (List<Map<String, Object>>) resultsObject.get("feature_importance");
-            assertThat(importanceArray, hasSize(greaterThan(0)));
-        }
+        assertResponse(prepareSearch(sourceIndex).setTrackTotalHits(true).setSize(1000), sourceData -> {
+            for (SearchHit hit : sourceData.getHits()) {
+                Map<String, Object> destDoc = getDestDoc(config, hit);
+                Map<String, Object> resultsObject = getFieldValue(destDoc, "ml");
+                assertThat(getFieldValue(resultsObject, predictedClassField), is(in(KEYWORD_FIELD_VALUES)));
+                assertThat(getFieldValue(resultsObject, "is_training"), is(destDoc.containsKey(KEYWORD_FIELD)));
+                assertTopClasses(resultsObject, 2, KEYWORD_FIELD, KEYWORD_FIELD_VALUES);
+                @SuppressWarnings("unchecked")
+                List<Map<String, Object>> importanceArray = (List<Map<String, Object>>) resultsObject.get("feature_importance");
+                assertThat(importanceArray, hasSize(greaterThan(0)));
+            }
+        });
 
         assertProgressComplete(jobId);
-        assertThat(searchStoredProgress(jobId).getHits().getTotalHits().value, equalTo(1L));
+        assertStoredProgressHits(jobId, 1);
         assertModelStatePersisted(stateDocId());
         assertExactlyOneInferenceModelPersisted(jobId);
         assertMlResultsFieldMappings(destIndex, predictedClassField, "keyword");
@@ -259,14 +262,15 @@ public class ClassificationIT extends MlNativeDataFrameAnalyticsIntegTestCase {
         waitUntilAnalyticsIsStopped(jobId);
 
         client().admin().indices().refresh(new RefreshRequest(destIndex));
-        SearchResponse sourceData = prepareSearch(sourceIndex).setTrackTotalHits(true).setSize(1000).get();
-        for (SearchHit hit : sourceData.getHits()) {
-            Map<String, Object> destDoc = getDestDoc(config, hit);
-            Map<String, Object> resultsObject = getFieldValue(destDoc, "ml");
-            assertThat(getFieldValue(resultsObject, predictedClassField), is(in(KEYWORD_FIELD_VALUES)));
-            assertThat(getFieldValue(resultsObject, "is_training"), is(true));
-            assertTopClasses(resultsObject, 2, KEYWORD_FIELD, KEYWORD_FIELD_VALUES);
-        }
+        assertResponse(prepareSearch(sourceIndex).setTrackTotalHits(true).setSize(1000), sourceData -> {
+            for (SearchHit hit : sourceData.getHits()) {
+                Map<String, Object> destDoc = getDestDoc(config, hit);
+                Map<String, Object> resultsObject = getFieldValue(destDoc, "ml");
+                assertThat(getFieldValue(resultsObject, predictedClassField), is(in(KEYWORD_FIELD_VALUES)));
+                assertThat(getFieldValue(resultsObject, "is_training"), is(true));
+                assertTopClasses(resultsObject, 2, KEYWORD_FIELD, KEYWORD_FIELD_VALUES);
+            }
+        });
 
         GetDataFrameAnalyticsStatsAction.Response.Stats stats = getAnalyticsStats(jobId);
         assertThat(stats.getDataCounts().getJobId(), equalTo(jobId));
@@ -275,7 +279,7 @@ public class ClassificationIT extends MlNativeDataFrameAnalyticsIntegTestCase {
         assertThat(stats.getDataCounts().getSkippedDocsCount(), equalTo(0L));
 
         assertProgressComplete(jobId);
-        assertThat(searchStoredProgress(jobId).getHits().getTotalHits().value, equalTo(1L));
+        assertStoredProgressHits(jobId, 1);
         assertModelStatePersisted(stateDocId());
         assertExactlyOneInferenceModelPersisted(jobId);
         assertMlResultsFieldMappings(destIndex, predictedClassField, "keyword");
@@ -347,17 +351,18 @@ public class ClassificationIT extends MlNativeDataFrameAnalyticsIntegTestCase {
         startAnalytics(jobId);
         waitUntilAnalyticsIsStopped(jobId);
 
+        assertResponse(prepareSearch(sourceIndex).setTrackTotalHits(true).setSize(1000), sourceData -> {
+            for (SearchHit hit : sourceData.getHits()) {
+                Map<String, Object> destDoc = getDestDoc(config, hit);
+                Map<String, Object> resultsObject = getFieldValue(destDoc, "ml");
+                assertThat(getFieldValue(resultsObject, predictedClassField), is(in(KEYWORD_FIELD_VALUES)));
+                assertTopClasses(resultsObject, 2, KEYWORD_FIELD, KEYWORD_FIELD_VALUES);
+            }
+        });
         client().admin().indices().refresh(new RefreshRequest(destIndex));
-        SearchResponse sourceData = prepareSearch(sourceIndex).setTrackTotalHits(true).setSize(1000).get();
-        for (SearchHit hit : sourceData.getHits()) {
-            Map<String, Object> destDoc = getDestDoc(config, hit);
-            Map<String, Object> resultsObject = getFieldValue(destDoc, "ml");
-            assertThat(getFieldValue(resultsObject, predictedClassField), is(in(KEYWORD_FIELD_VALUES)));
-            assertTopClasses(resultsObject, 2, KEYWORD_FIELD, KEYWORD_FIELD_VALUES);
-        }
 
         assertProgressComplete(jobId);
-        assertThat(searchStoredProgress(jobId).getHits().getTotalHits().value, equalTo(1L));
+        assertStoredProgressHits(jobId, 1);
         assertModelStatePersisted(stateDocId());
         assertExactlyOneInferenceModelPersisted(jobId);
         assertMlResultsFieldMappings(destIndex, predictedClassField, "keyword");
@@ -422,27 +427,27 @@ public class ClassificationIT extends MlNativeDataFrameAnalyticsIntegTestCase {
         startAnalytics(jobId);
         waitUntilAnalyticsIsStopped(jobId);
 
-        int trainingRowsCount = 0;
-        int nonTrainingRowsCount = 0;
         client().admin().indices().refresh(new RefreshRequest(destIndex));
-        SearchResponse sourceData = prepareSearch(sourceIndex).setTrackTotalHits(true).setSize(1000).get();
-        for (SearchHit hit : sourceData.getHits()) {
-            Map<String, Object> destDoc = getDestDoc(config, hit);
-            Map<String, Object> resultsObject = getFieldValue(destDoc, "ml");
-            assertThat(getFieldValue(resultsObject, predictedClassField), is(in(dependentVariableValues)));
-            assertTopClasses(resultsObject, expectedNumTopClasses, dependentVariable, dependentVariableValues);
-
-            // Let's just assert there's both training and non-training results
-            //
-            boolean isTraining = getFieldValue(resultsObject, "is_training");
-            if (isTraining) {
-                trainingRowsCount++;
-            } else {
-                nonTrainingRowsCount++;
+        assertResponse(prepareSearch(sourceIndex).setTrackTotalHits(true).setSize(1000), sourceData -> {
+            int trainingRowsCount = 0;
+            int nonTrainingRowsCount = 0;
+            for (SearchHit hit : sourceData.getHits()) {
+                Map<String, Object> destDoc = getDestDoc(config, hit);
+                Map<String, Object> resultsObject = getFieldValue(destDoc, "ml");
+                assertThat(getFieldValue(resultsObject, predictedClassField), is(in(dependentVariableValues)));
+                assertTopClasses(resultsObject, expectedNumTopClasses, dependentVariable, dependentVariableValues);
+                // Let's just assert there's both training and non-training results
+                //
+                boolean isTraining = getFieldValue(resultsObject, "is_training");
+                if (isTraining) {
+                    trainingRowsCount++;
+                } else {
+                    nonTrainingRowsCount++;
+                }
             }
-        }
-        assertThat(trainingRowsCount, greaterThan(0));
-        assertThat(nonTrainingRowsCount, greaterThan(0));
+            assertThat(trainingRowsCount, greaterThan(0));
+            assertThat(nonTrainingRowsCount, greaterThan(0));
+        });
 
         GetDataFrameAnalyticsStatsAction.Response.Stats stats = getAnalyticsStats(jobId);
         assertThat(stats.getDataCounts().getJobId(), equalTo(jobId));
@@ -453,7 +458,7 @@ public class ClassificationIT extends MlNativeDataFrameAnalyticsIntegTestCase {
         assertThat(stats.getDataCounts().getSkippedDocsCount(), equalTo(0L));
 
         assertProgressComplete(jobId);
-        assertThat(searchStoredProgress(jobId).getHits().getTotalHits().value, equalTo(1L));
+        assertStoredProgressHits(jobId, 1);
         assertModelStatePersisted(stateDocId());
         assertExactlyOneInferenceModelPersisted(jobId);
         assertMlResultsFieldMappings(destIndex, predictedClassField, expectedMappingTypeForPredictedField);
@@ -568,18 +573,18 @@ public class ClassificationIT extends MlNativeDataFrameAnalyticsIntegTestCase {
         }
 
         waitUntilAnalyticsIsStopped(jobId);
-
-        SearchResponse sourceData = prepareSearch(sourceIndex).setTrackTotalHits(true).setSize(1000).get();
-        for (SearchHit hit : sourceData.getHits()) {
-            Map<String, Object> destDoc = getDestDoc(config, hit);
-            Map<String, Object> resultsObject = getFieldValue(destDoc, "ml");
-            assertThat(getFieldValue(resultsObject, predictedClassField), is(in(KEYWORD_FIELD_VALUES)));
-            assertThat(getFieldValue(resultsObject, "is_training"), is(true));
-            assertTopClasses(resultsObject, 2, KEYWORD_FIELD, KEYWORD_FIELD_VALUES);
-        }
+        assertResponse(prepareSearch(sourceIndex).setTrackTotalHits(true).setSize(1000), sourceData -> {
+            for (SearchHit hit : sourceData.getHits()) {
+                Map<String, Object> destDoc = getDestDoc(config, hit);
+                Map<String, Object> resultsObject = getFieldValue(destDoc, "ml");
+                assertThat(getFieldValue(resultsObject, predictedClassField), is(in(KEYWORD_FIELD_VALUES)));
+                assertThat(getFieldValue(resultsObject, "is_training"), is(true));
+                assertTopClasses(resultsObject, 2, KEYWORD_FIELD, KEYWORD_FIELD_VALUES);
+            }
+        });
 
         assertProgressComplete(jobId);
-        assertThat(searchStoredProgress(jobId).getHits().getTotalHits().value, equalTo(1L));
+        assertStoredProgressHits(jobId, 1);
         assertModelStatePersisted(stateDocId());
         assertAtLeastOneInferenceModelPersisted(jobId);
         assertMlResultsFieldMappings(destIndex, predictedClassField, "keyword");
@@ -647,7 +652,7 @@ public class ClassificationIT extends MlNativeDataFrameAnalyticsIntegTestCase {
         waitUntilAnalyticsIsStopped(jobId);
 
         assertProgressComplete(jobId);
-        assertThat(searchStoredProgress(jobId).getHits().getTotalHits().value, equalTo(1L));
+        assertStoredProgressHits(jobId, 1);
         assertModelStatePersisted(stateDocId());
         assertExactlyOneInferenceModelPersisted(jobId);
         assertMlResultsFieldMappings(destIndex, predictedClassField, "keyword");
@@ -665,7 +670,7 @@ public class ClassificationIT extends MlNativeDataFrameAnalyticsIntegTestCase {
         waitUntilAnalyticsIsStopped(jobId);
 
         assertProgressComplete(jobId);
-        assertThat(searchStoredProgress(jobId).getHits().getTotalHits().value, equalTo(1L));
+        assertStoredProgressHits(jobId, 1);
         assertModelStatePersisted(stateDocId());
         assertExactlyOneInferenceModelPersisted(jobId);
         assertMlResultsFieldMappings(destIndex, predictedClassField, "keyword");
@@ -683,7 +688,7 @@ public class ClassificationIT extends MlNativeDataFrameAnalyticsIntegTestCase {
         waitUntilAnalyticsIsStopped(jobId);
 
         assertProgressComplete(jobId);
-        assertThat(searchStoredProgress(jobId).getHits().getTotalHits().value, equalTo(1L));
+        assertStoredProgressHits(jobId, 1);
         assertModelStatePersisted(stateDocId());
         assertExactlyOneInferenceModelPersisted(jobId);
         assertMlResultsFieldMappings(destIndex, predictedClassField, "keyword");
@@ -821,13 +826,13 @@ public class ClassificationIT extends MlNativeDataFrameAnalyticsIntegTestCase {
         waitUntilAnalyticsIsStopped(jobId);
 
         assertProgressComplete(jobId);
-        assertThat(searchStoredProgress(jobId).getHits().getTotalHits().value, equalTo(1L));
+        assertStoredProgressHits(jobId, 1);
         assertModelStatePersisted(stateDocId());
         assertExactlyOneInferenceModelPersisted(jobId);
 
         // Call _delete_expired_data API and check nothing was deleted
         assertThat(deleteExpiredData().isDeleted(), is(true));
-        assertThat(searchStoredProgress(jobId).getHits().getTotalHits().value, equalTo(1L));
+        assertStoredProgressHits(jobId, 1);
         assertModelStatePersisted(stateDocId());
 
         // Delete the config straight from the config index
@@ -840,8 +845,7 @@ public class ClassificationIT extends MlNativeDataFrameAnalyticsIntegTestCase {
         // Now calling the _delete_expired_data API should remove unused state
         assertThat(deleteExpiredData().isDeleted(), is(true));
 
-        SearchResponse stateIndexSearchResponse = prepareSearch(".ml-state*").execute().actionGet();
-        assertThat(stateIndexSearchResponse.getHits().getTotalHits().value, equalTo(0L));
+        assertHitCount(prepareSearch(".ml-state*"), 0);
     }
 
     public void testUpdateAnalytics() throws Exception {
@@ -928,21 +932,22 @@ public class ClassificationIT extends MlNativeDataFrameAnalyticsIntegTestCase {
         waitUntilAnalyticsIsStopped(jobId);
 
         client().admin().indices().refresh(new RefreshRequest(destIndex));
-        SearchResponse destData = prepareSearch(destIndex).setTrackTotalHits(true).setSize(1000).get();
-        for (SearchHit hit : destData.getHits()) {
-            Map<String, Object> destDoc = hit.getSourceAsMap();
-            Map<String, Object> resultsObject = getFieldValue(destDoc, "ml");
-            assertThat(getFieldValue(resultsObject, predictedClassField), is(in(KEYWORD_FIELD_VALUES)));
-            assertThat(getFieldValue(resultsObject, "is_training"), is(destDoc.containsKey(KEYWORD_FIELD)));
-            assertTopClasses(resultsObject, 2, dependentVariableRuntimeField, KEYWORD_FIELD_VALUES);
-            @SuppressWarnings("unchecked")
-            List<Map<String, Object>> importanceArray = (List<Map<String, Object>>) resultsObject.get("feature_importance");
-            assertThat(importanceArray, hasSize(1));
-            assertThat(importanceArray.get(0), hasEntry("feature_name", numericRuntimeField));
-        }
+        assertResponse(prepareSearch(destIndex).setTrackTotalHits(true).setSize(1000), destData -> {
+            for (SearchHit hit : destData.getHits()) {
+                Map<String, Object> destDoc = hit.getSourceAsMap();
+                Map<String, Object> resultsObject = getFieldValue(destDoc, "ml");
+                assertThat(getFieldValue(resultsObject, predictedClassField), is(in(KEYWORD_FIELD_VALUES)));
+                assertThat(getFieldValue(resultsObject, "is_training"), is(destDoc.containsKey(KEYWORD_FIELD)));
+                assertTopClasses(resultsObject, 2, dependentVariableRuntimeField, KEYWORD_FIELD_VALUES);
+                @SuppressWarnings("unchecked")
+                List<Map<String, Object>> importanceArray = (List<Map<String, Object>>) resultsObject.get("feature_importance");
+                assertThat(importanceArray, hasSize(1));
+                assertThat(importanceArray.get(0), hasEntry("feature_name", numericRuntimeField));
+            }
+        });
 
         assertProgressComplete(jobId);
-        assertThat(searchStoredProgress(jobId).getHits().getTotalHits().value, equalTo(1L));
+        assertStoredProgressHits(jobId, 1);
         assertModelStatePersisted(stateDocId());
         assertExactlyOneInferenceModelPersisted(jobId);
         assertMlResultsFieldMappings(destIndex, predictedClassField, "keyword");

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DeleteExpiredDataIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DeleteExpiredDataIT.java
@@ -12,7 +12,6 @@ import org.elasticsearch.action.admin.indices.get.GetIndexResponse;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.index.IndexRequest;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.action.update.UpdateAction;
@@ -54,6 +53,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.elasticsearch.xpack.core.ml.annotations.AnnotationTests.randomAnnotation;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.equalTo;
@@ -343,28 +343,27 @@ public class DeleteExpiredDataIT extends MlNativeAutodetectIntegTestCase {
         }
 
         // Verify .ml-state doesn't contain unused state documents
-        SearchResponse stateDocsResponse = prepareSearch(AnomalyDetectorsIndex.jobStateIndexPattern()).setFetchSource(false)
-            .setTrackTotalHits(true)
-            .setSize(10000)
-            .get();
+        assertResponse(
+            prepareSearch(AnomalyDetectorsIndex.jobStateIndexPattern()).setFetchSource(false).setTrackTotalHits(true).setSize(10000),
+            stateDocsResponse -> {
+                assertThat(stateDocsResponse.getHits().getTotalHits().value, greaterThanOrEqualTo(5L));
 
-        // Assert at least one state doc for each job
-        assertThat(stateDocsResponse.getHits().getTotalHits().value, greaterThanOrEqualTo(5L));
-
-        int nonExistingJobDocsCount = 0;
-        List<String> nonExistingJobExampleIds = new ArrayList<>();
-        for (SearchHit hit : stateDocsResponse.getHits().getHits()) {
-            if (hit.getId().startsWith("non_existing_job")) {
-                nonExistingJobDocsCount++;
-                if (nonExistingJobExampleIds.size() < 10) {
-                    nonExistingJobExampleIds.add(hit.getId());
+                int nonExistingJobDocsCount = 0;
+                List<String> nonExistingJobExampleIds = new ArrayList<>();
+                for (SearchHit hit : stateDocsResponse.getHits().getHits()) {
+                    if (hit.getId().startsWith("non_existing_job")) {
+                        nonExistingJobDocsCount++;
+                        if (nonExistingJobExampleIds.size() < 10) {
+                            nonExistingJobExampleIds.add(hit.getId());
+                        }
+                    }
                 }
+                assertThat(
+                    "Documents for non_existing_job are still around; examples: " + nonExistingJobExampleIds,
+                    nonExistingJobDocsCount,
+                    equalTo(0)
+                );
             }
-        }
-        assertThat(
-            "Documents for non_existing_job are still around; examples: " + nonExistingJobExampleIds,
-            nonExistingJobDocsCount,
-            equalTo(0)
         );
     }
 

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/InterimResultsDeletedAfterReopeningJobIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/InterimResultsDeletedAfterReopeningJobIT.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.ml.integration;
 
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.xpack.core.ml.job.config.AnalysisConfig;
@@ -24,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
@@ -108,7 +108,6 @@ public class InterimResultsDeletedAfterReopeningJobIT extends MlNativeAutodetect
 
     private void assertNoInterimResults(String jobId) {
         String indexName = AnomalyDetectorsIndex.jobResultsAliasedName(jobId);
-        SearchResponse search = prepareSearch(indexName).setSize(1000).setQuery(QueryBuilders.termQuery("is_interim", true)).get();
-        assertThat(search.getHits().getTotalHits().value, equalTo(0L));
+        assertHitCount(prepareSearch(indexName).setSize(1000).setQuery(QueryBuilders.termQuery("is_interim", true)), 0);
     }
 }

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeAutodetectIntegTestCase.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeAutodetectIntegTestCase.java
@@ -6,8 +6,8 @@
  */
 package org.elasticsearch.xpack.ml.integration;
 
+import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.Strings;
@@ -76,6 +76,8 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertCheckedResponse;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.elasticsearch.xcontent.json.JsonXContent.jsonXContent;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -265,7 +267,7 @@ abstract class MlNativeAutodetectIntegTestCase extends MlNativeIntegTestCase {
         }, maxWaitTimeSeconds, TimeUnit.SECONDS);
     }
 
-    protected void assertThatNumberOfAnnotationsIsEqualTo(int expectedNumberOfAnnotations) throws IOException {
+    protected void assertThatNumberOfAnnotationsIsEqualTo(int expectedNumberOfAnnotations) throws Exception {
         // Refresh the annotations index so that recently indexed annotation docs are visible.
         indicesAdmin().prepareRefresh(AnnotationIndex.LATEST_INDEX_NAME)
             .setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN_CLOSED_HIDDEN)
@@ -275,106 +277,113 @@ abstract class MlNativeAutodetectIntegTestCase extends MlNativeIntegTestCase {
         SearchRequest searchRequest = new SearchRequest(AnnotationIndex.READ_ALIAS_NAME).indicesOptions(
             IndicesOptions.LENIENT_EXPAND_OPEN_CLOSED_HIDDEN
         );
-        SearchResponse searchResponse = client().search(searchRequest).actionGet();
-        List<Annotation> annotations = new ArrayList<>();
-        for (SearchHit hit : searchResponse.getHits().getHits()) {
-            try (XContentParser parser = createParser(jsonXContent, hit.getSourceRef())) {
-                annotations.add(Annotation.fromXContent(parser, null));
+        assertCheckedResponse(client().search(searchRequest), searchResponse -> {
+            List<Annotation> annotations = new ArrayList<>();
+            for (SearchHit hit : searchResponse.getHits().getHits()) {
+                try (XContentParser parser = createParser(jsonXContent, hit.getSourceRef())) {
+                    annotations.add(Annotation.fromXContent(parser, null));
+                }
             }
-        }
-        assertThat("Annotations were: " + annotations, annotations, hasSize(expectedNumberOfAnnotations));
+            assertThat("Annotations were: " + annotations, annotations, hasSize(expectedNumberOfAnnotations));
+        });
     }
 
-    protected ForecastRequestStats getForecastStats(String jobId, String forecastId) {
-        SearchResponse searchResponse = prepareSearch(AnomalyDetectorsIndex.jobResultsAliasedName(jobId)).setQuery(
-            QueryBuilders.idsQuery().addIds(ForecastRequestStats.documentId(jobId, forecastId))
-        ).get();
+    protected ForecastRequestStats getForecastStats(String jobId, String forecastId) throws Exception {
+        SetOnce<ForecastRequestStats> forecastRequestStats = new SetOnce<>();
+        assertCheckedResponse(
+            prepareSearch(AnomalyDetectorsIndex.jobResultsAliasedName(jobId)).setQuery(
+                QueryBuilders.idsQuery().addIds(ForecastRequestStats.documentId(jobId, forecastId))
+            ),
+            searchResponse -> {
+                if (searchResponse.getHits().getHits().length == 0) {
+                    return;
+                }
+                assertThat(searchResponse.getHits().getHits().length, equalTo(1));
 
-        if (searchResponse.getHits().getHits().length == 0) {
-            return null;
-        }
-
-        assertThat(searchResponse.getHits().getHits().length, equalTo(1));
-
-        try (
-            XContentParser parser = XContentFactory.xContent(XContentType.JSON)
-                .createParser(
-                    NamedXContentRegistry.EMPTY,
-                    DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
-                    searchResponse.getHits().getHits()[0].getSourceRef().streamInput()
-                )
-        ) {
-            return ForecastRequestStats.STRICT_PARSER.apply(parser, null);
-        } catch (IOException e) {
-            throw new IllegalStateException(e);
-        }
+                try (
+                    XContentParser parser = XContentFactory.xContent(XContentType.JSON)
+                        .createParser(
+                            NamedXContentRegistry.EMPTY,
+                            DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                            searchResponse.getHits().getHits()[0].getSourceRef().streamInput()
+                        )
+                ) {
+                    forecastRequestStats.set(ForecastRequestStats.STRICT_PARSER.apply(parser, null));
+                }
+            }
+        );
+        return forecastRequestStats.get();
     }
 
-    protected List<ForecastRequestStats> getForecastStats() {
+    protected List<ForecastRequestStats> getForecastStats() throws Exception {
         List<ForecastRequestStats> forecastStats = new ArrayList<>();
-
-        SearchResponse searchResponse = prepareSearch(AnomalyDetectorsIndex.jobResultsIndexPrefix() + "*").setSize(1000)
-            .setQuery(
-                QueryBuilders.boolQuery()
-                    .filter(QueryBuilders.termQuery(Result.RESULT_TYPE.getPreferredName(), ForecastRequestStats.RESULT_TYPE_VALUE))
-            )
-            .execute()
-            .actionGet();
-        SearchHits hits = searchResponse.getHits();
-        for (SearchHit hit : hits) {
-            try {
-                XContentParser parser = XContentFactory.xContent(XContentType.JSON)
-                    .createParser(
-                        NamedXContentRegistry.EMPTY,
-                        DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
-                        hit.getSourceRef().streamInput()
-                    );
-                forecastStats.add(ForecastRequestStats.STRICT_PARSER.apply(parser, null));
-            } catch (IOException e) {
-                throw new IllegalStateException(e);
+        assertCheckedResponse(
+            prepareSearch(AnomalyDetectorsIndex.jobResultsIndexPrefix() + "*").setSize(1000)
+                .setQuery(
+                    QueryBuilders.boolQuery()
+                        .filter(QueryBuilders.termQuery(Result.RESULT_TYPE.getPreferredName(), ForecastRequestStats.RESULT_TYPE_VALUE))
+                ),
+            searchResponse -> {
+                SearchHits hits = searchResponse.getHits();
+                for (SearchHit hit : hits) {
+                    try (
+                        XContentParser parser = XContentFactory.xContent(XContentType.JSON)
+                            .createParser(
+                                NamedXContentRegistry.EMPTY,
+                                DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                                hit.getSourceRef().streamInput()
+                            )
+                    ) {
+                        forecastStats.add(ForecastRequestStats.STRICT_PARSER.apply(parser, null));
+                    }
+                }
             }
-        }
+        );
         return forecastStats;
     }
 
     protected long countForecastDocs(String jobId, String forecastId) {
-        SearchResponse searchResponse = prepareSearch(AnomalyDetectorsIndex.jobResultsIndexPrefix() + "*").setQuery(
-            QueryBuilders.boolQuery()
-                .filter(QueryBuilders.termQuery(Result.RESULT_TYPE.getPreferredName(), Forecast.RESULT_TYPE_VALUE))
-                .filter(QueryBuilders.termQuery(Job.ID.getPreferredName(), jobId))
-                .filter(QueryBuilders.termQuery(Forecast.FORECAST_ID.getPreferredName(), forecastId))
-        ).execute().actionGet();
-        return searchResponse.getHits().getTotalHits().value;
+        SetOnce<Long> count = new SetOnce<>();
+        assertResponse(
+            prepareSearch(AnomalyDetectorsIndex.jobResultsIndexPrefix() + "*").setSize(0)
+                .setQuery(
+                    QueryBuilders.boolQuery()
+                        .filter(QueryBuilders.termQuery(Result.RESULT_TYPE.getPreferredName(), Forecast.RESULT_TYPE_VALUE))
+                        .filter(QueryBuilders.termQuery(Job.ID.getPreferredName(), jobId))
+                        .filter(QueryBuilders.termQuery(Forecast.FORECAST_ID.getPreferredName(), forecastId))
+                ),
+            searchResponse -> count.set(searchResponse.getHits().getTotalHits().value)
+        );
+        return count.get();
     }
 
-    protected List<Forecast> getForecasts(String jobId, ForecastRequestStats forecastRequestStats) {
+    protected List<Forecast> getForecasts(String jobId, ForecastRequestStats forecastRequestStats) throws Exception {
         List<Forecast> forecasts = new ArrayList<>();
-        SearchResponse searchResponse = prepareSearch(AnomalyDetectorsIndex.jobResultsIndexPrefix() + "*").setSize(
-            (int) forecastRequestStats.getRecordCount()
-        )
-            .setQuery(
-                QueryBuilders.boolQuery()
-                    .filter(QueryBuilders.termQuery(Result.RESULT_TYPE.getPreferredName(), Forecast.RESULT_TYPE_VALUE))
-                    .filter(QueryBuilders.termQuery(Job.ID.getPreferredName(), jobId))
-                    .filter(QueryBuilders.termQuery(Forecast.FORECAST_ID.getPreferredName(), forecastRequestStats.getForecastId()))
-            )
-            .addSort(SortBuilders.fieldSort(Result.TIMESTAMP.getPreferredName()).order(SortOrder.ASC))
-            .execute()
-            .actionGet();
-        SearchHits hits = searchResponse.getHits();
-        for (SearchHit hit : hits) {
-            try {
-                XContentParser parser = XContentFactory.xContent(XContentType.JSON)
-                    .createParser(
-                        NamedXContentRegistry.EMPTY,
-                        DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
-                        hit.getSourceRef().streamInput()
-                    );
-                forecasts.add(Forecast.STRICT_PARSER.apply(parser, null));
-            } catch (IOException e) {
-                throw new IllegalStateException(e);
+        assertCheckedResponse(
+            prepareSearch(AnomalyDetectorsIndex.jobResultsIndexPrefix() + "*").setSize((int) forecastRequestStats.getRecordCount())
+                .setQuery(
+                    QueryBuilders.boolQuery()
+                        .filter(QueryBuilders.termQuery(Result.RESULT_TYPE.getPreferredName(), Forecast.RESULT_TYPE_VALUE))
+                        .filter(QueryBuilders.termQuery(Job.ID.getPreferredName(), jobId))
+                        .filter(QueryBuilders.termQuery(Forecast.FORECAST_ID.getPreferredName(), forecastRequestStats.getForecastId()))
+                )
+                .addSort(SortBuilders.fieldSort(Result.TIMESTAMP.getPreferredName()).order(SortOrder.ASC)),
+            searchResponse -> {
+                SearchHits hits = searchResponse.getHits();
+                for (SearchHit hit : hits) {
+                    try (
+                        XContentParser parser = XContentFactory.xContent(XContentType.JSON)
+                            .createParser(
+                                NamedXContentRegistry.EMPTY,
+                                DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                                hit.getSourceRef().streamInput()
+                            )
+                    ) {
+                        forecasts.add(Forecast.STRICT_PARSER.apply(parser, null));
+                    }
+                }
             }
-        }
+        );
         return forecasts;
     }
 

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ModelPlotsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ModelPlotsIT.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.ml.integration;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.index.IndexRequest;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -25,10 +24,11 @@ import org.junit.After;
 import org.junit.Before;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
@@ -159,11 +159,13 @@ public class ModelPlotsIT extends MlNativeAutodetectIntegTestCase {
     }
 
     private Set<String> modelPlotTerms(String jobId, String fieldName) {
-        SearchResponse searchResponse = prepareSearch(".ml-anomalies-" + jobId).setQuery(
-            QueryBuilders.termQuery("result_type", "model_plot")
-        ).addAggregation(AggregationBuilders.terms("model_plot_terms").field(fieldName)).get();
-
-        Terms aggregation = searchResponse.getAggregations().get("model_plot_terms");
-        return aggregation.getBuckets().stream().map(agg -> agg.getKeyAsString()).collect(Collectors.toSet());
+        Set<String> set = new HashSet<>();
+        assertResponse(
+            prepareSearch(".ml-anomalies-" + jobId).setQuery(QueryBuilders.termQuery("result_type", "model_plot"))
+                .addAggregation(AggregationBuilders.terms("model_plot_terms").field(fieldName)),
+            searchResponse -> ((Terms) searchResponse.getAggregations().get("model_plot_terms")).getBuckets()
+                .forEach(bucket -> set.add(bucket.getKeyAsString()))
+        );
+        return set;
     }
 }

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ModelSnapshotRetentionIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ModelSnapshotRetentionIT.java
@@ -15,7 +15,6 @@ import org.elasticsearch.action.index.IndexAction;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.search.SearchAction;
 import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.action.support.master.MasterNodeRequest;
@@ -48,6 +47,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex.createStateIndexAndAliasIfNecessary;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
@@ -170,7 +170,7 @@ public class ModelSnapshotRetentionIT extends MlNativeAutodetectIntegTestCase {
         assertThat(getAvailableModelStateDocIds(), is(expectedModelStateDocIds));
     }
 
-    private List<String> getAvailableModelSnapshotDocIds(String jobId) {
+    private List<String> getAvailableModelSnapshotDocIds(String jobId) throws Exception {
         SearchRequest searchRequest = new SearchRequest();
         searchRequest.indices(AnomalyDetectorsIndex.jobResultsAliasedName(jobId));
         QueryBuilder query = QueryBuilders.boolQuery()
@@ -180,7 +180,7 @@ public class ModelSnapshotRetentionIT extends MlNativeAutodetectIntegTestCase {
         return getDocIdsFromSearch(searchRequest);
     }
 
-    private List<String> getAvailableModelStateDocIds() {
+    private List<String> getAvailableModelStateDocIds() throws Exception {
         SearchRequest searchRequest = new SearchRequest();
         searchRequest.indices(AnomalyDetectorsIndex.jobStateIndexPattern());
         searchRequest.source(new SearchSourceBuilder().size(10000));
@@ -188,15 +188,14 @@ public class ModelSnapshotRetentionIT extends MlNativeAutodetectIntegTestCase {
         return getDocIdsFromSearch(searchRequest);
     }
 
-    private List<String> getDocIdsFromSearch(SearchRequest searchRequest) {
-
-        SearchResponse searchResponse = client().execute(SearchAction.INSTANCE, searchRequest).actionGet();
-
+    private List<String> getDocIdsFromSearch(SearchRequest searchRequest) throws Exception {
         List<String> docIds = new ArrayList<>();
-        assertThat(searchResponse.getHits(), notNullValue());
-        for (SearchHit searchHit : searchResponse.getHits().getHits()) {
-            docIds.add(searchHit.getId());
-        }
+        assertResponse(client().execute(SearchAction.INSTANCE, searchRequest), searchResponse -> {
+            assertThat(searchResponse.getHits(), notNullValue());
+            for (SearchHit searchHit : searchResponse.getHits().getHits()) {
+                docIds.add(searchHit.getId());
+            }
+        });
         Collections.sort(docIds);
         return docIds;
     }

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/OutlierDetectionWithMissingFieldsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/OutlierDetectionWithMissingFieldsIT.java
@@ -10,7 +10,6 @@ import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.index.IndexRequest;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.xpack.core.ml.action.GetDataFrameAnalyticsStatsAction;
@@ -20,6 +19,7 @@ import org.junit.After;
 
 import java.util.Map;
 
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -89,31 +89,32 @@ public class OutlierDetectionWithMissingFieldsIT extends MlNativeDataFrameAnalyt
         assertThat(stats.getDataCounts().getTestDocsCount(), equalTo(0L));
         assertThat(stats.getDataCounts().getSkippedDocsCount(), equalTo(2L));
 
-        SearchResponse sourceData = prepareSearch(sourceIndex).get();
-        for (SearchHit hit : sourceData.getHits()) {
-            GetResponse destDocGetResponse = client().prepareGet().setIndex(config.getDest().getIndex()).setId(hit.getId()).get();
-            assertThat(destDocGetResponse.isExists(), is(true));
-            Map<String, Object> sourceDoc = hit.getSourceAsMap();
-            Map<String, Object> destDoc = destDocGetResponse.getSource();
-            for (String field : sourceDoc.keySet()) {
-                assertThat(destDoc.containsKey(field), is(true));
-                assertThat(destDoc.get(field), equalTo(sourceDoc.get(field)));
-            }
-            if (destDoc.containsKey("numeric") && destDoc.get("numeric") instanceof Double) {
-                assertThat(destDoc.containsKey("ml"), is(true));
-                @SuppressWarnings("unchecked")
-                Map<String, Object> resultsObject = (Map<String, Object>) destDoc.get("ml");
+        assertResponse(prepareSearch(sourceIndex), sourceData -> {
+            for (SearchHit hit : sourceData.getHits()) {
+                GetResponse destDocGetResponse = client().prepareGet().setIndex(config.getDest().getIndex()).setId(hit.getId()).get();
+                assertThat(destDocGetResponse.isExists(), is(true));
+                Map<String, Object> sourceDoc = hit.getSourceAsMap();
+                Map<String, Object> destDoc = destDocGetResponse.getSource();
+                for (String field : sourceDoc.keySet()) {
+                    assertThat(destDoc.containsKey(field), is(true));
+                    assertThat(destDoc.get(field), equalTo(sourceDoc.get(field)));
+                }
+                if (destDoc.containsKey("numeric") && destDoc.get("numeric") instanceof Double) {
+                    assertThat(destDoc.containsKey("ml"), is(true));
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> resultsObject = (Map<String, Object>) destDoc.get("ml");
 
-                assertThat(resultsObject.containsKey("outlier_score"), is(true));
-                double outlierScore = (double) resultsObject.get("outlier_score");
-                assertThat(outlierScore, allOf(greaterThanOrEqualTo(0.0), lessThanOrEqualTo(1.0)));
-            } else {
-                assertThat(destDoc.containsKey("ml"), is(false));
+                    assertThat(resultsObject.containsKey("outlier_score"), is(true));
+                    double outlierScore = (double) resultsObject.get("outlier_score");
+                    assertThat(outlierScore, allOf(greaterThanOrEqualTo(0.0), lessThanOrEqualTo(1.0)));
+                } else {
+                    assertThat(destDoc.containsKey("ml"), is(false));
+                }
             }
-        }
+        });
 
         assertProgressComplete(id);
-        assertThat(searchStoredProgress(id).getHits().getTotalHits().value, equalTo(1L));
+        assertStoredProgressHits(id, 1);
     }
 
     @Override

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PersistJobIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PersistJobIT.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.ml.integration;
 
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.search.SearchHit;
@@ -24,7 +23,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.hamcrest.Matchers.empty;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
@@ -64,24 +64,24 @@ public class PersistJobIT extends MlNativeAutodetectIntegTestCase {
         long job1CloseTime = System.currentTimeMillis() / 1000;
 
         // Check that state has been persisted
-        SearchResponse stateDocsResponse1 = prepareSearch(AnomalyDetectorsIndex.jobStateIndexPattern()).setFetchSource(false)
-            .setTrackTotalHits(true)
-            .setSize(10000)
-            .get();
-
-        int numQuantileRecords = 0;
-        int numStateRecords = 0;
-        for (SearchHit hit : stateDocsResponse1.getHits().getHits()) {
-            logger.info("1: " + hit.getId());
-            if (hit.getId().contains("quantiles")) {
-                ++numQuantileRecords;
-            } else if (hit.getId().contains("model_state")) {
-                ++numStateRecords;
+        assertResponse(
+            prepareSearch(AnomalyDetectorsIndex.jobStateIndexPattern()).setFetchSource(false).setTrackTotalHits(true).setSize(10000),
+            stateDocsResponse1 -> {
+                int numQuantileRecords = 0;
+                int numStateRecords = 0;
+                for (SearchHit hit : stateDocsResponse1.getHits().getHits()) {
+                    logger.info("1: " + hit.getId());
+                    if (hit.getId().contains("quantiles")) {
+                        ++numQuantileRecords;
+                    } else if (hit.getId().contains("model_state")) {
+                        ++numStateRecords;
+                    }
+                }
+                assertThat(stateDocsResponse1.getHits().getTotalHits().value, equalTo(2L));
+                assertThat(numQuantileRecords, equalTo(1));
+                assertThat(numStateRecords, equalTo(1));
             }
-        }
-        assertThat(stateDocsResponse1.getHits().getTotalHits().value, equalTo(2L));
-        assertThat(numQuantileRecords, equalTo(1));
-        assertThat(numStateRecords, equalTo(1));
+        );
 
         // To generate unique snapshot IDs ensure that there is at least a 1s delay between the
         // time each job was closed
@@ -103,26 +103,26 @@ public class PersistJobIT extends MlNativeAutodetectIntegTestCase {
         closeJob(jobId);
 
         // Check that a new state record exists.
-        SearchResponse stateDocsResponse2 = prepareSearch(AnomalyDetectorsIndex.jobStateIndexPattern()).setFetchSource(false)
-            .setTrackTotalHits(true)
-            .setSize(10000)
-            .get();
+        assertResponse(
+            prepareSearch(AnomalyDetectorsIndex.jobStateIndexPattern()).setFetchSource(false).setTrackTotalHits(true).setSize(10000),
+            stateDocsResponse2 -> {
+                int numQuantileRecords = 0;
+                int numStateRecords = 0;
+                for (SearchHit hit : stateDocsResponse2.getHits().getHits()) {
+                    logger.info("2: " + hit.getId());
+                    if (hit.getId().contains("quantiles")) {
+                        ++numQuantileRecords;
+                    } else if (hit.getId().contains("model_state")) {
+                        ++numStateRecords;
+                    }
+                }
 
-        numQuantileRecords = 0;
-        numStateRecords = 0;
-        for (SearchHit hit : stateDocsResponse2.getHits().getHits()) {
-            logger.info("2: " + hit.getId());
-            if (hit.getId().contains("quantiles")) {
-                ++numQuantileRecords;
-            } else if (hit.getId().contains("model_state")) {
-                ++numStateRecords;
+                assertThat(stateDocsResponse2.getHits().getTotalHits().value, equalTo(3L));
+                assertThat(numQuantileRecords, equalTo(1));
+                assertThat(numStateRecords, equalTo(2));
+
             }
-        }
-
-        assertThat(stateDocsResponse2.getHits().getTotalHits().value, equalTo(3L));
-        assertThat(numQuantileRecords, equalTo(1));
-        assertThat(numStateRecords, equalTo(2));
-
+        );
         deleteJob(jobId);
     }
 
@@ -141,24 +141,24 @@ public class PersistJobIT extends MlNativeAutodetectIntegTestCase {
         closeJob(jobId);
 
         // Check that state has been persisted
-        SearchResponse stateDocsResponse = prepareSearch(AnomalyDetectorsIndex.jobStateIndexPattern()).setFetchSource(false)
-            .setTrackTotalHits(true)
-            .setSize(10000)
-            .get();
-
-        int numQuantileRecords = 0;
-        int numStateRecords = 0;
-        for (SearchHit hit : stateDocsResponse.getHits().getHits()) {
-            logger.info(hit.getId());
-            if (hit.getId().contains("quantiles")) {
-                ++numQuantileRecords;
-            } else if (hit.getId().contains("model_state")) {
-                ++numStateRecords;
+        assertResponse(
+            prepareSearch(AnomalyDetectorsIndex.jobStateIndexPattern()).setFetchSource(false).setTrackTotalHits(true).setSize(10000),
+            stateDocsResponse -> {
+                int numQuantileRecords = 0;
+                int numStateRecords = 0;
+                for (SearchHit hit : stateDocsResponse.getHits().getHits()) {
+                    logger.info(hit.getId());
+                    if (hit.getId().contains("quantiles")) {
+                        ++numQuantileRecords;
+                    } else if (hit.getId().contains("model_state")) {
+                        ++numStateRecords;
+                    }
+                }
+                assertThat(stateDocsResponse.getHits().getTotalHits().value, equalTo(2L));
+                assertThat(numQuantileRecords, equalTo(1));
+                assertThat(numStateRecords, equalTo(1));
             }
-        }
-        assertThat(stateDocsResponse.getHits().getTotalHits().value, equalTo(2L));
-        assertThat(numQuantileRecords, equalTo(1));
-        assertThat(numStateRecords, equalTo(1));
+        );
 
         // now check that the job can be happily restored - even though no data has been seen
         AcknowledgedResponse ack = openJob(jobId);
@@ -167,23 +167,23 @@ public class PersistJobIT extends MlNativeAutodetectIntegTestCase {
         closeJob(jobId);
         deleteJob(jobId);
 
-        stateDocsResponse = prepareSearch(AnomalyDetectorsIndex.jobStateIndexPattern()).setFetchSource(false)
-            .setTrackTotalHits(true)
-            .setSize(10000)
-            .get();
-        numQuantileRecords = 0;
-        numStateRecords = 0;
-        for (SearchHit hit : stateDocsResponse.getHits().getHits()) {
-            logger.info(hit.getId());
-            if (hit.getId().contains("quantiles")) {
-                ++numQuantileRecords;
-            } else if (hit.getId().contains("model_state")) {
-                ++numStateRecords;
+        assertResponse(
+            prepareSearch(AnomalyDetectorsIndex.jobStateIndexPattern()).setFetchSource(false).setTrackTotalHits(true).setSize(10000),
+            stateDocsResponse -> {
+                int numQuantileRecords = 0;
+                int numStateRecords = 0;
+                for (SearchHit hit : stateDocsResponse.getHits().getHits()) {
+                    logger.info(hit.getId());
+                    if (hit.getId().contains("quantiles")) {
+                        ++numQuantileRecords;
+                    } else if (hit.getId().contains("model_state")) {
+                        ++numStateRecords;
+                    }
+                }
+                assertThat(numQuantileRecords, equalTo(0));
+                assertThat(numStateRecords, equalTo(0));
             }
-        }
-        assertThat(numQuantileRecords, equalTo(0));
-        assertThat(numStateRecords, equalTo(0));
-
+        );
     }
 
     // Check an edge case where a job is opened and then immediately closed
@@ -195,12 +195,10 @@ public class PersistJobIT extends MlNativeAutodetectIntegTestCase {
         closeJob(jobId);
 
         // Check that state has not been persisted
-        SearchResponse stateDocsResponse = prepareSearch(AnomalyDetectorsIndex.jobStateIndexPattern()).get();
-        assertThat(Arrays.asList(stateDocsResponse.getHits().getHits()), empty());
+        assertHitCount(prepareSearch(AnomalyDetectorsIndex.jobStateIndexPattern()), 0);
 
         // Check that results have not been persisted
-        SearchResponse resultsDocsResponse = prepareSearch(AnomalyDetectorsIndex.jobResultsAliasedName(jobId)).get();
-        assertThat(Arrays.asList(resultsDocsResponse.getHits().getHits()), empty());
+        assertHitCount(prepareSearch(AnomalyDetectorsIndex.jobResultsAliasedName(jobId)), 0);
 
         deleteJob(jobId);
     }

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RegressionIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RegressionIT.java
@@ -13,7 +13,6 @@ import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.index.IndexRequest;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.core.Strings;
 import org.elasticsearch.rest.RestStatus;
@@ -46,6 +45,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.elasticsearch.test.hamcrest.OptionalMatchers.isPresent;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.equalTo;
@@ -112,68 +113,68 @@ public class RegressionIT extends MlNativeDataFrameAnalyticsIntegTestCase {
         startAnalytics(jobId);
         waitUntilAnalyticsIsStopped(jobId);
 
-        int trainingDocsWithEmptyFeatureImportance = 0;
-        int testDocsWithEmptyFeatureImportance = 0;
-
         // for debugging
         List<Map<String, Object>> badDocuments = new ArrayList<>();
-        SearchResponse sourceData = prepareSearch(sourceIndex).setTrackTotalHits(true).setSize(1000).get();
-        for (SearchHit hit : sourceData.getHits()) {
-            Map<String, Object> destDoc = getDestDoc(config, hit);
-            Map<String, Object> resultsObject = getMlResultsObjectFromDestDoc(destDoc);
+        assertResponse(prepareSearch(sourceIndex).setTrackTotalHits(true).setSize(1000), sourceData -> {
+            int trainingDocsWithEmptyFeatureImportance = 0;
+            int testDocsWithEmptyFeatureImportance = 0;
+            for (SearchHit hit : sourceData.getHits()) {
+                Map<String, Object> destDoc = getDestDoc(config, hit);
+                Map<String, Object> resultsObject = getMlResultsObjectFromDestDoc(destDoc);
 
-            // TODO reenable this assertion when the backend is stable
-            // it seems for this case values can be as far off as 2.0
+                // TODO reenable this assertion when the backend is stable
+                // it seems for this case values can be as far off as 2.0
 
-            // double featureValue = (double) destDoc.get(NUMERICAL_FEATURE_FIELD);
-            // double predictionValue = (double) resultsObject.get(predictedClassField);
-            // assertThat(predictionValue, closeTo(10 * featureValue, 2.0));
+                // double featureValue = (double) destDoc.get(NUMERICAL_FEATURE_FIELD);
+                // double predictionValue = (double) resultsObject.get(predictedClassField);
+                // assertThat(predictionValue, closeTo(10 * featureValue, 2.0));
 
-            assertThat(resultsObject.containsKey(predictedClassField), is(true));
-            assertThat(resultsObject.containsKey("is_training"), is(true));
-            assertThat(resultsObject.get("is_training"), is(destDoc.containsKey(DEPENDENT_VARIABLE_FIELD)));
-            @SuppressWarnings("unchecked")
-            List<Map<String, Object>> importanceArray = (List<Map<String, Object>>) resultsObject.get("feature_importance");
+                assertThat(resultsObject.containsKey(predictedClassField), is(true));
+                assertThat(resultsObject.containsKey("is_training"), is(true));
+                assertThat(resultsObject.get("is_training"), is(destDoc.containsKey(DEPENDENT_VARIABLE_FIELD)));
+                @SuppressWarnings("unchecked")
+                List<Map<String, Object>> importanceArray = (List<Map<String, Object>>) resultsObject.get("feature_importance");
 
-            if (importanceArray.isEmpty()) {
-                badDocuments.add(destDoc);
-                if (Boolean.TRUE.equals(resultsObject.get("is_training"))) {
-                    trainingDocsWithEmptyFeatureImportance++;
-                } else {
-                    testDocsWithEmptyFeatureImportance++;
+                if (importanceArray.isEmpty()) {
+                    badDocuments.add(destDoc);
+                    if (Boolean.TRUE.equals(resultsObject.get("is_training"))) {
+                        trainingDocsWithEmptyFeatureImportance++;
+                    } else {
+                        testDocsWithEmptyFeatureImportance++;
+                    }
                 }
+
+                assertThat(importanceArray, hasSize(greaterThan(0)));
+                assertThat(
+                    importanceArray.stream()
+                        .filter(
+                            m -> NUMERICAL_FEATURE_FIELD.equals(m.get("feature_name"))
+                                || DISCRETE_NUMERICAL_FEATURE_FIELD.equals(m.get("feature_name"))
+                        )
+                        .findAny(),
+                    isPresent()
+                );
             }
 
-            assertThat(importanceArray, hasSize(greaterThan(0)));
+            // If feature importance was empty for some of the docs this assertion helps us
+            // understand whether the offending docs were training or test docs.
             assertThat(
-                importanceArray.stream()
-                    .filter(
-                        m -> NUMERICAL_FEATURE_FIELD.equals(m.get("feature_name"))
-                            || DISCRETE_NUMERICAL_FEATURE_FIELD.equals(m.get("feature_name"))
-                    )
-                    .findAny(),
-                isPresent()
+                "There were ["
+                    + trainingDocsWithEmptyFeatureImportance
+                    + "] training docs and ["
+                    + testDocsWithEmptyFeatureImportance
+                    + "] test docs with empty feature importance"
+                    + " from "
+                    + sourceData.getHits().getTotalHits().value
+                    + " hits.\n"
+                    + badDocuments,
+                trainingDocsWithEmptyFeatureImportance + testDocsWithEmptyFeatureImportance,
+                equalTo(0)
             );
-        }
-
-        // If feature importance was empty for some of the docs this assertion helps us
-        // understand whether the offending docs were training or test docs.
-        assertThat(
-            "There were ["
-                + trainingDocsWithEmptyFeatureImportance
-                + "] training docs and ["
-                + testDocsWithEmptyFeatureImportance
-                + "] test docs with empty feature importance"
-                + " from "
-                + sourceData.getHits().getTotalHits().value
-                + " hits.\n"
-                + badDocuments,
-            trainingDocsWithEmptyFeatureImportance + testDocsWithEmptyFeatureImportance,
-            equalTo(0)
-        );
+        });
 
         assertProgressComplete(jobId);
-        assertThat(searchStoredProgress(jobId).getHits().getTotalHits().value, equalTo(1L));
+        assertStoredProgressHits(jobId, 1);
         assertModelStatePersisted(stateDocId());
         assertExactlyOneInferenceModelPersisted(jobId);
         assertMlResultsFieldMappings(destIndex, predictedClassField, "double");
@@ -206,18 +207,18 @@ public class RegressionIT extends MlNativeDataFrameAnalyticsIntegTestCase {
 
         startAnalytics(jobId);
         waitUntilAnalyticsIsStopped(jobId);
+        assertResponse(prepareSearch(sourceIndex).setTrackTotalHits(true).setSize(1000), sourceData -> {
+            for (SearchHit hit : sourceData.getHits()) {
+                Map<String, Object> resultsObject = getMlResultsObjectFromDestDoc(getDestDoc(config, hit));
 
-        SearchResponse sourceData = prepareSearch(sourceIndex).setTrackTotalHits(true).setSize(1000).get();
-        for (SearchHit hit : sourceData.getHits()) {
-            Map<String, Object> resultsObject = getMlResultsObjectFromDestDoc(getDestDoc(config, hit));
-
-            assertThat(resultsObject.containsKey(predictedClassField), is(true));
-            assertThat(resultsObject.containsKey("is_training"), is(true));
-            assertThat(resultsObject.get("is_training"), is(true));
-        }
+                assertThat(resultsObject.containsKey(predictedClassField), is(true));
+                assertThat(resultsObject.containsKey("is_training"), is(true));
+                assertThat(resultsObject.get("is_training"), is(true));
+            }
+        });
 
         assertProgressComplete(jobId);
-        assertThat(searchStoredProgress(jobId).getHits().getTotalHits().value, equalTo(1L));
+        assertStoredProgressHits(jobId, 1);
 
         GetDataFrameAnalyticsStatsAction.Response.Stats stats = getAnalyticsStats(jobId);
         assertThat(stats.getDataCounts().getJobId(), equalTo(jobId));
@@ -264,23 +265,24 @@ public class RegressionIT extends MlNativeDataFrameAnalyticsIntegTestCase {
         startAnalytics(jobId);
         waitUntilAnalyticsIsStopped(jobId);
 
-        int trainingRowsCount = 0;
-        int nonTrainingRowsCount = 0;
-        SearchResponse sourceData = prepareSearch(sourceIndex).setTrackTotalHits(true).setSize(1000).get();
-        for (SearchHit hit : sourceData.getHits()) {
-            Map<String, Object> resultsObject = getMlResultsObjectFromDestDoc(getDestDoc(config, hit));
+        assertResponse(prepareSearch(sourceIndex).setTrackTotalHits(true).setSize(1000), sourceData -> {
+            int trainingRowsCount = 0;
+            int nonTrainingRowsCount = 0;
+            for (SearchHit hit : sourceData.getHits()) {
+                Map<String, Object> resultsObject = getMlResultsObjectFromDestDoc(getDestDoc(config, hit));
 
-            assertThat(resultsObject.containsKey(predictedClassField), is(true));
-            assertThat(resultsObject.containsKey("is_training"), is(true));
-            // Let's just assert there's both training and non-training results
-            if ((boolean) resultsObject.get("is_training")) {
-                trainingRowsCount++;
-            } else {
-                nonTrainingRowsCount++;
+                assertThat(resultsObject.containsKey(predictedClassField), is(true));
+                assertThat(resultsObject.containsKey("is_training"), is(true));
+                // Let's just assert there's both training and non-training results
+                if ((boolean) resultsObject.get("is_training")) {
+                    trainingRowsCount++;
+                } else {
+                    nonTrainingRowsCount++;
+                }
             }
-        }
-        assertThat(trainingRowsCount, greaterThan(0));
-        assertThat(nonTrainingRowsCount, greaterThan(0));
+            assertThat(trainingRowsCount, greaterThan(0));
+            assertThat(nonTrainingRowsCount, greaterThan(0));
+        });
 
         GetDataFrameAnalyticsStatsAction.Response.Stats stats = getAnalyticsStats(jobId);
         assertThat(stats.getDataCounts().getJobId(), equalTo(jobId));
@@ -291,7 +293,7 @@ public class RegressionIT extends MlNativeDataFrameAnalyticsIntegTestCase {
         assertThat(stats.getDataCounts().getSkippedDocsCount(), equalTo(0L));
 
         assertProgressComplete(jobId);
-        assertThat(searchStoredProgress(jobId).getHits().getTotalHits().value, equalTo(1L));
+        assertStoredProgressHits(jobId, 1);
         assertModelStatePersisted(stateDocId());
         assertExactlyOneInferenceModelPersisted(jobId);
         assertMlResultsFieldMappings(destIndex, predictedClassField, "double");
@@ -344,17 +346,18 @@ public class RegressionIT extends MlNativeDataFrameAnalyticsIntegTestCase {
 
         waitUntilAnalyticsIsStopped(jobId);
 
-        SearchResponse sourceData = prepareSearch(sourceIndex).setTrackTotalHits(true).setSize(1000).get();
-        for (SearchHit hit : sourceData.getHits()) {
-            Map<String, Object> resultsObject = getMlResultsObjectFromDestDoc(getDestDoc(config, hit));
+        assertResponse(prepareSearch(sourceIndex).setTrackTotalHits(true).setSize(1000), sourceData -> {
+            for (SearchHit hit : sourceData.getHits()) {
+                Map<String, Object> resultsObject = getMlResultsObjectFromDestDoc(getDestDoc(config, hit));
 
-            assertThat(resultsObject.containsKey(predictedClassField), is(true));
-            assertThat(resultsObject.containsKey("is_training"), is(true));
-            assertThat(resultsObject.get("is_training"), is(true));
-        }
+                assertThat(resultsObject.containsKey(predictedClassField), is(true));
+                assertThat(resultsObject.containsKey("is_training"), is(true));
+                assertThat(resultsObject.get("is_training"), is(true));
+            }
+        });
 
         assertProgressComplete(jobId);
-        assertThat(searchStoredProgress(jobId).getHits().getTotalHits().value, equalTo(1L));
+        assertStoredProgressHits(jobId, 1);
         assertModelStatePersisted(stateDocId());
         assertAtLeastOneInferenceModelPersisted(jobId);
         assertMlResultsFieldMappings(destIndex, predictedClassField, "double");
@@ -420,14 +423,14 @@ public class RegressionIT extends MlNativeDataFrameAnalyticsIntegTestCase {
         waitUntilAnalyticsIsStopped(jobId);
 
         assertProgressComplete(jobId);
-        assertThat(searchStoredProgress(jobId).getHits().getTotalHits().value, equalTo(1L));
+        assertStoredProgressHits(jobId, 1);
         assertModelStatePersisted(stateDocId());
         assertExactlyOneInferenceModelPersisted(jobId);
         assertMlResultsFieldMappings(destIndex, predictedClassField, "double");
 
         // Call _delete_expired_data API and check nothing was deleted
         assertThat(deleteExpiredData().isDeleted(), is(true));
-        assertThat(searchStoredProgress(jobId).getHits().getTotalHits().value, equalTo(1L));
+        assertStoredProgressHits(jobId, 1);
         assertModelStatePersisted(stateDocId());
 
         // Delete the config straight from the config index
@@ -440,8 +443,7 @@ public class RegressionIT extends MlNativeDataFrameAnalyticsIntegTestCase {
         // Now calling the _delete_expired_data API should remove unused state
         assertThat(deleteExpiredData().isDeleted(), is(true));
 
-        SearchResponse stateIndexSearchResponse = prepareSearch(".ml-state*").execute().actionGet();
-        assertThat(stateIndexSearchResponse.getHits().getTotalHits().value, equalTo(0L));
+        assertHitCount(prepareSearch(".ml-state*"), 0L);
     }
 
     public void testDependentVariableIsLong() throws Exception {
@@ -498,30 +500,31 @@ public class RegressionIT extends MlNativeDataFrameAnalyticsIntegTestCase {
         startAnalytics(jobId);
         waitUntilAnalyticsIsStopped(jobId);
 
-        SearchResponse sourceData = prepareSearch(sourceIndex).setTrackTotalHits(true).setSize(1000).get();
-        for (SearchHit hit : sourceData.getHits()) {
-            Map<String, Object> destDoc = getDestDoc(config, hit);
-            Map<String, Object> resultsObject = getMlResultsObjectFromDestDoc(destDoc);
+        assertResponse(prepareSearch(sourceIndex).setTrackTotalHits(true).setSize(1000), sourceData -> {
+            for (SearchHit hit : sourceData.getHits()) {
+                Map<String, Object> destDoc = getDestDoc(config, hit);
+                Map<String, Object> resultsObject = getMlResultsObjectFromDestDoc(destDoc);
 
-            assertThat(resultsObject.containsKey(predictedClassField), is(true));
-            assertThat(resultsObject.containsKey("is_training"), is(true));
-            assertThat(resultsObject.get("is_training"), is(destDoc.containsKey(DEPENDENT_VARIABLE_FIELD)));
-            @SuppressWarnings("unchecked")
-            List<Map<String, Object>> importanceArray = (List<Map<String, Object>>) resultsObject.get("feature_importance");
-            assertThat(importanceArray, hasSize(greaterThan(0)));
-            assertThat(
-                importanceArray.stream()
-                    .filter(
-                        m -> NUMERICAL_FEATURE_FIELD.equals(m.get("feature_name"))
-                            || DISCRETE_NUMERICAL_FEATURE_FIELD.equals(m.get("feature_name"))
-                    )
-                    .findAny(),
-                isPresent()
-            );
-        }
+                assertThat(resultsObject.containsKey(predictedClassField), is(true));
+                assertThat(resultsObject.containsKey("is_training"), is(true));
+                assertThat(resultsObject.get("is_training"), is(destDoc.containsKey(DEPENDENT_VARIABLE_FIELD)));
+                @SuppressWarnings("unchecked")
+                List<Map<String, Object>> importanceArray = (List<Map<String, Object>>) resultsObject.get("feature_importance");
+                assertThat(importanceArray, hasSize(greaterThan(0)));
+                assertThat(
+                    importanceArray.stream()
+                        .filter(
+                            m -> NUMERICAL_FEATURE_FIELD.equals(m.get("feature_name"))
+                                || DISCRETE_NUMERICAL_FEATURE_FIELD.equals(m.get("feature_name"))
+                        )
+                        .findAny(),
+                    isPresent()
+                );
+            }
+        });
 
         assertProgressComplete(jobId);
-        assertThat(searchStoredProgress(jobId).getHits().getTotalHits().value, equalTo(1L));
+        assertStoredProgressHits(jobId, 1);
         assertModelStatePersisted(stateDocId());
         assertExactlyOneInferenceModelPersisted(jobId);
         assertMlResultsFieldMappings(destIndex, predictedClassField, "double");
@@ -605,29 +608,6 @@ public class RegressionIT extends MlNativeDataFrameAnalyticsIntegTestCase {
 
         waitUntilAnalyticsIsStopped(jobId);
 
-        double predictionErrorSum = 0.0;
-
-        SearchResponse sourceData = prepareSearch(sourceIndex).setSize(totalDocCount).get();
-        StringBuilder targetsPredictions = new StringBuilder(); // used to investigate #90599
-        for (SearchHit hit : sourceData.getHits()) {
-            Map<String, Object> destDoc = getDestDoc(config, hit);
-            Map<String, Object> resultsObject = getMlResultsObjectFromDestDoc(destDoc);
-
-            assertThat(resultsObject.containsKey(predictionField), is(true));
-            assertThat(resultsObject.containsKey("is_training"), is(true));
-
-            int featureValue = (int) destDoc.get("field_1");
-            double predictionValue = (double) resultsObject.get(predictionField);
-            predictionErrorSum += Math.abs(predictionValue - 2 * featureValue);
-
-            // collect the log of targets and predictions for debugging #90599
-            targetsPredictions.append(2 * featureValue).append(", ").append(predictionValue).append("\n");
-        }
-
-        // We assert on the mean prediction error in order to reduce the probability
-        // the test fails compared to asserting on the prediction of each individual doc.
-        double meanPredictionError = predictionErrorSum / sourceData.getHits().getHits().length;
-
         // obtain addition information for investigation of #90599
         String modelId = getModelId(jobId);
         TrainedModelMetadata modelMetadata = getModelMetadata(modelId);
@@ -639,15 +619,37 @@ public class RegressionIT extends MlNativeDataFrameAnalyticsIntegTestCase {
         TrainedModelDefinition modelDefinition = getModelDefinition(modelId);
         Ensemble ensemble = (Ensemble) modelDefinition.getTrainedModel();
         int numberTrees = ensemble.getModels().size();
-        String str = "Failure: failed for seed %d modelId %s numberTrees %d\n";
-        assertThat(
-            Strings.format(str, seed, modelId, numberTrees) + targetsPredictions + hyperparameters,
-            meanPredictionError,
-            lessThanOrEqualTo(3.0)
-        );
+
+        StringBuilder targetsPredictions = new StringBuilder(); // used to investigate #90599
+        assertResponse(prepareSearch(sourceIndex).setSize(totalDocCount), sourceData -> {
+            double predictionErrorSum = 0.0;
+            for (SearchHit hit : sourceData.getHits()) {
+                Map<String, Object> destDoc = getDestDoc(config, hit);
+                Map<String, Object> resultsObject = getMlResultsObjectFromDestDoc(destDoc);
+
+                assertThat(resultsObject.containsKey(predictionField), is(true));
+                assertThat(resultsObject.containsKey("is_training"), is(true));
+
+                int featureValue = (int) destDoc.get("field_1");
+                double predictionValue = (double) resultsObject.get(predictionField);
+                predictionErrorSum += Math.abs(predictionValue - 2 * featureValue);
+
+                // collect the log of targets and predictions for debugging #90599
+                targetsPredictions.append(2 * featureValue).append(", ").append(predictionValue).append("\n");
+            }
+            // We assert on the mean prediction error in order to reduce the probability
+            // the test fails compared to asserting on the prediction of each individual doc.
+            double meanPredictionError = predictionErrorSum / sourceData.getHits().getHits().length;
+            String str = "Failure: failed for seed %d modelId %s numberTrees %d\n";
+            assertThat(
+                Strings.format(str, seed, modelId, numberTrees) + targetsPredictions + hyperparameters,
+                meanPredictionError,
+                lessThanOrEqualTo(3.0)
+            );
+        });
 
         assertProgressComplete(jobId);
-        assertThat(searchStoredProgress(jobId).getHits().getTotalHits().value, equalTo(1L));
+        assertStoredProgressHits(jobId, 1);
         assertModelStatePersisted(stateDocId());
         assertExactlyOneInferenceModelPersisted(jobId);
         assertMlResultsFieldMappings(destIndex, predictionField, "double");
@@ -704,18 +706,19 @@ public class RegressionIT extends MlNativeDataFrameAnalyticsIntegTestCase {
         waitUntilAnalyticsIsStopped(jobId);
 
         // for debugging
-        SearchResponse sourceData = prepareSearch(sourceIndex).setTrackTotalHits(true).setSize(1000).get();
-        for (SearchHit hit : sourceData.getHits()) {
-            Map<String, Object> destDoc = getDestDoc(config, hit);
-            Map<String, Object> resultsObject = getMlResultsObjectFromDestDoc(destDoc);
+        assertResponse(prepareSearch(sourceIndex).setTrackTotalHits(true).setSize(1000), sourceData -> {
+            for (SearchHit hit : sourceData.getHits()) {
+                Map<String, Object> destDoc = getDestDoc(config, hit);
+                Map<String, Object> resultsObject = getMlResultsObjectFromDestDoc(destDoc);
 
-            assertThat(resultsObject.containsKey(predictedClassField), is(true));
-            assertThat(resultsObject.containsKey("is_training"), is(true));
-            assertThat(resultsObject.get("is_training"), is(destDoc.containsKey(DEPENDENT_VARIABLE_FIELD)));
-        }
+                assertThat(resultsObject.containsKey(predictedClassField), is(true));
+                assertThat(resultsObject.containsKey("is_training"), is(true));
+                assertThat(resultsObject.get("is_training"), is(destDoc.containsKey(DEPENDENT_VARIABLE_FIELD)));
+            }
+        });
 
         assertProgressComplete(jobId);
-        assertThat(searchStoredProgress(jobId).getHits().getTotalHits().value, equalTo(1L));
+        assertStoredProgressHits(jobId, 1);
         assertModelStatePersisted(stateDocId());
         assertExactlyOneInferenceModelPersisted(jobId);
         assertMlResultsFieldMappings(destIndex, predictedClassField, "double");
@@ -794,23 +797,23 @@ public class RegressionIT extends MlNativeDataFrameAnalyticsIntegTestCase {
 
         startAnalytics(jobId);
         waitUntilAnalyticsIsStopped(jobId);
+        assertResponse(prepareSearch(destIndex).setTrackTotalHits(true).setSize(1000), destData -> {
+            for (SearchHit hit : destData.getHits()) {
+                Map<String, Object> destDoc = hit.getSourceAsMap();
+                Map<String, Object> resultsObject = getMlResultsObjectFromDestDoc(destDoc);
 
-        SearchResponse destData = prepareSearch(destIndex).setTrackTotalHits(true).setSize(1000).get();
-        for (SearchHit hit : destData.getHits()) {
-            Map<String, Object> destDoc = hit.getSourceAsMap();
-            Map<String, Object> resultsObject = getMlResultsObjectFromDestDoc(destDoc);
-
-            assertThat(resultsObject.containsKey(predictedClassField), is(true));
-            assertThat(resultsObject.containsKey("is_training"), is(true));
-            assertThat(resultsObject.get("is_training"), is(destDoc.containsKey(DEPENDENT_VARIABLE_FIELD)));
-            @SuppressWarnings("unchecked")
-            List<Map<String, Object>> importanceArray = (List<Map<String, Object>>) resultsObject.get("feature_importance");
-            assertThat(importanceArray, hasSize(1));
-            assertThat(importanceArray.get(0), hasEntry("feature_name", numericRuntimeField));
-        }
+                assertThat(resultsObject.containsKey(predictedClassField), is(true));
+                assertThat(resultsObject.containsKey("is_training"), is(true));
+                assertThat(resultsObject.get("is_training"), is(destDoc.containsKey(DEPENDENT_VARIABLE_FIELD)));
+                @SuppressWarnings("unchecked")
+                List<Map<String, Object>> importanceArray = (List<Map<String, Object>>) resultsObject.get("feature_importance");
+                assertThat(importanceArray, hasSize(1));
+                assertThat(importanceArray.get(0), hasEntry("feature_name", numericRuntimeField));
+            }
+        });
 
         assertProgressComplete(jobId);
-        assertThat(searchStoredProgress(jobId).getHits().getTotalHits().value, equalTo(1L));
+        assertStoredProgressHits(jobId, 1);
         assertModelStatePersisted(stateDocId());
         assertExactlyOneInferenceModelPersisted(jobId);
         assertMlResultsFieldMappings(destIndex, predictedClassField, "double");

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ResetJobIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ResetJobIT.java
@@ -17,7 +17,6 @@ import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.DataCounts;
 import org.elasticsearch.xpack.core.ml.job.results.Bucket;
 import org.junit.After;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -34,7 +33,7 @@ public class ResetJobIT extends MlNativeAutodetectIntegTestCase {
         cleanUp();
     }
 
-    public void testReset() throws IOException {
+    public void testReset() throws Exception {
         TimeValue bucketSpan = TimeValue.timeValueMinutes(30);
         long startTime = 1514764800000L;
         final int bucketCount = 100;

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RevertModelSnapshotIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RevertModelSnapshotIT.java
@@ -6,8 +6,8 @@
  */
 package org.elasticsearch.xpack.ml.integration;
 
+import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.action.index.IndexRequest;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -48,6 +48,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertCheckedResponse;
 import static org.elasticsearch.xpack.core.ml.annotations.AnnotationTests.randomAnnotation;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -288,21 +289,24 @@ public class RevertModelSnapshotIT extends MlNativeAutodetectIntegTestCase {
         return data;
     }
 
-    private Quantiles getQuantiles(String jobId) {
-        SearchResponse response = prepareSearch(".ml-state*").setQuery(QueryBuilders.idsQuery().addIds(Quantiles.documentId(jobId)))
-            .setSize(1)
-            .get();
-        SearchHits hits = response.getHits();
-        assertThat(hits.getTotalHits().value, equalTo(1L));
-        try {
-            XContentParser parser = JsonXContent.jsonXContent.createParser(
-                XContentParserConfiguration.EMPTY,
-                hits.getAt(0).getSourceAsString()
-            );
-            return Quantiles.LENIENT_PARSER.apply(parser, null);
-        } catch (IOException e) {
-            throw new IllegalStateException(e);
-        }
+    private Quantiles getQuantiles(String jobId) throws Exception {
+        SetOnce<Quantiles> quantilesSetOnce = new SetOnce<>();
+        assertCheckedResponse(
+            prepareSearch(".ml-state*").setQuery(QueryBuilders.idsQuery().addIds(Quantiles.documentId(jobId))).setSize(1),
+            response -> {
+                SearchHits hits = response.getHits();
+                assertThat(hits.getTotalHits().value, equalTo(1L));
+                try (
+                    XContentParser parser = JsonXContent.jsonXContent.createParser(
+                        XContentParserConfiguration.EMPTY,
+                        hits.getAt(0).getSourceAsString()
+                    )
+                ) {
+                    quantilesSetOnce.set(Quantiles.LENIENT_PARSER.apply(parser, null));
+                }
+            }
+        );
+        return quantilesSetOnce.get();
     }
 
     private static IndexRequest randomAnnotationIndexRequest(String jobId, Instant timestamp, Event event) throws IOException {

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RunDataFrameAnalyticsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RunDataFrameAnalyticsIT.java
@@ -13,7 +13,6 @@ import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.index.IndexRequest;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.TimeValue;
@@ -36,6 +35,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyString;
@@ -102,40 +103,41 @@ public class RunDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsIntegTest
         assertThat(stats.getDataCounts().getTestDocsCount(), equalTo(0L));
         assertThat(stats.getDataCounts().getSkippedDocsCount(), equalTo(0L));
 
-        SearchResponse sourceData = prepareSearch(sourceIndex).get();
-        double scoreOfOutlier = 0.0;
-        double scoreOfNonOutlier = -1.0;
-        for (SearchHit hit : sourceData.getHits()) {
-            GetResponse destDocGetResponse = client().prepareGet().setIndex(config.getDest().getIndex()).setId(hit.getId()).get();
-            assertThat(destDocGetResponse.isExists(), is(true));
-            Map<String, Object> sourceDoc = hit.getSourceAsMap();
-            Map<String, Object> destDoc = destDocGetResponse.getSource();
-            for (String field : sourceDoc.keySet()) {
-                assertThat(destDoc.containsKey(field), is(true));
-                assertThat(destDoc.get(field), equalTo(sourceDoc.get(field)));
-            }
-            assertThat(destDoc.containsKey("ml"), is(true));
+        assertResponse(prepareSearch(sourceIndex), sourceData -> {
+            double scoreOfOutlier = 0.0;
+            double scoreOfNonOutlier = -1.0;
+            for (SearchHit hit : sourceData.getHits()) {
+                GetResponse destDocGetResponse = client().prepareGet().setIndex(config.getDest().getIndex()).setId(hit.getId()).get();
+                assertThat(destDocGetResponse.isExists(), is(true));
+                Map<String, Object> sourceDoc = hit.getSourceAsMap();
+                Map<String, Object> destDoc = destDocGetResponse.getSource();
+                for (String field : sourceDoc.keySet()) {
+                    assertThat(destDoc.containsKey(field), is(true));
+                    assertThat(destDoc.get(field), equalTo(sourceDoc.get(field)));
+                }
+                assertThat(destDoc.containsKey("ml"), is(true));
 
-            @SuppressWarnings("unchecked")
-            Map<String, Object> resultsObject = (Map<String, Object>) destDoc.get("ml");
+                @SuppressWarnings("unchecked")
+                Map<String, Object> resultsObject = (Map<String, Object>) destDoc.get("ml");
 
-            assertThat(resultsObject.containsKey("outlier_score"), is(true));
-            double outlierScore = (double) resultsObject.get("outlier_score");
-            assertThat(outlierScore, allOf(greaterThanOrEqualTo(0.0), lessThanOrEqualTo(1.0)));
-            if (hit.getId().equals("outlier")) {
-                scoreOfOutlier = outlierScore;
-            } else {
-                if (scoreOfNonOutlier < 0) {
-                    scoreOfNonOutlier = outlierScore;
+                assertThat(resultsObject.containsKey("outlier_score"), is(true));
+                double outlierScore = (double) resultsObject.get("outlier_score");
+                assertThat(outlierScore, allOf(greaterThanOrEqualTo(0.0), lessThanOrEqualTo(1.0)));
+                if (hit.getId().equals("outlier")) {
+                    scoreOfOutlier = outlierScore;
                 } else {
-                    assertThat(outlierScore, equalTo(scoreOfNonOutlier));
+                    if (scoreOfNonOutlier < 0) {
+                        scoreOfNonOutlier = outlierScore;
+                    } else {
+                        assertThat(outlierScore, equalTo(scoreOfNonOutlier));
+                    }
                 }
             }
-        }
-        assertThat(scoreOfOutlier, is(greaterThan(scoreOfNonOutlier)));
+            assertThat(scoreOfOutlier, is(greaterThan(scoreOfNonOutlier)));
+        });
 
         assertProgressComplete(id);
-        assertThat(searchStoredProgress(id).getHits().getTotalHits().value, equalTo(1L));
+        assertStoredProgressHits(id, 1);
         assertThatAuditMessagesMatch(
             id,
             "Created analytics with type [outlier_detection]",
@@ -230,17 +232,17 @@ public class RunDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsIntegTest
         waitUntilAnalyticsIsStopped(id);
 
         // Check we've got all docs
-        SearchResponse searchResponse = prepareSearch(config.getDest().getIndex()).setTrackTotalHits(true).get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo((long) docCount));
+        assertHitCount(prepareSearch(config.getDest().getIndex()).setTrackTotalHits(true), docCount);
 
         // Check they all have an outlier_score
-        searchResponse = prepareSearch(config.getDest().getIndex()).setTrackTotalHits(true)
-            .setQuery(QueryBuilders.existsQuery("custom_ml.outlier_score"))
-            .get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo((long) docCount));
+        assertHitCount(
+            prepareSearch(config.getDest().getIndex()).setTrackTotalHits(true)
+                .setQuery(QueryBuilders.existsQuery("custom_ml.outlier_score")),
+            docCount
+        );
 
         assertProgressComplete(id);
-        assertThat(searchStoredProgress(id).getHits().getTotalHits().value, equalTo(1L));
+        assertStoredProgressHits(id, 1);
         assertThatAuditMessagesMatch(
             id,
             "Created analytics with type [outlier_detection]",
@@ -311,28 +313,29 @@ public class RunDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsIntegTest
         startAnalytics(id);
         waitUntilAnalyticsIsStopped(id);
 
-        SearchResponse sourceData = prepareSearch(sourceIndex).get();
-        for (SearchHit hit : sourceData.getHits()) {
-            GetResponse destDocGetResponse = client().prepareGet().setIndex(config.getDest().getIndex()).setId(hit.getId()).get();
-            assertThat(destDocGetResponse.isExists(), is(true));
-            Map<String, Object> sourceDoc = hit.getSourceAsMap();
-            Map<String, Object> destDoc = destDocGetResponse.getSource();
-            for (String field : sourceDoc.keySet()) {
-                assertThat(destDoc.containsKey(field), is(true));
-                assertThat(destDoc.get(field), equalTo(sourceDoc.get(field)));
+        assertResponse(prepareSearch(sourceIndex), sourceData -> {
+            for (SearchHit hit : sourceData.getHits()) {
+                GetResponse destDocGetResponse = client().prepareGet().setIndex(config.getDest().getIndex()).setId(hit.getId()).get();
+                assertThat(destDocGetResponse.isExists(), is(true));
+                Map<String, Object> sourceDoc = hit.getSourceAsMap();
+                Map<String, Object> destDoc = destDocGetResponse.getSource();
+                for (String field : sourceDoc.keySet()) {
+                    assertThat(destDoc.containsKey(field), is(true));
+                    assertThat(destDoc.get(field), equalTo(sourceDoc.get(field)));
+                }
+                assertThat(destDoc.containsKey("ml"), is(true));
+
+                @SuppressWarnings("unchecked")
+                Map<String, Object> resultsObject = (Map<String, Object>) destDoc.get("ml");
+
+                assertThat(resultsObject.containsKey("outlier_score"), is(true));
+                double outlierScore = (double) resultsObject.get("outlier_score");
+                assertThat(outlierScore, allOf(greaterThanOrEqualTo(0.0), lessThanOrEqualTo(1.0)));
             }
-            assertThat(destDoc.containsKey("ml"), is(true));
-
-            @SuppressWarnings("unchecked")
-            Map<String, Object> resultsObject = (Map<String, Object>) destDoc.get("ml");
-
-            assertThat(resultsObject.containsKey("outlier_score"), is(true));
-            double outlierScore = (double) resultsObject.get("outlier_score");
-            assertThat(outlierScore, allOf(greaterThanOrEqualTo(0.0), lessThanOrEqualTo(1.0)));
-        }
+        });
 
         assertProgressComplete(id);
-        assertThat(searchStoredProgress(id).getHits().getTotalHits().value, equalTo(1L));
+        assertStoredProgressHits(id, 1);
         assertThatAuditMessagesMatch(
             id,
             "Created analytics with type [outlier_detection]",
@@ -391,16 +394,17 @@ public class RunDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsIntegTest
             return;
         }
 
-        SearchResponse searchResponse = prepareSearch(config.getDest().getIndex()).setTrackTotalHits(true).get();
-        if (searchResponse.getHits().getTotalHits().value == docCount) {
-            searchResponse = prepareSearch(config.getDest().getIndex()).setTrackTotalHits(true)
-                .setQuery(QueryBuilders.existsQuery("custom_ml.outlier_score"))
-                .get();
-            logger.debug("We stopped during analysis: [{}] < [{}]", searchResponse.getHits().getTotalHits().value, docCount);
-            assertThat(searchResponse.getHits().getTotalHits().value, lessThan((long) docCount));
-        } else {
-            logger.debug("We stopped during reindexing: [{}] < [{}]", searchResponse.getHits().getTotalHits().value, docCount);
-        }
+        assertResponse(prepareSearch(config.getDest().getIndex()).setTrackTotalHits(true), searchResponse -> {
+            if (searchResponse.getHits().getTotalHits().value == docCount) {
+                searchResponse = prepareSearch(config.getDest().getIndex()).setTrackTotalHits(true)
+                    .setQuery(QueryBuilders.existsQuery("custom_ml.outlier_score"))
+                    .get();
+                logger.debug("We stopped during analysis: [{}] < [{}]", searchResponse.getHits().getTotalHits().value, docCount);
+                assertThat(searchResponse.getHits().getTotalHits().value, lessThan((long) docCount));
+            } else {
+                logger.debug("We stopped during reindexing: [{}] < [{}]", searchResponse.getHits().getTotalHits().value, docCount);
+            }
+        });
 
         assertThatAuditMessagesMatch(
             id,
@@ -457,17 +461,16 @@ public class RunDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsIntegTest
         waitUntilAnalyticsIsStopped(id);
 
         // Check we've got all docs
-        SearchResponse searchResponse = prepareSearch(config.getDest().getIndex()).setTrackTotalHits(true).get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo((long) bulkRequestBuilder.numberOfActions()));
+        assertHitCount(prepareSearch(config.getDest().getIndex()).setTrackTotalHits(true), bulkRequestBuilder.numberOfActions());
 
         // Check they all have an outlier_score
-        searchResponse = prepareSearch(config.getDest().getIndex()).setTrackTotalHits(true)
-            .setQuery(QueryBuilders.existsQuery("ml.outlier_score"))
-            .get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo((long) bulkRequestBuilder.numberOfActions()));
+        assertHitCount(
+            prepareSearch(config.getDest().getIndex()).setTrackTotalHits(true).setQuery(QueryBuilders.existsQuery("ml.outlier_score")),
+            bulkRequestBuilder.numberOfActions()
+        );
 
         assertProgressComplete(id);
-        assertThat(searchStoredProgress(id).getHits().getTotalHits().value, equalTo(1L));
+        assertStoredProgressHits(id, 1);
         assertThatAuditMessagesMatch(
             id,
             "Created analytics with type [outlier_detection]",
@@ -520,17 +523,15 @@ public class RunDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsIntegTest
         waitUntilAnalyticsIsStopped(id);
 
         // Check we've got all docs
-        SearchResponse searchResponse = prepareSearch(config.getDest().getIndex()).setTrackTotalHits(true).get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo((long) bulkRequestBuilder.numberOfActions()));
-
+        assertHitCount(prepareSearch(config.getDest().getIndex()).setTrackTotalHits(true), bulkRequestBuilder.numberOfActions());
         // Check they all have an outlier_score
-        searchResponse = prepareSearch(config.getDest().getIndex()).setTrackTotalHits(true)
-            .setQuery(QueryBuilders.existsQuery("ml.outlier_score"))
-            .get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo((long) bulkRequestBuilder.numberOfActions()));
+        assertHitCount(
+            prepareSearch(config.getDest().getIndex()).setTrackTotalHits(true).setQuery(QueryBuilders.existsQuery("ml.outlier_score")),
+            bulkRequestBuilder.numberOfActions()
+        );
 
         assertProgressComplete(id);
-        assertThat(searchStoredProgress(id).getHits().getTotalHits().value, equalTo(1L));
+        assertStoredProgressHits(id, 1);
         assertThatAuditMessagesMatch(
             id,
             "Created analytics with type [outlier_detection]",
@@ -686,17 +687,17 @@ public class RunDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsIntegTest
         waitUntilAnalyticsIsStopped(id);
 
         // Check we've got all docs
-        SearchResponse searchResponse = prepareSearch(config.getDest().getIndex()).setTrackTotalHits(true).get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo((long) docCount));
+        assertHitCount(prepareSearch(config.getDest().getIndex()).setTrackTotalHits(true), docCount);
 
         // Check they all have an outlier_score
-        searchResponse = prepareSearch(config.getDest().getIndex()).setTrackTotalHits(true)
-            .setQuery(QueryBuilders.existsQuery("custom_ml.outlier_score"))
-            .get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo((long) docCount));
+        assertHitCount(
+            prepareSearch(config.getDest().getIndex()).setTrackTotalHits(true)
+                .setQuery(QueryBuilders.existsQuery("custom_ml.outlier_score")),
+            docCount
+        );
 
         assertProgressComplete(id);
-        assertThat(searchStoredProgress(id).getHits().getTotalHits().value, equalTo(1L));
+        assertStoredProgressHits(id, 1);
     }
 
     public void testOutlierDetectionWithCustomParams() throws Exception {
@@ -745,42 +746,43 @@ public class RunDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsIntegTest
         startAnalytics(id);
         waitUntilAnalyticsIsStopped(id);
 
-        SearchResponse sourceData = prepareSearch(sourceIndex).get();
-        double scoreOfOutlier = 0.0;
-        double scoreOfNonOutlier = -1.0;
-        for (SearchHit hit : sourceData.getHits()) {
-            GetResponse destDocGetResponse = client().prepareGet().setIndex(config.getDest().getIndex()).setId(hit.getId()).get();
-            assertThat(destDocGetResponse.isExists(), is(true));
-            Map<String, Object> sourceDoc = hit.getSourceAsMap();
-            Map<String, Object> destDoc = destDocGetResponse.getSource();
-            for (String field : sourceDoc.keySet()) {
-                assertThat(destDoc.containsKey(field), is(true));
-                assertThat(destDoc.get(field), equalTo(sourceDoc.get(field)));
-            }
-            assertThat(destDoc.containsKey("ml"), is(true));
+        assertResponse(prepareSearch(sourceIndex), sourceData -> {
+            double scoreOfOutlier = 0.0;
+            double scoreOfNonOutlier = -1.0;
+            for (SearchHit hit : sourceData.getHits()) {
+                GetResponse destDocGetResponse = client().prepareGet().setIndex(config.getDest().getIndex()).setId(hit.getId()).get();
+                assertThat(destDocGetResponse.isExists(), is(true));
+                Map<String, Object> sourceDoc = hit.getSourceAsMap();
+                Map<String, Object> destDoc = destDocGetResponse.getSource();
+                for (String field : sourceDoc.keySet()) {
+                    assertThat(destDoc.containsKey(field), is(true));
+                    assertThat(destDoc.get(field), equalTo(sourceDoc.get(field)));
+                }
+                assertThat(destDoc.containsKey("ml"), is(true));
 
-            @SuppressWarnings("unchecked")
-            Map<String, Object> resultsObject = (Map<String, Object>) destDoc.get("ml");
+                @SuppressWarnings("unchecked")
+                Map<String, Object> resultsObject = (Map<String, Object>) destDoc.get("ml");
 
-            assertThat(resultsObject.containsKey("outlier_score"), is(true));
-            assertThat(resultsObject.containsKey("feature_influence"), is(false));
+                assertThat(resultsObject.containsKey("outlier_score"), is(true));
+                assertThat(resultsObject.containsKey("feature_influence"), is(false));
 
-            double outlierScore = (double) resultsObject.get("outlier_score");
-            assertThat(outlierScore, allOf(greaterThanOrEqualTo(0.0), lessThanOrEqualTo(1.0)));
-            if (hit.getId().equals("outlier")) {
-                scoreOfOutlier = outlierScore;
-            } else {
-                if (scoreOfNonOutlier < 0) {
-                    scoreOfNonOutlier = outlierScore;
+                double outlierScore = (double) resultsObject.get("outlier_score");
+                assertThat(outlierScore, allOf(greaterThanOrEqualTo(0.0), lessThanOrEqualTo(1.0)));
+                if (hit.getId().equals("outlier")) {
+                    scoreOfOutlier = outlierScore;
                 } else {
-                    assertThat(outlierScore, equalTo(scoreOfNonOutlier));
+                    if (scoreOfNonOutlier < 0) {
+                        scoreOfNonOutlier = outlierScore;
+                    } else {
+                        assertThat(outlierScore, equalTo(scoreOfNonOutlier));
+                    }
                 }
             }
-        }
-        assertThat(scoreOfOutlier, is(greaterThan(scoreOfNonOutlier)));
+            assertThat(scoreOfOutlier, is(greaterThan(scoreOfNonOutlier)));
+        });
 
         assertProgressComplete(id);
-        assertThat(searchStoredProgress(id).getHits().getTotalHits().value, equalTo(1L));
+        assertStoredProgressHits(id, 1);
         assertThatAuditMessagesMatch(
             id,
             "Created analytics with type [outlier_detection]",
@@ -854,45 +856,46 @@ public class RunDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsIntegTest
         assertThat(stats.getDataCounts().getTestDocsCount(), equalTo(0L));
         assertThat(stats.getDataCounts().getSkippedDocsCount(), equalTo(0L));
 
-        SearchResponse sourceData = prepareSearch(sourceIndex).get();
-        double scoreOfOutlier = 0.0;
-        double scoreOfNonOutlier = -1.0;
-        for (SearchHit hit : sourceData.getHits()) {
-            GetResponse destDocGetResponse = client().prepareGet().setIndex(config.getDest().getIndex()).setId(hit.getId()).get();
-            assertThat(destDocGetResponse.isExists(), is(true));
-            Map<String, Object> sourceDoc = hit.getSourceAsMap();
-            Map<String, Object> destDoc = destDocGetResponse.getSource();
-            for (String field : sourceDoc.keySet()) {
-                assertThat(destDoc.containsKey(field), is(true));
-                assertThat(destDoc.get(field), equalTo(sourceDoc.get(field)));
-            }
-            assertThat(destDoc.containsKey("ml"), is(true));
-
-            @SuppressWarnings("unchecked")
-            Map<String, Object> resultsObject = (Map<String, Object>) destDoc.get("ml");
-
-            assertThat(resultsObject.containsKey("outlier_score"), is(true));
-            double outlierScore = (double) resultsObject.get("outlier_score");
-            assertThat(outlierScore, allOf(greaterThanOrEqualTo(0.0), lessThanOrEqualTo(1.0)));
-            if (hit.getId().equals("outlier")) {
-                scoreOfOutlier = outlierScore;
+        assertResponse(prepareSearch(sourceIndex), sourceData -> {
+            double scoreOfOutlier = 0.0;
+            double scoreOfNonOutlier = -1.0;
+            for (SearchHit hit : sourceData.getHits()) {
+                GetResponse destDocGetResponse = client().prepareGet().setIndex(config.getDest().getIndex()).setId(hit.getId()).get();
+                assertThat(destDocGetResponse.isExists(), is(true));
+                Map<String, Object> sourceDoc = hit.getSourceAsMap();
+                Map<String, Object> destDoc = destDocGetResponse.getSource();
+                for (String field : sourceDoc.keySet()) {
+                    assertThat(destDoc.containsKey(field), is(true));
+                    assertThat(destDoc.get(field), equalTo(sourceDoc.get(field)));
+                }
+                assertThat(destDoc.containsKey("ml"), is(true));
 
                 @SuppressWarnings("unchecked")
-                List<Map<String, Object>> featureInfluence = (List<Map<String, Object>>) resultsObject.get("feature_influence");
-                assertThat(featureInfluence.size(), equalTo(1));
-                assertThat(featureInfluence.get(0).get("feature_name"), equalTo("runtime_numeric"));
-            } else {
-                if (scoreOfNonOutlier < 0) {
-                    scoreOfNonOutlier = outlierScore;
+                Map<String, Object> resultsObject = (Map<String, Object>) destDoc.get("ml");
+
+                assertThat(resultsObject.containsKey("outlier_score"), is(true));
+                double outlierScore = (double) resultsObject.get("outlier_score");
+                assertThat(outlierScore, allOf(greaterThanOrEqualTo(0.0), lessThanOrEqualTo(1.0)));
+                if (hit.getId().equals("outlier")) {
+                    scoreOfOutlier = outlierScore;
+
+                    @SuppressWarnings("unchecked")
+                    List<Map<String, Object>> featureInfluence = (List<Map<String, Object>>) resultsObject.get("feature_influence");
+                    assertThat(featureInfluence.size(), equalTo(1));
+                    assertThat(featureInfluence.get(0).get("feature_name"), equalTo("runtime_numeric"));
                 } else {
-                    assertThat(outlierScore, equalTo(scoreOfNonOutlier));
+                    if (scoreOfNonOutlier < 0) {
+                        scoreOfNonOutlier = outlierScore;
+                    } else {
+                        assertThat(outlierScore, equalTo(scoreOfNonOutlier));
+                    }
                 }
             }
-        }
-        assertThat(scoreOfOutlier, is(greaterThan(scoreOfNonOutlier)));
+            assertThat(scoreOfOutlier, is(greaterThan(scoreOfNonOutlier)));
+        });
 
         assertProgressComplete(id);
-        assertThat(searchStoredProgress(id).getHits().getTotalHits().value, equalTo(1L));
+        assertStoredProgressHits(id, 1);
         assertThatAuditMessagesMatch(
             id,
             "Created analytics with type [outlier_detection]",
@@ -959,45 +962,46 @@ public class RunDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsIntegTest
         assertThat(stats.getDataCounts().getTestDocsCount(), equalTo(0L));
         assertThat(stats.getDataCounts().getSkippedDocsCount(), equalTo(0L));
 
-        SearchResponse sourceData = prepareSearch(sourceIndex).get();
-        double scoreOfOutlier = 0.0;
-        double scoreOfNonOutlier = -1.0;
-        for (SearchHit hit : sourceData.getHits()) {
-            GetResponse destDocGetResponse = client().prepareGet().setIndex(config.getDest().getIndex()).setId(hit.getId()).get();
-            assertThat(destDocGetResponse.isExists(), is(true));
-            Map<String, Object> sourceDoc = hit.getSourceAsMap();
-            Map<String, Object> destDoc = destDocGetResponse.getSource();
-            for (String field : sourceDoc.keySet()) {
-                assertThat(destDoc.containsKey(field), is(true));
-                assertThat(destDoc.get(field), equalTo(sourceDoc.get(field)));
-            }
-            assertThat(destDoc.containsKey("ml"), is(true));
-
-            @SuppressWarnings("unchecked")
-            Map<String, Object> resultsObject = (Map<String, Object>) destDoc.get("ml");
-
-            assertThat(resultsObject.containsKey("outlier_score"), is(true));
-            double outlierScore = (double) resultsObject.get("outlier_score");
-            assertThat(outlierScore, allOf(greaterThanOrEqualTo(0.0), lessThanOrEqualTo(1.0)));
-            if (hit.getId().equals("outlier")) {
-                scoreOfOutlier = outlierScore;
+        assertResponse(prepareSearch(sourceIndex), sourceData -> {
+            double scoreOfOutlier = 0.0;
+            double scoreOfNonOutlier = -1.0;
+            for (SearchHit hit : sourceData.getHits()) {
+                GetResponse destDocGetResponse = client().prepareGet().setIndex(config.getDest().getIndex()).setId(hit.getId()).get();
+                assertThat(destDocGetResponse.isExists(), is(true));
+                Map<String, Object> sourceDoc = hit.getSourceAsMap();
+                Map<String, Object> destDoc = destDocGetResponse.getSource();
+                for (String field : sourceDoc.keySet()) {
+                    assertThat(destDoc.containsKey(field), is(true));
+                    assertThat(destDoc.get(field), equalTo(sourceDoc.get(field)));
+                }
+                assertThat(destDoc.containsKey("ml"), is(true));
 
                 @SuppressWarnings("unchecked")
-                List<Map<String, Object>> featureInfluence = (List<Map<String, Object>>) resultsObject.get("feature_influence");
-                assertThat(featureInfluence.size(), equalTo(1));
-                assertThat(featureInfluence.get(0).get("feature_name"), equalTo("runtime_numeric"));
-            } else {
-                if (scoreOfNonOutlier < 0) {
-                    scoreOfNonOutlier = outlierScore;
+                Map<String, Object> resultsObject = (Map<String, Object>) destDoc.get("ml");
+
+                assertThat(resultsObject.containsKey("outlier_score"), is(true));
+                double outlierScore = (double) resultsObject.get("outlier_score");
+                assertThat(outlierScore, allOf(greaterThanOrEqualTo(0.0), lessThanOrEqualTo(1.0)));
+                if (hit.getId().equals("outlier")) {
+                    scoreOfOutlier = outlierScore;
+
+                    @SuppressWarnings("unchecked")
+                    List<Map<String, Object>> featureInfluence = (List<Map<String, Object>>) resultsObject.get("feature_influence");
+                    assertThat(featureInfluence.size(), equalTo(1));
+                    assertThat(featureInfluence.get(0).get("feature_name"), equalTo("runtime_numeric"));
                 } else {
-                    assertThat(outlierScore, equalTo(scoreOfNonOutlier));
+                    if (scoreOfNonOutlier < 0) {
+                        scoreOfNonOutlier = outlierScore;
+                    } else {
+                        assertThat(outlierScore, equalTo(scoreOfNonOutlier));
+                    }
                 }
             }
-        }
-        assertThat(scoreOfOutlier, is(greaterThan(scoreOfNonOutlier)));
+            assertThat(scoreOfOutlier, is(greaterThan(scoreOfNonOutlier)));
+        });
 
         assertProgressComplete(id);
-        assertThat(searchStoredProgress(id).getHits().getTotalHits().value, equalTo(1L));
+        assertStoredProgressHits(id, 1);
         assertThatAuditMessagesMatch(
             id,
             "Created analytics with type [outlier_detection]",

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ScheduledEventsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ScheduledEventsIT.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.ml.integration;
 
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -33,6 +32,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
@@ -246,20 +246,23 @@ public class ScheduledEventsIT extends MlNativeAutodetectIntegTestCase {
         postScheduledEvents(calendarId, events);
 
         // Wait until the notification that the process was updated is indexed
-        assertBusy(() -> {
-            SearchResponse searchResponse = prepareSearch(NotificationsIndex.NOTIFICATIONS_INDEX).setSize(1)
-                .addSort("timestamp", SortOrder.DESC)
-                .setQuery(
-                    QueryBuilders.boolQuery()
-                        .filter(QueryBuilders.termQuery("job_id", job.getId()))
-                        .filter(QueryBuilders.termQuery("level", "info"))
-                )
-                .get();
-            SearchHit[] hits = searchResponse.getHits().getHits();
-            assertThat(hits.length, equalTo(1));
-            assertThat(hits[0].getSourceAsMap().get("message"), equalTo("Updated calendars in running process"));
-        });
-
+        assertBusy(
+            () -> assertResponse(
+                client().prepareSearch(NotificationsIndex.NOTIFICATIONS_INDEX)
+                    .setSize(1)
+                    .addSort("timestamp", SortOrder.DESC)
+                    .setQuery(
+                        QueryBuilders.boolQuery()
+                            .filter(QueryBuilders.termQuery("job_id", job.getId()))
+                            .filter(QueryBuilders.termQuery("level", "info"))
+                    ),
+                searchResponse -> {
+                    SearchHit[] hits = searchResponse.getHits().getHits();
+                    assertThat(hits.length, equalTo(1));
+                    assertThat(hits[0].getSourceAsMap().get("message"), equalTo("Updated calendars in running process"));
+                }
+            )
+        );
         // write some more buckets of data that cover the scheduled event period
         postData(
             job.getId(),
@@ -332,19 +335,22 @@ public class ScheduledEventsIT extends MlNativeAutodetectIntegTestCase {
         client().execute(UpdateJobAction.INSTANCE, jobUpdateRequest).actionGet();
 
         // Wait until the notification that the job was updated is indexed
-        assertBusy(() -> {
-            SearchResponse searchResponse = prepareSearch(NotificationsIndex.NOTIFICATIONS_INDEX).setSize(1)
-                .addSort("timestamp", SortOrder.DESC)
-                .setQuery(
-                    QueryBuilders.boolQuery()
-                        .filter(QueryBuilders.termQuery("job_id", job.getId()))
-                        .filter(QueryBuilders.termQuery("level", "info"))
-                )
-                .get();
-            SearchHit[] hits = searchResponse.getHits().getHits();
-            assertThat(hits.length, equalTo(1));
-            assertThat(hits[0].getSourceAsMap().get("message"), equalTo("Job updated: [groups]"));
-        });
+        assertBusy(
+            () -> assertResponse(
+                prepareSearch(NotificationsIndex.NOTIFICATIONS_INDEX).setSize(1)
+                    .addSort("timestamp", SortOrder.DESC)
+                    .setQuery(
+                        QueryBuilders.boolQuery()
+                            .filter(QueryBuilders.termQuery("job_id", job.getId()))
+                            .filter(QueryBuilders.termQuery("level", "info"))
+                    ),
+                searchResponse -> {
+                    SearchHit[] hits = searchResponse.getHits().getHits();
+                    assertThat(hits.length, equalTo(1));
+                    assertThat(hits[0].getSourceAsMap().get("message"), equalTo("Job updated: [groups]"));
+                }
+            )
+        );
 
         // write some more buckets of data that cover the scheduled event period
         postData(
@@ -418,19 +424,22 @@ public class ScheduledEventsIT extends MlNativeAutodetectIntegTestCase {
         postScheduledEvents(calendarId, postOpenJobEvents);
 
         // Wait until the notification that the job was updated is indexed
-        assertBusy(() -> {
-            SearchResponse searchResponse = prepareSearch(NotificationsIndex.NOTIFICATIONS_INDEX).setSize(1)
-                .addSort("timestamp", SortOrder.DESC)
-                .setQuery(
-                    QueryBuilders.boolQuery()
-                        .filter(QueryBuilders.termQuery("job_id", job.getId()))
-                        .filter(QueryBuilders.termQuery("level", "info"))
-                )
-                .get();
-            SearchHit[] hits = searchResponse.getHits().getHits();
-            assertThat(hits.length, equalTo(1));
-            assertThat(hits[0].getSourceAsMap().get("message"), equalTo("Updated calendars in running process"));
-        });
+        assertBusy(
+            () -> assertResponse(
+                prepareSearch(NotificationsIndex.NOTIFICATIONS_INDEX).setSize(1)
+                    .addSort("timestamp", SortOrder.DESC)
+                    .setQuery(
+                        QueryBuilders.boolQuery()
+                            .filter(QueryBuilders.termQuery("job_id", job.getId()))
+                            .filter(QueryBuilders.termQuery("level", "info"))
+                    ),
+                searchResponse -> {
+                    SearchHit[] hits = searchResponse.getHits().getHits();
+                    assertThat(hits.length, equalTo(1));
+                    assertThat(hits[0].getSourceAsMap().get("message"), equalTo("Updated calendars in running process"));
+                }
+            )
+        );
 
         // write some buckets of data
         postData(

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AutodetectResultProcessorIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AutodetectResultProcessorIT.java
@@ -7,7 +7,6 @@
 package org.elasticsearch.xpack.ml.integration;
 
 import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
@@ -99,6 +98,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.stream.Collectors.toList;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertCheckedResponse;
 import static org.elasticsearch.xcontent.json.JsonXContent.jsonXContent;
 import static org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex.createStateIndexAndAliasIfNecessary;
 import static org.hamcrest.Matchers.closeTo;
@@ -781,11 +781,12 @@ public class AutodetectResultProcessorIT extends MlSingleNodeTestCase {
             .actionGet();
 
         SearchRequest searchRequest = new SearchRequest(AnnotationIndex.READ_ALIAS_NAME);
-        SearchResponse searchResponse = client().search(searchRequest).actionGet();
         List<Annotation> annotations = new ArrayList<>();
-        for (SearchHit hit : searchResponse.getHits().getHits()) {
-            annotations.add(parseAnnotation(hit.getSourceRef()));
-        }
+        assertCheckedResponse(client().search(searchRequest), searchResponse -> {
+            for (SearchHit hit : searchResponse.getHits().getHits()) {
+                annotations.add(parseAnnotation(hit.getSourceRef()));
+            }
+        });
         return annotations;
     }
 

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/NetworkDisruptionIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/NetworkDisruptionIT.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.ml.integration;
 
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.unit.ByteSizeValue;
@@ -28,6 +27,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 
 public class NetworkDisruptionIT extends BaseMlIntegTestCase {
 
@@ -81,19 +82,23 @@ public class NetworkDisruptionIT extends BaseMlIntegTestCase {
         assertEquals(newJobNode, finalJobNode);
 
         // The job running on the original node should have been killed, and hence should not have persisted quantiles
-        SearchResponse searchResponse = prepareSearch(AnomalyDetectorsIndex.jobStateIndexPattern()).setQuery(
-            QueryBuilders.idsQuery().addIds(Quantiles.documentId(job.getId()))
-        ).setTrackTotalHits(true).setIndicesOptions(IndicesOptions.lenientExpandOpen()).execute().actionGet();
-        assertEquals(0L, searchResponse.getHits().getTotalHits().value);
+        assertHitCount(
+            prepareSearch(AnomalyDetectorsIndex.jobStateIndexPattern()).setQuery(
+                QueryBuilders.idsQuery().addIds(Quantiles.documentId(job.getId()))
+            ).setTrackTotalHits(true).setIndicesOptions(IndicesOptions.lenientExpandOpen()),
+            0
+        );
 
         CloseJobAction.Request closeJobRequest = new CloseJobAction.Request(job.getId());
         CloseJobAction.Response closeJobResponse = client().execute(CloseJobAction.INSTANCE, closeJobRequest).actionGet();
         assertTrue(closeJobResponse.isClosed());
 
         // The relocated job was closed rather than killed, and hence should have persisted quantiles
-        searchResponse = prepareSearch(AnomalyDetectorsIndex.jobStateIndexPattern()).setQuery(
-            QueryBuilders.idsQuery().addIds(Quantiles.documentId(job.getId()))
-        ).setTrackTotalHits(true).setIndicesOptions(IndicesOptions.lenientExpandOpen()).execute().actionGet();
-        assertEquals(1L, searchResponse.getHits().getTotalHits().value);
+        assertHitCount(
+            prepareSearch(AnomalyDetectorsIndex.jobStateIndexPattern()).setQuery(
+                QueryBuilders.idsQuery().addIds(Quantiles.documentId(job.getId()))
+            ).setTrackTotalHits(true).setIndicesOptions(IndicesOptions.lenientExpandOpen()),
+            1
+        );
     }
 }


### PR DESCRIPTION
Moving towards ref counted search responses, this removes all direct references to SearchResponse from ML tests.

The remaining references in ML tests are for mocked search responses.

Additionally, while making this change, I noticed there are multiple places in ML production code that have the `SearchResponse searchResponse = ` pattern. Meaning, once we refCount `SearchResponse`, those places will have to be updated as well (in a future PR).

Related to: https://github.com/elastic/elasticsearch/pull/100966
Related to: https://github.com/elastic/elasticsearch/issues/99590

