### PR TITLE
Add vector_operation_count in profile output for knn searches

### DIFF
--- a/docs/changelog/102032.yaml
+++ b/docs/changelog/102032.yaml
@@ -1,0 +1,5 @@
+pr: 102032
+summary: Add vector_operation_count in profile output for knn searches
+area: Vector Search
+type: enhancement
+issues: []

--- a/docs/reference/search/profile.asciidoc
+++ b/docs/reference/search/profile.asciidoc
@@ -1272,6 +1272,7 @@ One of the `dfs.knn` sections for a shard looks like the following:
 "dfs" : {
     "knn" : [
         {
+        "vector_operations_count" : 4,
         "query" : [
             {
                 "type" : "DocAndScoreQuery",
@@ -1321,7 +1322,7 @@ In the `dfs.knn` portion of the response we can see the output
 the of timings for <<query-section, query>>, <<rewrite-section, rewrite>>,
 and <<collectors-section, collector>>. Unlike many other queries, kNN
 search does the bulk of the work during the query rewrite. This means
-`rewrite_time` represents the time spent on kNN search.
+`rewrite_time` represents the time spent on kNN search. The attribute `vector_operations_count` represents the overall count of vector operations performed during the kNN search.
 
 [[profiling-considerations]]
 ===== Profiling Considerations

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/370_profile.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/370_profile.yml
@@ -230,6 +230,72 @@ dfs knn vector profiling:
   - gt: { profile.shards.0.dfs.knn.0.collector.0.time_in_nanos: 0 }
 
 ---
+dfs knn vector profiling with vector_operations_count:
+  - skip:
+      version: ' - 8.11.99'
+      reason: vector_operations_count in dfs profiling added in 8.12.0
+
+  - do:
+      indices.create:
+        index: images
+        body:
+          settings:
+            index.number_of_shards: 1
+          mappings:
+            properties:
+              image:
+                type: "dense_vector"
+                dims: 3
+                index: true
+                similarity: "l2_norm"
+
+  - do:
+      index:
+        index: images
+        id: "1"
+        refresh: true
+        body:
+          image: [1, 5, -20]
+
+  - do:
+      search:
+        index: images
+        body:
+          profile: true
+          knn:
+            field: "image"
+            query_vector: [-5, 9, -12]
+            k: 1
+            num_candidates: 100
+
+  - match: { hits.total.value: 1 }
+  - match: { profile.shards.0.dfs.knn.0.query.0.type: "DocAndScoreQuery" }
+  - match: { profile.shards.0.dfs.knn.0.query.0.description: "DocAndScore[100]" }
+  - match: { profile.shards.0.dfs.knn.0.vector_operations_count: 1 }
+  - gt: { profile.shards.0.dfs.knn.0.query.0.time_in_nanos: 0 }
+  - match: { profile.shards.0.dfs.knn.0.query.0.breakdown.set_min_competitive_score_count: 0 }
+  - match: { profile.shards.0.dfs.knn.0.query.0.breakdown.set_min_competitive_score: 0 }
+  - match: { profile.shards.0.dfs.knn.0.query.0.breakdown.match_count: 0 }
+  - match: { profile.shards.0.dfs.knn.0.query.0.breakdown.match: 0 }
+  - match: { profile.shards.0.dfs.knn.0.query.0.breakdown.shallow_advance_count: 0 }
+  - match: { profile.shards.0.dfs.knn.0.query.0.breakdown.shallow_advance: 0 }
+  - gt: { profile.shards.0.dfs.knn.0.query.0.breakdown.next_doc_count: 0 }
+  - gt: { profile.shards.0.dfs.knn.0.query.0.breakdown.next_doc: 0 }
+  - gt: { profile.shards.0.dfs.knn.0.query.0.breakdown.score_count: 0 }
+  - gt: { profile.shards.0.dfs.knn.0.query.0.breakdown.score: 0 }
+  - match: { profile.shards.0.dfs.knn.0.query.0.breakdown.compute_max_score_count: 0 }
+  - match: { profile.shards.0.dfs.knn.0.query.0.breakdown.compute_max_score: 0 }
+  - gt: { profile.shards.0.dfs.knn.0.query.0.breakdown.build_scorer_count: 0 }
+  - gt: { profile.shards.0.dfs.knn.0.query.0.breakdown.build_scorer: 0 }
+  - gt: { profile.shards.0.dfs.knn.0.query.0.breakdown.create_weight: 0 }
+  - gt: { profile.shards.0.dfs.knn.0.query.0.breakdown.create_weight_count: 0 }
+  - gt: { profile.shards.0.dfs.knn.0.rewrite_time: 0 }
+  - match: { profile.shards.0.dfs.knn.0.collector.0.name: "SimpleTopScoreDocCollector" }
+  - match: { profile.shards.0.dfs.knn.0.collector.0.reason: "search_top_hits" }
+  - gt: { profile.shards.0.dfs.knn.0.collector.0.time_in_nanos: 0 }
+
+
+---
 dfs profile for search with dfs_query_then_fetch:
   - skip:
       version: ' - 8.5.99'

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -173,6 +173,7 @@ public class TransportVersions {
     public static final TransportVersion ML_INFERENCE_OPENAI_ADDED = def(8_542_00_0);
     public static final TransportVersion SHUTDOWN_MIGRATION_STATUS_INCLUDE_COUNTS = def(8_543_00_0);
     public static final TransportVersion TRANSFORM_GET_CHECKPOINT_QUERY_AND_CLUSTER_ADDED = def(8_544_00_0);
+    public static final TransportVersion VECTOR_OPS_COUNT_ADDED = def(8_545_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
@@ -27,11 +27,9 @@ import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
 import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.KnnByteVectorQuery;
-import org.apache.lucene.search.KnnFloatVectorQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.join.BitSetProducer;
 import org.apache.lucene.search.join.DiversifyingChildrenByteKnnVectorQuery;
-import org.apache.lucene.search.join.DiversifyingChildrenFloatKnnVectorQuery;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.VectorUtil;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
@@ -53,6 +51,10 @@ import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
+import org.elasticsearch.search.vectors.ProfilingDiversifyingChildrenByteKnnVectorQuery;
+import org.elasticsearch.search.vectors.ProfilingDiversifyingChildrenFloatKnnVectorQuery;
+import org.elasticsearch.search.vectors.ProfilingKnnByteVectorQuery;
+import org.elasticsearch.search.vectors.ProfilingKnnFloatVectorQuery;
 import org.elasticsearch.search.vectors.VectorSimilarityQuery;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -905,12 +907,12 @@ public class DenseVectorFieldMapper extends FieldMapper {
                         bytes[i] = (byte) queryVector[i];
                     }
                     yield parentFilter != null
-                        ? new DiversifyingChildrenByteKnnVectorQuery(name(), bytes, filter, numCands, parentFilter)
-                        : new KnnByteVectorQuery(name(), bytes, numCands, filter);
+                        ? new ProfilingDiversifyingChildrenByteKnnVectorQuery(name(), bytes, filter, numCands, parentFilter)
+                        : new ProfilingKnnByteVectorQuery(name(), bytes, numCands, filter);
                 }
                 case FLOAT -> parentFilter != null
-                    ? new DiversifyingChildrenFloatKnnVectorQuery(name(), queryVector, filter, numCands, parentFilter)
-                    : new KnnFloatVectorQuery(name(), queryVector, numCands, filter);
+                    ? new ProfilingDiversifyingChildrenFloatKnnVectorQuery(name(), queryVector, filter, numCands, parentFilter)
+                    : new ProfilingKnnFloatVectorQuery(name(), queryVector, numCands, filter);
             };
 
             if (similarityThreshold != null) {

--- a/server/src/main/java/org/elasticsearch/search/dfs/DfsPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/dfs/DfsPhase.java
@@ -33,6 +33,7 @@ import org.elasticsearch.search.profile.query.QueryProfiler;
 import org.elasticsearch.search.rescore.RescoreContext;
 import org.elasticsearch.search.vectors.KnnSearchBuilder;
 import org.elasticsearch.search.vectors.KnnVectorQueryBuilder;
+import org.elasticsearch.search.vectors.ProfilingQuery;
 import org.elasticsearch.tasks.TaskCancelledException;
 
 import java.io.IOException;
@@ -215,6 +216,11 @@ public class DfsPhase {
                 CollectorResult.REASON_SEARCH_TOP_HITS
             );
             topDocs = searcher.search(knnQuery, ipcm);
+
+            if (knnQuery instanceof ProfilingQuery profilingQuery) {
+                profilingQuery.profile(knnProfiler);
+            }
+
             knnProfiler.setCollectorResult(ipcm.getCollectorTree());
         }
         // Set profiler back after running KNN searches

--- a/server/src/main/java/org/elasticsearch/search/profile/Profilers.java
+++ b/server/src/main/java/org/elasticsearch/search/profile/Profilers.java
@@ -65,7 +65,8 @@ public final class Profilers {
         QueryProfileShardResult result = new QueryProfileShardResult(
             queryProfiler.getTree(),
             queryProfiler.getRewriteTime(),
-            queryProfiler.getCollectorResult()
+            queryProfiler.getCollectorResult(),
+            null
         );
         AggregationProfileShardResult aggResults = new AggregationProfileShardResult(aggProfiler.getTree());
         return new SearchProfileQueryPhaseResult(Collections.singletonList(result), aggResults);

--- a/server/src/main/java/org/elasticsearch/search/profile/SearchProfileDfsPhaseResult.java
+++ b/server/src/main/java/org/elasticsearch/search/profile/SearchProfileDfsPhaseResult.java
@@ -148,7 +148,8 @@ public class SearchProfileDfsPhaseResult implements Writeable, ToXContentObject 
         return new QueryProfileShardResult(
             profileResults,
             totalRewriteTime,
-            new CollectorResult("KnnQueryCollector", CollectorResult.REASON_SEARCH_MULTI, totalCollectionTime, subCollectorResults)
+            new CollectorResult("KnnQueryCollector", CollectorResult.REASON_SEARCH_MULTI, totalCollectionTime, subCollectorResults),
+            null
         );
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/profile/dfs/DfsProfiler.java
+++ b/server/src/main/java/org/elasticsearch/search/profile/dfs/DfsProfiler.java
@@ -68,7 +68,12 @@ public class DfsProfiler extends AbstractProfileBreakdown<DfsTimingType> {
             final List<QueryProfileShardResult> queryProfileShardResult = new ArrayList<>(knnQueryProfilers.size());
             for (QueryProfiler queryProfiler : knnQueryProfilers) {
                 queryProfileShardResult.add(
-                    new QueryProfileShardResult(queryProfiler.getTree(), queryProfiler.getRewriteTime(), queryProfiler.getCollectorResult())
+                    new QueryProfileShardResult(
+                        queryProfiler.getTree(),
+                        queryProfiler.getRewriteTime(),
+                        queryProfiler.getCollectorResult(),
+                        queryProfiler.getVectorOpsCount()
+                    )
                 );
             }
             return new SearchProfileDfsPhaseResult(dfsProfileResult, queryProfileShardResult);

--- a/server/src/main/java/org/elasticsearch/search/profile/query/QueryProfileShardResult.java
+++ b/server/src/main/java/org/elasticsearch/search/profile/query/QueryProfileShardResult.java
@@ -8,10 +8,12 @@
 
 package org.elasticsearch.search.profile.query;
 
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.search.profile.ProfileResult;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -35,17 +37,27 @@ public final class QueryProfileShardResult implements Writeable, ToXContentObjec
     public static final String REWRITE_TIME = "rewrite_time";
     public static final String QUERY_ARRAY = "query";
 
+    public static final String VECTOR_OPERATIONS_COUNT = "vector_operations_count";
+
     private final List<ProfileResult> queryProfileResults;
 
     private final CollectorResult profileCollector;
 
     private final long rewriteTime;
 
-    public QueryProfileShardResult(List<ProfileResult> queryProfileResults, long rewriteTime, CollectorResult profileCollector) {
+    private final Long vectorOperationsCount;
+
+    public QueryProfileShardResult(
+        List<ProfileResult> queryProfileResults,
+        long rewriteTime,
+        CollectorResult profileCollector,
+        @Nullable Long vectorOperationsCount
+    ) {
         assert (profileCollector != null);
         this.queryProfileResults = queryProfileResults;
         this.profileCollector = profileCollector;
         this.rewriteTime = rewriteTime;
+        this.vectorOperationsCount = vectorOperationsCount;
     }
 
     /**
@@ -60,6 +72,9 @@ public final class QueryProfileShardResult implements Writeable, ToXContentObjec
 
         profileCollector = new CollectorResult(in);
         rewriteTime = in.readLong();
+        vectorOperationsCount = (in.getTransportVersion().onOrAfter(TransportVersions.VECTOR_OPS_COUNT_ADDED))
+            ? in.readOptionalLong()
+            : null;
     }
 
     @Override
@@ -70,6 +85,9 @@ public final class QueryProfileShardResult implements Writeable, ToXContentObjec
         }
         profileCollector.writeTo(out);
         out.writeLong(rewriteTime);
+        if (out.getTransportVersion().onOrAfter(TransportVersions.VECTOR_OPS_COUNT_ADDED)) {
+            out.writeOptionalLong(vectorOperationsCount);
+        }
     }
 
     public List<ProfileResult> getQueryResults() {
@@ -87,6 +105,9 @@ public final class QueryProfileShardResult implements Writeable, ToXContentObjec
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
+        if (vectorOperationsCount != null) {
+            builder.field(VECTOR_OPERATIONS_COUNT, vectorOperationsCount);
+        }
         builder.startArray(QUERY_ARRAY);
         for (ProfileResult p : queryProfileResults) {
             p.toXContent(builder, params);
@@ -127,6 +148,7 @@ public final class QueryProfileShardResult implements Writeable, ToXContentObjec
         String currentFieldName = null;
         List<ProfileResult> queryProfileResults = new ArrayList<>();
         long rewriteTime = 0;
+        Long vectorOperationsCount = null;
         CollectorResult collector = null;
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.FIELD_NAME) {
@@ -134,6 +156,8 @@ public final class QueryProfileShardResult implements Writeable, ToXContentObjec
             } else if (token.isValue()) {
                 if (REWRITE_TIME.equals(currentFieldName)) {
                     rewriteTime = parser.longValue();
+                } else if (VECTOR_OPERATIONS_COUNT.equals(currentFieldName)) {
+                    vectorOperationsCount = parser.longValue();
                 } else {
                     parser.skipChildren();
                 }
@@ -153,6 +177,6 @@ public final class QueryProfileShardResult implements Writeable, ToXContentObjec
                 parser.skipChildren();
             }
         }
-        return new QueryProfileShardResult(queryProfileResults, rewriteTime, collector);
+        return new QueryProfileShardResult(queryProfileResults, rewriteTime, collector, vectorOperationsCount);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/profile/query/QueryProfiler.java
+++ b/server/src/main/java/org/elasticsearch/search/profile/query/QueryProfiler.java
@@ -31,8 +31,18 @@ public final class QueryProfiler extends AbstractProfiler<QueryProfileBreakdown,
      */
     private CollectorResult collectorResult;
 
+    private long vectorOpsCount;
+
     public QueryProfiler() {
         super(new InternalQueryProfileTree());
+    }
+
+    public void setVectorOpsCount(long vectorOpsCount) {
+        this.vectorOpsCount = vectorOpsCount;
+    }
+
+    public long getVectorOpsCount() {
+        return this.vectorOpsCount;
     }
 
     /** Set the collector result that is associated with this profiler. */

--- a/server/src/main/java/org/elasticsearch/search/vectors/ProfilingDiversifyingChildrenByteKnnVectorQuery.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/ProfilingDiversifyingChildrenByteKnnVectorQuery.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.search.vectors;
+
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.join.BitSetProducer;
+import org.apache.lucene.search.join.DiversifyingChildrenByteKnnVectorQuery;
+import org.elasticsearch.search.profile.query.QueryProfiler;
+
+public class ProfilingDiversifyingChildrenByteKnnVectorQuery extends DiversifyingChildrenByteKnnVectorQuery implements ProfilingQuery {
+    private long vectorOpsCount;
+
+    public ProfilingDiversifyingChildrenByteKnnVectorQuery(
+        String field,
+        byte[] query,
+        Query childFilter,
+        int k,
+        BitSetProducer parentsFilter
+    ) {
+        super(field, query, childFilter, k, parentsFilter);
+    }
+
+    @Override
+    protected TopDocs mergeLeafResults(TopDocs[] perLeafResults) {
+        TopDocs topK = super.mergeLeafResults(perLeafResults);
+        vectorOpsCount = topK.totalHits.value;
+        return topK;
+    }
+
+    @Override
+    public void profile(QueryProfiler queryProfiler) {
+        queryProfiler.setVectorOpsCount(vectorOpsCount);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/vectors/ProfilingDiversifyingChildrenFloatKnnVectorQuery.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/ProfilingDiversifyingChildrenFloatKnnVectorQuery.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.search.vectors;
+
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.join.BitSetProducer;
+import org.apache.lucene.search.join.DiversifyingChildrenFloatKnnVectorQuery;
+import org.elasticsearch.search.profile.query.QueryProfiler;
+
+public class ProfilingDiversifyingChildrenFloatKnnVectorQuery extends DiversifyingChildrenFloatKnnVectorQuery implements ProfilingQuery {
+    private long vectorOpsCount;
+
+    public ProfilingDiversifyingChildrenFloatKnnVectorQuery(
+        String field,
+        float[] query,
+        Query childFilter,
+        int k,
+        BitSetProducer parentsFilter
+    ) {
+        super(field, query, childFilter, k, parentsFilter);
+    }
+
+    @Override
+    protected TopDocs mergeLeafResults(TopDocs[] perLeafResults) {
+        TopDocs topK = super.mergeLeafResults(perLeafResults);
+        vectorOpsCount = topK.totalHits.value;
+        return topK;
+    }
+
+    @Override
+    public void profile(QueryProfiler queryProfiler) {
+        queryProfiler.setVectorOpsCount(vectorOpsCount);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/vectors/ProfilingKnnByteVectorQuery.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/ProfilingKnnByteVectorQuery.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.search.vectors;
+
+import org.apache.lucene.search.KnnByteVectorQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TopDocs;
+import org.elasticsearch.search.profile.query.QueryProfiler;
+
+public class ProfilingKnnByteVectorQuery extends KnnByteVectorQuery implements ProfilingQuery {
+    private long vectorOpsCount;
+
+    public ProfilingKnnByteVectorQuery(String field, byte[] target, int k, Query filter) {
+        super(field, target, k, filter);
+    }
+
+    @Override
+    protected TopDocs mergeLeafResults(TopDocs[] perLeafResults) {
+        TopDocs topK = super.mergeLeafResults(perLeafResults);
+        vectorOpsCount = topK.totalHits.value;
+        return topK;
+    }
+
+    @Override
+    public void profile(QueryProfiler queryProfiler) {
+        queryProfiler.setVectorOpsCount(vectorOpsCount);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/vectors/ProfilingKnnFloatVectorQuery.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/ProfilingKnnFloatVectorQuery.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.search.vectors;
+
+import org.apache.lucene.search.KnnFloatVectorQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TopDocs;
+import org.elasticsearch.search.profile.query.QueryProfiler;
+
+public class ProfilingKnnFloatVectorQuery extends KnnFloatVectorQuery implements ProfilingQuery {
+    private long vectorOpsCount;
+
+    public ProfilingKnnFloatVectorQuery(String field, float[] target, int k, Query filter) {
+        super(field, target, k, filter);
+    }
+
+    @Override
+    protected TopDocs mergeLeafResults(TopDocs[] perLeafResults) {
+        TopDocs topK = super.mergeLeafResults(perLeafResults);
+        vectorOpsCount = topK.totalHits.value;
+        return topK;
+    }
+
+    @Override
+    public void profile(QueryProfiler queryProfiler) {
+        queryProfiler.setVectorOpsCount(vectorOpsCount);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/vectors/ProfilingQuery.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/ProfilingQuery.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.search.vectors;
+
+import org.apache.lucene.document.KnnFloatVectorField;
+import org.elasticsearch.search.profile.query.QueryProfiler;
+
+/**
+ *
+ * <p> This interface includes the declaration of an abstract method, profile(). Classes implementing this interface
+ * must provide an implementation for profile() to store profiling information in the {@link QueryProfiler}.
+ */
+
+public interface ProfilingQuery {
+
+    /**
+     * Store the profiling information in the {@link QueryProfiler}
+     * @param queryProfiler an instance of  {@link KnnFloatVectorField}.
+     */
+    void profile(QueryProfiler queryProfiler);
+}

--- a/server/src/test/java/org/elasticsearch/search/profile/query/QueryProfileShardResultTests.java
+++ b/server/src/test/java/org/elasticsearch/search/profile/query/QueryProfileShardResultTests.java
@@ -33,7 +33,9 @@ public class QueryProfileShardResultTests extends AbstractXContentSerializingTes
         if (randomBoolean()) {
             rewriteTime = rewriteTime % 1000; // make sure to often test this with small values too
         }
-        return new QueryProfileShardResult(queryProfileResults, rewriteTime, profileCollector);
+
+        Long vectorOperationsCount = randomBoolean() ? null : randomNonNegativeLong();
+        return new QueryProfileShardResult(queryProfileResults, rewriteTime, profileCollector, vectorOperationsCount);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/vectors/AbstractKnnVectorQueryBuilderTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/AbstractKnnVectorQueryBuilderTestCase.java
@@ -10,8 +10,6 @@ package org.elasticsearch.search.vectors;
 
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
-import org.apache.lucene.search.KnnByteVectorQuery;
-import org.apache.lucene.search.KnnFloatVectorQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
@@ -101,13 +99,13 @@ abstract class AbstractKnnVectorQueryBuilderTestCase extends AbstractQueryTestCa
             Query knnQuery = ((VectorSimilarityQuery) query).getInnerKnnQuery();
             assertThat(((VectorSimilarityQuery) query).getSimilarity(), equalTo(queryBuilder.getVectorSimilarity()));
             switch (elementType()) {
-                case FLOAT -> assertTrue(knnQuery instanceof KnnFloatVectorQuery);
-                case BYTE -> assertTrue(knnQuery instanceof KnnByteVectorQuery);
+                case FLOAT -> assertTrue(knnQuery instanceof ProfilingKnnFloatVectorQuery);
+                case BYTE -> assertTrue(knnQuery instanceof ProfilingKnnByteVectorQuery);
             }
         } else {
             switch (elementType()) {
-                case FLOAT -> assertTrue(query instanceof KnnFloatVectorQuery);
-                case BYTE -> assertTrue(query instanceof KnnByteVectorQuery);
+                case FLOAT -> assertTrue(query instanceof ProfilingKnnFloatVectorQuery);
+                case BYTE -> assertTrue(query instanceof ProfilingKnnByteVectorQuery);
             }
         }
 
@@ -119,13 +117,13 @@ abstract class AbstractKnnVectorQueryBuilderTestCase extends AbstractQueryTestCa
         Query filterQuery = booleanQuery.clauses().isEmpty() ? null : booleanQuery;
         // The field should always be resolved to the concrete field
         Query knnVectorQueryBuilt = switch (elementType()) {
-            case BYTE -> new KnnByteVectorQuery(
+            case BYTE -> new ProfilingKnnByteVectorQuery(
                 VECTOR_FIELD,
                 getByteQueryVector(queryBuilder.queryVector()),
                 queryBuilder.numCands(),
                 filterQuery
             );
-            case FLOAT -> new KnnFloatVectorQuery(VECTOR_FIELD, queryBuilder.queryVector(), queryBuilder.numCands(), filterQuery);
+            case FLOAT -> new ProfilingKnnFloatVectorQuery(VECTOR_FIELD, queryBuilder.queryVector(), queryBuilder.numCands(), filterQuery);
         };
         if (query instanceof VectorSimilarityQuery vectorSimilarityQuery) {
             query = vectorSimilarityQuery.getInnerKnnQuery();


### PR DESCRIPTION
In this PR, a new field named **vector_operations_count** has been introduced under the "knn" section for the [profile API](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-profile.html). This attribute is designed to monitor the number of vector operations performed for a specific KNN query.

```
POST my-knn-index/_bulk?refresh=true
{ "index": { "_id": "1" } }
{ "my-vector": [1, 5, -20] }
{ "index": { "_id": "2" } }
{ "my-vector": [42, 8, -15] }
{ "index": { "_id": "3" } }
{ "my-vector": [15, 11, 23] }


POST my-knn-index/_search
{
  "profile": true, 
  "knn": {
    "field": "my-vector",
    "query_vector": [-5, 9, -12],
    "k": 3,
    "num_candidates": 100
  }
}
```

knn section for profile response is as follows:

```
 "knn": [
            {
              "vector_operations_count": 4,
              "query": [
                {
                  "type": "DocAndScoreQuery",
                  "description": "DocAndScore[100]",
                  "time_in_nanos": 559334,
                  "breakdown": {
                    "set_min_competitive_score_count": 0,
                    "match_count": 0,
                    "shallow_advance_count": 0,
                    "set_min_competitive_score": 0,
                    "next_doc": 6916,
                    "match": 0,
                    "score_count": 3,
                    "next_doc_count": 4,
                    "compute_max_score_count": 0,
                    "compute_max_score": 0,
                    "advance": 0,
                    "advance_count": 0,
                    "score": 4209,
                    "count_weight_count": 0,
                    "build_scorer_count": 2,
                    "create_weight": 182167,
                    "shallow_advance": 0,
                    "count_weight": 0,
                    "create_weight_count": 1,
                    "build_scorer": 366042
                  }
                }
              ],
              "rewrite_time": 2850208,
              "collector": [
                {
                  "name": "SimpleTopScoreDocCollector",
                  "reason": "search_top_hits",
                  "time_in_nanos": 27459
                }
              ]
            }
```



