### PR TITLE
Capture new action with a NodeFeature and fall back to NodeStats when necessary

### DIFF
--- a/docs/changelog/102033.yaml
+++ b/docs/changelog/102033.yaml
@@ -1,0 +1,6 @@
+pr: 102033
+summary: Capture new action with a `NodeFeature` and fall back to `NodeStats` when
+  necessary
+area: ILM+SLM
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/java/module-info.java
+++ b/x-pack/plugin/core/src/main/java/module-info.java
@@ -227,4 +227,6 @@ module org.elasticsearch.xcore {
         with
             org.elasticsearch.xpack.core.ml.MlConfigVersionComponent,
             org.elasticsearch.xpack.core.transform.TransformConfigVersionComponent;
+
+    provides org.elasticsearch.features.FeatureSpecification with org.elasticsearch.xpack.core.datatiers.DataTiersFeatures;
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/datatiers/DataTiersFeatures.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/datatiers/DataTiersFeatures.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.datatiers;
+
+import org.elasticsearch.features.FeatureSpecification;
+import org.elasticsearch.features.NodeFeature;
+
+import java.util.Set;
+
+public class DataTiersFeatures implements FeatureSpecification {
+
+    @Override
+    public Set<NodeFeature> getFeatures() {
+        return Set.of(NodesDataTiersUsageTransportAction.LOCALLY_PRECALCULATED_STATS_FEATURE);
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/datatiers/NodesDataTiersUsageTransportAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/datatiers/NodesDataTiersUsageTransportAction.java
@@ -27,6 +27,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.index.store.StoreStats;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.NodeIndicesStats;
@@ -55,6 +56,8 @@ public class NodesDataTiersUsageTransportAction extends TransportNodesAction<
     NodeDataTiersUsage> {
 
     public static final ActionType<NodesResponse> TYPE = ActionType.localOnly("cluster:monitor/nodes/data_tier_usage");
+    static final NodeFeature LOCALLY_PRECALCULATED_STATS_FEATURE = new NodeFeature("data_tier.locally.precalculated_stats");
+
     private static final CommonStatsFlags STATS_FLAGS = new CommonStatsFlags().clear()
         .set(CommonStatsFlags.Flag.Docs, true)
         .set(CommonStatsFlags.Flag.Store, true);
@@ -107,7 +110,7 @@ public class NodesDataTiersUsageTransportAction extends TransportNodesAction<
         return new NodeDataTiersUsage(clusterService.localNode(), usageStatsByTier);
     }
 
-    // For testing
+    // For bwc & testing purposes
     static Map<String, NodeDataTiersUsage.UsageStats> aggregateStats(
         RoutingNode routingNode,
         Metadata metadata,
@@ -122,6 +125,9 @@ public class NodesDataTiersUsageTransportAction extends TransportNodesAction<
             .collect(Collectors.toSet());
         for (String indexName : localIndices) {
             IndexMetadata indexMetadata = metadata.index(indexName);
+            if (indexMetadata == null) {
+                continue;
+            }
             String tier = indexMetadata.getTierPreference().isEmpty() ? null : indexMetadata.getTierPreference().get(0);
             if (tier != null) {
                 NodeDataTiersUsage.UsageStats usageStats = usageStatsByTier.computeIfAbsent(

--- a/x-pack/plugin/core/src/main/resources/META-INF/services/org.elasticsearch.features.FeatureSpecification
+++ b/x-pack/plugin/core/src/main/resources/META-INF/services/org.elasticsearch.features.FeatureSpecification
@@ -1,0 +1,8 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+#
+
+org.elasticsearch.xpack.core.datatiers.DataTiersFeatures


### PR DESCRIPTION
Follow up from #101128. We did not use the `FeatureService` to check if all the nodes of the cluster are implementing the new action and this is causing failures in a mixed cluster.