### PR TITLE
Remove explicit SearchResponse references from server bucket aggs (part1)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/BooleanTermsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/BooleanTermsIT.java
@@ -8,14 +8,13 @@
 package org.elasticsearch.search.aggregations.bucket;
 
 import org.elasticsearch.action.index.IndexRequestBuilder;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.search.aggregations.Aggregator.SubAggCollectionMode;
 import org.elasticsearch.search.aggregations.bucket.terms.LongTerms;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.terms.UnmappedTerms;
 import org.elasticsearch.test.ESIntegTestCase;
 
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -73,81 +72,84 @@ public class BooleanTermsIT extends ESIntegTestCase {
     }
 
     public void testSingleValueField() throws Exception {
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            new TermsAggregationBuilder("terms").field(SINGLE_VALUED_FIELD_NAME).collectMode(randomFrom(SubAggCollectionMode.values()))
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                new TermsAggregationBuilder("terms").field(SINGLE_VALUED_FIELD_NAME).collectMode(randomFrom(SubAggCollectionMode.values()))
+            ),
+            response -> {
+                LongTerms terms = response.getAggregations().get("terms");
+                assertThat(terms, notNullValue());
+                assertThat(terms.getName(), equalTo("terms"));
+                final int bucketCount = numSingleFalses > 0 && numSingleTrues > 0 ? 2 : numSingleFalses + numSingleTrues > 0 ? 1 : 0;
+                assertThat(terms.getBuckets().size(), equalTo(bucketCount));
 
-        assertNoFailures(response);
+                LongTerms.Bucket bucket = terms.getBucketByKey("false");
+                if (numSingleFalses == 0) {
+                    assertNull(bucket);
+                } else {
+                    assertNotNull(bucket);
+                    assertEquals(numSingleFalses, bucket.getDocCount());
+                    assertEquals("false", bucket.getKeyAsString());
+                }
 
-        LongTerms terms = response.getAggregations().get("terms");
-        assertThat(terms, notNullValue());
-        assertThat(terms.getName(), equalTo("terms"));
-        final int bucketCount = numSingleFalses > 0 && numSingleTrues > 0 ? 2 : numSingleFalses + numSingleTrues > 0 ? 1 : 0;
-        assertThat(terms.getBuckets().size(), equalTo(bucketCount));
-
-        LongTerms.Bucket bucket = terms.getBucketByKey("false");
-        if (numSingleFalses == 0) {
-            assertNull(bucket);
-        } else {
-            assertNotNull(bucket);
-            assertEquals(numSingleFalses, bucket.getDocCount());
-            assertEquals("false", bucket.getKeyAsString());
-        }
-
-        bucket = terms.getBucketByKey("true");
-        if (numSingleTrues == 0) {
-            assertNull(bucket);
-        } else {
-            assertNotNull(bucket);
-            assertEquals(numSingleTrues, bucket.getDocCount());
-            assertEquals("true", bucket.getKeyAsString());
-        }
+                bucket = terms.getBucketByKey("true");
+                if (numSingleTrues == 0) {
+                    assertNull(bucket);
+                } else {
+                    assertNotNull(bucket);
+                    assertEquals(numSingleTrues, bucket.getDocCount());
+                    assertEquals("true", bucket.getKeyAsString());
+                }
+            }
+        );
     }
 
     public void testMultiValueField() throws Exception {
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            new TermsAggregationBuilder("terms").field(MULTI_VALUED_FIELD_NAME).collectMode(randomFrom(SubAggCollectionMode.values()))
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                new TermsAggregationBuilder("terms").field(MULTI_VALUED_FIELD_NAME).collectMode(randomFrom(SubAggCollectionMode.values()))
+            ),
+            response -> {
+                LongTerms terms = response.getAggregations().get("terms");
+                assertThat(terms, notNullValue());
+                assertThat(terms.getName(), equalTo("terms"));
+                final int bucketCount = numMultiFalses > 0 && numMultiTrues > 0 ? 2 : numMultiFalses + numMultiTrues > 0 ? 1 : 0;
+                assertThat(terms.getBuckets(), hasSize(bucketCount));
 
-        assertNoFailures(response);
+                LongTerms.Bucket bucket = terms.getBucketByKey("false");
+                if (numMultiFalses == 0) {
+                    assertNull(bucket);
+                } else {
+                    assertNotNull(bucket);
+                    assertEquals(numMultiFalses, bucket.getDocCount());
+                    assertEquals("false", bucket.getKeyAsString());
+                }
 
-        LongTerms terms = response.getAggregations().get("terms");
-        assertThat(terms, notNullValue());
-        assertThat(terms.getName(), equalTo("terms"));
-        final int bucketCount = numMultiFalses > 0 && numMultiTrues > 0 ? 2 : numMultiFalses + numMultiTrues > 0 ? 1 : 0;
-        assertThat(terms.getBuckets(), hasSize(bucketCount));
-
-        LongTerms.Bucket bucket = terms.getBucketByKey("false");
-        if (numMultiFalses == 0) {
-            assertNull(bucket);
-        } else {
-            assertNotNull(bucket);
-            assertEquals(numMultiFalses, bucket.getDocCount());
-            assertEquals("false", bucket.getKeyAsString());
-        }
-
-        bucket = terms.getBucketByKey("true");
-        if (numMultiTrues == 0) {
-            assertNull(bucket);
-        } else {
-            assertNotNull(bucket);
-            assertEquals(numMultiTrues, bucket.getDocCount());
-            assertEquals("true", bucket.getKeyAsString());
-        }
+                bucket = terms.getBucketByKey("true");
+                if (numMultiTrues == 0) {
+                    assertNull(bucket);
+                } else {
+                    assertNotNull(bucket);
+                    assertEquals(numMultiTrues, bucket.getDocCount());
+                    assertEquals("true", bucket.getKeyAsString());
+                }
+            }
+        );
     }
 
     public void testUnmapped() throws Exception {
-        SearchResponse response = prepareSearch("idx_unmapped").addAggregation(
-            new TermsAggregationBuilder("terms").field(SINGLE_VALUED_FIELD_NAME)
-                .size(between(1, 5))
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-        ).get();
-
-        assertNoFailures(response);
-
-        UnmappedTerms terms = response.getAggregations().get("terms");
-        assertThat(terms, notNullValue());
-        assertThat(terms.getName(), equalTo("terms"));
-        assertThat(terms.getBuckets().size(), equalTo(0));
+        assertNoFailuresAndResponse(
+            prepareSearch("idx_unmapped").addAggregation(
+                new TermsAggregationBuilder("terms").field(SINGLE_VALUED_FIELD_NAME)
+                    .size(between(1, 5))
+                    .collectMode(randomFrom(SubAggCollectionMode.values()))
+            ),
+            response -> {
+                UnmappedTerms terms = response.getAggregations().get("terms");
+                assertThat(terms, notNullValue());
+                assertThat(terms.getName(), equalTo("terms"));
+                assertThat(terms.getBuckets().size(), equalTo(0));
+            }
+        );
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/DateHistogramIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/DateHistogramIT.java
@@ -10,7 +10,6 @@ package org.elasticsearch.search.aggregations.bucket;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateFormatter;
@@ -61,6 +60,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.stats;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHits;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
@@ -225,94 +225,100 @@ public class DateHistogramIT extends ESIntegTestCase {
     }
 
     public void testSingleValuedField() throws Exception {
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            dateHistogram("histo").field("date").calendarInterval(DateHistogramInterval.MONTH)
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(dateHistogram("histo").field("date").calendarInterval(DateHistogramInterval.MONTH)),
+            response -> {
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo, notNullValue());
+                assertThat(histo.getName(), equalTo("histo"));
+                List<? extends Bucket> buckets = histo.getBuckets();
+                assertThat(buckets.size(), equalTo(3));
 
-        assertNoFailures(response);
+                ZonedDateTime key = ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+                Histogram.Bucket bucket = buckets.get(0);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
+                assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
+                assertThat(bucket.getDocCount(), equalTo(1L));
 
-        Histogram histo = response.getAggregations().get("histo");
-        assertThat(histo, notNullValue());
-        assertThat(histo.getName(), equalTo("histo"));
-        List<? extends Bucket> buckets = histo.getBuckets();
-        assertThat(buckets.size(), equalTo(3));
+                key = ZonedDateTime.of(2012, 2, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+                bucket = buckets.get(1);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
+                assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
+                assertThat(bucket.getDocCount(), equalTo(2L));
 
-        ZonedDateTime key = ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        Histogram.Bucket bucket = buckets.get(0);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
-        assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(1L));
-
-        key = ZonedDateTime.of(2012, 2, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        bucket = buckets.get(1);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
-        assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(2L));
-
-        key = ZonedDateTime.of(2012, 3, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        bucket = buckets.get(2);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
-        assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(3L));
+                key = ZonedDateTime.of(2012, 3, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+                bucket = buckets.get(2);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
+                assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
+                assertThat(bucket.getDocCount(), equalTo(3L));
+            }
+        );
     }
 
     public void testSingleValuedFieldWithTimeZone() throws Exception {
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            dateHistogram("histo").field("date").calendarInterval(DateHistogramInterval.DAY).minDocCount(1).timeZone(ZoneId.of("+01:00"))
-        ).execute().actionGet();
-        ZoneId tz = ZoneId.of("+01:00");
-        assertNoFailures(response);
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                dateHistogram("histo").field("date")
+                    .calendarInterval(DateHistogramInterval.DAY)
+                    .minDocCount(1)
+                    .timeZone(ZoneId.of("+01:00"))
+            ),
+            response -> {
+                ZoneId tz = ZoneId.of("+01:00");
+                ;
 
-        Histogram histo = response.getAggregations().get("histo");
-        assertThat(histo, notNullValue());
-        assertThat(histo.getName(), equalTo("histo"));
-        List<? extends Bucket> buckets = histo.getBuckets();
-        assertThat(buckets.size(), equalTo(6));
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo, notNullValue());
+                assertThat(histo.getName(), equalTo("histo"));
+                List<? extends Bucket> buckets = histo.getBuckets();
+                assertThat(buckets.size(), equalTo(6));
 
-        ZonedDateTime key = ZonedDateTime.of(2012, 1, 1, 23, 0, 0, 0, ZoneOffset.UTC);
-        Histogram.Bucket bucket = buckets.get(0);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key, tz)));
-        assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(1L));
+                ZonedDateTime key = ZonedDateTime.of(2012, 1, 1, 23, 0, 0, 0, ZoneOffset.UTC);
+                Histogram.Bucket bucket = buckets.get(0);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key, tz)));
+                assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
+                assertThat(bucket.getDocCount(), equalTo(1L));
 
-        key = ZonedDateTime.of(2012, 2, 1, 23, 0, 0, 0, ZoneOffset.UTC);
-        bucket = buckets.get(1);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key, tz)));
-        assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(1L));
+                key = ZonedDateTime.of(2012, 2, 1, 23, 0, 0, 0, ZoneOffset.UTC);
+                bucket = buckets.get(1);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key, tz)));
+                assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
+                assertThat(bucket.getDocCount(), equalTo(1L));
 
-        key = ZonedDateTime.of(2012, 2, 14, 23, 0, 0, 0, ZoneOffset.UTC);
-        bucket = buckets.get(2);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key, tz)));
-        assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(1L));
+                key = ZonedDateTime.of(2012, 2, 14, 23, 0, 0, 0, ZoneOffset.UTC);
+                bucket = buckets.get(2);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key, tz)));
+                assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
+                assertThat(bucket.getDocCount(), equalTo(1L));
 
-        key = ZonedDateTime.of(2012, 3, 1, 23, 0, 0, 0, ZoneOffset.UTC);
-        bucket = buckets.get(3);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key, tz)));
-        assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(1L));
+                key = ZonedDateTime.of(2012, 3, 1, 23, 0, 0, 0, ZoneOffset.UTC);
+                bucket = buckets.get(3);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key, tz)));
+                assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
+                assertThat(bucket.getDocCount(), equalTo(1L));
 
-        key = ZonedDateTime.of(2012, 3, 14, 23, 0, 0, 0, ZoneOffset.UTC);
-        bucket = buckets.get(4);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key, tz)));
-        assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(1L));
+                key = ZonedDateTime.of(2012, 3, 14, 23, 0, 0, 0, ZoneOffset.UTC);
+                bucket = buckets.get(4);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key, tz)));
+                assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
+                assertThat(bucket.getDocCount(), equalTo(1L));
 
-        key = ZonedDateTime.of(2012, 3, 22, 23, 0, 0, 0, ZoneOffset.UTC);
-        bucket = buckets.get(5);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key, tz)));
-        assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(1L));
+                key = ZonedDateTime.of(2012, 3, 22, 23, 0, 0, 0, ZoneOffset.UTC);
+                bucket = buckets.get(5);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key, tz)));
+                assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
+                assertThat(bucket.getDocCount(), equalTo(1L));
+            }
+        );
     }
 
     public void testSingleValued_timeZone_epoch() throws Exception {
@@ -322,257 +328,268 @@ public class DateHistogramIT extends ESIntegTestCase {
             format = format + "||date_optional_time";
         }
         ZoneId tz = ZoneId.of("+01:00");
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            dateHistogram("histo").field("date").calendarInterval(DateHistogramInterval.DAY).minDocCount(1).timeZone(tz).format(format)
-        ).get();
-        assertNoFailures(response);
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                dateHistogram("histo").field("date").calendarInterval(DateHistogramInterval.DAY).minDocCount(1).timeZone(tz).format(format)
+            ),
+            response -> {
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo, notNullValue());
+                assertThat(histo.getName(), equalTo("histo"));
+                List<? extends Bucket> buckets = histo.getBuckets();
+                assertThat(buckets.size(), equalTo(6));
 
-        Histogram histo = response.getAggregations().get("histo");
-        assertThat(histo, notNullValue());
-        assertThat(histo.getName(), equalTo("histo"));
-        List<? extends Bucket> buckets = histo.getBuckets();
-        assertThat(buckets.size(), equalTo(6));
+                List<ZonedDateTime> expectedKeys = new ArrayList<>();
+                expectedKeys.add(ZonedDateTime.of(2012, 1, 1, 23, 0, 0, 0, ZoneOffset.UTC));
+                expectedKeys.add(ZonedDateTime.of(2012, 2, 1, 23, 0, 0, 0, ZoneOffset.UTC));
+                expectedKeys.add(ZonedDateTime.of(2012, 2, 14, 23, 0, 0, 0, ZoneOffset.UTC));
+                expectedKeys.add(ZonedDateTime.of(2012, 3, 1, 23, 0, 0, 0, ZoneOffset.UTC));
+                expectedKeys.add(ZonedDateTime.of(2012, 3, 14, 23, 0, 0, 0, ZoneOffset.UTC));
+                expectedKeys.add(ZonedDateTime.of(2012, 3, 22, 23, 0, 0, 0, ZoneOffset.UTC));
 
-        List<ZonedDateTime> expectedKeys = new ArrayList<>();
-        expectedKeys.add(ZonedDateTime.of(2012, 1, 1, 23, 0, 0, 0, ZoneOffset.UTC));
-        expectedKeys.add(ZonedDateTime.of(2012, 2, 1, 23, 0, 0, 0, ZoneOffset.UTC));
-        expectedKeys.add(ZonedDateTime.of(2012, 2, 14, 23, 0, 0, 0, ZoneOffset.UTC));
-        expectedKeys.add(ZonedDateTime.of(2012, 3, 1, 23, 0, 0, 0, ZoneOffset.UTC));
-        expectedKeys.add(ZonedDateTime.of(2012, 3, 14, 23, 0, 0, 0, ZoneOffset.UTC));
-        expectedKeys.add(ZonedDateTime.of(2012, 3, 22, 23, 0, 0, 0, ZoneOffset.UTC));
-
-        Iterator<ZonedDateTime> keyIterator = expectedKeys.iterator();
-        for (Histogram.Bucket bucket : buckets) {
-            assertThat(bucket, notNullValue());
-            ZonedDateTime expectedKey = keyIterator.next();
-            String bucketKey = bucket.getKeyAsString();
-            String expectedBucketName = Long.toString(expectedKey.toInstant().toEpochMilli() / millisDivider);
-            assertThat(bucketKey, equalTo(expectedBucketName));
-            assertThat(((ZonedDateTime) bucket.getKey()), equalTo(expectedKey));
-            assertThat(bucket.getDocCount(), equalTo(1L));
-        }
+                Iterator<ZonedDateTime> keyIterator = expectedKeys.iterator();
+                for (Histogram.Bucket bucket : buckets) {
+                    assertThat(bucket, notNullValue());
+                    ZonedDateTime expectedKey = keyIterator.next();
+                    String bucketKey = bucket.getKeyAsString();
+                    String expectedBucketName = Long.toString(expectedKey.toInstant().toEpochMilli() / millisDivider);
+                    assertThat(bucketKey, equalTo(expectedBucketName));
+                    assertThat(((ZonedDateTime) bucket.getKey()), equalTo(expectedKey));
+                    assertThat(bucket.getDocCount(), equalTo(1L));
+                }
+            }
+        );
     }
 
     public void testSingleValuedFieldOrderedByKeyAsc() throws Exception {
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            dateHistogram("histo").field("date").calendarInterval(DateHistogramInterval.MONTH).order(BucketOrder.key(true))
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                dateHistogram("histo").field("date").calendarInterval(DateHistogramInterval.MONTH).order(BucketOrder.key(true))
+            ),
+            response -> {
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo, notNullValue());
+                assertThat(histo.getName(), equalTo("histo"));
+                List<? extends Bucket> buckets = histo.getBuckets();
+                assertThat(buckets.size(), equalTo(3));
 
-        assertNoFailures(response);
-
-        Histogram histo = response.getAggregations().get("histo");
-        assertThat(histo, notNullValue());
-        assertThat(histo.getName(), equalTo("histo"));
-        List<? extends Bucket> buckets = histo.getBuckets();
-        assertThat(buckets.size(), equalTo(3));
-
-        int i = 0;
-        for (Histogram.Bucket bucket : buckets) {
-            assertThat(((ZonedDateTime) bucket.getKey()), equalTo(ZonedDateTime.of(2012, i + 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)));
-            i++;
-        }
+                int i = 0;
+                for (Histogram.Bucket bucket : buckets) {
+                    assertThat(((ZonedDateTime) bucket.getKey()), equalTo(ZonedDateTime.of(2012, i + 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)));
+                    i++;
+                }
+            }
+        );
     }
 
     public void testSingleValuedFieldOrderedByKeyDesc() throws Exception {
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            dateHistogram("histo").field("date").calendarInterval(DateHistogramInterval.MONTH).order(BucketOrder.key(false))
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                dateHistogram("histo").field("date").calendarInterval(DateHistogramInterval.MONTH).order(BucketOrder.key(false))
+            ),
+            response -> {
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo, notNullValue());
+                assertThat(histo.getName(), equalTo("histo"));
+                assertThat(histo.getBuckets().size(), equalTo(3));
 
-        assertNoFailures(response);
-
-        Histogram histo = response.getAggregations().get("histo");
-        assertThat(histo, notNullValue());
-        assertThat(histo.getName(), equalTo("histo"));
-        assertThat(histo.getBuckets().size(), equalTo(3));
-
-        int i = 2;
-        for (Histogram.Bucket bucket : histo.getBuckets()) {
-            assertThat(((ZonedDateTime) bucket.getKey()), equalTo(ZonedDateTime.of(2012, i + 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)));
-            i--;
-        }
+                int i = 2;
+                for (Histogram.Bucket bucket : histo.getBuckets()) {
+                    assertThat(((ZonedDateTime) bucket.getKey()), equalTo(ZonedDateTime.of(2012, i + 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)));
+                    i--;
+                }
+            }
+        );
     }
 
     public void testSingleValuedFieldOrderedByCountAsc() throws Exception {
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            dateHistogram("histo").field("date").calendarInterval(DateHistogramInterval.MONTH).order(BucketOrder.count(true))
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                dateHistogram("histo").field("date").calendarInterval(DateHistogramInterval.MONTH).order(BucketOrder.count(true))
+            ),
+            response -> {
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo, notNullValue());
+                assertThat(histo.getName(), equalTo("histo"));
+                assertThat(histo.getBuckets().size(), equalTo(3));
 
-        assertNoFailures(response);
-
-        Histogram histo = response.getAggregations().get("histo");
-        assertThat(histo, notNullValue());
-        assertThat(histo.getName(), equalTo("histo"));
-        assertThat(histo.getBuckets().size(), equalTo(3));
-
-        int i = 0;
-        for (Histogram.Bucket bucket : histo.getBuckets()) {
-            assertThat(((ZonedDateTime) bucket.getKey()), equalTo(ZonedDateTime.of(2012, i + 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)));
-            i++;
-        }
+                int i = 0;
+                for (Histogram.Bucket bucket : histo.getBuckets()) {
+                    assertThat(((ZonedDateTime) bucket.getKey()), equalTo(ZonedDateTime.of(2012, i + 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)));
+                    i++;
+                }
+            }
+        );
     }
 
     public void testSingleValuedFieldOrderedByCountDesc() throws Exception {
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            dateHistogram("histo").field("date").calendarInterval(DateHistogramInterval.MONTH).order(BucketOrder.count(false))
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                dateHistogram("histo").field("date").calendarInterval(DateHistogramInterval.MONTH).order(BucketOrder.count(false))
+            ),
+            response -> {
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo, notNullValue());
+                assertThat(histo.getName(), equalTo("histo"));
+                assertThat(histo.getBuckets().size(), equalTo(3));
 
-        assertNoFailures(response);
-
-        Histogram histo = response.getAggregations().get("histo");
-        assertThat(histo, notNullValue());
-        assertThat(histo.getName(), equalTo("histo"));
-        assertThat(histo.getBuckets().size(), equalTo(3));
-
-        int i = 2;
-        for (Histogram.Bucket bucket : histo.getBuckets()) {
-            assertThat(((ZonedDateTime) bucket.getKey()), equalTo(ZonedDateTime.of(2012, i + 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)));
-            i--;
-        }
+                int i = 2;
+                for (Histogram.Bucket bucket : histo.getBuckets()) {
+                    assertThat(((ZonedDateTime) bucket.getKey()), equalTo(ZonedDateTime.of(2012, i + 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)));
+                    i--;
+                }
+            }
+        );
     }
 
     public void testSingleValuedFieldWithSubAggregation() throws Exception {
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            dateHistogram("histo").field("date").calendarInterval(DateHistogramInterval.MONTH).subAggregation(sum("sum").field("value"))
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                dateHistogram("histo").field("date").calendarInterval(DateHistogramInterval.MONTH).subAggregation(sum("sum").field("value"))
+            ),
+            response -> {
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo, notNullValue());
+                assertThat(histo.getName(), equalTo("histo"));
+                List<? extends Bucket> buckets = histo.getBuckets();
+                assertThat(buckets.size(), equalTo(3));
+                assertThat(((InternalAggregation) histo).getProperty("_bucket_count"), equalTo(3));
+                Object[] propertiesKeys = (Object[]) ((InternalAggregation) histo).getProperty("_key");
+                Object[] propertiesDocCounts = (Object[]) ((InternalAggregation) histo).getProperty("_count");
+                Object[] propertiesCounts = (Object[]) ((InternalAggregation) histo).getProperty("sum.value");
 
-        assertNoFailures(response);
+                ZonedDateTime key = ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+                Histogram.Bucket bucket = buckets.get(0);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
+                assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
+                assertThat(bucket.getDocCount(), equalTo(1L));
+                Sum sum = bucket.getAggregations().get("sum");
+                assertThat(sum, notNullValue());
+                assertThat(sum.value(), equalTo(1.0));
+                assertThat((ZonedDateTime) propertiesKeys[0], equalTo(key));
+                assertThat((long) propertiesDocCounts[0], equalTo(1L));
+                assertThat((double) propertiesCounts[0], equalTo(1.0));
 
-        Histogram histo = response.getAggregations().get("histo");
-        assertThat(histo, notNullValue());
-        assertThat(histo.getName(), equalTo("histo"));
-        List<? extends Bucket> buckets = histo.getBuckets();
-        assertThat(buckets.size(), equalTo(3));
-        assertThat(((InternalAggregation) histo).getProperty("_bucket_count"), equalTo(3));
-        Object[] propertiesKeys = (Object[]) ((InternalAggregation) histo).getProperty("_key");
-        Object[] propertiesDocCounts = (Object[]) ((InternalAggregation) histo).getProperty("_count");
-        Object[] propertiesCounts = (Object[]) ((InternalAggregation) histo).getProperty("sum.value");
+                key = ZonedDateTime.of(2012, 2, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+                bucket = buckets.get(1);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
+                assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
+                assertThat(bucket.getDocCount(), equalTo(2L));
+                sum = bucket.getAggregations().get("sum");
+                assertThat(sum, notNullValue());
+                assertThat(sum.value(), equalTo(5.0));
+                assertThat((ZonedDateTime) propertiesKeys[1], equalTo(key));
+                assertThat((long) propertiesDocCounts[1], equalTo(2L));
+                assertThat((double) propertiesCounts[1], equalTo(5.0));
 
-        ZonedDateTime key = ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        Histogram.Bucket bucket = buckets.get(0);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
-        assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(1L));
-        Sum sum = bucket.getAggregations().get("sum");
-        assertThat(sum, notNullValue());
-        assertThat(sum.value(), equalTo(1.0));
-        assertThat((ZonedDateTime) propertiesKeys[0], equalTo(key));
-        assertThat((long) propertiesDocCounts[0], equalTo(1L));
-        assertThat((double) propertiesCounts[0], equalTo(1.0));
-
-        key = ZonedDateTime.of(2012, 2, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        bucket = buckets.get(1);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
-        assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(2L));
-        sum = bucket.getAggregations().get("sum");
-        assertThat(sum, notNullValue());
-        assertThat(sum.value(), equalTo(5.0));
-        assertThat((ZonedDateTime) propertiesKeys[1], equalTo(key));
-        assertThat((long) propertiesDocCounts[1], equalTo(2L));
-        assertThat((double) propertiesCounts[1], equalTo(5.0));
-
-        key = ZonedDateTime.of(2012, 3, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        bucket = buckets.get(2);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
-        assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(3L));
-        sum = bucket.getAggregations().get("sum");
-        assertThat(sum, notNullValue());
-        assertThat(sum.value(), equalTo(15.0));
-        assertThat((ZonedDateTime) propertiesKeys[2], equalTo(key));
-        assertThat((long) propertiesDocCounts[2], equalTo(3L));
-        assertThat((double) propertiesCounts[2], equalTo(15.0));
+                key = ZonedDateTime.of(2012, 3, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+                bucket = buckets.get(2);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
+                assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
+                assertThat(bucket.getDocCount(), equalTo(3L));
+                sum = bucket.getAggregations().get("sum");
+                assertThat(sum, notNullValue());
+                assertThat(sum.value(), equalTo(15.0));
+                assertThat((ZonedDateTime) propertiesKeys[2], equalTo(key));
+                assertThat((long) propertiesDocCounts[2], equalTo(3L));
+                assertThat((double) propertiesCounts[2], equalTo(15.0));
+            }
+        );
     }
 
     public void testSingleValuedFieldOrderedBySubAggregationAsc() throws Exception {
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            dateHistogram("histo").field("date")
-                .calendarInterval(DateHistogramInterval.MONTH)
-                .order(BucketOrder.aggregation("sum", true))
-                .subAggregation(max("sum").field("value"))
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                dateHistogram("histo").field("date")
+                    .calendarInterval(DateHistogramInterval.MONTH)
+                    .order(BucketOrder.aggregation("sum", true))
+                    .subAggregation(max("sum").field("value"))
+            ),
+            response -> {
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo, notNullValue());
+                assertThat(histo.getName(), equalTo("histo"));
+                assertThat(histo.getBuckets().size(), equalTo(3));
 
-        assertNoFailures(response);
-
-        Histogram histo = response.getAggregations().get("histo");
-        assertThat(histo, notNullValue());
-        assertThat(histo.getName(), equalTo("histo"));
-        assertThat(histo.getBuckets().size(), equalTo(3));
-
-        int i = 0;
-        for (Histogram.Bucket bucket : histo.getBuckets()) {
-            assertThat(((ZonedDateTime) bucket.getKey()), equalTo(ZonedDateTime.of(2012, i + 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)));
-            i++;
-        }
+                int i = 0;
+                for (Histogram.Bucket bucket : histo.getBuckets()) {
+                    assertThat(((ZonedDateTime) bucket.getKey()), equalTo(ZonedDateTime.of(2012, i + 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)));
+                    i++;
+                }
+            }
+        );
     }
 
     public void testSingleValuedFieldOrderedBySubAggregationDesc() throws Exception {
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            dateHistogram("histo").field("date")
-                .calendarInterval(DateHistogramInterval.MONTH)
-                .order(BucketOrder.aggregation("sum", false))
-                .subAggregation(max("sum").field("value"))
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                dateHistogram("histo").field("date")
+                    .calendarInterval(DateHistogramInterval.MONTH)
+                    .order(BucketOrder.aggregation("sum", false))
+                    .subAggregation(max("sum").field("value"))
+            ),
+            response -> {
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo, notNullValue());
+                assertThat(histo.getName(), equalTo("histo"));
+                assertThat(histo.getBuckets().size(), equalTo(3));
 
-        assertNoFailures(response);
-
-        Histogram histo = response.getAggregations().get("histo");
-        assertThat(histo, notNullValue());
-        assertThat(histo.getName(), equalTo("histo"));
-        assertThat(histo.getBuckets().size(), equalTo(3));
-
-        int i = 2;
-        for (Histogram.Bucket bucket : histo.getBuckets()) {
-            assertThat(((ZonedDateTime) bucket.getKey()), equalTo(ZonedDateTime.of(2012, i + 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)));
-            i--;
-        }
+                int i = 2;
+                for (Histogram.Bucket bucket : histo.getBuckets()) {
+                    assertThat(((ZonedDateTime) bucket.getKey()), equalTo(ZonedDateTime.of(2012, i + 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)));
+                    i--;
+                }
+            }
+        );
     }
 
     public void testSingleValuedFieldOrderedByMultiValuedSubAggregationDesc() throws Exception {
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            dateHistogram("histo").field("date")
-                .calendarInterval(DateHistogramInterval.MONTH)
-                .order(BucketOrder.aggregation("stats", "sum", false))
-                .subAggregation(stats("stats").field("value"))
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                dateHistogram("histo").field("date")
+                    .calendarInterval(DateHistogramInterval.MONTH)
+                    .order(BucketOrder.aggregation("stats", "sum", false))
+                    .subAggregation(stats("stats").field("value"))
+            ),
+            response -> {
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo, notNullValue());
+                assertThat(histo.getName(), equalTo("histo"));
+                assertThat(histo.getBuckets().size(), equalTo(3));
 
-        assertNoFailures(response);
-
-        Histogram histo = response.getAggregations().get("histo");
-        assertThat(histo, notNullValue());
-        assertThat(histo.getName(), equalTo("histo"));
-        assertThat(histo.getBuckets().size(), equalTo(3));
-
-        int i = 2;
-        for (Histogram.Bucket bucket : histo.getBuckets()) {
-            assertThat(((ZonedDateTime) bucket.getKey()), equalTo(ZonedDateTime.of(2012, i + 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)));
-            i--;
-        }
+                int i = 2;
+                for (Histogram.Bucket bucket : histo.getBuckets()) {
+                    assertThat(((ZonedDateTime) bucket.getKey()), equalTo(ZonedDateTime.of(2012, i + 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)));
+                    i--;
+                }
+            }
+        );
     }
 
     public void testSingleValuedFieldOrderedByTieBreaker() throws Exception {
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            dateHistogram("histo").field("date")
-                .calendarInterval(DateHistogramInterval.MONTH)
-                .order(BucketOrder.aggregation("max_constant", randomBoolean()))
-                .subAggregation(max("max_constant").field("constant"))
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                dateHistogram("histo").field("date")
+                    .calendarInterval(DateHistogramInterval.MONTH)
+                    .order(BucketOrder.aggregation("max_constant", randomBoolean()))
+                    .subAggregation(max("max_constant").field("constant"))
+            ),
+            response -> {
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo, notNullValue());
+                assertThat(histo.getName(), equalTo("histo"));
+                assertThat(histo.getBuckets().size(), equalTo(3));
 
-        assertNoFailures(response);
-
-        Histogram histo = response.getAggregations().get("histo");
-        assertThat(histo, notNullValue());
-        assertThat(histo.getName(), equalTo("histo"));
-        assertThat(histo.getBuckets().size(), equalTo(3));
-
-        int i = 1;
-        for (Histogram.Bucket bucket : histo.getBuckets()) {
-            assertThat(bucket.getKey(), equalTo(date(i, 1)));
-            i++;
-        }
+                int i = 1;
+                for (Histogram.Bucket bucket : histo.getBuckets()) {
+                    assertThat(bucket.getKey(), equalTo(date(i, 1)));
+                    i++;
+                }
+            }
+        );
     }
 
     public void testSingleValuedFieldOrderedByIllegalAgg() throws Exception {
@@ -607,41 +624,42 @@ public class DateHistogramIT extends ESIntegTestCase {
     public void testSingleValuedFieldWithValueScript() throws Exception {
         Map<String, Object> params = new HashMap<>();
         params.put("fieldname", "date");
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            dateHistogram("histo").field("date")
-                .script(new Script(ScriptType.INLINE, "mockscript", DateScriptMocksPlugin.LONG_PLUS_ONE_MONTH, params))
-                .calendarInterval(DateHistogramInterval.MONTH)
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                dateHistogram("histo").field("date")
+                    .script(new Script(ScriptType.INLINE, "mockscript", DateScriptMocksPlugin.LONG_PLUS_ONE_MONTH, params))
+                    .calendarInterval(DateHistogramInterval.MONTH)
+            ),
+            response -> {
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo, notNullValue());
+                assertThat(histo.getName(), equalTo("histo"));
 
-        assertNoFailures(response);
+                List<? extends Bucket> buckets = histo.getBuckets();
+                assertThat(buckets.size(), equalTo(3));
 
-        Histogram histo = response.getAggregations().get("histo");
-        assertThat(histo, notNullValue());
-        assertThat(histo.getName(), equalTo("histo"));
+                ZonedDateTime key = ZonedDateTime.of(2012, 2, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+                Histogram.Bucket bucket = buckets.get(0);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
+                assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
+                assertThat(bucket.getDocCount(), equalTo(1L));
 
-        List<? extends Bucket> buckets = histo.getBuckets();
-        assertThat(buckets.size(), equalTo(3));
+                key = ZonedDateTime.of(2012, 3, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+                bucket = buckets.get(1);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
+                assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
+                assertThat(bucket.getDocCount(), equalTo(2L));
 
-        ZonedDateTime key = ZonedDateTime.of(2012, 2, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        Histogram.Bucket bucket = buckets.get(0);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
-        assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(1L));
-
-        key = ZonedDateTime.of(2012, 3, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        bucket = buckets.get(1);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
-        assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(2L));
-
-        key = ZonedDateTime.of(2012, 4, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        bucket = buckets.get(2);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
-        assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(3L));
+                key = ZonedDateTime.of(2012, 4, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+                bucket = buckets.get(2);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
+                assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
+                assertThat(bucket.getDocCount(), equalTo(3L));
+            }
+        );
     }
 
     /*
@@ -654,80 +672,80 @@ public class DateHistogramIT extends ESIntegTestCase {
      */
 
     public void testMultiValuedField() throws Exception {
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            dateHistogram("histo").field("dates").calendarInterval(DateHistogramInterval.MONTH)
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(dateHistogram("histo").field("dates").calendarInterval(DateHistogramInterval.MONTH)),
+            response -> {
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo, notNullValue());
+                assertThat(histo.getName(), equalTo("histo"));
+                List<? extends Bucket> buckets = histo.getBuckets();
+                assertThat(buckets.size(), equalTo(4));
 
-        assertNoFailures(response);
+                ZonedDateTime key = ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+                Histogram.Bucket bucket = buckets.get(0);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
+                assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
+                assertThat(bucket.getDocCount(), equalTo(1L));
 
-        Histogram histo = response.getAggregations().get("histo");
-        assertThat(histo, notNullValue());
-        assertThat(histo.getName(), equalTo("histo"));
-        List<? extends Bucket> buckets = histo.getBuckets();
-        assertThat(buckets.size(), equalTo(4));
+                key = ZonedDateTime.of(2012, 2, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+                bucket = buckets.get(1);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
+                assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
+                assertThat(bucket.getDocCount(), equalTo(3L));
 
-        ZonedDateTime key = ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        Histogram.Bucket bucket = buckets.get(0);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
-        assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(1L));
+                key = ZonedDateTime.of(2012, 3, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+                bucket = buckets.get(2);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
+                assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
+                assertThat(bucket.getDocCount(), equalTo(5L));
 
-        key = ZonedDateTime.of(2012, 2, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        bucket = buckets.get(1);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
-        assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(3L));
-
-        key = ZonedDateTime.of(2012, 3, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        bucket = buckets.get(2);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
-        assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(5L));
-
-        key = ZonedDateTime.of(2012, 4, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        bucket = buckets.get(3);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
-        assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(3L));
+                key = ZonedDateTime.of(2012, 4, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+                bucket = buckets.get(3);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
+                assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
+                assertThat(bucket.getDocCount(), equalTo(3L));
+            }
+        );
     }
 
     public void testMultiValuedFieldOrderedByCountDesc() throws Exception {
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            dateHistogram("histo").field("dates").calendarInterval(DateHistogramInterval.MONTH).order(BucketOrder.count(false))
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                dateHistogram("histo").field("dates").calendarInterval(DateHistogramInterval.MONTH).order(BucketOrder.count(false))
+            ),
+            response -> {
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo, notNullValue());
+                assertThat(histo.getName(), equalTo("histo"));
+                assertThat(histo.getBuckets().size(), equalTo(4));
 
-        assertNoFailures(response);
+                List<Histogram.Bucket> buckets = new ArrayList<>(histo.getBuckets());
 
-        Histogram histo = response.getAggregations().get("histo");
-        assertThat(histo, notNullValue());
-        assertThat(histo.getName(), equalTo("histo"));
-        assertThat(histo.getBuckets().size(), equalTo(4));
+                Histogram.Bucket bucket = buckets.get(0);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKey(), equalTo(date(3, 1)));
+                assertThat(bucket.getDocCount(), equalTo(5L));
 
-        List<Histogram.Bucket> buckets = new ArrayList<>(histo.getBuckets());
+                bucket = buckets.get(1);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKey(), equalTo(date(2, 1)));
+                assertThat(bucket.getDocCount(), equalTo(3L));
 
-        Histogram.Bucket bucket = buckets.get(0);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKey(), equalTo(date(3, 1)));
-        assertThat(bucket.getDocCount(), equalTo(5L));
+                bucket = buckets.get(2);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKey(), equalTo(date(4, 1)));
+                assertThat(bucket.getDocCount(), equalTo(3L));
 
-        bucket = buckets.get(1);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKey(), equalTo(date(2, 1)));
-        assertThat(bucket.getDocCount(), equalTo(3L));
-
-        bucket = buckets.get(2);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKey(), equalTo(date(4, 1)));
-        assertThat(bucket.getDocCount(), equalTo(3L));
-
-        bucket = buckets.get(3);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKey(), equalTo(date(1, 1)));
-        assertThat(bucket.getDocCount(), equalTo(1L));
+                bucket = buckets.get(3);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKey(), equalTo(date(1, 1)));
+                assertThat(bucket.getDocCount(), equalTo(1L));
+            }
+        );
     }
 
     /**
@@ -743,47 +761,48 @@ public class DateHistogramIT extends ESIntegTestCase {
     public void testMultiValuedFieldWithValueScript() throws Exception {
         Map<String, Object> params = new HashMap<>();
         params.put("fieldname", "dates");
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            dateHistogram("histo").field("dates")
-                .script(new Script(ScriptType.INLINE, "mockscript", DateScriptMocksPlugin.LONG_PLUS_ONE_MONTH, params))
-                .calendarInterval(DateHistogramInterval.MONTH)
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                dateHistogram("histo").field("dates")
+                    .script(new Script(ScriptType.INLINE, "mockscript", DateScriptMocksPlugin.LONG_PLUS_ONE_MONTH, params))
+                    .calendarInterval(DateHistogramInterval.MONTH)
+            ),
+            response -> {
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo, notNullValue());
+                assertThat(histo.getName(), equalTo("histo"));
+                List<? extends Bucket> buckets = histo.getBuckets();
+                assertThat(buckets.size(), equalTo(4));
 
-        assertNoFailures(response);
+                ZonedDateTime key = ZonedDateTime.of(2012, 2, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+                Histogram.Bucket bucket = buckets.get(0);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
+                assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
+                assertThat(bucket.getDocCount(), equalTo(1L));
 
-        Histogram histo = response.getAggregations().get("histo");
-        assertThat(histo, notNullValue());
-        assertThat(histo.getName(), equalTo("histo"));
-        List<? extends Bucket> buckets = histo.getBuckets();
-        assertThat(buckets.size(), equalTo(4));
+                key = ZonedDateTime.of(2012, 3, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+                bucket = buckets.get(1);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
+                assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
+                assertThat(bucket.getDocCount(), equalTo(3L));
 
-        ZonedDateTime key = ZonedDateTime.of(2012, 2, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        Histogram.Bucket bucket = buckets.get(0);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
-        assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(1L));
+                key = ZonedDateTime.of(2012, 4, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+                bucket = buckets.get(2);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
+                assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
+                assertThat(bucket.getDocCount(), equalTo(5L));
 
-        key = ZonedDateTime.of(2012, 3, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        bucket = buckets.get(1);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
-        assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(3L));
-
-        key = ZonedDateTime.of(2012, 4, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        bucket = buckets.get(2);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
-        assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(5L));
-
-        key = ZonedDateTime.of(2012, 5, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        bucket = buckets.get(3);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
-        assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(3L));
+                key = ZonedDateTime.of(2012, 5, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+                bucket = buckets.get(3);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
+                assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
+                assertThat(bucket.getDocCount(), equalTo(3L));
+            }
+        );
     }
 
     /**
@@ -797,84 +816,86 @@ public class DateHistogramIT extends ESIntegTestCase {
     public void testScriptSingleValue() throws Exception {
         Map<String, Object> params = new HashMap<>();
         params.put("fieldname", "date");
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            dateHistogram("histo").script(new Script(ScriptType.INLINE, "mockscript", DateScriptMocksPlugin.EXTRACT_FIELD, params))
-                .calendarInterval(DateHistogramInterval.MONTH)
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                dateHistogram("histo").script(new Script(ScriptType.INLINE, "mockscript", DateScriptMocksPlugin.EXTRACT_FIELD, params))
+                    .calendarInterval(DateHistogramInterval.MONTH)
+            ),
+            response -> {
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo, notNullValue());
+                assertThat(histo.getName(), equalTo("histo"));
+                List<? extends Bucket> buckets = histo.getBuckets();
+                assertThat(buckets.size(), equalTo(3));
 
-        assertNoFailures(response);
+                ZonedDateTime key = ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+                Histogram.Bucket bucket = buckets.get(0);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
+                assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
+                assertThat(bucket.getDocCount(), equalTo(1L));
 
-        Histogram histo = response.getAggregations().get("histo");
-        assertThat(histo, notNullValue());
-        assertThat(histo.getName(), equalTo("histo"));
-        List<? extends Bucket> buckets = histo.getBuckets();
-        assertThat(buckets.size(), equalTo(3));
+                key = ZonedDateTime.of(2012, 2, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+                bucket = buckets.get(1);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
+                assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
+                assertThat(bucket.getDocCount(), equalTo(2L));
 
-        ZonedDateTime key = ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        Histogram.Bucket bucket = buckets.get(0);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
-        assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(1L));
-
-        key = ZonedDateTime.of(2012, 2, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        bucket = buckets.get(1);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
-        assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(2L));
-
-        key = ZonedDateTime.of(2012, 3, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        bucket = buckets.get(2);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
-        assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(3L));
+                key = ZonedDateTime.of(2012, 3, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+                bucket = buckets.get(2);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
+                assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
+                assertThat(bucket.getDocCount(), equalTo(3L));
+            }
+        );
     }
 
     public void testScriptMultiValued() throws Exception {
         Map<String, Object> params = new HashMap<>();
         params.put("fieldname", "dates");
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            dateHistogram("histo").script(new Script(ScriptType.INLINE, "mockscript", DateScriptMocksPlugin.EXTRACT_FIELD, params))
-                .calendarInterval(DateHistogramInterval.MONTH)
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                dateHistogram("histo").script(new Script(ScriptType.INLINE, "mockscript", DateScriptMocksPlugin.EXTRACT_FIELD, params))
+                    .calendarInterval(DateHistogramInterval.MONTH)
+            ),
+            response -> {
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo, notNullValue());
+                assertThat(histo.getName(), equalTo("histo"));
+                List<? extends Bucket> buckets = histo.getBuckets();
+                assertThat(buckets.size(), equalTo(4));
 
-        assertNoFailures(response);
+                ZonedDateTime key = ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+                Histogram.Bucket bucket = buckets.get(0);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
+                assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
+                assertThat(bucket.getDocCount(), equalTo(1L));
 
-        Histogram histo = response.getAggregations().get("histo");
-        assertThat(histo, notNullValue());
-        assertThat(histo.getName(), equalTo("histo"));
-        List<? extends Bucket> buckets = histo.getBuckets();
-        assertThat(buckets.size(), equalTo(4));
+                key = ZonedDateTime.of(2012, 2, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+                bucket = buckets.get(1);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
+                assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
+                assertThat(bucket.getDocCount(), equalTo(3L));
 
-        ZonedDateTime key = ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        Histogram.Bucket bucket = buckets.get(0);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
-        assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(1L));
+                key = ZonedDateTime.of(2012, 3, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+                bucket = buckets.get(2);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
+                assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
+                assertThat(bucket.getDocCount(), equalTo(5L));
 
-        key = ZonedDateTime.of(2012, 2, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        bucket = buckets.get(1);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
-        assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(3L));
-
-        key = ZonedDateTime.of(2012, 3, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        bucket = buckets.get(2);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
-        assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(5L));
-
-        key = ZonedDateTime.of(2012, 4, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        bucket = buckets.get(3);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
-        assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(3L));
+                key = ZonedDateTime.of(2012, 4, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+                bucket = buckets.get(3);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
+                assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
+                assertThat(bucket.getDocCount(), equalTo(3L));
+            }
+        );
     }
 
     /*
@@ -887,78 +908,81 @@ public class DateHistogramIT extends ESIntegTestCase {
     */
 
     public void testUnmapped() throws Exception {
-        SearchResponse response = prepareSearch("idx_unmapped").addAggregation(
-            dateHistogram("histo").field("date").calendarInterval(DateHistogramInterval.MONTH)
-        ).get();
-
-        assertNoFailures(response);
-
-        Histogram histo = response.getAggregations().get("histo");
-        assertThat(histo, notNullValue());
-        assertThat(histo.getName(), equalTo("histo"));
-        assertThat(histo.getBuckets().size(), equalTo(0));
+        assertNoFailuresAndResponse(
+            prepareSearch("idx_unmapped").addAggregation(
+                dateHistogram("histo").field("date").calendarInterval(DateHistogramInterval.MONTH)
+            ),
+            response -> {
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo, notNullValue());
+                assertThat(histo.getName(), equalTo("histo"));
+                assertThat(histo.getBuckets().size(), equalTo(0));
+            }
+        );
     }
 
     public void testPartiallyUnmapped() throws Exception {
-        SearchResponse response = prepareSearch("idx", "idx_unmapped").addAggregation(
-            dateHistogram("histo").field("date").calendarInterval(DateHistogramInterval.MONTH)
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx", "idx_unmapped").addAggregation(
+                dateHistogram("histo").field("date").calendarInterval(DateHistogramInterval.MONTH)
+            ),
+            response -> {
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo, notNullValue());
+                assertThat(histo.getName(), equalTo("histo"));
+                List<? extends Bucket> buckets = histo.getBuckets();
+                assertThat(buckets.size(), equalTo(3));
 
-        assertNoFailures(response);
+                ZonedDateTime key = ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+                Histogram.Bucket bucket = buckets.get(0);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
+                assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
+                assertThat(bucket.getDocCount(), equalTo(1L));
 
-        Histogram histo = response.getAggregations().get("histo");
-        assertThat(histo, notNullValue());
-        assertThat(histo.getName(), equalTo("histo"));
-        List<? extends Bucket> buckets = histo.getBuckets();
-        assertThat(buckets.size(), equalTo(3));
+                key = ZonedDateTime.of(2012, 2, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+                bucket = buckets.get(1);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
+                assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
+                assertThat(bucket.getDocCount(), equalTo(2L));
 
-        ZonedDateTime key = ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        Histogram.Bucket bucket = buckets.get(0);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
-        assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(1L));
-
-        key = ZonedDateTime.of(2012, 2, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        bucket = buckets.get(1);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
-        assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(2L));
-
-        key = ZonedDateTime.of(2012, 3, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-        bucket = buckets.get(2);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
-        assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(3L));
+                key = ZonedDateTime.of(2012, 3, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+                bucket = buckets.get(2);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
+                assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
+                assertThat(bucket.getDocCount(), equalTo(3L));
+            }
+        );
     }
 
     public void testEmptyAggregation() throws Exception {
-        SearchResponse searchResponse = prepareSearch("empty_bucket_idx").setQuery(matchAllQuery())
-            .addAggregation(
-                histogram("histo").field("value")
-                    .interval(1L)
-                    .minDocCount(0)
-                    .subAggregation(dateHistogram("date_histo").field("value").fixedInterval(DateHistogramInterval.HOUR))
-            )
-            .get();
+        assertNoFailuresAndResponse(
+            prepareSearch("empty_bucket_idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    histogram("histo").field("value")
+                        .interval(1L)
+                        .minDocCount(0)
+                        .subAggregation(dateHistogram("date_histo").field("value").fixedInterval(DateHistogramInterval.HOUR))
+                ),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(2L));
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo, Matchers.notNullValue());
+                List<? extends Histogram.Bucket> buckets = histo.getBuckets();
+                assertThat(buckets.size(), equalTo(3));
 
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(2L));
-        Histogram histo = searchResponse.getAggregations().get("histo");
-        assertThat(histo, Matchers.notNullValue());
-        List<? extends Histogram.Bucket> buckets = histo.getBuckets();
-        assertThat(buckets.size(), equalTo(3));
+                Histogram.Bucket bucket = buckets.get(1);
+                assertThat(bucket, Matchers.notNullValue());
+                assertThat(bucket.getKeyAsString(), equalTo("1.0"));
 
-        Histogram.Bucket bucket = buckets.get(1);
-        assertThat(bucket, Matchers.notNullValue());
-        assertThat(bucket.getKeyAsString(), equalTo("1.0"));
-
-        Histogram dateHisto = bucket.getAggregations().get("date_histo");
-        assertThat(dateHisto, Matchers.notNullValue());
-        assertThat(dateHisto.getName(), equalTo("date_histo"));
-        assertThat(dateHisto.getBuckets().isEmpty(), is(true));
-
+                Histogram dateHisto = bucket.getAggregations().get("date_histo");
+                assertThat(dateHisto, Matchers.notNullValue());
+                assertThat(dateHisto.getName(), equalTo("date_histo"));
+                assertThat(dateHisto.getBuckets().isEmpty(), is(true));
+            }
+        );
     }
 
     public void testSingleValueWithTimeZone() throws Exception {
@@ -973,30 +997,32 @@ public class DateHistogramIT extends ESIntegTestCase {
         }
         indexRandom(true, reqs);
 
-        SearchResponse response = prepareSearch("idx2").setQuery(matchAllQuery())
-            .addAggregation(
-                dateHistogram("date_histo").field("date")
-                    .timeZone(ZoneId.of("-02:00"))
-                    .calendarInterval(DateHistogramInterval.DAY)
-                    .format("yyyy-MM-dd:HH-mm-ssZZZZZ")
-            )
-            .get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx2").setQuery(matchAllQuery())
+                .addAggregation(
+                    dateHistogram("date_histo").field("date")
+                        .timeZone(ZoneId.of("-02:00"))
+                        .calendarInterval(DateHistogramInterval.DAY)
+                        .format("yyyy-MM-dd:HH-mm-ssZZZZZ")
+                ),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(5L));
 
-        assertThat(response.getHits().getTotalHits().value, equalTo(5L));
+                Histogram histo = response.getAggregations().get("date_histo");
+                List<? extends Histogram.Bucket> buckets = histo.getBuckets();
+                assertThat(buckets.size(), equalTo(2));
 
-        Histogram histo = response.getAggregations().get("date_histo");
-        List<? extends Histogram.Bucket> buckets = histo.getBuckets();
-        assertThat(buckets.size(), equalTo(2));
+                Histogram.Bucket bucket = buckets.get(0);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKeyAsString(), equalTo("2014-03-10:00-00-00-02:00"));
+                assertThat(bucket.getDocCount(), equalTo(2L));
 
-        Histogram.Bucket bucket = buckets.get(0);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKeyAsString(), equalTo("2014-03-10:00-00-00-02:00"));
-        assertThat(bucket.getDocCount(), equalTo(2L));
-
-        bucket = buckets.get(1);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKeyAsString(), equalTo("2014-03-11:00-00-00-02:00"));
-        assertThat(bucket.getDocCount(), equalTo(3L));
+                bucket = buckets.get(1);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKeyAsString(), equalTo("2014-03-11:00-00-00-02:00"));
+                assertThat(bucket.getDocCount(), equalTo(3L));
+            }
+        );
     }
 
     public void testSingleValueFieldWithExtendedBounds() throws Exception {
@@ -1066,46 +1092,41 @@ public class DateHistogramIT extends ESIntegTestCase {
         long[] extendedValueCounts = new long[bucketsCount];
         System.arraycopy(docCounts, 0, extendedValueCounts, addedBucketsLeft, docCounts.length);
 
-        SearchResponse response = null;
         try {
-            response = prepareSearch("idx2").addAggregation(
-                dateHistogram("histo").field("date")
-                    .fixedInterval(DateHistogramInterval.days(interval))
-                    .minDocCount(0)
-                    // when explicitly specifying a format, the extended bounds should be defined by the same format
-                    .extendedBounds(new LongBounds(format(boundsMin, pattern), format(boundsMax, pattern)))
-                    .format(pattern)
-            ).get();
+            assertNoFailuresAndResponse(
+                prepareSearch("idx2").addAggregation(
+                    dateHistogram("histo").field("date")
+                        .fixedInterval(DateHistogramInterval.days(interval))
+                        .minDocCount(0)
+                        // when explicitly specifying a format, the extended bounds should be defined by the same format
+                        .extendedBounds(new LongBounds(format(boundsMin, pattern), format(boundsMax, pattern)))
+                        .format(pattern)
+                ),
+                response -> {
+                    if (invalidBoundsError) {
+                        fail("Expected an exception to be thrown when bounds.min is greater than bounds.max");
+                    }
+                    Histogram histo = response.getAggregations().get("histo");
+                    assertThat(histo, notNullValue());
+                    assertThat(histo.getName(), equalTo("histo"));
+                    List<? extends Bucket> buckets = histo.getBuckets();
+                    assertThat(buckets.size(), equalTo(bucketsCount));
 
-            if (invalidBoundsError) {
-                fail("Expected an exception to be thrown when bounds.min is greater than bounds.max");
-                return;
-            }
-
+                    ZonedDateTime key = baseKey.isBefore(boundsMinKey) ? baseKey : boundsMinKey;
+                    for (int i = 0; i < bucketsCount; i++) {
+                        Histogram.Bucket bucket = buckets.get(i);
+                        assertThat(bucket, notNullValue());
+                        assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
+                        assertThat(bucket.getKeyAsString(), equalTo(format(key, pattern)));
+                        assertThat(bucket.getDocCount(), equalTo(extendedValueCounts[i]));
+                        key = key.plusDays(interval);
+                    }
+                }
+            );
         } catch (Exception e) {
-            if (invalidBoundsError) {
-                // expected
-                return;
-            } else {
+            if (invalidBoundsError == false) {
                 throw e;
             }
-        }
-        assertNoFailures(response);
-
-        Histogram histo = response.getAggregations().get("histo");
-        assertThat(histo, notNullValue());
-        assertThat(histo.getName(), equalTo("histo"));
-        List<? extends Bucket> buckets = histo.getBuckets();
-        assertThat(buckets.size(), equalTo(bucketsCount));
-
-        ZonedDateTime key = baseKey.isBefore(boundsMinKey) ? baseKey : boundsMinKey;
-        for (int i = 0; i < bucketsCount; i++) {
-            Histogram.Bucket bucket = buckets.get(i);
-            assertThat(bucket, notNullValue());
-            assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
-            assertThat(bucket.getKeyAsString(), equalTo(format(key, pattern)));
-            assertThat(bucket.getDocCount(), equalTo(extendedValueCounts[i]));
-            key = key.plusDays(interval);
         }
     }
 
@@ -1133,45 +1154,47 @@ public class DateHistogramIT extends ESIntegTestCase {
         indexRandom(true, builders);
         ensureSearchable(index);
 
-        SearchResponse response = null;
         // retrieve those docs with the same time zone and extended bounds
-        response = prepareSearch(index).setQuery(
-            QueryBuilders.rangeQuery("date").from("now/d").to("now/d").includeLower(true).includeUpper(true).timeZone(timezone.getId())
-        )
-            .addAggregation(
-                dateHistogram("histo").field("date")
-                    .calendarInterval(DateHistogramInterval.hours(1))
-                    .timeZone(timezone)
-                    .minDocCount(0)
-                    .extendedBounds(new LongBounds("now/d", "now/d+23h"))
+        assertNoFailuresAndResponse(
+            prepareSearch(index).setQuery(
+                QueryBuilders.rangeQuery("date").from("now/d").to("now/d").includeLower(true).includeUpper(true).timeZone(timezone.getId())
             )
-            .get();
-        assertNoFailures(response);
+                .addAggregation(
+                    dateHistogram("histo").field("date")
+                        .calendarInterval(DateHistogramInterval.hours(1))
+                        .timeZone(timezone)
+                        .minDocCount(0)
+                        .extendedBounds(new LongBounds("now/d", "now/d+23h"))
+                ),
+            response -> {
 
-        assertThat(
-            "Expected 24 buckets for one day aggregation with hourly interval",
-            response.getHits().getTotalHits().value,
-            equalTo(2L)
-        );
+                assertThat(
+                    "Expected 24 buckets for one day aggregation with hourly interval",
+                    response.getHits().getTotalHits().value,
+                    equalTo(2L)
+                );
 
-        Histogram histo = response.getAggregations().get("histo");
-        assertThat(histo, notNullValue());
-        assertThat(histo.getName(), equalTo("histo"));
-        List<? extends Bucket> buckets = histo.getBuckets();
-        assertThat(buckets.size(), equalTo(24));
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo, notNullValue());
+                assertThat(histo.getName(), equalTo("histo"));
+                List<? extends Bucket> buckets = histo.getBuckets();
+                assertThat(buckets.size(), equalTo(24));
 
-        for (int i = 0; i < buckets.size(); i++) {
-            Histogram.Bucket bucket = buckets.get(i);
-            assertThat(bucket, notNullValue());
-            ZonedDateTime zonedDateTime = timeZoneStartToday.plus(i * 60 * 60 * 1000, ChronoUnit.MILLIS);
-            assertThat("InternalBucket " + i + " had wrong key", (ZonedDateTime) bucket.getKey(), equalTo(zonedDateTime));
-            if (i == 0 || i == 12) {
-                assertThat(bucket.getDocCount(), equalTo(1L));
-            } else {
-                assertThat(bucket.getDocCount(), equalTo(0L));
+                for (int i = 0; i < buckets.size(); i++) {
+                    Histogram.Bucket bucket = buckets.get(i);
+                    assertThat(bucket, notNullValue());
+                    ZonedDateTime zonedDateTime = timeZoneStartToday.plus(i * 60 * 60 * 1000, ChronoUnit.MILLIS);
+                    assertThat("InternalBucket " + i + " had wrong key", (ZonedDateTime) bucket.getKey(), equalTo(zonedDateTime));
+                    if (i == 0 || i == 12) {
+                        assertThat(bucket.getDocCount(), equalTo(1L));
+                    } else {
+                        assertThat(bucket.getDocCount(), equalTo(0L));
+                    }
+                }
             }
-        }
+        );
         internalCluster().wipeIndices(index);
+
     }
 
     /**
@@ -1193,40 +1216,40 @@ public class DateHistogramIT extends ESIntegTestCase {
         indexRandom(true, builders);
         ensureSearchable(index);
 
-        SearchResponse response = null;
         // retrieve those docs with the same time zone and extended bounds
-        response = prepareSearch(index).addAggregation(
-            dateHistogram("histo").field("date")
-                .calendarInterval(DateHistogramInterval.days(1))
-                .offset("+6h")
-                .minDocCount(0)
-                .extendedBounds(new LongBounds("2016-01-01T06:00:00Z", "2016-01-08T08:00:00Z"))
-        ).get();
-        assertNoFailures(response);
+        assertNoFailuresAndResponse(
+            prepareSearch(index).addAggregation(
+                dateHistogram("histo").field("date")
+                    .calendarInterval(DateHistogramInterval.days(1))
+                    .offset("+6h")
+                    .minDocCount(0)
+                    .extendedBounds(new LongBounds("2016-01-01T06:00:00Z", "2016-01-08T08:00:00Z"))
+            ),
+            response -> {
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo, notNullValue());
+                assertThat(histo.getName(), equalTo("histo"));
+                List<? extends Bucket> buckets = histo.getBuckets();
+                assertThat(buckets.size(), equalTo(8));
 
-        Histogram histo = response.getAggregations().get("histo");
-        assertThat(histo, notNullValue());
-        assertThat(histo.getName(), equalTo("histo"));
-        List<? extends Bucket> buckets = histo.getBuckets();
-        assertThat(buckets.size(), equalTo(8));
-
-        assertEquals("2016-01-01T06:00:00.000Z", buckets.get(0).getKeyAsString());
-        assertEquals(0, buckets.get(0).getDocCount());
-        assertEquals("2016-01-02T06:00:00.000Z", buckets.get(1).getKeyAsString());
-        assertEquals(0, buckets.get(1).getDocCount());
-        assertEquals("2016-01-03T06:00:00.000Z", buckets.get(2).getKeyAsString());
-        assertEquals(2, buckets.get(2).getDocCount());
-        assertEquals("2016-01-04T06:00:00.000Z", buckets.get(3).getKeyAsString());
-        assertEquals(0, buckets.get(3).getDocCount());
-        assertEquals("2016-01-05T06:00:00.000Z", buckets.get(4).getKeyAsString());
-        assertEquals(0, buckets.get(4).getDocCount());
-        assertEquals("2016-01-06T06:00:00.000Z", buckets.get(5).getKeyAsString());
-        assertEquals(2, buckets.get(5).getDocCount());
-        assertEquals("2016-01-07T06:00:00.000Z", buckets.get(6).getKeyAsString());
-        assertEquals(0, buckets.get(6).getDocCount());
-        assertEquals("2016-01-08T06:00:00.000Z", buckets.get(7).getKeyAsString());
-        assertEquals(0, buckets.get(7).getDocCount());
-
+                assertEquals("2016-01-01T06:00:00.000Z", buckets.get(0).getKeyAsString());
+                assertEquals(0, buckets.get(0).getDocCount());
+                assertEquals("2016-01-02T06:00:00.000Z", buckets.get(1).getKeyAsString());
+                assertEquals(0, buckets.get(1).getDocCount());
+                assertEquals("2016-01-03T06:00:00.000Z", buckets.get(2).getKeyAsString());
+                assertEquals(2, buckets.get(2).getDocCount());
+                assertEquals("2016-01-04T06:00:00.000Z", buckets.get(3).getKeyAsString());
+                assertEquals(0, buckets.get(3).getDocCount());
+                assertEquals("2016-01-05T06:00:00.000Z", buckets.get(4).getKeyAsString());
+                assertEquals(0, buckets.get(4).getDocCount());
+                assertEquals("2016-01-06T06:00:00.000Z", buckets.get(5).getKeyAsString());
+                assertEquals(2, buckets.get(5).getDocCount());
+                assertEquals("2016-01-07T06:00:00.000Z", buckets.get(6).getKeyAsString());
+                assertEquals(0, buckets.get(6).getDocCount());
+                assertEquals("2016-01-08T06:00:00.000Z", buckets.get(7).getKeyAsString());
+                assertEquals(0, buckets.get(7).getDocCount());
+            }
+        );
         internalCluster().wipeIndices(index);
     }
 
@@ -1250,59 +1273,67 @@ public class DateHistogramIT extends ESIntegTestCase {
         }
         indexRandom(true, reqs);
 
-        SearchResponse response = prepareSearch("idx2").setQuery(matchAllQuery())
-            .addAggregation(dateHistogram("date_histo").field("date").calendarInterval(DateHistogramInterval.DAY))
-            .get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx2").setQuery(matchAllQuery())
+                .addAggregation(dateHistogram("date_histo").field("date").calendarInterval(DateHistogramInterval.DAY)),
+            response -> {
 
-        assertSearchHits(response, "0", "1", "2", "3", "4");
+                assertSearchHits(response, "0", "1", "2", "3", "4");
 
-        Histogram histo = response.getAggregations().get("date_histo");
-        List<? extends Histogram.Bucket> buckets = histo.getBuckets();
-        assertThat(buckets.size(), equalTo(1));
+                Histogram histo = response.getAggregations().get("date_histo");
+                List<? extends Histogram.Bucket> buckets = histo.getBuckets();
+                assertThat(buckets.size(), equalTo(1));
 
-        ZonedDateTime key = ZonedDateTime.of(2014, 3, 10, 0, 0, 0, 0, ZoneOffset.UTC);
-        Histogram.Bucket bucket = buckets.get(0);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
-        assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(5L));
+                ZonedDateTime key = ZonedDateTime.of(2014, 3, 10, 0, 0, 0, 0, ZoneOffset.UTC);
+                Histogram.Bucket bucket = buckets.get(0);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
+                assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
+                assertThat(bucket.getDocCount(), equalTo(5L));
+            }
+        );
     }
 
     public void testIssue6965() {
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            dateHistogram("histo").field("date").timeZone(ZoneId.of("+01:00")).calendarInterval(DateHistogramInterval.MONTH).minDocCount(0)
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                dateHistogram("histo").field("date")
+                    .timeZone(ZoneId.of("+01:00"))
+                    .calendarInterval(DateHistogramInterval.MONTH)
+                    .minDocCount(0)
+            ),
+            response -> {
 
-        assertNoFailures(response);
+                ZoneId tz = ZoneId.of("+01:00");
 
-        ZoneId tz = ZoneId.of("+01:00");
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo, notNullValue());
+                assertThat(histo.getName(), equalTo("histo"));
+                List<? extends Bucket> buckets = histo.getBuckets();
+                assertThat(buckets.size(), equalTo(3));
 
-        Histogram histo = response.getAggregations().get("histo");
-        assertThat(histo, notNullValue());
-        assertThat(histo.getName(), equalTo("histo"));
-        List<? extends Bucket> buckets = histo.getBuckets();
-        assertThat(buckets.size(), equalTo(3));
+                ZonedDateTime key = ZonedDateTime.of(2011, 12, 31, 23, 0, 0, 0, ZoneOffset.UTC);
+                Histogram.Bucket bucket = buckets.get(0);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key, tz)));
+                assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
+                assertThat(bucket.getDocCount(), equalTo(1L));
 
-        ZonedDateTime key = ZonedDateTime.of(2011, 12, 31, 23, 0, 0, 0, ZoneOffset.UTC);
-        Histogram.Bucket bucket = buckets.get(0);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key, tz)));
-        assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(1L));
+                key = ZonedDateTime.of(2012, 1, 31, 23, 0, 0, 0, ZoneOffset.UTC);
+                bucket = buckets.get(1);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key, tz)));
+                assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
+                assertThat(bucket.getDocCount(), equalTo(2L));
 
-        key = ZonedDateTime.of(2012, 1, 31, 23, 0, 0, 0, ZoneOffset.UTC);
-        bucket = buckets.get(1);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key, tz)));
-        assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(2L));
-
-        key = ZonedDateTime.of(2012, 2, 29, 23, 0, 0, 0, ZoneOffset.UTC);
-        bucket = buckets.get(2);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key, tz)));
-        assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
-        assertThat(bucket.getDocCount(), equalTo(3L));
+                key = ZonedDateTime.of(2012, 2, 29, 23, 0, 0, 0, ZoneOffset.UTC);
+                bucket = buckets.get(2);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key, tz)));
+                assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
+                assertThat(bucket.getDocCount(), equalTo(3L));
+            }
+        );
     }
 
     public void testDSTBoundaryIssue9491() throws InterruptedException, ExecutionException {
@@ -1313,17 +1344,20 @@ public class DateHistogramIT extends ESIntegTestCase {
             client().prepareIndex("test9491").setSource("d", "2014-11-08T13:00:00Z")
         );
         ensureSearchable("test9491");
-        SearchResponse response = prepareSearch("test9491").addAggregation(
-            dateHistogram("histo").field("d")
-                .calendarInterval(DateHistogramInterval.YEAR)
-                .timeZone(ZoneId.of("Asia/Jerusalem"))
-                .format("yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX")
-        ).get();
-        assertNoFailures(response);
-        Histogram histo = response.getAggregations().get("histo");
-        assertThat(histo.getBuckets().size(), equalTo(1));
-        assertThat(histo.getBuckets().get(0).getKeyAsString(), equalTo("2014-01-01T00:00:00.000+02:00"));
-        internalCluster().wipeIndices("test9491");
+        assertNoFailuresAndResponse(
+            prepareSearch("test9491").addAggregation(
+                dateHistogram("histo").field("d")
+                    .calendarInterval(DateHistogramInterval.YEAR)
+                    .timeZone(ZoneId.of("Asia/Jerusalem"))
+                    .format("yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX")
+            ),
+            response -> {
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo.getBuckets().size(), equalTo(1));
+                assertThat(histo.getBuckets().get(0).getKeyAsString(), equalTo("2014-01-01T00:00:00.000+02:00"));
+                internalCluster().wipeIndices("test9491");
+            }
+        );
     }
 
     public void testIssue8209() throws InterruptedException, ExecutionException {
@@ -1335,25 +1369,28 @@ public class DateHistogramIT extends ESIntegTestCase {
             client().prepareIndex("test8209").setSource("d", "2014-04-30T00:00:00Z")
         );
         ensureSearchable("test8209");
-        SearchResponse response = prepareSearch("test8209").addAggregation(
-            dateHistogram("histo").field("d")
-                .calendarInterval(DateHistogramInterval.MONTH)
-                .format("yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX")
-                .timeZone(ZoneId.of("CET"))
-                .minDocCount(0)
-        ).get();
-        assertNoFailures(response);
-        Histogram histo = response.getAggregations().get("histo");
-        assertThat(histo.getBuckets().size(), equalTo(4));
-        assertThat(histo.getBuckets().get(0).getKeyAsString(), equalTo("2014-01-01T00:00:00.000+01:00"));
-        assertThat(histo.getBuckets().get(0).getDocCount(), equalTo(1L));
-        assertThat(histo.getBuckets().get(1).getKeyAsString(), equalTo("2014-02-01T00:00:00.000+01:00"));
-        assertThat(histo.getBuckets().get(1).getDocCount(), equalTo(0L));
-        assertThat(histo.getBuckets().get(2).getKeyAsString(), equalTo("2014-03-01T00:00:00.000+01:00"));
-        assertThat(histo.getBuckets().get(2).getDocCount(), equalTo(0L));
-        assertThat(histo.getBuckets().get(3).getKeyAsString(), equalTo("2014-04-01T00:00:00.000+02:00"));
-        assertThat(histo.getBuckets().get(3).getDocCount(), equalTo(2L));
-        internalCluster().wipeIndices("test8209");
+        assertNoFailuresAndResponse(
+            prepareSearch("test8209").addAggregation(
+                dateHistogram("histo").field("d")
+                    .calendarInterval(DateHistogramInterval.MONTH)
+                    .format("yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX")
+                    .timeZone(ZoneId.of("CET"))
+                    .minDocCount(0)
+            ),
+            response -> {
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo.getBuckets().size(), equalTo(4));
+                assertThat(histo.getBuckets().get(0).getKeyAsString(), equalTo("2014-01-01T00:00:00.000+01:00"));
+                assertThat(histo.getBuckets().get(0).getDocCount(), equalTo(1L));
+                assertThat(histo.getBuckets().get(1).getKeyAsString(), equalTo("2014-02-01T00:00:00.000+01:00"));
+                assertThat(histo.getBuckets().get(1).getDocCount(), equalTo(0L));
+                assertThat(histo.getBuckets().get(2).getKeyAsString(), equalTo("2014-03-01T00:00:00.000+01:00"));
+                assertThat(histo.getBuckets().get(2).getDocCount(), equalTo(0L));
+                assertThat(histo.getBuckets().get(3).getKeyAsString(), equalTo("2014-04-01T00:00:00.000+02:00"));
+                assertThat(histo.getBuckets().get(3).getDocCount(), equalTo(2L));
+                internalCluster().wipeIndices("test8209");
+            }
+        );
     }
 
     // TODO: add some tests for negative fixed and calendar intervals
@@ -1370,19 +1407,22 @@ public class DateHistogramIT extends ESIntegTestCase {
         indexRandom(true, client().prepareIndex(indexDateUnmapped).setSource("foo", "bar"));
         ensureSearchable(indexDateUnmapped);
 
-        SearchResponse response = prepareSearch(indexDateUnmapped).addAggregation(
-            dateHistogram("histo").field("dateField")
-                .calendarInterval(DateHistogramInterval.MONTH)
-                .format("yyyy-MM")
-                .minDocCount(0)
-                .extendedBounds(new LongBounds("2018-01", "2018-01"))
-        ).get();
-        assertNoFailures(response);
-        Histogram histo = response.getAggregations().get("histo");
-        assertThat(histo.getBuckets().size(), equalTo(1));
-        assertThat(histo.getBuckets().get(0).getKeyAsString(), equalTo("2018-01"));
-        assertThat(histo.getBuckets().get(0).getDocCount(), equalTo(0L));
-        internalCluster().wipeIndices(indexDateUnmapped);
+        assertNoFailuresAndResponse(
+            prepareSearch(indexDateUnmapped).addAggregation(
+                dateHistogram("histo").field("dateField")
+                    .calendarInterval(DateHistogramInterval.MONTH)
+                    .format("yyyy-MM")
+                    .minDocCount(0)
+                    .extendedBounds(new LongBounds("2018-01", "2018-01"))
+            ),
+            response -> {
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo.getBuckets().size(), equalTo(1));
+                assertThat(histo.getBuckets().get(0).getKeyAsString(), equalTo("2018-01"));
+                assertThat(histo.getBuckets().get(0).getDocCount(), equalTo(0L));
+                internalCluster().wipeIndices(indexDateUnmapped);
+            }
+        );
     }
 
     /**
@@ -1395,27 +1435,31 @@ public class DateHistogramIT extends ESIntegTestCase {
         assertAcked(indicesAdmin().prepareCreate(index).setMapping("d", "type=date,format=epoch_millis").get());
         indexRandom(true, client().prepareIndex(index).setSource("d", "1477954800000"));
         ensureSearchable(index);
-        SearchResponse response = prepareSearch(index).addAggregation(
-            dateHistogram("histo").field("d").calendarInterval(DateHistogramInterval.MONTH).timeZone(ZoneId.of("Europe/Berlin"))
-        ).get();
-        assertNoFailures(response);
-        Histogram histo = response.getAggregations().get("histo");
-        assertThat(histo.getBuckets().size(), equalTo(1));
-        assertThat(histo.getBuckets().get(0).getKeyAsString(), equalTo("1477954800000"));
-        assertThat(histo.getBuckets().get(0).getDocCount(), equalTo(1L));
-
-        response = prepareSearch(index).addAggregation(
-            dateHistogram("histo").field("d")
-                .calendarInterval(DateHistogramInterval.MONTH)
-                .timeZone(ZoneId.of("Europe/Berlin"))
-                .format("yyyy-MM-dd")
-        ).get();
-        assertNoFailures(response);
-        histo = response.getAggregations().get("histo");
-        assertThat(histo.getBuckets().size(), equalTo(1));
-        assertThat(histo.getBuckets().get(0).getKeyAsString(), equalTo("2016-11-01"));
-        assertThat(histo.getBuckets().get(0).getDocCount(), equalTo(1L));
-
+        assertNoFailuresAndResponse(
+            prepareSearch(index).addAggregation(
+                dateHistogram("histo").field("d").calendarInterval(DateHistogramInterval.MONTH).timeZone(ZoneId.of("Europe/Berlin"))
+            ),
+            response -> {
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo.getBuckets().size(), equalTo(1));
+                assertThat(histo.getBuckets().get(0).getKeyAsString(), equalTo("1477954800000"));
+                assertThat(histo.getBuckets().get(0).getDocCount(), equalTo(1L));
+            }
+        );
+        assertNoFailuresAndResponse(
+            prepareSearch(index).addAggregation(
+                dateHistogram("histo").field("d")
+                    .calendarInterval(DateHistogramInterval.MONTH)
+                    .timeZone(ZoneId.of("Europe/Berlin"))
+                    .format("yyyy-MM-dd")
+            ),
+            response -> {
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo.getBuckets().size(), equalTo(1));
+                assertThat(histo.getBuckets().get(0).getKeyAsString(), equalTo("2016-11-01"));
+                assertThat(histo.getBuckets().get(0).getDocCount(), equalTo(1L));
+            }
+        );
         internalCluster().wipeIndices(index);
     }
 
@@ -1427,62 +1471,73 @@ public class DateHistogramIT extends ESIntegTestCase {
      * "2015-10-25T04:00:00.000+01:00".
      */
     public void testDSTEndTransition() throws Exception {
-        SearchResponse response = prepareSearch("idx").setQuery(new MatchNoneQueryBuilder())
-            .addAggregation(
-                dateHistogram("histo").field("date")
-                    .timeZone(ZoneId.of("Europe/Oslo"))
-                    .calendarInterval(DateHistogramInterval.HOUR)
-                    .minDocCount(0)
-                    .extendedBounds(new LongBounds("2015-10-25T02:00:00.000+02:00", "2015-10-25T04:00:00.000+01:00"))
-            )
-            .get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").setQuery(new MatchNoneQueryBuilder())
+                .addAggregation(
+                    dateHistogram("histo").field("date")
+                        .timeZone(ZoneId.of("Europe/Oslo"))
+                        .calendarInterval(DateHistogramInterval.HOUR)
+                        .minDocCount(0)
+                        .extendedBounds(new LongBounds("2015-10-25T02:00:00.000+02:00", "2015-10-25T04:00:00.000+01:00"))
+                ),
+            response -> {
 
-        Histogram histo = response.getAggregations().get("histo");
-        List<? extends Bucket> buckets = histo.getBuckets();
-        assertThat(buckets.size(), equalTo(4));
-        assertThat(
-            ((ZonedDateTime) buckets.get(1).getKey()).toInstant().toEpochMilli() - ((ZonedDateTime) buckets.get(0).getKey()).toInstant()
-                .toEpochMilli(),
-            equalTo(3600000L)
-        );
-        assertThat(
-            ((ZonedDateTime) buckets.get(2).getKey()).toInstant().toEpochMilli() - ((ZonedDateTime) buckets.get(1).getKey()).toInstant()
-                .toEpochMilli(),
-            equalTo(3600000L)
-        );
-        assertThat(
-            ((ZonedDateTime) buckets.get(3).getKey()).toInstant().toEpochMilli() - ((ZonedDateTime) buckets.get(2).getKey()).toInstant()
-                .toEpochMilli(),
-            equalTo(3600000L)
+                Histogram histo = response.getAggregations().get("histo");
+                List<? extends Bucket> buckets = histo.getBuckets();
+                assertThat(buckets.size(), equalTo(4));
+                assertThat(
+                    ((ZonedDateTime) buckets.get(1).getKey()).toInstant().toEpochMilli() - ((ZonedDateTime) buckets.get(0).getKey())
+                        .toInstant()
+                        .toEpochMilli(),
+                    equalTo(3600000L)
+                );
+                assertThat(
+                    ((ZonedDateTime) buckets.get(2).getKey()).toInstant().toEpochMilli() - ((ZonedDateTime) buckets.get(1).getKey())
+                        .toInstant()
+                        .toEpochMilli(),
+                    equalTo(3600000L)
+                );
+                assertThat(
+                    ((ZonedDateTime) buckets.get(3).getKey()).toInstant().toEpochMilli() - ((ZonedDateTime) buckets.get(2).getKey())
+                        .toInstant()
+                        .toEpochMilli(),
+                    equalTo(3600000L)
+                );
+            }
         );
 
-        response = prepareSearch("idx").setQuery(new MatchNoneQueryBuilder())
-            .addAggregation(
-                dateHistogram("histo").field("date")
-                    .timeZone(ZoneId.of("Europe/Oslo"))
-                    .calendarInterval(DateHistogramInterval.HOUR)
-                    .minDocCount(0)
-                    .extendedBounds(new LongBounds("2015-10-25T02:00:00.000+02:00", "2015-10-25T04:00:00.000+01:00"))
-            )
-            .get();
-
-        histo = response.getAggregations().get("histo");
-        buckets = histo.getBuckets();
-        assertThat(buckets.size(), equalTo(4));
-        assertThat(
-            ((ZonedDateTime) buckets.get(1).getKey()).toInstant().toEpochMilli() - ((ZonedDateTime) buckets.get(0).getKey()).toInstant()
-                .toEpochMilli(),
-            equalTo(3600000L)
-        );
-        assertThat(
-            ((ZonedDateTime) buckets.get(2).getKey()).toInstant().toEpochMilli() - ((ZonedDateTime) buckets.get(1).getKey()).toInstant()
-                .toEpochMilli(),
-            equalTo(3600000L)
-        );
-        assertThat(
-            ((ZonedDateTime) buckets.get(3).getKey()).toInstant().toEpochMilli() - ((ZonedDateTime) buckets.get(2).getKey()).toInstant()
-                .toEpochMilli(),
-            equalTo(3600000L)
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").setQuery(new MatchNoneQueryBuilder())
+                .addAggregation(
+                    dateHistogram("histo").field("date")
+                        .timeZone(ZoneId.of("Europe/Oslo"))
+                        .calendarInterval(DateHistogramInterval.HOUR)
+                        .minDocCount(0)
+                        .extendedBounds(new LongBounds("2015-10-25T02:00:00.000+02:00", "2015-10-25T04:00:00.000+01:00"))
+                ),
+            response -> {
+                Histogram histo = response.getAggregations().get("histo");
+                List<? extends Bucket> buckets = histo.getBuckets();
+                assertThat(buckets.size(), equalTo(4));
+                assertThat(
+                    ((ZonedDateTime) buckets.get(1).getKey()).toInstant().toEpochMilli() - ((ZonedDateTime) buckets.get(0).getKey())
+                        .toInstant()
+                        .toEpochMilli(),
+                    equalTo(3600000L)
+                );
+                assertThat(
+                    ((ZonedDateTime) buckets.get(2).getKey()).toInstant().toEpochMilli() - ((ZonedDateTime) buckets.get(1).getKey())
+                        .toInstant()
+                        .toEpochMilli(),
+                    equalTo(3600000L)
+                );
+                assertThat(
+                    ((ZonedDateTime) buckets.get(3).getKey()).toInstant().toEpochMilli() - ((ZonedDateTime) buckets.get(2).getKey())
+                        .toInstant()
+                        .toEpochMilli(),
+                    equalTo(3600000L)
+                );
+            }
         );
     }
 
@@ -1516,14 +1571,14 @@ public class DateHistogramIT extends ESIntegTestCase {
         // Test that a request using a nondeterministic script does not get cached
         Map<String, Object> params = new HashMap<>();
         params.put("fieldname", "d");
-        SearchResponse r = prepareSearch("cache_test_idx").setSize(0)
-            .addAggregation(
-                dateHistogram("histo").field("d")
-                    .script(new Script(ScriptType.INLINE, "mockscript", DateScriptMocksPlugin.CURRENT_DATE, params))
-                    .calendarInterval(DateHistogramInterval.MONTH)
-            )
-            .get();
-        assertNoFailures(r);
+        assertNoFailures(
+            prepareSearch("cache_test_idx").setSize(0)
+                .addAggregation(
+                    dateHistogram("histo").field("d")
+                        .script(new Script(ScriptType.INLINE, "mockscript", DateScriptMocksPlugin.CURRENT_DATE, params))
+                        .calendarInterval(DateHistogramInterval.MONTH)
+                )
+        );
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -1535,14 +1590,14 @@ public class DateHistogramIT extends ESIntegTestCase {
         );
 
         // Test that a request using a deterministic script gets cached
-        r = prepareSearch("cache_test_idx").setSize(0)
-            .addAggregation(
-                dateHistogram("histo").field("d")
-                    .script(new Script(ScriptType.INLINE, "mockscript", DateScriptMocksPlugin.LONG_PLUS_ONE_MONTH, params))
-                    .calendarInterval(DateHistogramInterval.MONTH)
-            )
-            .get();
-        assertNoFailures(r);
+        assertNoFailures(
+            prepareSearch("cache_test_idx").setSize(0)
+                .addAggregation(
+                    dateHistogram("histo").field("d")
+                        .script(new Script(ScriptType.INLINE, "mockscript", DateScriptMocksPlugin.LONG_PLUS_ONE_MONTH, params))
+                        .calendarInterval(DateHistogramInterval.MONTH)
+                )
+        );
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -1554,10 +1609,10 @@ public class DateHistogramIT extends ESIntegTestCase {
         );
 
         // Ensure that non-scripted requests are cached as normal
-        r = prepareSearch("cache_test_idx").setSize(0)
-            .addAggregation(dateHistogram("histo").field("d").calendarInterval(DateHistogramInterval.MONTH))
-            .get();
-        assertNoFailures(r);
+        assertNoFailures(
+            prepareSearch("cache_test_idx").setSize(0)
+                .addAggregation(dateHistogram("histo").field("d").calendarInterval(DateHistogramInterval.MONTH))
+        );
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -1611,34 +1666,35 @@ public class DateHistogramIT extends ESIntegTestCase {
 
     private void assertMultiSortResponse(int[] expectedDays, BucketOrder... order) {
         ZonedDateTime[] expectedKeys = Arrays.stream(expectedDays).mapToObj(d -> date(1, d)).toArray(ZonedDateTime[]::new);
-        SearchResponse response = prepareSearch("sort_idx").addAggregation(
-            dateHistogram("histo").field("date")
-                .calendarInterval(DateHistogramInterval.DAY)
-                .order(BucketOrder.compound(order))
-                .subAggregation(avg("avg_l").field("l"))
-                .subAggregation(sum("sum_d").field("d"))
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("sort_idx").addAggregation(
+                dateHistogram("histo").field("date")
+                    .calendarInterval(DateHistogramInterval.DAY)
+                    .order(BucketOrder.compound(order))
+                    .subAggregation(avg("avg_l").field("l"))
+                    .subAggregation(sum("sum_d").field("d"))
+            ),
+            response -> {
+                Histogram histogram = response.getAggregations().get("histo");
+                assertThat(histogram, notNullValue());
+                assertThat(histogram.getName(), equalTo("histo"));
+                assertThat(histogram.getBuckets().size(), equalTo(expectedKeys.length));
 
-        assertNoFailures(response);
-
-        Histogram histogram = response.getAggregations().get("histo");
-        assertThat(histogram, notNullValue());
-        assertThat(histogram.getName(), equalTo("histo"));
-        assertThat(histogram.getBuckets().size(), equalTo(expectedKeys.length));
-
-        int i = 0;
-        for (Histogram.Bucket bucket : histogram.getBuckets()) {
-            assertThat(bucket, notNullValue());
-            assertThat(key(bucket), equalTo(expectedKeys[i]));
-            assertThat(bucket.getDocCount(), equalTo(expectedMultiSortBuckets.get(expectedKeys[i]).get("_count")));
-            Avg avg = bucket.getAggregations().get("avg_l");
-            assertThat(avg, notNullValue());
-            assertThat(avg.getValue(), equalTo(expectedMultiSortBuckets.get(expectedKeys[i]).get("avg_l")));
-            Sum sum = bucket.getAggregations().get("sum_d");
-            assertThat(sum, notNullValue());
-            assertThat(sum.value(), equalTo(expectedMultiSortBuckets.get(expectedKeys[i]).get("sum_d")));
-            i++;
-        }
+                int i = 0;
+                for (Histogram.Bucket bucket : histogram.getBuckets()) {
+                    assertThat(bucket, notNullValue());
+                    assertThat(key(bucket), equalTo(expectedKeys[i]));
+                    assertThat(bucket.getDocCount(), equalTo(expectedMultiSortBuckets.get(expectedKeys[i]).get("_count")));
+                    Avg avg = bucket.getAggregations().get("avg_l");
+                    assertThat(avg, notNullValue());
+                    assertThat(avg.getValue(), equalTo(expectedMultiSortBuckets.get(expectedKeys[i]).get("avg_l")));
+                    Sum sum = bucket.getAggregations().get("sum_d");
+                    assertThat(sum, notNullValue());
+                    assertThat(sum.value(), equalTo(expectedMultiSortBuckets.get(expectedKeys[i]).get("sum_d")));
+                    i++;
+                }
+            }
+        );
     }
 
     private ZonedDateTime key(Histogram.Bucket bucket) {
@@ -1655,63 +1711,68 @@ public class DateHistogramIT extends ESIntegTestCase {
         indexRandom(true, client().prepareIndex("nanos").setId("2").setSource("date", "2000-01-02"));
 
         // Search interval 24 hours
-        SearchResponse r = prepareSearch("nanos").addAggregation(
-            dateHistogram("histo").field("date")
-                .fixedInterval(DateHistogramInterval.seconds(60 * 60 * 24))
-                .timeZone(ZoneId.of("Europe/Berlin"))
-        ).addDocValueField("date").get();
-        assertNoFailures(r);
+        assertNoFailuresAndResponse(
+            prepareSearch("nanos").addAggregation(
+                dateHistogram("histo").field("date")
+                    .fixedInterval(DateHistogramInterval.seconds(60 * 60 * 24))
+                    .timeZone(ZoneId.of("Europe/Berlin"))
+            ).addDocValueField("date"),
+            response -> {
+                Histogram histogram = response.getAggregations().get("histo");
+                List<? extends Bucket> buckets = histogram.getBuckets();
+                assertEquals(2, buckets.size());
+                assertEquals(946681200000L, ((ZonedDateTime) buckets.get(0).getKey()).toEpochSecond() * 1000);
+                assertEquals(1, buckets.get(0).getDocCount());
+                assertEquals(946767600000L, ((ZonedDateTime) buckets.get(1).getKey()).toEpochSecond() * 1000);
+                assertEquals(1, buckets.get(1).getDocCount());
+            }
+        );
 
-        Histogram histogram = r.getAggregations().get("histo");
-        List<? extends Bucket> buckets = histogram.getBuckets();
-        assertEquals(2, buckets.size());
-        assertEquals(946681200000L, ((ZonedDateTime) buckets.get(0).getKey()).toEpochSecond() * 1000);
-        assertEquals(1, buckets.get(0).getDocCount());
-        assertEquals(946767600000L, ((ZonedDateTime) buckets.get(1).getKey()).toEpochSecond() * 1000);
-        assertEquals(1, buckets.get(1).getDocCount());
-
-        r = prepareSearch("nanos").addAggregation(
-            dateHistogram("histo").field("date").fixedInterval(DateHistogramInterval.seconds(60 * 60 * 24)).timeZone(ZoneId.of("UTC"))
-        ).addDocValueField("date").get();
-        assertNoFailures(r);
-
-        histogram = r.getAggregations().get("histo");
-        buckets = histogram.getBuckets();
-        assertEquals(2, buckets.size());
-        assertEquals(946684800000L, ((ZonedDateTime) buckets.get(0).getKey()).toEpochSecond() * 1000);
-        assertEquals(1, buckets.get(0).getDocCount());
-        assertEquals(946771200000L, ((ZonedDateTime) buckets.get(1).getKey()).toEpochSecond() * 1000);
-        assertEquals(1, buckets.get(1).getDocCount());
+        assertNoFailuresAndResponse(
+            prepareSearch("nanos").addAggregation(
+                dateHistogram("histo").field("date").fixedInterval(DateHistogramInterval.seconds(60 * 60 * 24)).timeZone(ZoneId.of("UTC"))
+            ).addDocValueField("date"),
+            response -> {
+                Histogram histogram = response.getAggregations().get("histo");
+                List<? extends Bucket> buckets = histogram.getBuckets();
+                assertEquals(2, buckets.size());
+                assertEquals(946684800000L, ((ZonedDateTime) buckets.get(0).getKey()).toEpochSecond() * 1000);
+                assertEquals(1, buckets.get(0).getDocCount());
+                assertEquals(946771200000L, ((ZonedDateTime) buckets.get(1).getKey()).toEpochSecond() * 1000);
+                assertEquals(1, buckets.get(1).getDocCount());
+            }
+        );
     }
 
     public void testDateKeyFormatting() {
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            dateHistogram("histo").field("date").calendarInterval(DateHistogramInterval.MONTH).timeZone(ZoneId.of("America/Edmonton"))
-        ).get();
-
-        assertNoFailures(response);
-
-        InternalDateHistogram histogram = response.getAggregations().get("histo");
-        List<InternalDateHistogram.Bucket> buckets = histogram.getBuckets();
-        assertThat(buckets.get(0).getKeyAsString(), equalTo("2012-01-01T00:00:00.000-07:00"));
-        assertThat(buckets.get(1).getKeyAsString(), equalTo("2012-02-01T00:00:00.000-07:00"));
-        assertThat(buckets.get(2).getKeyAsString(), equalTo("2012-03-01T00:00:00.000-07:00"));
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                dateHistogram("histo").field("date").calendarInterval(DateHistogramInterval.MONTH).timeZone(ZoneId.of("America/Edmonton"))
+            ),
+            response -> {
+                InternalDateHistogram histogram = response.getAggregations().get("histo");
+                List<InternalDateHistogram.Bucket> buckets = histogram.getBuckets();
+                assertThat(buckets.get(0).getKeyAsString(), equalTo("2012-01-01T00:00:00.000-07:00"));
+                assertThat(buckets.get(1).getKeyAsString(), equalTo("2012-02-01T00:00:00.000-07:00"));
+                assertThat(buckets.get(2).getKeyAsString(), equalTo("2012-03-01T00:00:00.000-07:00"));
+            }
+        );
     }
 
     public void testHardBoundsOnDates() {
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            dateHistogram("histo").field("date")
-                .calendarInterval(DateHistogramInterval.DAY)
-                .hardBounds(new LongBounds("2012-02-01T00:00:00.000", "2012-03-03T00:00:00.000"))
-        ).get();
-
-        assertNoFailures(response);
-
-        InternalDateHistogram histogram = response.getAggregations().get("histo");
-        List<InternalDateHistogram.Bucket> buckets = histogram.getBuckets();
-        assertThat(buckets.size(), equalTo(30));
-        assertThat(buckets.get(1).getKeyAsString(), equalTo("2012-02-03T00:00:00.000Z"));
-        assertThat(buckets.get(29).getKeyAsString(), equalTo("2012-03-02T00:00:00.000Z"));
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                dateHistogram("histo").field("date")
+                    .calendarInterval(DateHistogramInterval.DAY)
+                    .hardBounds(new LongBounds("2012-02-01T00:00:00.000", "2012-03-03T00:00:00.000"))
+            ),
+            response -> {
+                InternalDateHistogram histogram = response.getAggregations().get("histo");
+                List<InternalDateHistogram.Bucket> buckets = histogram.getBuckets();
+                assertThat(buckets.size(), equalTo(30));
+                assertThat(buckets.get(1).getKeyAsString(), equalTo("2012-02-03T00:00:00.000Z"));
+                assertThat(buckets.get(29).getKeyAsString(), equalTo("2012-03-02T00:00:00.000Z"));
+            }
+        );
     }
-
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/DateHistogramOffsetIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/DateHistogramOffsetIT.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.search.aggregations.bucket;
 
 import org.elasticsearch.action.index.IndexRequestBuilder;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.time.DateFormatters;
 import org.elasticsearch.index.mapper.DateFieldMapper;
@@ -25,6 +24,7 @@ import java.util.List;
 
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.dateHistogram;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.IsNull.notNullValue;
@@ -72,39 +72,43 @@ public class DateHistogramOffsetIT extends ESIntegTestCase {
     public void testSingleValueWithPositiveOffset() throws Exception {
         prepareIndex(date("2014-03-11T00:00:00+00:00"), 5, 1, 0);
 
-        SearchResponse response = prepareSearch("idx2").setQuery(matchAllQuery())
-            .addAggregation(
-                dateHistogram("date_histo").field("date").offset("2h").format(DATE_FORMAT).fixedInterval(DateHistogramInterval.DAY)
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx2").setQuery(matchAllQuery())
+                .addAggregation(
+                    dateHistogram("date_histo").field("date").offset("2h").format(DATE_FORMAT).fixedInterval(DateHistogramInterval.DAY)
+                ),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(5L));
 
-        assertThat(response.getHits().getTotalHits().value, equalTo(5L));
+                Histogram histo = response.getAggregations().get("date_histo");
+                List<? extends Histogram.Bucket> buckets = histo.getBuckets();
+                assertThat(buckets.size(), equalTo(2));
 
-        Histogram histo = response.getAggregations().get("date_histo");
-        List<? extends Histogram.Bucket> buckets = histo.getBuckets();
-        assertThat(buckets.size(), equalTo(2));
-
-        checkBucketFor(buckets.get(0), ZonedDateTime.of(2014, 3, 10, 2, 0, 0, 0, ZoneOffset.UTC), 2L);
-        checkBucketFor(buckets.get(1), ZonedDateTime.of(2014, 3, 11, 2, 0, 0, 0, ZoneOffset.UTC), 3L);
+                checkBucketFor(buckets.get(0), ZonedDateTime.of(2014, 3, 10, 2, 0, 0, 0, ZoneOffset.UTC), 2L);
+                checkBucketFor(buckets.get(1), ZonedDateTime.of(2014, 3, 11, 2, 0, 0, 0, ZoneOffset.UTC), 3L);
+            }
+        );
     }
 
     public void testSingleValueWithNegativeOffset() throws Exception {
         prepareIndex(date("2014-03-11T00:00:00+00:00"), 5, -1, 0);
 
-        SearchResponse response = prepareSearch("idx2").setQuery(matchAllQuery())
-            .addAggregation(
-                dateHistogram("date_histo").field("date").offset("-2h").format(DATE_FORMAT).fixedInterval(DateHistogramInterval.DAY)
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx2").setQuery(matchAllQuery())
+                .addAggregation(
+                    dateHistogram("date_histo").field("date").offset("-2h").format(DATE_FORMAT).fixedInterval(DateHistogramInterval.DAY)
+                ),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(5L));
 
-        assertThat(response.getHits().getTotalHits().value, equalTo(5L));
+                Histogram histo = response.getAggregations().get("date_histo");
+                List<? extends Histogram.Bucket> buckets = histo.getBuckets();
+                assertThat(buckets.size(), equalTo(2));
 
-        Histogram histo = response.getAggregations().get("date_histo");
-        List<? extends Histogram.Bucket> buckets = histo.getBuckets();
-        assertThat(buckets.size(), equalTo(2));
-
-        checkBucketFor(buckets.get(0), ZonedDateTime.of(2014, 3, 9, 22, 0, 0, 0, ZoneOffset.UTC), 2L);
-        checkBucketFor(buckets.get(1), ZonedDateTime.of(2014, 3, 10, 22, 0, 0, 0, ZoneOffset.UTC), 3L);
+                checkBucketFor(buckets.get(0), ZonedDateTime.of(2014, 3, 9, 22, 0, 0, 0, ZoneOffset.UTC), 2L);
+                checkBucketFor(buckets.get(1), ZonedDateTime.of(2014, 3, 10, 22, 0, 0, 0, ZoneOffset.UTC), 3L);
+            }
+        );
     }
 
     /**
@@ -114,27 +118,29 @@ public class DateHistogramOffsetIT extends ESIntegTestCase {
         prepareIndex(date("2014-03-11T00:00:00+00:00"), 12, 1, 0);
         prepareIndex(date("2014-03-14T00:00:00+00:00"), 12, 1, 13);
 
-        SearchResponse response = prepareSearch("idx2").setQuery(matchAllQuery())
-            .addAggregation(
-                dateHistogram("date_histo").field("date")
-                    .offset("6h")
-                    .minDocCount(0)
-                    .format(DATE_FORMAT)
-                    .fixedInterval(DateHistogramInterval.DAY)
-            )
-            .get();
+        assertResponse(
+            prepareSearch("idx2").setQuery(matchAllQuery())
+                .addAggregation(
+                    dateHistogram("date_histo").field("date")
+                        .offset("6h")
+                        .minDocCount(0)
+                        .format(DATE_FORMAT)
+                        .fixedInterval(DateHistogramInterval.DAY)
+                ),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(24L));
 
-        assertThat(response.getHits().getTotalHits().value, equalTo(24L));
+                Histogram histo = response.getAggregations().get("date_histo");
+                List<? extends Histogram.Bucket> buckets = histo.getBuckets();
+                assertThat(buckets.size(), equalTo(5));
 
-        Histogram histo = response.getAggregations().get("date_histo");
-        List<? extends Histogram.Bucket> buckets = histo.getBuckets();
-        assertThat(buckets.size(), equalTo(5));
-
-        checkBucketFor(buckets.get(0), ZonedDateTime.of(2014, 3, 10, 6, 0, 0, 0, ZoneOffset.UTC), 6L);
-        checkBucketFor(buckets.get(1), ZonedDateTime.of(2014, 3, 11, 6, 0, 0, 0, ZoneOffset.UTC), 6L);
-        checkBucketFor(buckets.get(2), ZonedDateTime.of(2014, 3, 12, 6, 0, 0, 0, ZoneOffset.UTC), 0L);
-        checkBucketFor(buckets.get(3), ZonedDateTime.of(2014, 3, 13, 6, 0, 0, 0, ZoneOffset.UTC), 6L);
-        checkBucketFor(buckets.get(4), ZonedDateTime.of(2014, 3, 14, 6, 0, 0, 0, ZoneOffset.UTC), 6L);
+                checkBucketFor(buckets.get(0), ZonedDateTime.of(2014, 3, 10, 6, 0, 0, 0, ZoneOffset.UTC), 6L);
+                checkBucketFor(buckets.get(1), ZonedDateTime.of(2014, 3, 11, 6, 0, 0, 0, ZoneOffset.UTC), 6L);
+                checkBucketFor(buckets.get(2), ZonedDateTime.of(2014, 3, 12, 6, 0, 0, 0, ZoneOffset.UTC), 0L);
+                checkBucketFor(buckets.get(3), ZonedDateTime.of(2014, 3, 13, 6, 0, 0, 0, ZoneOffset.UTC), 6L);
+                checkBucketFor(buckets.get(4), ZonedDateTime.of(2014, 3, 14, 6, 0, 0, 0, ZoneOffset.UTC), 6L);
+            }
+        );
     }
 
     /**

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/DateRangeIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/DateRangeIT.java
@@ -10,7 +10,6 @@ package org.elasticsearch.search.aggregations.bucket;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.script.Script;
@@ -43,6 +42,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.histogra
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -127,166 +127,173 @@ public class DateRangeIT extends ESIntegTestCase {
         } else {
             rangeBuilder.script(new Script(ScriptType.INLINE, "mockscript", DateScriptMocksPlugin.EXTRACT_FIELD, params));
         }
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            rangeBuilder.addUnboundedTo("a long time ago", "now-50y")
-                .addRange("recently", "now-50y", "now-1y")
-                .addUnboundedFrom("last year", "now-1y")
-                .timeZone(ZoneId.of("Etc/GMT+5"))
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                rangeBuilder.addUnboundedTo("a long time ago", "now-50y")
+                    .addRange("recently", "now-50y", "now-1y")
+                    .addUnboundedFrom("last year", "now-1y")
+                    .timeZone(ZoneId.of("Etc/GMT+5"))
+            ),
+            response -> {
+                Range range = response.getAggregations().get("range");
+                assertThat(range, notNullValue());
+                assertThat(range.getName(), equalTo("range"));
+                assertThat(range.getBuckets().size(), equalTo(3));
 
-        assertNoFailures(response);
+                List<Range.Bucket> buckets = new ArrayList<>(range.getBuckets());
 
-        Range range = response.getAggregations().get("range");
-        assertThat(range, notNullValue());
-        assertThat(range.getName(), equalTo("range"));
-        assertThat(range.getBuckets().size(), equalTo(3));
+                Range.Bucket bucket = buckets.get(0);
+                assertThat((String) bucket.getKey(), equalTo("a long time ago"));
+                assertThat(bucket.getKeyAsString(), equalTo("a long time ago"));
+                assertThat(bucket.getDocCount(), equalTo(0L));
 
-        List<Range.Bucket> buckets = new ArrayList<>(range.getBuckets());
+                bucket = buckets.get(1);
+                assertThat((String) bucket.getKey(), equalTo("recently"));
+                assertThat(bucket.getKeyAsString(), equalTo("recently"));
+                assertThat(bucket.getDocCount(), equalTo((long) numDocs));
 
-        Range.Bucket bucket = buckets.get(0);
-        assertThat((String) bucket.getKey(), equalTo("a long time ago"));
-        assertThat(bucket.getKeyAsString(), equalTo("a long time ago"));
-        assertThat(bucket.getDocCount(), equalTo(0L));
-
-        bucket = buckets.get(1);
-        assertThat((String) bucket.getKey(), equalTo("recently"));
-        assertThat(bucket.getKeyAsString(), equalTo("recently"));
-        assertThat(bucket.getDocCount(), equalTo((long) numDocs));
-
-        bucket = buckets.get(2);
-        assertThat((String) bucket.getKey(), equalTo("last year"));
-        assertThat(bucket.getKeyAsString(), equalTo("last year"));
-        assertThat(bucket.getDocCount(), equalTo(0L));
+                bucket = buckets.get(2);
+                assertThat((String) bucket.getKey(), equalTo("last year"));
+                assertThat(bucket.getKeyAsString(), equalTo("last year"));
+                assertThat(bucket.getDocCount(), equalTo(0L));
+            }
+        );
     }
 
     public void testSingleValueField() throws Exception {
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            dateRange("range").field("date").addUnboundedTo(date(2, 15)).addRange(date(2, 15), date(3, 15)).addUnboundedFrom(date(3, 15))
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                dateRange("range").field("date")
+                    .addUnboundedTo(date(2, 15))
+                    .addRange(date(2, 15), date(3, 15))
+                    .addUnboundedFrom(date(3, 15))
+            ),
+            response -> {
+                Range range = response.getAggregations().get("range");
+                assertThat(range, notNullValue());
+                assertThat(range.getName(), equalTo("range"));
+                List<? extends Bucket> buckets = range.getBuckets();
+                assertThat(buckets.size(), equalTo(3));
 
-        assertNoFailures(response);
+                Range.Bucket bucket = buckets.get(0);
+                assertThat(bucket, notNullValue());
+                assertThat((String) bucket.getKey(), equalTo("*-2012-02-15T00:00:00.000Z"));
+                assertThat(((ZonedDateTime) bucket.getFrom()), nullValue());
+                assertThat(((ZonedDateTime) bucket.getTo()), equalTo(date(2, 15)));
+                assertThat(bucket.getFromAsString(), nullValue());
+                assertThat(bucket.getToAsString(), equalTo("2012-02-15T00:00:00.000Z"));
+                assertThat(bucket.getDocCount(), equalTo(2L));
 
-        Range range = response.getAggregations().get("range");
-        assertThat(range, notNullValue());
-        assertThat(range.getName(), equalTo("range"));
-        List<? extends Bucket> buckets = range.getBuckets();
-        assertThat(buckets.size(), equalTo(3));
+                bucket = buckets.get(1);
+                assertThat(bucket, notNullValue());
+                assertThat((String) bucket.getKey(), equalTo("2012-02-15T00:00:00.000Z-2012-03-15T00:00:00.000Z"));
+                assertThat(((ZonedDateTime) bucket.getFrom()), equalTo(date(2, 15)));
+                assertThat(((ZonedDateTime) bucket.getTo()), equalTo(date(3, 15)));
+                assertThat(bucket.getFromAsString(), equalTo("2012-02-15T00:00:00.000Z"));
+                assertThat(bucket.getToAsString(), equalTo("2012-03-15T00:00:00.000Z"));
+                assertThat(bucket.getDocCount(), equalTo(2L));
 
-        Range.Bucket bucket = buckets.get(0);
-        assertThat(bucket, notNullValue());
-        assertThat((String) bucket.getKey(), equalTo("*-2012-02-15T00:00:00.000Z"));
-        assertThat(((ZonedDateTime) bucket.getFrom()), nullValue());
-        assertThat(((ZonedDateTime) bucket.getTo()), equalTo(date(2, 15)));
-        assertThat(bucket.getFromAsString(), nullValue());
-        assertThat(bucket.getToAsString(), equalTo("2012-02-15T00:00:00.000Z"));
-        assertThat(bucket.getDocCount(), equalTo(2L));
-
-        bucket = buckets.get(1);
-        assertThat(bucket, notNullValue());
-        assertThat((String) bucket.getKey(), equalTo("2012-02-15T00:00:00.000Z-2012-03-15T00:00:00.000Z"));
-        assertThat(((ZonedDateTime) bucket.getFrom()), equalTo(date(2, 15)));
-        assertThat(((ZonedDateTime) bucket.getTo()), equalTo(date(3, 15)));
-        assertThat(bucket.getFromAsString(), equalTo("2012-02-15T00:00:00.000Z"));
-        assertThat(bucket.getToAsString(), equalTo("2012-03-15T00:00:00.000Z"));
-        assertThat(bucket.getDocCount(), equalTo(2L));
-
-        bucket = buckets.get(2);
-        assertThat(bucket, notNullValue());
-        assertThat((String) bucket.getKey(), equalTo("2012-03-15T00:00:00.000Z-*"));
-        assertThat(((ZonedDateTime) bucket.getFrom()), equalTo(date(3, 15)));
-        assertThat(((ZonedDateTime) bucket.getTo()), nullValue());
-        assertThat(bucket.getFromAsString(), equalTo("2012-03-15T00:00:00.000Z"));
-        assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(numDocs - 4L));
+                bucket = buckets.get(2);
+                assertThat(bucket, notNullValue());
+                assertThat((String) bucket.getKey(), equalTo("2012-03-15T00:00:00.000Z-*"));
+                assertThat(((ZonedDateTime) bucket.getFrom()), equalTo(date(3, 15)));
+                assertThat(((ZonedDateTime) bucket.getTo()), nullValue());
+                assertThat(bucket.getFromAsString(), equalTo("2012-03-15T00:00:00.000Z"));
+                assertThat(bucket.getToAsString(), nullValue());
+                assertThat(bucket.getDocCount(), equalTo(numDocs - 4L));
+            }
+        );
     }
 
     public void testSingleValueFieldWithStringDates() throws Exception {
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            dateRange("range").field("date")
-                .addUnboundedTo("2012-02-15")
-                .addRange("2012-02-15", "2012-03-15")
-                .addUnboundedFrom("2012-03-15")
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                dateRange("range").field("date")
+                    .addUnboundedTo("2012-02-15")
+                    .addRange("2012-02-15", "2012-03-15")
+                    .addUnboundedFrom("2012-03-15")
+            ),
+            response -> {
+                Range range = response.getAggregations().get("range");
+                assertThat(range, notNullValue());
+                assertThat(range.getName(), equalTo("range"));
+                List<? extends Bucket> buckets = range.getBuckets();
+                assertThat(buckets.size(), equalTo(3));
 
-        assertNoFailures(response);
+                Range.Bucket bucket = buckets.get(0);
+                assertThat(bucket, notNullValue());
+                assertThat((String) bucket.getKey(), equalTo("*-2012-02-15T00:00:00.000Z"));
+                assertThat(((ZonedDateTime) bucket.getFrom()), nullValue());
+                assertThat(((ZonedDateTime) bucket.getTo()), equalTo(date(2, 15)));
+                assertThat(bucket.getFromAsString(), nullValue());
+                assertThat(bucket.getToAsString(), equalTo("2012-02-15T00:00:00.000Z"));
+                assertThat(bucket.getDocCount(), equalTo(2L));
 
-        Range range = response.getAggregations().get("range");
-        assertThat(range, notNullValue());
-        assertThat(range.getName(), equalTo("range"));
-        List<? extends Bucket> buckets = range.getBuckets();
-        assertThat(buckets.size(), equalTo(3));
+                bucket = buckets.get(1);
+                assertThat(bucket, notNullValue());
+                assertThat((String) bucket.getKey(), equalTo("2012-02-15T00:00:00.000Z-2012-03-15T00:00:00.000Z"));
+                assertThat(((ZonedDateTime) bucket.getFrom()), equalTo(date(2, 15)));
+                assertThat(((ZonedDateTime) bucket.getTo()), equalTo(date(3, 15)));
+                assertThat(bucket.getFromAsString(), equalTo("2012-02-15T00:00:00.000Z"));
+                assertThat(bucket.getToAsString(), equalTo("2012-03-15T00:00:00.000Z"));
+                assertThat(bucket.getDocCount(), equalTo(2L));
 
-        Range.Bucket bucket = buckets.get(0);
-        assertThat(bucket, notNullValue());
-        assertThat((String) bucket.getKey(), equalTo("*-2012-02-15T00:00:00.000Z"));
-        assertThat(((ZonedDateTime) bucket.getFrom()), nullValue());
-        assertThat(((ZonedDateTime) bucket.getTo()), equalTo(date(2, 15)));
-        assertThat(bucket.getFromAsString(), nullValue());
-        assertThat(bucket.getToAsString(), equalTo("2012-02-15T00:00:00.000Z"));
-        assertThat(bucket.getDocCount(), equalTo(2L));
-
-        bucket = buckets.get(1);
-        assertThat(bucket, notNullValue());
-        assertThat((String) bucket.getKey(), equalTo("2012-02-15T00:00:00.000Z-2012-03-15T00:00:00.000Z"));
-        assertThat(((ZonedDateTime) bucket.getFrom()), equalTo(date(2, 15)));
-        assertThat(((ZonedDateTime) bucket.getTo()), equalTo(date(3, 15)));
-        assertThat(bucket.getFromAsString(), equalTo("2012-02-15T00:00:00.000Z"));
-        assertThat(bucket.getToAsString(), equalTo("2012-03-15T00:00:00.000Z"));
-        assertThat(bucket.getDocCount(), equalTo(2L));
-
-        bucket = buckets.get(2);
-        assertThat(bucket, notNullValue());
-        assertThat((String) bucket.getKey(), equalTo("2012-03-15T00:00:00.000Z-*"));
-        assertThat(((ZonedDateTime) bucket.getFrom()), equalTo(date(3, 15)));
-        assertThat(((ZonedDateTime) bucket.getTo()), nullValue());
-        assertThat(bucket.getFromAsString(), equalTo("2012-03-15T00:00:00.000Z"));
-        assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(numDocs - 4L));
+                bucket = buckets.get(2);
+                assertThat(bucket, notNullValue());
+                assertThat((String) bucket.getKey(), equalTo("2012-03-15T00:00:00.000Z-*"));
+                assertThat(((ZonedDateTime) bucket.getFrom()), equalTo(date(3, 15)));
+                assertThat(((ZonedDateTime) bucket.getTo()), nullValue());
+                assertThat(bucket.getFromAsString(), equalTo("2012-03-15T00:00:00.000Z"));
+                assertThat(bucket.getToAsString(), nullValue());
+                assertThat(bucket.getDocCount(), equalTo(numDocs - 4L));
+            }
+        );
     }
 
     public void testSingleValueFieldWithStringDatesWithCustomFormat() throws Exception {
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            dateRange("range").field("date")
-                .format("yyyy-MM-dd")
-                .addUnboundedTo("2012-02-15")
-                .addRange("2012-02-15", "2012-03-15")
-                .addUnboundedFrom("2012-03-15")
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                dateRange("range").field("date")
+                    .format("yyyy-MM-dd")
+                    .addUnboundedTo("2012-02-15")
+                    .addRange("2012-02-15", "2012-03-15")
+                    .addUnboundedFrom("2012-03-15")
+            ),
+            response -> {
+                Range range = response.getAggregations().get("range");
+                assertThat(range, notNullValue());
+                assertThat(range.getName(), equalTo("range"));
+                List<? extends Bucket> buckets = range.getBuckets();
+                assertThat(buckets.size(), equalTo(3));
 
-        assertNoFailures(response);
+                Range.Bucket bucket = buckets.get(0);
+                assertThat(bucket, notNullValue());
+                assertThat((String) bucket.getKey(), equalTo("*-2012-02-15"));
+                assertThat(((ZonedDateTime) bucket.getFrom()), nullValue());
+                assertThat(((ZonedDateTime) bucket.getTo()), equalTo(date(2, 15)));
+                assertThat(bucket.getFromAsString(), nullValue());
+                assertThat(bucket.getToAsString(), equalTo("2012-02-15"));
+                assertThat(bucket.getDocCount(), equalTo(2L));
 
-        Range range = response.getAggregations().get("range");
-        assertThat(range, notNullValue());
-        assertThat(range.getName(), equalTo("range"));
-        List<? extends Bucket> buckets = range.getBuckets();
-        assertThat(buckets.size(), equalTo(3));
+                bucket = buckets.get(1);
+                assertThat(bucket, notNullValue());
+                assertThat((String) bucket.getKey(), equalTo("2012-02-15-2012-03-15"));
+                assertThat(((ZonedDateTime) bucket.getFrom()), equalTo(date(2, 15)));
+                assertThat(((ZonedDateTime) bucket.getTo()), equalTo(date(3, 15)));
+                assertThat(bucket.getFromAsString(), equalTo("2012-02-15"));
+                assertThat(bucket.getToAsString(), equalTo("2012-03-15"));
+                assertThat(bucket.getDocCount(), equalTo(2L));
 
-        Range.Bucket bucket = buckets.get(0);
-        assertThat(bucket, notNullValue());
-        assertThat((String) bucket.getKey(), equalTo("*-2012-02-15"));
-        assertThat(((ZonedDateTime) bucket.getFrom()), nullValue());
-        assertThat(((ZonedDateTime) bucket.getTo()), equalTo(date(2, 15)));
-        assertThat(bucket.getFromAsString(), nullValue());
-        assertThat(bucket.getToAsString(), equalTo("2012-02-15"));
-        assertThat(bucket.getDocCount(), equalTo(2L));
-
-        bucket = buckets.get(1);
-        assertThat(bucket, notNullValue());
-        assertThat((String) bucket.getKey(), equalTo("2012-02-15-2012-03-15"));
-        assertThat(((ZonedDateTime) bucket.getFrom()), equalTo(date(2, 15)));
-        assertThat(((ZonedDateTime) bucket.getTo()), equalTo(date(3, 15)));
-        assertThat(bucket.getFromAsString(), equalTo("2012-02-15"));
-        assertThat(bucket.getToAsString(), equalTo("2012-03-15"));
-        assertThat(bucket.getDocCount(), equalTo(2L));
-
-        bucket = buckets.get(2);
-        assertThat(bucket, notNullValue());
-        assertThat((String) bucket.getKey(), equalTo("2012-03-15-*"));
-        assertThat(((ZonedDateTime) bucket.getFrom()), equalTo(date(3, 15)));
-        assertThat(((ZonedDateTime) bucket.getTo()), nullValue());
-        assertThat(bucket.getFromAsString(), equalTo("2012-03-15"));
-        assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(numDocs - 4L));
+                bucket = buckets.get(2);
+                assertThat(bucket, notNullValue());
+                assertThat((String) bucket.getKey(), equalTo("2012-03-15-*"));
+                assertThat(((ZonedDateTime) bucket.getFrom()), equalTo(date(3, 15)));
+                assertThat(((ZonedDateTime) bucket.getTo()), nullValue());
+                assertThat(bucket.getFromAsString(), equalTo("2012-03-15"));
+                assertThat(bucket.getToAsString(), nullValue());
+                assertThat(bucket.getDocCount(), equalTo(numDocs - 4L));
+            }
+        );
     }
 
     public void testSingleValueFieldWithDateMath() throws Exception {
@@ -297,92 +304,97 @@ public class DateRangeIT extends ESIntegTestCase {
         String mar15Suffix = timeZoneOffset == 0 ? "Z" : date(3, 15, timezone).format(DateTimeFormatter.ofPattern("xxx", Locale.ROOT));
         long expectedFirstBucketCount = timeZoneOffset < 0 ? 3L : 2L;
 
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            dateRange("range").field("date")
-                .addUnboundedTo("2012-02-15")
-                .addRange("2012-02-15", "2012-02-15||+1M")
-                .addUnboundedFrom("2012-02-15||+1M")
-                .timeZone(timezone)
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                dateRange("range").field("date")
+                    .addUnboundedTo("2012-02-15")
+                    .addRange("2012-02-15", "2012-02-15||+1M")
+                    .addUnboundedFrom("2012-02-15||+1M")
+                    .timeZone(timezone)
+            ),
+            response -> {
+                Range range = response.getAggregations().get("range");
+                assertThat(range, notNullValue());
+                assertThat(range.getName(), equalTo("range"));
+                List<? extends Bucket> buckets = range.getBuckets();
+                assertThat(buckets.size(), equalTo(3));
 
-        assertNoFailures(response);
+                Range.Bucket bucket = buckets.get(0);
+                assertThat(bucket, notNullValue());
+                assertThat((String) bucket.getKey(), equalTo("*-2012-02-15T00:00:00.000" + feb15Suffix));
+                assertThat(((ZonedDateTime) bucket.getFrom()), nullValue());
+                assertThat(((ZonedDateTime) bucket.getTo()), equalTo(date(2, 15, timezone).withZoneSameInstant(ZoneOffset.UTC)));
+                assertThat(bucket.getFromAsString(), nullValue());
+                assertThat(bucket.getToAsString(), equalTo("2012-02-15T00:00:00.000" + feb15Suffix));
+                assertThat(bucket.getDocCount(), equalTo(expectedFirstBucketCount));
 
-        Range range = response.getAggregations().get("range");
-        assertThat(range, notNullValue());
-        assertThat(range.getName(), equalTo("range"));
-        List<? extends Bucket> buckets = range.getBuckets();
-        assertThat(buckets.size(), equalTo(3));
+                bucket = buckets.get(1);
+                assertThat(bucket, notNullValue());
+                assertThat(
+                    (String) bucket.getKey(),
+                    equalTo("2012-02-15T00:00:00.000" + feb15Suffix + "-2012-03-15T00:00:00.000" + mar15Suffix)
+                );
+                assertThat(((ZonedDateTime) bucket.getFrom()), equalTo(date(2, 15, timezone).withZoneSameInstant(ZoneOffset.UTC)));
+                assertThat(((ZonedDateTime) bucket.getTo()), equalTo(date(3, 15, timezone).withZoneSameInstant(ZoneOffset.UTC)));
+                assertThat(bucket.getFromAsString(), equalTo("2012-02-15T00:00:00.000" + feb15Suffix));
+                assertThat(bucket.getToAsString(), equalTo("2012-03-15T00:00:00.000" + mar15Suffix));
+                assertThat(bucket.getDocCount(), equalTo(2L));
 
-        Range.Bucket bucket = buckets.get(0);
-        assertThat(bucket, notNullValue());
-        assertThat((String) bucket.getKey(), equalTo("*-2012-02-15T00:00:00.000" + feb15Suffix));
-        assertThat(((ZonedDateTime) bucket.getFrom()), nullValue());
-        assertThat(((ZonedDateTime) bucket.getTo()), equalTo(date(2, 15, timezone).withZoneSameInstant(ZoneOffset.UTC)));
-        assertThat(bucket.getFromAsString(), nullValue());
-        assertThat(bucket.getToAsString(), equalTo("2012-02-15T00:00:00.000" + feb15Suffix));
-        assertThat(bucket.getDocCount(), equalTo(expectedFirstBucketCount));
-
-        bucket = buckets.get(1);
-        assertThat(bucket, notNullValue());
-        assertThat((String) bucket.getKey(), equalTo("2012-02-15T00:00:00.000" + feb15Suffix + "-2012-03-15T00:00:00.000" + mar15Suffix));
-        assertThat(((ZonedDateTime) bucket.getFrom()), equalTo(date(2, 15, timezone).withZoneSameInstant(ZoneOffset.UTC)));
-        assertThat(((ZonedDateTime) bucket.getTo()), equalTo(date(3, 15, timezone).withZoneSameInstant(ZoneOffset.UTC)));
-        assertThat(bucket.getFromAsString(), equalTo("2012-02-15T00:00:00.000" + feb15Suffix));
-        assertThat(bucket.getToAsString(), equalTo("2012-03-15T00:00:00.000" + mar15Suffix));
-        assertThat(bucket.getDocCount(), equalTo(2L));
-
-        bucket = buckets.get(2);
-        assertThat(bucket, notNullValue());
-        assertThat((String) bucket.getKey(), equalTo("2012-03-15T00:00:00.000" + mar15Suffix + "-*"));
-        assertThat(((ZonedDateTime) bucket.getFrom()), equalTo(date(3, 15, timezone).withZoneSameInstant(ZoneOffset.UTC)));
-        assertThat(((ZonedDateTime) bucket.getTo()), nullValue());
-        assertThat(bucket.getFromAsString(), equalTo("2012-03-15T00:00:00.000" + mar15Suffix));
-        assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(numDocs - 2L - expectedFirstBucketCount));
+                bucket = buckets.get(2);
+                assertThat(bucket, notNullValue());
+                assertThat((String) bucket.getKey(), equalTo("2012-03-15T00:00:00.000" + mar15Suffix + "-*"));
+                assertThat(((ZonedDateTime) bucket.getFrom()), equalTo(date(3, 15, timezone).withZoneSameInstant(ZoneOffset.UTC)));
+                assertThat(((ZonedDateTime) bucket.getTo()), nullValue());
+                assertThat(bucket.getFromAsString(), equalTo("2012-03-15T00:00:00.000" + mar15Suffix));
+                assertThat(bucket.getToAsString(), nullValue());
+                assertThat(bucket.getDocCount(), equalTo(numDocs - 2L - expectedFirstBucketCount));
+            }
+        );
     }
 
     public void testSingleValueFieldWithCustomKey() throws Exception {
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            dateRange("range").field("date")
-                .addUnboundedTo("r1", date(2, 15))
-                .addRange("r2", date(2, 15), date(3, 15))
-                .addUnboundedFrom("r3", date(3, 15))
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                dateRange("range").field("date")
+                    .addUnboundedTo("r1", date(2, 15))
+                    .addRange("r2", date(2, 15), date(3, 15))
+                    .addUnboundedFrom("r3", date(3, 15))
+            ),
+            response -> {
+                Range range = response.getAggregations().get("range");
+                assertThat(range, notNullValue());
+                assertThat(range.getName(), equalTo("range"));
+                List<? extends Bucket> buckets = range.getBuckets();
+                assertThat(buckets.size(), equalTo(3));
 
-        assertNoFailures(response);
+                Range.Bucket bucket = buckets.get(0);
+                assertThat(bucket, notNullValue());
+                assertThat((String) bucket.getKey(), equalTo("r1"));
+                assertThat(((ZonedDateTime) bucket.getFrom()), nullValue());
+                assertThat(((ZonedDateTime) bucket.getTo()), equalTo(date(2, 15)));
+                assertThat(bucket.getFromAsString(), nullValue());
+                assertThat(bucket.getToAsString(), equalTo("2012-02-15T00:00:00.000Z"));
+                assertThat(bucket.getDocCount(), equalTo(2L));
 
-        Range range = response.getAggregations().get("range");
-        assertThat(range, notNullValue());
-        assertThat(range.getName(), equalTo("range"));
-        List<? extends Bucket> buckets = range.getBuckets();
-        assertThat(buckets.size(), equalTo(3));
+                bucket = buckets.get(1);
+                assertThat(bucket, notNullValue());
+                assertThat((String) bucket.getKey(), equalTo("r2"));
+                assertThat(((ZonedDateTime) bucket.getFrom()), equalTo(date(2, 15)));
+                assertThat(((ZonedDateTime) bucket.getTo()), equalTo(date(3, 15)));
+                assertThat(bucket.getFromAsString(), equalTo("2012-02-15T00:00:00.000Z"));
+                assertThat(bucket.getToAsString(), equalTo("2012-03-15T00:00:00.000Z"));
+                assertThat(bucket.getDocCount(), equalTo(2L));
 
-        Range.Bucket bucket = buckets.get(0);
-        assertThat(bucket, notNullValue());
-        assertThat((String) bucket.getKey(), equalTo("r1"));
-        assertThat(((ZonedDateTime) bucket.getFrom()), nullValue());
-        assertThat(((ZonedDateTime) bucket.getTo()), equalTo(date(2, 15)));
-        assertThat(bucket.getFromAsString(), nullValue());
-        assertThat(bucket.getToAsString(), equalTo("2012-02-15T00:00:00.000Z"));
-        assertThat(bucket.getDocCount(), equalTo(2L));
-
-        bucket = buckets.get(1);
-        assertThat(bucket, notNullValue());
-        assertThat((String) bucket.getKey(), equalTo("r2"));
-        assertThat(((ZonedDateTime) bucket.getFrom()), equalTo(date(2, 15)));
-        assertThat(((ZonedDateTime) bucket.getTo()), equalTo(date(3, 15)));
-        assertThat(bucket.getFromAsString(), equalTo("2012-02-15T00:00:00.000Z"));
-        assertThat(bucket.getToAsString(), equalTo("2012-03-15T00:00:00.000Z"));
-        assertThat(bucket.getDocCount(), equalTo(2L));
-
-        bucket = buckets.get(2);
-        assertThat(bucket, notNullValue());
-        assertThat((String) bucket.getKey(), equalTo("r3"));
-        assertThat(((ZonedDateTime) bucket.getFrom()), equalTo(date(3, 15)));
-        assertThat(((ZonedDateTime) bucket.getTo()), nullValue());
-        assertThat(bucket.getFromAsString(), equalTo("2012-03-15T00:00:00.000Z"));
-        assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(numDocs - 4L));
+                bucket = buckets.get(2);
+                assertThat(bucket, notNullValue());
+                assertThat((String) bucket.getKey(), equalTo("r3"));
+                assertThat(((ZonedDateTime) bucket.getFrom()), equalTo(date(3, 15)));
+                assertThat(((ZonedDateTime) bucket.getTo()), nullValue());
+                assertThat(bucket.getFromAsString(), equalTo("2012-03-15T00:00:00.000Z"));
+                assertThat(bucket.getToAsString(), nullValue());
+                assertThat(bucket.getDocCount(), equalTo(numDocs - 4L));
+            }
+        );
     }
 
     /*
@@ -395,68 +407,69 @@ public class DateRangeIT extends ESIntegTestCase {
      */
 
     public void testSingleValuedFieldWithSubAggregation() throws Exception {
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            dateRange("range").field("date")
-                .addUnboundedTo("r1", date(2, 15))
-                .addRange("r2", date(2, 15), date(3, 15))
-                .addUnboundedFrom("r3", date(3, 15))
-                .subAggregation(sum("sum").field("value"))
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                dateRange("range").field("date")
+                    .addUnboundedTo("r1", date(2, 15))
+                    .addRange("r2", date(2, 15), date(3, 15))
+                    .addUnboundedFrom("r3", date(3, 15))
+                    .subAggregation(sum("sum").field("value"))
+            ),
+            response -> {
+                Range range = response.getAggregations().get("range");
+                assertThat(range, notNullValue());
+                assertThat(range.getName(), equalTo("range"));
+                List<? extends Bucket> buckets = range.getBuckets();
+                assertThat(buckets.size(), equalTo(3));
+                assertThat(((InternalAggregation) range).getProperty("_bucket_count"), equalTo(3));
+                Object[] propertiesKeys = (Object[]) ((InternalAggregation) range).getProperty("_key");
+                Object[] propertiesDocCounts = (Object[]) ((InternalAggregation) range).getProperty("_count");
+                Object[] propertiesCounts = (Object[]) ((InternalAggregation) range).getProperty("sum.value");
 
-        assertNoFailures(response);
+                Range.Bucket bucket = buckets.get(0);
+                assertThat(bucket, notNullValue());
+                assertThat((String) bucket.getKey(), equalTo("r1"));
+                assertThat(((ZonedDateTime) bucket.getFrom()), nullValue());
+                assertThat(((ZonedDateTime) bucket.getTo()), equalTo(date(2, 15)));
+                assertThat(bucket.getFromAsString(), nullValue());
+                assertThat(bucket.getToAsString(), equalTo("2012-02-15T00:00:00.000Z"));
+                assertThat(bucket.getDocCount(), equalTo(2L));
+                Sum sum = bucket.getAggregations().get("sum");
+                assertThat(sum, notNullValue());
+                assertThat(sum.value(), equalTo((double) 1 + 2));
+                assertThat((String) propertiesKeys[0], equalTo("r1"));
+                assertThat((long) propertiesDocCounts[0], equalTo(2L));
+                assertThat((double) propertiesCounts[0], equalTo((double) 1 + 2));
 
-        Range range = response.getAggregations().get("range");
-        assertThat(range, notNullValue());
-        assertThat(range.getName(), equalTo("range"));
-        List<? extends Bucket> buckets = range.getBuckets();
-        assertThat(buckets.size(), equalTo(3));
-        assertThat(((InternalAggregation) range).getProperty("_bucket_count"), equalTo(3));
-        Object[] propertiesKeys = (Object[]) ((InternalAggregation) range).getProperty("_key");
-        Object[] propertiesDocCounts = (Object[]) ((InternalAggregation) range).getProperty("_count");
-        Object[] propertiesCounts = (Object[]) ((InternalAggregation) range).getProperty("sum.value");
+                bucket = buckets.get(1);
+                assertThat(bucket, notNullValue());
+                assertThat((String) bucket.getKey(), equalTo("r2"));
+                assertThat(((ZonedDateTime) bucket.getFrom()), equalTo(date(2, 15)));
+                assertThat(((ZonedDateTime) bucket.getTo()), equalTo(date(3, 15)));
+                assertThat(bucket.getFromAsString(), equalTo("2012-02-15T00:00:00.000Z"));
+                assertThat(bucket.getToAsString(), equalTo("2012-03-15T00:00:00.000Z"));
+                assertThat(bucket.getDocCount(), equalTo(2L));
+                sum = bucket.getAggregations().get("sum");
+                assertThat(sum, notNullValue());
+                assertThat(sum.value(), equalTo((double) 3 + 4));
+                assertThat((String) propertiesKeys[1], equalTo("r2"));
+                assertThat((long) propertiesDocCounts[1], equalTo(2L));
+                assertThat((double) propertiesCounts[1], equalTo((double) 3 + 4));
 
-        Range.Bucket bucket = buckets.get(0);
-        assertThat(bucket, notNullValue());
-        assertThat((String) bucket.getKey(), equalTo("r1"));
-        assertThat(((ZonedDateTime) bucket.getFrom()), nullValue());
-        assertThat(((ZonedDateTime) bucket.getTo()), equalTo(date(2, 15)));
-        assertThat(bucket.getFromAsString(), nullValue());
-        assertThat(bucket.getToAsString(), equalTo("2012-02-15T00:00:00.000Z"));
-        assertThat(bucket.getDocCount(), equalTo(2L));
-        Sum sum = bucket.getAggregations().get("sum");
-        assertThat(sum, notNullValue());
-        assertThat(sum.value(), equalTo((double) 1 + 2));
-        assertThat((String) propertiesKeys[0], equalTo("r1"));
-        assertThat((long) propertiesDocCounts[0], equalTo(2L));
-        assertThat((double) propertiesCounts[0], equalTo((double) 1 + 2));
-
-        bucket = buckets.get(1);
-        assertThat(bucket, notNullValue());
-        assertThat((String) bucket.getKey(), equalTo("r2"));
-        assertThat(((ZonedDateTime) bucket.getFrom()), equalTo(date(2, 15)));
-        assertThat(((ZonedDateTime) bucket.getTo()), equalTo(date(3, 15)));
-        assertThat(bucket.getFromAsString(), equalTo("2012-02-15T00:00:00.000Z"));
-        assertThat(bucket.getToAsString(), equalTo("2012-03-15T00:00:00.000Z"));
-        assertThat(bucket.getDocCount(), equalTo(2L));
-        sum = bucket.getAggregations().get("sum");
-        assertThat(sum, notNullValue());
-        assertThat(sum.value(), equalTo((double) 3 + 4));
-        assertThat((String) propertiesKeys[1], equalTo("r2"));
-        assertThat((long) propertiesDocCounts[1], equalTo(2L));
-        assertThat((double) propertiesCounts[1], equalTo((double) 3 + 4));
-
-        bucket = buckets.get(2);
-        assertThat(bucket, notNullValue());
-        assertThat((String) bucket.getKey(), equalTo("r3"));
-        assertThat(((ZonedDateTime) bucket.getFrom()), equalTo(date(3, 15)));
-        assertThat(((ZonedDateTime) bucket.getTo()), nullValue());
-        assertThat(bucket.getFromAsString(), equalTo("2012-03-15T00:00:00.000Z"));
-        assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(numDocs - 4L));
-        sum = bucket.getAggregations().get("sum");
-        assertThat(sum, notNullValue());
-        assertThat((String) propertiesKeys[2], equalTo("r3"));
-        assertThat((long) propertiesDocCounts[2], equalTo(numDocs - 4L));
+                bucket = buckets.get(2);
+                assertThat(bucket, notNullValue());
+                assertThat((String) bucket.getKey(), equalTo("r3"));
+                assertThat(((ZonedDateTime) bucket.getFrom()), equalTo(date(3, 15)));
+                assertThat(((ZonedDateTime) bucket.getTo()), nullValue());
+                assertThat(bucket.getFromAsString(), equalTo("2012-03-15T00:00:00.000Z"));
+                assertThat(bucket.getToAsString(), nullValue());
+                assertThat(bucket.getDocCount(), equalTo(numDocs - 4L));
+                sum = bucket.getAggregations().get("sum");
+                assertThat(sum, notNullValue());
+                assertThat((String) propertiesKeys[2], equalTo("r3"));
+                assertThat((long) propertiesDocCounts[2], equalTo(numDocs - 4L));
+            }
+        );
     }
 
     /*
@@ -469,113 +482,123 @@ public class DateRangeIT extends ESIntegTestCase {
      */
 
     public void testMultiValuedField() throws Exception {
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            dateRange("range").field("dates").addUnboundedTo(date(2, 15)).addRange(date(2, 15), date(3, 15)).addUnboundedFrom(date(3, 15))
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                dateRange("range").field("dates")
+                    .addUnboundedTo(date(2, 15))
+                    .addRange(date(2, 15), date(3, 15))
+                    .addUnboundedFrom(date(3, 15))
+            ),
+            response -> {
+                Range range = response.getAggregations().get("range");
+                assertThat(range, notNullValue());
+                assertThat(range.getName(), equalTo("range"));
+                List<? extends Bucket> buckets = range.getBuckets();
+                assertThat(buckets.size(), equalTo(3));
 
-        assertNoFailures(response);
+                Range.Bucket bucket = buckets.get(0);
+                assertThat(bucket, notNullValue());
+                assertThat((String) bucket.getKey(), equalTo("*-2012-02-15T00:00:00.000Z"));
+                assertThat(((ZonedDateTime) bucket.getFrom()), nullValue());
+                assertThat(((ZonedDateTime) bucket.getTo()), equalTo(date(2, 15)));
+                assertThat(bucket.getFromAsString(), nullValue());
+                assertThat(bucket.getToAsString(), equalTo("2012-02-15T00:00:00.000Z"));
+                assertThat(bucket.getDocCount(), equalTo(2L));
 
-        Range range = response.getAggregations().get("range");
-        assertThat(range, notNullValue());
-        assertThat(range.getName(), equalTo("range"));
-        List<? extends Bucket> buckets = range.getBuckets();
-        assertThat(buckets.size(), equalTo(3));
+                bucket = buckets.get(1);
+                assertThat(bucket, notNullValue());
+                assertThat((String) bucket.getKey(), equalTo("2012-02-15T00:00:00.000Z-2012-03-15T00:00:00.000Z"));
+                assertThat(((ZonedDateTime) bucket.getFrom()), equalTo(date(2, 15)));
+                assertThat(((ZonedDateTime) bucket.getTo()), equalTo(date(3, 15)));
+                assertThat(bucket.getFromAsString(), equalTo("2012-02-15T00:00:00.000Z"));
+                assertThat(bucket.getToAsString(), equalTo("2012-03-15T00:00:00.000Z"));
+                assertThat(bucket.getDocCount(), equalTo(3L));
 
-        Range.Bucket bucket = buckets.get(0);
-        assertThat(bucket, notNullValue());
-        assertThat((String) bucket.getKey(), equalTo("*-2012-02-15T00:00:00.000Z"));
-        assertThat(((ZonedDateTime) bucket.getFrom()), nullValue());
-        assertThat(((ZonedDateTime) bucket.getTo()), equalTo(date(2, 15)));
-        assertThat(bucket.getFromAsString(), nullValue());
-        assertThat(bucket.getToAsString(), equalTo("2012-02-15T00:00:00.000Z"));
-        assertThat(bucket.getDocCount(), equalTo(2L));
-
-        bucket = buckets.get(1);
-        assertThat(bucket, notNullValue());
-        assertThat((String) bucket.getKey(), equalTo("2012-02-15T00:00:00.000Z-2012-03-15T00:00:00.000Z"));
-        assertThat(((ZonedDateTime) bucket.getFrom()), equalTo(date(2, 15)));
-        assertThat(((ZonedDateTime) bucket.getTo()), equalTo(date(3, 15)));
-        assertThat(bucket.getFromAsString(), equalTo("2012-02-15T00:00:00.000Z"));
-        assertThat(bucket.getToAsString(), equalTo("2012-03-15T00:00:00.000Z"));
-        assertThat(bucket.getDocCount(), equalTo(3L));
-
-        bucket = buckets.get(2);
-        assertThat(bucket, notNullValue());
-        assertThat((String) bucket.getKey(), equalTo("2012-03-15T00:00:00.000Z-*"));
-        assertThat(((ZonedDateTime) bucket.getFrom()), equalTo(date(3, 15)));
-        assertThat(((ZonedDateTime) bucket.getTo()), nullValue());
-        assertThat(bucket.getFromAsString(), equalTo("2012-03-15T00:00:00.000Z"));
-        assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(numDocs - 2L));
+                bucket = buckets.get(2);
+                assertThat(bucket, notNullValue());
+                assertThat((String) bucket.getKey(), equalTo("2012-03-15T00:00:00.000Z-*"));
+                assertThat(((ZonedDateTime) bucket.getFrom()), equalTo(date(3, 15)));
+                assertThat(((ZonedDateTime) bucket.getTo()), nullValue());
+                assertThat(bucket.getFromAsString(), equalTo("2012-03-15T00:00:00.000Z"));
+                assertThat(bucket.getToAsString(), nullValue());
+                assertThat(bucket.getDocCount(), equalTo(numDocs - 2L));
+            }
+        );
     }
 
     public void testPartiallyUnmapped() throws Exception {
-        SearchResponse response = prepareSearch("idx", "idx_unmapped").addAggregation(
-            dateRange("range").field("date").addUnboundedTo(date(2, 15)).addRange(date(2, 15), date(3, 15)).addUnboundedFrom(date(3, 15))
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx", "idx_unmapped").addAggregation(
+                dateRange("range").field("date")
+                    .addUnboundedTo(date(2, 15))
+                    .addRange(date(2, 15), date(3, 15))
+                    .addUnboundedFrom(date(3, 15))
+            ),
+            response -> {
+                Range range = response.getAggregations().get("range");
+                assertThat(range, notNullValue());
+                assertThat(range.getName(), equalTo("range"));
+                List<? extends Bucket> buckets = range.getBuckets();
+                assertThat(buckets.size(), equalTo(3));
 
-        assertNoFailures(response);
+                Range.Bucket bucket = buckets.get(0);
+                assertThat(bucket, notNullValue());
+                assertThat((String) bucket.getKey(), equalTo("*-2012-02-15T00:00:00.000Z"));
+                assertThat(((ZonedDateTime) bucket.getFrom()), nullValue());
+                assertThat(((ZonedDateTime) bucket.getTo()), equalTo(date(2, 15)));
+                assertThat(bucket.getFromAsString(), nullValue());
+                assertThat(bucket.getToAsString(), equalTo("2012-02-15T00:00:00.000Z"));
+                assertThat(bucket.getDocCount(), equalTo(2L));
 
-        Range range = response.getAggregations().get("range");
-        assertThat(range, notNullValue());
-        assertThat(range.getName(), equalTo("range"));
-        List<? extends Bucket> buckets = range.getBuckets();
-        assertThat(buckets.size(), equalTo(3));
+                bucket = buckets.get(1);
+                assertThat(bucket, notNullValue());
+                assertThat((String) bucket.getKey(), equalTo("2012-02-15T00:00:00.000Z-2012-03-15T00:00:00.000Z"));
+                assertThat(((ZonedDateTime) bucket.getFrom()), equalTo(date(2, 15)));
+                assertThat(((ZonedDateTime) bucket.getTo()), equalTo(date(3, 15)));
+                assertThat(bucket.getFromAsString(), equalTo("2012-02-15T00:00:00.000Z"));
+                assertThat(bucket.getToAsString(), equalTo("2012-03-15T00:00:00.000Z"));
+                assertThat(bucket.getDocCount(), equalTo(2L));
 
-        Range.Bucket bucket = buckets.get(0);
-        assertThat(bucket, notNullValue());
-        assertThat((String) bucket.getKey(), equalTo("*-2012-02-15T00:00:00.000Z"));
-        assertThat(((ZonedDateTime) bucket.getFrom()), nullValue());
-        assertThat(((ZonedDateTime) bucket.getTo()), equalTo(date(2, 15)));
-        assertThat(bucket.getFromAsString(), nullValue());
-        assertThat(bucket.getToAsString(), equalTo("2012-02-15T00:00:00.000Z"));
-        assertThat(bucket.getDocCount(), equalTo(2L));
-
-        bucket = buckets.get(1);
-        assertThat(bucket, notNullValue());
-        assertThat((String) bucket.getKey(), equalTo("2012-02-15T00:00:00.000Z-2012-03-15T00:00:00.000Z"));
-        assertThat(((ZonedDateTime) bucket.getFrom()), equalTo(date(2, 15)));
-        assertThat(((ZonedDateTime) bucket.getTo()), equalTo(date(3, 15)));
-        assertThat(bucket.getFromAsString(), equalTo("2012-02-15T00:00:00.000Z"));
-        assertThat(bucket.getToAsString(), equalTo("2012-03-15T00:00:00.000Z"));
-        assertThat(bucket.getDocCount(), equalTo(2L));
-
-        bucket = buckets.get(2);
-        assertThat(bucket, notNullValue());
-        assertThat((String) bucket.getKey(), equalTo("2012-03-15T00:00:00.000Z-*"));
-        assertThat(((ZonedDateTime) bucket.getFrom()), equalTo(date(3, 15)));
-        assertThat(((ZonedDateTime) bucket.getTo()), nullValue());
-        assertThat(bucket.getFromAsString(), equalTo("2012-03-15T00:00:00.000Z"));
-        assertThat(bucket.getToAsString(), nullValue());
-        assertThat(bucket.getDocCount(), equalTo(numDocs - 4L));
+                bucket = buckets.get(2);
+                assertThat(bucket, notNullValue());
+                assertThat((String) bucket.getKey(), equalTo("2012-03-15T00:00:00.000Z-*"));
+                assertThat(((ZonedDateTime) bucket.getFrom()), equalTo(date(3, 15)));
+                assertThat(((ZonedDateTime) bucket.getTo()), nullValue());
+                assertThat(bucket.getFromAsString(), equalTo("2012-03-15T00:00:00.000Z"));
+                assertThat(bucket.getToAsString(), nullValue());
+                assertThat(bucket.getDocCount(), equalTo(numDocs - 4L));
+            }
+        );
     }
 
     public void testEmptyAggregation() throws Exception {
-        SearchResponse searchResponse = prepareSearch("empty_bucket_idx").setQuery(matchAllQuery())
-            .addAggregation(
-                histogram("histo").field("value")
-                    .interval(1L)
-                    .minDocCount(0)
-                    .subAggregation(dateRange("date_range").field("value").addRange("0-1", 0, 1))
-            )
-            .get();
+        assertNoFailuresAndResponse(
+            prepareSearch("empty_bucket_idx").setQuery(matchAllQuery())
+                .addAggregation(
+                    histogram("histo").field("value")
+                        .interval(1L)
+                        .minDocCount(0)
+                        .subAggregation(dateRange("date_range").field("value").addRange("0-1", 0, 1))
+                ),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(2L));
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo, Matchers.notNullValue());
+                Histogram.Bucket bucket = histo.getBuckets().get(1);
+                assertThat(bucket, Matchers.notNullValue());
 
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(2L));
-        Histogram histo = searchResponse.getAggregations().get("histo");
-        assertThat(histo, Matchers.notNullValue());
-        Histogram.Bucket bucket = histo.getBuckets().get(1);
-        assertThat(bucket, Matchers.notNullValue());
-
-        Range dateRange = bucket.getAggregations().get("date_range");
-        List<Range.Bucket> buckets = new ArrayList<>(dateRange.getBuckets());
-        assertThat(dateRange, Matchers.notNullValue());
-        assertThat(dateRange.getName(), equalTo("date_range"));
-        assertThat(buckets.size(), is(1));
-        assertThat((String) buckets.get(0).getKey(), equalTo("0-1"));
-        assertThat(((ZonedDateTime) buckets.get(0).getFrom()).toInstant().toEpochMilli(), equalTo(0L));
-        assertThat(((ZonedDateTime) buckets.get(0).getTo()).toInstant().toEpochMilli(), equalTo(1L));
-        assertThat(buckets.get(0).getDocCount(), equalTo(0L));
-        assertThat(buckets.get(0).getAggregations().asList().isEmpty(), is(true));
+                Range dateRange = bucket.getAggregations().get("date_range");
+                List<Range.Bucket> buckets = new ArrayList<>(dateRange.getBuckets());
+                assertThat(dateRange, Matchers.notNullValue());
+                assertThat(dateRange.getName(), equalTo("date_range"));
+                assertThat(buckets.size(), is(1));
+                assertThat((String) buckets.get(0).getKey(), equalTo("0-1"));
+                assertThat(((ZonedDateTime) buckets.get(0).getFrom()).toInstant().toEpochMilli(), equalTo(0L));
+                assertThat(((ZonedDateTime) buckets.get(0).getTo()).toInstant().toEpochMilli(), equalTo(1L));
+                assertThat(buckets.get(0).getDocCount(), equalTo(0L));
+                assertThat(buckets.get(0).getAggregations().asList().isEmpty(), is(true));
+            }
+        );
     }
 
     public void testNoRangesInQuery() {
@@ -621,17 +644,17 @@ public class DateRangeIT extends ESIntegTestCase {
         // Test that a request using a nondeterministic script does not get cached
         Map<String, Object> params = new HashMap<>();
         params.put("fieldname", "date");
-        SearchResponse r = prepareSearch("cache_test_idx").setSize(0)
-            .addAggregation(
-                dateRange("foo").field("date")
-                    .script(new Script(ScriptType.INLINE, "mockscript", DateScriptMocksPlugin.CURRENT_DATE, params))
-                    .addRange(
-                        ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC),
-                        ZonedDateTime.of(2013, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)
-                    )
-            )
-            .get();
-        assertNoFailures(r);
+        assertNoFailures(
+            prepareSearch("cache_test_idx").setSize(0)
+                .addAggregation(
+                    dateRange("foo").field("date")
+                        .script(new Script(ScriptType.INLINE, "mockscript", DateScriptMocksPlugin.CURRENT_DATE, params))
+                        .addRange(
+                            ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC),
+                            ZonedDateTime.of(2013, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)
+                        )
+                )
+        );
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -643,17 +666,17 @@ public class DateRangeIT extends ESIntegTestCase {
         );
 
         // Test that a request using a deterministic script gets cached
-        r = prepareSearch("cache_test_idx").setSize(0)
-            .addAggregation(
-                dateRange("foo").field("date")
-                    .script(new Script(ScriptType.INLINE, "mockscript", DateScriptMocksPlugin.DOUBLE_PLUS_ONE_MONTH, params))
-                    .addRange(
-                        ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC),
-                        ZonedDateTime.of(2013, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)
-                    )
-            )
-            .get();
-        assertNoFailures(r);
+        assertNoFailures(
+            prepareSearch("cache_test_idx").setSize(0)
+                .addAggregation(
+                    dateRange("foo").field("date")
+                        .script(new Script(ScriptType.INLINE, "mockscript", DateScriptMocksPlugin.DOUBLE_PLUS_ONE_MONTH, params))
+                        .addRange(
+                            ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC),
+                            ZonedDateTime.of(2013, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)
+                        )
+                )
+        );
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -665,16 +688,16 @@ public class DateRangeIT extends ESIntegTestCase {
         );
 
         // Ensure that non-scripted requests are cached as normal
-        r = prepareSearch("cache_test_idx").setSize(0)
-            .addAggregation(
-                dateRange("foo").field("date")
-                    .addRange(
-                        ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC),
-                        ZonedDateTime.of(2013, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)
-                    )
-            )
-            .get();
-        assertNoFailures(r);
+        assertNoFailures(
+            prepareSearch("cache_test_idx").setSize(0)
+                .addAggregation(
+                    dateRange("foo").field("date")
+                        .addRange(
+                            ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC),
+                            ZonedDateTime.of(2013, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)
+                        )
+                )
+        );
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -702,38 +725,47 @@ public class DateRangeIT extends ESIntegTestCase {
 
         // using no format should work when to/from is compatible with format in
         // mapping
-        SearchResponse searchResponse = prepareSearch(indexName).setSize(0)
-            .addAggregation(dateRange("date_range").field("date").addRange("00:16:40", "00:50:00").addRange("00:50:00", "01:06:40"))
-            .get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(3L));
-        List<Range.Bucket> buckets = checkBuckets(searchResponse.getAggregations().get("date_range"), "date_range", 2);
-        assertBucket(buckets.get(0), 2L, "00:16:40-00:50:00", 1000000L, 3000000L);
-        assertBucket(buckets.get(1), 1L, "00:50:00-01:06:40", 3000000L, 4000000L);
-
+        assertNoFailuresAndResponse(
+            prepareSearch(indexName).setSize(0)
+                .addAggregation(dateRange("date_range").field("date").addRange("00:16:40", "00:50:00").addRange("00:50:00", "01:06:40")),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(3L));
+                List<Range.Bucket> buckets = checkBuckets(response.getAggregations().get("date_range"), "date_range", 2);
+                assertBucket(buckets.get(0), 2L, "00:16:40-00:50:00", 1000000L, 3000000L);
+                assertBucket(buckets.get(1), 1L, "00:50:00-01:06:40", 3000000L, 4000000L);
+            }
+        );
         // using different format should work when to/from is compatible with
         // format in aggregation
-        searchResponse = prepareSearch(indexName).setSize(0)
-            .addAggregation(
-                dateRange("date_range").field("date").addRange("00.16.40", "00.50.00").addRange("00.50.00", "01.06.40").format("HH.mm.ss")
-            )
-            .get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(3L));
-        buckets = checkBuckets(searchResponse.getAggregations().get("date_range"), "date_range", 2);
-        assertBucket(buckets.get(0), 2L, "00.16.40-00.50.00", 1000000L, 3000000L);
-        assertBucket(buckets.get(1), 1L, "00.50.00-01.06.40", 3000000L, 4000000L);
-
+        assertNoFailuresAndResponse(
+            prepareSearch(indexName).setSize(0)
+                .addAggregation(
+                    dateRange("date_range").field("date")
+                        .addRange("00.16.40", "00.50.00")
+                        .addRange("00.50.00", "01.06.40")
+                        .format("HH.mm.ss")
+                ),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(3L));
+                List<Range.Bucket> buckets = checkBuckets(response.getAggregations().get("date_range"), "date_range", 2);
+                assertBucket(buckets.get(0), 2L, "00.16.40-00.50.00", 1000000L, 3000000L);
+                assertBucket(buckets.get(1), 1L, "00.50.00-01.06.40", 3000000L, 4000000L);
+            }
+        );
         // providing numeric input with format should work, but bucket keys are
         // different now
-        searchResponse = prepareSearch(indexName).setSize(0)
-            .addAggregation(
-                dateRange("date_range").field("date").addRange(1000000, 3000000).addRange(3000000, 4000000).format("epoch_millis")
-            )
-            .get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(3L));
-        buckets = checkBuckets(searchResponse.getAggregations().get("date_range"), "date_range", 2);
-        assertBucket(buckets.get(0), 2L, "1000000-3000000", 1000000L, 3000000L);
-        assertBucket(buckets.get(1), 1L, "3000000-4000000", 3000000L, 4000000L);
-
+        assertNoFailuresAndResponse(
+            prepareSearch(indexName).setSize(0)
+                .addAggregation(
+                    dateRange("date_range").field("date").addRange(1000000, 3000000).addRange(3000000, 4000000).format("epoch_millis")
+                ),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(3L));
+                List<Range.Bucket> buckets = checkBuckets(response.getAggregations().get("date_range"), "date_range", 2);
+                assertBucket(buckets.get(0), 2L, "1000000-3000000", 1000000L, 3000000L);
+                assertBucket(buckets.get(1), 1L, "3000000-4000000", 3000000L, 4000000L);
+            }
+        );
         // providing numeric input without format should throw an exception
         ElasticsearchException e = expectThrows(
             ElasticsearchException.class,
@@ -760,55 +792,69 @@ public class DateRangeIT extends ESIntegTestCase {
 
         // using no format should work when to/from is compatible with format in
         // mapping
-        SearchResponse searchResponse = prepareSearch(indexName).setSize(0)
-            .addAggregation(dateRange("date_range").field("date").addRange(1000, 3000).addRange(3000, 4000))
-            .get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(3L));
-        List<Bucket> buckets = checkBuckets(searchResponse.getAggregations().get("date_range"), "date_range", 2);
-        assertBucket(buckets.get(0), 2L, "1000-3000", 1000000L, 3000000L);
-        assertBucket(buckets.get(1), 1L, "3000-4000", 3000000L, 4000000L);
-
+        assertNoFailuresAndResponse(
+            prepareSearch(indexName).setSize(0)
+                .addAggregation(dateRange("date_range").field("date").addRange(1000, 3000).addRange(3000, 4000)),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(3L));
+                List<Bucket> buckets = checkBuckets(response.getAggregations().get("date_range"), "date_range", 2);
+                assertBucket(buckets.get(0), 2L, "1000-3000", 1000000L, 3000000L);
+                assertBucket(buckets.get(1), 1L, "3000-4000", 3000000L, 4000000L);
+            }
+        );
         // using no format should also work when and to/from are string values
-        searchResponse = prepareSearch(indexName).setSize(0)
-            .addAggregation(dateRange("date_range").field("date").addRange("1000", "3000").addRange("3000", "4000"))
-            .get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(3L));
-        buckets = checkBuckets(searchResponse.getAggregations().get("date_range"), "date_range", 2);
-        assertBucket(buckets.get(0), 2L, "1000-3000", 1000000L, 3000000L);
-        assertBucket(buckets.get(1), 1L, "3000-4000", 3000000L, 4000000L);
-
+        assertNoFailuresAndResponse(
+            prepareSearch(indexName).setSize(0)
+                .addAggregation(dateRange("date_range").field("date").addRange("1000", "3000").addRange("3000", "4000")),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(3L));
+                List<Range.Bucket> buckets = checkBuckets(response.getAggregations().get("date_range"), "date_range", 2);
+                assertBucket(buckets.get(0), 2L, "1000-3000", 1000000L, 3000000L);
+                assertBucket(buckets.get(1), 1L, "3000-4000", 3000000L, 4000000L);
+            }
+        );
         // also e-notation should work, fractional parts should be truncated
-        searchResponse = prepareSearch(indexName).setSize(0)
-            .addAggregation(dateRange("date_range").field("date").addRange(1.0e3, 3000.8123).addRange(3000.8123, 4.0e3))
-            .get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(3L));
-        buckets = checkBuckets(searchResponse.getAggregations().get("date_range"), "date_range", 2);
-        assertBucket(buckets.get(0), 2L, "1000-3000", 1000000L, 3000000L);
-        assertBucket(buckets.get(1), 1L, "3000-4000", 3000000L, 4000000L);
-
+        assertNoFailuresAndResponse(
+            prepareSearch(indexName).setSize(0)
+                .addAggregation(dateRange("date_range").field("date").addRange(1.0e3, 3000.8123).addRange(3000.8123, 4.0e3)),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(3L));
+                List<Range.Bucket> buckets = checkBuckets(response.getAggregations().get("date_range"), "date_range", 2);
+                assertBucket(buckets.get(0), 2L, "1000-3000", 1000000L, 3000000L);
+                assertBucket(buckets.get(1), 1L, "3000-4000", 3000000L, 4000000L);
+            }
+        );
         // using different format should work when to/from is compatible with
         // format in aggregation
-        searchResponse = prepareSearch(indexName).setSize(0)
-            .addAggregation(
-                dateRange("date_range").field("date").addRange("00.16.40", "00.50.00").addRange("00.50.00", "01.06.40").format("HH.mm.ss")
-            )
-            .get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(3L));
-        buckets = checkBuckets(searchResponse.getAggregations().get("date_range"), "date_range", 2);
-        assertBucket(buckets.get(0), 2L, "00.16.40-00.50.00", 1000000L, 3000000L);
-        assertBucket(buckets.get(1), 1L, "00.50.00-01.06.40", 3000000L, 4000000L);
-
+        assertNoFailuresAndResponse(
+            prepareSearch(indexName).setSize(0)
+                .addAggregation(
+                    dateRange("date_range").field("date")
+                        .addRange("00.16.40", "00.50.00")
+                        .addRange("00.50.00", "01.06.40")
+                        .format("HH.mm.ss")
+                ),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(3L));
+                List<Range.Bucket> buckets = checkBuckets(response.getAggregations().get("date_range"), "date_range", 2);
+                assertBucket(buckets.get(0), 2L, "00.16.40-00.50.00", 1000000L, 3000000L);
+                assertBucket(buckets.get(1), 1L, "00.50.00-01.06.40", 3000000L, 4000000L);
+            }
+        );
         // providing different numeric input with format should work, but bucket
         // keys are different now
-        searchResponse = prepareSearch(indexName).setSize(0)
-            .addAggregation(
-                dateRange("date_range").field("date").addRange(1000000, 3000000).addRange(3000000, 4000000).format("epoch_millis")
-            )
-            .get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(3L));
-        buckets = checkBuckets(searchResponse.getAggregations().get("date_range"), "date_range", 2);
-        assertBucket(buckets.get(0), 2L, "1000000-3000000", 1000000L, 3000000L);
-        assertBucket(buckets.get(1), 1L, "3000000-4000000", 3000000L, 4000000L);
+        assertNoFailuresAndResponse(
+            prepareSearch(indexName).setSize(0)
+                .addAggregation(
+                    dateRange("date_range").field("date").addRange(1000000, 3000000).addRange(3000000, 4000000).format("epoch_millis")
+                ),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(3L));
+                List<Range.Bucket> buckets = checkBuckets(response.getAggregations().get("date_range"), "date_range", 2);
+                assertBucket(buckets.get(0), 2L, "1000000-3000000", 1000000L, 3000000L);
+                assertBucket(buckets.get(1), 1L, "3000000-4000000", 3000000L, 4000000L);
+            }
+        );
     }
 
     private static List<Range.Bucket> checkBuckets(Range dateRange, String expectedAggName, long expectedBucketsSize) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsIT.java
@@ -10,7 +10,6 @@ package org.elasticsearch.search.aggregations.bucket.terms;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
@@ -59,6 +58,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.stats;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -295,132 +295,148 @@ public class StringTermsIT extends AbstractTermsTestCase {
 
     private void runTestFieldWithPartitionedFiltering(String field) throws Exception {
         // Find total number of unique terms
-        SearchResponse allResponse = prepareSearch("idx").addAggregation(
-            new TermsAggregationBuilder("terms").field(field).size(10000).collectMode(randomFrom(SubAggCollectionMode.values()))
-        ).get();
-        assertNoFailures(allResponse);
-        StringTerms terms = allResponse.getAggregations().get("terms");
-        assertThat(terms, notNullValue());
-        assertThat(terms.getName(), equalTo("terms"));
-        int expectedCardinality = terms.getBuckets().size();
+        int[] expectedCardinality = new int[1];
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                new TermsAggregationBuilder("terms").field(field).size(10000).collectMode(randomFrom(SubAggCollectionMode.values()))
+            ),
+            response -> {
+                StringTerms terms = response.getAggregations().get("terms");
+                assertThat(terms, notNullValue());
+                assertThat(terms.getName(), equalTo("terms"));
+                expectedCardinality[0] = terms.getBuckets().size();
+            }
+        );
 
         // Gather terms using partitioned aggregations
         final int numPartitions = randomIntBetween(2, 4);
         Set<String> foundTerms = new HashSet<>();
         for (int partition = 0; partition < numPartitions; partition++) {
-            SearchResponse response = prepareSearch("idx").addAggregation(
-                new TermsAggregationBuilder("terms").field(field)
-                    .includeExclude(new IncludeExclude(partition, numPartitions))
-                    .collectMode(randomFrom(SubAggCollectionMode.values()))
-            ).get();
-            assertNoFailures(response);
-            terms = response.getAggregations().get("terms");
-            assertThat(terms, notNullValue());
-            assertThat(terms.getName(), equalTo("terms"));
-            for (StringTerms.Bucket bucket : terms.getBuckets()) {
-                assertTrue(foundTerms.add(bucket.getKeyAsString()));
-            }
+            assertNoFailuresAndResponse(
+                prepareSearch("idx").addAggregation(
+                    new TermsAggregationBuilder("terms").field(field)
+                        .includeExclude(new IncludeExclude(partition, numPartitions))
+                        .collectMode(randomFrom(SubAggCollectionMode.values()))
+                ),
+                response -> {
+                    StringTerms terms = response.getAggregations().get("terms");
+                    assertThat(terms, notNullValue());
+                    assertThat(terms.getName(), equalTo("terms"));
+                    for (StringTerms.Bucket bucket : terms.getBuckets()) {
+                        assertTrue(foundTerms.add(bucket.getKeyAsString()));
+                    }
+                }
+            );
         }
-        assertEquals(expectedCardinality, foundTerms.size());
+        assertEquals(expectedCardinality[0], foundTerms.size());
     }
 
     public void testSingleValuedFieldWithValueScript() throws Exception {
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            new TermsAggregationBuilder("terms").executionHint(randomExecutionHint())
-                .field(SINGLE_VALUED_FIELD_NAME)
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-                .script(new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "'foo_' + _value", Collections.emptyMap()))
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                new TermsAggregationBuilder("terms").executionHint(randomExecutionHint())
+                    .field(SINGLE_VALUED_FIELD_NAME)
+                    .collectMode(randomFrom(SubAggCollectionMode.values()))
+                    .script(new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "'foo_' + _value", Collections.emptyMap()))
+            ),
+            response -> {
+                StringTerms terms = response.getAggregations().get("terms");
+                assertThat(terms, notNullValue());
+                assertThat(terms.getName(), equalTo("terms"));
+                assertThat(terms.getBuckets().size(), equalTo(5));
 
-        assertNoFailures(response);
-
-        StringTerms terms = response.getAggregations().get("terms");
-        assertThat(terms, notNullValue());
-        assertThat(terms.getName(), equalTo("terms"));
-        assertThat(terms.getBuckets().size(), equalTo(5));
-
-        for (int i = 0; i < 5; i++) {
-            StringTerms.Bucket bucket = terms.getBucketByKey("foo_val" + i);
-            assertThat(bucket, notNullValue());
-            assertThat(bucket.getKeyAsString(), equalTo("foo_val" + i));
-            assertThat(bucket.getDocCount(), equalTo(1L));
-        }
+                for (int i = 0; i < 5; i++) {
+                    StringTerms.Bucket bucket = terms.getBucketByKey("foo_val" + i);
+                    assertThat(bucket, notNullValue());
+                    assertThat(bucket.getKeyAsString(), equalTo("foo_val" + i));
+                    assertThat(bucket.getDocCount(), equalTo(1L));
+                }
+            }
+        );
     }
 
     public void testMultiValuedFieldWithValueScriptNotUnique() throws Exception {
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            new TermsAggregationBuilder("terms").executionHint(randomExecutionHint())
-                .field(MULTI_VALUED_FIELD_NAME)
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-                .script(new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "_value.substring(0,3)", Collections.emptyMap()))
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                new TermsAggregationBuilder("terms").executionHint(randomExecutionHint())
+                    .field(MULTI_VALUED_FIELD_NAME)
+                    .collectMode(randomFrom(SubAggCollectionMode.values()))
+                    .script(new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "_value.substring(0,3)", Collections.emptyMap()))
+            ),
+            response -> {
+                StringTerms terms = response.getAggregations().get("terms");
+                assertThat(terms, notNullValue());
+                assertThat(terms.getName(), equalTo("terms"));
+                assertThat(terms.getBuckets().size(), equalTo(1));
 
-        assertNoFailures(response);
-
-        StringTerms terms = response.getAggregations().get("terms");
-        assertThat(terms, notNullValue());
-        assertThat(terms.getName(), equalTo("terms"));
-        assertThat(terms.getBuckets().size(), equalTo(1));
-
-        StringTerms.Bucket bucket = terms.getBucketByKey("val");
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKeyAsString(), equalTo("val"));
-        assertThat(bucket.getDocCount(), equalTo(5L));
+                StringTerms.Bucket bucket = terms.getBucketByKey("val");
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKeyAsString(), equalTo("val"));
+                assertThat(bucket.getDocCount(), equalTo(5L));
+            }
+        );
     }
 
     public void testMultiValuedScript() throws Exception {
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            new TermsAggregationBuilder("terms").executionHint(randomExecutionHint())
-                .script(
-                    new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "doc['" + MULTI_VALUED_FIELD_NAME + "']", Collections.emptyMap())
-                )
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                new TermsAggregationBuilder("terms").executionHint(randomExecutionHint())
+                    .script(
+                        new Script(
+                            ScriptType.INLINE,
+                            CustomScriptPlugin.NAME,
+                            "doc['" + MULTI_VALUED_FIELD_NAME + "']",
+                            Collections.emptyMap()
+                        )
+                    )
+                    .collectMode(randomFrom(SubAggCollectionMode.values()))
+            ),
+            response -> {
+                StringTerms terms = response.getAggregations().get("terms");
+                assertThat(terms, notNullValue());
+                assertThat(terms.getName(), equalTo("terms"));
+                assertThat(terms.getBuckets().size(), equalTo(6));
 
-        assertNoFailures(response);
-
-        StringTerms terms = response.getAggregations().get("terms");
-        assertThat(terms, notNullValue());
-        assertThat(terms.getName(), equalTo("terms"));
-        assertThat(terms.getBuckets().size(), equalTo(6));
-
-        for (int i = 0; i < 6; i++) {
-            Terms.Bucket bucket = terms.getBucketByKey("val" + i);
-            assertThat(bucket, notNullValue());
-            assertThat(bucket.getKeyAsString(), equalTo("val" + i));
-            if (i == 0 || i == 5) {
-                assertThat(bucket.getDocCount(), equalTo(1L));
-            } else {
-                assertThat(bucket.getDocCount(), equalTo(2L));
+                for (int i = 0; i < 6; i++) {
+                    Terms.Bucket bucket = terms.getBucketByKey("val" + i);
+                    assertThat(bucket, notNullValue());
+                    assertThat(bucket.getKeyAsString(), equalTo("val" + i));
+                    if (i == 0 || i == 5) {
+                        assertThat(bucket.getDocCount(), equalTo(1L));
+                    } else {
+                        assertThat(bucket.getDocCount(), equalTo(2L));
+                    }
+                }
             }
-        }
+        );
     }
 
     public void testMultiValuedFieldWithValueScript() throws Exception {
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            new TermsAggregationBuilder("terms").executionHint(randomExecutionHint())
-                .field(MULTI_VALUED_FIELD_NAME)
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-                .script(new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "'foo_' + _value", Collections.emptyMap()))
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                new TermsAggregationBuilder("terms").executionHint(randomExecutionHint())
+                    .field(MULTI_VALUED_FIELD_NAME)
+                    .collectMode(randomFrom(SubAggCollectionMode.values()))
+                    .script(new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "'foo_' + _value", Collections.emptyMap()))
+            ),
+            response -> {
+                StringTerms terms = response.getAggregations().get("terms");
+                assertThat(terms, notNullValue());
+                assertThat(terms.getName(), equalTo("terms"));
+                assertThat(terms.getBuckets().size(), equalTo(6));
 
-        assertNoFailures(response);
-
-        StringTerms terms = response.getAggregations().get("terms");
-        assertThat(terms, notNullValue());
-        assertThat(terms.getName(), equalTo("terms"));
-        assertThat(terms.getBuckets().size(), equalTo(6));
-
-        for (int i = 0; i < 6; i++) {
-            StringTerms.Bucket bucket = terms.getBucketByKey("foo_val" + i);
-            assertThat(bucket, notNullValue());
-            assertThat(bucket.getKeyAsString(), equalTo("foo_val" + i));
-            if (i == 0 || i == 5) {
-                assertThat(bucket.getDocCount(), equalTo(1L));
-            } else {
-                assertThat(bucket.getDocCount(), equalTo(2L));
+                for (int i = 0; i < 6; i++) {
+                    StringTerms.Bucket bucket = terms.getBucketByKey("foo_val" + i);
+                    assertThat(bucket, notNullValue());
+                    assertThat(bucket.getKeyAsString(), equalTo("foo_val" + i));
+                    if (i == 0 || i == 5) {
+                        assertThat(bucket.getDocCount(), equalTo(1L));
+                    } else {
+                        assertThat(bucket.getDocCount(), equalTo(2L));
+                    }
+                }
             }
-        }
+        );
     }
 
     /*
@@ -443,25 +459,26 @@ public class StringTermsIT extends AbstractTermsTestCase {
             Collections.emptyMap()
         );
 
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            new TermsAggregationBuilder("terms").collectMode(randomFrom(SubAggCollectionMode.values()))
-                .executionHint(randomExecutionHint())
-                .script(script)
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                new TermsAggregationBuilder("terms").collectMode(randomFrom(SubAggCollectionMode.values()))
+                    .executionHint(randomExecutionHint())
+                    .script(script)
+            ),
+            response -> {
+                StringTerms terms = response.getAggregations().get("terms");
+                assertThat(terms, notNullValue());
+                assertThat(terms.getName(), equalTo("terms"));
+                assertThat(terms.getBuckets().size(), equalTo(5));
 
-        assertNoFailures(response);
-
-        StringTerms terms = response.getAggregations().get("terms");
-        assertThat(terms, notNullValue());
-        assertThat(terms.getName(), equalTo("terms"));
-        assertThat(terms.getBuckets().size(), equalTo(5));
-
-        for (int i = 0; i < 5; i++) {
-            StringTerms.Bucket bucket = terms.getBucketByKey("val" + i);
-            assertThat(bucket, notNullValue());
-            assertThat(bucket.getKeyAsString(), equalTo("val" + i));
-            assertThat(bucket.getDocCount(), equalTo(1L));
-        }
+                for (int i = 0; i < 5; i++) {
+                    StringTerms.Bucket bucket = terms.getBucketByKey("val" + i);
+                    assertThat(bucket, notNullValue());
+                    assertThat(bucket.getKeyAsString(), equalTo("val" + i));
+                    assertThat(bucket.getDocCount(), equalTo(1L));
+                }
+            }
+        );
     }
 
     public void testScriptSingleValueExplicitSingleValue() throws Exception {
@@ -472,108 +489,114 @@ public class StringTermsIT extends AbstractTermsTestCase {
             Collections.emptyMap()
         );
 
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            new TermsAggregationBuilder("terms").collectMode(randomFrom(SubAggCollectionMode.values()))
-                .executionHint(randomExecutionHint())
-                .script(script)
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                new TermsAggregationBuilder("terms").collectMode(randomFrom(SubAggCollectionMode.values()))
+                    .executionHint(randomExecutionHint())
+                    .script(script)
+            ),
+            response -> {
+                StringTerms terms = response.getAggregations().get("terms");
+                assertThat(terms, notNullValue());
+                assertThat(terms.getName(), equalTo("terms"));
+                assertThat(terms.getBuckets().size(), equalTo(5));
 
-        assertNoFailures(response);
-
-        StringTerms terms = response.getAggregations().get("terms");
-        assertThat(terms, notNullValue());
-        assertThat(terms.getName(), equalTo("terms"));
-        assertThat(terms.getBuckets().size(), equalTo(5));
-
-        for (int i = 0; i < 5; i++) {
-            StringTerms.Bucket bucket = terms.getBucketByKey("val" + i);
-            assertThat(bucket, notNullValue());
-            assertThat(bucket.getKeyAsString(), equalTo("val" + i));
-            assertThat(bucket.getDocCount(), equalTo(1L));
-        }
+                for (int i = 0; i < 5; i++) {
+                    StringTerms.Bucket bucket = terms.getBucketByKey("val" + i);
+                    assertThat(bucket, notNullValue());
+                    assertThat(bucket.getKeyAsString(), equalTo("val" + i));
+                    assertThat(bucket.getDocCount(), equalTo(1L));
+                }
+            }
+        );
     }
 
     public void testScriptMultiValued() throws Exception {
-        SearchResponse response = prepareSearch("idx")
+        assertNoFailuresAndResponse(
+            prepareSearch("idx")
 
-            .addAggregation(
-                new TermsAggregationBuilder("terms").collectMode(randomFrom(SubAggCollectionMode.values()))
-                    .executionHint(randomExecutionHint())
-                    .script(
-                        new Script(
-                            ScriptType.INLINE,
-                            CustomScriptPlugin.NAME,
-                            "doc['" + MULTI_VALUED_FIELD_NAME + "']",
-                            Collections.emptyMap()
+                .addAggregation(
+                    new TermsAggregationBuilder("terms").collectMode(randomFrom(SubAggCollectionMode.values()))
+                        .executionHint(randomExecutionHint())
+                        .script(
+                            new Script(
+                                ScriptType.INLINE,
+                                CustomScriptPlugin.NAME,
+                                "doc['" + MULTI_VALUED_FIELD_NAME + "']",
+                                Collections.emptyMap()
+                            )
                         )
-                    )
-            )
-            .get();
+                ),
+            response -> {
+                StringTerms terms = response.getAggregations().get("terms");
+                assertThat(terms, notNullValue());
+                assertThat(terms.getName(), equalTo("terms"));
+                assertThat(terms.getBuckets().size(), equalTo(6));
 
-        assertNoFailures(response);
-
-        StringTerms terms = response.getAggregations().get("terms");
-        assertThat(terms, notNullValue());
-        assertThat(terms.getName(), equalTo("terms"));
-        assertThat(terms.getBuckets().size(), equalTo(6));
-
-        for (int i = 0; i < 6; i++) {
-            StringTerms.Bucket bucket = terms.getBucketByKey("val" + i);
-            assertThat(bucket, notNullValue());
-            assertThat(bucket.getKeyAsString(), equalTo("val" + i));
-            if (i == 0 || i == 5) {
-                assertThat(bucket.getDocCount(), equalTo(1L));
-            } else {
-                assertThat(bucket.getDocCount(), equalTo(2L));
+                for (int i = 0; i < 6; i++) {
+                    StringTerms.Bucket bucket = terms.getBucketByKey("val" + i);
+                    assertThat(bucket, notNullValue());
+                    assertThat(bucket.getKeyAsString(), equalTo("val" + i));
+                    if (i == 0 || i == 5) {
+                        assertThat(bucket.getDocCount(), equalTo(1L));
+                    } else {
+                        assertThat(bucket.getDocCount(), equalTo(2L));
+                    }
+                }
             }
-        }
+        );
     }
 
     public void testPartiallyUnmapped() throws Exception {
-        SearchResponse response = prepareSearch("idx", "idx_unmapped").addAggregation(
-            new TermsAggregationBuilder("terms").executionHint(randomExecutionHint())
-                .field(SINGLE_VALUED_FIELD_NAME)
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx", "idx_unmapped").addAggregation(
+                new TermsAggregationBuilder("terms").executionHint(randomExecutionHint())
+                    .field(SINGLE_VALUED_FIELD_NAME)
+                    .collectMode(randomFrom(SubAggCollectionMode.values()))
+            ),
+            response -> {
+                StringTerms terms = response.getAggregations().get("terms");
+                assertThat(terms, notNullValue());
+                assertThat(terms.getName(), equalTo("terms"));
+                assertThat(terms.getBuckets().size(), equalTo(5));
 
-        assertNoFailures(response);
-
-        StringTerms terms = response.getAggregations().get("terms");
-        assertThat(terms, notNullValue());
-        assertThat(terms.getName(), equalTo("terms"));
-        assertThat(terms.getBuckets().size(), equalTo(5));
-
-        for (int i = 0; i < 5; i++) {
-            StringTerms.Bucket bucket = terms.getBucketByKey("val" + i);
-            assertThat(bucket, notNullValue());
-            assertThat(bucket.getKeyAsString(), equalTo("val" + i));
-            assertThat(bucket.getDocCount(), equalTo(1L));
-        }
+                for (int i = 0; i < 5; i++) {
+                    StringTerms.Bucket bucket = terms.getBucketByKey("val" + i);
+                    assertThat(bucket, notNullValue());
+                    assertThat(bucket.getKeyAsString(), equalTo("val" + i));
+                    assertThat(bucket.getDocCount(), equalTo(1L));
+                }
+            }
+        );
     }
 
     public void testStringTermsNestedIntoPerBucketAggregator() throws Exception {
         // no execution hint so that the logic that decides whether or not to use ordinals is executed
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            filter("filter", termQuery(MULTI_VALUED_FIELD_NAME, "val3")).subAggregation(
-                new TermsAggregationBuilder("terms").field(MULTI_VALUED_FIELD_NAME).collectMode(randomFrom(SubAggCollectionMode.values()))
-            )
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                filter("filter", termQuery(MULTI_VALUED_FIELD_NAME, "val3")).subAggregation(
+                    new TermsAggregationBuilder("terms").field(MULTI_VALUED_FIELD_NAME)
+                        .collectMode(randomFrom(SubAggCollectionMode.values()))
+                )
+            ),
+            response -> {
+                assertThat(response.getFailedShards(), equalTo(0));
 
-        assertThat(response.getFailedShards(), equalTo(0));
+                Filter filter = response.getAggregations().get("filter");
 
-        Filter filter = response.getAggregations().get("filter");
+                StringTerms terms = filter.getAggregations().get("terms");
+                assertThat(terms, notNullValue());
+                assertThat(terms.getName(), equalTo("terms"));
+                assertThat(terms.getBuckets().size(), equalTo(3));
 
-        StringTerms terms = filter.getAggregations().get("terms");
-        assertThat(terms, notNullValue());
-        assertThat(terms.getName(), equalTo("terms"));
-        assertThat(terms.getBuckets().size(), equalTo(3));
-
-        for (int i = 2; i <= 4; i++) {
-            StringTerms.Bucket bucket = terms.getBucketByKey("val" + i);
-            assertThat(bucket, notNullValue());
-            assertThat(bucket.getKeyAsString(), equalTo("val" + i));
-            assertThat(bucket.getDocCount(), equalTo(i == 3 ? 2L : 1L));
-        }
+                for (int i = 2; i <= 4; i++) {
+                    StringTerms.Bucket bucket = terms.getBucketByKey("val" + i);
+                    assertThat(bucket, notNullValue());
+                    assertThat(bucket.getKeyAsString(), equalTo("val" + i));
+                    assertThat(bucket.getDocCount(), equalTo(i == 3 ? 2L : 1L));
+                }
+            }
+        );
     }
 
     public void testSingleValuedFieldOrderedByIllegalAgg() throws Exception {
@@ -612,93 +635,95 @@ public class StringTermsIT extends AbstractTermsTestCase {
 
     public void testSingleValuedFieldOrderedBySingleBucketSubAggregationAsc() throws Exception {
         boolean asc = randomBoolean();
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            new TermsAggregationBuilder("tags").executionHint(randomExecutionHint())
-                .field("tag")
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-                .order(BucketOrder.aggregation("filter", asc))
-                .subAggregation(filter("filter", QueryBuilders.matchAllQuery()))
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                new TermsAggregationBuilder("tags").executionHint(randomExecutionHint())
+                    .field("tag")
+                    .collectMode(randomFrom(SubAggCollectionMode.values()))
+                    .order(BucketOrder.aggregation("filter", asc))
+                    .subAggregation(filter("filter", QueryBuilders.matchAllQuery()))
+            ),
+            response -> {
+                StringTerms tags = response.getAggregations().get("tags");
+                assertThat(tags, notNullValue());
+                assertThat(tags.getName(), equalTo("tags"));
+                assertThat(tags.getBuckets().size(), equalTo(2));
 
-        assertNoFailures(response);
+                Iterator<StringTerms.Bucket> iters = tags.getBuckets().iterator();
 
-        StringTerms tags = response.getAggregations().get("tags");
-        assertThat(tags, notNullValue());
-        assertThat(tags.getName(), equalTo("tags"));
-        assertThat(tags.getBuckets().size(), equalTo(2));
+                Terms.Bucket tag = iters.next();
+                assertThat(tag, notNullValue());
+                assertThat(tag.getKeyAsString(), equalTo(asc ? "less" : "more"));
+                assertThat(tag.getDocCount(), equalTo(asc ? 2L : 3L));
+                Filter filter = tag.getAggregations().get("filter");
+                assertThat(filter, notNullValue());
+                assertThat(filter.getDocCount(), equalTo(asc ? 2L : 3L));
 
-        Iterator<StringTerms.Bucket> iters = tags.getBuckets().iterator();
-
-        Terms.Bucket tag = iters.next();
-        assertThat(tag, notNullValue());
-        assertThat(tag.getKeyAsString(), equalTo(asc ? "less" : "more"));
-        assertThat(tag.getDocCount(), equalTo(asc ? 2L : 3L));
-        Filter filter = tag.getAggregations().get("filter");
-        assertThat(filter, notNullValue());
-        assertThat(filter.getDocCount(), equalTo(asc ? 2L : 3L));
-
-        tag = iters.next();
-        assertThat(tag, notNullValue());
-        assertThat(tag.getKeyAsString(), equalTo(asc ? "more" : "less"));
-        assertThat(tag.getDocCount(), equalTo(asc ? 3L : 2L));
-        filter = tag.getAggregations().get("filter");
-        assertThat(filter, notNullValue());
-        assertThat(filter.getDocCount(), equalTo(asc ? 3L : 2L));
+                tag = iters.next();
+                assertThat(tag, notNullValue());
+                assertThat(tag.getKeyAsString(), equalTo(asc ? "more" : "less"));
+                assertThat(tag.getDocCount(), equalTo(asc ? 3L : 2L));
+                filter = tag.getAggregations().get("filter");
+                assertThat(filter, notNullValue());
+                assertThat(filter.getDocCount(), equalTo(asc ? 3L : 2L));
+            }
+        );
     }
 
     public void testSingleValuedFieldOrderedBySubAggregationAscMultiHierarchyLevels() throws Exception {
         boolean asc = randomBoolean();
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            new TermsAggregationBuilder("tags").executionHint(randomExecutionHint())
-                .field("tag")
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-                .order(BucketOrder.aggregation("filter1>filter2>stats.max", asc))
-                .subAggregation(
-                    filter("filter1", QueryBuilders.matchAllQuery()).subAggregation(
-                        filter("filter2", QueryBuilders.matchAllQuery()).subAggregation(stats("stats").field("i"))
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                new TermsAggregationBuilder("tags").executionHint(randomExecutionHint())
+                    .field("tag")
+                    .collectMode(randomFrom(SubAggCollectionMode.values()))
+                    .order(BucketOrder.aggregation("filter1>filter2>stats.max", asc))
+                    .subAggregation(
+                        filter("filter1", QueryBuilders.matchAllQuery()).subAggregation(
+                            filter("filter2", QueryBuilders.matchAllQuery()).subAggregation(stats("stats").field("i"))
+                        )
                     )
-                )
-        ).get();
+            ),
+            response -> {
+                StringTerms tags = response.getAggregations().get("tags");
+                assertThat(tags, notNullValue());
+                assertThat(tags.getName(), equalTo("tags"));
+                assertThat(tags.getBuckets().size(), equalTo(2));
 
-        assertNoFailures(response);
+                Iterator<StringTerms.Bucket> iters = tags.getBuckets().iterator();
 
-        StringTerms tags = response.getAggregations().get("tags");
-        assertThat(tags, notNullValue());
-        assertThat(tags.getName(), equalTo("tags"));
-        assertThat(tags.getBuckets().size(), equalTo(2));
+                // the max for "more" is 2
+                // the max for "less" is 4
 
-        Iterator<StringTerms.Bucket> iters = tags.getBuckets().iterator();
+                StringTerms.Bucket tag = iters.next();
+                assertThat(tag, notNullValue());
+                assertThat(tag.getKeyAsString(), equalTo(asc ? "more" : "less"));
+                assertThat(tag.getDocCount(), equalTo(asc ? 3L : 2L));
+                Filter filter1 = tag.getAggregations().get("filter1");
+                assertThat(filter1, notNullValue());
+                assertThat(filter1.getDocCount(), equalTo(asc ? 3L : 2L));
+                Filter filter2 = filter1.getAggregations().get("filter2");
+                assertThat(filter2, notNullValue());
+                assertThat(filter2.getDocCount(), equalTo(asc ? 3L : 2L));
+                Stats stats = filter2.getAggregations().get("stats");
+                assertThat(stats, notNullValue());
+                assertThat(stats.getMax(), equalTo(asc ? 2.0 : 4.0));
 
-        // the max for "more" is 2
-        // the max for "less" is 4
-
-        StringTerms.Bucket tag = iters.next();
-        assertThat(tag, notNullValue());
-        assertThat(tag.getKeyAsString(), equalTo(asc ? "more" : "less"));
-        assertThat(tag.getDocCount(), equalTo(asc ? 3L : 2L));
-        Filter filter1 = tag.getAggregations().get("filter1");
-        assertThat(filter1, notNullValue());
-        assertThat(filter1.getDocCount(), equalTo(asc ? 3L : 2L));
-        Filter filter2 = filter1.getAggregations().get("filter2");
-        assertThat(filter2, notNullValue());
-        assertThat(filter2.getDocCount(), equalTo(asc ? 3L : 2L));
-        Stats stats = filter2.getAggregations().get("stats");
-        assertThat(stats, notNullValue());
-        assertThat(stats.getMax(), equalTo(asc ? 2.0 : 4.0));
-
-        tag = iters.next();
-        assertThat(tag, notNullValue());
-        assertThat(tag.getKeyAsString(), equalTo(asc ? "less" : "more"));
-        assertThat(tag.getDocCount(), equalTo(asc ? 2L : 3L));
-        filter1 = tag.getAggregations().get("filter1");
-        assertThat(filter1, notNullValue());
-        assertThat(filter1.getDocCount(), equalTo(asc ? 2L : 3L));
-        filter2 = filter1.getAggregations().get("filter2");
-        assertThat(filter2, notNullValue());
-        assertThat(filter2.getDocCount(), equalTo(asc ? 2L : 3L));
-        stats = filter2.getAggregations().get("stats");
-        assertThat(stats, notNullValue());
-        assertThat(stats.getMax(), equalTo(asc ? 4.0 : 2.0));
+                tag = iters.next();
+                assertThat(tag, notNullValue());
+                assertThat(tag.getKeyAsString(), equalTo(asc ? "less" : "more"));
+                assertThat(tag.getDocCount(), equalTo(asc ? 2L : 3L));
+                filter1 = tag.getAggregations().get("filter1");
+                assertThat(filter1, notNullValue());
+                assertThat(filter1.getDocCount(), equalTo(asc ? 2L : 3L));
+                filter2 = filter1.getAggregations().get("filter2");
+                assertThat(filter2, notNullValue());
+                assertThat(filter2.getDocCount(), equalTo(asc ? 2L : 3L));
+                stats = filter2.getAggregations().get("stats");
+                assertThat(stats, notNullValue());
+                assertThat(stats.getMax(), equalTo(asc ? 4.0 : 2.0));
+            }
+        );
     }
 
     public void testSingleValuedFieldOrderedBySubAggregationAscMultiHierarchyLevelsSpecialChars() throws Exception {
@@ -709,57 +734,58 @@ public class StringTermsIT extends AbstractTermsTestCase {
         statsNameBuilder.append(randomAlphaOfLengthBetween(3, 10).replace("[", "").replace("]", "").replace(">", ""));
         String statsName = statsNameBuilder.toString();
         boolean asc = randomBoolean();
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            new TermsAggregationBuilder("tags").executionHint(randomExecutionHint())
-                .field("tag")
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-                .order(BucketOrder.aggregation("filter1>" + filter2Name + ">" + statsName + ".max", asc))
-                .subAggregation(
-                    filter("filter1", QueryBuilders.matchAllQuery()).subAggregation(
-                        filter(filter2Name, QueryBuilders.matchAllQuery()).subAggregation(stats(statsName).field("i"))
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                new TermsAggregationBuilder("tags").executionHint(randomExecutionHint())
+                    .field("tag")
+                    .collectMode(randomFrom(SubAggCollectionMode.values()))
+                    .order(BucketOrder.aggregation("filter1>" + filter2Name + ">" + statsName + ".max", asc))
+                    .subAggregation(
+                        filter("filter1", QueryBuilders.matchAllQuery()).subAggregation(
+                            filter(filter2Name, QueryBuilders.matchAllQuery()).subAggregation(stats(statsName).field("i"))
+                        )
                     )
-                )
-        ).get();
+            ),
+            response -> {
+                StringTerms tags = response.getAggregations().get("tags");
+                assertThat(tags, notNullValue());
+                assertThat(tags.getName(), equalTo("tags"));
+                assertThat(tags.getBuckets().size(), equalTo(2));
 
-        assertNoFailures(response);
+                Iterator<StringTerms.Bucket> iters = tags.getBuckets().iterator();
 
-        StringTerms tags = response.getAggregations().get("tags");
-        assertThat(tags, notNullValue());
-        assertThat(tags.getName(), equalTo("tags"));
-        assertThat(tags.getBuckets().size(), equalTo(2));
+                // the max for "more" is 2
+                // the max for "less" is 4
 
-        Iterator<StringTerms.Bucket> iters = tags.getBuckets().iterator();
+                StringTerms.Bucket tag = iters.next();
+                assertThat(tag, notNullValue());
+                assertThat(tag.getKeyAsString(), equalTo(asc ? "more" : "less"));
+                assertThat(tag.getDocCount(), equalTo(asc ? 3L : 2L));
+                Filter filter1 = tag.getAggregations().get("filter1");
+                assertThat(filter1, notNullValue());
+                assertThat(filter1.getDocCount(), equalTo(asc ? 3L : 2L));
+                Filter filter2 = filter1.getAggregations().get(filter2Name);
+                assertThat(filter2, notNullValue());
+                assertThat(filter2.getDocCount(), equalTo(asc ? 3L : 2L));
+                Stats stats = filter2.getAggregations().get(statsName);
+                assertThat(stats, notNullValue());
+                assertThat(stats.getMax(), equalTo(asc ? 2.0 : 4.0));
 
-        // the max for "more" is 2
-        // the max for "less" is 4
-
-        StringTerms.Bucket tag = iters.next();
-        assertThat(tag, notNullValue());
-        assertThat(tag.getKeyAsString(), equalTo(asc ? "more" : "less"));
-        assertThat(tag.getDocCount(), equalTo(asc ? 3L : 2L));
-        Filter filter1 = tag.getAggregations().get("filter1");
-        assertThat(filter1, notNullValue());
-        assertThat(filter1.getDocCount(), equalTo(asc ? 3L : 2L));
-        Filter filter2 = filter1.getAggregations().get(filter2Name);
-        assertThat(filter2, notNullValue());
-        assertThat(filter2.getDocCount(), equalTo(asc ? 3L : 2L));
-        Stats stats = filter2.getAggregations().get(statsName);
-        assertThat(stats, notNullValue());
-        assertThat(stats.getMax(), equalTo(asc ? 2.0 : 4.0));
-
-        tag = iters.next();
-        assertThat(tag, notNullValue());
-        assertThat(tag.getKeyAsString(), equalTo(asc ? "less" : "more"));
-        assertThat(tag.getDocCount(), equalTo(asc ? 2L : 3L));
-        filter1 = tag.getAggregations().get("filter1");
-        assertThat(filter1, notNullValue());
-        assertThat(filter1.getDocCount(), equalTo(asc ? 2L : 3L));
-        filter2 = filter1.getAggregations().get(filter2Name);
-        assertThat(filter2, notNullValue());
-        assertThat(filter2.getDocCount(), equalTo(asc ? 2L : 3L));
-        stats = filter2.getAggregations().get(statsName);
-        assertThat(stats, notNullValue());
-        assertThat(stats.getMax(), equalTo(asc ? 4.0 : 2.0));
+                tag = iters.next();
+                assertThat(tag, notNullValue());
+                assertThat(tag.getKeyAsString(), equalTo(asc ? "less" : "more"));
+                assertThat(tag.getDocCount(), equalTo(asc ? 2L : 3L));
+                filter1 = tag.getAggregations().get("filter1");
+                assertThat(filter1, notNullValue());
+                assertThat(filter1.getDocCount(), equalTo(asc ? 2L : 3L));
+                filter2 = filter1.getAggregations().get(filter2Name);
+                assertThat(filter2, notNullValue());
+                assertThat(filter2.getDocCount(), equalTo(asc ? 2L : 3L));
+                stats = filter2.getAggregations().get(statsName);
+                assertThat(stats, notNullValue());
+                assertThat(stats.getMax(), equalTo(asc ? 4.0 : 2.0));
+            }
+        );
     }
 
     public void testSingleValuedFieldOrderedBySubAggregationAscMultiHierarchyLevelsSpecialCharsNoDotNotation() throws Exception {
@@ -770,57 +796,58 @@ public class StringTermsIT extends AbstractTermsTestCase {
         statsNameBuilder.append(randomAlphaOfLengthBetween(3, 10).replace("[", "").replace("]", "").replace(">", ""));
         String statsName = statsNameBuilder.toString();
         boolean asc = randomBoolean();
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            new TermsAggregationBuilder("tags").executionHint(randomExecutionHint())
-                .field("tag")
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-                .order(BucketOrder.aggregation("filter1>" + filter2Name + ">" + statsName + "[max]", asc))
-                .subAggregation(
-                    filter("filter1", QueryBuilders.matchAllQuery()).subAggregation(
-                        filter(filter2Name, QueryBuilders.matchAllQuery()).subAggregation(stats(statsName).field("i"))
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                new TermsAggregationBuilder("tags").executionHint(randomExecutionHint())
+                    .field("tag")
+                    .collectMode(randomFrom(SubAggCollectionMode.values()))
+                    .order(BucketOrder.aggregation("filter1>" + filter2Name + ">" + statsName + "[max]", asc))
+                    .subAggregation(
+                        filter("filter1", QueryBuilders.matchAllQuery()).subAggregation(
+                            filter(filter2Name, QueryBuilders.matchAllQuery()).subAggregation(stats(statsName).field("i"))
+                        )
                     )
-                )
-        ).get();
+            ),
+            response -> {
+                StringTerms tags = response.getAggregations().get("tags");
+                assertThat(tags, notNullValue());
+                assertThat(tags.getName(), equalTo("tags"));
+                assertThat(tags.getBuckets().size(), equalTo(2));
 
-        assertNoFailures(response);
+                Iterator<StringTerms.Bucket> iters = tags.getBuckets().iterator();
 
-        StringTerms tags = response.getAggregations().get("tags");
-        assertThat(tags, notNullValue());
-        assertThat(tags.getName(), equalTo("tags"));
-        assertThat(tags.getBuckets().size(), equalTo(2));
+                // the max for "more" is 2
+                // the max for "less" is 4
 
-        Iterator<StringTerms.Bucket> iters = tags.getBuckets().iterator();
+                StringTerms.Bucket tag = iters.next();
+                assertThat(tag, notNullValue());
+                assertThat(tag.getKeyAsString(), equalTo(asc ? "more" : "less"));
+                assertThat(tag.getDocCount(), equalTo(asc ? 3L : 2L));
+                Filter filter1 = tag.getAggregations().get("filter1");
+                assertThat(filter1, notNullValue());
+                assertThat(filter1.getDocCount(), equalTo(asc ? 3L : 2L));
+                Filter filter2 = filter1.getAggregations().get(filter2Name);
+                assertThat(filter2, notNullValue());
+                assertThat(filter2.getDocCount(), equalTo(asc ? 3L : 2L));
+                Stats stats = filter2.getAggregations().get(statsName);
+                assertThat(stats, notNullValue());
+                assertThat(stats.getMax(), equalTo(asc ? 2.0 : 4.0));
 
-        // the max for "more" is 2
-        // the max for "less" is 4
-
-        StringTerms.Bucket tag = iters.next();
-        assertThat(tag, notNullValue());
-        assertThat(tag.getKeyAsString(), equalTo(asc ? "more" : "less"));
-        assertThat(tag.getDocCount(), equalTo(asc ? 3L : 2L));
-        Filter filter1 = tag.getAggregations().get("filter1");
-        assertThat(filter1, notNullValue());
-        assertThat(filter1.getDocCount(), equalTo(asc ? 3L : 2L));
-        Filter filter2 = filter1.getAggregations().get(filter2Name);
-        assertThat(filter2, notNullValue());
-        assertThat(filter2.getDocCount(), equalTo(asc ? 3L : 2L));
-        Stats stats = filter2.getAggregations().get(statsName);
-        assertThat(stats, notNullValue());
-        assertThat(stats.getMax(), equalTo(asc ? 2.0 : 4.0));
-
-        tag = iters.next();
-        assertThat(tag, notNullValue());
-        assertThat(tag.getKeyAsString(), equalTo(asc ? "less" : "more"));
-        assertThat(tag.getDocCount(), equalTo(asc ? 2L : 3L));
-        filter1 = tag.getAggregations().get("filter1");
-        assertThat(filter1, notNullValue());
-        assertThat(filter1.getDocCount(), equalTo(asc ? 2L : 3L));
-        filter2 = filter1.getAggregations().get(filter2Name);
-        assertThat(filter2, notNullValue());
-        assertThat(filter2.getDocCount(), equalTo(asc ? 2L : 3L));
-        stats = filter2.getAggregations().get(statsName);
-        assertThat(stats, notNullValue());
-        assertThat(stats.getMax(), equalTo(asc ? 4.0 : 2.0));
+                tag = iters.next();
+                assertThat(tag, notNullValue());
+                assertThat(tag.getKeyAsString(), equalTo(asc ? "less" : "more"));
+                assertThat(tag.getDocCount(), equalTo(asc ? 2L : 3L));
+                filter1 = tag.getAggregations().get("filter1");
+                assertThat(filter1, notNullValue());
+                assertThat(filter1.getDocCount(), equalTo(asc ? 2L : 3L));
+                filter2 = filter1.getAggregations().get(filter2Name);
+                assertThat(filter2, notNullValue());
+                assertThat(filter2.getDocCount(), equalTo(asc ? 2L : 3L));
+                stats = filter2.getAggregations().get(statsName);
+                assertThat(stats, notNullValue());
+                assertThat(stats.getMax(), equalTo(asc ? 4.0 : 2.0));
+            }
+        );
     }
 
     public void testSingleValuedFieldOrderedByMissingSubAggregation() throws Exception {
@@ -868,7 +895,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
     public void testSingleValuedFieldOrderedByMultiValuedSubAggregationWithUnknownMetric() throws Exception {
         for (String index : Arrays.asList("idx", "idx_unmapped")) {
             try {
-                SearchResponse response = prepareSearch(index).addAggregation(
+                prepareSearch(index).addAggregation(
                     new TermsAggregationBuilder("terms").executionHint(randomExecutionHint())
                         .field(SINGLE_VALUED_FIELD_NAME)
                         .collectMode(randomFrom(SubAggCollectionMode.values()))
@@ -877,9 +904,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
                 ).get();
                 fail(
                     "Expected search to fail when trying to sort terms aggregation by multi-valued sug-aggregation "
-                        + "with an unknown specified metric to order by. response had "
-                        + response.getFailedShards()
-                        + " failed shards."
+                        + "with an unknown specified metric to order by"
                 );
 
             } catch (ElasticsearchException e) {
@@ -912,139 +937,140 @@ public class StringTermsIT extends AbstractTermsTestCase {
 
     public void testSingleValuedFieldOrderedByMultiValueSubAggregationAsc() throws Exception {
         boolean asc = true;
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            new TermsAggregationBuilder("terms").executionHint(randomExecutionHint())
-                .field(SINGLE_VALUED_FIELD_NAME)
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-                .order(BucketOrder.aggregation("stats.avg", asc))
-                .subAggregation(stats("stats").field("i"))
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                new TermsAggregationBuilder("terms").executionHint(randomExecutionHint())
+                    .field(SINGLE_VALUED_FIELD_NAME)
+                    .collectMode(randomFrom(SubAggCollectionMode.values()))
+                    .order(BucketOrder.aggregation("stats.avg", asc))
+                    .subAggregation(stats("stats").field("i"))
+            ),
+            response -> {
+                StringTerms terms = response.getAggregations().get("terms");
+                assertThat(terms, notNullValue());
+                assertThat(terms.getName(), equalTo("terms"));
+                assertThat(terms.getBuckets().size(), equalTo(5));
 
-        assertNoFailures(response);
+                int i = 0;
+                for (StringTerms.Bucket bucket : terms.getBuckets()) {
+                    assertThat(bucket, notNullValue());
+                    assertThat(bucket.getKeyAsString(), equalTo("val" + i));
+                    assertThat(bucket.getDocCount(), equalTo(1L));
 
-        StringTerms terms = response.getAggregations().get("terms");
-        assertThat(terms, notNullValue());
-        assertThat(terms.getName(), equalTo("terms"));
-        assertThat(terms.getBuckets().size(), equalTo(5));
-
-        int i = 0;
-        for (StringTerms.Bucket bucket : terms.getBuckets()) {
-            assertThat(bucket, notNullValue());
-            assertThat(bucket.getKeyAsString(), equalTo("val" + i));
-            assertThat(bucket.getDocCount(), equalTo(1L));
-
-            Stats stats = bucket.getAggregations().get("stats");
-            assertThat(stats, notNullValue());
-            assertThat(stats.getMax(), equalTo((double) i));
-            i++;
-        }
+                    Stats stats = bucket.getAggregations().get("stats");
+                    assertThat(stats, notNullValue());
+                    assertThat(stats.getMax(), equalTo((double) i));
+                    i++;
+                }
+            }
+        );
     }
 
     public void testSingleValuedFieldOrderedByMultiValueSubAggregationDesc() throws Exception {
         boolean asc = false;
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            new TermsAggregationBuilder("terms").executionHint(randomExecutionHint())
-                .field(SINGLE_VALUED_FIELD_NAME)
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-                .order(BucketOrder.aggregation("stats.avg", asc))
-                .subAggregation(stats("stats").field("i"))
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                new TermsAggregationBuilder("terms").executionHint(randomExecutionHint())
+                    .field(SINGLE_VALUED_FIELD_NAME)
+                    .collectMode(randomFrom(SubAggCollectionMode.values()))
+                    .order(BucketOrder.aggregation("stats.avg", asc))
+                    .subAggregation(stats("stats").field("i"))
+            ),
+            response -> {
+                StringTerms terms = response.getAggregations().get("terms");
+                assertThat(terms, notNullValue());
+                assertThat(terms.getName(), equalTo("terms"));
+                assertThat(terms.getBuckets().size(), equalTo(5));
 
-        assertNoFailures(response);
+                int i = 4;
+                for (StringTerms.Bucket bucket : terms.getBuckets()) {
+                    assertThat(bucket, notNullValue());
+                    assertThat(bucket.getKeyAsString(), equalTo("val" + i));
+                    assertThat(bucket.getDocCount(), equalTo(1L));
 
-        StringTerms terms = response.getAggregations().get("terms");
-        assertThat(terms, notNullValue());
-        assertThat(terms.getName(), equalTo("terms"));
-        assertThat(terms.getBuckets().size(), equalTo(5));
-
-        int i = 4;
-        for (StringTerms.Bucket bucket : terms.getBuckets()) {
-            assertThat(bucket, notNullValue());
-            assertThat(bucket.getKeyAsString(), equalTo("val" + i));
-            assertThat(bucket.getDocCount(), equalTo(1L));
-
-            Stats stats = bucket.getAggregations().get("stats");
-            assertThat(stats, notNullValue());
-            assertThat(stats.getMax(), equalTo((double) i));
-            i--;
-        }
-
+                    Stats stats = bucket.getAggregations().get("stats");
+                    assertThat(stats, notNullValue());
+                    assertThat(stats.getMax(), equalTo((double) i));
+                    i--;
+                }
+            }
+        );
     }
 
     public void testSingleValuedFieldOrderedByMultiValueExtendedStatsAsc() throws Exception {
         boolean asc = true;
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            new TermsAggregationBuilder("terms").executionHint(randomExecutionHint())
-                .field(SINGLE_VALUED_FIELD_NAME)
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-                .order(BucketOrder.aggregation("stats.sum_of_squares", asc))
-                .subAggregation(extendedStats("stats").field("i"))
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                new TermsAggregationBuilder("terms").executionHint(randomExecutionHint())
+                    .field(SINGLE_VALUED_FIELD_NAME)
+                    .collectMode(randomFrom(SubAggCollectionMode.values()))
+                    .order(BucketOrder.aggregation("stats.sum_of_squares", asc))
+                    .subAggregation(extendedStats("stats").field("i"))
+            ),
+            response -> {
+                StringTerms terms = response.getAggregations().get("terms");
+                assertThat(terms, notNullValue());
+                assertThat(terms.getName(), equalTo("terms"));
+                assertThat(terms.getBuckets().size(), equalTo(5));
 
-        assertNoFailures(response);
+                int i = 0;
+                for (StringTerms.Bucket bucket : terms.getBuckets()) {
+                    assertThat(bucket, notNullValue());
+                    assertThat(bucket.getKeyAsString(), equalTo("val" + i));
+                    assertThat(bucket.getDocCount(), equalTo(1L));
 
-        StringTerms terms = response.getAggregations().get("terms");
-        assertThat(terms, notNullValue());
-        assertThat(terms.getName(), equalTo("terms"));
-        assertThat(terms.getBuckets().size(), equalTo(5));
-
-        int i = 0;
-        for (StringTerms.Bucket bucket : terms.getBuckets()) {
-            assertThat(bucket, notNullValue());
-            assertThat(bucket.getKeyAsString(), equalTo("val" + i));
-            assertThat(bucket.getDocCount(), equalTo(1L));
-
-            ExtendedStats stats = bucket.getAggregations().get("stats");
-            assertThat(stats, notNullValue());
-            assertThat(stats.getMax(), equalTo((double) i));
-            i++;
-        }
-
+                    ExtendedStats stats = bucket.getAggregations().get("stats");
+                    assertThat(stats, notNullValue());
+                    assertThat(stats.getMax(), equalTo((double) i));
+                    i++;
+                }
+            }
+        );
     }
 
     public void testSingleValuedFieldOrderedByStatsAggAscWithTermsSubAgg() throws Exception {
         boolean asc = true;
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            new TermsAggregationBuilder("terms").executionHint(randomExecutionHint())
-                .field(SINGLE_VALUED_FIELD_NAME)
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-                .order(BucketOrder.aggregation("stats.sum_of_squares", asc))
-                .subAggregation(extendedStats("stats").field("i"))
-                .subAggregation(
-                    new TermsAggregationBuilder("subTerms").field("s_values").collectMode(randomFrom(SubAggCollectionMode.values()))
-                )
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                new TermsAggregationBuilder("terms").executionHint(randomExecutionHint())
+                    .field(SINGLE_VALUED_FIELD_NAME)
+                    .collectMode(randomFrom(SubAggCollectionMode.values()))
+                    .order(BucketOrder.aggregation("stats.sum_of_squares", asc))
+                    .subAggregation(extendedStats("stats").field("i"))
+                    .subAggregation(
+                        new TermsAggregationBuilder("subTerms").field("s_values").collectMode(randomFrom(SubAggCollectionMode.values()))
+                    )
+            ),
+            response -> {
+                StringTerms terms = response.getAggregations().get("terms");
+                assertThat(terms, notNullValue());
+                assertThat(terms.getName(), equalTo("terms"));
+                assertThat(terms.getBuckets().size(), equalTo(5));
 
-        assertNoFailures(response);
+                int i = 0;
+                for (StringTerms.Bucket bucket : terms.getBuckets()) {
+                    assertThat(bucket, notNullValue());
+                    assertThat(bucket.getKeyAsString(), equalTo("val" + i));
+                    assertThat(bucket.getDocCount(), equalTo(1L));
 
-        StringTerms terms = response.getAggregations().get("terms");
-        assertThat(terms, notNullValue());
-        assertThat(terms.getName(), equalTo("terms"));
-        assertThat(terms.getBuckets().size(), equalTo(5));
+                    ExtendedStats stats = bucket.getAggregations().get("stats");
+                    assertThat(stats, notNullValue());
+                    assertThat(stats.getMax(), equalTo((double) i));
 
-        int i = 0;
-        for (StringTerms.Bucket bucket : terms.getBuckets()) {
-            assertThat(bucket, notNullValue());
-            assertThat(bucket.getKeyAsString(), equalTo("val" + i));
-            assertThat(bucket.getDocCount(), equalTo(1L));
-
-            ExtendedStats stats = bucket.getAggregations().get("stats");
-            assertThat(stats, notNullValue());
-            assertThat(stats.getMax(), equalTo((double) i));
-
-            StringTerms subTermsAgg = bucket.getAggregations().get("subTerms");
-            assertThat(subTermsAgg, notNullValue());
-            assertThat(subTermsAgg.getBuckets().size(), equalTo(2));
-            int j = i;
-            for (StringTerms.Bucket subBucket : subTermsAgg.getBuckets()) {
-                assertThat(subBucket, notNullValue());
-                assertThat(subBucket.getKeyAsString(), equalTo("val" + j));
-                assertThat(subBucket.getDocCount(), equalTo(1L));
-                j++;
+                    StringTerms subTermsAgg = bucket.getAggregations().get("subTerms");
+                    assertThat(subTermsAgg, notNullValue());
+                    assertThat(subTermsAgg.getBuckets().size(), equalTo(2));
+                    int j = i;
+                    for (StringTerms.Bucket subBucket : subTermsAgg.getBuckets()) {
+                        assertThat(subBucket, notNullValue());
+                        assertThat(subBucket.getKeyAsString(), equalTo("val" + j));
+                        assertThat(subBucket.getDocCount(), equalTo(1L));
+                        j++;
+                    }
+                    i++;
+                }
             }
-            i++;
-        }
-
+        );
     }
 
     public void testSingleValuedFieldOrderedBySingleValueSubAggregationAscAndTermsDesc() throws Exception {
@@ -1088,57 +1114,60 @@ public class StringTermsIT extends AbstractTermsTestCase {
     }
 
     private void assertMultiSortResponse(String[] expectedKeys, BucketOrder... order) {
-        SearchResponse response = prepareSearch("sort_idx").addAggregation(
-            new TermsAggregationBuilder("terms").executionHint(randomExecutionHint())
-                .field(SINGLE_VALUED_FIELD_NAME)
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-                .order(BucketOrder.compound(order))
-                .subAggregation(avg("avg_l").field("l"))
-                .subAggregation(sum("sum_d").field("d"))
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("sort_idx").addAggregation(
+                new TermsAggregationBuilder("terms").executionHint(randomExecutionHint())
+                    .field(SINGLE_VALUED_FIELD_NAME)
+                    .collectMode(randomFrom(SubAggCollectionMode.values()))
+                    .order(BucketOrder.compound(order))
+                    .subAggregation(avg("avg_l").field("l"))
+                    .subAggregation(sum("sum_d").field("d"))
+            ),
+            response -> {
+                StringTerms terms = response.getAggregations().get("terms");
+                assertThat(terms, notNullValue());
+                assertThat(terms.getName(), equalTo("terms"));
+                assertThat(terms.getBuckets().size(), equalTo(expectedKeys.length));
 
-        assertNoFailures(response);
-
-        StringTerms terms = response.getAggregations().get("terms");
-        assertThat(terms, notNullValue());
-        assertThat(terms.getName(), equalTo("terms"));
-        assertThat(terms.getBuckets().size(), equalTo(expectedKeys.length));
-
-        int i = 0;
-        for (StringTerms.Bucket bucket : terms.getBuckets()) {
-            assertThat(bucket, notNullValue());
-            assertThat(bucket.getKeyAsString(), equalTo(expectedKeys[i]));
-            assertThat(bucket.getDocCount(), equalTo(expectedMultiSortBuckets.get(expectedKeys[i]).get("_count")));
-            Avg avg = bucket.getAggregations().get("avg_l");
-            assertThat(avg, notNullValue());
-            assertThat(avg.getValue(), equalTo(expectedMultiSortBuckets.get(expectedKeys[i]).get("avg_l")));
-            Sum sum = bucket.getAggregations().get("sum_d");
-            assertThat(sum, notNullValue());
-            assertThat(sum.value(), equalTo(expectedMultiSortBuckets.get(expectedKeys[i]).get("sum_d")));
-            i++;
-        }
+                int i = 0;
+                for (StringTerms.Bucket bucket : terms.getBuckets()) {
+                    assertThat(bucket, notNullValue());
+                    assertThat(bucket.getKeyAsString(), equalTo(expectedKeys[i]));
+                    assertThat(bucket.getDocCount(), equalTo(expectedMultiSortBuckets.get(expectedKeys[i]).get("_count")));
+                    Avg avg = bucket.getAggregations().get("avg_l");
+                    assertThat(avg, notNullValue());
+                    assertThat(avg.getValue(), equalTo(expectedMultiSortBuckets.get(expectedKeys[i]).get("avg_l")));
+                    Sum sum = bucket.getAggregations().get("sum_d");
+                    assertThat(sum, notNullValue());
+                    assertThat(sum.value(), equalTo(expectedMultiSortBuckets.get(expectedKeys[i]).get("sum_d")));
+                    i++;
+                }
+            }
+        );
     }
 
     public void testIndexMetaField() throws Exception {
-        SearchResponse response = prepareSearch("idx", "empty_bucket_idx").addAggregation(
-            new TermsAggregationBuilder("terms").collectMode(randomFrom(SubAggCollectionMode.values()))
-                .executionHint(randomExecutionHint())
-                .field(IndexFieldMapper.NAME)
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx", "empty_bucket_idx").addAggregation(
+                new TermsAggregationBuilder("terms").collectMode(randomFrom(SubAggCollectionMode.values()))
+                    .executionHint(randomExecutionHint())
+                    .field(IndexFieldMapper.NAME)
+            ),
+            response -> {
+                StringTerms terms = response.getAggregations().get("terms");
+                assertThat(terms, notNullValue());
+                assertThat(terms.getName(), equalTo("terms"));
+                assertThat(terms.getBuckets().size(), equalTo(2));
 
-        assertNoFailures(response);
-        StringTerms terms = response.getAggregations().get("terms");
-        assertThat(terms, notNullValue());
-        assertThat(terms.getName(), equalTo("terms"));
-        assertThat(terms.getBuckets().size(), equalTo(2));
-
-        int i = 0;
-        for (StringTerms.Bucket bucket : terms.getBuckets()) {
-            assertThat(bucket, notNullValue());
-            assertThat(bucket.getKeyAsString(), equalTo(i == 0 ? "idx" : "empty_bucket_idx"));
-            assertThat(bucket.getDocCount(), equalTo(i == 0 ? 5L : 2L));
-            i++;
-        }
+                int i = 0;
+                for (StringTerms.Bucket bucket : terms.getBuckets()) {
+                    assertThat(bucket, notNullValue());
+                    assertThat(bucket.getKeyAsString(), equalTo(i == 0 ? "idx" : "empty_bucket_idx"));
+                    assertThat(bucket.getDocCount(), equalTo(i == 0 ? 5L : 2L));
+                    i++;
+                }
+            }
+        );
     }
 
     public void testOtherDocCount() {
@@ -1171,13 +1200,13 @@ public class StringTermsIT extends AbstractTermsTestCase {
         );
 
         // Test that a request using a nondeterministic script does not get cached
-        SearchResponse r = prepareSearch("cache_test_idx").setSize(0)
-            .addAggregation(
-                new TermsAggregationBuilder("terms").field("d")
-                    .script(new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "Math.random()", Collections.emptyMap()))
-            )
-            .get();
-        assertNoFailures(r);
+        assertNoFailures(
+            prepareSearch("cache_test_idx").setSize(0)
+                .addAggregation(
+                    new TermsAggregationBuilder("terms").field("d")
+                        .script(new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "Math.random()", Collections.emptyMap()))
+                )
+        );
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -1189,13 +1218,13 @@ public class StringTermsIT extends AbstractTermsTestCase {
         );
 
         // Test that a request using a deterministic script gets cached
-        r = prepareSearch("cache_test_idx").setSize(0)
-            .addAggregation(
-                new TermsAggregationBuilder("terms").field("d")
-                    .script(new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "'foo_' + _value", Collections.emptyMap()))
-            )
-            .get();
-        assertNoFailures(r);
+        assertNoFailures(
+            prepareSearch("cache_test_idx").setSize(0)
+                .addAggregation(
+                    new TermsAggregationBuilder("terms").field("d")
+                        .script(new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "'foo_' + _value", Collections.emptyMap()))
+                )
+        );
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -1207,8 +1236,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
         );
 
         // Ensure that non-scripted requests are cached as normal
-        r = prepareSearch("cache_test_idx").setSize(0).addAggregation(new TermsAggregationBuilder("terms").field("d")).get();
-        assertNoFailures(r);
+        assertNoFailures(prepareSearch("cache_test_idx").setSize(0).addAggregation(new TermsAggregationBuilder("terms").field("d")));
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -1230,13 +1258,12 @@ public class StringTermsIT extends AbstractTermsTestCase {
         String source = builder.toString();
 
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, source)) {
-            SearchResponse response = prepareSearch("idx").setSource(new SearchSourceBuilder().parseXContent(parser, true)).get();
-
-            assertNoFailures(response);
-            LongTerms terms = response.getAggregations().get("terms");
-            assertThat(terms, notNullValue());
-            assertThat(terms.getName(), equalTo("terms"));
-            assertThat(terms.getBuckets().size(), equalTo(1));
+            assertNoFailuresAndResponse(prepareSearch("idx").setSource(new SearchSourceBuilder().parseXContent(parser, true)), response -> {
+                LongTerms terms = response.getAggregations().get("terms");
+                assertThat(terms, notNullValue());
+                assertThat(terms.getName(), equalTo("terms"));
+                assertThat(terms.getBuckets().size(), equalTo(1));
+            });
         }
 
         String invalidValueType = source.replaceAll("\"value_type\":\"n.*\"", "\"value_type\":\"foobar\"");


### PR DESCRIPTION
Remove explicit references from `org.elasticsearch.search.aggregations.buckets`