### PR TITLE
Added decRef calls to SearchResponse tests

### DIFF
--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/local/LocalExporterIntegTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/local/LocalExporterIntegTests.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.monitoring.exporter.local;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesResponse;
 import org.elasticsearch.action.index.IndexRequestBuilder;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -43,6 +42,7 @@ import java.util.stream.Collectors;
 
 import static org.elasticsearch.search.aggregations.AggregationBuilders.max;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.elasticsearch.xpack.core.monitoring.MonitoredSystem.BEATS;
 import static org.elasticsearch.xpack.core.monitoring.MonitoredSystem.KIBANA;
 import static org.elasticsearch.xpack.core.monitoring.MonitoredSystem.LOGSTASH;
@@ -111,8 +111,10 @@ public class LocalExporterIntegTests extends LocalExporterIntegTestCase {
                     assertThat(indexExists(".monitoring-*"), is(true));
                     ensureYellowAndNoInitializingShards(".monitoring-*");
 
-                    SearchResponse response = prepareSearch(".monitoring-*").get();
-                    assertThat((long) nbDocs, lessThanOrEqualTo(response.getHits().getTotalHits().value));
+                    assertResponse(
+                        prepareSearch(".monitoring-*"),
+                        response -> assertThat((long) nbDocs, lessThanOrEqualTo(response.getHits().getTotalHits().value))
+                    );
                 });
 
                 checkMonitoringTemplates();
@@ -169,25 +171,25 @@ public class LocalExporterIntegTests extends LocalExporterIntegTestCase {
                     greaterThan(0L)
                 );
 
-                SearchResponse response = prepareSearch(".monitoring-es-*").setSize(0)
-                    .setQuery(QueryBuilders.termQuery("type", "node_stats"))
-                    .addAggregation(terms("agg_nodes_ids").field("node_stats.node_id"))
-                    .get();
-
-                Terms aggregation = response.getAggregations().get("agg_nodes_ids");
-                assertEquals(
-                    "Aggregation on node_id must return a bucket per node involved in test",
-                    numNodes,
-                    aggregation.getBuckets().size()
+                assertResponse(
+                    prepareSearch(".monitoring-es-*").setSize(0)
+                        .setQuery(QueryBuilders.termQuery("type", "node_stats"))
+                        .addAggregation(terms("agg_nodes_ids").field("node_stats.node_id")),
+                    response -> {
+                        Terms aggregation = response.getAggregations().get("agg_nodes_ids");
+                        assertEquals(
+                            "Aggregation on node_id must return a bucket per node involved in test",
+                            numNodes,
+                            aggregation.getBuckets().size()
+                        );
+                        for (String nodeName : internalCluster().getNodeNames()) {
+                            String nodeId = internalCluster().clusterService(nodeName).localNode().getId();
+                            Terms.Bucket bucket = aggregation.getBucketByKey(nodeId);
+                            assertTrue("No bucket found for node id [" + nodeId + "]", bucket != null);
+                            assertTrue(bucket.getDocCount() >= 1L);
+                        }
+                    }
                 );
-
-                for (String nodeName : internalCluster().getNodeNames()) {
-                    String nodeId = internalCluster().clusterService(nodeName).localNode().getId();
-                    Terms.Bucket bucket = aggregation.getBucketByKey(nodeId);
-                    assertTrue("No bucket found for node id [" + nodeId + "]", bucket != null);
-                    assertTrue(bucket.getDocCount() >= 1L);
-                }
-
             }, 30L, TimeUnit.SECONDS);
 
             checkMonitoringTemplates();
@@ -206,24 +208,27 @@ public class LocalExporterIntegTests extends LocalExporterIntegTestCase {
                 ensureYellowAndNoInitializingShards(".monitoring-*");
                 refresh(".monitoring-es-*");
 
-                SearchResponse response = prepareSearch(".monitoring-es-*").setSize(0)
-                    .setQuery(QueryBuilders.termQuery("type", "node_stats"))
-                    .addAggregation(
-                        terms("agg_nodes_ids").field("node_stats.node_id").subAggregation(max("agg_last_time_collected").field("timestamp"))
-                    )
-                    .get();
+                assertResponse(
+                    prepareSearch(".monitoring-es-*").setSize(0)
+                        .setQuery(QueryBuilders.termQuery("type", "node_stats"))
+                        .addAggregation(
+                            terms("agg_nodes_ids").field("node_stats.node_id")
+                                .subAggregation(max("agg_last_time_collected").field("timestamp"))
+                        ),
+                    response -> {
+                        Terms aggregation = response.getAggregations().get("agg_nodes_ids");
+                        for (String nodeName : internalCluster().getNodeNames()) {
+                            String nodeId = internalCluster().clusterService(nodeName).localNode().getId();
+                            Terms.Bucket bucket = aggregation.getBucketByKey(nodeId);
+                            assertTrue("No bucket found for node id [" + nodeId + "]", bucket != null);
+                            assertTrue(bucket.getDocCount() >= 1L);
 
-                Terms aggregation = response.getAggregations().get("agg_nodes_ids");
-                for (String nodeName : internalCluster().getNodeNames()) {
-                    String nodeId = internalCluster().clusterService(nodeName).localNode().getId();
-                    Terms.Bucket bucket = aggregation.getBucketByKey(nodeId);
-                    assertTrue("No bucket found for node id [" + nodeId + "]", bucket != null);
-                    assertTrue(bucket.getDocCount() >= 1L);
-
-                    Max subAggregation = bucket.getAggregations().get("agg_last_time_collected");
-                    ZonedDateTime lastCollection = Instant.ofEpochMilli(Math.round(subAggregation.value())).atZone(ZoneOffset.UTC);
-                    assertTrue(lastCollection.plusSeconds(elapsedInSeconds).isBefore(ZonedDateTime.now(ZoneOffset.UTC)));
-                }
+                            Max subAggregation = bucket.getAggregations().get("agg_last_time_collected");
+                            ZonedDateTime lastCollection = Instant.ofEpochMilli(Math.round(subAggregation.value())).atZone(ZoneOffset.UTC);
+                            assertTrue(lastCollection.plusSeconds(elapsedInSeconds).isBefore(ZonedDateTime.now(ZoneOffset.UTC)));
+                        }
+                    }
+                );
             } else {
                 assertTrue(ZonedDateTime.now(ZoneOffset.UTC).isAfter(startTime.plusSeconds(elapsedInSeconds)));
             }
@@ -264,43 +269,43 @@ public class LocalExporterIntegTests extends LocalExporterIntegTestCase {
         DateFormatter dateParser = DateFormatter.forPattern("strict_date_time");
         DateFormatter dateFormatter = DateFormatter.forPattern(customTimeFormat).withZone(ZoneOffset.UTC);
 
-        SearchResponse searchResponse = prepareSearch(".monitoring-*").setSize(100).get();
-        assertThat(searchResponse.getHits().getTotalHits().value, greaterThan(0L));
+        assertResponse(prepareSearch(".monitoring-*").setSize(100), rsp -> {
+            assertThat(rsp.getHits().getTotalHits().value, greaterThan(0L));
+            for (SearchHit hit : rsp.getHits().getHits()) {
+                final Map<String, Object> source = hit.getSourceAsMap();
 
-        for (SearchHit hit : searchResponse.getHits().getHits()) {
-            final Map<String, Object> source = hit.getSourceAsMap();
+                assertTrue(source != null && source.isEmpty() == false);
 
-            assertTrue(source != null && source.isEmpty() == false);
+                final String timestamp = (String) source.get("timestamp");
+                final String type = (String) source.get("type");
 
-            final String timestamp = (String) source.get("timestamp");
-            final String type = (String) source.get("type");
+                assertTrue("document is missing cluster_uuid field", Strings.hasText((String) source.get("cluster_uuid")));
+                assertTrue("document is missing timestamp field", Strings.hasText(timestamp));
+                assertTrue("document is missing type field", Strings.hasText(type));
 
-            assertTrue("document is missing cluster_uuid field", Strings.hasText((String) source.get("cluster_uuid")));
-            assertTrue("document is missing timestamp field", Strings.hasText(timestamp));
-            assertTrue("document is missing type field", Strings.hasText(type));
+                @SuppressWarnings("unchecked")
+                Map<String, Object> docSource = (Map<String, Object>) source.get("doc");
 
-            @SuppressWarnings("unchecked")
-            Map<String, Object> docSource = (Map<String, Object>) source.get("doc");
+                MonitoredSystem expectedSystem;
+                if (docSource == null) {
+                    // This is a document indexed by the Monitoring service
+                    expectedSystem = MonitoredSystem.ES;
+                } else {
+                    // This is a document indexed through the Monitoring Bulk API
+                    expectedSystem = MonitoredSystem.fromSystem((String) docSource.get("expected_system"));
+                }
 
-            MonitoredSystem expectedSystem;
-            if (docSource == null) {
-                // This is a document indexed by the Monitoring service
-                expectedSystem = MonitoredSystem.ES;
-            } else {
-                // This is a document indexed through the Monitoring Bulk API
-                expectedSystem = MonitoredSystem.fromSystem((String) docSource.get("expected_system"));
+                String dateTime = dateFormatter.format(dateParser.parse(timestamp));
+                final String expectedIndex = ".monitoring-" + expectedSystem.getSystem() + "-" + TEMPLATE_VERSION + "-" + dateTime;
+                assertEquals("Expected " + expectedIndex + " but got " + hit.getIndex(), expectedIndex, hit.getIndex());
+
+                @SuppressWarnings("unchecked")
+                Map<String, Object> sourceNode = (Map<String, Object>) source.get("source_node");
+                if ("shards".equals(type) == false) {
+                    assertNotNull("document is missing source_node field", sourceNode);
+                }
             }
-
-            String dateTime = dateFormatter.format(dateParser.parse(timestamp));
-            final String expectedIndex = ".monitoring-" + expectedSystem.getSystem() + "-" + TEMPLATE_VERSION + "-" + dateTime;
-            assertEquals("Expected " + expectedIndex + " but got " + hit.getIndex(), expectedIndex, hit.getIndex());
-
-            @SuppressWarnings("unchecked")
-            Map<String, Object> sourceNode = (Map<String, Object>) source.get("source_node");
-            if ("shards".equals(type) == false) {
-                assertNotNull("document is missing source_node field", sourceNode);
-            }
-        }
+        });
     }
 
     public static MonitoringBulkDoc createMonitoringBulkDoc() throws IOException {

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/local/LocalExporterResourceIntegTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/local/LocalExporterResourceIntegTests.java
@@ -7,7 +7,6 @@
 package org.elasticsearch.xpack.monitoring.exporter.local;
 
 import org.elasticsearch.Version;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -36,6 +35,7 @@ import java.util.Set;
 
 import static org.elasticsearch.test.ESIntegTestCase.Scope.TEST;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
@@ -289,16 +289,16 @@ public class LocalExporterResourceIntegTests extends LocalExporterIntegTestCase 
         String clusterUUID = clusterService().state().getMetadata().clusterUUID();
         SearchSourceBuilder searchSource = SearchSourceBuilder.searchSource()
             .query(QueryBuilders.matchQuery("metadata.xpack.cluster_uuid", clusterUUID));
-        SearchResponse searchResponse = prepareSearch(".watches").setSource(searchSource).get();
-        if (searchResponse.getHits().getTotalHits().value > 0) {
-            List<String> invalidWatches = new ArrayList<>();
-            for (SearchHit hit : searchResponse.getHits().getHits()) {
-                invalidWatches.add(ObjectPath.eval("metadata.xpack.watch", hit.getSourceAsMap()));
+
+        assertResponse(prepareSearch(".watches").setSource(searchSource), response -> {
+            if (response.getHits().getTotalHits().value > 0) {
+                List<String> invalidWatches = new ArrayList<>();
+                for (SearchHit hit : response.getHits().getHits()) {
+                    invalidWatches.add(ObjectPath.eval("metadata.xpack.watch", hit.getSourceAsMap()));
+                }
+                fail("Found [" + response.getHits().getTotalHits().value + "] invalid watches when none were expected: " + invalidWatches);
             }
-            fail(
-                "Found [" + searchResponse.getHits().getTotalHits().value + "] invalid watches when none were expected: " + invalidWatches
-            );
-        }
+        });
     }
 
     private void assertResourcesExist() throws Exception {

--- a/x-pack/plugin/rank-rrf/src/internalClusterTest/java/org/elasticsearch/xpack/rank/rrf/RRFRankCoordinatorCanMatchIT.java
+++ b/x-pack/plugin/rank-rrf/src/internalClusterTest/java/org/elasticsearch/xpack/rank/rrf/RRFRankCoordinatorCanMatchIT.java
@@ -10,7 +10,6 @@ package org.elasticsearch.xpack.rank.rrf;
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.PointValues;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.index.IndexSettings;
@@ -35,6 +34,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 
 @ESIntegTestCase.ClusterScope(maxNumDataNodes = 3)
 @ESIntegTestCase.SuiteScopeTestCase
@@ -130,117 +130,129 @@ public class RRFRankCoordinatorCanMatchIT extends ESIntegTestCase {
         });
 
         // match 2 separate shard with no overlap in queries
-        SearchResponse response = prepareSearch("time_index").setSearchType(SearchType.QUERY_THEN_FETCH)
-            .setPreFilterShardSize(1)
-            .setRankBuilder(new RRFRankBuilder(20, 1))
-            .setTrackTotalHits(false)
-            .setSubSearches(
-                List.of(
-                    new SubSearchSourceBuilder(QueryBuilders.rangeQuery("@timestamp").gt(495).lte(499)),
-                    new SubSearchSourceBuilder(QueryBuilders.rangeQuery("@timestamp").gte(500).lt(505))
+        assertResponse(
+            prepareSearch("time_index").setSearchType(SearchType.QUERY_THEN_FETCH)
+                .setPreFilterShardSize(1)
+                .setRankBuilder(new RRFRankBuilder(20, 1))
+                .setTrackTotalHits(false)
+                .setSubSearches(
+                    List.of(
+                        new SubSearchSourceBuilder(QueryBuilders.rangeQuery("@timestamp").gt(495).lte(499)),
+                        new SubSearchSourceBuilder(QueryBuilders.rangeQuery("@timestamp").gte(500).lt(505))
+                    )
                 )
-            )
-            .setSize(5)
-            .get();
-
-        assertNull(response.getHits().getTotalHits());
-        assertEquals(5, response.getHits().getHits().length);
-        assertEquals(5, response.getSuccessfulShards());
-        assertEquals(3, response.getSkippedShards());
+                .setSize(5),
+            response -> {
+                assertNull(response.getHits().getTotalHits());
+                assertEquals(5, response.getHits().getHits().length);
+                assertEquals(5, response.getSuccessfulShards());
+                assertEquals(3, response.getSkippedShards());
+            }
+        );
 
         // match 2 shards with overlap in queries
-        response = prepareSearch("time_index").setSearchType(SearchType.QUERY_THEN_FETCH)
-            .setPreFilterShardSize(1)
-            .setRankBuilder(new RRFRankBuilder(20, 1))
-            .setTrackTotalHits(false)
-            .setSubSearches(
-                List.of(
-                    new SubSearchSourceBuilder(QueryBuilders.rangeQuery("@timestamp").gt(495).lte(505)),
-                    new SubSearchSourceBuilder(QueryBuilders.rangeQuery("@timestamp").gte(497).lt(507))
+        assertResponse(
+            prepareSearch("time_index").setSearchType(SearchType.QUERY_THEN_FETCH)
+                .setPreFilterShardSize(1)
+                .setRankBuilder(new RRFRankBuilder(20, 1))
+                .setTrackTotalHits(false)
+                .setSubSearches(
+                    List.of(
+                        new SubSearchSourceBuilder(QueryBuilders.rangeQuery("@timestamp").gt(495).lte(505)),
+                        new SubSearchSourceBuilder(QueryBuilders.rangeQuery("@timestamp").gte(497).lt(507))
+                    )
                 )
-            )
-            .setSize(5)
-            .get();
-
-        assertNull(response.getHits().getTotalHits());
-        assertEquals(5, response.getHits().getHits().length);
-        assertEquals(5, response.getSuccessfulShards());
-        assertEquals(3, response.getSkippedShards());
+                .setSize(5),
+            response -> {
+                assertNull(response.getHits().getTotalHits());
+                assertEquals(5, response.getHits().getHits().length);
+                assertEquals(5, response.getSuccessfulShards());
+                assertEquals(3, response.getSkippedShards());
+            }
+        );
 
         // match one shard with one query in range and one query out of range
-        response = prepareSearch("time_index").setSearchType(SearchType.QUERY_THEN_FETCH)
-            .setPreFilterShardSize(1)
-            .setRankBuilder(new RRFRankBuilder(20, 1))
-            .setTrackTotalHits(false)
-            .setSubSearches(
-                List.of(
-                    new SubSearchSourceBuilder(QueryBuilders.rangeQuery("@timestamp").gt(501).lte(505)),
-                    new SubSearchSourceBuilder(QueryBuilders.rangeQuery("@timestamp").gte(10000).lt(10005))
+        assertResponse(
+            prepareSearch("time_index").setSearchType(SearchType.QUERY_THEN_FETCH)
+                .setPreFilterShardSize(1)
+                .setRankBuilder(new RRFRankBuilder(20, 1))
+                .setTrackTotalHits(false)
+                .setSubSearches(
+                    List.of(
+                        new SubSearchSourceBuilder(QueryBuilders.rangeQuery("@timestamp").gt(501).lte(505)),
+                        new SubSearchSourceBuilder(QueryBuilders.rangeQuery("@timestamp").gte(10000).lt(10005))
+                    )
                 )
-            )
-            .setSize(5)
-            .get();
-
-        assertNull(response.getHits().getTotalHits());
-        assertEquals(4, response.getHits().getHits().length);
-        assertEquals(5, response.getSuccessfulShards());
-        assertEquals(4, response.getSkippedShards());
+                .setSize(5),
+            response -> {
+                assertNull(response.getHits().getTotalHits());
+                assertEquals(4, response.getHits().getHits().length);
+                assertEquals(5, response.getSuccessfulShards());
+                assertEquals(4, response.getSkippedShards());
+            }
+        );
 
         // match no shards, but still use one to generate a search response
-        response = prepareSearch("time_index").setSearchType(SearchType.QUERY_THEN_FETCH)
-            .setPreFilterShardSize(1)
-            .setRankBuilder(new RRFRankBuilder(20, 1))
-            .setTrackTotalHits(false)
-            .setSubSearches(
-                List.of(
-                    new SubSearchSourceBuilder(QueryBuilders.rangeQuery("@timestamp").gt(4000).lte(5000)),
-                    new SubSearchSourceBuilder(QueryBuilders.rangeQuery("@timestamp").gte(10000).lt(10005))
+        assertResponse(
+            prepareSearch("time_index").setSearchType(SearchType.QUERY_THEN_FETCH)
+                .setPreFilterShardSize(1)
+                .setRankBuilder(new RRFRankBuilder(20, 1))
+                .setTrackTotalHits(false)
+                .setSubSearches(
+                    List.of(
+                        new SubSearchSourceBuilder(QueryBuilders.rangeQuery("@timestamp").gt(4000).lte(5000)),
+                        new SubSearchSourceBuilder(QueryBuilders.rangeQuery("@timestamp").gte(10000).lt(10005))
+                    )
                 )
-            )
-            .setSize(5)
-            .get();
-
-        assertNull(response.getHits().getTotalHits());
-        assertEquals(0, response.getHits().getHits().length);
-        assertEquals(5, response.getSuccessfulShards());
-        assertEquals(4, response.getSkippedShards());
+                .setSize(5),
+            response -> {
+                assertNull(response.getHits().getTotalHits());
+                assertEquals(0, response.getHits().getHits().length);
+                assertEquals(5, response.getSuccessfulShards());
+                assertEquals(4, response.getSkippedShards());
+            }
+        );
 
         // match one shard with with no overlap in queries
-        response = prepareSearch("time_index").setSearchType(SearchType.QUERY_THEN_FETCH)
-            .setPreFilterShardSize(1)
-            .setRankBuilder(new RRFRankBuilder(20, 1))
-            .setTrackTotalHits(false)
-            .setSubSearches(
-                List.of(
-                    new SubSearchSourceBuilder(QueryBuilders.rangeQuery("@timestamp").gt(600).lte(605)),
-                    new SubSearchSourceBuilder(QueryBuilders.rangeQuery("@timestamp").gte(700).lt(705))
+        assertResponse(
+            prepareSearch("time_index").setSearchType(SearchType.QUERY_THEN_FETCH)
+                .setPreFilterShardSize(1)
+                .setRankBuilder(new RRFRankBuilder(20, 1))
+                .setTrackTotalHits(false)
+                .setSubSearches(
+                    List.of(
+                        new SubSearchSourceBuilder(QueryBuilders.rangeQuery("@timestamp").gt(600).lte(605)),
+                        new SubSearchSourceBuilder(QueryBuilders.rangeQuery("@timestamp").gte(700).lt(705))
+                    )
                 )
-            )
-            .setSize(5)
-            .get();
-
-        assertNull(response.getHits().getTotalHits());
-        assertEquals(5, response.getHits().getHits().length);
-        assertEquals(5, response.getSuccessfulShards());
-        assertEquals(4, response.getSkippedShards());
+                .setSize(5),
+            response -> {
+                assertNull(response.getHits().getTotalHits());
+                assertEquals(5, response.getHits().getHits().length);
+                assertEquals(5, response.getSuccessfulShards());
+                assertEquals(4, response.getSkippedShards());
+            }
+        );
 
         // match one shard with exact overlap in queries
-        response = prepareSearch("time_index").setSearchType(SearchType.QUERY_THEN_FETCH)
-            .setPreFilterShardSize(1)
-            .setRankBuilder(new RRFRankBuilder(20, 1))
-            .setTrackTotalHits(false)
-            .setSubSearches(
-                List.of(
-                    new SubSearchSourceBuilder(QueryBuilders.rangeQuery("@timestamp").gt(600).lte(605)),
-                    new SubSearchSourceBuilder(QueryBuilders.rangeQuery("@timestamp").gte(600).lt(605))
+        assertResponse(
+            prepareSearch("time_index").setSearchType(SearchType.QUERY_THEN_FETCH)
+                .setPreFilterShardSize(1)
+                .setRankBuilder(new RRFRankBuilder(20, 1))
+                .setTrackTotalHits(false)
+                .setSubSearches(
+                    List.of(
+                        new SubSearchSourceBuilder(QueryBuilders.rangeQuery("@timestamp").gt(600).lte(605)),
+                        new SubSearchSourceBuilder(QueryBuilders.rangeQuery("@timestamp").gte(600).lt(605))
+                    )
                 )
-            )
-            .setSize(5)
-            .get();
-
-        assertNull(response.getHits().getTotalHits());
-        assertEquals(5, response.getHits().getHits().length);
-        assertEquals(5, response.getSuccessfulShards());
-        assertEquals(4, response.getSkippedShards());
+                .setSize(5),
+            response -> {
+                assertNull(response.getHits().getTotalHits());
+                assertEquals(5, response.getHits().getHits().length);
+                assertEquals(5, response.getSuccessfulShards());
+                assertEquals(4, response.getSkippedShards());
+            }
+        );
     }
 }

--- a/x-pack/plugin/rank-rrf/src/internalClusterTest/java/org/elasticsearch/xpack/rank/rrf/RRFRankMultiShardIT.java
+++ b/x-pack/plugin/rank-rrf/src/internalClusterTest/java/org/elasticsearch/xpack/rank/rrf/RRFRankMultiShardIT.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.rank.rrf;
 
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -28,6 +27,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 
 @ESIntegTestCase.ClusterScope(maxNumDataNodes = 3)
 @ESIntegTestCase.SuiteScopeTestCase
@@ -139,69 +139,72 @@ public class RRFRankMultiShardIT extends ESIntegTestCase {
     public void testTotalDocsSmallerThanSize() {
         float[] queryVector = { 0.0f };
         KnnSearchBuilder knnSearch = new KnnSearchBuilder("vector", queryVector, 3, 3, null);
-        SearchResponse response = prepareSearch("tiny_index").setRankBuilder(new RRFRankBuilder(100, 1))
-            .setKnnSearch(List.of(knnSearch))
-            .setQuery(QueryBuilders.termQuery("text", "term"))
-            .addFetchField("vector")
-            .addFetchField("text")
-            .get();
+        assertResponse(
+            prepareSearch("tiny_index").setRankBuilder(new RRFRankBuilder(100, 1))
+                .setKnnSearch(List.of(knnSearch))
+                .setQuery(QueryBuilders.termQuery("text", "term"))
+                .addFetchField("vector")
+                .addFetchField("text"),
+            response -> {
+                // we cast to Number when looking at values in vector fields because different xContentTypes may return Float or Double
+                assertEquals(3, response.getHits().getHits().length);
 
-        // we cast to Number when looking at values in vector fields because different xContentTypes may return Float or Double
+                SearchHit hit = response.getHits().getAt(0);
+                assertEquals(1, hit.getRank());
+                assertEquals(0.0, ((Number) hit.field("vector").getValue()).doubleValue(), 0.0);
+                assertEquals("term term", hit.field("text").getValue());
 
-        assertEquals(3, response.getHits().getHits().length);
+                hit = response.getHits().getAt(1);
+                assertEquals(2, hit.getRank());
+                assertEquals(2.0, ((Number) hit.field("vector").getValue()).doubleValue(), 0.0);
+                assertEquals("term", hit.field("text").getValue());
 
-        SearchHit hit = response.getHits().getAt(0);
-        assertEquals(1, hit.getRank());
-        assertEquals(0.0, ((Number) hit.field("vector").getValue()).doubleValue(), 0.0);
-        assertEquals("term term", hit.field("text").getValue());
-
-        hit = response.getHits().getAt(1);
-        assertEquals(2, hit.getRank());
-        assertEquals(2.0, ((Number) hit.field("vector").getValue()).doubleValue(), 0.0);
-        assertEquals("term", hit.field("text").getValue());
-
-        hit = response.getHits().getAt(2);
-        assertEquals(3, hit.getRank());
-        assertEquals(1.0, ((Number) hit.field("vector").getValue()).doubleValue(), 0.0);
-        assertEquals("other", hit.field("text").getValue());
+                hit = response.getHits().getAt(2);
+                assertEquals(3, hit.getRank());
+                assertEquals(1.0, ((Number) hit.field("vector").getValue()).doubleValue(), 0.0);
+                assertEquals("other", hit.field("text").getValue());
+            }
+        );
     }
 
     public void testBM25AndKnn() {
         float[] queryVector = { 500.0f };
         KnnSearchBuilder knnSearch = new KnnSearchBuilder("vector_asc", queryVector, 101, 1001, null);
-        SearchResponse response = prepareSearch("nrd_index").setRankBuilder(new RRFRankBuilder(101, 1))
-            .setTrackTotalHits(false)
-            .setKnnSearch(List.of(knnSearch))
-            .setQuery(
-                QueryBuilders.boolQuery()
-                    .should(QueryBuilders.termQuery("text0", "500").boost(11.0f))
-                    .should(QueryBuilders.termQuery("text0", "499").boost(10.0f))
-                    .should(QueryBuilders.termQuery("text0", "498").boost(9.0f))
-                    .should(QueryBuilders.termQuery("text0", "497").boost(8.0f))
-                    .should(QueryBuilders.termQuery("text0", "496").boost(7.0f))
-                    .should(QueryBuilders.termQuery("text0", "495").boost(6.0f))
-                    .should(QueryBuilders.termQuery("text0", "494").boost(5.0f))
-                    .should(QueryBuilders.termQuery("text0", "493").boost(4.0f))
-                    .should(QueryBuilders.termQuery("text0", "492").boost(3.0f))
-                    .should(QueryBuilders.termQuery("text0", "491").boost(2.0f))
-            )
-            .addFetchField("vector_asc")
-            .addFetchField("text0")
-            .setSize(11)
-            .get();
+        assertResponse(
+            prepareSearch("nrd_index").setRankBuilder(new RRFRankBuilder(101, 1))
+                .setTrackTotalHits(false)
+                .setKnnSearch(List.of(knnSearch))
+                .setQuery(
+                    QueryBuilders.boolQuery()
+                        .should(QueryBuilders.termQuery("text0", "500").boost(11.0f))
+                        .should(QueryBuilders.termQuery("text0", "499").boost(10.0f))
+                        .should(QueryBuilders.termQuery("text0", "498").boost(9.0f))
+                        .should(QueryBuilders.termQuery("text0", "497").boost(8.0f))
+                        .should(QueryBuilders.termQuery("text0", "496").boost(7.0f))
+                        .should(QueryBuilders.termQuery("text0", "495").boost(6.0f))
+                        .should(QueryBuilders.termQuery("text0", "494").boost(5.0f))
+                        .should(QueryBuilders.termQuery("text0", "493").boost(4.0f))
+                        .should(QueryBuilders.termQuery("text0", "492").boost(3.0f))
+                        .should(QueryBuilders.termQuery("text0", "491").boost(2.0f))
+                )
+                .addFetchField("vector_asc")
+                .addFetchField("text0")
+                .setSize(11),
+            response -> {
+                assertNull(response.getHits().getTotalHits());
+                assertEquals(11, response.getHits().getHits().length);
 
-        assertNull(response.getHits().getTotalHits());
-        assertEquals(11, response.getHits().getHits().length);
+                SearchHit hit = response.getHits().getAt(0);
+                assertEquals(1, hit.getRank());
+                assertEquals(500.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
+                assertEquals("term 500", hit.field("text0").getValue());
 
-        SearchHit hit = response.getHits().getAt(0);
-        assertEquals(1, hit.getRank());
-        assertEquals(500.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
-        assertEquals("term 500", hit.field("text0").getValue());
-
-        Set<Double> vectors = Arrays.stream(response.getHits().getHits())
-            .map(h -> ((Number) h.field("vector_asc").getValue()).doubleValue())
-            .collect(Collectors.toSet());
-        assertEquals(Set.of(492.0, 493.0, 494.0, 495.0, 496.0, 497.0, 498.0, 499.0, 500.0, 501.0, 502.0), vectors);
+                Set<Double> vectors = Arrays.stream(response.getHits().getHits())
+                    .map(h -> ((Number) h.field("vector_asc").getValue()).doubleValue())
+                    .collect(Collectors.toSet());
+                assertEquals(Set.of(492.0, 493.0, 494.0, 495.0, 496.0, 497.0, 498.0, 499.0, 500.0, 501.0, 502.0), vectors);
+            }
+        );
     }
 
     public void testMultipleOnlyKnn() {
@@ -209,48 +212,50 @@ public class RRFRankMultiShardIT extends ESIntegTestCase {
         float[] queryVectorDesc = { 500.0f };
         KnnSearchBuilder knnSearchAsc = new KnnSearchBuilder("vector_asc", queryVectorAsc, 51, 1001, null);
         KnnSearchBuilder knnSearchDesc = new KnnSearchBuilder("vector_desc", queryVectorDesc, 51, 1001, null);
-        SearchResponse response = prepareSearch("nrd_index").setRankBuilder(new RRFRankBuilder(51, 1))
-            .setTrackTotalHits(true)
-            .setKnnSearch(List.of(knnSearchAsc, knnSearchDesc))
-            .addFetchField("vector_asc")
-            .addFetchField("text0")
-            .setSize(19)
-            .get();
+        assertResponse(
+            prepareSearch("nrd_index").setRankBuilder(new RRFRankBuilder(51, 1))
+                .setTrackTotalHits(true)
+                .setKnnSearch(List.of(knnSearchAsc, knnSearchDesc))
+                .addFetchField("vector_asc")
+                .addFetchField("text0")
+                .setSize(19),
+            response -> {
+                assertEquals(51, response.getHits().getTotalHits().value);
+                assertEquals(19, response.getHits().getHits().length);
 
-        assertEquals(51, response.getHits().getTotalHits().value);
-        assertEquals(19, response.getHits().getHits().length);
+                SearchHit hit = response.getHits().getAt(0);
+                assertEquals(1, hit.getRank());
+                assertEquals(500.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
+                assertEquals("term 500", hit.field("text0").getValue());
 
-        SearchHit hit = response.getHits().getAt(0);
-        assertEquals(1, hit.getRank());
-        assertEquals(500.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
-        assertEquals("term 500", hit.field("text0").getValue());
-
-        Set<Double> vectors = Arrays.stream(response.getHits().getHits())
-            .map(h -> ((Number) h.field("vector_asc").getValue()).doubleValue())
-            .collect(Collectors.toSet());
-        assertEquals(
-            Set.of(
-                491.0,
-                492.0,
-                493.0,
-                494.0,
-                495.0,
-                496.0,
-                497.0,
-                498.0,
-                499.0,
-                500.0,
-                501.0,
-                502.0,
-                503.0,
-                504.0,
-                505.0,
-                506.0,
-                507.0,
-                508.0,
-                509.0
-            ),
-            vectors
+                Set<Double> vectors = Arrays.stream(response.getHits().getHits())
+                    .map(h -> ((Number) h.field("vector_asc").getValue()).doubleValue())
+                    .collect(Collectors.toSet());
+                assertEquals(
+                    Set.of(
+                        491.0,
+                        492.0,
+                        493.0,
+                        494.0,
+                        495.0,
+                        496.0,
+                        497.0,
+                        498.0,
+                        499.0,
+                        500.0,
+                        501.0,
+                        502.0,
+                        503.0,
+                        504.0,
+                        505.0,
+                        506.0,
+                        507.0,
+                        508.0,
+                        509.0
+                    ),
+                    vectors
+                );
+            }
         );
     }
 
@@ -259,124 +264,128 @@ public class RRFRankMultiShardIT extends ESIntegTestCase {
         float[] queryVectorDesc = { 500.0f };
         KnnSearchBuilder knnSearchAsc = new KnnSearchBuilder("vector_asc", queryVectorAsc, 51, 1001, null);
         KnnSearchBuilder knnSearchDesc = new KnnSearchBuilder("vector_desc", queryVectorDesc, 51, 1001, null);
-        SearchResponse response = prepareSearch("nrd_index").setRankBuilder(new RRFRankBuilder(51, 1))
-            .setTrackTotalHits(false)
-            .setKnnSearch(List.of(knnSearchAsc, knnSearchDesc))
-            .setQuery(
-                QueryBuilders.boolQuery()
-                    .should(QueryBuilders.termQuery("text0", "500").boost(10.0f))
-                    .should(QueryBuilders.termQuery("text0", "499").boost(20.0f))
-                    .should(QueryBuilders.termQuery("text0", "498").boost(8.0f))
-                    .should(QueryBuilders.termQuery("text0", "497").boost(7.0f))
-                    .should(QueryBuilders.termQuery("text0", "496").boost(6.0f))
-                    .should(QueryBuilders.termQuery("text0", "485").boost(5.0f))
-                    .should(QueryBuilders.termQuery("text0", "494").boost(4.0f))
-                    .should(QueryBuilders.termQuery("text0", "506").boost(3.0f))
-                    .should(QueryBuilders.termQuery("text0", "505").boost(2.0f))
-                    .should(QueryBuilders.termQuery("text0", "511").boost(9.0f))
-            )
-            .addFetchField("vector_asc")
-            .addFetchField("vector_desc")
-            .addFetchField("text0")
-            .setSize(19)
-            .get();
+        assertResponse(
+            prepareSearch("nrd_index").setRankBuilder(new RRFRankBuilder(51, 1))
+                .setTrackTotalHits(false)
+                .setKnnSearch(List.of(knnSearchAsc, knnSearchDesc))
+                .setQuery(
+                    QueryBuilders.boolQuery()
+                        .should(QueryBuilders.termQuery("text0", "500").boost(10.0f))
+                        .should(QueryBuilders.termQuery("text0", "499").boost(20.0f))
+                        .should(QueryBuilders.termQuery("text0", "498").boost(8.0f))
+                        .should(QueryBuilders.termQuery("text0", "497").boost(7.0f))
+                        .should(QueryBuilders.termQuery("text0", "496").boost(6.0f))
+                        .should(QueryBuilders.termQuery("text0", "485").boost(5.0f))
+                        .should(QueryBuilders.termQuery("text0", "494").boost(4.0f))
+                        .should(QueryBuilders.termQuery("text0", "506").boost(3.0f))
+                        .should(QueryBuilders.termQuery("text0", "505").boost(2.0f))
+                        .should(QueryBuilders.termQuery("text0", "511").boost(9.0f))
+                )
+                .addFetchField("vector_asc")
+                .addFetchField("vector_desc")
+                .addFetchField("text0")
+                .setSize(19),
+            response -> {
+                assertNull(response.getHits().getTotalHits());
+                assertEquals(19, response.getHits().getHits().length);
 
-        assertNull(response.getHits().getTotalHits());
-        assertEquals(19, response.getHits().getHits().length);
+                SearchHit hit = response.getHits().getAt(0);
+                assertEquals(1, hit.getRank());
+                assertEquals(500.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
+                assertEquals(500.0, ((Number) hit.field("vector_desc").getValue()).doubleValue(), 0.0);
+                assertEquals("term 500", hit.field("text0").getValue());
 
-        SearchHit hit = response.getHits().getAt(0);
-        assertEquals(1, hit.getRank());
-        assertEquals(500.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
-        assertEquals(500.0, ((Number) hit.field("vector_desc").getValue()).doubleValue(), 0.0);
-        assertEquals("term 500", hit.field("text0").getValue());
+                hit = response.getHits().getAt(1);
+                assertEquals(2, hit.getRank());
+                assertEquals(499.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
+                assertEquals(501.0, ((Number) hit.field("vector_desc").getValue()).doubleValue(), 0.0);
+                assertEquals("term 499", hit.field("text0").getValue());
 
-        hit = response.getHits().getAt(1);
-        assertEquals(2, hit.getRank());
-        assertEquals(499.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
-        assertEquals(501.0, ((Number) hit.field("vector_desc").getValue()).doubleValue(), 0.0);
-        assertEquals("term 499", hit.field("text0").getValue());
-
-        Set<Double> vectors = Arrays.stream(response.getHits().getHits())
-            .map(h -> ((Number) h.field("vector_asc").getValue()).doubleValue())
-            .collect(Collectors.toSet());
-        assertEquals(
-            Set.of(
-                485.0,
-                492.0,
-                493.0,
-                494.0,
-                495.0,
-                496.0,
-                497.0,
-                498.0,
-                499.0,
-                500.0,
-                501.0,
-                502.0,
-                503.0,
-                504.0,
-                505.0,
-                506.0,
-                507.0,
-                508.0,
-                511.0
-            ),
-            vectors
+                Set<Double> vectors = Arrays.stream(response.getHits().getHits())
+                    .map(h -> ((Number) h.field("vector_asc").getValue()).doubleValue())
+                    .collect(Collectors.toSet());
+                assertEquals(
+                    Set.of(
+                        485.0,
+                        492.0,
+                        493.0,
+                        494.0,
+                        495.0,
+                        496.0,
+                        497.0,
+                        498.0,
+                        499.0,
+                        500.0,
+                        501.0,
+                        502.0,
+                        503.0,
+                        504.0,
+                        505.0,
+                        506.0,
+                        507.0,
+                        508.0,
+                        511.0
+                    ),
+                    vectors
+                );
+            }
         );
     }
 
     public void testBM25AndKnnWithBucketAggregation() {
         float[] queryVector = { 500.0f };
         KnnSearchBuilder knnSearch = new KnnSearchBuilder("vector_asc", queryVector, 101, 1001, null);
-        SearchResponse response = prepareSearch("nrd_index").setRankBuilder(new RRFRankBuilder(101, 1))
-            .setTrackTotalHits(true)
-            .setKnnSearch(List.of(knnSearch))
-            .setQuery(
-                QueryBuilders.boolQuery()
-                    .should(QueryBuilders.termQuery("text0", "500").boost(11.0f))
-                    .should(QueryBuilders.termQuery("text0", "499").boost(10.0f))
-                    .should(QueryBuilders.termQuery("text0", "498").boost(9.0f))
-                    .should(QueryBuilders.termQuery("text0", "497").boost(8.0f))
-                    .should(QueryBuilders.termQuery("text0", "496").boost(7.0f))
-                    .should(QueryBuilders.termQuery("text0", "495").boost(6.0f))
-                    .should(QueryBuilders.termQuery("text0", "494").boost(5.0f))
-                    .should(QueryBuilders.termQuery("text0", "493").boost(4.0f))
-                    .should(QueryBuilders.termQuery("text0", "492").boost(3.0f))
-                    .should(QueryBuilders.termQuery("text0", "491").boost(2.0f))
-            )
-            .addFetchField("vector_asc")
-            .addFetchField("text0")
-            .setSize(11)
-            .addAggregation(AggregationBuilders.terms("sums").field("int"))
-            .get();
+        assertResponse(
+            prepareSearch("nrd_index").setRankBuilder(new RRFRankBuilder(101, 1))
+                .setTrackTotalHits(true)
+                .setKnnSearch(List.of(knnSearch))
+                .setQuery(
+                    QueryBuilders.boolQuery()
+                        .should(QueryBuilders.termQuery("text0", "500").boost(11.0f))
+                        .should(QueryBuilders.termQuery("text0", "499").boost(10.0f))
+                        .should(QueryBuilders.termQuery("text0", "498").boost(9.0f))
+                        .should(QueryBuilders.termQuery("text0", "497").boost(8.0f))
+                        .should(QueryBuilders.termQuery("text0", "496").boost(7.0f))
+                        .should(QueryBuilders.termQuery("text0", "495").boost(6.0f))
+                        .should(QueryBuilders.termQuery("text0", "494").boost(5.0f))
+                        .should(QueryBuilders.termQuery("text0", "493").boost(4.0f))
+                        .should(QueryBuilders.termQuery("text0", "492").boost(3.0f))
+                        .should(QueryBuilders.termQuery("text0", "491").boost(2.0f))
+                )
+                .addFetchField("vector_asc")
+                .addFetchField("text0")
+                .setSize(11)
+                .addAggregation(AggregationBuilders.terms("sums").field("int")),
+            response -> {
+                assertEquals(101, response.getHits().getTotalHits().value);
+                assertEquals(11, response.getHits().getHits().length);
 
-        assertEquals(101, response.getHits().getTotalHits().value);
-        assertEquals(11, response.getHits().getHits().length);
+                SearchHit hit = response.getHits().getAt(0);
+                assertEquals(1, hit.getRank());
+                assertEquals(500.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
+                assertEquals("term 500", hit.field("text0").getValue());
 
-        SearchHit hit = response.getHits().getAt(0);
-        assertEquals(1, hit.getRank());
-        assertEquals(500.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
-        assertEquals("term 500", hit.field("text0").getValue());
+                Set<Double> vectors = Arrays.stream(response.getHits().getHits())
+                    .map(h -> ((Number) h.field("vector_asc").getValue()).doubleValue())
+                    .collect(Collectors.toSet());
+                assertEquals(Set.of(492.0, 493.0, 494.0, 495.0, 496.0, 497.0, 498.0, 499.0, 500.0, 501.0, 502.0), vectors);
 
-        Set<Double> vectors = Arrays.stream(response.getHits().getHits())
-            .map(h -> ((Number) h.field("vector_asc").getValue()).doubleValue())
-            .collect(Collectors.toSet());
-        assertEquals(Set.of(492.0, 493.0, 494.0, 495.0, 496.0, 497.0, 498.0, 499.0, 500.0, 501.0, 502.0), vectors);
+                LongTerms aggregation = response.getAggregations().get("sums");
+                assertEquals(3, aggregation.getBuckets().size());
 
-        LongTerms aggregation = response.getAggregations().get("sums");
-        assertEquals(3, aggregation.getBuckets().size());
-
-        for (LongTerms.Bucket bucket : aggregation.getBuckets()) {
-            if (0L == (long) bucket.getKey()) {
-                assertEquals(34, bucket.getDocCount());
-            } else if (1L == (long) bucket.getKey()) {
-                assertEquals(34, bucket.getDocCount());
-            } else if (2L == (long) bucket.getKey()) {
-                assertEquals(33, bucket.getDocCount());
-            } else {
-                throw new IllegalArgumentException("unexpected bucket key [" + bucket.getKey() + "]");
+                for (LongTerms.Bucket bucket : aggregation.getBuckets()) {
+                    if (0L == (long) bucket.getKey()) {
+                        assertEquals(34, bucket.getDocCount());
+                    } else if (1L == (long) bucket.getKey()) {
+                        assertEquals(34, bucket.getDocCount());
+                    } else if (2L == (long) bucket.getKey()) {
+                        assertEquals(33, bucket.getDocCount());
+                    } else {
+                        throw new IllegalArgumentException("unexpected bucket key [" + bucket.getKey() + "]");
+                    }
+                }
             }
-        }
+        );
     }
 
     public void testMultipleOnlyKnnWithAggregation() {
@@ -384,65 +393,67 @@ public class RRFRankMultiShardIT extends ESIntegTestCase {
         float[] queryVectorDesc = { 500.0f };
         KnnSearchBuilder knnSearchAsc = new KnnSearchBuilder("vector_asc", queryVectorAsc, 51, 1001, null);
         KnnSearchBuilder knnSearchDesc = new KnnSearchBuilder("vector_desc", queryVectorDesc, 51, 1001, null);
-        SearchResponse response = prepareSearch("nrd_index").setRankBuilder(new RRFRankBuilder(51, 1))
-            .setTrackTotalHits(false)
-            .setKnnSearch(List.of(knnSearchAsc, knnSearchDesc))
-            .addFetchField("vector_asc")
-            .addFetchField("text0")
-            .setSize(19)
-            .addAggregation(AggregationBuilders.terms("sums").field("int"))
-            .get();
+        assertResponse(
+            prepareSearch("nrd_index").setRankBuilder(new RRFRankBuilder(51, 1))
+                .setTrackTotalHits(false)
+                .setKnnSearch(List.of(knnSearchAsc, knnSearchDesc))
+                .addFetchField("vector_asc")
+                .addFetchField("text0")
+                .setSize(19)
+                .addAggregation(AggregationBuilders.terms("sums").field("int")),
+            response -> {
+                assertNull(response.getHits().getTotalHits());
+                assertEquals(19, response.getHits().getHits().length);
 
-        assertNull(response.getHits().getTotalHits());
-        assertEquals(19, response.getHits().getHits().length);
+                SearchHit hit = response.getHits().getAt(0);
+                assertEquals(1, hit.getRank());
+                assertEquals(500.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
+                assertEquals("term 500", hit.field("text0").getValue());
 
-        SearchHit hit = response.getHits().getAt(0);
-        assertEquals(1, hit.getRank());
-        assertEquals(500.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
-        assertEquals("term 500", hit.field("text0").getValue());
+                Set<Double> vectors = Arrays.stream(response.getHits().getHits())
+                    .map(h -> ((Number) h.field("vector_asc").getValue()).doubleValue())
+                    .collect(Collectors.toSet());
+                assertEquals(
+                    Set.of(
+                        491.0,
+                        492.0,
+                        493.0,
+                        494.0,
+                        495.0,
+                        496.0,
+                        497.0,
+                        498.0,
+                        499.0,
+                        500.0,
+                        501.0,
+                        502.0,
+                        503.0,
+                        504.0,
+                        505.0,
+                        506.0,
+                        507.0,
+                        508.0,
+                        509.0
+                    ),
+                    vectors
+                );
 
-        Set<Double> vectors = Arrays.stream(response.getHits().getHits())
-            .map(h -> ((Number) h.field("vector_asc").getValue()).doubleValue())
-            .collect(Collectors.toSet());
-        assertEquals(
-            Set.of(
-                491.0,
-                492.0,
-                493.0,
-                494.0,
-                495.0,
-                496.0,
-                497.0,
-                498.0,
-                499.0,
-                500.0,
-                501.0,
-                502.0,
-                503.0,
-                504.0,
-                505.0,
-                506.0,
-                507.0,
-                508.0,
-                509.0
-            ),
-            vectors
-        );
+                LongTerms aggregation = response.getAggregations().get("sums");
+                assertEquals(3, aggregation.getBuckets().size());
 
-        LongTerms aggregation = response.getAggregations().get("sums");
-        assertEquals(3, aggregation.getBuckets().size());
-
-        for (LongTerms.Bucket bucket : aggregation.getBuckets()) {
-            if (0L == (long) bucket.getKey()) {
-                assertEquals(17, bucket.getDocCount());
-            } else if (1L == (long) bucket.getKey()) {
-                assertEquals(17, bucket.getDocCount());
-            } else if (2L == (long) bucket.getKey()) {
-                assertEquals(17, bucket.getDocCount());
-            } else {
-                throw new IllegalArgumentException("unexpected bucket key [" + bucket.getKey() + "]");
+                for (LongTerms.Bucket bucket : aggregation.getBuckets()) {
+                    if (0L == (long) bucket.getKey()) {
+                        assertEquals(17, bucket.getDocCount());
+                    } else if (1L == (long) bucket.getKey()) {
+                        assertEquals(17, bucket.getDocCount());
+                    } else if (2L == (long) bucket.getKey()) {
+                        assertEquals(17, bucket.getDocCount());
+                    } else {
+                        throw new IllegalArgumentException("unexpected bucket key [" + bucket.getKey() + "]");
+                    }
+                }
             }
-        }
+        );
     }
 
     public void testBM25AndMultipleKnnWithAggregation() {
@@ -450,369 +461,379 @@ public class RRFRankMultiShardIT extends ESIntegTestCase {
         float[] queryVectorDesc = { 500.0f };
         KnnSearchBuilder knnSearchAsc = new KnnSearchBuilder("vector_asc", queryVectorAsc, 51, 1001, null);
         KnnSearchBuilder knnSearchDesc = new KnnSearchBuilder("vector_desc", queryVectorDesc, 51, 1001, null);
-        SearchResponse response = prepareSearch("nrd_index").setRankBuilder(new RRFRankBuilder(51, 1))
-            .setTrackTotalHits(true)
-            .setKnnSearch(List.of(knnSearchAsc, knnSearchDesc))
-            .setQuery(
-                QueryBuilders.boolQuery()
-                    .should(QueryBuilders.termQuery("text0", "500").boost(10.0f))
-                    .should(QueryBuilders.termQuery("text0", "499").boost(20.0f))
-                    .should(QueryBuilders.termQuery("text0", "498").boost(8.0f))
-                    .should(QueryBuilders.termQuery("text0", "497").boost(7.0f))
-                    .should(QueryBuilders.termQuery("text0", "496").boost(6.0f))
-                    .should(QueryBuilders.termQuery("text0", "485").boost(5.0f))
-                    .should(QueryBuilders.termQuery("text0", "494").boost(4.0f))
-                    .should(QueryBuilders.termQuery("text0", "506").boost(3.0f))
-                    .should(QueryBuilders.termQuery("text0", "505").boost(2.0f))
-                    .should(QueryBuilders.termQuery("text0", "511").boost(9.0f))
-            )
-            .addFetchField("vector_asc")
-            .addFetchField("vector_desc")
-            .addFetchField("text0")
-            .setSize(19)
-            .addAggregation(AggregationBuilders.terms("sums").field("int"))
-            .setStats("search")
-            .get();
+        assertResponse(
+            prepareSearch("nrd_index").setRankBuilder(new RRFRankBuilder(51, 1))
+                .setTrackTotalHits(true)
+                .setKnnSearch(List.of(knnSearchAsc, knnSearchDesc))
+                .setQuery(
+                    QueryBuilders.boolQuery()
+                        .should(QueryBuilders.termQuery("text0", "500").boost(10.0f))
+                        .should(QueryBuilders.termQuery("text0", "499").boost(20.0f))
+                        .should(QueryBuilders.termQuery("text0", "498").boost(8.0f))
+                        .should(QueryBuilders.termQuery("text0", "497").boost(7.0f))
+                        .should(QueryBuilders.termQuery("text0", "496").boost(6.0f))
+                        .should(QueryBuilders.termQuery("text0", "485").boost(5.0f))
+                        .should(QueryBuilders.termQuery("text0", "494").boost(4.0f))
+                        .should(QueryBuilders.termQuery("text0", "506").boost(3.0f))
+                        .should(QueryBuilders.termQuery("text0", "505").boost(2.0f))
+                        .should(QueryBuilders.termQuery("text0", "511").boost(9.0f))
+                )
+                .addFetchField("vector_asc")
+                .addFetchField("vector_desc")
+                .addFetchField("text0")
+                .setSize(19)
+                .addAggregation(AggregationBuilders.terms("sums").field("int"))
+                .setStats("search"),
+            response -> {
+                assertEquals(51, response.getHits().getTotalHits().value);
+                assertEquals(19, response.getHits().getHits().length);
 
-        assertEquals(51, response.getHits().getTotalHits().value);
-        assertEquals(19, response.getHits().getHits().length);
+                SearchHit hit = response.getHits().getAt(0);
+                assertEquals(1, hit.getRank());
+                assertEquals(500.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
+                assertEquals(500.0, ((Number) hit.field("vector_desc").getValue()).doubleValue(), 0.0);
+                assertEquals("term 500", hit.field("text0").getValue());
 
-        SearchHit hit = response.getHits().getAt(0);
-        assertEquals(1, hit.getRank());
-        assertEquals(500.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
-        assertEquals(500.0, ((Number) hit.field("vector_desc").getValue()).doubleValue(), 0.0);
-        assertEquals("term 500", hit.field("text0").getValue());
+                hit = response.getHits().getAt(1);
+                assertEquals(2, hit.getRank());
+                assertEquals(499.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
+                assertEquals(501.0, ((Number) hit.field("vector_desc").getValue()).doubleValue(), 0.0);
+                assertEquals("term 499", hit.field("text0").getValue());
 
-        hit = response.getHits().getAt(1);
-        assertEquals(2, hit.getRank());
-        assertEquals(499.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
-        assertEquals(501.0, ((Number) hit.field("vector_desc").getValue()).doubleValue(), 0.0);
-        assertEquals("term 499", hit.field("text0").getValue());
+                Set<Double> vectors = Arrays.stream(response.getHits().getHits())
+                    .map(h -> ((Number) h.field("vector_asc").getValue()).doubleValue())
+                    .collect(Collectors.toSet());
+                assertEquals(
+                    Set.of(
+                        485.0,
+                        492.0,
+                        493.0,
+                        494.0,
+                        495.0,
+                        496.0,
+                        497.0,
+                        498.0,
+                        499.0,
+                        500.0,
+                        501.0,
+                        502.0,
+                        503.0,
+                        504.0,
+                        505.0,
+                        506.0,
+                        507.0,
+                        508.0,
+                        511.0
+                    ),
+                    vectors
+                );
 
-        Set<Double> vectors = Arrays.stream(response.getHits().getHits())
-            .map(h -> ((Number) h.field("vector_asc").getValue()).doubleValue())
-            .collect(Collectors.toSet());
-        assertEquals(
-            Set.of(
-                485.0,
-                492.0,
-                493.0,
-                494.0,
-                495.0,
-                496.0,
-                497.0,
-                498.0,
-                499.0,
-                500.0,
-                501.0,
-                502.0,
-                503.0,
-                504.0,
-                505.0,
-                506.0,
-                507.0,
-                508.0,
-                511.0
-            ),
-            vectors
-        );
+                LongTerms aggregation = response.getAggregations().get("sums");
+                assertEquals(3, aggregation.getBuckets().size());
 
-        LongTerms aggregation = response.getAggregations().get("sums");
-        assertEquals(3, aggregation.getBuckets().size());
-
-        for (LongTerms.Bucket bucket : aggregation.getBuckets()) {
-            if (0L == (long) bucket.getKey()) {
-                assertEquals(17, bucket.getDocCount());
-            } else if (1L == (long) bucket.getKey()) {
-                assertEquals(17, bucket.getDocCount());
-            } else if (2L == (long) bucket.getKey()) {
-                assertEquals(17, bucket.getDocCount());
-            } else {
-                throw new IllegalArgumentException("unexpected bucket key [" + bucket.getKey() + "]");
+                for (LongTerms.Bucket bucket : aggregation.getBuckets()) {
+                    if (0L == (long) bucket.getKey()) {
+                        assertEquals(17, bucket.getDocCount());
+                    } else if (1L == (long) bucket.getKey()) {
+                        assertEquals(17, bucket.getDocCount());
+                    } else if (2L == (long) bucket.getKey()) {
+                        assertEquals(17, bucket.getDocCount());
+                    } else {
+                        throw new IllegalArgumentException("unexpected bucket key [" + bucket.getKey() + "]");
+                    }
+                }
             }
-        }
+        );
     }
 
     public void testMultiBM25() {
         for (SearchType searchType : SearchType.CURRENTLY_SUPPORTED) {
-            SearchResponse response = prepareSearch("nrd_index").setSearchType(searchType)
-                .setRankBuilder(new RRFRankBuilder(8, 1))
-                .setTrackTotalHits(false)
-                .setSubSearches(
-                    List.of(
-                        new SubSearchSourceBuilder(
-                            QueryBuilders.boolQuery()
-                                .should(QueryBuilders.termQuery("text0", "500").boost(10.0f))
-                                .should(QueryBuilders.termQuery("text0", "499").boost(9.0f))
-                                .should(QueryBuilders.termQuery("text0", "498").boost(8.0f))
-                                .should(QueryBuilders.termQuery("text0", "497").boost(7.0f))
-                                .should(QueryBuilders.termQuery("text0", "496").boost(6.0f))
-                                .should(QueryBuilders.termQuery("text0", "495").boost(5.0f))
-                                .should(QueryBuilders.termQuery("text0", "494").boost(4.0f))
-                                .should(QueryBuilders.termQuery("text0", "492").boost(3.0f))
-                                .should(QueryBuilders.termQuery("text0", "491").boost(2.0f))
-                                .should(QueryBuilders.termQuery("text0", "490").boost(1.0f))
-                        ),
-                        new SubSearchSourceBuilder(
-                            QueryBuilders.boolQuery()
-                                .should(QueryBuilders.termQuery("text1", "508").boost(9.0f))
-                                .should(QueryBuilders.termQuery("text1", "304").boost(8.0f))
-                                .should(QueryBuilders.termQuery("text1", "501").boost(7.0f))
-                                .should(QueryBuilders.termQuery("text1", "504").boost(6.0f))
-                                .should(QueryBuilders.termQuery("text1", "502").boost(5.0f))
-                                .should(QueryBuilders.termQuery("text1", "499").boost(4.0f))
-                                .should(QueryBuilders.termQuery("text1", "800").boost(3.0f))
-                                .should(QueryBuilders.termQuery("text1", "201").boost(2.0f))
-                                .should(QueryBuilders.termQuery("text1", "492").boost(1.0f))
+            assertResponse(
+                prepareSearch("nrd_index").setSearchType(searchType)
+                    .setRankBuilder(new RRFRankBuilder(8, 1))
+                    .setTrackTotalHits(false)
+                    .setSubSearches(
+                        List.of(
+                            new SubSearchSourceBuilder(
+                                QueryBuilders.boolQuery()
+                                    .should(QueryBuilders.termQuery("text0", "500").boost(10.0f))
+                                    .should(QueryBuilders.termQuery("text0", "499").boost(9.0f))
+                                    .should(QueryBuilders.termQuery("text0", "498").boost(8.0f))
+                                    .should(QueryBuilders.termQuery("text0", "497").boost(7.0f))
+                                    .should(QueryBuilders.termQuery("text0", "496").boost(6.0f))
+                                    .should(QueryBuilders.termQuery("text0", "495").boost(5.0f))
+                                    .should(QueryBuilders.termQuery("text0", "494").boost(4.0f))
+                                    .should(QueryBuilders.termQuery("text0", "492").boost(3.0f))
+                                    .should(QueryBuilders.termQuery("text0", "491").boost(2.0f))
+                                    .should(QueryBuilders.termQuery("text0", "490").boost(1.0f))
+                            ),
+                            new SubSearchSourceBuilder(
+                                QueryBuilders.boolQuery()
+                                    .should(QueryBuilders.termQuery("text1", "508").boost(9.0f))
+                                    .should(QueryBuilders.termQuery("text1", "304").boost(8.0f))
+                                    .should(QueryBuilders.termQuery("text1", "501").boost(7.0f))
+                                    .should(QueryBuilders.termQuery("text1", "504").boost(6.0f))
+                                    .should(QueryBuilders.termQuery("text1", "502").boost(5.0f))
+                                    .should(QueryBuilders.termQuery("text1", "499").boost(4.0f))
+                                    .should(QueryBuilders.termQuery("text1", "800").boost(3.0f))
+                                    .should(QueryBuilders.termQuery("text1", "201").boost(2.0f))
+                                    .should(QueryBuilders.termQuery("text1", "492").boost(1.0f))
+                            )
                         )
                     )
-                )
-                .addFetchField("text0")
-                .addFetchField("text1")
-                .setSize(5)
-                .get();
+                    .addFetchField("text0")
+                    .addFetchField("text1")
+                    .setSize(5),
+                response -> {
+                    assertNull(response.getHits().getTotalHits());
+                    assertEquals(5, response.getHits().getHits().length);
 
-            assertNull(response.getHits().getTotalHits());
-            assertEquals(5, response.getHits().getHits().length);
+                    SearchHit hit = response.getHits().getAt(0);
+                    assertEquals(1, hit.getRank());
+                    assertEquals("term 492", hit.field("text0").getValue());
+                    assertEquals("term 508", hit.field("text1").getValue());
 
-            SearchHit hit = response.getHits().getAt(0);
-            assertEquals(1, hit.getRank());
-            assertEquals("term 492", hit.field("text0").getValue());
-            assertEquals("term 508", hit.field("text1").getValue());
+                    hit = response.getHits().getAt(1);
+                    assertEquals(2, hit.getRank());
+                    assertEquals("term 499", hit.field("text0").getValue());
+                    assertEquals("term 501", hit.field("text1").getValue());
 
-            hit = response.getHits().getAt(1);
-            assertEquals(2, hit.getRank());
-            assertEquals("term 499", hit.field("text0").getValue());
-            assertEquals("term 501", hit.field("text1").getValue());
+                    hit = response.getHits().getAt(2);
+                    assertEquals(3, hit.getRank());
+                    assertEquals("term 500", hit.field("text0").getValue());
+                    assertEquals("term 500", hit.field("text1").getValue());
 
-            hit = response.getHits().getAt(2);
-            assertEquals(3, hit.getRank());
-            assertEquals("term 500", hit.field("text0").getValue());
-            assertEquals("term 500", hit.field("text1").getValue());
+                    hit = response.getHits().getAt(3);
+                    assertEquals(4, hit.getRank());
+                    assertEquals("term 498", hit.field("text0").getValue());
+                    assertEquals("term 502", hit.field("text1").getValue());
 
-            hit = response.getHits().getAt(3);
-            assertEquals(4, hit.getRank());
-            assertEquals("term 498", hit.field("text0").getValue());
-            assertEquals("term 502", hit.field("text1").getValue());
-
-            hit = response.getHits().getAt(4);
-            assertEquals(5, hit.getRank());
-            assertEquals("term 496", hit.field("text0").getValue());
-            assertEquals("term 504", hit.field("text1").getValue());
+                    hit = response.getHits().getAt(4);
+                    assertEquals(5, hit.getRank());
+                    assertEquals("term 496", hit.field("text0").getValue());
+                    assertEquals("term 504", hit.field("text1").getValue());
+                }
+            );
         }
     }
 
     public void testMultiBM25WithAggregation() {
         for (SearchType searchType : SearchType.CURRENTLY_SUPPORTED) {
-            SearchResponse response = prepareSearch("nrd_index").setSearchType(searchType)
-                .setRankBuilder(new RRFRankBuilder(8, 1))
-                .setTrackTotalHits(false)
-                .setSubSearches(
-                    List.of(
-                        new SubSearchSourceBuilder(
-                            QueryBuilders.boolQuery()
-                                .should(QueryBuilders.termQuery("text0", "500").boost(10.0f))
-                                .should(QueryBuilders.termQuery("text0", "499").boost(9.0f))
-                                .should(QueryBuilders.termQuery("text0", "498").boost(8.0f))
-                                .should(QueryBuilders.termQuery("text0", "497").boost(7.0f))
-                                .should(QueryBuilders.termQuery("text0", "496").boost(6.0f))
-                                .should(QueryBuilders.termQuery("text0", "495").boost(5.0f))
-                                .should(QueryBuilders.termQuery("text0", "494").boost(4.0f))
-                                .should(QueryBuilders.termQuery("text0", "492").boost(3.0f))
-                                .should(QueryBuilders.termQuery("text0", "491").boost(2.0f))
-                                .should(QueryBuilders.termQuery("text0", "490").boost(1.0f))
-                        ),
-                        new SubSearchSourceBuilder(
-                            QueryBuilders.boolQuery()
-                                .should(QueryBuilders.termQuery("text1", "508").boost(9.0f))
-                                .should(QueryBuilders.termQuery("text1", "304").boost(8.0f))
-                                .should(QueryBuilders.termQuery("text1", "501").boost(7.0f))
-                                .should(QueryBuilders.termQuery("text1", "504").boost(6.0f))
-                                .should(QueryBuilders.termQuery("text1", "502").boost(5.0f))
-                                .should(QueryBuilders.termQuery("text1", "499").boost(4.0f))
-                                .should(QueryBuilders.termQuery("text1", "801").boost(3.0f))
-                                .should(QueryBuilders.termQuery("text1", "201").boost(2.0f))
-                                .should(QueryBuilders.termQuery("text1", "492").boost(1.0f))
+            assertResponse(
+                prepareSearch("nrd_index").setSearchType(searchType)
+                    .setRankBuilder(new RRFRankBuilder(8, 1))
+                    .setTrackTotalHits(false)
+                    .setSubSearches(
+                        List.of(
+                            new SubSearchSourceBuilder(
+                                QueryBuilders.boolQuery()
+                                    .should(QueryBuilders.termQuery("text0", "500").boost(10.0f))
+                                    .should(QueryBuilders.termQuery("text0", "499").boost(9.0f))
+                                    .should(QueryBuilders.termQuery("text0", "498").boost(8.0f))
+                                    .should(QueryBuilders.termQuery("text0", "497").boost(7.0f))
+                                    .should(QueryBuilders.termQuery("text0", "496").boost(6.0f))
+                                    .should(QueryBuilders.termQuery("text0", "495").boost(5.0f))
+                                    .should(QueryBuilders.termQuery("text0", "494").boost(4.0f))
+                                    .should(QueryBuilders.termQuery("text0", "492").boost(3.0f))
+                                    .should(QueryBuilders.termQuery("text0", "491").boost(2.0f))
+                                    .should(QueryBuilders.termQuery("text0", "490").boost(1.0f))
+                            ),
+                            new SubSearchSourceBuilder(
+                                QueryBuilders.boolQuery()
+                                    .should(QueryBuilders.termQuery("text1", "508").boost(9.0f))
+                                    .should(QueryBuilders.termQuery("text1", "304").boost(8.0f))
+                                    .should(QueryBuilders.termQuery("text1", "501").boost(7.0f))
+                                    .should(QueryBuilders.termQuery("text1", "504").boost(6.0f))
+                                    .should(QueryBuilders.termQuery("text1", "502").boost(5.0f))
+                                    .should(QueryBuilders.termQuery("text1", "499").boost(4.0f))
+                                    .should(QueryBuilders.termQuery("text1", "801").boost(3.0f))
+                                    .should(QueryBuilders.termQuery("text1", "201").boost(2.0f))
+                                    .should(QueryBuilders.termQuery("text1", "492").boost(1.0f))
+                            )
                         )
                     )
-                )
-                .addFetchField("text0")
-                .addFetchField("text1")
-                .setSize(5)
-                .addAggregation(AggregationBuilders.terms("sums").field("int"))
-                .get();
+                    .addFetchField("text0")
+                    .addFetchField("text1")
+                    .setSize(5)
+                    .addAggregation(AggregationBuilders.terms("sums").field("int")),
+                response -> {
+                    assertNull(response.getHits().getTotalHits());
+                    assertEquals(5, response.getHits().getHits().length);
 
-            assertNull(response.getHits().getTotalHits());
-            assertEquals(5, response.getHits().getHits().length);
+                    SearchHit hit = response.getHits().getAt(0);
+                    assertEquals(1, hit.getRank());
+                    assertEquals("term 492", hit.field("text0").getValue());
+                    assertEquals("term 508", hit.field("text1").getValue());
 
-            SearchHit hit = response.getHits().getAt(0);
-            assertEquals(1, hit.getRank());
-            assertEquals("term 492", hit.field("text0").getValue());
-            assertEquals("term 508", hit.field("text1").getValue());
+                    hit = response.getHits().getAt(1);
+                    assertEquals(2, hit.getRank());
+                    assertEquals("term 499", hit.field("text0").getValue());
+                    assertEquals("term 501", hit.field("text1").getValue());
 
-            hit = response.getHits().getAt(1);
-            assertEquals(2, hit.getRank());
-            assertEquals("term 499", hit.field("text0").getValue());
-            assertEquals("term 501", hit.field("text1").getValue());
+                    hit = response.getHits().getAt(2);
+                    assertEquals(3, hit.getRank());
+                    assertEquals("term 500", hit.field("text0").getValue());
+                    assertEquals("term 500", hit.field("text1").getValue());
 
-            hit = response.getHits().getAt(2);
-            assertEquals(3, hit.getRank());
-            assertEquals("term 500", hit.field("text0").getValue());
-            assertEquals("term 500", hit.field("text1").getValue());
+                    hit = response.getHits().getAt(3);
+                    assertEquals(4, hit.getRank());
+                    assertEquals("term 498", hit.field("text0").getValue());
+                    assertEquals("term 502", hit.field("text1").getValue());
 
-            hit = response.getHits().getAt(3);
-            assertEquals(4, hit.getRank());
-            assertEquals("term 498", hit.field("text0").getValue());
-            assertEquals("term 502", hit.field("text1").getValue());
+                    hit = response.getHits().getAt(4);
+                    assertEquals(5, hit.getRank());
+                    assertEquals("term 496", hit.field("text0").getValue());
+                    assertEquals("term 504", hit.field("text1").getValue());
 
-            hit = response.getHits().getAt(4);
-            assertEquals(5, hit.getRank());
-            assertEquals("term 496", hit.field("text0").getValue());
-            assertEquals("term 504", hit.field("text1").getValue());
+                    LongTerms aggregation = response.getAggregations().get("sums");
+                    assertEquals(3, aggregation.getBuckets().size());
 
-            LongTerms aggregation = response.getAggregations().get("sums");
-            assertEquals(3, aggregation.getBuckets().size());
-
-            for (LongTerms.Bucket bucket : aggregation.getBuckets()) {
-                if (0L == (long) bucket.getKey()) {
-                    assertEquals(5, bucket.getDocCount());
-                } else if (1L == (long) bucket.getKey()) {
-                    assertEquals(6, bucket.getDocCount());
-                } else if (2L == (long) bucket.getKey()) {
-                    assertEquals(4, bucket.getDocCount());
-                } else {
-                    throw new IllegalArgumentException("unexpected bucket key [" + bucket.getKey() + "]");
+                    for (LongTerms.Bucket bucket : aggregation.getBuckets()) {
+                        if (0L == (long) bucket.getKey()) {
+                            assertEquals(5, bucket.getDocCount());
+                        } else if (1L == (long) bucket.getKey()) {
+                            assertEquals(6, bucket.getDocCount());
+                        } else if (2L == (long) bucket.getKey()) {
+                            assertEquals(4, bucket.getDocCount());
+                        } else {
+                            throw new IllegalArgumentException("unexpected bucket key [" + bucket.getKey() + "]");
+                        }
+                    }
                 }
-            }
+            );
         }
     }
 
     public void testMultiBM25AndSingleKnn() {
         float[] queryVector = { 500.0f };
         KnnSearchBuilder knnSearch = new KnnSearchBuilder("vector_asc", queryVector, 101, 1001, null);
-        SearchResponse response = prepareSearch("nrd_index").setRankBuilder(new RRFRankBuilder(101, 1))
-            .setTrackTotalHits(false)
-            .setKnnSearch(List.of(knnSearch))
-            .setSubSearches(
-                List.of(
-                    new SubSearchSourceBuilder(
-                        QueryBuilders.boolQuery()
-                            .should(QueryBuilders.termQuery("text0", "500").boost(10.0f))
-                            .should(QueryBuilders.termQuery("text0", "499").boost(9.0f))
-                            .should(QueryBuilders.termQuery("text0", "498").boost(8.0f))
-                            .should(QueryBuilders.termQuery("text0", "497").boost(7.0f))
-                            .should(QueryBuilders.termQuery("text0", "496").boost(6.0f))
-                            .should(QueryBuilders.termQuery("text0", "495").boost(5.0f))
-                            .should(QueryBuilders.termQuery("text0", "494").boost(4.0f))
-                            .should(QueryBuilders.termQuery("text0", "492").boost(3.0f))
-                            .should(QueryBuilders.termQuery("text0", "491").boost(2.0f))
-                            .should(QueryBuilders.termQuery("text0", "490").boost(1.0f))
-                    ),
-                    new SubSearchSourceBuilder(
-                        QueryBuilders.boolQuery()
-                            .should(QueryBuilders.termQuery("text1", "508").boost(9.0f))
-                            .should(QueryBuilders.termQuery("text1", "304").boost(8.0f))
-                            .should(QueryBuilders.termQuery("text1", "501").boost(7.0f))
-                            .should(QueryBuilders.termQuery("text1", "504").boost(6.0f))
-                            .should(QueryBuilders.termQuery("text1", "492").boost(5.0f))
-                            .should(QueryBuilders.termQuery("text1", "502").boost(4.0f))
-                            .should(QueryBuilders.termQuery("text1", "499").boost(3.0f))
-                            .should(QueryBuilders.termQuery("text1", "800").boost(2.0f))
-                            .should(QueryBuilders.termQuery("text1", "201").boost(1.0f))
+        assertResponse(
+            prepareSearch("nrd_index").setRankBuilder(new RRFRankBuilder(101, 1))
+                .setTrackTotalHits(false)
+                .setKnnSearch(List.of(knnSearch))
+                .setSubSearches(
+                    List.of(
+                        new SubSearchSourceBuilder(
+                            QueryBuilders.boolQuery()
+                                .should(QueryBuilders.termQuery("text0", "500").boost(10.0f))
+                                .should(QueryBuilders.termQuery("text0", "499").boost(9.0f))
+                                .should(QueryBuilders.termQuery("text0", "498").boost(8.0f))
+                                .should(QueryBuilders.termQuery("text0", "497").boost(7.0f))
+                                .should(QueryBuilders.termQuery("text0", "496").boost(6.0f))
+                                .should(QueryBuilders.termQuery("text0", "495").boost(5.0f))
+                                .should(QueryBuilders.termQuery("text0", "494").boost(4.0f))
+                                .should(QueryBuilders.termQuery("text0", "492").boost(3.0f))
+                                .should(QueryBuilders.termQuery("text0", "491").boost(2.0f))
+                                .should(QueryBuilders.termQuery("text0", "490").boost(1.0f))
+                        ),
+                        new SubSearchSourceBuilder(
+                            QueryBuilders.boolQuery()
+                                .should(QueryBuilders.termQuery("text1", "508").boost(9.0f))
+                                .should(QueryBuilders.termQuery("text1", "304").boost(8.0f))
+                                .should(QueryBuilders.termQuery("text1", "501").boost(7.0f))
+                                .should(QueryBuilders.termQuery("text1", "504").boost(6.0f))
+                                .should(QueryBuilders.termQuery("text1", "492").boost(5.0f))
+                                .should(QueryBuilders.termQuery("text1", "502").boost(4.0f))
+                                .should(QueryBuilders.termQuery("text1", "499").boost(3.0f))
+                                .should(QueryBuilders.termQuery("text1", "800").boost(2.0f))
+                                .should(QueryBuilders.termQuery("text1", "201").boost(1.0f))
+                        )
                     )
                 )
-            )
-            .addFetchField("text0")
-            .addFetchField("text1")
-            .addFetchField("vector_asc")
-            .setSize(5)
-            .get();
+                .addFetchField("text0")
+                .addFetchField("text1")
+                .addFetchField("vector_asc")
+                .setSize(5),
+            response -> {
+                assertNull(response.getHits().getTotalHits());
+                assertEquals(5, response.getHits().getHits().length);
 
-        assertNull(response.getHits().getTotalHits());
-        assertEquals(5, response.getHits().getHits().length);
+                SearchHit hit = response.getHits().getAt(0);
+                assertEquals(1, hit.getRank());
+                assertEquals("term 500", hit.field("text0").getValue());
+                assertEquals("term 500", hit.field("text1").getValue());
+                assertEquals(500.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
 
-        SearchHit hit = response.getHits().getAt(0);
-        assertEquals(1, hit.getRank());
-        assertEquals("term 500", hit.field("text0").getValue());
-        assertEquals("term 500", hit.field("text1").getValue());
-        assertEquals(500.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
-
-        Set<Double> vectors = Arrays.stream(response.getHits().getHits())
-            .map(h -> ((Number) h.field("vector_asc").getValue()).doubleValue())
-            .collect(Collectors.toSet());
-        assertEquals(Set.of(492.0, 496.0, 498.0, 499.0, 500.0), vectors);
+                Set<Double> vectors = Arrays.stream(response.getHits().getHits())
+                    .map(h -> ((Number) h.field("vector_asc").getValue()).doubleValue())
+                    .collect(Collectors.toSet());
+                assertEquals(Set.of(492.0, 496.0, 498.0, 499.0, 500.0), vectors);
+            }
+        );
     }
 
     public void testMultiBM25AndSingleKnnWithAggregation() {
         float[] queryVector = { 500.0f };
         KnnSearchBuilder knnSearch = new KnnSearchBuilder("vector_asc", queryVector, 101, 1001, null);
-        SearchResponse response = prepareSearch("nrd_index").setRankBuilder(new RRFRankBuilder(101, 1))
-            .setTrackTotalHits(false)
-            .setKnnSearch(List.of(knnSearch))
-            .setSubSearches(
-                List.of(
-                    new SubSearchSourceBuilder(
-                        QueryBuilders.boolQuery()
-                            .should(QueryBuilders.termQuery("text0", "500").boost(10.0f))
-                            .should(QueryBuilders.termQuery("text0", "499").boost(9.0f))
-                            .should(QueryBuilders.termQuery("text0", "498").boost(8.0f))
-                            .should(QueryBuilders.termQuery("text0", "497").boost(7.0f))
-                            .should(QueryBuilders.termQuery("text0", "496").boost(6.0f))
-                            .should(QueryBuilders.termQuery("text0", "495").boost(5.0f))
-                            .should(QueryBuilders.termQuery("text0", "494").boost(4.0f))
-                            .should(QueryBuilders.termQuery("text0", "492").boost(3.0f))
-                            .should(QueryBuilders.termQuery("text0", "491").boost(2.0f))
-                            .should(QueryBuilders.termQuery("text0", "490").boost(1.0f))
-                    ),
-                    new SubSearchSourceBuilder(
-                        QueryBuilders.boolQuery()
-                            .should(QueryBuilders.termQuery("text1", "508").boost(9.0f))
-                            .should(QueryBuilders.termQuery("text1", "304").boost(8.0f))
-                            .should(QueryBuilders.termQuery("text1", "501").boost(7.0f))
-                            .should(QueryBuilders.termQuery("text1", "504").boost(6.0f))
-                            .should(QueryBuilders.termQuery("text1", "492").boost(5.0f))
-                            .should(QueryBuilders.termQuery("text1", "502").boost(4.0f))
-                            .should(QueryBuilders.termQuery("text1", "499").boost(3.0f))
-                            .should(QueryBuilders.termQuery("text1", "800").boost(2.0f))
-                            .should(QueryBuilders.termQuery("text1", "201").boost(1.0f))
+        assertResponse(
+            prepareSearch("nrd_index").setRankBuilder(new RRFRankBuilder(101, 1))
+                .setTrackTotalHits(false)
+                .setKnnSearch(List.of(knnSearch))
+                .setSubSearches(
+                    List.of(
+                        new SubSearchSourceBuilder(
+                            QueryBuilders.boolQuery()
+                                .should(QueryBuilders.termQuery("text0", "500").boost(10.0f))
+                                .should(QueryBuilders.termQuery("text0", "499").boost(9.0f))
+                                .should(QueryBuilders.termQuery("text0", "498").boost(8.0f))
+                                .should(QueryBuilders.termQuery("text0", "497").boost(7.0f))
+                                .should(QueryBuilders.termQuery("text0", "496").boost(6.0f))
+                                .should(QueryBuilders.termQuery("text0", "495").boost(5.0f))
+                                .should(QueryBuilders.termQuery("text0", "494").boost(4.0f))
+                                .should(QueryBuilders.termQuery("text0", "492").boost(3.0f))
+                                .should(QueryBuilders.termQuery("text0", "491").boost(2.0f))
+                                .should(QueryBuilders.termQuery("text0", "490").boost(1.0f))
+                        ),
+                        new SubSearchSourceBuilder(
+                            QueryBuilders.boolQuery()
+                                .should(QueryBuilders.termQuery("text1", "508").boost(9.0f))
+                                .should(QueryBuilders.termQuery("text1", "304").boost(8.0f))
+                                .should(QueryBuilders.termQuery("text1", "501").boost(7.0f))
+                                .should(QueryBuilders.termQuery("text1", "504").boost(6.0f))
+                                .should(QueryBuilders.termQuery("text1", "492").boost(5.0f))
+                                .should(QueryBuilders.termQuery("text1", "502").boost(4.0f))
+                                .should(QueryBuilders.termQuery("text1", "499").boost(3.0f))
+                                .should(QueryBuilders.termQuery("text1", "800").boost(2.0f))
+                                .should(QueryBuilders.termQuery("text1", "201").boost(1.0f))
+                        )
                     )
                 )
-            )
-            .addFetchField("text0")
-            .addFetchField("text1")
-            .addFetchField("vector_asc")
-            .setSize(5)
-            .addAggregation(AggregationBuilders.terms("sums").field("int"))
-            .get();
+                .addFetchField("text0")
+                .addFetchField("text1")
+                .addFetchField("vector_asc")
+                .setSize(5)
+                .addAggregation(AggregationBuilders.terms("sums").field("int")),
+            response -> {
+                assertNull(response.getHits().getTotalHits());
+                assertEquals(5, response.getHits().getHits().length);
 
-        assertNull(response.getHits().getTotalHits());
-        assertEquals(5, response.getHits().getHits().length);
+                SearchHit hit = response.getHits().getAt(0);
+                assertEquals(1, hit.getRank());
+                assertEquals("term 500", hit.field("text0").getValue());
+                assertEquals("term 500", hit.field("text1").getValue());
+                assertEquals(500.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
 
-        SearchHit hit = response.getHits().getAt(0);
-        assertEquals(1, hit.getRank());
-        assertEquals("term 500", hit.field("text0").getValue());
-        assertEquals("term 500", hit.field("text1").getValue());
-        assertEquals(500.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
+                Set<Double> vectors = Arrays.stream(response.getHits().getHits())
+                    .map(h -> ((Number) h.field("vector_asc").getValue()).doubleValue())
+                    .collect(Collectors.toSet());
+                assertEquals(Set.of(492.0, 496.0, 498.0, 499.0, 500.0), vectors);
 
-        Set<Double> vectors = Arrays.stream(response.getHits().getHits())
-            .map(h -> ((Number) h.field("vector_asc").getValue()).doubleValue())
-            .collect(Collectors.toSet());
-        assertEquals(Set.of(492.0, 496.0, 498.0, 499.0, 500.0), vectors);
+                LongTerms aggregation = response.getAggregations().get("sums");
+                assertEquals(3, aggregation.getBuckets().size());
 
-        LongTerms aggregation = response.getAggregations().get("sums");
-        assertEquals(3, aggregation.getBuckets().size());
-
-        for (LongTerms.Bucket bucket : aggregation.getBuckets()) {
-            if (0L == (long) bucket.getKey()) {
-                assertEquals(35, bucket.getDocCount());
-            } else if (1L == (long) bucket.getKey()) {
-                assertEquals(35, bucket.getDocCount());
-            } else if (2L == (long) bucket.getKey()) {
-                assertEquals(34, bucket.getDocCount());
-            } else {
-                throw new IllegalArgumentException("unexpected bucket key [" + bucket.getKey() + "]");
+                for (LongTerms.Bucket bucket : aggregation.getBuckets()) {
+                    if (0L == (long) bucket.getKey()) {
+                        assertEquals(35, bucket.getDocCount());
+                    } else if (1L == (long) bucket.getKey()) {
+                        assertEquals(35, bucket.getDocCount());
+                    } else if (2L == (long) bucket.getKey()) {
+                        assertEquals(34, bucket.getDocCount());
+                    } else {
+                        throw new IllegalArgumentException("unexpected bucket key [" + bucket.getKey() + "]");
+                    }
+                }
             }
-        }
+        );
     }
 
     public void testMultiBM25AndMultipleKnn() {
@@ -820,59 +841,61 @@ public class RRFRankMultiShardIT extends ESIntegTestCase {
         float[] queryVectorDesc = { 500.0f };
         KnnSearchBuilder knnSearchAsc = new KnnSearchBuilder("vector_asc", queryVectorAsc, 101, 1001, null);
         KnnSearchBuilder knnSearchDesc = new KnnSearchBuilder("vector_desc", queryVectorDesc, 101, 1001, null);
-        SearchResponse response = prepareSearch("nrd_index").setRankBuilder(new RRFRankBuilder(101, 1))
-            .setTrackTotalHits(false)
-            .setKnnSearch(List.of(knnSearchAsc, knnSearchDesc))
-            .setSubSearches(
-                List.of(
-                    new SubSearchSourceBuilder(
-                        QueryBuilders.boolQuery()
-                            .should(QueryBuilders.termQuery("text0", "500").boost(10.0f))
-                            .should(QueryBuilders.termQuery("text0", "499").boost(9.0f))
-                            .should(QueryBuilders.termQuery("text0", "498").boost(8.0f))
-                            .should(QueryBuilders.termQuery("text0", "497").boost(7.0f))
-                            .should(QueryBuilders.termQuery("text0", "496").boost(6.0f))
-                            .should(QueryBuilders.termQuery("text0", "495").boost(5.0f))
-                            .should(QueryBuilders.termQuery("text0", "494").boost(4.0f))
-                            .should(QueryBuilders.termQuery("text0", "492").boost(3.0f))
-                            .should(QueryBuilders.termQuery("text0", "491").boost(2.0f))
-                            .should(QueryBuilders.termQuery("text0", "490").boost(1.0f))
-                    ),
-                    new SubSearchSourceBuilder(
-                        QueryBuilders.boolQuery()
-                            .should(QueryBuilders.termQuery("text1", "508").boost(9.0f))
-                            .should(QueryBuilders.termQuery("text1", "304").boost(8.0f))
-                            .should(QueryBuilders.termQuery("text1", "501").boost(7.0f))
-                            .should(QueryBuilders.termQuery("text1", "504").boost(6.0f))
-                            .should(QueryBuilders.termQuery("text1", "492").boost(5.0f))
-                            .should(QueryBuilders.termQuery("text1", "502").boost(4.0f))
-                            .should(QueryBuilders.termQuery("text1", "499").boost(3.0f))
-                            .should(QueryBuilders.termQuery("text1", "800").boost(2.0f))
-                            .should(QueryBuilders.termQuery("text1", "201").boost(1.0f))
+        assertResponse(
+            prepareSearch("nrd_index").setRankBuilder(new RRFRankBuilder(101, 1))
+                .setTrackTotalHits(false)
+                .setKnnSearch(List.of(knnSearchAsc, knnSearchDesc))
+                .setSubSearches(
+                    List.of(
+                        new SubSearchSourceBuilder(
+                            QueryBuilders.boolQuery()
+                                .should(QueryBuilders.termQuery("text0", "500").boost(10.0f))
+                                .should(QueryBuilders.termQuery("text0", "499").boost(9.0f))
+                                .should(QueryBuilders.termQuery("text0", "498").boost(8.0f))
+                                .should(QueryBuilders.termQuery("text0", "497").boost(7.0f))
+                                .should(QueryBuilders.termQuery("text0", "496").boost(6.0f))
+                                .should(QueryBuilders.termQuery("text0", "495").boost(5.0f))
+                                .should(QueryBuilders.termQuery("text0", "494").boost(4.0f))
+                                .should(QueryBuilders.termQuery("text0", "492").boost(3.0f))
+                                .should(QueryBuilders.termQuery("text0", "491").boost(2.0f))
+                                .should(QueryBuilders.termQuery("text0", "490").boost(1.0f))
+                        ),
+                        new SubSearchSourceBuilder(
+                            QueryBuilders.boolQuery()
+                                .should(QueryBuilders.termQuery("text1", "508").boost(9.0f))
+                                .should(QueryBuilders.termQuery("text1", "304").boost(8.0f))
+                                .should(QueryBuilders.termQuery("text1", "501").boost(7.0f))
+                                .should(QueryBuilders.termQuery("text1", "504").boost(6.0f))
+                                .should(QueryBuilders.termQuery("text1", "492").boost(5.0f))
+                                .should(QueryBuilders.termQuery("text1", "502").boost(4.0f))
+                                .should(QueryBuilders.termQuery("text1", "499").boost(3.0f))
+                                .should(QueryBuilders.termQuery("text1", "800").boost(2.0f))
+                                .should(QueryBuilders.termQuery("text1", "201").boost(1.0f))
+                        )
                     )
                 )
-            )
-            .addFetchField("text0")
-            .addFetchField("text1")
-            .addFetchField("vector_asc")
-            .addFetchField("vector_desc")
-            .setSize(5)
-            .get();
+                .addFetchField("text0")
+                .addFetchField("text1")
+                .addFetchField("vector_asc")
+                .addFetchField("vector_desc")
+                .setSize(5),
+            response -> {
+                assertNull(response.getHits().getTotalHits());
+                assertEquals(5, response.getHits().getHits().length);
 
-        assertNull(response.getHits().getTotalHits());
-        assertEquals(5, response.getHits().getHits().length);
+                SearchHit hit = response.getHits().getAt(0);
+                assertEquals(1, hit.getRank());
+                assertEquals("term 500", hit.field("text0").getValue());
+                assertEquals("term 500", hit.field("text1").getValue());
+                assertEquals(500.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
+                assertEquals(500.0, ((Number) hit.field("vector_desc").getValue()).doubleValue(), 0.0);
 
-        SearchHit hit = response.getHits().getAt(0);
-        assertEquals(1, hit.getRank());
-        assertEquals("term 500", hit.field("text0").getValue());
-        assertEquals("term 500", hit.field("text1").getValue());
-        assertEquals(500.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
-        assertEquals(500.0, ((Number) hit.field("vector_desc").getValue()).doubleValue(), 0.0);
-
-        Set<Double> vectors = Arrays.stream(response.getHits().getHits())
-            .map(h -> ((Number) h.field("vector_asc").getValue()).doubleValue())
-            .collect(Collectors.toSet());
-        assertEquals(Set.of(492.0, 498.0, 499.0, 500.0, 501.0), vectors);
+                Set<Double> vectors = Arrays.stream(response.getHits().getHits())
+                    .map(h -> ((Number) h.field("vector_asc").getValue()).doubleValue())
+                    .collect(Collectors.toSet());
+                assertEquals(Set.of(492.0, 498.0, 499.0, 500.0, 501.0), vectors);
+            }
+        );
     }
 
     public void testMultiBM25AndMultipleKnnWithAggregation() {
@@ -880,74 +903,76 @@ public class RRFRankMultiShardIT extends ESIntegTestCase {
         float[] queryVectorDesc = { 500.0f };
         KnnSearchBuilder knnSearchAsc = new KnnSearchBuilder("vector_asc", queryVectorAsc, 101, 1001, null);
         KnnSearchBuilder knnSearchDesc = new KnnSearchBuilder("vector_desc", queryVectorDesc, 101, 1001, null);
-        SearchResponse response = prepareSearch("nrd_index").setRankBuilder(new RRFRankBuilder(101, 1))
-            .setTrackTotalHits(false)
-            .setKnnSearch(List.of(knnSearchAsc, knnSearchDesc))
-            .setSubSearches(
-                List.of(
-                    new SubSearchSourceBuilder(
-                        QueryBuilders.boolQuery()
-                            .should(QueryBuilders.termQuery("text0", "500").boost(10.0f))
-                            .should(QueryBuilders.termQuery("text0", "499").boost(9.0f))
-                            .should(QueryBuilders.termQuery("text0", "498").boost(8.0f))
-                            .should(QueryBuilders.termQuery("text0", "497").boost(7.0f))
-                            .should(QueryBuilders.termQuery("text0", "496").boost(6.0f))
-                            .should(QueryBuilders.termQuery("text0", "495").boost(5.0f))
-                            .should(QueryBuilders.termQuery("text0", "494").boost(4.0f))
-                            .should(QueryBuilders.termQuery("text0", "492").boost(3.0f))
-                            .should(QueryBuilders.termQuery("text0", "491").boost(2.0f))
-                            .should(QueryBuilders.termQuery("text0", "490").boost(1.0f))
-                    ),
-                    new SubSearchSourceBuilder(
-                        QueryBuilders.boolQuery()
-                            .should(QueryBuilders.termQuery("text1", "508").boost(9.0f))
-                            .should(QueryBuilders.termQuery("text1", "304").boost(8.0f))
-                            .should(QueryBuilders.termQuery("text1", "501").boost(7.0f))
-                            .should(QueryBuilders.termQuery("text1", "504").boost(6.0f))
-                            .should(QueryBuilders.termQuery("text1", "492").boost(5.0f))
-                            .should(QueryBuilders.termQuery("text1", "502").boost(4.0f))
-                            .should(QueryBuilders.termQuery("text1", "499").boost(3.0f))
-                            .should(QueryBuilders.termQuery("text1", "800").boost(2.0f))
-                            .should(QueryBuilders.termQuery("text1", "201").boost(1.0f))
+        assertResponse(
+            prepareSearch("nrd_index").setRankBuilder(new RRFRankBuilder(101, 1))
+                .setTrackTotalHits(false)
+                .setKnnSearch(List.of(knnSearchAsc, knnSearchDesc))
+                .setSubSearches(
+                    List.of(
+                        new SubSearchSourceBuilder(
+                            QueryBuilders.boolQuery()
+                                .should(QueryBuilders.termQuery("text0", "500").boost(10.0f))
+                                .should(QueryBuilders.termQuery("text0", "499").boost(9.0f))
+                                .should(QueryBuilders.termQuery("text0", "498").boost(8.0f))
+                                .should(QueryBuilders.termQuery("text0", "497").boost(7.0f))
+                                .should(QueryBuilders.termQuery("text0", "496").boost(6.0f))
+                                .should(QueryBuilders.termQuery("text0", "495").boost(5.0f))
+                                .should(QueryBuilders.termQuery("text0", "494").boost(4.0f))
+                                .should(QueryBuilders.termQuery("text0", "492").boost(3.0f))
+                                .should(QueryBuilders.termQuery("text0", "491").boost(2.0f))
+                                .should(QueryBuilders.termQuery("text0", "490").boost(1.0f))
+                        ),
+                        new SubSearchSourceBuilder(
+                            QueryBuilders.boolQuery()
+                                .should(QueryBuilders.termQuery("text1", "508").boost(9.0f))
+                                .should(QueryBuilders.termQuery("text1", "304").boost(8.0f))
+                                .should(QueryBuilders.termQuery("text1", "501").boost(7.0f))
+                                .should(QueryBuilders.termQuery("text1", "504").boost(6.0f))
+                                .should(QueryBuilders.termQuery("text1", "492").boost(5.0f))
+                                .should(QueryBuilders.termQuery("text1", "502").boost(4.0f))
+                                .should(QueryBuilders.termQuery("text1", "499").boost(3.0f))
+                                .should(QueryBuilders.termQuery("text1", "800").boost(2.0f))
+                                .should(QueryBuilders.termQuery("text1", "201").boost(1.0f))
+                        )
                     )
                 )
-            )
-            .addFetchField("text0")
-            .addFetchField("text1")
-            .addFetchField("vector_asc")
-            .addFetchField("vector_desc")
-            .setSize(5)
-            .addAggregation(AggregationBuilders.terms("sums").field("int"))
-            .get();
+                .addFetchField("text0")
+                .addFetchField("text1")
+                .addFetchField("vector_asc")
+                .addFetchField("vector_desc")
+                .setSize(5)
+                .addAggregation(AggregationBuilders.terms("sums").field("int")),
+            response -> {
+                assertNull(response.getHits().getTotalHits());
+                assertEquals(5, response.getHits().getHits().length);
 
-        assertNull(response.getHits().getTotalHits());
-        assertEquals(5, response.getHits().getHits().length);
+                SearchHit hit = response.getHits().getAt(0);
+                assertEquals(1, hit.getRank());
+                assertEquals("term 500", hit.field("text0").getValue());
+                assertEquals("term 500", hit.field("text1").getValue());
+                assertEquals(500.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
+                assertEquals(500.0, ((Number) hit.field("vector_desc").getValue()).doubleValue(), 0.0);
 
-        SearchHit hit = response.getHits().getAt(0);
-        assertEquals(1, hit.getRank());
-        assertEquals("term 500", hit.field("text0").getValue());
-        assertEquals("term 500", hit.field("text1").getValue());
-        assertEquals(500.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
-        assertEquals(500.0, ((Number) hit.field("vector_desc").getValue()).doubleValue(), 0.0);
+                Set<Double> vectors = Arrays.stream(response.getHits().getHits())
+                    .map(h -> ((Number) h.field("vector_asc").getValue()).doubleValue())
+                    .collect(Collectors.toSet());
+                assertEquals(Set.of(492.0, 498.0, 499.0, 500.0, 501.0), vectors);
 
-        Set<Double> vectors = Arrays.stream(response.getHits().getHits())
-            .map(h -> ((Number) h.field("vector_asc").getValue()).doubleValue())
-            .collect(Collectors.toSet());
-        assertEquals(Set.of(492.0, 498.0, 499.0, 500.0, 501.0), vectors);
+                LongTerms aggregation = response.getAggregations().get("sums");
+                assertEquals(3, aggregation.getBuckets().size());
 
-        LongTerms aggregation = response.getAggregations().get("sums");
-        assertEquals(3, aggregation.getBuckets().size());
-
-        for (LongTerms.Bucket bucket : aggregation.getBuckets()) {
-            if (0L == (long) bucket.getKey()) {
-                assertEquals(35, bucket.getDocCount());
-            } else if (1L == (long) bucket.getKey()) {
-                assertEquals(35, bucket.getDocCount());
-            } else if (2L == (long) bucket.getKey()) {
-                assertEquals(34, bucket.getDocCount());
-            } else {
-                throw new IllegalArgumentException("unexpected bucket key [" + bucket.getKey() + "]");
+                for (LongTerms.Bucket bucket : aggregation.getBuckets()) {
+                    if (0L == (long) bucket.getKey()) {
+                        assertEquals(35, bucket.getDocCount());
+                    } else if (1L == (long) bucket.getKey()) {
+                        assertEquals(35, bucket.getDocCount());
+                    } else if (2L == (long) bucket.getKey()) {
+                        assertEquals(34, bucket.getDocCount());
+                    } else {
+                        throw new IllegalArgumentException("unexpected bucket key [" + bucket.getKey() + "]");
+                    }
+                }
             }
-        }
+        );
     }
 }

--- a/x-pack/plugin/rank-rrf/src/internalClusterTest/java/org/elasticsearch/xpack/rank/rrf/RRFRankShardCanMatchIT.java
+++ b/x-pack/plugin/rank-rrf/src/internalClusterTest/java/org/elasticsearch/xpack/rank/rrf/RRFRankShardCanMatchIT.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.rank.rrf;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.action.DocWriteResponse;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -31,6 +30,7 @@ import java.util.Collection;
 import java.util.List;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 
 @ESIntegTestCase.ClusterScope(maxNumDataNodes = 3)
 @ESIntegTestCase.SuiteScopeTestCase
@@ -144,98 +144,108 @@ public class RRFRankShardCanMatchIT extends ESIntegTestCase {
         indicesAdmin().prepareRefresh("value_index").get();
 
         // match 2 separate shard with no overlap in queries
-        SearchResponse response = prepareSearch("value_index").setSearchType(SearchType.QUERY_THEN_FETCH)
-            .setPreFilterShardSize(1)
-            .setRankBuilder(new RRFRankBuilder(20, 1))
-            .setTrackTotalHits(false)
-            .setSubSearches(
-                List.of(
-                    new SubSearchSourceBuilder(new SkipShardPlugin.SkipShardQueryBuilder(shardA, shardB, "value", "9")),
-                    new SubSearchSourceBuilder(new SkipShardPlugin.SkipShardQueryBuilder(shardA, shardB, "value", "19"))
+        assertResponse(
+            prepareSearch("value_index").setSearchType(SearchType.QUERY_THEN_FETCH)
+                .setPreFilterShardSize(1)
+                .setRankBuilder(new RRFRankBuilder(20, 1))
+                .setTrackTotalHits(false)
+                .setSubSearches(
+                    List.of(
+                        new SubSearchSourceBuilder(new SkipShardPlugin.SkipShardQueryBuilder(shardA, shardB, "value", "9")),
+                        new SubSearchSourceBuilder(new SkipShardPlugin.SkipShardQueryBuilder(shardA, shardB, "value", "19"))
+                    )
                 )
-            )
-            .setSize(5)
-            .get();
-
-        assertNull(response.getHits().getTotalHits());
-        assertEquals(2, response.getHits().getHits().length);
-        assertEquals(5, response.getSuccessfulShards());
-        assertEquals(3, response.getSkippedShards());
+                .setSize(5),
+            response -> {
+                assertNull(response.getHits().getTotalHits());
+                assertEquals(2, response.getHits().getHits().length);
+                assertEquals(5, response.getSuccessfulShards());
+                assertEquals(3, response.getSkippedShards());
+            }
+        );
 
         // match one shard with one query and do not match the other shard with one query
-        response = prepareSearch("value_index").setSearchType(SearchType.QUERY_THEN_FETCH)
-            .setPreFilterShardSize(1)
-            .setRankBuilder(new RRFRankBuilder(20, 1))
-            .setTrackTotalHits(false)
-            .setSubSearches(
-                List.of(
-                    new SubSearchSourceBuilder(new SkipShardPlugin.SkipShardQueryBuilder(shardA, shardB, "value", "30")),
-                    new SubSearchSourceBuilder(new SkipShardPlugin.SkipShardQueryBuilder(shardA, shardB, "value", "19"))
+        assertResponse(
+            prepareSearch("value_index").setSearchType(SearchType.QUERY_THEN_FETCH)
+                .setPreFilterShardSize(1)
+                .setRankBuilder(new RRFRankBuilder(20, 1))
+                .setTrackTotalHits(false)
+                .setSubSearches(
+                    List.of(
+                        new SubSearchSourceBuilder(new SkipShardPlugin.SkipShardQueryBuilder(shardA, shardB, "value", "30")),
+                        new SubSearchSourceBuilder(new SkipShardPlugin.SkipShardQueryBuilder(shardA, shardB, "value", "19"))
+                    )
                 )
-            )
-            .setSize(5)
-            .get();
-
-        assertNull(response.getHits().getTotalHits());
-        assertEquals(1, response.getHits().getHits().length);
-        assertEquals(5, response.getSuccessfulShards());
-        assertEquals(4, response.getSkippedShards());
+                .setSize(5),
+            response -> {
+                assertNull(response.getHits().getTotalHits());
+                assertEquals(1, response.getHits().getHits().length);
+                assertEquals(5, response.getSuccessfulShards());
+                assertEquals(4, response.getSkippedShards());
+            }
+        );
 
         // match no shards, but still use one to generate a search response
-        response = prepareSearch("value_index").setSearchType(SearchType.QUERY_THEN_FETCH)
-            .setPreFilterShardSize(1)
-            .setRankBuilder(new RRFRankBuilder(20, 1))
-            .setTrackTotalHits(false)
-            .setSubSearches(
-                List.of(
-                    new SubSearchSourceBuilder(new SkipShardPlugin.SkipShardQueryBuilder(shardA, shardB, "value", "30")),
-                    new SubSearchSourceBuilder(new SkipShardPlugin.SkipShardQueryBuilder(shardA, shardB, "value", "40"))
+        assertResponse(
+            prepareSearch("value_index").setSearchType(SearchType.QUERY_THEN_FETCH)
+                .setPreFilterShardSize(1)
+                .setRankBuilder(new RRFRankBuilder(20, 1))
+                .setTrackTotalHits(false)
+                .setSubSearches(
+                    List.of(
+                        new SubSearchSourceBuilder(new SkipShardPlugin.SkipShardQueryBuilder(shardA, shardB, "value", "30")),
+                        new SubSearchSourceBuilder(new SkipShardPlugin.SkipShardQueryBuilder(shardA, shardB, "value", "40"))
+                    )
                 )
-            )
-            .setSize(5)
-            .get();
-
-        assertNull(response.getHits().getTotalHits());
-        assertEquals(0, response.getHits().getHits().length);
-        assertEquals(5, response.getSuccessfulShards());
-        assertEquals(4, response.getSkippedShards());
+                .setSize(5),
+            response -> {
+                assertNull(response.getHits().getTotalHits());
+                assertEquals(0, response.getHits().getHits().length);
+                assertEquals(5, response.getSuccessfulShards());
+                assertEquals(4, response.getSkippedShards());
+            }
+        );
 
         // match the same shard for both queries
-        response = prepareSearch("value_index").setSearchType(SearchType.QUERY_THEN_FETCH)
-            .setPreFilterShardSize(1)
-            .setRankBuilder(new RRFRankBuilder(20, 1))
-            .setTrackTotalHits(false)
-            .setSubSearches(
-                List.of(
-                    new SubSearchSourceBuilder(new SkipShardPlugin.SkipShardQueryBuilder(shardA, shardB, "value", "15")),
-                    new SubSearchSourceBuilder(new SkipShardPlugin.SkipShardQueryBuilder(shardA, shardB, "value", "16"))
+        assertResponse(
+            prepareSearch("value_index").setSearchType(SearchType.QUERY_THEN_FETCH)
+                .setPreFilterShardSize(1)
+                .setRankBuilder(new RRFRankBuilder(20, 1))
+                .setTrackTotalHits(false)
+                .setSubSearches(
+                    List.of(
+                        new SubSearchSourceBuilder(new SkipShardPlugin.SkipShardQueryBuilder(shardA, shardB, "value", "15")),
+                        new SubSearchSourceBuilder(new SkipShardPlugin.SkipShardQueryBuilder(shardA, shardB, "value", "16"))
+                    )
                 )
-            )
-            .setSize(5)
-            .get();
-
-        assertNull(response.getHits().getTotalHits());
-        assertEquals(2, response.getHits().getHits().length);
-        assertEquals(5, response.getSuccessfulShards());
-        assertEquals(4, response.getSkippedShards());
+                .setSize(5),
+            response -> {
+                assertNull(response.getHits().getTotalHits());
+                assertEquals(2, response.getHits().getHits().length);
+                assertEquals(5, response.getSuccessfulShards());
+                assertEquals(4, response.getSkippedShards());
+            }
+        );
 
         // match one shard with the exact same query
-        response = prepareSearch("value_index").setSearchType(SearchType.QUERY_THEN_FETCH)
-            .setPreFilterShardSize(1)
-            .setRankBuilder(new RRFRankBuilder(20, 1))
-            .setTrackTotalHits(false)
-            .setSubSearches(
-                List.of(
-                    new SubSearchSourceBuilder(new SkipShardPlugin.SkipShardQueryBuilder(shardA, shardB, "value", "8")),
-                    new SubSearchSourceBuilder(new SkipShardPlugin.SkipShardQueryBuilder(shardA, shardB, "value", "8"))
+        assertResponse(
+            prepareSearch("value_index").setSearchType(SearchType.QUERY_THEN_FETCH)
+                .setPreFilterShardSize(1)
+                .setRankBuilder(new RRFRankBuilder(20, 1))
+                .setTrackTotalHits(false)
+                .setSubSearches(
+                    List.of(
+                        new SubSearchSourceBuilder(new SkipShardPlugin.SkipShardQueryBuilder(shardA, shardB, "value", "8")),
+                        new SubSearchSourceBuilder(new SkipShardPlugin.SkipShardQueryBuilder(shardA, shardB, "value", "8"))
+                    )
                 )
-            )
-            .setSize(5)
-            .get();
-
-        assertNull(response.getHits().getTotalHits());
-        assertEquals(1, response.getHits().getHits().length);
-        assertEquals(5, response.getSuccessfulShards());
-        assertEquals(4, response.getSkippedShards());
+                .setSize(5),
+            response -> {
+                assertNull(response.getHits().getTotalHits());
+                assertEquals(1, response.getHits().getHits().length);
+                assertEquals(5, response.getSuccessfulShards());
+                assertEquals(4, response.getSkippedShards());
+            }
+        );
     }
 }

--- a/x-pack/plugin/rank-rrf/src/internalClusterTest/java/org/elasticsearch/xpack/rank/rrf/RRFRankSingleShardIT.java
+++ b/x-pack/plugin/rank-rrf/src/internalClusterTest/java/org/elasticsearch/xpack/rank/rrf/RRFRankSingleShardIT.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.rank.rrf;
 
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
@@ -28,6 +27,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 
 public class RRFRankSingleShardIT extends ESSingleNodeTestCase {
 
@@ -124,71 +125,75 @@ public class RRFRankSingleShardIT extends ESSingleNodeTestCase {
     public void testTotalDocsSmallerThanSize() {
         float[] queryVector = { 0.0f };
         KnnSearchBuilder knnSearch = new KnnSearchBuilder("vector", queryVector, 3, 3, null);
-        SearchResponse response = client().prepareSearch("tiny_index")
-            .setRankBuilder(new RRFRankBuilder(100, 1))
-            .setKnnSearch(List.of(knnSearch))
-            .setQuery(QueryBuilders.termQuery("text", "term"))
-            .addFetchField("vector")
-            .addFetchField("text")
-            .get();
 
-        // we cast to Number when looking at values in vector fields because different xContentTypes may return Float or Double
+        assertResponse(
+            client().prepareSearch("tiny_index")
+                .setRankBuilder(new RRFRankBuilder(100, 1))
+                .setKnnSearch(List.of(knnSearch))
+                .setQuery(QueryBuilders.termQuery("text", "term"))
+                .addFetchField("vector")
+                .addFetchField("text"),
+            response -> {
+                // we cast to Number when looking at values in vector fields because different xContentTypes may return Float or Double
+                assertEquals(3, response.getHits().getHits().length);
 
-        assertEquals(3, response.getHits().getHits().length);
+                SearchHit hit = response.getHits().getAt(0);
+                assertEquals(1, hit.getRank());
+                assertEquals(0.0, ((Number) hit.field("vector").getValue()).doubleValue(), 0.0);
+                assertEquals("term term", hit.field("text").getValue());
 
-        SearchHit hit = response.getHits().getAt(0);
-        assertEquals(1, hit.getRank());
-        assertEquals(0.0, ((Number) hit.field("vector").getValue()).doubleValue(), 0.0);
-        assertEquals("term term", hit.field("text").getValue());
+                hit = response.getHits().getAt(1);
+                assertEquals(2, hit.getRank());
+                assertEquals(2.0, ((Number) hit.field("vector").getValue()).doubleValue(), 0.0);
+                assertEquals("term", hit.field("text").getValue());
 
-        hit = response.getHits().getAt(1);
-        assertEquals(2, hit.getRank());
-        assertEquals(2.0, ((Number) hit.field("vector").getValue()).doubleValue(), 0.0);
-        assertEquals("term", hit.field("text").getValue());
-
-        hit = response.getHits().getAt(2);
-        assertEquals(3, hit.getRank());
-        assertEquals(1.0, ((Number) hit.field("vector").getValue()).doubleValue(), 0.0);
-        assertEquals("other", hit.field("text").getValue());
+                hit = response.getHits().getAt(2);
+                assertEquals(3, hit.getRank());
+                assertEquals(1.0, ((Number) hit.field("vector").getValue()).doubleValue(), 0.0);
+                assertEquals("other", hit.field("text").getValue());
+            }
+        );
     }
 
     public void testBM25AndKnn() {
         float[] queryVector = { 500.0f };
         KnnSearchBuilder knnSearch = new KnnSearchBuilder("vector_asc", queryVector, 101, 1001, null);
-        SearchResponse response = client().prepareSearch("nrd_index")
-            .setRankBuilder(new RRFRankBuilder(101, 1))
-            .setTrackTotalHits(false)
-            .setKnnSearch(List.of(knnSearch))
-            .setQuery(
-                QueryBuilders.boolQuery()
-                    .should(QueryBuilders.termQuery("text0", "500").boost(11.0f))
-                    .should(QueryBuilders.termQuery("text0", "499").boost(10.0f))
-                    .should(QueryBuilders.termQuery("text0", "498").boost(9.0f))
-                    .should(QueryBuilders.termQuery("text0", "497").boost(8.0f))
-                    .should(QueryBuilders.termQuery("text0", "496").boost(7.0f))
-                    .should(QueryBuilders.termQuery("text0", "495").boost(6.0f))
-                    .should(QueryBuilders.termQuery("text0", "494").boost(5.0f))
-                    .should(QueryBuilders.termQuery("text0", "493").boost(4.0f))
-                    .should(QueryBuilders.termQuery("text0", "492").boost(3.0f))
-                    .should(QueryBuilders.termQuery("text0", "491").boost(2.0f))
-            )
-            .addFetchField("vector_asc")
-            .addFetchField("text0")
-            .setSize(11)
-            .get();
+        assertResponse(
+            client().prepareSearch("nrd_index")
+                .setRankBuilder(new RRFRankBuilder(101, 1))
+                .setTrackTotalHits(false)
+                .setKnnSearch(List.of(knnSearch))
+                .setQuery(
+                    QueryBuilders.boolQuery()
+                        .should(QueryBuilders.termQuery("text0", "500").boost(11.0f))
+                        .should(QueryBuilders.termQuery("text0", "499").boost(10.0f))
+                        .should(QueryBuilders.termQuery("text0", "498").boost(9.0f))
+                        .should(QueryBuilders.termQuery("text0", "497").boost(8.0f))
+                        .should(QueryBuilders.termQuery("text0", "496").boost(7.0f))
+                        .should(QueryBuilders.termQuery("text0", "495").boost(6.0f))
+                        .should(QueryBuilders.termQuery("text0", "494").boost(5.0f))
+                        .should(QueryBuilders.termQuery("text0", "493").boost(4.0f))
+                        .should(QueryBuilders.termQuery("text0", "492").boost(3.0f))
+                        .should(QueryBuilders.termQuery("text0", "491").boost(2.0f))
+                )
+                .addFetchField("vector_asc")
+                .addFetchField("text0")
+                .setSize(11),
+            response -> {
+                assertNull(response.getHits().getTotalHits());
+                assertEquals(11, response.getHits().getHits().length);
 
-        assertNull(response.getHits().getTotalHits());
-        assertEquals(11, response.getHits().getHits().length);
+                SearchHit hit = response.getHits().getAt(0);
+                assertEquals(1, hit.getRank());
+                assertEquals(500.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
+                assertEquals("term 500", hit.field("text0").getValue());
 
-        SearchHit hit = response.getHits().getAt(0);
-        assertEquals(1, hit.getRank());
-        assertEquals(500.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
-        assertEquals("term 500", hit.field("text0").getValue());
-
-        Set<Double> vectors = Arrays.stream(response.getHits().getHits())
-            .map(h -> ((Number) h.field("vector_asc").getValue()).doubleValue())
-            .collect(Collectors.toSet());
-        assertEquals(Set.of(492.0, 493.0, 494.0, 495.0, 496.0, 497.0, 498.0, 499.0, 500.0, 501.0, 502.0), vectors);
+                Set<Double> vectors = Arrays.stream(response.getHits().getHits())
+                    .map(h -> ((Number) h.field("vector_asc").getValue()).doubleValue())
+                    .collect(Collectors.toSet());
+                assertEquals(Set.of(492.0, 493.0, 494.0, 495.0, 496.0, 497.0, 498.0, 499.0, 500.0, 501.0, 502.0), vectors);
+            }
+        );
     }
 
     public void testMultipleOnlyKnn() {
@@ -196,49 +201,51 @@ public class RRFRankSingleShardIT extends ESSingleNodeTestCase {
         float[] queryVectorDesc = { 500.0f };
         KnnSearchBuilder knnSearchAsc = new KnnSearchBuilder("vector_asc", queryVectorAsc, 51, 1001, null);
         KnnSearchBuilder knnSearchDesc = new KnnSearchBuilder("vector_desc", queryVectorDesc, 51, 1001, null);
-        SearchResponse response = client().prepareSearch("nrd_index")
-            .setRankBuilder(new RRFRankBuilder(51, 1))
-            .setTrackTotalHits(true)
-            .setKnnSearch(List.of(knnSearchAsc, knnSearchDesc))
-            .addFetchField("vector_asc")
-            .addFetchField("text0")
-            .setSize(19)
-            .get();
+        assertResponse(
+            client().prepareSearch("nrd_index")
+                .setRankBuilder(new RRFRankBuilder(51, 1))
+                .setTrackTotalHits(true)
+                .setKnnSearch(List.of(knnSearchAsc, knnSearchDesc))
+                .addFetchField("vector_asc")
+                .addFetchField("text0")
+                .setSize(19),
+            response -> {
+                assertEquals(51, response.getHits().getTotalHits().value);
+                assertEquals(19, response.getHits().getHits().length);
 
-        assertEquals(51, response.getHits().getTotalHits().value);
-        assertEquals(19, response.getHits().getHits().length);
+                SearchHit hit = response.getHits().getAt(0);
+                assertEquals(1, hit.getRank());
+                assertEquals(500.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
+                assertEquals("term 500", hit.field("text0").getValue());
 
-        SearchHit hit = response.getHits().getAt(0);
-        assertEquals(1, hit.getRank());
-        assertEquals(500.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
-        assertEquals("term 500", hit.field("text0").getValue());
-
-        Set<Double> vectors = Arrays.stream(response.getHits().getHits())
-            .map(h -> ((Number) h.field("vector_asc").getValue()).doubleValue())
-            .collect(Collectors.toSet());
-        assertEquals(
-            Set.of(
-                491.0,
-                492.0,
-                493.0,
-                494.0,
-                495.0,
-                496.0,
-                497.0,
-                498.0,
-                499.0,
-                500.0,
-                501.0,
-                502.0,
-                503.0,
-                504.0,
-                505.0,
-                506.0,
-                507.0,
-                508.0,
-                509.0
-            ),
-            vectors
+                Set<Double> vectors = Arrays.stream(response.getHits().getHits())
+                    .map(h -> ((Number) h.field("vector_asc").getValue()).doubleValue())
+                    .collect(Collectors.toSet());
+                assertEquals(
+                    Set.of(
+                        491.0,
+                        492.0,
+                        493.0,
+                        494.0,
+                        495.0,
+                        496.0,
+                        497.0,
+                        498.0,
+                        499.0,
+                        500.0,
+                        501.0,
+                        502.0,
+                        503.0,
+                        504.0,
+                        505.0,
+                        506.0,
+                        507.0,
+                        508.0,
+                        509.0
+                    ),
+                    vectors
+                );
+            }
         );
     }
 
@@ -247,126 +254,130 @@ public class RRFRankSingleShardIT extends ESSingleNodeTestCase {
         float[] queryVectorDesc = { 500.0f };
         KnnSearchBuilder knnSearchAsc = new KnnSearchBuilder("vector_asc", queryVectorAsc, 51, 1001, null);
         KnnSearchBuilder knnSearchDesc = new KnnSearchBuilder("vector_desc", queryVectorDesc, 51, 1001, null);
-        SearchResponse response = client().prepareSearch("nrd_index")
-            .setRankBuilder(new RRFRankBuilder(51, 1))
-            .setTrackTotalHits(false)
-            .setKnnSearch(List.of(knnSearchAsc, knnSearchDesc))
-            .setQuery(
-                QueryBuilders.boolQuery()
-                    .should(QueryBuilders.termQuery("text0", "500").boost(10.0f))
-                    .should(QueryBuilders.termQuery("text0", "499").boost(20.0f))
-                    .should(QueryBuilders.termQuery("text0", "498").boost(8.0f))
-                    .should(QueryBuilders.termQuery("text0", "497").boost(7.0f))
-                    .should(QueryBuilders.termQuery("text0", "496").boost(6.0f))
-                    .should(QueryBuilders.termQuery("text0", "485").boost(5.0f))
-                    .should(QueryBuilders.termQuery("text0", "494").boost(4.0f))
-                    .should(QueryBuilders.termQuery("text0", "506").boost(3.0f))
-                    .should(QueryBuilders.termQuery("text0", "505").boost(2.0f))
-                    .should(QueryBuilders.termQuery("text0", "511").boost(9.0f))
-            )
-            .addFetchField("vector_asc")
-            .addFetchField("vector_desc")
-            .addFetchField("text0")
-            .setSize(19)
-            .get();
+        assertResponse(
+            client().prepareSearch("nrd_index")
+                .setRankBuilder(new RRFRankBuilder(51, 1))
+                .setTrackTotalHits(false)
+                .setKnnSearch(List.of(knnSearchAsc, knnSearchDesc))
+                .setQuery(
+                    QueryBuilders.boolQuery()
+                        .should(QueryBuilders.termQuery("text0", "500").boost(10.0f))
+                        .should(QueryBuilders.termQuery("text0", "499").boost(20.0f))
+                        .should(QueryBuilders.termQuery("text0", "498").boost(8.0f))
+                        .should(QueryBuilders.termQuery("text0", "497").boost(7.0f))
+                        .should(QueryBuilders.termQuery("text0", "496").boost(6.0f))
+                        .should(QueryBuilders.termQuery("text0", "485").boost(5.0f))
+                        .should(QueryBuilders.termQuery("text0", "494").boost(4.0f))
+                        .should(QueryBuilders.termQuery("text0", "506").boost(3.0f))
+                        .should(QueryBuilders.termQuery("text0", "505").boost(2.0f))
+                        .should(QueryBuilders.termQuery("text0", "511").boost(9.0f))
+                )
+                .addFetchField("vector_asc")
+                .addFetchField("vector_desc")
+                .addFetchField("text0")
+                .setSize(19),
+            response -> {
+                assertNull(response.getHits().getTotalHits());
+                assertEquals(19, response.getHits().getHits().length);
 
-        assertNull(response.getHits().getTotalHits());
-        assertEquals(19, response.getHits().getHits().length);
+                SearchHit hit = response.getHits().getAt(0);
+                assertEquals(1, hit.getRank());
+                assertEquals(500.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
+                assertEquals(500.0, ((Number) hit.field("vector_desc").getValue()).doubleValue(), 0.0);
+                assertEquals("term 500", hit.field("text0").getValue());
 
-        SearchHit hit = response.getHits().getAt(0);
-        assertEquals(1, hit.getRank());
-        assertEquals(500.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
-        assertEquals(500.0, ((Number) hit.field("vector_desc").getValue()).doubleValue(), 0.0);
-        assertEquals("term 500", hit.field("text0").getValue());
+                hit = response.getHits().getAt(1);
+                assertEquals(2, hit.getRank());
+                assertEquals(499.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
+                assertEquals(501.0, ((Number) hit.field("vector_desc").getValue()).doubleValue(), 0.0);
+                assertEquals("term 499", hit.field("text0").getValue());
 
-        hit = response.getHits().getAt(1);
-        assertEquals(2, hit.getRank());
-        assertEquals(499.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
-        assertEquals(501.0, ((Number) hit.field("vector_desc").getValue()).doubleValue(), 0.0);
-        assertEquals("term 499", hit.field("text0").getValue());
-
-        Set<Double> vectors = Arrays.stream(response.getHits().getHits())
-            .map(h -> ((Number) h.field("vector_asc").getValue()).doubleValue())
-            .collect(Collectors.toSet());
-        assertEquals(
-            Set.of(
-                485.0,
-                492.0,
-                493.0,
-                494.0,
-                495.0,
-                496.0,
-                497.0,
-                498.0,
-                499.0,
-                500.0,
-                501.0,
-                502.0,
-                503.0,
-                504.0,
-                505.0,
-                506.0,
-                507.0,
-                508.0,
-                511.0
-            ),
-            vectors
+                Set<Double> vectors = Arrays.stream(response.getHits().getHits())
+                    .map(h -> ((Number) h.field("vector_asc").getValue()).doubleValue())
+                    .collect(Collectors.toSet());
+                assertEquals(
+                    Set.of(
+                        485.0,
+                        492.0,
+                        493.0,
+                        494.0,
+                        495.0,
+                        496.0,
+                        497.0,
+                        498.0,
+                        499.0,
+                        500.0,
+                        501.0,
+                        502.0,
+                        503.0,
+                        504.0,
+                        505.0,
+                        506.0,
+                        507.0,
+                        508.0,
+                        511.0
+                    ),
+                    vectors
+                );
+            }
         );
     }
 
     public void testBM25AndKnnWithBucketAggregation() {
         float[] queryVector = { 500.0f };
         KnnSearchBuilder knnSearch = new KnnSearchBuilder("vector_asc", queryVector, 101, 1001, null);
-        SearchResponse response = client().prepareSearch("nrd_index")
-            .setRankBuilder(new RRFRankBuilder(101, 1))
-            .setTrackTotalHits(true)
-            .setKnnSearch(List.of(knnSearch))
-            .setQuery(
-                QueryBuilders.boolQuery()
-                    .should(QueryBuilders.termQuery("text0", "500").boost(11.0f))
-                    .should(QueryBuilders.termQuery("text0", "499").boost(10.0f))
-                    .should(QueryBuilders.termQuery("text0", "498").boost(9.0f))
-                    .should(QueryBuilders.termQuery("text0", "497").boost(8.0f))
-                    .should(QueryBuilders.termQuery("text0", "496").boost(7.0f))
-                    .should(QueryBuilders.termQuery("text0", "495").boost(6.0f))
-                    .should(QueryBuilders.termQuery("text0", "494").boost(5.0f))
-                    .should(QueryBuilders.termQuery("text0", "493").boost(4.0f))
-                    .should(QueryBuilders.termQuery("text0", "492").boost(3.0f))
-                    .should(QueryBuilders.termQuery("text0", "491").boost(2.0f))
-            )
-            .addFetchField("vector_asc")
-            .addFetchField("text0")
-            .setSize(11)
-            .addAggregation(AggregationBuilders.terms("sums").field("int"))
-            .get();
+        assertResponse(
+            client().prepareSearch("nrd_index")
+                .setRankBuilder(new RRFRankBuilder(101, 1))
+                .setTrackTotalHits(true)
+                .setKnnSearch(List.of(knnSearch))
+                .setQuery(
+                    QueryBuilders.boolQuery()
+                        .should(QueryBuilders.termQuery("text0", "500").boost(11.0f))
+                        .should(QueryBuilders.termQuery("text0", "499").boost(10.0f))
+                        .should(QueryBuilders.termQuery("text0", "498").boost(9.0f))
+                        .should(QueryBuilders.termQuery("text0", "497").boost(8.0f))
+                        .should(QueryBuilders.termQuery("text0", "496").boost(7.0f))
+                        .should(QueryBuilders.termQuery("text0", "495").boost(6.0f))
+                        .should(QueryBuilders.termQuery("text0", "494").boost(5.0f))
+                        .should(QueryBuilders.termQuery("text0", "493").boost(4.0f))
+                        .should(QueryBuilders.termQuery("text0", "492").boost(3.0f))
+                        .should(QueryBuilders.termQuery("text0", "491").boost(2.0f))
+                )
+                .addFetchField("vector_asc")
+                .addFetchField("text0")
+                .setSize(11)
+                .addAggregation(AggregationBuilders.terms("sums").field("int")),
+            response -> {
+                assertEquals(101, response.getHits().getTotalHits().value);
+                assertEquals(11, response.getHits().getHits().length);
 
-        assertEquals(101, response.getHits().getTotalHits().value);
-        assertEquals(11, response.getHits().getHits().length);
+                SearchHit hit = response.getHits().getAt(0);
+                assertEquals(1, hit.getRank());
+                assertEquals(500.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
+                assertEquals("term 500", hit.field("text0").getValue());
 
-        SearchHit hit = response.getHits().getAt(0);
-        assertEquals(1, hit.getRank());
-        assertEquals(500.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
-        assertEquals("term 500", hit.field("text0").getValue());
+                Set<Double> vectors = Arrays.stream(response.getHits().getHits())
+                    .map(h -> ((Number) h.field("vector_asc").getValue()).doubleValue())
+                    .collect(Collectors.toSet());
+                assertEquals(Set.of(492.0, 493.0, 494.0, 495.0, 496.0, 497.0, 498.0, 499.0, 500.0, 501.0, 502.0), vectors);
 
-        Set<Double> vectors = Arrays.stream(response.getHits().getHits())
-            .map(h -> ((Number) h.field("vector_asc").getValue()).doubleValue())
-            .collect(Collectors.toSet());
-        assertEquals(Set.of(492.0, 493.0, 494.0, 495.0, 496.0, 497.0, 498.0, 499.0, 500.0, 501.0, 502.0), vectors);
+                LongTerms aggregation = response.getAggregations().get("sums");
+                assertEquals(3, aggregation.getBuckets().size());
 
-        LongTerms aggregation = response.getAggregations().get("sums");
-        assertEquals(3, aggregation.getBuckets().size());
-
-        for (LongTerms.Bucket bucket : aggregation.getBuckets()) {
-            if (0L == (long) bucket.getKey()) {
-                assertEquals(34, bucket.getDocCount());
-            } else if (1L == (long) bucket.getKey()) {
-                assertEquals(34, bucket.getDocCount());
-            } else if (2L == (long) bucket.getKey()) {
-                assertEquals(33, bucket.getDocCount());
-            } else {
-                throw new IllegalArgumentException("unexpected bucket key [" + bucket.getKey() + "]");
+                for (LongTerms.Bucket bucket : aggregation.getBuckets()) {
+                    if (0L == (long) bucket.getKey()) {
+                        assertEquals(34, bucket.getDocCount());
+                    } else if (1L == (long) bucket.getKey()) {
+                        assertEquals(34, bucket.getDocCount());
+                    } else if (2L == (long) bucket.getKey()) {
+                        assertEquals(33, bucket.getDocCount());
+                    } else {
+                        throw new IllegalArgumentException("unexpected bucket key [" + bucket.getKey() + "]");
+                    }
+                }
             }
-        }
+        );
     }
 
     public void testMultipleOnlyKnnWithAggregation() {
@@ -374,66 +385,68 @@ public class RRFRankSingleShardIT extends ESSingleNodeTestCase {
         float[] queryVectorDesc = { 500.0f };
         KnnSearchBuilder knnSearchAsc = new KnnSearchBuilder("vector_asc", queryVectorAsc, 51, 1001, null);
         KnnSearchBuilder knnSearchDesc = new KnnSearchBuilder("vector_desc", queryVectorDesc, 51, 1001, null);
-        SearchResponse response = client().prepareSearch("nrd_index")
-            .setRankBuilder(new RRFRankBuilder(51, 1))
-            .setTrackTotalHits(false)
-            .setKnnSearch(List.of(knnSearchAsc, knnSearchDesc))
-            .addFetchField("vector_asc")
-            .addFetchField("text0")
-            .setSize(19)
-            .addAggregation(AggregationBuilders.terms("sums").field("int"))
-            .get();
+        assertResponse(
+            client().prepareSearch("nrd_index")
+                .setRankBuilder(new RRFRankBuilder(51, 1))
+                .setTrackTotalHits(false)
+                .setKnnSearch(List.of(knnSearchAsc, knnSearchDesc))
+                .addFetchField("vector_asc")
+                .addFetchField("text0")
+                .setSize(19)
+                .addAggregation(AggregationBuilders.terms("sums").field("int")),
+            response -> {
+                assertNull(response.getHits().getTotalHits());
+                assertEquals(19, response.getHits().getHits().length);
 
-        assertNull(response.getHits().getTotalHits());
-        assertEquals(19, response.getHits().getHits().length);
+                SearchHit hit = response.getHits().getAt(0);
+                assertEquals(1, hit.getRank());
+                assertEquals(500.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
+                assertEquals("term 500", hit.field("text0").getValue());
 
-        SearchHit hit = response.getHits().getAt(0);
-        assertEquals(1, hit.getRank());
-        assertEquals(500.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
-        assertEquals("term 500", hit.field("text0").getValue());
+                Set<Double> vectors = Arrays.stream(response.getHits().getHits())
+                    .map(h -> ((Number) h.field("vector_asc").getValue()).doubleValue())
+                    .collect(Collectors.toSet());
+                assertEquals(
+                    Set.of(
+                        491.0,
+                        492.0,
+                        493.0,
+                        494.0,
+                        495.0,
+                        496.0,
+                        497.0,
+                        498.0,
+                        499.0,
+                        500.0,
+                        501.0,
+                        502.0,
+                        503.0,
+                        504.0,
+                        505.0,
+                        506.0,
+                        507.0,
+                        508.0,
+                        509.0
+                    ),
+                    vectors
+                );
 
-        Set<Double> vectors = Arrays.stream(response.getHits().getHits())
-            .map(h -> ((Number) h.field("vector_asc").getValue()).doubleValue())
-            .collect(Collectors.toSet());
-        assertEquals(
-            Set.of(
-                491.0,
-                492.0,
-                493.0,
-                494.0,
-                495.0,
-                496.0,
-                497.0,
-                498.0,
-                499.0,
-                500.0,
-                501.0,
-                502.0,
-                503.0,
-                504.0,
-                505.0,
-                506.0,
-                507.0,
-                508.0,
-                509.0
-            ),
-            vectors
-        );
+                LongTerms aggregation = response.getAggregations().get("sums");
+                assertEquals(3, aggregation.getBuckets().size());
 
-        LongTerms aggregation = response.getAggregations().get("sums");
-        assertEquals(3, aggregation.getBuckets().size());
-
-        for (LongTerms.Bucket bucket : aggregation.getBuckets()) {
-            if (0L == (long) bucket.getKey()) {
-                assertEquals(17, bucket.getDocCount());
-            } else if (1L == (long) bucket.getKey()) {
-                assertEquals(17, bucket.getDocCount());
-            } else if (2L == (long) bucket.getKey()) {
-                assertEquals(17, bucket.getDocCount());
-            } else {
-                throw new IllegalArgumentException("unexpected bucket key [" + bucket.getKey() + "]");
+                for (LongTerms.Bucket bucket : aggregation.getBuckets()) {
+                    if (0L == (long) bucket.getKey()) {
+                        assertEquals(17, bucket.getDocCount());
+                    } else if (1L == (long) bucket.getKey()) {
+                        assertEquals(17, bucket.getDocCount());
+                    } else if (2L == (long) bucket.getKey()) {
+                        assertEquals(17, bucket.getDocCount());
+                    } else {
+                        throw new IllegalArgumentException("unexpected bucket key [" + bucket.getKey() + "]");
+                    }
+                }
             }
-        }
+        );
     }
 
     public void testBM25AndMultipleKnnWithAggregation() {
@@ -441,374 +454,384 @@ public class RRFRankSingleShardIT extends ESSingleNodeTestCase {
         float[] queryVectorDesc = { 500.0f };
         KnnSearchBuilder knnSearchAsc = new KnnSearchBuilder("vector_asc", queryVectorAsc, 51, 1001, null);
         KnnSearchBuilder knnSearchDesc = new KnnSearchBuilder("vector_desc", queryVectorDesc, 51, 1001, null);
-        SearchResponse response = client().prepareSearch("nrd_index")
-            .setRankBuilder(new RRFRankBuilder(51, 1))
-            .setTrackTotalHits(true)
-            .setKnnSearch(List.of(knnSearchAsc, knnSearchDesc))
-            .setQuery(
-                QueryBuilders.boolQuery()
-                    .should(QueryBuilders.termQuery("text0", "500").boost(10.0f))
-                    .should(QueryBuilders.termQuery("text0", "499").boost(20.0f))
-                    .should(QueryBuilders.termQuery("text0", "498").boost(8.0f))
-                    .should(QueryBuilders.termQuery("text0", "497").boost(7.0f))
-                    .should(QueryBuilders.termQuery("text0", "496").boost(6.0f))
-                    .should(QueryBuilders.termQuery("text0", "485").boost(5.0f))
-                    .should(QueryBuilders.termQuery("text0", "494").boost(4.0f))
-                    .should(QueryBuilders.termQuery("text0", "506").boost(3.0f))
-                    .should(QueryBuilders.termQuery("text0", "505").boost(2.0f))
-                    .should(QueryBuilders.termQuery("text0", "511").boost(9.0f))
-            )
-            .addFetchField("vector_asc")
-            .addFetchField("vector_desc")
-            .addFetchField("text0")
-            .setSize(19)
-            .addAggregation(AggregationBuilders.terms("sums").field("int"))
-            .setStats("search")
-            .get();
+        assertResponse(
+            client().prepareSearch("nrd_index")
+                .setRankBuilder(new RRFRankBuilder(51, 1))
+                .setTrackTotalHits(true)
+                .setKnnSearch(List.of(knnSearchAsc, knnSearchDesc))
+                .setQuery(
+                    QueryBuilders.boolQuery()
+                        .should(QueryBuilders.termQuery("text0", "500").boost(10.0f))
+                        .should(QueryBuilders.termQuery("text0", "499").boost(20.0f))
+                        .should(QueryBuilders.termQuery("text0", "498").boost(8.0f))
+                        .should(QueryBuilders.termQuery("text0", "497").boost(7.0f))
+                        .should(QueryBuilders.termQuery("text0", "496").boost(6.0f))
+                        .should(QueryBuilders.termQuery("text0", "485").boost(5.0f))
+                        .should(QueryBuilders.termQuery("text0", "494").boost(4.0f))
+                        .should(QueryBuilders.termQuery("text0", "506").boost(3.0f))
+                        .should(QueryBuilders.termQuery("text0", "505").boost(2.0f))
+                        .should(QueryBuilders.termQuery("text0", "511").boost(9.0f))
+                )
+                .addFetchField("vector_asc")
+                .addFetchField("vector_desc")
+                .addFetchField("text0")
+                .setSize(19)
+                .addAggregation(AggregationBuilders.terms("sums").field("int"))
+                .setStats("search"),
+            response -> {
+                assertEquals(51, response.getHits().getTotalHits().value);
+                assertEquals(19, response.getHits().getHits().length);
 
-        assertEquals(51, response.getHits().getTotalHits().value);
-        assertEquals(19, response.getHits().getHits().length);
+                SearchHit hit = response.getHits().getAt(0);
+                assertEquals(1, hit.getRank());
+                assertEquals(500.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
+                assertEquals(500.0, ((Number) hit.field("vector_desc").getValue()).doubleValue(), 0.0);
+                assertEquals("term 500", hit.field("text0").getValue());
 
-        SearchHit hit = response.getHits().getAt(0);
-        assertEquals(1, hit.getRank());
-        assertEquals(500.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
-        assertEquals(500.0, ((Number) hit.field("vector_desc").getValue()).doubleValue(), 0.0);
-        assertEquals("term 500", hit.field("text0").getValue());
+                hit = response.getHits().getAt(1);
+                assertEquals(2, hit.getRank());
+                assertEquals(499.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
+                assertEquals(501.0, ((Number) hit.field("vector_desc").getValue()).doubleValue(), 0.0);
+                assertEquals("term 499", hit.field("text0").getValue());
 
-        hit = response.getHits().getAt(1);
-        assertEquals(2, hit.getRank());
-        assertEquals(499.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
-        assertEquals(501.0, ((Number) hit.field("vector_desc").getValue()).doubleValue(), 0.0);
-        assertEquals("term 499", hit.field("text0").getValue());
+                Set<Double> vectors = Arrays.stream(response.getHits().getHits())
+                    .map(h -> ((Number) h.field("vector_asc").getValue()).doubleValue())
+                    .collect(Collectors.toSet());
+                assertEquals(
+                    Set.of(
+                        485.0,
+                        492.0,
+                        493.0,
+                        494.0,
+                        495.0,
+                        496.0,
+                        497.0,
+                        498.0,
+                        499.0,
+                        500.0,
+                        501.0,
+                        502.0,
+                        503.0,
+                        504.0,
+                        505.0,
+                        506.0,
+                        507.0,
+                        508.0,
+                        511.0
+                    ),
+                    vectors
+                );
 
-        Set<Double> vectors = Arrays.stream(response.getHits().getHits())
-            .map(h -> ((Number) h.field("vector_asc").getValue()).doubleValue())
-            .collect(Collectors.toSet());
-        assertEquals(
-            Set.of(
-                485.0,
-                492.0,
-                493.0,
-                494.0,
-                495.0,
-                496.0,
-                497.0,
-                498.0,
-                499.0,
-                500.0,
-                501.0,
-                502.0,
-                503.0,
-                504.0,
-                505.0,
-                506.0,
-                507.0,
-                508.0,
-                511.0
-            ),
-            vectors
-        );
+                LongTerms aggregation = response.getAggregations().get("sums");
+                assertEquals(3, aggregation.getBuckets().size());
 
-        LongTerms aggregation = response.getAggregations().get("sums");
-        assertEquals(3, aggregation.getBuckets().size());
-
-        for (LongTerms.Bucket bucket : aggregation.getBuckets()) {
-            if (0L == (long) bucket.getKey()) {
-                assertEquals(17, bucket.getDocCount());
-            } else if (1L == (long) bucket.getKey()) {
-                assertEquals(17, bucket.getDocCount());
-            } else if (2L == (long) bucket.getKey()) {
-                assertEquals(17, bucket.getDocCount());
-            } else {
-                throw new IllegalArgumentException("unexpected bucket key [" + bucket.getKey() + "]");
+                for (LongTerms.Bucket bucket : aggregation.getBuckets()) {
+                    if (0L == (long) bucket.getKey()) {
+                        assertEquals(17, bucket.getDocCount());
+                    } else if (1L == (long) bucket.getKey()) {
+                        assertEquals(17, bucket.getDocCount());
+                    } else if (2L == (long) bucket.getKey()) {
+                        assertEquals(17, bucket.getDocCount());
+                    } else {
+                        throw new IllegalArgumentException("unexpected bucket key [" + bucket.getKey() + "]");
+                    }
+                }
             }
-        }
+        );
     }
 
     public void testMultiBM25() {
         for (SearchType searchType : SearchType.CURRENTLY_SUPPORTED) {
-            SearchResponse response = client().prepareSearch("nrd_index")
-                .setSearchType(searchType)
-                .setRankBuilder(new RRFRankBuilder(8, 1))
-                .setTrackTotalHits(false)
-                .setSubSearches(
-                    List.of(
-                        new SubSearchSourceBuilder(
-                            QueryBuilders.boolQuery()
-                                .should(QueryBuilders.termQuery("text0", "500").boost(10.0f))
-                                .should(QueryBuilders.termQuery("text0", "499").boost(9.0f))
-                                .should(QueryBuilders.termQuery("text0", "498").boost(8.0f))
-                                .should(QueryBuilders.termQuery("text0", "497").boost(7.0f))
-                                .should(QueryBuilders.termQuery("text0", "496").boost(6.0f))
-                                .should(QueryBuilders.termQuery("text0", "495").boost(5.0f))
-                                .should(QueryBuilders.termQuery("text0", "494").boost(4.0f))
-                                .should(QueryBuilders.termQuery("text0", "492").boost(3.0f))
-                                .should(QueryBuilders.termQuery("text0", "491").boost(2.0f))
-                                .should(QueryBuilders.termQuery("text0", "490").boost(1.0f))
-                        ),
-                        new SubSearchSourceBuilder(
-                            QueryBuilders.boolQuery()
-                                .should(QueryBuilders.termQuery("text1", "508").boost(9.0f))
-                                .should(QueryBuilders.termQuery("text1", "304").boost(8.0f))
-                                .should(QueryBuilders.termQuery("text1", "501").boost(7.0f))
-                                .should(QueryBuilders.termQuery("text1", "504").boost(6.0f))
-                                .should(QueryBuilders.termQuery("text1", "502").boost(5.0f))
-                                .should(QueryBuilders.termQuery("text1", "499").boost(4.0f))
-                                .should(QueryBuilders.termQuery("text1", "800").boost(3.0f))
-                                .should(QueryBuilders.termQuery("text1", "201").boost(2.0f))
-                                .should(QueryBuilders.termQuery("text1", "492").boost(1.0f))
+            assertResponse(
+                client().prepareSearch("nrd_index")
+                    .setSearchType(searchType)
+                    .setRankBuilder(new RRFRankBuilder(8, 1))
+                    .setTrackTotalHits(false)
+                    .setSubSearches(
+                        List.of(
+                            new SubSearchSourceBuilder(
+                                QueryBuilders.boolQuery()
+                                    .should(QueryBuilders.termQuery("text0", "500").boost(10.0f))
+                                    .should(QueryBuilders.termQuery("text0", "499").boost(9.0f))
+                                    .should(QueryBuilders.termQuery("text0", "498").boost(8.0f))
+                                    .should(QueryBuilders.termQuery("text0", "497").boost(7.0f))
+                                    .should(QueryBuilders.termQuery("text0", "496").boost(6.0f))
+                                    .should(QueryBuilders.termQuery("text0", "495").boost(5.0f))
+                                    .should(QueryBuilders.termQuery("text0", "494").boost(4.0f))
+                                    .should(QueryBuilders.termQuery("text0", "492").boost(3.0f))
+                                    .should(QueryBuilders.termQuery("text0", "491").boost(2.0f))
+                                    .should(QueryBuilders.termQuery("text0", "490").boost(1.0f))
+                            ),
+                            new SubSearchSourceBuilder(
+                                QueryBuilders.boolQuery()
+                                    .should(QueryBuilders.termQuery("text1", "508").boost(9.0f))
+                                    .should(QueryBuilders.termQuery("text1", "304").boost(8.0f))
+                                    .should(QueryBuilders.termQuery("text1", "501").boost(7.0f))
+                                    .should(QueryBuilders.termQuery("text1", "504").boost(6.0f))
+                                    .should(QueryBuilders.termQuery("text1", "502").boost(5.0f))
+                                    .should(QueryBuilders.termQuery("text1", "499").boost(4.0f))
+                                    .should(QueryBuilders.termQuery("text1", "800").boost(3.0f))
+                                    .should(QueryBuilders.termQuery("text1", "201").boost(2.0f))
+                                    .should(QueryBuilders.termQuery("text1", "492").boost(1.0f))
+                            )
                         )
                     )
-                )
-                .addFetchField("text0")
-                .addFetchField("text1")
-                .setSize(5)
-                .get();
+                    .addFetchField("text0")
+                    .addFetchField("text1")
+                    .setSize(5),
+                response -> {
+                    assertNull(response.getHits().getTotalHits());
+                    assertEquals(5, response.getHits().getHits().length);
 
-            assertNull(response.getHits().getTotalHits());
-            assertEquals(5, response.getHits().getHits().length);
+                    SearchHit hit = response.getHits().getAt(0);
+                    assertEquals(1, hit.getRank());
+                    assertEquals("term 492", hit.field("text0").getValue());
+                    assertEquals("term 508", hit.field("text1").getValue());
 
-            SearchHit hit = response.getHits().getAt(0);
-            assertEquals(1, hit.getRank());
-            assertEquals("term 492", hit.field("text0").getValue());
-            assertEquals("term 508", hit.field("text1").getValue());
+                    hit = response.getHits().getAt(1);
+                    assertEquals(2, hit.getRank());
+                    assertEquals("term 499", hit.field("text0").getValue());
+                    assertEquals("term 501", hit.field("text1").getValue());
 
-            hit = response.getHits().getAt(1);
-            assertEquals(2, hit.getRank());
-            assertEquals("term 499", hit.field("text0").getValue());
-            assertEquals("term 501", hit.field("text1").getValue());
+                    hit = response.getHits().getAt(2);
+                    assertEquals(3, hit.getRank());
+                    assertEquals("term 500", hit.field("text0").getValue());
+                    assertEquals("term 500", hit.field("text1").getValue());
 
-            hit = response.getHits().getAt(2);
-            assertEquals(3, hit.getRank());
-            assertEquals("term 500", hit.field("text0").getValue());
-            assertEquals("term 500", hit.field("text1").getValue());
+                    hit = response.getHits().getAt(3);
+                    assertEquals(4, hit.getRank());
+                    assertEquals("term 498", hit.field("text0").getValue());
+                    assertEquals("term 502", hit.field("text1").getValue());
 
-            hit = response.getHits().getAt(3);
-            assertEquals(4, hit.getRank());
-            assertEquals("term 498", hit.field("text0").getValue());
-            assertEquals("term 502", hit.field("text1").getValue());
-
-            hit = response.getHits().getAt(4);
-            assertEquals(5, hit.getRank());
-            assertEquals("term 496", hit.field("text0").getValue());
-            assertEquals("term 504", hit.field("text1").getValue());
+                    hit = response.getHits().getAt(4);
+                    assertEquals(5, hit.getRank());
+                    assertEquals("term 496", hit.field("text0").getValue());
+                    assertEquals("term 504", hit.field("text1").getValue());
+                }
+            );
         }
     }
 
     public void testMultiBM25WithAggregation() {
         for (SearchType searchType : SearchType.CURRENTLY_SUPPORTED) {
-            SearchResponse response = client().prepareSearch("nrd_index")
-                .setSearchType(searchType)
-                .setRankBuilder(new RRFRankBuilder(8, 1))
-                .setTrackTotalHits(false)
-                .setSubSearches(
-                    List.of(
-                        new SubSearchSourceBuilder(
-                            QueryBuilders.boolQuery()
-                                .should(QueryBuilders.termQuery("text0", "500").boost(10.0f))
-                                .should(QueryBuilders.termQuery("text0", "499").boost(9.0f))
-                                .should(QueryBuilders.termQuery("text0", "498").boost(8.0f))
-                                .should(QueryBuilders.termQuery("text0", "497").boost(7.0f))
-                                .should(QueryBuilders.termQuery("text0", "496").boost(6.0f))
-                                .should(QueryBuilders.termQuery("text0", "495").boost(5.0f))
-                                .should(QueryBuilders.termQuery("text0", "494").boost(4.0f))
-                                .should(QueryBuilders.termQuery("text0", "492").boost(3.0f))
-                                .should(QueryBuilders.termQuery("text0", "491").boost(2.0f))
-                                .should(QueryBuilders.termQuery("text0", "490").boost(1.0f))
-                        ),
-                        new SubSearchSourceBuilder(
-                            QueryBuilders.boolQuery()
-                                .should(QueryBuilders.termQuery("text1", "508").boost(9.0f))
-                                .should(QueryBuilders.termQuery("text1", "304").boost(8.0f))
-                                .should(QueryBuilders.termQuery("text1", "501").boost(7.0f))
-                                .should(QueryBuilders.termQuery("text1", "504").boost(6.0f))
-                                .should(QueryBuilders.termQuery("text1", "502").boost(5.0f))
-                                .should(QueryBuilders.termQuery("text1", "499").boost(4.0f))
-                                .should(QueryBuilders.termQuery("text1", "801").boost(3.0f))
-                                .should(QueryBuilders.termQuery("text1", "201").boost(2.0f))
-                                .should(QueryBuilders.termQuery("text1", "492").boost(1.0f))
+            assertResponse(
+                client().prepareSearch("nrd_index")
+                    .setSearchType(searchType)
+                    .setRankBuilder(new RRFRankBuilder(8, 1))
+                    .setTrackTotalHits(false)
+                    .setSubSearches(
+                        List.of(
+                            new SubSearchSourceBuilder(
+                                QueryBuilders.boolQuery()
+                                    .should(QueryBuilders.termQuery("text0", "500").boost(10.0f))
+                                    .should(QueryBuilders.termQuery("text0", "499").boost(9.0f))
+                                    .should(QueryBuilders.termQuery("text0", "498").boost(8.0f))
+                                    .should(QueryBuilders.termQuery("text0", "497").boost(7.0f))
+                                    .should(QueryBuilders.termQuery("text0", "496").boost(6.0f))
+                                    .should(QueryBuilders.termQuery("text0", "495").boost(5.0f))
+                                    .should(QueryBuilders.termQuery("text0", "494").boost(4.0f))
+                                    .should(QueryBuilders.termQuery("text0", "492").boost(3.0f))
+                                    .should(QueryBuilders.termQuery("text0", "491").boost(2.0f))
+                                    .should(QueryBuilders.termQuery("text0", "490").boost(1.0f))
+                            ),
+                            new SubSearchSourceBuilder(
+                                QueryBuilders.boolQuery()
+                                    .should(QueryBuilders.termQuery("text1", "508").boost(9.0f))
+                                    .should(QueryBuilders.termQuery("text1", "304").boost(8.0f))
+                                    .should(QueryBuilders.termQuery("text1", "501").boost(7.0f))
+                                    .should(QueryBuilders.termQuery("text1", "504").boost(6.0f))
+                                    .should(QueryBuilders.termQuery("text1", "502").boost(5.0f))
+                                    .should(QueryBuilders.termQuery("text1", "499").boost(4.0f))
+                                    .should(QueryBuilders.termQuery("text1", "801").boost(3.0f))
+                                    .should(QueryBuilders.termQuery("text1", "201").boost(2.0f))
+                                    .should(QueryBuilders.termQuery("text1", "492").boost(1.0f))
+                            )
                         )
                     )
-                )
-                .addFetchField("text0")
-                .addFetchField("text1")
-                .setSize(5)
-                .addAggregation(AggregationBuilders.terms("sums").field("int"))
-                .get();
+                    .addFetchField("text0")
+                    .addFetchField("text1")
+                    .setSize(5)
+                    .addAggregation(AggregationBuilders.terms("sums").field("int")),
+                response -> {
+                    assertNull(response.getHits().getTotalHits());
+                    assertEquals(5, response.getHits().getHits().length);
 
-            assertNull(response.getHits().getTotalHits());
-            assertEquals(5, response.getHits().getHits().length);
+                    SearchHit hit = response.getHits().getAt(0);
+                    assertEquals(1, hit.getRank());
+                    assertEquals("term 492", hit.field("text0").getValue());
+                    assertEquals("term 508", hit.field("text1").getValue());
 
-            SearchHit hit = response.getHits().getAt(0);
-            assertEquals(1, hit.getRank());
-            assertEquals("term 492", hit.field("text0").getValue());
-            assertEquals("term 508", hit.field("text1").getValue());
+                    hit = response.getHits().getAt(1);
+                    assertEquals(2, hit.getRank());
+                    assertEquals("term 499", hit.field("text0").getValue());
+                    assertEquals("term 501", hit.field("text1").getValue());
 
-            hit = response.getHits().getAt(1);
-            assertEquals(2, hit.getRank());
-            assertEquals("term 499", hit.field("text0").getValue());
-            assertEquals("term 501", hit.field("text1").getValue());
+                    hit = response.getHits().getAt(2);
+                    assertEquals(3, hit.getRank());
+                    assertEquals("term 500", hit.field("text0").getValue());
+                    assertEquals("term 500", hit.field("text1").getValue());
 
-            hit = response.getHits().getAt(2);
-            assertEquals(3, hit.getRank());
-            assertEquals("term 500", hit.field("text0").getValue());
-            assertEquals("term 500", hit.field("text1").getValue());
+                    hit = response.getHits().getAt(3);
+                    assertEquals(4, hit.getRank());
+                    assertEquals("term 498", hit.field("text0").getValue());
+                    assertEquals("term 502", hit.field("text1").getValue());
 
-            hit = response.getHits().getAt(3);
-            assertEquals(4, hit.getRank());
-            assertEquals("term 498", hit.field("text0").getValue());
-            assertEquals("term 502", hit.field("text1").getValue());
+                    hit = response.getHits().getAt(4);
+                    assertEquals(5, hit.getRank());
+                    assertEquals("term 496", hit.field("text0").getValue());
+                    assertEquals("term 504", hit.field("text1").getValue());
 
-            hit = response.getHits().getAt(4);
-            assertEquals(5, hit.getRank());
-            assertEquals("term 496", hit.field("text0").getValue());
-            assertEquals("term 504", hit.field("text1").getValue());
+                    LongTerms aggregation = response.getAggregations().get("sums");
+                    assertEquals(3, aggregation.getBuckets().size());
 
-            LongTerms aggregation = response.getAggregations().get("sums");
-            assertEquals(3, aggregation.getBuckets().size());
-
-            for (LongTerms.Bucket bucket : aggregation.getBuckets()) {
-                if (0L == (long) bucket.getKey()) {
-                    assertEquals(5, bucket.getDocCount());
-                } else if (1L == (long) bucket.getKey()) {
-                    assertEquals(6, bucket.getDocCount());
-                } else if (2L == (long) bucket.getKey()) {
-                    assertEquals(4, bucket.getDocCount());
-                } else {
-                    throw new IllegalArgumentException("unexpected bucket key [" + bucket.getKey() + "]");
+                    for (LongTerms.Bucket bucket : aggregation.getBuckets()) {
+                        if (0L == (long) bucket.getKey()) {
+                            assertEquals(5, bucket.getDocCount());
+                        } else if (1L == (long) bucket.getKey()) {
+                            assertEquals(6, bucket.getDocCount());
+                        } else if (2L == (long) bucket.getKey()) {
+                            assertEquals(4, bucket.getDocCount());
+                        } else {
+                            throw new IllegalArgumentException("unexpected bucket key [" + bucket.getKey() + "]");
+                        }
+                    }
                 }
-            }
+            );
         }
     }
 
     public void testMultiBM25AndSingleKnn() {
         float[] queryVector = { 500.0f };
         KnnSearchBuilder knnSearch = new KnnSearchBuilder("vector_asc", queryVector, 101, 1001, null);
-        SearchResponse response = client().prepareSearch("nrd_index")
-            .setRankBuilder(new RRFRankBuilder(101, 1))
-            .setTrackTotalHits(false)
-            .setKnnSearch(List.of(knnSearch))
-            .setSubSearches(
-                List.of(
-                    new SubSearchSourceBuilder(
-                        QueryBuilders.boolQuery()
-                            .should(QueryBuilders.termQuery("text0", "500").boost(10.0f))
-                            .should(QueryBuilders.termQuery("text0", "499").boost(9.0f))
-                            .should(QueryBuilders.termQuery("text0", "498").boost(8.0f))
-                            .should(QueryBuilders.termQuery("text0", "497").boost(7.0f))
-                            .should(QueryBuilders.termQuery("text0", "496").boost(6.0f))
-                            .should(QueryBuilders.termQuery("text0", "495").boost(5.0f))
-                            .should(QueryBuilders.termQuery("text0", "494").boost(4.0f))
-                            .should(QueryBuilders.termQuery("text0", "492").boost(3.0f))
-                            .should(QueryBuilders.termQuery("text0", "491").boost(2.0f))
-                            .should(QueryBuilders.termQuery("text0", "490").boost(1.0f))
-                    ),
-                    new SubSearchSourceBuilder(
-                        QueryBuilders.boolQuery()
-                            .should(QueryBuilders.termQuery("text1", "508").boost(9.0f))
-                            .should(QueryBuilders.termQuery("text1", "304").boost(8.0f))
-                            .should(QueryBuilders.termQuery("text1", "501").boost(7.0f))
-                            .should(QueryBuilders.termQuery("text1", "504").boost(6.0f))
-                            .should(QueryBuilders.termQuery("text1", "492").boost(5.0f))
-                            .should(QueryBuilders.termQuery("text1", "502").boost(4.0f))
-                            .should(QueryBuilders.termQuery("text1", "499").boost(3.0f))
-                            .should(QueryBuilders.termQuery("text1", "800").boost(2.0f))
-                            .should(QueryBuilders.termQuery("text1", "201").boost(1.0f))
+        assertResponse(
+            client().prepareSearch("nrd_index")
+                .setRankBuilder(new RRFRankBuilder(101, 1))
+                .setTrackTotalHits(false)
+                .setKnnSearch(List.of(knnSearch))
+                .setSubSearches(
+                    List.of(
+                        new SubSearchSourceBuilder(
+                            QueryBuilders.boolQuery()
+                                .should(QueryBuilders.termQuery("text0", "500").boost(10.0f))
+                                .should(QueryBuilders.termQuery("text0", "499").boost(9.0f))
+                                .should(QueryBuilders.termQuery("text0", "498").boost(8.0f))
+                                .should(QueryBuilders.termQuery("text0", "497").boost(7.0f))
+                                .should(QueryBuilders.termQuery("text0", "496").boost(6.0f))
+                                .should(QueryBuilders.termQuery("text0", "495").boost(5.0f))
+                                .should(QueryBuilders.termQuery("text0", "494").boost(4.0f))
+                                .should(QueryBuilders.termQuery("text0", "492").boost(3.0f))
+                                .should(QueryBuilders.termQuery("text0", "491").boost(2.0f))
+                                .should(QueryBuilders.termQuery("text0", "490").boost(1.0f))
+                        ),
+                        new SubSearchSourceBuilder(
+                            QueryBuilders.boolQuery()
+                                .should(QueryBuilders.termQuery("text1", "508").boost(9.0f))
+                                .should(QueryBuilders.termQuery("text1", "304").boost(8.0f))
+                                .should(QueryBuilders.termQuery("text1", "501").boost(7.0f))
+                                .should(QueryBuilders.termQuery("text1", "504").boost(6.0f))
+                                .should(QueryBuilders.termQuery("text1", "492").boost(5.0f))
+                                .should(QueryBuilders.termQuery("text1", "502").boost(4.0f))
+                                .should(QueryBuilders.termQuery("text1", "499").boost(3.0f))
+                                .should(QueryBuilders.termQuery("text1", "800").boost(2.0f))
+                                .should(QueryBuilders.termQuery("text1", "201").boost(1.0f))
+                        )
                     )
                 )
-            )
-            .addFetchField("text0")
-            .addFetchField("text1")
-            .addFetchField("vector_asc")
-            .setSize(5)
-            .get();
+                .addFetchField("text0")
+                .addFetchField("text1")
+                .addFetchField("vector_asc")
+                .setSize(5),
+            response -> {
+                assertNull(response.getHits().getTotalHits());
+                assertEquals(5, response.getHits().getHits().length);
 
-        assertNull(response.getHits().getTotalHits());
-        assertEquals(5, response.getHits().getHits().length);
+                SearchHit hit = response.getHits().getAt(0);
+                assertEquals(1, hit.getRank());
+                assertEquals("term 500", hit.field("text0").getValue());
+                assertEquals("term 500", hit.field("text1").getValue());
+                assertEquals(500.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
 
-        SearchHit hit = response.getHits().getAt(0);
-        assertEquals(1, hit.getRank());
-        assertEquals("term 500", hit.field("text0").getValue());
-        assertEquals("term 500", hit.field("text1").getValue());
-        assertEquals(500.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
-
-        Set<Double> vectors = Arrays.stream(response.getHits().getHits())
-            .map(h -> ((Number) h.field("vector_asc").getValue()).doubleValue())
-            .collect(Collectors.toSet());
-        assertEquals(Set.of(492.0, 496.0, 498.0, 499.0, 500.0), vectors);
+                Set<Double> vectors = Arrays.stream(response.getHits().getHits())
+                    .map(h -> ((Number) h.field("vector_asc").getValue()).doubleValue())
+                    .collect(Collectors.toSet());
+                assertEquals(Set.of(492.0, 496.0, 498.0, 499.0, 500.0), vectors);
+            }
+        );
     }
 
     public void testMultiBM25AndSingleKnnWithAggregation() {
         float[] queryVector = { 500.0f };
         KnnSearchBuilder knnSearch = new KnnSearchBuilder("vector_asc", queryVector, 101, 1001, null);
-        SearchResponse response = client().prepareSearch("nrd_index")
-            .setRankBuilder(new RRFRankBuilder(101, 1))
-            .setTrackTotalHits(false)
-            .setKnnSearch(List.of(knnSearch))
-            .setSubSearches(
-                List.of(
-                    new SubSearchSourceBuilder(
-                        QueryBuilders.boolQuery()
-                            .should(QueryBuilders.termQuery("text0", "500").boost(10.0f))
-                            .should(QueryBuilders.termQuery("text0", "499").boost(9.0f))
-                            .should(QueryBuilders.termQuery("text0", "498").boost(8.0f))
-                            .should(QueryBuilders.termQuery("text0", "497").boost(7.0f))
-                            .should(QueryBuilders.termQuery("text0", "496").boost(6.0f))
-                            .should(QueryBuilders.termQuery("text0", "495").boost(5.0f))
-                            .should(QueryBuilders.termQuery("text0", "494").boost(4.0f))
-                            .should(QueryBuilders.termQuery("text0", "492").boost(3.0f))
-                            .should(QueryBuilders.termQuery("text0", "491").boost(2.0f))
-                            .should(QueryBuilders.termQuery("text0", "490").boost(1.0f))
-                    ),
-                    new SubSearchSourceBuilder(
-                        QueryBuilders.boolQuery()
-                            .should(QueryBuilders.termQuery("text1", "508").boost(9.0f))
-                            .should(QueryBuilders.termQuery("text1", "304").boost(8.0f))
-                            .should(QueryBuilders.termQuery("text1", "501").boost(7.0f))
-                            .should(QueryBuilders.termQuery("text1", "504").boost(6.0f))
-                            .should(QueryBuilders.termQuery("text1", "492").boost(5.0f))
-                            .should(QueryBuilders.termQuery("text1", "502").boost(4.0f))
-                            .should(QueryBuilders.termQuery("text1", "499").boost(3.0f))
-                            .should(QueryBuilders.termQuery("text1", "800").boost(2.0f))
-                            .should(QueryBuilders.termQuery("text1", "201").boost(1.0f))
+        assertResponse(
+            client().prepareSearch("nrd_index")
+                .setRankBuilder(new RRFRankBuilder(101, 1))
+                .setTrackTotalHits(false)
+                .setKnnSearch(List.of(knnSearch))
+                .setSubSearches(
+                    List.of(
+                        new SubSearchSourceBuilder(
+                            QueryBuilders.boolQuery()
+                                .should(QueryBuilders.termQuery("text0", "500").boost(10.0f))
+                                .should(QueryBuilders.termQuery("text0", "499").boost(9.0f))
+                                .should(QueryBuilders.termQuery("text0", "498").boost(8.0f))
+                                .should(QueryBuilders.termQuery("text0", "497").boost(7.0f))
+                                .should(QueryBuilders.termQuery("text0", "496").boost(6.0f))
+                                .should(QueryBuilders.termQuery("text0", "495").boost(5.0f))
+                                .should(QueryBuilders.termQuery("text0", "494").boost(4.0f))
+                                .should(QueryBuilders.termQuery("text0", "492").boost(3.0f))
+                                .should(QueryBuilders.termQuery("text0", "491").boost(2.0f))
+                                .should(QueryBuilders.termQuery("text0", "490").boost(1.0f))
+                        ),
+                        new SubSearchSourceBuilder(
+                            QueryBuilders.boolQuery()
+                                .should(QueryBuilders.termQuery("text1", "508").boost(9.0f))
+                                .should(QueryBuilders.termQuery("text1", "304").boost(8.0f))
+                                .should(QueryBuilders.termQuery("text1", "501").boost(7.0f))
+                                .should(QueryBuilders.termQuery("text1", "504").boost(6.0f))
+                                .should(QueryBuilders.termQuery("text1", "492").boost(5.0f))
+                                .should(QueryBuilders.termQuery("text1", "502").boost(4.0f))
+                                .should(QueryBuilders.termQuery("text1", "499").boost(3.0f))
+                                .should(QueryBuilders.termQuery("text1", "800").boost(2.0f))
+                                .should(QueryBuilders.termQuery("text1", "201").boost(1.0f))
+                        )
                     )
                 )
-            )
-            .addFetchField("text0")
-            .addFetchField("text1")
-            .addFetchField("vector_asc")
-            .setSize(5)
-            .addAggregation(AggregationBuilders.terms("sums").field("int"))
-            .get();
+                .addFetchField("text0")
+                .addFetchField("text1")
+                .addFetchField("vector_asc")
+                .setSize(5)
+                .addAggregation(AggregationBuilders.terms("sums").field("int")),
+            response -> {
+                assertNull(response.getHits().getTotalHits());
+                assertEquals(5, response.getHits().getHits().length);
 
-        assertNull(response.getHits().getTotalHits());
-        assertEquals(5, response.getHits().getHits().length);
+                SearchHit hit = response.getHits().getAt(0);
+                assertEquals(1, hit.getRank());
+                assertEquals("term 500", hit.field("text0").getValue());
+                assertEquals("term 500", hit.field("text1").getValue());
+                assertEquals(500.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
 
-        SearchHit hit = response.getHits().getAt(0);
-        assertEquals(1, hit.getRank());
-        assertEquals("term 500", hit.field("text0").getValue());
-        assertEquals("term 500", hit.field("text1").getValue());
-        assertEquals(500.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
+                Set<Double> vectors = Arrays.stream(response.getHits().getHits())
+                    .map(h -> ((Number) h.field("vector_asc").getValue()).doubleValue())
+                    .collect(Collectors.toSet());
+                assertEquals(Set.of(492.0, 496.0, 498.0, 499.0, 500.0), vectors);
 
-        Set<Double> vectors = Arrays.stream(response.getHits().getHits())
-            .map(h -> ((Number) h.field("vector_asc").getValue()).doubleValue())
-            .collect(Collectors.toSet());
-        assertEquals(Set.of(492.0, 496.0, 498.0, 499.0, 500.0), vectors);
+                LongTerms aggregation = response.getAggregations().get("sums");
+                assertEquals(3, aggregation.getBuckets().size());
 
-        LongTerms aggregation = response.getAggregations().get("sums");
-        assertEquals(3, aggregation.getBuckets().size());
-
-        for (LongTerms.Bucket bucket : aggregation.getBuckets()) {
-            if (0L == (long) bucket.getKey()) {
-                assertEquals(35, bucket.getDocCount());
-            } else if (1L == (long) bucket.getKey()) {
-                assertEquals(35, bucket.getDocCount());
-            } else if (2L == (long) bucket.getKey()) {
-                assertEquals(34, bucket.getDocCount());
-            } else {
-                throw new IllegalArgumentException("unexpected bucket key [" + bucket.getKey() + "]");
+                for (LongTerms.Bucket bucket : aggregation.getBuckets()) {
+                    if (0L == (long) bucket.getKey()) {
+                        assertEquals(35, bucket.getDocCount());
+                    } else if (1L == (long) bucket.getKey()) {
+                        assertEquals(35, bucket.getDocCount());
+                    } else if (2L == (long) bucket.getKey()) {
+                        assertEquals(34, bucket.getDocCount());
+                    } else {
+                        throw new IllegalArgumentException("unexpected bucket key [" + bucket.getKey() + "]");
+                    }
+                }
             }
-        }
+        );
     }
 
     public void testMultiBM25AndMultipleKnn() {
@@ -816,60 +839,62 @@ public class RRFRankSingleShardIT extends ESSingleNodeTestCase {
         float[] queryVectorDesc = { 500.0f };
         KnnSearchBuilder knnSearchAsc = new KnnSearchBuilder("vector_asc", queryVectorAsc, 101, 1001, null);
         KnnSearchBuilder knnSearchDesc = new KnnSearchBuilder("vector_desc", queryVectorDesc, 101, 1001, null);
-        SearchResponse response = client().prepareSearch("nrd_index")
-            .setRankBuilder(new RRFRankBuilder(101, 1))
-            .setTrackTotalHits(false)
-            .setKnnSearch(List.of(knnSearchAsc, knnSearchDesc))
-            .setSubSearches(
-                List.of(
-                    new SubSearchSourceBuilder(
-                        QueryBuilders.boolQuery()
-                            .should(QueryBuilders.termQuery("text0", "500").boost(10.0f))
-                            .should(QueryBuilders.termQuery("text0", "499").boost(9.0f))
-                            .should(QueryBuilders.termQuery("text0", "498").boost(8.0f))
-                            .should(QueryBuilders.termQuery("text0", "497").boost(7.0f))
-                            .should(QueryBuilders.termQuery("text0", "496").boost(6.0f))
-                            .should(QueryBuilders.termQuery("text0", "495").boost(5.0f))
-                            .should(QueryBuilders.termQuery("text0", "494").boost(4.0f))
-                            .should(QueryBuilders.termQuery("text0", "492").boost(3.0f))
-                            .should(QueryBuilders.termQuery("text0", "491").boost(2.0f))
-                            .should(QueryBuilders.termQuery("text0", "490").boost(1.0f))
-                    ),
-                    new SubSearchSourceBuilder(
-                        QueryBuilders.boolQuery()
-                            .should(QueryBuilders.termQuery("text1", "508").boost(9.0f))
-                            .should(QueryBuilders.termQuery("text1", "304").boost(8.0f))
-                            .should(QueryBuilders.termQuery("text1", "501").boost(7.0f))
-                            .should(QueryBuilders.termQuery("text1", "504").boost(6.0f))
-                            .should(QueryBuilders.termQuery("text1", "492").boost(5.0f))
-                            .should(QueryBuilders.termQuery("text1", "502").boost(4.0f))
-                            .should(QueryBuilders.termQuery("text1", "499").boost(3.0f))
-                            .should(QueryBuilders.termQuery("text1", "800").boost(2.0f))
-                            .should(QueryBuilders.termQuery("text1", "201").boost(1.0f))
+        assertResponse(
+            client().prepareSearch("nrd_index")
+                .setRankBuilder(new RRFRankBuilder(101, 1))
+                .setTrackTotalHits(false)
+                .setKnnSearch(List.of(knnSearchAsc, knnSearchDesc))
+                .setSubSearches(
+                    List.of(
+                        new SubSearchSourceBuilder(
+                            QueryBuilders.boolQuery()
+                                .should(QueryBuilders.termQuery("text0", "500").boost(10.0f))
+                                .should(QueryBuilders.termQuery("text0", "499").boost(9.0f))
+                                .should(QueryBuilders.termQuery("text0", "498").boost(8.0f))
+                                .should(QueryBuilders.termQuery("text0", "497").boost(7.0f))
+                                .should(QueryBuilders.termQuery("text0", "496").boost(6.0f))
+                                .should(QueryBuilders.termQuery("text0", "495").boost(5.0f))
+                                .should(QueryBuilders.termQuery("text0", "494").boost(4.0f))
+                                .should(QueryBuilders.termQuery("text0", "492").boost(3.0f))
+                                .should(QueryBuilders.termQuery("text0", "491").boost(2.0f))
+                                .should(QueryBuilders.termQuery("text0", "490").boost(1.0f))
+                        ),
+                        new SubSearchSourceBuilder(
+                            QueryBuilders.boolQuery()
+                                .should(QueryBuilders.termQuery("text1", "508").boost(9.0f))
+                                .should(QueryBuilders.termQuery("text1", "304").boost(8.0f))
+                                .should(QueryBuilders.termQuery("text1", "501").boost(7.0f))
+                                .should(QueryBuilders.termQuery("text1", "504").boost(6.0f))
+                                .should(QueryBuilders.termQuery("text1", "492").boost(5.0f))
+                                .should(QueryBuilders.termQuery("text1", "502").boost(4.0f))
+                                .should(QueryBuilders.termQuery("text1", "499").boost(3.0f))
+                                .should(QueryBuilders.termQuery("text1", "800").boost(2.0f))
+                                .should(QueryBuilders.termQuery("text1", "201").boost(1.0f))
+                        )
                     )
                 )
-            )
-            .addFetchField("text0")
-            .addFetchField("text1")
-            .addFetchField("vector_asc")
-            .addFetchField("vector_desc")
-            .setSize(5)
-            .get();
+                .addFetchField("text0")
+                .addFetchField("text1")
+                .addFetchField("vector_asc")
+                .addFetchField("vector_desc")
+                .setSize(5),
+            response -> {
+                assertNull(response.getHits().getTotalHits());
+                assertEquals(5, response.getHits().getHits().length);
 
-        assertNull(response.getHits().getTotalHits());
-        assertEquals(5, response.getHits().getHits().length);
+                SearchHit hit = response.getHits().getAt(0);
+                assertEquals(1, hit.getRank());
+                assertEquals("term 500", hit.field("text0").getValue());
+                assertEquals("term 500", hit.field("text1").getValue());
+                assertEquals(500.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
+                assertEquals(500.0, ((Number) hit.field("vector_desc").getValue()).doubleValue(), 0.0);
 
-        SearchHit hit = response.getHits().getAt(0);
-        assertEquals(1, hit.getRank());
-        assertEquals("term 500", hit.field("text0").getValue());
-        assertEquals("term 500", hit.field("text1").getValue());
-        assertEquals(500.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
-        assertEquals(500.0, ((Number) hit.field("vector_desc").getValue()).doubleValue(), 0.0);
-
-        Set<Double> vectors = Arrays.stream(response.getHits().getHits())
-            .map(h -> ((Number) h.field("vector_asc").getValue()).doubleValue())
-            .collect(Collectors.toSet());
-        assertEquals(Set.of(492.0, 498.0, 499.0, 500.0, 501.0), vectors);
+                Set<Double> vectors = Arrays.stream(response.getHits().getHits())
+                    .map(h -> ((Number) h.field("vector_asc").getValue()).doubleValue())
+                    .collect(Collectors.toSet());
+                assertEquals(Set.of(492.0, 498.0, 499.0, 500.0, 501.0), vectors);
+            }
+        );
     }
 
     public void testMultiBM25AndMultipleKnnWithAggregation() {
@@ -877,75 +902,77 @@ public class RRFRankSingleShardIT extends ESSingleNodeTestCase {
         float[] queryVectorDesc = { 500.0f };
         KnnSearchBuilder knnSearchAsc = new KnnSearchBuilder("vector_asc", queryVectorAsc, 101, 1001, null);
         KnnSearchBuilder knnSearchDesc = new KnnSearchBuilder("vector_desc", queryVectorDesc, 101, 1001, null);
-        SearchResponse response = client().prepareSearch("nrd_index")
-            .setRankBuilder(new RRFRankBuilder(101, 1))
-            .setTrackTotalHits(false)
-            .setKnnSearch(List.of(knnSearchAsc, knnSearchDesc))
-            .setSubSearches(
-                List.of(
-                    new SubSearchSourceBuilder(
-                        QueryBuilders.boolQuery()
-                            .should(QueryBuilders.termQuery("text0", "500").boost(10.0f))
-                            .should(QueryBuilders.termQuery("text0", "499").boost(9.0f))
-                            .should(QueryBuilders.termQuery("text0", "498").boost(8.0f))
-                            .should(QueryBuilders.termQuery("text0", "497").boost(7.0f))
-                            .should(QueryBuilders.termQuery("text0", "496").boost(6.0f))
-                            .should(QueryBuilders.termQuery("text0", "495").boost(5.0f))
-                            .should(QueryBuilders.termQuery("text0", "494").boost(4.0f))
-                            .should(QueryBuilders.termQuery("text0", "492").boost(3.0f))
-                            .should(QueryBuilders.termQuery("text0", "491").boost(2.0f))
-                            .should(QueryBuilders.termQuery("text0", "490").boost(1.0f))
-                    ),
-                    new SubSearchSourceBuilder(
-                        QueryBuilders.boolQuery()
-                            .should(QueryBuilders.termQuery("text1", "508").boost(9.0f))
-                            .should(QueryBuilders.termQuery("text1", "304").boost(8.0f))
-                            .should(QueryBuilders.termQuery("text1", "501").boost(7.0f))
-                            .should(QueryBuilders.termQuery("text1", "504").boost(6.0f))
-                            .should(QueryBuilders.termQuery("text1", "492").boost(5.0f))
-                            .should(QueryBuilders.termQuery("text1", "502").boost(4.0f))
-                            .should(QueryBuilders.termQuery("text1", "499").boost(3.0f))
-                            .should(QueryBuilders.termQuery("text1", "800").boost(2.0f))
-                            .should(QueryBuilders.termQuery("text1", "201").boost(1.0f))
+        assertResponse(
+            client().prepareSearch("nrd_index")
+                .setRankBuilder(new RRFRankBuilder(101, 1))
+                .setTrackTotalHits(false)
+                .setKnnSearch(List.of(knnSearchAsc, knnSearchDesc))
+                .setSubSearches(
+                    List.of(
+                        new SubSearchSourceBuilder(
+                            QueryBuilders.boolQuery()
+                                .should(QueryBuilders.termQuery("text0", "500").boost(10.0f))
+                                .should(QueryBuilders.termQuery("text0", "499").boost(9.0f))
+                                .should(QueryBuilders.termQuery("text0", "498").boost(8.0f))
+                                .should(QueryBuilders.termQuery("text0", "497").boost(7.0f))
+                                .should(QueryBuilders.termQuery("text0", "496").boost(6.0f))
+                                .should(QueryBuilders.termQuery("text0", "495").boost(5.0f))
+                                .should(QueryBuilders.termQuery("text0", "494").boost(4.0f))
+                                .should(QueryBuilders.termQuery("text0", "492").boost(3.0f))
+                                .should(QueryBuilders.termQuery("text0", "491").boost(2.0f))
+                                .should(QueryBuilders.termQuery("text0", "490").boost(1.0f))
+                        ),
+                        new SubSearchSourceBuilder(
+                            QueryBuilders.boolQuery()
+                                .should(QueryBuilders.termQuery("text1", "508").boost(9.0f))
+                                .should(QueryBuilders.termQuery("text1", "304").boost(8.0f))
+                                .should(QueryBuilders.termQuery("text1", "501").boost(7.0f))
+                                .should(QueryBuilders.termQuery("text1", "504").boost(6.0f))
+                                .should(QueryBuilders.termQuery("text1", "492").boost(5.0f))
+                                .should(QueryBuilders.termQuery("text1", "502").boost(4.0f))
+                                .should(QueryBuilders.termQuery("text1", "499").boost(3.0f))
+                                .should(QueryBuilders.termQuery("text1", "800").boost(2.0f))
+                                .should(QueryBuilders.termQuery("text1", "201").boost(1.0f))
+                        )
                     )
                 )
-            )
-            .addFetchField("text0")
-            .addFetchField("text1")
-            .addFetchField("vector_asc")
-            .addFetchField("vector_desc")
-            .setSize(5)
-            .addAggregation(AggregationBuilders.terms("sums").field("int"))
-            .get();
+                .addFetchField("text0")
+                .addFetchField("text1")
+                .addFetchField("vector_asc")
+                .addFetchField("vector_desc")
+                .setSize(5)
+                .addAggregation(AggregationBuilders.terms("sums").field("int")),
+            response -> {
+                assertNull(response.getHits().getTotalHits());
+                assertEquals(5, response.getHits().getHits().length);
 
-        assertNull(response.getHits().getTotalHits());
-        assertEquals(5, response.getHits().getHits().length);
+                SearchHit hit = response.getHits().getAt(0);
+                assertEquals(1, hit.getRank());
+                assertEquals("term 500", hit.field("text0").getValue());
+                assertEquals("term 500", hit.field("text1").getValue());
+                assertEquals(500.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
+                assertEquals(500.0, ((Number) hit.field("vector_desc").getValue()).doubleValue(), 0.0);
 
-        SearchHit hit = response.getHits().getAt(0);
-        assertEquals(1, hit.getRank());
-        assertEquals("term 500", hit.field("text0").getValue());
-        assertEquals("term 500", hit.field("text1").getValue());
-        assertEquals(500.0, ((Number) hit.field("vector_asc").getValue()).doubleValue(), 0.0);
-        assertEquals(500.0, ((Number) hit.field("vector_desc").getValue()).doubleValue(), 0.0);
+                Set<Double> vectors = Arrays.stream(response.getHits().getHits())
+                    .map(h -> ((Number) h.field("vector_asc").getValue()).doubleValue())
+                    .collect(Collectors.toSet());
+                assertEquals(Set.of(492.0, 498.0, 499.0, 500.0, 501.0), vectors);
 
-        Set<Double> vectors = Arrays.stream(response.getHits().getHits())
-            .map(h -> ((Number) h.field("vector_asc").getValue()).doubleValue())
-            .collect(Collectors.toSet());
-        assertEquals(Set.of(492.0, 498.0, 499.0, 500.0, 501.0), vectors);
+                LongTerms aggregation = response.getAggregations().get("sums");
+                assertEquals(3, aggregation.getBuckets().size());
 
-        LongTerms aggregation = response.getAggregations().get("sums");
-        assertEquals(3, aggregation.getBuckets().size());
-
-        for (LongTerms.Bucket bucket : aggregation.getBuckets()) {
-            if (0L == (long) bucket.getKey()) {
-                assertEquals(35, bucket.getDocCount());
-            } else if (1L == (long) bucket.getKey()) {
-                assertEquals(35, bucket.getDocCount());
-            } else if (2L == (long) bucket.getKey()) {
-                assertEquals(34, bucket.getDocCount());
-            } else {
-                throw new IllegalArgumentException("unexpected bucket key [" + bucket.getKey() + "]");
+                for (LongTerms.Bucket bucket : aggregation.getBuckets()) {
+                    if (0L == (long) bucket.getKey()) {
+                        assertEquals(35, bucket.getDocCount());
+                    } else if (1L == (long) bucket.getKey()) {
+                        assertEquals(35, bucket.getDocCount());
+                    } else if (2L == (long) bucket.getKey()) {
+                        assertEquals(34, bucket.getDocCount());
+                    } else {
+                        throw new IllegalArgumentException("unexpected bucket key [" + bucket.getKey() + "]");
+                    }
+                }
             }
-        }
+        );
     }
 }

--- a/x-pack/plugin/search-business-rules/src/internalClusterTest/java/org/elasticsearch/xpack/searchbusinessrules/PinnedQueryBuilderIT.java
+++ b/x-pack/plugin/search-business-rules/src/internalClusterTest/java/org/elasticsearch/xpack/searchbusinessrules/PinnedQueryBuilderIT.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.searchbusinessrules;
 
 import org.apache.lucene.search.Explanation;
 import org.elasticsearch.action.admin.indices.alias.Alias;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.query.Operator;
@@ -32,6 +31,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFirstHit;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFourthHit;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSecondHit;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertThirdHit;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.hasId;
@@ -113,50 +113,45 @@ public class PinnedQueryBuilderIT extends ESIntegTestCase {
     private void assertPinnedPromotions(PinnedQueryBuilder pqb, LinkedHashSet<String> pins, int iter, int numRelevantDocs) {
         int from = randomIntBetween(0, numRelevantDocs);
         int size = randomIntBetween(10, 100);
-        SearchResponse searchResponse = prepareSearch().setQuery(pqb)
-            .setTrackTotalHits(true)
-            .setSize(size)
-            .setFrom(from)
-            .setSearchType(DFS_QUERY_THEN_FETCH)
-            .get();
+        assertResponse(
+            prepareSearch().setQuery(pqb).setTrackTotalHits(true).setSize(size).setFrom(from).setSearchType(DFS_QUERY_THEN_FETCH),
+            response -> {
+                long numHits = response.getHits().getTotalHits().value;
+                assertThat(numHits, lessThanOrEqualTo((long) numRelevantDocs + pins.size()));
 
-        long numHits = searchResponse.getHits().getTotalHits().value;
-        assertThat(numHits, lessThanOrEqualTo((long) numRelevantDocs + pins.size()));
-
-        // Check pins are sorted by increasing score, (unlike organic, there are no duplicate scores)
-        float lastScore = Float.MAX_VALUE;
-        SearchHit[] hits = searchResponse.getHits().getHits();
-        for (int hitNumber = 0; hitNumber < Math.min(hits.length, pins.size() - from); hitNumber++) {
-            assertThat("Hit " + hitNumber + " in iter " + iter + " wrong" + pins, hits[hitNumber].getScore(), lessThan(lastScore));
-            lastScore = hits[hitNumber].getScore();
-        }
-        // Check that the pins appear in the requested order (globalHitNumber is cursor independent of from and size window used)
-        int globalHitNumber = 0;
-        for (String id : pins) {
-            if (globalHitNumber < size && globalHitNumber >= from) {
-                assertThat(
-                    "Hit " + globalHitNumber + " in iter " + iter + " wrong" + pins,
-                    hits[globalHitNumber - from].getId(),
-                    equalTo(id)
-                );
-            }
-            globalHitNumber++;
-        }
-        // Test the organic hits are sorted by text relevance
-        boolean highScoresExhausted = false;
-        for (; globalHitNumber < hits.length + from; globalHitNumber++) {
-            if (globalHitNumber >= from) {
-                int id = Integer.parseInt(hits[globalHitNumber - from].getId());
-                if (id % 2 == 0) {
-                    highScoresExhausted = true;
-                } else {
-                    assertFalse("All odd IDs should have scored higher than even IDs in organic results", highScoresExhausted);
+                // Check pins are sorted by increasing score, (unlike organic, there are no duplicate scores)
+                float lastScore = Float.MAX_VALUE;
+                SearchHit[] hits = response.getHits().getHits();
+                for (int hitNumber = 0; hitNumber < Math.min(hits.length, pins.size() - from); hitNumber++) {
+                    assertThat("Hit " + hitNumber + " in iter " + iter + " wrong" + pins, hits[hitNumber].getScore(), lessThan(lastScore));
+                    lastScore = hits[hitNumber].getScore();
                 }
-
+                // Check that the pins appear in the requested order (globalHitNumber is cursor independent of from and size window used)
+                int globalHitNumber = 0;
+                for (String id : pins) {
+                    if (globalHitNumber < size && globalHitNumber >= from) {
+                        assertThat(
+                            "Hit " + globalHitNumber + " in iter " + iter + " wrong" + pins,
+                            hits[globalHitNumber - from].getId(),
+                            equalTo(id)
+                        );
+                    }
+                    globalHitNumber++;
+                }
+                // Test the organic hits are sorted by text relevance
+                boolean highScoresExhausted = false;
+                for (; globalHitNumber < hits.length + from; globalHitNumber++) {
+                    if (globalHitNumber >= from) {
+                        int id = Integer.parseInt(hits[globalHitNumber - from].getId());
+                        if (id % 2 == 0) {
+                            highScoresExhausted = true;
+                        } else {
+                            assertFalse("All odd IDs should have scored higher than even IDs in organic results", highScoresExhausted);
+                        }
+                    }
+                }
             }
-
-        }
-
+        );
     }
 
     /**
@@ -193,10 +188,10 @@ public class PinnedQueryBuilderIT extends ESIntegTestCase {
     }
 
     private void assertExhaustiveScoring(PinnedQueryBuilder pqb) {
-        SearchResponse searchResponse = prepareSearch().setQuery(pqb).setTrackTotalHits(true).setSearchType(DFS_QUERY_THEN_FETCH).get();
-
-        long numHits = searchResponse.getHits().getTotalHits().value;
-        assertThat(numHits, equalTo(2L));
+        assertResponse(prepareSearch().setQuery(pqb).setTrackTotalHits(true).setSearchType(DFS_QUERY_THEN_FETCH), response -> {
+            long numHits = response.getHits().getTotalHits().value;
+            assertThat(numHits, equalTo(2L));
+        });
     }
 
     public void testExplain() throws Exception {
@@ -227,19 +222,19 @@ public class PinnedQueryBuilderIT extends ESIntegTestCase {
     }
 
     private void assertExplain(PinnedQueryBuilder pqb) {
-        SearchResponse searchResponse = prepareSearch().setSearchType(SearchType.DFS_QUERY_THEN_FETCH).setQuery(pqb).setExplain(true).get();
-        assertHitCount(searchResponse, 3);
-        assertFirstHit(searchResponse, hasId("2"));
-        assertSecondHit(searchResponse, hasId("1"));
-        assertThirdHit(searchResponse, hasId("4"));
+        assertResponse(prepareSearch().setSearchType(SearchType.DFS_QUERY_THEN_FETCH).setQuery(pqb).setExplain(true), searchResponse -> {
+            assertHitCount(searchResponse, 3);
+            assertFirstHit(searchResponse, hasId("2"));
+            assertSecondHit(searchResponse, hasId("1"));
+            assertThirdHit(searchResponse, hasId("4"));
 
-        Explanation pinnedExplanation = searchResponse.getHits().getAt(0).getExplanation();
-        assertThat(pinnedExplanation, notNullValue());
-        assertThat(pinnedExplanation.isMatch(), equalTo(true));
-        assertThat(pinnedExplanation.getDetails().length, equalTo(1));
-        assertThat(pinnedExplanation.getDetails()[0].isMatch(), equalTo(true));
-        assertThat(pinnedExplanation.getDetails()[0].getDescription(), containsString("ConstantScore"));
-
+            Explanation pinnedExplanation = searchResponse.getHits().getAt(0).getExplanation();
+            assertThat(pinnedExplanation, notNullValue());
+            assertThat(pinnedExplanation.isMatch(), equalTo(true));
+            assertThat(pinnedExplanation.getDetails().length, equalTo(1));
+            assertThat(pinnedExplanation.getDetails()[0].isMatch(), equalTo(true));
+            assertThat(pinnedExplanation.getDetails()[0].getDescription(), containsString("ConstantScore"));
+        });
     }
 
     public void testHighlight() throws Exception {
@@ -271,16 +266,16 @@ public class PinnedQueryBuilderIT extends ESIntegTestCase {
         HighlightBuilder testHighlighter = new HighlightBuilder();
         testHighlighter.field("field1");
 
-        SearchResponse searchResponse = prepareSearch().setSearchType(SearchType.DFS_QUERY_THEN_FETCH)
-            .setQuery(pqb)
-            .highlighter(testHighlighter)
-            .setExplain(true)
-            .get();
-        assertHitCount(searchResponse, 1);
-        Map<String, HighlightField> highlights = searchResponse.getHits().getHits()[0].getHighlightFields();
-        assertThat(highlights.size(), equalTo(1));
-        HighlightField highlight = highlights.get("field1");
-        assertThat(highlight.fragments()[0].toString(), equalTo("<em>the</em> <em>quick</em> <em>brown</em> fox"));
+        assertResponse(
+            prepareSearch().setSearchType(SearchType.DFS_QUERY_THEN_FETCH).setQuery(pqb).highlighter(testHighlighter).setExplain(true),
+            searchResponse -> {
+                assertHitCount(searchResponse, 1);
+                Map<String, HighlightField> highlights = searchResponse.getHits().getHits()[0].getHighlightFields();
+                assertThat(highlights.size(), equalTo(1));
+                HighlightField highlight = highlights.get("field1");
+                assertThat(highlight.fragments()[0].toString(), equalTo("<em>the</em> <em>quick</em> <em>brown</em> fox"));
+            }
+        );
     }
 
     public void testMultiIndexDocs() throws Exception {
@@ -330,13 +325,13 @@ public class PinnedQueryBuilderIT extends ESIntegTestCase {
             new Item("test1", "b")
         );
 
-        SearchResponse searchResponse = prepareSearch().setQuery(pqb).setTrackTotalHits(true).setSearchType(DFS_QUERY_THEN_FETCH).get();
-
-        assertHitCount(searchResponse, 4);
-        assertFirstHit(searchResponse, both(hasIndex("test2")).and(hasId("a")));
-        assertSecondHit(searchResponse, both(hasIndex("test1")).and(hasId("a")));
-        assertThirdHit(searchResponse, both(hasIndex("test1")).and(hasId("b")));
-        assertFourthHit(searchResponse, both(hasIndex("test2")).and(hasId("c")));
+        assertResponse(prepareSearch().setQuery(pqb).setTrackTotalHits(true).setSearchType(DFS_QUERY_THEN_FETCH), searchResponse -> {
+            assertHitCount(searchResponse, 4);
+            assertFirstHit(searchResponse, both(hasIndex("test2")).and(hasId("a")));
+            assertSecondHit(searchResponse, both(hasIndex("test1")).and(hasId("a")));
+            assertThirdHit(searchResponse, both(hasIndex("test1")).and(hasId("b")));
+            assertFourthHit(searchResponse, both(hasIndex("test2")).and(hasId("c")));
+        });
     }
 
     public void testMultiIndexWithAliases() throws Exception {
@@ -370,12 +365,12 @@ public class PinnedQueryBuilderIT extends ESIntegTestCase {
             new Item("test", "a")
         );
 
-        SearchResponse searchResponse = prepareSearch().setQuery(pqb).setTrackTotalHits(true).setSearchType(DFS_QUERY_THEN_FETCH).get();
-
-        assertHitCount(searchResponse, 3);
-        assertFirstHit(searchResponse, both(hasIndex("test")).and(hasId("b")));
-        assertSecondHit(searchResponse, both(hasIndex("test")).and(hasId("a")));
-        assertThirdHit(searchResponse, both(hasIndex("test")).and(hasId("c")));
+        assertResponse(prepareSearch().setQuery(pqb).setTrackTotalHits(true).setSearchType(DFS_QUERY_THEN_FETCH), searchResponse -> {
+            assertHitCount(searchResponse, 3);
+            assertFirstHit(searchResponse, both(hasIndex("test")).and(hasId("b")));
+            assertSecondHit(searchResponse, both(hasIndex("test")).and(hasId("a")));
+            assertThirdHit(searchResponse, both(hasIndex("test")).and(hasId("c")));
+        });
     }
 
     public void testMultiIndexWithAliasesAndDuplicateIds() throws Exception {
@@ -428,12 +423,12 @@ public class PinnedQueryBuilderIT extends ESIntegTestCase {
             new Item("test-alias", "a")
         );
 
-        SearchResponse searchResponse = prepareSearch().setQuery(pqb).setTrackTotalHits(true).setSearchType(DFS_QUERY_THEN_FETCH).get();
-
-        assertHitCount(searchResponse, 4);
-        assertFirstHit(searchResponse, both(hasIndex("test1")).and(hasId("b")));
-        assertSecondHit(searchResponse, hasId("a"));
-        assertThirdHit(searchResponse, hasId("a"));
-        assertFourthHit(searchResponse, both(hasIndex("test1")).and(hasId("c")));
+        assertResponse(prepareSearch().setQuery(pqb).setTrackTotalHits(true).setSearchType(DFS_QUERY_THEN_FETCH), searchResponse -> {
+            assertHitCount(searchResponse, 4);
+            assertFirstHit(searchResponse, both(hasIndex("test1")).and(hasId("b")));
+            assertSecondHit(searchResponse, hasId("a"));
+            assertThirdHit(searchResponse, hasId("a"));
+            assertFourthHit(searchResponse, both(hasIndex("test1")).and(hasId("c")));
+        });
     }
 }


### PR DESCRIPTION
Tests covered these sections of the ES repo
x-pack/plugin/monitoring
x-pack/plugin/rank-rrf
x-pack/plugin/rollup
x-pack/plugin/search-business-rules

The decRef was either added explicitly or implicitly by using ElasticsearchAssertions.assertResponse.
