### PR TITLE
Removing the use of Version.CURRENT from watcher

### DIFF
--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
@@ -272,6 +272,14 @@ public class Watcher extends Plugin implements SystemIndexPlugin, ScriptPlugin, 
     private static final Logger logger = LogManager.getLogger(Watcher.class);
     private static final int WATCHES_INDEX_MAPPINGS_VERSION = 1;
     private static final int TRIGGERED_WATCHES_INDEX_MAPPINGS_VERSION = 1;
+    /**
+     * No longer used for determining the age of mappings, but system index descriptor
+     * code requires <em>something</em> be set. We use a value that can be parsed by
+     * old nodes in mixed-version clusters, just in case any old code exists that
+     * tries to parse <code>version</code> from index metadata, and that will indicate
+     * to these old nodes that the mappings are newer than they are.
+     */
+    private static final String LEGACY_VERSION_FIELD_VALUE = Version.V_8_12_0.toString();
     private WatcherIndexingListener listener;
     private HttpClient httpClient;
     private BulkProcessor2 bulkProcessor;
@@ -863,7 +871,7 @@ public class Watcher extends Plugin implements SystemIndexPlugin, ScriptPlugin, 
                 builder.field("dynamic", "strict");
                 {
                     builder.startObject("_meta");
-                    builder.field("version", Version.CURRENT);
+                    builder.field("version", LEGACY_VERSION_FIELD_VALUE);
                     builder.field(SystemIndexDescriptor.VERSION_META_KEY, WATCHES_INDEX_MAPPINGS_VERSION);
                     builder.endObject();
                 }
@@ -955,7 +963,7 @@ public class Watcher extends Plugin implements SystemIndexPlugin, ScriptPlugin, 
                 builder.field("dynamic", "strict");
                 {
                     builder.startObject("_meta");
-                    builder.field("version", Version.CURRENT);
+                    builder.field("version", LEGACY_VERSION_FIELD_VALUE);
                     builder.field(SystemIndexDescriptor.VERSION_META_KEY, TRIGGERED_WATCHES_INDEX_MAPPINGS_VERSION);
                     builder.endObject();
                 }

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.watcher;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
@@ -279,7 +278,7 @@ public class Watcher extends Plugin implements SystemIndexPlugin, ScriptPlugin, 
      * tries to parse <code>version</code> from index metadata, and that will indicate
      * to these old nodes that the mappings are newer than they are.
      */
-    private static final String LEGACY_VERSION_FIELD_VALUE = Version.V_8_12_0.toString();
+    private static final String LEGACY_VERSION_FIELD_VALUE = "8.12.0";
     private WatcherIndexingListener listener;
     private HttpClient httpClient;
     private BulkProcessor2 bulkProcessor;

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherLifeCycleServiceTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherLifeCycleServiceTests.java
@@ -7,7 +7,6 @@
 package org.elasticsearch.xpack.watcher;
 
 import org.elasticsearch.ElasticsearchTimeoutException;
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterName;
@@ -622,10 +621,6 @@ public class WatcherLifeCycleServiceTests extends ESTestCase {
     }
 
     private static DiscoveryNode newNode(String nodeName) {
-        return newNode(nodeName, Version.CURRENT);
-    }
-
-    private static DiscoveryNode newNode(String nodeName, Version version) {
-        return DiscoveryNodeUtils.builder(nodeName).version(version).build();
+        return DiscoveryNodeUtils.builder(nodeName).build();
     }
 }


### PR DESCRIPTION
Previously, we put a `version` field in the `_meta` block for the watch system index mappings. The value of this field was the current version of Elasticsearch. It was used by the system to know if mappings were up to date. We're now putting a numeric version into the `managed_index_mappings_version` field in the `_meta` block for the watch system index mappings for the same purpose to get away from using the elasticsearch version. This will only be updated when the mappings change.
We have to leave the `version` in place since it could be read by an older node in a mixed cluster. In order to make it clear that this is no longer in use going forward, I've frozen the value of `version` at 8.12.0. That way any older node will recognize it as newer.
I also removed the use of Version.CURRENT from a test (it was unnecessary there), so that someone looking for outdated uses of Version.CURRENT doesn't run across it.

This was modeled after the change in [x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlIndexTemplateRegistry.java](https://github.com/elastic/elasticsearch/pull/99921/files#diff-8942f9fb0c3c36e4d578f2af2e42e39af0ac64d06b833572979cdc220fc59d1d) (down to plagiarizing the comment).