### PR TITLE
Fix exclude when a wildcard targets an alias

### DIFF
--- a/docs/changelog/102047.yaml
+++ b/docs/changelog/102047.yaml
@@ -1,0 +1,6 @@
+pr: 102047
+summary: Exclude concrete indices when wildcard targets an alias with multi-target syntax
+area: Search
+type: bug
+issues:
+  - 98077

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolverTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolverTests.java
@@ -466,6 +466,17 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         assertThat(request.indices(), arrayContainingInAnyOrder(expectedIndices));
     }
 
+    public void testWildcardOverlapWithAliasExcludeWildcard() {
+        final User user = new User("data-stream-tester3", "data_stream_test3");
+        SearchRequest request = new SearchRequest("logs*", "-logs-00002*");
+        List<String> indices = resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)).getLocal();
+        String[] expectedIndices = new String[] { "logs-00001", "logs-00003" };
+        assertThat(indices, hasSize(expectedIndices.length));
+        assertThat(request.indices().length, equalTo(expectedIndices.length));
+        assertThat(indices, hasItems(expectedIndices));
+        assertThat(request.indices(), arrayContainingInAnyOrder(expectedIndices));
+    }
+
     public void testWildcardOverlapWithAliasExcludeAlias() {
         final User user = new User("data-stream-tester3", "data_stream_test3");
         SearchRequest request = new SearchRequest("logs*", "-logs-alias");

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolverTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolverTests.java
@@ -455,6 +455,29 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
         );
     }
 
+    public void testWildcardOverlapWithAliasExcludeIndex() {
+        final User user = new User("data-stream-tester3", "data_stream_test3");
+        SearchRequest request = new SearchRequest("logs*", "-logs-00002");
+        List<String> indices = resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)).getLocal();
+        String[] expectedIndices = new String[] { "logs-00001", "logs-00003" };
+        assertThat(indices, hasSize(expectedIndices.length));
+        assertThat(request.indices().length, equalTo(expectedIndices.length));
+        assertThat(indices, hasItems(expectedIndices));
+        assertThat(request.indices(), arrayContainingInAnyOrder(expectedIndices));
+    }
+
+    public void testWildcardOverlapWithAliasExcludeAlias() {
+        final User user = new User("data-stream-tester3", "data_stream_test3");
+        SearchRequest request = new SearchRequest("logs*", "-logs-alias");
+        List<String> indices = resolveIndices(request, buildAuthorizedIndices(user, SearchAction.NAME)).getLocal();
+        // as stated in the documentation the concrete indices are included even if the alias is removed
+        String[] expectedIndices = new String[] { "logs-00001", "logs-00002", "logs-00003" };
+        assertThat(indices, hasSize(expectedIndices.length));
+        assertThat(request.indices().length, equalTo(expectedIndices.length));
+        assertThat(indices, hasItems(expectedIndices));
+        assertThat(request.indices(), arrayContainingInAnyOrder(expectedIndices));
+    }
+
     public void testExplicitDashIndices() {
         SearchRequest request = new SearchRequest("-index10", "-index20");
         List<String> indices = resolveIndices(request, buildAuthorizedIndices(userDashIndices, SearchAction.NAME)).getLocal();


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

Closes #98077

The documentation mentions that excludes with aliases do not work, and concrete indices should be used instead ([Multi-target syntax](https://www.elastic.co/guide/en/elasticsearch/reference/8.9/api-conventions.html#api-multi-index)). This proposed fix does not alter the documented behavior, but a modification of it might be less surprising for users.