### PR TITLE
Repo analysis: allow configuration of register ops

### DIFF
--- a/docs/changelog/102051.yaml
+++ b/docs/changelog/102051.yaml
@@ -1,0 +1,5 @@
+pr: 102051
+summary: "Repo analysis: allow configuration of register ops"
+area: Snapshot/Restore
+type: enhancement
+issues: []

--- a/docs/reference/snapshot-restore/apis/repo-analysis-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/repo-analysis-api.asciidoc
@@ -204,9 +204,9 @@ the blobs written during the test. Defaults to `1gb`. For realistic experiments
 you should set this to at least `1tb`.
 
 `register_operation_count`::
-(Optional, integer) The number of linearizable register operations to perform
-in total. Defaults to `10`. For realistic experiments you should set this to at
-least `100`.
+(Optional, integer) The minimum number of linearizable register operations to
+perform in total. Defaults to `10`. For realistic experiments you should set
+this to at least `100`.
 
 `timeout`::
 (Optional, <<time-units, time units>>) Specifies the period of time to wait for

--- a/docs/reference/snapshot-restore/apis/repo-analysis-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/repo-analysis-api.asciidoc
@@ -141,8 +141,10 @@ between versions. The request parameters and response format depend on details
 of the implementation so may also be different in newer versions.
 
 The analysis comprises a number of blob-level tasks, as set by the `blob_count`
-parameter. The blob-level tasks are distributed over the data and
-master-eligible nodes in the cluster for execution.
+parameter, and a number of compare-and-exchange operations on linearizable
+registers, as set by the `register_operation_count` advanced parameter. These
+tasks are distributed over the data and master-eligible nodes in the cluster
+for execution.
 
 For most blob-level tasks, the executing node first writes a blob to the
 repository, and then instructs some of the other nodes in the cluster to
@@ -213,6 +215,10 @@ will usually not need to adjust them.
 `concurrency`::
 (Optional, integer) The number of write operations to perform concurrently.
 Defaults to `10`.
+
+`register_operation_count`::
+(Optional, integer) The number of linearizable register operations to perform
+in total. Defaults to `100`.
 
 `read_node_count`::
 (Optional, integer) The number of nodes on which to perform a read operation

--- a/docs/reference/snapshot-restore/apis/repo-analysis-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/repo-analysis-api.asciidoc
@@ -59,12 +59,13 @@ the impact of running an analysis inadvertently and to provide a sensible
 starting point for your investigations. Run your first analysis with the default
 parameter values to check for simple problems. If successful, run a sequence of
 increasingly large analyses until you encounter a failure or you reach a
-`blob_count` of at least `2000`, a `max_blob_size` of at least `2gb`, and a
-`max_total_data_size` of at least `1tb`. Always specify a generous timeout,
-possibly `1h` or longer, to allow time for each analysis to run to completion.
-Perform the analyses using a multi-node cluster of a similar size to your
-production cluster so that it can detect any problems that only arise when the
-repository is accessed by many nodes at once.
+`blob_count` of at least `2000`, a `max_blob_size` of at least `2gb`, a
+`max_total_data_size` of at least `1tb`, and a `register_operation_count` of at
+least `100`. Always specify a generous timeout, possibly `1h` or longer, to
+allow time for each analysis to run to completion. Perform the analyses using a
+multi-node cluster of a similar size to your production cluster so that it can
+detect any problems that only arise when the repository is accessed by many
+nodes at once.
 
 If the analysis fails then {es} detected that your repository behaved
 unexpectedly. This usually means you are using a third-party storage system
@@ -142,9 +143,9 @@ of the implementation so may also be different in newer versions.
 
 The analysis comprises a number of blob-level tasks, as set by the `blob_count`
 parameter, and a number of compare-and-exchange operations on linearizable
-registers, as set by the `register_operation_count` advanced parameter. These
-tasks are distributed over the data and master-eligible nodes in the cluster
-for execution.
+registers, as set by the `register_operation_count` parameter. These tasks are
+distributed over the data and master-eligible nodes in the cluster for
+execution.
 
 For most blob-level tasks, the executing node first writes a blob to the
 repository, and then instructs some of the other nodes in the cluster to
@@ -202,6 +203,11 @@ this to at least `2gb`.
 the blobs written during the test. Defaults to `1gb`. For realistic experiments
 you should set this to at least `1tb`.
 
+`register_operation_count`::
+(Optional, integer) The number of linearizable register operations to perform
+in total. Defaults to `10`. For realistic experiments you should set this to at
+least `100`.
+
 `timeout`::
 (Optional, <<time-units, time units>>) Specifies the period of time to wait for
 the test to complete. If no response is received before the timeout expires,
@@ -215,10 +221,6 @@ will usually not need to adjust them.
 `concurrency`::
 (Optional, integer) The number of write operations to perform concurrently.
 Defaults to `10`.
-
-`register_operation_count`::
-(Optional, integer) The number of linearizable register operations to perform
-in total. Defaults to `100`.
 
 `read_node_count`::
 (Optional, integer) The number of nodes on which to perform a read operation

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -162,7 +162,7 @@ public class TransportVersions {
     public static final TransportVersion ML_INFERENCE_TASK_SETTINGS_OPTIONAL_ADDED = def(8_531_00_0);
     public static final TransportVersion DEPRECATED_COMPONENT_TEMPLATES_ADDED = def(8_532_00_0);
     public static final TransportVersion UPDATE_NON_DYNAMIC_SETTINGS_ADDED = def(8_533_00_0);
-
+    public static final TransportVersion REPO_ANALYSIS_REGISTER_OP_COUNT_ADDED = def(8_534_00_0);
     /*
      * STOP! READ THIS FIRST! No, really,
      *        ____ _____ ___  ____  _        ____  _____    _    ____    _____ _   _ ___ ____    _____ ___ ____  ____ _____ _

--- a/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryAnalysisSuccessIT.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryAnalysisSuccessIT.java
@@ -505,6 +505,10 @@ public class RepositoryAnalysisSuccessIT extends AbstractSnapshotIntegTestCase {
 
             final BytesReference witness;
             synchronized (registerMutex) {
+                // synchronized to avoid concurrent updates from interfering with the assertions which follow this update, but NB we aren't
+                // testing the atomicity of this particular compareAndExchange() operation (itself implemented with a lock), we're testing
+                // the sequence of how these operations are executed, so the mutex here is fine.
+
                 witness = registers.computeIfAbsent(key, ignored -> new BytesRegister()).compareAndExchange(expected, updated);
 
                 if (isContendedRegisterKey(key)) {

--- a/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryAnalysisSuccessIT.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryAnalysisSuccessIT.java
@@ -522,9 +522,11 @@ public class RepositoryAnalysisSuccessIT extends AbstractSnapshotIntegTestCase {
                 } else {
                     assertEquals(expected, witness); // uncontended writes always succeed
                     assertNotEquals(expected, updated); // uncontended register sees only updates
-                    final var updatedValue = longFromBytes(updated);
-                    assertThat(updatedValue, allOf(greaterThan(0L), equalTo(uncontendedRegisterValue + 1)));
-                    uncontendedRegisterValue = updatedValue;
+                    if (updated.length() != 0) {
+                        final var updatedValue = longFromBytes(updated);
+                        assertThat(updatedValue, allOf(greaterThan(0L), equalTo(uncontendedRegisterValue + 1)));
+                        uncontendedRegisterValue = updatedValue;
+                    } // else this was the final step which writes an empty register
                 }
             }
 

--- a/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryAnalyzeAction.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryAnalyzeAction.java
@@ -865,7 +865,7 @@ public class RepositoryAnalyzeAction extends HandledTransportAction<RepositoryAn
 
         private int blobCount = 100;
         private int concurrency = 10;
-        private int registerOperationCount = 100;
+        private int registerOperationCount = 10;
         private int readNodeCount = 10;
         private int earlyReadNodeCount = 2;
         private long seed = 0L;

--- a/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryAnalyzeAction.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryAnalyzeAction.java
@@ -945,7 +945,7 @@ public class RepositoryAnalyzeAction extends HandledTransportAction<RepositoryAn
             if (out.getTransportVersion().onOrAfter(TransportVersions.REPO_ANALYSIS_REGISTER_OP_COUNT_ADDED)) {
                 out.writeVInt(registerOperationCount);
             } else if (registerOperationCount != concurrency) {
-                throw new IllegalStateException(
+                throw new IllegalArgumentException(
                     "cannot send request with registerOperationCount != concurrency on transport version ["
                         + out.getTransportVersion()
                         + "]"
@@ -961,7 +961,7 @@ public class RepositoryAnalyzeAction extends HandledTransportAction<RepositoryAn
             if (out.getTransportVersion().onOrAfter(TransportVersions.V_7_14_0)) {
                 out.writeBoolean(abortWritePermitted);
             } else if (abortWritePermitted) {
-                throw new IllegalStateException(
+                throw new IllegalArgumentException(
                     "cannot send abortWritePermitted request on transport version [" + out.getTransportVersion() + "]"
                 );
             }

--- a/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/RestRepositoryAnalyzeAction.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/RestRepositoryAnalyzeAction.java
@@ -40,6 +40,9 @@ public class RestRepositoryAnalyzeAction extends BaseRestHandler {
 
         analyzeRepositoryRequest.blobCount(request.paramAsInt("blob_count", analyzeRepositoryRequest.getBlobCount()));
         analyzeRepositoryRequest.concurrency(request.paramAsInt("concurrency", analyzeRepositoryRequest.getConcurrency()));
+        analyzeRepositoryRequest.registerOperationCount(
+            request.paramAsInt("register_operation_count", analyzeRepositoryRequest.getRegisterOperationCount())
+        );
         analyzeRepositoryRequest.readNodeCount(request.paramAsInt("read_node_count", analyzeRepositoryRequest.getReadNodeCount()));
         analyzeRepositoryRequest.earlyReadNodeCount(
             request.paramAsInt("early_read_node_count", analyzeRepositoryRequest.getEarlyReadNodeCount())


### PR DESCRIPTION
Adds the `?register_operation_count` parameter that allows to control
the number of register operations separately from the number of regular
blob operations.