### PR TITLE
Remove explicit SearchResponse references from server bucket aggs (part 5)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/CombiIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/CombiIT.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.search.aggregations;
 
 import org.elasticsearch.action.index.IndexRequestBuilder;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.search.aggregations.Aggregator.SubAggCollectionMode;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.missing.Missing;
@@ -24,7 +23,7 @@ import java.util.Map;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.histogram;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.missing;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
@@ -60,27 +59,28 @@ public class CombiIT extends ESIntegTestCase {
         indexRandom(true, builders);
         ensureSearchable();
 
+        final long finalMissingValues = missingValues;
         SubAggCollectionMode aggCollectionMode = randomFrom(SubAggCollectionMode.values());
-        SearchResponse response = prepareSearch("idx").addAggregation(missing("missing_values").field("value"))
-            .addAggregation(terms("values").field("value").collectMode(aggCollectionMode))
-            .get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(missing("missing_values").field("value"))
+                .addAggregation(terms("values").field("value").collectMode(aggCollectionMode)),
+            response -> {
+                Aggregations aggs = response.getAggregations();
 
-        assertNoFailures(response);
+                Missing missing = aggs.get("missing_values");
+                assertNotNull(missing);
+                assertThat(missing.getDocCount(), equalTo(finalMissingValues));
 
-        Aggregations aggs = response.getAggregations();
-
-        Missing missing = aggs.get("missing_values");
-        assertNotNull(missing);
-        assertThat(missing.getDocCount(), equalTo(missingValues));
-
-        Terms terms = aggs.get("values");
-        assertNotNull(terms);
-        List<? extends Terms.Bucket> buckets = terms.getBuckets();
-        assertThat(buckets.size(), equalTo(values.size()));
-        for (Terms.Bucket bucket : buckets) {
-            values.remove(((Number) bucket.getKey()).intValue());
-        }
-        assertTrue(values.isEmpty());
+                Terms terms = aggs.get("values");
+                assertNotNull(terms);
+                List<? extends Terms.Bucket> buckets = terms.getBuckets();
+                assertThat(buckets.size(), equalTo(values.size()));
+                for (Terms.Bucket bucket : buckets) {
+                    values.remove(((Number) bucket.getKey()).intValue());
+                }
+                assertTrue(values.isEmpty());
+            }
+        );
     }
 
     /**
@@ -108,13 +108,16 @@ public class CombiIT extends ESIntegTestCase {
         ensureSearchable("idx");
 
         SubAggCollectionMode aggCollectionMode = randomFrom(SubAggCollectionMode.values());
-        SearchResponse searchResponse = prepareSearch("idx").addAggregation(
-            histogram("values").field("value1").interval(1).subAggregation(terms("names").field("name").collectMode(aggCollectionMode))
-        ).get();
-
-        assertThat(searchResponse.getHits().getTotalHits().value, Matchers.equalTo(0L));
-        Histogram values = searchResponse.getAggregations().get("values");
-        assertThat(values, notNullValue());
-        assertThat(values.getBuckets().isEmpty(), is(true));
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                histogram("values").field("value1").interval(1).subAggregation(terms("names").field("name").collectMode(aggCollectionMode))
+            ),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, Matchers.equalTo(0L));
+                Histogram values = response.getAggregations().get("values");
+                assertThat(values, notNullValue());
+                assertThat(values.getBuckets().isEmpty(), is(true));
+            }
+        );
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/EquivalenceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/EquivalenceIT.java
@@ -10,7 +10,6 @@ package org.elasticsearch.search.aggregations;
 
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchRequestBuilder;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.Maps;
@@ -57,6 +56,8 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAllSuccessful;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.IsNull.notNullValue;
@@ -164,34 +165,35 @@ public class EquivalenceIT extends ESIntegTestCase {
             reqBuilder = reqBuilder.addAggregation(filter("filter" + i, filter));
         }
 
-        SearchResponse resp = reqBuilder.get();
-        Range range = resp.getAggregations().get("range");
-        List<? extends Bucket> buckets = range.getBuckets();
+        assertResponse(reqBuilder, response -> {
+            Range range = response.getAggregations().get("range");
+            List<? extends Bucket> buckets = range.getBuckets();
 
-        Map<String, Bucket> bucketMap = Maps.newMapWithExpectedSize(buckets.size());
-        for (Bucket bucket : buckets) {
-            bucketMap.put(bucket.getKeyAsString(), bucket);
-        }
-
-        for (int i = 0; i < ranges.length; ++i) {
-
-            long count = 0;
-            for (double[] values : docs) {
-                for (double value : values) {
-                    if (value >= ranges[i][0] && value < ranges[i][1]) {
-                        ++count;
-                        break;
-                    }
-                }
+            Map<String, Bucket> bucketMap = Maps.newMapWithExpectedSize(buckets.size());
+            for (Bucket bucket : buckets) {
+                bucketMap.put(bucket.getKeyAsString(), bucket);
             }
 
-            final Range.Bucket bucket = bucketMap.get(Integer.toString(i));
-            assertEquals(bucket.getKeyAsString(), Integer.toString(i), bucket.getKeyAsString());
-            assertEquals(bucket.getKeyAsString(), count, bucket.getDocCount());
+            for (int i = 0; i < ranges.length; ++i) {
 
-            final Filter filter = resp.getAggregations().get("filter" + i);
-            assertThat(filter.getDocCount(), equalTo(count));
-        }
+                long count = 0;
+                for (double[] values : docs) {
+                    for (double value : values) {
+                        if (value >= ranges[i][0] && value < ranges[i][1]) {
+                            ++count;
+                            break;
+                        }
+                    }
+                }
+
+                final Range.Bucket bucket = bucketMap.get(Integer.toString(i));
+                assertEquals(bucket.getKeyAsString(), Integer.toString(i), bucket.getKeyAsString());
+                assertEquals(bucket.getKeyAsString(), count, bucket.getDocCount());
+
+                final Filter filter = response.getAggregations().get("filter" + i);
+                assertThat(filter.getDocCount(), equalTo(count));
+            }
+        });
     }
 
     // test long/double/string terms aggs with high number of buckets that require array growth
@@ -254,68 +256,71 @@ public class EquivalenceIT extends ESIntegTestCase {
 
         assertNoFailures(indicesAdmin().prepareRefresh("idx").setIndicesOptions(IndicesOptions.lenientExpandOpen()).execute().get());
 
-        SearchResponse resp = prepareSearch("idx").addAggregation(
-            terms("long").field("long_values")
-                .size(maxNumTerms)
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-                .subAggregation(min("min").field("num"))
-        )
-            .addAggregation(
-                terms("double").field("double_values")
+        assertResponse(
+            prepareSearch("idx").addAggregation(
+                terms("long").field("long_values")
                     .size(maxNumTerms)
                     .collectMode(randomFrom(SubAggCollectionMode.values()))
-                    .subAggregation(max("max").field("num"))
+                    .subAggregation(min("min").field("num"))
             )
-            .addAggregation(
-                terms("string_map").field("string_values")
-                    .collectMode(randomFrom(SubAggCollectionMode.values()))
-                    .executionHint(TermsAggregatorFactory.ExecutionMode.MAP.toString())
-                    .size(maxNumTerms)
-                    .subAggregation(stats("stats").field("num"))
-            )
-            .addAggregation(
-                terms("string_global_ordinals").field("string_values")
-                    .collectMode(randomFrom(SubAggCollectionMode.values()))
-                    .executionHint(TermsAggregatorFactory.ExecutionMode.GLOBAL_ORDINALS.toString())
-                    .size(maxNumTerms)
-                    .subAggregation(extendedStats("stats").field("num"))
-            )
-            .addAggregation(
-                terms("string_global_ordinals_doc_values").field("string_values.doc_values")
-                    .collectMode(randomFrom(SubAggCollectionMode.values()))
-                    .executionHint(TermsAggregatorFactory.ExecutionMode.GLOBAL_ORDINALS.toString())
-                    .size(maxNumTerms)
-                    .subAggregation(extendedStats("stats").field("num"))
-            )
-            .get();
-        assertAllSuccessful(resp);
-        assertEquals(numDocs, resp.getHits().getTotalHits().value);
+                .addAggregation(
+                    terms("double").field("double_values")
+                        .size(maxNumTerms)
+                        .collectMode(randomFrom(SubAggCollectionMode.values()))
+                        .subAggregation(max("max").field("num"))
+                )
+                .addAggregation(
+                    terms("string_map").field("string_values")
+                        .collectMode(randomFrom(SubAggCollectionMode.values()))
+                        .executionHint(TermsAggregatorFactory.ExecutionMode.MAP.toString())
+                        .size(maxNumTerms)
+                        .subAggregation(stats("stats").field("num"))
+                )
+                .addAggregation(
+                    terms("string_global_ordinals").field("string_values")
+                        .collectMode(randomFrom(SubAggCollectionMode.values()))
+                        .executionHint(TermsAggregatorFactory.ExecutionMode.GLOBAL_ORDINALS.toString())
+                        .size(maxNumTerms)
+                        .subAggregation(extendedStats("stats").field("num"))
+                )
+                .addAggregation(
+                    terms("string_global_ordinals_doc_values").field("string_values.doc_values")
+                        .collectMode(randomFrom(SubAggCollectionMode.values()))
+                        .executionHint(TermsAggregatorFactory.ExecutionMode.GLOBAL_ORDINALS.toString())
+                        .size(maxNumTerms)
+                        .subAggregation(extendedStats("stats").field("num"))
+                ),
+            response -> {
+                assertAllSuccessful(response);
+                assertEquals(numDocs, response.getHits().getTotalHits().value);
 
-        final Terms longTerms = resp.getAggregations().get("long");
-        final Terms doubleTerms = resp.getAggregations().get("double");
-        final Terms stringMapTerms = resp.getAggregations().get("string_map");
-        final Terms stringGlobalOrdinalsTerms = resp.getAggregations().get("string_global_ordinals");
-        final Terms stringGlobalOrdinalsDVTerms = resp.getAggregations().get("string_global_ordinals_doc_values");
+                final Terms longTerms = response.getAggregations().get("long");
+                final Terms doubleTerms = response.getAggregations().get("double");
+                final Terms stringMapTerms = response.getAggregations().get("string_map");
+                final Terms stringGlobalOrdinalsTerms = response.getAggregations().get("string_global_ordinals");
+                final Terms stringGlobalOrdinalsDVTerms = response.getAggregations().get("string_global_ordinals_doc_values");
 
-        assertEquals(valuesSet.size(), longTerms.getBuckets().size());
-        assertEquals(valuesSet.size(), doubleTerms.getBuckets().size());
-        assertEquals(valuesSet.size(), stringMapTerms.getBuckets().size());
-        assertEquals(valuesSet.size(), stringGlobalOrdinalsTerms.getBuckets().size());
-        assertEquals(valuesSet.size(), stringGlobalOrdinalsDVTerms.getBuckets().size());
-        for (Terms.Bucket bucket : longTerms.getBuckets()) {
-            final Terms.Bucket doubleBucket = doubleTerms.getBucketByKey(Double.toString(Long.parseLong(bucket.getKeyAsString())));
-            final Terms.Bucket stringMapBucket = stringMapTerms.getBucketByKey(bucket.getKeyAsString());
-            final Terms.Bucket stringGlobalOrdinalsBucket = stringGlobalOrdinalsTerms.getBucketByKey(bucket.getKeyAsString());
-            final Terms.Bucket stringGlobalOrdinalsDVBucket = stringGlobalOrdinalsDVTerms.getBucketByKey(bucket.getKeyAsString());
-            assertNotNull(doubleBucket);
-            assertNotNull(stringMapBucket);
-            assertNotNull(stringGlobalOrdinalsBucket);
-            assertNotNull(stringGlobalOrdinalsDVBucket);
-            assertEquals(bucket.getDocCount(), doubleBucket.getDocCount());
-            assertEquals(bucket.getDocCount(), stringMapBucket.getDocCount());
-            assertEquals(bucket.getDocCount(), stringGlobalOrdinalsBucket.getDocCount());
-            assertEquals(bucket.getDocCount(), stringGlobalOrdinalsDVBucket.getDocCount());
-        }
+                assertEquals(valuesSet.size(), longTerms.getBuckets().size());
+                assertEquals(valuesSet.size(), doubleTerms.getBuckets().size());
+                assertEquals(valuesSet.size(), stringMapTerms.getBuckets().size());
+                assertEquals(valuesSet.size(), stringGlobalOrdinalsTerms.getBuckets().size());
+                assertEquals(valuesSet.size(), stringGlobalOrdinalsDVTerms.getBuckets().size());
+                for (Terms.Bucket bucket : longTerms.getBuckets()) {
+                    final Terms.Bucket doubleBucket = doubleTerms.getBucketByKey(Double.toString(Long.parseLong(bucket.getKeyAsString())));
+                    final Terms.Bucket stringMapBucket = stringMapTerms.getBucketByKey(bucket.getKeyAsString());
+                    final Terms.Bucket stringGlobalOrdinalsBucket = stringGlobalOrdinalsTerms.getBucketByKey(bucket.getKeyAsString());
+                    final Terms.Bucket stringGlobalOrdinalsDVBucket = stringGlobalOrdinalsDVTerms.getBucketByKey(bucket.getKeyAsString());
+                    assertNotNull(doubleBucket);
+                    assertNotNull(stringMapBucket);
+                    assertNotNull(stringGlobalOrdinalsBucket);
+                    assertNotNull(stringGlobalOrdinalsDVBucket);
+                    assertEquals(bucket.getDocCount(), doubleBucket.getDocCount());
+                    assertEquals(bucket.getDocCount(), stringMapBucket.getDocCount());
+                    assertEquals(bucket.getDocCount(), stringGlobalOrdinalsBucket.getDocCount());
+                    assertEquals(bucket.getDocCount(), stringGlobalOrdinalsDVBucket.getDocCount());
+                }
+            }
+        );
     }
 
     // Duel between histograms and scripted terms
@@ -355,25 +360,26 @@ public class EquivalenceIT extends ESIntegTestCase {
         Map<String, Object> params = new HashMap<>();
         params.put("interval", interval);
 
-        SearchResponse resp = prepareSearch("idx").addAggregation(
-            terms("terms").field("values")
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-                .script(new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "floor(_value / interval)", params))
-                .size(maxNumTerms)
-        ).addAggregation(histogram("histo").field("values").interval(interval).minDocCount(1)).get();
-
-        assertNoFailures(resp);
-
-        Terms terms = resp.getAggregations().get("terms");
-        assertThat(terms, notNullValue());
-        Histogram histo = resp.getAggregations().get("histo");
-        assertThat(histo, notNullValue());
-        assertThat(terms.getBuckets().size(), equalTo(histo.getBuckets().size()));
-        for (Histogram.Bucket bucket : histo.getBuckets()) {
-            final double key = ((Number) bucket.getKey()).doubleValue() / interval;
-            final Terms.Bucket termsBucket = terms.getBucketByKey(String.valueOf(key));
-            assertEquals(bucket.getDocCount(), termsBucket.getDocCount());
-        }
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                terms("terms").field("values")
+                    .collectMode(randomFrom(SubAggCollectionMode.values()))
+                    .script(new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "floor(_value / interval)", params))
+                    .size(maxNumTerms)
+            ).addAggregation(histogram("histo").field("values").interval(interval).minDocCount(1)),
+            response -> {
+                Terms terms = response.getAggregations().get("terms");
+                assertThat(terms, notNullValue());
+                Histogram histo = response.getAggregations().get("histo");
+                assertThat(histo, notNullValue());
+                assertThat(terms.getBuckets().size(), equalTo(histo.getBuckets().size()));
+                for (Histogram.Bucket bucket : histo.getBuckets()) {
+                    final double key = ((Number) bucket.getKey()).doubleValue() / interval;
+                    final Terms.Bucket termsBucket = terms.getBucketByKey(String.valueOf(key));
+                    assertEquals(bucket.getDocCount(), termsBucket.getDocCount());
+                }
+            }
+        );
     }
 
     public void testLargeNumbersOfPercentileBuckets() throws Exception {
@@ -398,13 +404,17 @@ public class EquivalenceIT extends ESIntegTestCase {
         }
         indexRandom(true, indexingRequests);
 
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            terms("terms").field("double_value")
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-                .subAggregation(percentiles("pcts").field("double_value"))
-        ).get();
-        assertAllSuccessful(response);
-        assertEquals(numDocs, response.getHits().getTotalHits().value);
+        assertResponse(
+            prepareSearch("idx").addAggregation(
+                terms("terms").field("double_value")
+                    .collectMode(randomFrom(SubAggCollectionMode.values()))
+                    .subAggregation(percentiles("pcts").field("double_value"))
+            ),
+            response -> {
+                assertAllSuccessful(response);
+                assertEquals(numDocs, response.getHits().getTotalHits().value);
+            }
+        );
     }
 
     // https://github.com/elastic/elasticsearch/issues/6435
@@ -412,41 +422,42 @@ public class EquivalenceIT extends ESIntegTestCase {
         createIndex("idx");
         final int value = randomIntBetween(0, 10);
         indexRandom(true, client().prepareIndex("idx").setSource("f", value));
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            filter("filter", QueryBuilders.matchAllQuery()).subAggregation(
-                range("range").field("f").addUnboundedTo(6).addUnboundedFrom(6).subAggregation(sum("sum").field("f"))
-            )
-        ).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                filter("filter", QueryBuilders.matchAllQuery()).subAggregation(
+                    range("range").field("f").addUnboundedTo(6).addUnboundedFrom(6).subAggregation(sum("sum").field("f"))
+                )
+            ),
+            response -> {
+                Filter filter = response.getAggregations().get("filter");
+                assertNotNull(filter);
+                assertEquals(1, filter.getDocCount());
 
-        assertNoFailures(response);
+                Range range = filter.getAggregations().get("range");
+                assertThat(range, notNullValue());
+                assertThat(range.getName(), equalTo("range"));
+                List<? extends Bucket> buckets = range.getBuckets();
+                assertThat(buckets.size(), equalTo(2));
 
-        Filter filter = response.getAggregations().get("filter");
-        assertNotNull(filter);
-        assertEquals(1, filter.getDocCount());
+                Range.Bucket bucket = buckets.get(0);
+                assertThat(bucket, notNullValue());
+                assertThat((String) bucket.getKey(), equalTo("*-6.0"));
+                assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo(Double.NEGATIVE_INFINITY));
+                assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(6.0));
+                assertThat(bucket.getDocCount(), equalTo(value < 6 ? 1L : 0L));
+                Sum sum = bucket.getAggregations().get("sum");
+                assertEquals(value < 6 ? value : 0, sum.value(), 0d);
 
-        Range range = filter.getAggregations().get("range");
-        assertThat(range, notNullValue());
-        assertThat(range.getName(), equalTo("range"));
-        List<? extends Bucket> buckets = range.getBuckets();
-        assertThat(buckets.size(), equalTo(2));
-
-        Range.Bucket bucket = buckets.get(0);
-        assertThat(bucket, notNullValue());
-        assertThat((String) bucket.getKey(), equalTo("*-6.0"));
-        assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo(Double.NEGATIVE_INFINITY));
-        assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(6.0));
-        assertThat(bucket.getDocCount(), equalTo(value < 6 ? 1L : 0L));
-        Sum sum = bucket.getAggregations().get("sum");
-        assertEquals(value < 6 ? value : 0, sum.value(), 0d);
-
-        bucket = buckets.get(1);
-        assertThat(bucket, notNullValue());
-        assertThat((String) bucket.getKey(), equalTo("6.0-*"));
-        assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo(6.0));
-        assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(Double.POSITIVE_INFINITY));
-        assertThat(bucket.getDocCount(), equalTo(value >= 6 ? 1L : 0L));
-        sum = bucket.getAggregations().get("sum");
-        assertEquals(value >= 6 ? value : 0, sum.value(), 0d);
+                bucket = buckets.get(1);
+                assertThat(bucket, notNullValue());
+                assertThat((String) bucket.getKey(), equalTo("6.0-*"));
+                assertThat(((Number) bucket.getFrom()).doubleValue(), equalTo(6.0));
+                assertThat(((Number) bucket.getTo()).doubleValue(), equalTo(Double.POSITIVE_INFINITY));
+                assertThat(bucket.getDocCount(), equalTo(value >= 6 ? 1L : 0L));
+                sum = bucket.getAggregations().get("sum");
+                assertEquals(value >= 6 ? value : 0, sum.value(), 0d);
+            }
+        );
     }
 
     private void assertEquals(Terms t1, Terms t2) {
@@ -473,42 +484,48 @@ public class EquivalenceIT extends ESIntegTestCase {
         }
         indexRandom(true, reqs);
 
-        final SearchResponse r1 = prepareSearch("idx").addAggregation(
-            terms("f1").field("f1")
-                .collectMode(SubAggCollectionMode.DEPTH_FIRST)
-                .subAggregation(
-                    terms("f2").field("f2")
-                        .collectMode(SubAggCollectionMode.DEPTH_FIRST)
-                        .subAggregation(terms("f3").field("f3").collectMode(SubAggCollectionMode.DEPTH_FIRST))
-                )
-        ).get();
-        assertNoFailures(r1);
-        final SearchResponse r2 = prepareSearch("idx").addAggregation(
-            terms("f1").field("f1")
-                .collectMode(SubAggCollectionMode.BREADTH_FIRST)
-                .subAggregation(
-                    terms("f2").field("f2")
-                        .collectMode(SubAggCollectionMode.BREADTH_FIRST)
-                        .subAggregation(terms("f3").field("f3").collectMode(SubAggCollectionMode.BREADTH_FIRST))
-                )
-        ).get();
-        assertNoFailures(r2);
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                terms("f1").field("f1")
+                    .collectMode(SubAggCollectionMode.DEPTH_FIRST)
+                    .subAggregation(
+                        terms("f2").field("f2")
+                            .collectMode(SubAggCollectionMode.DEPTH_FIRST)
+                            .subAggregation(terms("f3").field("f3").collectMode(SubAggCollectionMode.DEPTH_FIRST))
+                    )
+            ),
+            response1 -> {
+                assertNoFailuresAndResponse(
+                    prepareSearch("idx").addAggregation(
+                        terms("f1").field("f1")
+                            .collectMode(SubAggCollectionMode.BREADTH_FIRST)
+                            .subAggregation(
+                                terms("f2").field("f2")
+                                    .collectMode(SubAggCollectionMode.BREADTH_FIRST)
+                                    .subAggregation(terms("f3").field("f3").collectMode(SubAggCollectionMode.BREADTH_FIRST))
+                            )
+                    ),
+                    response2 -> {
 
-        final Terms t1 = r1.getAggregations().get("f1");
-        final Terms t2 = r2.getAggregations().get("f1");
-        assertEquals(t1, t2);
-        for (Terms.Bucket b1 : t1.getBuckets()) {
-            final Terms.Bucket b2 = t2.getBucketByKey(b1.getKeyAsString());
-            final Terms sub1 = b1.getAggregations().get("f2");
-            final Terms sub2 = b2.getAggregations().get("f2");
-            assertEquals(sub1, sub2);
-            for (Terms.Bucket subB1 : sub1.getBuckets()) {
-                final Terms.Bucket subB2 = sub2.getBucketByKey(subB1.getKeyAsString());
-                final Terms subSub1 = subB1.getAggregations().get("f3");
-                final Terms subSub2 = subB2.getAggregations().get("f3");
-                assertEquals(subSub1, subSub2);
+                        final Terms t1 = response1.getAggregations().get("f1");
+                        final Terms t2 = response2.getAggregations().get("f1");
+                        assertEquals(t1, t2);
+                        for (Terms.Bucket b1 : t1.getBuckets()) {
+                            final Terms.Bucket b2 = t2.getBucketByKey(b1.getKeyAsString());
+                            final Terms sub1 = b1.getAggregations().get("f2");
+                            final Terms sub2 = b2.getAggregations().get("f2");
+                            assertEquals(sub1, sub2);
+                            for (Terms.Bucket subB1 : sub1.getBuckets()) {
+                                final Terms.Bucket subB2 = sub2.getBucketByKey(subB1.getKeyAsString());
+                                final Terms subSub1 = subB1.getAggregations().get("f3");
+                                final Terms subSub2 = subB2.getAggregations().get("f3");
+                                assertEquals(subSub1, subSub2);
+                            }
+                        }
+                    }
+                );
             }
-        }
+        );
     }
 
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/FiltersAggsRewriteIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/FiltersAggsRewriteIT.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.search.aggregations;
 
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.query.WrapperQueryBuilder;
@@ -23,6 +22,8 @@ import org.elasticsearch.xcontent.XContentType;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 
 public class FiltersAggsRewriteIT extends ESSingleNodeTestCase {
 
@@ -54,11 +55,12 @@ public class FiltersAggsRewriteIT extends ESSingleNodeTestCase {
         Map<String, Object> metadata = new HashMap<>();
         metadata.put(randomAlphaOfLengthBetween(1, 20), randomAlphaOfLengthBetween(1, 20));
         builder.setMetadata(metadata);
-        SearchResponse searchResponse = client().prepareSearch("test").setSize(0).addAggregation(builder).get();
-        assertEquals(3, searchResponse.getHits().getTotalHits().value);
-        InternalFilters filters = searchResponse.getAggregations().get("titles");
-        assertEquals(1, filters.getBuckets().size());
-        assertEquals(2, filters.getBuckets().get(0).getDocCount());
-        assertEquals(metadata, filters.getMetadata());
+        assertResponse(client().prepareSearch("test").setSize(0).addAggregation(builder), response -> {
+            assertEquals(3, response.getHits().getTotalHits().value);
+            InternalFilters filters = response.getAggregations().get("titles");
+            assertEquals(1, filters.getBuckets().size());
+            assertEquals(2, filters.getBuckets().get(0).getDocCount());
+            assertEquals(metadata, filters.getMetadata());
+        });
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/MetadataIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/MetadataIT.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.search.aggregations;
 
 import org.elasticsearch.action.index.IndexRequestBuilder;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.metrics.Sum;
 import org.elasticsearch.search.aggregations.pipeline.InternalBucketMetricValue;
@@ -22,7 +21,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.search.aggregations.PipelineAggregatorBuilders.maxBucket;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
 
 public class MetadataIT extends ESIntegTestCase {
 
@@ -39,32 +38,33 @@ public class MetadataIT extends ESIntegTestCase {
         final var nestedMetadata = Map.of("nested", "value");
         var metadata = Map.of("key", "value", "numeric", 1.2, "bool", true, "complex", nestedMetadata);
 
-        SearchResponse response = prepareSearch("idx").addAggregation(
-            terms("the_terms").setMetadata(metadata).field("name").subAggregation(sum("the_sum").setMetadata(metadata).field("value"))
-        ).addAggregation(maxBucket("the_max_bucket", "the_terms>the_sum").setMetadata(metadata)).get();
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                terms("the_terms").setMetadata(metadata).field("name").subAggregation(sum("the_sum").setMetadata(metadata).field("value"))
+            ).addAggregation(maxBucket("the_max_bucket", "the_terms>the_sum").setMetadata(metadata)),
+            response -> {
+                Aggregations aggs = response.getAggregations();
+                assertNotNull(aggs);
 
-        assertNoFailures(response);
+                Terms terms = aggs.get("the_terms");
+                assertNotNull(terms);
+                assertMetadata(terms.getMetadata());
 
-        Aggregations aggs = response.getAggregations();
-        assertNotNull(aggs);
+                List<? extends Terms.Bucket> buckets = terms.getBuckets();
+                for (Terms.Bucket bucket : buckets) {
+                    Aggregations subAggs = bucket.getAggregations();
+                    assertNotNull(subAggs);
 
-        Terms terms = aggs.get("the_terms");
-        assertNotNull(terms);
-        assertMetadata(terms.getMetadata());
+                    Sum sum = subAggs.get("the_sum");
+                    assertNotNull(sum);
+                    assertMetadata(sum.getMetadata());
+                }
 
-        List<? extends Terms.Bucket> buckets = terms.getBuckets();
-        for (Terms.Bucket bucket : buckets) {
-            Aggregations subAggs = bucket.getAggregations();
-            assertNotNull(subAggs);
-
-            Sum sum = subAggs.get("the_sum");
-            assertNotNull(sum);
-            assertMetadata(sum.getMetadata());
-        }
-
-        InternalBucketMetricValue maxBucket = aggs.get("the_max_bucket");
-        assertNotNull(maxBucket);
-        assertMetadata(maxBucket.getMetadata());
+                InternalBucketMetricValue maxBucket = aggs.get("the_max_bucket");
+                assertNotNull(maxBucket);
+                assertMetadata(maxBucket.getMetadata());
+            }
+        );
     }
 
     private void assertMetadata(Map<String, Object> returnedMetadata) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/SignificantTermsSignificanceScoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/SignificantTermsSignificanceScoreIT.java
@@ -9,7 +9,6 @@ package org.elasticsearch.search.aggregations.bucket;
 
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchRequestBuilder;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentHelper;
@@ -57,7 +56,9 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.signific
 import static org.elasticsearch.search.aggregations.AggregationBuilders.significantText;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertCheckedResponse;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -130,71 +131,70 @@ public class SignificantTermsSignificanceScoreIT extends ESIntegTestCase {
             );
         }
 
-        SearchResponse response = request.get();
-
-        assertNoFailures(response);
-        StringTerms classes = response.getAggregations().get("class");
-        assertThat(classes.getBuckets().size(), equalTo(2));
-        for (Terms.Bucket classBucket : classes.getBuckets()) {
-            Map<String, Aggregation> aggs = classBucket.getAggregations().asMap();
-            assertTrue(aggs.containsKey("sig_terms"));
-            SignificantTerms agg = (SignificantTerms) aggs.get("sig_terms");
-            assertThat(agg.getBuckets().size(), equalTo(1));
-            String term = agg.iterator().next().getKeyAsString();
-            String classTerm = classBucket.getKeyAsString();
-            assertTrue(term.equals(classTerm));
-        }
-
-        XContentBuilder responseBuilder = XContentFactory.jsonBuilder();
-        responseBuilder.startObject();
-        classes.toXContent(responseBuilder, ToXContent.EMPTY_PARAMS);
-        responseBuilder.endObject();
-
-        Object[] args = new Object[] { type.equals("long") ? "0" : "\"0\"", type.equals("long") ? "1" : "\"1\"" };
-        String result = Strings.format("""
-            {
-              "class": {
-                "doc_count_error_upper_bound": 0,
-                "sum_other_doc_count": 0,
-                "buckets": [
-                  {
-                    "key": "0",
-                    "doc_count": 4,
-                    "sig_terms": {
-                      "doc_count": 4,
-                      "bg_count": 7,
-                      "buckets": [
-                        {
-                          "key": %s,
-                          "doc_count": 4,
-                          "score": 0.39999999999999997,
-                          "bg_count": 5
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "key": "1",
-                    "doc_count": 3,
-                    "sig_terms": {
-                      "doc_count": 3,
-                      "bg_count": 7,
-                      "buckets": [
-                        {
-                          "key":%s,
-                          "doc_count": 3,
-                          "score": 0.75,
-                          "bg_count": 4
-                        }
-                      ]
-                    }
-                  }
-                ]
-              }
+        assertCheckedResponse(request, response -> {
+            assertNoFailures(response);
+            StringTerms classes = response.getAggregations().get("class");
+            assertThat(classes.getBuckets().size(), equalTo(2));
+            for (Terms.Bucket classBucket : classes.getBuckets()) {
+                Map<String, Aggregation> aggs = classBucket.getAggregations().asMap();
+                assertTrue(aggs.containsKey("sig_terms"));
+                SignificantTerms agg = (SignificantTerms) aggs.get("sig_terms");
+                assertThat(agg.getBuckets().size(), equalTo(1));
+                String term = agg.iterator().next().getKeyAsString();
+                String classTerm = classBucket.getKeyAsString();
+                assertTrue(term.equals(classTerm));
             }
-            """, args);
-        assertThat(Strings.toString(responseBuilder), equalTo(XContentHelper.stripWhitespace(result)));
 
+            XContentBuilder responseBuilder = XContentFactory.jsonBuilder();
+            responseBuilder.startObject();
+            classes.toXContent(responseBuilder, ToXContent.EMPTY_PARAMS);
+            responseBuilder.endObject();
+
+            Object[] args = new Object[] { type.equals("long") ? "0" : "\"0\"", type.equals("long") ? "1" : "\"1\"" };
+            String result = Strings.format("""
+                {
+                  "class": {
+                    "doc_count_error_upper_bound": 0,
+                    "sum_other_doc_count": 0,
+                    "buckets": [
+                      {
+                        "key": "0",
+                        "doc_count": 4,
+                        "sig_terms": {
+                          "doc_count": 4,
+                          "bg_count": 7,
+                          "buckets": [
+                            {
+                              "key": %s,
+                              "doc_count": 4,
+                              "score": 0.39999999999999997,
+                              "bg_count": 5
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": "1",
+                        "doc_count": 3,
+                        "sig_terms": {
+                          "doc_count": 3,
+                          "bg_count": 7,
+                          "buckets": [
+                            {
+                              "key":%s,
+                              "doc_count": 3,
+                              "score": 0.75,
+                              "bg_count": 4
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+                """, args);
+            assertThat(Strings.toString(responseBuilder), equalTo(XContentHelper.stripWhitespace(result)));
+        });
     }
 
     public void testPopularTermManyDeletedDocs() throws Exception {
@@ -286,9 +286,6 @@ public class SignificantTermsSignificanceScoreIT extends ESIntegTestCase {
             );
         }
 
-        SearchResponse response1 = request1.get();
-        assertNoFailures(response1);
-
         SearchRequestBuilder request2;
         if (useSigText) {
             request2 = prepareSearch(INDEX_NAME).addAggregation(
@@ -324,32 +321,32 @@ public class SignificantTermsSignificanceScoreIT extends ESIntegTestCase {
                 );
         }
 
-        SearchResponse response2 = request2.get();
+        assertNoFailuresAndResponse(request1, response1 -> assertNoFailuresAndResponse(request2, response2 -> {
+            StringTerms classes = response1.getAggregations().get("class");
 
-        StringTerms classes = response1.getAggregations().get("class");
+            SignificantTerms sigTerms0 = ((SignificantTerms) (classes.getBucketByKey("0").getAggregations().asMap().get("sig_terms")));
+            assertThat(sigTerms0.getBuckets().size(), equalTo(2));
+            double score00Background = sigTerms0.getBucketByKey("0").getSignificanceScore();
+            double score01Background = sigTerms0.getBucketByKey("1").getSignificanceScore();
+            SignificantTerms sigTerms1 = ((SignificantTerms) (classes.getBucketByKey("1").getAggregations().asMap().get("sig_terms")));
+            double score10Background = sigTerms1.getBucketByKey("0").getSignificanceScore();
+            double score11Background = sigTerms1.getBucketByKey("1").getSignificanceScore();
 
-        SignificantTerms sigTerms0 = ((SignificantTerms) (classes.getBucketByKey("0").getAggregations().asMap().get("sig_terms")));
-        assertThat(sigTerms0.getBuckets().size(), equalTo(2));
-        double score00Background = sigTerms0.getBucketByKey("0").getSignificanceScore();
-        double score01Background = sigTerms0.getBucketByKey("1").getSignificanceScore();
-        SignificantTerms sigTerms1 = ((SignificantTerms) (classes.getBucketByKey("1").getAggregations().asMap().get("sig_terms")));
-        double score10Background = sigTerms1.getBucketByKey("0").getSignificanceScore();
-        double score11Background = sigTerms1.getBucketByKey("1").getSignificanceScore();
+            Aggregations aggs = response2.getAggregations();
 
-        Aggregations aggs = response2.getAggregations();
+            sigTerms0 = (SignificantTerms) ((InternalFilter) aggs.get("0")).getAggregations().getAsMap().get("sig_terms");
+            double score00SeparateSets = sigTerms0.getBucketByKey("0").getSignificanceScore();
+            double score01SeparateSets = sigTerms0.getBucketByKey("1").getSignificanceScore();
 
-        sigTerms0 = (SignificantTerms) ((InternalFilter) aggs.get("0")).getAggregations().getAsMap().get("sig_terms");
-        double score00SeparateSets = sigTerms0.getBucketByKey("0").getSignificanceScore();
-        double score01SeparateSets = sigTerms0.getBucketByKey("1").getSignificanceScore();
+            sigTerms1 = (SignificantTerms) ((InternalFilter) aggs.get("1")).getAggregations().getAsMap().get("sig_terms");
+            double score10SeparateSets = sigTerms1.getBucketByKey("0").getSignificanceScore();
+            double score11SeparateSets = sigTerms1.getBucketByKey("1").getSignificanceScore();
 
-        sigTerms1 = (SignificantTerms) ((InternalFilter) aggs.get("1")).getAggregations().getAsMap().get("sig_terms");
-        double score10SeparateSets = sigTerms1.getBucketByKey("0").getSignificanceScore();
-        double score11SeparateSets = sigTerms1.getBucketByKey("1").getSignificanceScore();
-
-        assertThat(score00Background, equalTo(score00SeparateSets));
-        assertThat(score01Background, equalTo(score01SeparateSets));
-        assertThat(score10Background, equalTo(score10SeparateSets));
-        assertThat(score11Background, equalTo(score11SeparateSets));
+            assertThat(score00Background, equalTo(score00SeparateSets));
+            assertThat(score01Background, equalTo(score01SeparateSets));
+            assertThat(score10Background, equalTo(score10SeparateSets));
+            assertThat(score11Background, equalTo(score11SeparateSets));
+        }));
     }
 
     public void testScoresEqualForPositiveAndNegative() throws Exception {
@@ -385,25 +382,23 @@ public class SignificantTermsSignificanceScoreIT extends ESIntegTestCase {
                     )
             );
         }
-        SearchResponse response = request.get();
-        assertNoFailures(response);
+        assertNoFailuresAndResponse(request, response -> {
+            StringTerms classes = response.getAggregations().get("class");
+            assertThat(classes.getBuckets().size(), equalTo(2));
+            Iterator<? extends Terms.Bucket> classBuckets = classes.getBuckets().iterator();
 
-        assertNoFailures(response);
-        StringTerms classes = response.getAggregations().get("class");
-        assertThat(classes.getBuckets().size(), equalTo(2));
-        Iterator<? extends Terms.Bucket> classBuckets = classes.getBuckets().iterator();
+            Aggregations aggregations = classBuckets.next().getAggregations();
+            SignificantTerms sigTerms = aggregations.get("mySignificantTerms");
 
-        Aggregations aggregations = classBuckets.next().getAggregations();
-        SignificantTerms sigTerms = aggregations.get("mySignificantTerms");
-
-        List<? extends SignificantTerms.Bucket> classA = sigTerms.getBuckets();
-        Iterator<SignificantTerms.Bucket> classBBucketIterator = sigTerms.iterator();
-        assertThat(classA.size(), greaterThan(0));
-        for (SignificantTerms.Bucket classABucket : classA) {
-            SignificantTerms.Bucket classBBucket = classBBucketIterator.next();
-            assertThat(classABucket.getKey(), equalTo(classBBucket.getKey()));
-            assertThat(classABucket.getSignificanceScore(), closeTo(classBBucket.getSignificanceScore(), 1.e-5));
-        }
+            List<? extends SignificantTerms.Bucket> classA = sigTerms.getBuckets();
+            Iterator<SignificantTerms.Bucket> classBBucketIterator = sigTerms.iterator();
+            assertThat(classA.size(), greaterThan(0));
+            for (SignificantTerms.Bucket classABucket : classA) {
+                SignificantTerms.Bucket classBBucket = classBBucketIterator.next();
+                assertThat(classABucket.getKey(), equalTo(classBBucket.getKey()));
+                assertThat(classABucket.getSignificanceScore(), closeTo(classBBucket.getSignificanceScore(), 1.e-5));
+            }
+        });
     }
 
     /**
@@ -423,16 +418,15 @@ public class SignificantTermsSignificanceScoreIT extends ESIntegTestCase {
             .size(1000)
             .subAggregation(subAgg);
 
-        SearchResponse response = prepareSearch("test").setQuery(query).addAggregation(agg).get();
-        assertNoFailures(response);
+        assertNoFailuresAndResponse(prepareSearch("test").setQuery(query).addAggregation(agg), response -> {
+            SignificantTerms sigTerms = response.getAggregations().get("significant_terms");
+            assertThat(sigTerms.getBuckets().size(), equalTo(2));
 
-        SignificantTerms sigTerms = response.getAggregations().get("significant_terms");
-        assertThat(sigTerms.getBuckets().size(), equalTo(2));
-
-        for (SignificantTerms.Bucket bucket : sigTerms) {
-            StringTerms terms = bucket.getAggregations().get("class");
-            assertThat(terms.getBuckets().size(), equalTo(2));
-        }
+            for (SignificantTerms.Bucket bucket : sigTerms) {
+                StringTerms terms = bucket.getAggregations().get("class");
+                assertThat(terms.getBuckets().size(), equalTo(2));
+            }
+        });
     }
 
     private void indexEqualTestData() throws ExecutionException, InterruptedException {
@@ -497,17 +491,17 @@ public class SignificantTermsSignificanceScoreIT extends ESIntegTestCase {
                     )
             );
         }
-        SearchResponse response = request.get();
-        assertNoFailures(response);
-        for (Terms.Bucket classBucket : ((Terms) response.getAggregations().get("class")).getBuckets()) {
-            SignificantTerms sigTerms = classBucket.getAggregations().get("mySignificantTerms");
-            for (SignificantTerms.Bucket bucket : sigTerms.getBuckets()) {
-                assertThat(
-                    bucket.getSignificanceScore(),
-                    is((double) bucket.getSubsetDf() + bucket.getSubsetSize() + bucket.getSupersetDf() + bucket.getSupersetSize())
-                );
+        assertNoFailuresAndResponse(request, response -> {
+            for (Terms.Bucket classBucket : ((Terms) response.getAggregations().get("class")).getBuckets()) {
+                SignificantTerms sigTerms = classBucket.getAggregations().get("mySignificantTerms");
+                for (SignificantTerms.Bucket bucket : sigTerms.getBuckets()) {
+                    assertThat(
+                        bucket.getSignificanceScore(),
+                        is((double) bucket.getSubsetDf() + bucket.getSubsetSize() + bucket.getSupersetDf() + bucket.getSupersetSize())
+                    );
+                }
             }
-        }
+        });
     }
 
     private ScriptHeuristic getScriptSignificanceHeuristic() throws IOException {
@@ -579,17 +573,15 @@ public class SignificantTermsSignificanceScoreIT extends ESIntegTestCase {
             new Script(ScriptType.INLINE, "mockscript", "Math.random()", Collections.emptyMap())
         );
         boolean useSigText = randomBoolean();
-        SearchResponse r;
+        SearchRequestBuilder request;
         if (useSigText) {
-            r = prepareSearch("cache_test_idx").setSize(0)
-                .addAggregation(significantText("foo", "t").significanceHeuristic(scriptHeuristic))
-                .get();
+            request = prepareSearch("cache_test_idx").setSize(0)
+                .addAggregation(significantText("foo", "t").significanceHeuristic(scriptHeuristic));
         } else {
-            r = prepareSearch("cache_test_idx").setSize(0)
-                .addAggregation(significantTerms("foo").field("s").significanceHeuristic(scriptHeuristic))
-                .get();
+            request = prepareSearch("cache_test_idx").setSize(0)
+                .addAggregation(significantTerms("foo").field("s").significanceHeuristic(scriptHeuristic));
         }
-        assertNoFailures(r);
+        assertNoFailures(request);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -604,15 +596,13 @@ public class SignificantTermsSignificanceScoreIT extends ESIntegTestCase {
         scriptHeuristic = getScriptSignificanceHeuristic();
         useSigText = randomBoolean();
         if (useSigText) {
-            r = prepareSearch("cache_test_idx").setSize(0)
-                .addAggregation(significantText("foo", "t").significanceHeuristic(scriptHeuristic))
-                .get();
+            request = prepareSearch("cache_test_idx").setSize(0)
+                .addAggregation(significantText("foo", "t").significanceHeuristic(scriptHeuristic));
         } else {
-            r = prepareSearch("cache_test_idx").setSize(0)
-                .addAggregation(significantTerms("foo").field("s").significanceHeuristic(scriptHeuristic))
-                .get();
+            request = prepareSearch("cache_test_idx").setSize(0)
+                .addAggregation(significantTerms("foo").field("s").significanceHeuristic(scriptHeuristic));
         }
-        assertNoFailures(r);
+        assertNoFailures(request);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
@@ -625,11 +615,11 @@ public class SignificantTermsSignificanceScoreIT extends ESIntegTestCase {
 
         // Ensure that non-scripted requests are cached as normal
         if (useSigText) {
-            r = prepareSearch("cache_test_idx").setSize(0).addAggregation(significantText("foo", "t")).get();
+            request = prepareSearch("cache_test_idx").setSize(0).addAggregation(significantText("foo", "t"));
         } else {
-            r = prepareSearch("cache_test_idx").setSize(0).addAggregation(significantTerms("foo").field("s")).get();
+            request = prepareSearch("cache_test_idx").setSize(0).addAggregation(significantTerms("foo").field("s"));
         }
-        assertNoFailures(r);
+        assertNoFailures(request);
 
         assertThat(
             indicesAdmin().prepareStats("cache_test_idx").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/TermsDocCountErrorIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/TermsDocCountErrorIT.java
@@ -28,7 +28,7 @@ import java.util.Map;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.sum;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.equalTo;
@@ -267,691 +267,643 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
     public void testStringValueField() throws Exception {
         int size = randomIntBetween(1, 20);
         int shardSize = randomIntBetween(size, size * 2);
-        SearchResponse accurateResponse = prepareSearch("idx").addAggregation(
-            terms("terms").executionHint(randomExecutionHint())
-                .field(STRING_FIELD_NAME)
-                .showTermDocCountError(true)
-                .size(10000)
-                .shardSize(10000)
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-        ).get();
-
-        assertNoFailures(accurateResponse);
-
-        SearchResponse testResponse = prepareSearch("idx").addAggregation(
-            terms("terms").executionHint(randomExecutionHint())
-                .field(STRING_FIELD_NAME)
-                .showTermDocCountError(true)
-                .size(size)
-                .shardSize(shardSize)
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-        ).get();
-
-        assertNoFailures(testResponse);
-
-        assertDocCountErrorWithinBounds(size, accurateResponse, testResponse);
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                terms("terms").executionHint(randomExecutionHint())
+                    .field(STRING_FIELD_NAME)
+                    .showTermDocCountError(true)
+                    .size(10000)
+                    .shardSize(10000)
+                    .collectMode(randomFrom(SubAggCollectionMode.values()))
+            ),
+            accurateResponse -> assertNoFailuresAndResponse(
+                prepareSearch("idx").addAggregation(
+                    terms("terms").executionHint(randomExecutionHint())
+                        .field(STRING_FIELD_NAME)
+                        .showTermDocCountError(true)
+                        .size(size)
+                        .shardSize(shardSize)
+                        .collectMode(randomFrom(SubAggCollectionMode.values()))
+                ),
+                testResponse -> assertDocCountErrorWithinBounds(size, accurateResponse, testResponse)
+            )
+        );
     }
 
     public void testStringValueFieldSingleShard() throws Exception {
         int size = randomIntBetween(1, 20);
         int shardSize = randomIntBetween(size, size * 2);
-        SearchResponse accurateResponse = prepareSearch("idx_single_shard").addAggregation(
-            terms("terms").executionHint(randomExecutionHint())
-                .field(STRING_FIELD_NAME)
-                .showTermDocCountError(true)
-                .size(10000)
-                .shardSize(10000)
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-        ).get();
-
-        assertNoFailures(accurateResponse);
-
-        SearchResponse testResponse = prepareSearch("idx_single_shard").addAggregation(
-            terms("terms").executionHint(randomExecutionHint())
-                .field(STRING_FIELD_NAME)
-                .showTermDocCountError(true)
-                .size(size)
-                .shardSize(shardSize)
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-        ).get();
-
-        assertNoFailures(testResponse);
-
-        assertNoDocCountError(size, accurateResponse, testResponse);
+        assertNoFailuresAndResponse(
+            prepareSearch("idx_single_shard").addAggregation(
+                terms("terms").executionHint(randomExecutionHint())
+                    .field(STRING_FIELD_NAME)
+                    .showTermDocCountError(true)
+                    .size(10000)
+                    .shardSize(10000)
+                    .collectMode(randomFrom(SubAggCollectionMode.values()))
+            ),
+            accurateResponse -> assertNoFailuresAndResponse(
+                prepareSearch("idx_single_shard").addAggregation(
+                    terms("terms").executionHint(randomExecutionHint())
+                        .field(STRING_FIELD_NAME)
+                        .showTermDocCountError(true)
+                        .size(size)
+                        .shardSize(shardSize)
+                        .collectMode(randomFrom(SubAggCollectionMode.values()))
+                ),
+                testResponse -> assertNoDocCountError(size, accurateResponse, testResponse)
+            )
+        );
     }
 
     public void testStringValueFieldWithRouting() throws Exception {
         int size = randomIntBetween(1, 20);
         int shardSize = randomIntBetween(size, size * 2);
 
-        SearchResponse testResponse = prepareSearch("idx_with_routing").setRouting(String.valueOf(between(1, numRoutingValues)))
-            .addAggregation(
-                terms("terms").executionHint(randomExecutionHint())
-                    .field(STRING_FIELD_NAME)
-                    .showTermDocCountError(true)
-                    .size(size)
-                    .shardSize(shardSize)
-                    .collectMode(randomFrom(SubAggCollectionMode.values()))
-            )
-            .get();
-
-        assertNoFailures(testResponse);
-
-        assertNoDocCountErrorSingleResponse(size, testResponse);
+        assertNoFailuresAndResponse(
+            prepareSearch("idx_with_routing").setRouting(String.valueOf(between(1, numRoutingValues)))
+                .addAggregation(
+                    terms("terms").executionHint(randomExecutionHint())
+                        .field(STRING_FIELD_NAME)
+                        .showTermDocCountError(true)
+                        .size(size)
+                        .shardSize(shardSize)
+                        .collectMode(randomFrom(SubAggCollectionMode.values()))
+                ),
+            testResponse -> assertNoDocCountErrorSingleResponse(size, testResponse)
+        );
     }
 
     public void testStringValueFieldDocCountAsc() throws Exception {
         int size = randomIntBetween(1, 20);
         int shardSize = randomIntBetween(size, size * 2);
-        SearchResponse accurateResponse = prepareSearch("idx_single_shard").addAggregation(
-            terms("terms").executionHint(randomExecutionHint())
-                .field(STRING_FIELD_NAME)
-                .showTermDocCountError(true)
-                .size(10000)
-                .shardSize(10000)
-                .order(BucketOrder.count(true))
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-        ).get();
-
-        assertNoFailures(accurateResponse);
-
-        SearchResponse testResponse = prepareSearch("idx_single_shard").addAggregation(
-            terms("terms").executionHint(randomExecutionHint())
-                .field(STRING_FIELD_NAME)
-                .showTermDocCountError(true)
-                .size(size)
-                .shardSize(shardSize)
-                .order(BucketOrder.count(true))
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-        ).get();
-
-        assertNoFailures(testResponse);
-
-        assertUnboundedDocCountError(size, accurateResponse, testResponse);
+        assertNoFailuresAndResponse(
+            prepareSearch("idx_single_shard").addAggregation(
+                terms("terms").executionHint(randomExecutionHint())
+                    .field(STRING_FIELD_NAME)
+                    .showTermDocCountError(true)
+                    .size(10000)
+                    .shardSize(10000)
+                    .order(BucketOrder.count(true))
+                    .collectMode(randomFrom(SubAggCollectionMode.values()))
+            ),
+            accurateResponse -> assertNoFailuresAndResponse(
+                prepareSearch("idx_single_shard").addAggregation(
+                    terms("terms").executionHint(randomExecutionHint())
+                        .field(STRING_FIELD_NAME)
+                        .showTermDocCountError(true)
+                        .size(size)
+                        .shardSize(shardSize)
+                        .order(BucketOrder.count(true))
+                        .collectMode(randomFrom(SubAggCollectionMode.values()))
+                ),
+                testResponse -> assertUnboundedDocCountError(size, accurateResponse, testResponse)
+            )
+        );
     }
 
     public void testStringValueFieldTermSortAsc() throws Exception {
         int size = randomIntBetween(1, 20);
         int shardSize = randomIntBetween(size, size * 2);
-        SearchResponse accurateResponse = prepareSearch("idx_single_shard").addAggregation(
-            terms("terms").executionHint(randomExecutionHint())
-                .field(STRING_FIELD_NAME)
-                .showTermDocCountError(true)
-                .size(10000)
-                .shardSize(10000)
-                .order(BucketOrder.key(true))
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-        ).get();
-
-        assertNoFailures(accurateResponse);
-
-        SearchResponse testResponse = prepareSearch("idx_single_shard").addAggregation(
-            terms("terms").executionHint(randomExecutionHint())
-                .field(STRING_FIELD_NAME)
-                .showTermDocCountError(true)
-                .size(size)
-                .shardSize(shardSize)
-                .order(BucketOrder.key(true))
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-        ).get();
-
-        assertNoFailures(testResponse);
-
-        assertNoDocCountError(size, accurateResponse, testResponse);
+        assertNoFailuresAndResponse(
+            prepareSearch("idx_single_shard").addAggregation(
+                terms("terms").executionHint(randomExecutionHint())
+                    .field(STRING_FIELD_NAME)
+                    .showTermDocCountError(true)
+                    .size(10000)
+                    .shardSize(10000)
+                    .order(BucketOrder.key(true))
+                    .collectMode(randomFrom(SubAggCollectionMode.values()))
+            ),
+            accurateResponse -> assertNoFailuresAndResponse(
+                prepareSearch("idx_single_shard").addAggregation(
+                    terms("terms").executionHint(randomExecutionHint())
+                        .field(STRING_FIELD_NAME)
+                        .showTermDocCountError(true)
+                        .size(size)
+                        .shardSize(shardSize)
+                        .order(BucketOrder.key(true))
+                        .collectMode(randomFrom(SubAggCollectionMode.values()))
+                ),
+                testResponse -> assertNoDocCountError(size, accurateResponse, testResponse)
+            )
+        );
     }
 
     public void testStringValueFieldTermSortDesc() throws Exception {
         int size = randomIntBetween(1, 20);
         int shardSize = randomIntBetween(size, size * 2);
-        SearchResponse accurateResponse = prepareSearch("idx_single_shard").addAggregation(
-            terms("terms").executionHint(randomExecutionHint())
-                .field(STRING_FIELD_NAME)
-                .showTermDocCountError(true)
-                .size(10000)
-                .shardSize(10000)
-                .order(BucketOrder.key(false))
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-        ).get();
-
-        assertNoFailures(accurateResponse);
-
-        SearchResponse testResponse = prepareSearch("idx_single_shard").addAggregation(
-            terms("terms").executionHint(randomExecutionHint())
-                .field(STRING_FIELD_NAME)
-                .showTermDocCountError(true)
-                .size(size)
-                .shardSize(shardSize)
-                .order(BucketOrder.key(false))
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-        ).get();
-
-        assertNoFailures(testResponse);
-
-        assertNoDocCountError(size, accurateResponse, testResponse);
+        assertNoFailuresAndResponse(
+            prepareSearch("idx_single_shard").addAggregation(
+                terms("terms").executionHint(randomExecutionHint())
+                    .field(STRING_FIELD_NAME)
+                    .showTermDocCountError(true)
+                    .size(10000)
+                    .shardSize(10000)
+                    .order(BucketOrder.key(false))
+                    .collectMode(randomFrom(SubAggCollectionMode.values()))
+            ),
+            accurateResponse -> assertNoFailuresAndResponse(
+                prepareSearch("idx_single_shard").addAggregation(
+                    terms("terms").executionHint(randomExecutionHint())
+                        .field(STRING_FIELD_NAME)
+                        .showTermDocCountError(true)
+                        .size(size)
+                        .shardSize(shardSize)
+                        .order(BucketOrder.key(false))
+                        .collectMode(randomFrom(SubAggCollectionMode.values()))
+                ),
+                testResponse -> assertNoDocCountError(size, accurateResponse, testResponse)
+            )
+        );
     }
 
     public void testStringValueFieldSubAggAsc() throws Exception {
         int size = randomIntBetween(1, 20);
         int shardSize = randomIntBetween(size, size * 2);
-        SearchResponse accurateResponse = prepareSearch("idx_single_shard").addAggregation(
-            terms("terms").executionHint(randomExecutionHint())
-                .field(STRING_FIELD_NAME)
-                .showTermDocCountError(true)
-                .size(10000)
-                .shardSize(10000)
-                .order(BucketOrder.aggregation("sortAgg", true))
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-                .subAggregation(sum("sortAgg").field(LONG_FIELD_NAME))
-        ).get();
-
-        assertNoFailures(accurateResponse);
-
-        SearchResponse testResponse = prepareSearch("idx_single_shard").addAggregation(
-            terms("terms").executionHint(randomExecutionHint())
-                .field(STRING_FIELD_NAME)
-                .showTermDocCountError(true)
-                .size(size)
-                .shardSize(shardSize)
-                .order(BucketOrder.aggregation("sortAgg", true))
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-                .subAggregation(sum("sortAgg").field(LONG_FIELD_NAME))
-        ).get();
-
-        assertNoFailures(testResponse);
-
-        assertUnboundedDocCountError(size, accurateResponse, testResponse);
+        assertNoFailuresAndResponse(
+            prepareSearch("idx_single_shard").addAggregation(
+                terms("terms").executionHint(randomExecutionHint())
+                    .field(STRING_FIELD_NAME)
+                    .showTermDocCountError(true)
+                    .size(10000)
+                    .shardSize(10000)
+                    .order(BucketOrder.aggregation("sortAgg", true))
+                    .collectMode(randomFrom(SubAggCollectionMode.values()))
+                    .subAggregation(sum("sortAgg").field(LONG_FIELD_NAME))
+            ),
+            accurateResponse -> assertNoFailuresAndResponse(
+                prepareSearch("idx_single_shard").addAggregation(
+                    terms("terms").executionHint(randomExecutionHint())
+                        .field(STRING_FIELD_NAME)
+                        .showTermDocCountError(true)
+                        .size(size)
+                        .shardSize(shardSize)
+                        .order(BucketOrder.aggregation("sortAgg", true))
+                        .collectMode(randomFrom(SubAggCollectionMode.values()))
+                        .subAggregation(sum("sortAgg").field(LONG_FIELD_NAME))
+                ),
+                testResponse -> assertUnboundedDocCountError(size, accurateResponse, testResponse)
+            )
+        );
     }
 
     public void testStringValueFieldSubAggDesc() throws Exception {
         int size = randomIntBetween(1, 20);
         int shardSize = randomIntBetween(size, size * 2);
-        SearchResponse accurateResponse = prepareSearch("idx_single_shard").addAggregation(
-            terms("terms").executionHint(randomExecutionHint())
-                .field(STRING_FIELD_NAME)
-                .showTermDocCountError(true)
-                .size(10000)
-                .shardSize(10000)
-                .order(BucketOrder.aggregation("sortAgg", false))
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-                .subAggregation(sum("sortAgg").field(LONG_FIELD_NAME))
-        ).get();
-
-        assertNoFailures(accurateResponse);
-
-        SearchResponse testResponse = prepareSearch("idx_single_shard").addAggregation(
-            terms("terms").executionHint(randomExecutionHint())
-                .field(STRING_FIELD_NAME)
-                .showTermDocCountError(true)
-                .size(size)
-                .shardSize(shardSize)
-                .order(BucketOrder.aggregation("sortAgg", false))
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-                .subAggregation(sum("sortAgg").field(LONG_FIELD_NAME))
-        ).get();
-
-        assertNoFailures(testResponse);
-
-        assertUnboundedDocCountError(size, accurateResponse, testResponse);
+        assertNoFailuresAndResponse(
+            prepareSearch("idx_single_shard").addAggregation(
+                terms("terms").executionHint(randomExecutionHint())
+                    .field(STRING_FIELD_NAME)
+                    .showTermDocCountError(true)
+                    .size(10000)
+                    .shardSize(10000)
+                    .order(BucketOrder.aggregation("sortAgg", false))
+                    .collectMode(randomFrom(SubAggCollectionMode.values()))
+                    .subAggregation(sum("sortAgg").field(LONG_FIELD_NAME))
+            ),
+            accurateResponse -> assertNoFailuresAndResponse(
+                prepareSearch("idx_single_shard").addAggregation(
+                    terms("terms").executionHint(randomExecutionHint())
+                        .field(STRING_FIELD_NAME)
+                        .showTermDocCountError(true)
+                        .size(size)
+                        .shardSize(shardSize)
+                        .order(BucketOrder.aggregation("sortAgg", false))
+                        .collectMode(randomFrom(SubAggCollectionMode.values()))
+                        .subAggregation(sum("sortAgg").field(LONG_FIELD_NAME))
+                ),
+                testResponse -> assertUnboundedDocCountError(size, accurateResponse, testResponse)
+            )
+        );
     }
 
     public void testLongValueField() throws Exception {
         int size = randomIntBetween(1, 20);
         int shardSize = randomIntBetween(size, size * 2);
-        SearchResponse accurateResponse = prepareSearch("idx").addAggregation(
-            terms("terms").executionHint(randomExecutionHint())
-                .field(LONG_FIELD_NAME)
-                .showTermDocCountError(true)
-                .size(10000)
-                .shardSize(10000)
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-        ).get();
-
-        assertNoFailures(accurateResponse);
-
-        SearchResponse testResponse = prepareSearch("idx").addAggregation(
-            terms("terms").executionHint(randomExecutionHint())
-                .field(LONG_FIELD_NAME)
-                .showTermDocCountError(true)
-                .size(size)
-                .shardSize(shardSize)
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-        ).get();
-
-        assertNoFailures(testResponse);
-
-        assertDocCountErrorWithinBounds(size, accurateResponse, testResponse);
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                terms("terms").executionHint(randomExecutionHint())
+                    .field(LONG_FIELD_NAME)
+                    .showTermDocCountError(true)
+                    .size(10000)
+                    .shardSize(10000)
+                    .collectMode(randomFrom(SubAggCollectionMode.values()))
+            ),
+            accurateResponse -> assertNoFailuresAndResponse(
+                prepareSearch("idx").addAggregation(
+                    terms("terms").executionHint(randomExecutionHint())
+                        .field(LONG_FIELD_NAME)
+                        .showTermDocCountError(true)
+                        .size(size)
+                        .shardSize(shardSize)
+                        .collectMode(randomFrom(SubAggCollectionMode.values()))
+                ),
+                testResponse -> assertDocCountErrorWithinBounds(size, accurateResponse, testResponse)
+            )
+        );
     }
 
     public void testLongValueFieldSingleShard() throws Exception {
         int size = randomIntBetween(1, 20);
         int shardSize = randomIntBetween(size, size * 2);
-        SearchResponse accurateResponse = prepareSearch("idx_single_shard").addAggregation(
-            terms("terms").executionHint(randomExecutionHint())
-                .field(LONG_FIELD_NAME)
-                .showTermDocCountError(true)
-                .size(10000)
-                .shardSize(10000)
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-        ).get();
-
-        assertNoFailures(accurateResponse);
-
-        SearchResponse testResponse = prepareSearch("idx_single_shard").addAggregation(
-            terms("terms").executionHint(randomExecutionHint())
-                .field(LONG_FIELD_NAME)
-                .showTermDocCountError(true)
-                .size(size)
-                .shardSize(shardSize)
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-        ).get();
-
-        assertNoFailures(testResponse);
-
-        assertNoDocCountError(size, accurateResponse, testResponse);
+        assertNoFailuresAndResponse(
+            prepareSearch("idx_single_shard").addAggregation(
+                terms("terms").executionHint(randomExecutionHint())
+                    .field(LONG_FIELD_NAME)
+                    .showTermDocCountError(true)
+                    .size(10000)
+                    .shardSize(10000)
+                    .collectMode(randomFrom(SubAggCollectionMode.values()))
+            ),
+            accurateResponse -> assertNoFailuresAndResponse(
+                prepareSearch("idx_single_shard").addAggregation(
+                    terms("terms").executionHint(randomExecutionHint())
+                        .field(LONG_FIELD_NAME)
+                        .showTermDocCountError(true)
+                        .size(size)
+                        .shardSize(shardSize)
+                        .collectMode(randomFrom(SubAggCollectionMode.values()))
+                ),
+                testResponse -> assertNoDocCountError(size, accurateResponse, testResponse)
+            )
+        );
     }
 
     public void testLongValueFieldWithRouting() throws Exception {
         int size = randomIntBetween(1, 20);
         int shardSize = randomIntBetween(size, size * 2);
 
-        SearchResponse testResponse = prepareSearch("idx_with_routing").setRouting(String.valueOf(between(1, numRoutingValues)))
-            .addAggregation(
-                terms("terms").executionHint(randomExecutionHint())
-                    .field(LONG_FIELD_NAME)
-                    .showTermDocCountError(true)
-                    .size(size)
-                    .shardSize(shardSize)
-                    .collectMode(randomFrom(SubAggCollectionMode.values()))
-            )
-            .get();
-
-        assertNoFailures(testResponse);
-
-        assertNoDocCountErrorSingleResponse(size, testResponse);
+        assertNoFailuresAndResponse(
+            prepareSearch("idx_with_routing").setRouting(String.valueOf(between(1, numRoutingValues)))
+                .addAggregation(
+                    terms("terms").executionHint(randomExecutionHint())
+                        .field(LONG_FIELD_NAME)
+                        .showTermDocCountError(true)
+                        .size(size)
+                        .shardSize(shardSize)
+                        .collectMode(randomFrom(SubAggCollectionMode.values()))
+                ),
+            testResponse -> assertNoDocCountErrorSingleResponse(size, testResponse)
+        );
     }
 
     public void testLongValueFieldDocCountAsc() throws Exception {
         int size = randomIntBetween(1, 20);
         int shardSize = randomIntBetween(size, size * 2);
-        SearchResponse accurateResponse = prepareSearch("idx_single_shard").addAggregation(
-            terms("terms").executionHint(randomExecutionHint())
-                .field(LONG_FIELD_NAME)
-                .showTermDocCountError(true)
-                .size(10000)
-                .shardSize(10000)
-                .order(BucketOrder.count(true))
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-        ).get();
-
-        assertNoFailures(accurateResponse);
-
-        SearchResponse testResponse = prepareSearch("idx_single_shard").addAggregation(
-            terms("terms").executionHint(randomExecutionHint())
-                .field(LONG_FIELD_NAME)
-                .showTermDocCountError(true)
-                .size(size)
-                .shardSize(shardSize)
-                .order(BucketOrder.count(true))
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-        ).get();
-
-        assertNoFailures(testResponse);
-
-        assertUnboundedDocCountError(size, accurateResponse, testResponse);
+        assertNoFailuresAndResponse(
+            prepareSearch("idx_single_shard").addAggregation(
+                terms("terms").executionHint(randomExecutionHint())
+                    .field(LONG_FIELD_NAME)
+                    .showTermDocCountError(true)
+                    .size(10000)
+                    .shardSize(10000)
+                    .order(BucketOrder.count(true))
+                    .collectMode(randomFrom(SubAggCollectionMode.values()))
+            ),
+            accurateResponse -> assertNoFailuresAndResponse(
+                prepareSearch("idx_single_shard").addAggregation(
+                    terms("terms").executionHint(randomExecutionHint())
+                        .field(LONG_FIELD_NAME)
+                        .showTermDocCountError(true)
+                        .size(size)
+                        .shardSize(shardSize)
+                        .order(BucketOrder.count(true))
+                        .collectMode(randomFrom(SubAggCollectionMode.values()))
+                ),
+                testResponse -> assertUnboundedDocCountError(size, accurateResponse, testResponse)
+            )
+        );
     }
 
     public void testLongValueFieldTermSortAsc() throws Exception {
         int size = randomIntBetween(1, 20);
         int shardSize = randomIntBetween(size, size * 2);
-        SearchResponse accurateResponse = prepareSearch("idx_single_shard").addAggregation(
-            terms("terms").executionHint(randomExecutionHint())
-                .field(LONG_FIELD_NAME)
-                .showTermDocCountError(true)
-                .size(10000)
-                .shardSize(10000)
-                .order(BucketOrder.key(true))
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-        ).get();
-
-        assertNoFailures(accurateResponse);
-
-        SearchResponse testResponse = prepareSearch("idx_single_shard").addAggregation(
-            terms("terms").executionHint(randomExecutionHint())
-                .field(LONG_FIELD_NAME)
-                .showTermDocCountError(true)
-                .size(size)
-                .shardSize(shardSize)
-                .order(BucketOrder.key(true))
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-        ).get();
-
-        assertNoFailures(testResponse);
-
-        assertNoDocCountError(size, accurateResponse, testResponse);
+        assertNoFailuresAndResponse(
+            prepareSearch("idx_single_shard").addAggregation(
+                terms("terms").executionHint(randomExecutionHint())
+                    .field(LONG_FIELD_NAME)
+                    .showTermDocCountError(true)
+                    .size(10000)
+                    .shardSize(10000)
+                    .order(BucketOrder.key(true))
+                    .collectMode(randomFrom(SubAggCollectionMode.values()))
+            ),
+            accurateResponse -> assertNoFailuresAndResponse(
+                prepareSearch("idx_single_shard").addAggregation(
+                    terms("terms").executionHint(randomExecutionHint())
+                        .field(LONG_FIELD_NAME)
+                        .showTermDocCountError(true)
+                        .size(size)
+                        .shardSize(shardSize)
+                        .order(BucketOrder.key(true))
+                        .collectMode(randomFrom(SubAggCollectionMode.values()))
+                ),
+                testResponse -> assertNoDocCountError(size, accurateResponse, testResponse)
+            )
+        );
     }
 
     public void testLongValueFieldTermSortDesc() throws Exception {
         int size = randomIntBetween(1, 20);
         int shardSize = randomIntBetween(size, size * 2);
-        SearchResponse accurateResponse = prepareSearch("idx_single_shard").addAggregation(
-            terms("terms").executionHint(randomExecutionHint())
-                .field(LONG_FIELD_NAME)
-                .showTermDocCountError(true)
-                .size(10000)
-                .shardSize(10000)
-                .order(BucketOrder.key(false))
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-        ).get();
-
-        assertNoFailures(accurateResponse);
-
-        SearchResponse testResponse = prepareSearch("idx_single_shard").addAggregation(
-            terms("terms").executionHint(randomExecutionHint())
-                .field(LONG_FIELD_NAME)
-                .showTermDocCountError(true)
-                .size(size)
-                .shardSize(shardSize)
-                .order(BucketOrder.key(false))
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-        ).get();
-
-        assertNoFailures(testResponse);
-
-        assertNoDocCountError(size, accurateResponse, testResponse);
+        assertNoFailuresAndResponse(
+            prepareSearch("idx_single_shard").addAggregation(
+                terms("terms").executionHint(randomExecutionHint())
+                    .field(LONG_FIELD_NAME)
+                    .showTermDocCountError(true)
+                    .size(10000)
+                    .shardSize(10000)
+                    .order(BucketOrder.key(false))
+                    .collectMode(randomFrom(SubAggCollectionMode.values()))
+            ),
+            accurateResponse -> assertNoFailuresAndResponse(
+                prepareSearch("idx_single_shard").addAggregation(
+                    terms("terms").executionHint(randomExecutionHint())
+                        .field(LONG_FIELD_NAME)
+                        .showTermDocCountError(true)
+                        .size(size)
+                        .shardSize(shardSize)
+                        .order(BucketOrder.key(false))
+                        .collectMode(randomFrom(SubAggCollectionMode.values()))
+                ),
+                testResponse -> assertNoDocCountError(size, accurateResponse, testResponse)
+            )
+        );
     }
 
     public void testLongValueFieldSubAggAsc() throws Exception {
         int size = randomIntBetween(1, 20);
         int shardSize = randomIntBetween(size, size * 2);
-        SearchResponse accurateResponse = prepareSearch("idx_single_shard").addAggregation(
-            terms("terms").executionHint(randomExecutionHint())
-                .field(LONG_FIELD_NAME)
-                .showTermDocCountError(true)
-                .size(10000)
-                .shardSize(10000)
-                .order(BucketOrder.aggregation("sortAgg", true))
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-                .subAggregation(sum("sortAgg").field(LONG_FIELD_NAME))
-        ).get();
-
-        assertNoFailures(accurateResponse);
-
-        SearchResponse testResponse = prepareSearch("idx_single_shard").addAggregation(
-            terms("terms").executionHint(randomExecutionHint())
-                .field(LONG_FIELD_NAME)
-                .showTermDocCountError(true)
-                .size(size)
-                .shardSize(shardSize)
-                .order(BucketOrder.aggregation("sortAgg", true))
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-                .subAggregation(sum("sortAgg").field(LONG_FIELD_NAME))
-        ).get();
-
-        assertNoFailures(testResponse);
-
-        assertUnboundedDocCountError(size, accurateResponse, testResponse);
+        assertNoFailuresAndResponse(
+            prepareSearch("idx_single_shard").addAggregation(
+                terms("terms").executionHint(randomExecutionHint())
+                    .field(LONG_FIELD_NAME)
+                    .showTermDocCountError(true)
+                    .size(10000)
+                    .shardSize(10000)
+                    .order(BucketOrder.aggregation("sortAgg", true))
+                    .collectMode(randomFrom(SubAggCollectionMode.values()))
+                    .subAggregation(sum("sortAgg").field(LONG_FIELD_NAME))
+            ),
+            accurateResponse -> assertNoFailuresAndResponse(
+                prepareSearch("idx_single_shard").addAggregation(
+                    terms("terms").executionHint(randomExecutionHint())
+                        .field(LONG_FIELD_NAME)
+                        .showTermDocCountError(true)
+                        .size(size)
+                        .shardSize(shardSize)
+                        .order(BucketOrder.aggregation("sortAgg", true))
+                        .collectMode(randomFrom(SubAggCollectionMode.values()))
+                        .subAggregation(sum("sortAgg").field(LONG_FIELD_NAME))
+                ),
+                testResponse -> assertUnboundedDocCountError(size, accurateResponse, testResponse)
+            )
+        );
     }
 
     public void testLongValueFieldSubAggDesc() throws Exception {
         int size = randomIntBetween(1, 20);
         int shardSize = randomIntBetween(size, size * 2);
-        SearchResponse accurateResponse = prepareSearch("idx_single_shard").addAggregation(
-            terms("terms").executionHint(randomExecutionHint())
-                .field(LONG_FIELD_NAME)
-                .showTermDocCountError(true)
-                .size(10000)
-                .shardSize(10000)
-                .order(BucketOrder.aggregation("sortAgg", false))
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-                .subAggregation(sum("sortAgg").field(DOUBLE_FIELD_NAME))
-        ).get();
-
-        assertNoFailures(accurateResponse);
-
-        SearchResponse testResponse = prepareSearch("idx_single_shard").addAggregation(
-            terms("terms").executionHint(randomExecutionHint())
-                .field(LONG_FIELD_NAME)
-                .showTermDocCountError(true)
-                .size(size)
-                .shardSize(shardSize)
-                .order(BucketOrder.aggregation("sortAgg", false))
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-                .subAggregation(sum("sortAgg").field(DOUBLE_FIELD_NAME))
-        ).get();
-
-        assertNoFailures(testResponse);
-
-        assertUnboundedDocCountError(size, accurateResponse, testResponse);
+        assertNoFailuresAndResponse(
+            prepareSearch("idx_single_shard").addAggregation(
+                terms("terms").executionHint(randomExecutionHint())
+                    .field(LONG_FIELD_NAME)
+                    .showTermDocCountError(true)
+                    .size(10000)
+                    .shardSize(10000)
+                    .order(BucketOrder.aggregation("sortAgg", false))
+                    .collectMode(randomFrom(SubAggCollectionMode.values()))
+                    .subAggregation(sum("sortAgg").field(DOUBLE_FIELD_NAME))
+            ),
+            accurateResponse -> assertNoFailuresAndResponse(
+                prepareSearch("idx_single_shard").addAggregation(
+                    terms("terms").executionHint(randomExecutionHint())
+                        .field(LONG_FIELD_NAME)
+                        .showTermDocCountError(true)
+                        .size(size)
+                        .shardSize(shardSize)
+                        .order(BucketOrder.aggregation("sortAgg", false))
+                        .collectMode(randomFrom(SubAggCollectionMode.values()))
+                        .subAggregation(sum("sortAgg").field(DOUBLE_FIELD_NAME))
+                ),
+                testResponse -> assertUnboundedDocCountError(size, accurateResponse, testResponse)
+            )
+        );
     }
 
     public void testDoubleValueField() throws Exception {
         int size = randomIntBetween(1, 20);
         int shardSize = randomIntBetween(size, size * 2);
-        SearchResponse accurateResponse = prepareSearch("idx").addAggregation(
-            terms("terms").executionHint(randomExecutionHint())
-                .field(DOUBLE_FIELD_NAME)
-                .showTermDocCountError(true)
-                .size(10000)
-                .shardSize(10000)
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-        ).get();
-
-        assertNoFailures(accurateResponse);
-
-        SearchResponse testResponse = prepareSearch("idx").addAggregation(
-            terms("terms").executionHint(randomExecutionHint())
-                .field(DOUBLE_FIELD_NAME)
-                .showTermDocCountError(true)
-                .size(size)
-                .shardSize(shardSize)
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-        ).get();
-
-        assertNoFailures(testResponse);
-
-        assertDocCountErrorWithinBounds(size, accurateResponse, testResponse);
+        assertNoFailuresAndResponse(
+            prepareSearch("idx").addAggregation(
+                terms("terms").executionHint(randomExecutionHint())
+                    .field(DOUBLE_FIELD_NAME)
+                    .showTermDocCountError(true)
+                    .size(10000)
+                    .shardSize(10000)
+                    .collectMode(randomFrom(SubAggCollectionMode.values()))
+            ),
+            accurateResponse -> assertNoFailuresAndResponse(
+                prepareSearch("idx").addAggregation(
+                    terms("terms").executionHint(randomExecutionHint())
+                        .field(DOUBLE_FIELD_NAME)
+                        .showTermDocCountError(true)
+                        .size(size)
+                        .shardSize(shardSize)
+                        .collectMode(randomFrom(SubAggCollectionMode.values()))
+                ),
+                testResponse -> assertDocCountErrorWithinBounds(size, accurateResponse, testResponse)
+            )
+        );
     }
 
     public void testDoubleValueFieldSingleShard() throws Exception {
         int size = randomIntBetween(1, 20);
         int shardSize = randomIntBetween(size, size * 2);
-        SearchResponse accurateResponse = prepareSearch("idx_single_shard").addAggregation(
-            terms("terms").executionHint(randomExecutionHint())
-                .field(DOUBLE_FIELD_NAME)
-                .showTermDocCountError(true)
-                .size(10000)
-                .shardSize(10000)
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-        ).get();
-
-        assertNoFailures(accurateResponse);
-
-        SearchResponse testResponse = prepareSearch("idx_single_shard").addAggregation(
-            terms("terms").executionHint(randomExecutionHint())
-                .field(DOUBLE_FIELD_NAME)
-                .showTermDocCountError(true)
-                .size(size)
-                .shardSize(shardSize)
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-        ).get();
-
-        assertNoFailures(testResponse);
-
-        assertNoDocCountError(size, accurateResponse, testResponse);
+        assertNoFailuresAndResponse(
+            prepareSearch("idx_single_shard").addAggregation(
+                terms("terms").executionHint(randomExecutionHint())
+                    .field(DOUBLE_FIELD_NAME)
+                    .showTermDocCountError(true)
+                    .size(10000)
+                    .shardSize(10000)
+                    .collectMode(randomFrom(SubAggCollectionMode.values()))
+            ),
+            accurateResponse -> assertNoFailuresAndResponse(
+                prepareSearch("idx_single_shard").addAggregation(
+                    terms("terms").executionHint(randomExecutionHint())
+                        .field(DOUBLE_FIELD_NAME)
+                        .showTermDocCountError(true)
+                        .size(size)
+                        .shardSize(shardSize)
+                        .collectMode(randomFrom(SubAggCollectionMode.values()))
+                ),
+                testResponse -> assertNoDocCountError(size, accurateResponse, testResponse)
+            )
+        );
     }
 
     public void testDoubleValueFieldWithRouting() throws Exception {
         int size = randomIntBetween(1, 20);
         int shardSize = randomIntBetween(size, size * 2);
 
-        SearchResponse testResponse = prepareSearch("idx_with_routing").setRouting(String.valueOf(between(1, numRoutingValues)))
-            .addAggregation(
-                terms("terms").executionHint(randomExecutionHint())
-                    .field(DOUBLE_FIELD_NAME)
-                    .showTermDocCountError(true)
-                    .size(size)
-                    .shardSize(shardSize)
-                    .collectMode(randomFrom(SubAggCollectionMode.values()))
-            )
-            .get();
-
-        assertNoFailures(testResponse);
-
-        assertNoDocCountErrorSingleResponse(size, testResponse);
+        assertNoFailuresAndResponse(
+            prepareSearch("idx_with_routing").setRouting(String.valueOf(between(1, numRoutingValues)))
+                .addAggregation(
+                    terms("terms").executionHint(randomExecutionHint())
+                        .field(DOUBLE_FIELD_NAME)
+                        .showTermDocCountError(true)
+                        .size(size)
+                        .shardSize(shardSize)
+                        .collectMode(randomFrom(SubAggCollectionMode.values()))
+                ),
+            testResponse -> assertNoDocCountErrorSingleResponse(size, testResponse)
+        );
     }
 
     public void testDoubleValueFieldDocCountAsc() throws Exception {
         int size = randomIntBetween(1, 20);
         int shardSize = randomIntBetween(size, size * 2);
-        SearchResponse accurateResponse = prepareSearch("idx_single_shard").addAggregation(
-            terms("terms").executionHint(randomExecutionHint())
-                .field(DOUBLE_FIELD_NAME)
-                .showTermDocCountError(true)
-                .size(10000)
-                .shardSize(10000)
-                .order(BucketOrder.count(true))
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-        ).get();
-
-        assertNoFailures(accurateResponse);
-
-        SearchResponse testResponse = prepareSearch("idx_single_shard").addAggregation(
-            terms("terms").executionHint(randomExecutionHint())
-                .field(DOUBLE_FIELD_NAME)
-                .showTermDocCountError(true)
-                .size(size)
-                .shardSize(shardSize)
-                .order(BucketOrder.count(true))
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-        ).get();
-
-        assertNoFailures(testResponse);
-
-        assertUnboundedDocCountError(size, accurateResponse, testResponse);
+        assertNoFailuresAndResponse(
+            prepareSearch("idx_single_shard").addAggregation(
+                terms("terms").executionHint(randomExecutionHint())
+                    .field(DOUBLE_FIELD_NAME)
+                    .showTermDocCountError(true)
+                    .size(10000)
+                    .shardSize(10000)
+                    .order(BucketOrder.count(true))
+                    .collectMode(randomFrom(SubAggCollectionMode.values()))
+            ),
+            accurateResponse -> assertNoFailuresAndResponse(
+                prepareSearch("idx_single_shard").addAggregation(
+                    terms("terms").executionHint(randomExecutionHint())
+                        .field(DOUBLE_FIELD_NAME)
+                        .showTermDocCountError(true)
+                        .size(size)
+                        .shardSize(shardSize)
+                        .order(BucketOrder.count(true))
+                        .collectMode(randomFrom(SubAggCollectionMode.values()))
+                ),
+                testResponse -> assertUnboundedDocCountError(size, accurateResponse, testResponse)
+            )
+        );
     }
 
     public void testDoubleValueFieldTermSortAsc() throws Exception {
         int size = randomIntBetween(1, 20);
         int shardSize = randomIntBetween(size, size * 2);
-        SearchResponse accurateResponse = prepareSearch("idx_single_shard").addAggregation(
-            terms("terms").executionHint(randomExecutionHint())
-                .field(DOUBLE_FIELD_NAME)
-                .showTermDocCountError(true)
-                .size(10000)
-                .shardSize(10000)
-                .order(BucketOrder.key(true))
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-        ).get();
-
-        assertNoFailures(accurateResponse);
-
-        SearchResponse testResponse = prepareSearch("idx_single_shard").addAggregation(
-            terms("terms").executionHint(randomExecutionHint())
-                .field(DOUBLE_FIELD_NAME)
-                .showTermDocCountError(true)
-                .size(size)
-                .shardSize(shardSize)
-                .order(BucketOrder.key(true))
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-        ).get();
-
-        assertNoFailures(testResponse);
-
-        assertNoDocCountError(size, accurateResponse, testResponse);
+        assertNoFailuresAndResponse(
+            prepareSearch("idx_single_shard").addAggregation(
+                terms("terms").executionHint(randomExecutionHint())
+                    .field(DOUBLE_FIELD_NAME)
+                    .showTermDocCountError(true)
+                    .size(10000)
+                    .shardSize(10000)
+                    .order(BucketOrder.key(true))
+                    .collectMode(randomFrom(SubAggCollectionMode.values()))
+            ),
+            accurateResponse -> assertNoFailuresAndResponse(
+                prepareSearch("idx_single_shard").addAggregation(
+                    terms("terms").executionHint(randomExecutionHint())
+                        .field(DOUBLE_FIELD_NAME)
+                        .showTermDocCountError(true)
+                        .size(size)
+                        .shardSize(shardSize)
+                        .order(BucketOrder.key(true))
+                        .collectMode(randomFrom(SubAggCollectionMode.values()))
+                ),
+                testResponse -> assertNoDocCountError(size, accurateResponse, testResponse)
+            )
+        );
     }
 
     public void testDoubleValueFieldTermSortDesc() throws Exception {
         int size = randomIntBetween(1, 20);
         int shardSize = randomIntBetween(size, size * 2);
-        SearchResponse accurateResponse = prepareSearch("idx_single_shard").addAggregation(
-            terms("terms").executionHint(randomExecutionHint())
-                .field(DOUBLE_FIELD_NAME)
-                .showTermDocCountError(true)
-                .size(10000)
-                .shardSize(10000)
-                .order(BucketOrder.key(false))
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-        ).get();
-
-        assertNoFailures(accurateResponse);
-
-        SearchResponse testResponse = prepareSearch("idx_single_shard").addAggregation(
-            terms("terms").executionHint(randomExecutionHint())
-                .field(DOUBLE_FIELD_NAME)
-                .showTermDocCountError(true)
-                .size(size)
-                .shardSize(shardSize)
-                .order(BucketOrder.key(false))
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-        ).get();
-
-        assertNoFailures(testResponse);
-
-        assertNoDocCountError(size, accurateResponse, testResponse);
+        assertNoFailuresAndResponse(
+            prepareSearch("idx_single_shard").addAggregation(
+                terms("terms").executionHint(randomExecutionHint())
+                    .field(DOUBLE_FIELD_NAME)
+                    .showTermDocCountError(true)
+                    .size(10000)
+                    .shardSize(10000)
+                    .order(BucketOrder.key(false))
+                    .collectMode(randomFrom(SubAggCollectionMode.values()))
+            ),
+            accurateResponse -> assertNoFailuresAndResponse(
+                prepareSearch("idx_single_shard").addAggregation(
+                    terms("terms").executionHint(randomExecutionHint())
+                        .field(DOUBLE_FIELD_NAME)
+                        .showTermDocCountError(true)
+                        .size(size)
+                        .shardSize(shardSize)
+                        .order(BucketOrder.key(false))
+                        .collectMode(randomFrom(SubAggCollectionMode.values()))
+                ),
+                testResponse -> assertNoDocCountError(size, accurateResponse, testResponse)
+            )
+        );
     }
 
     public void testDoubleValueFieldSubAggAsc() throws Exception {
         int size = randomIntBetween(1, 20);
         int shardSize = randomIntBetween(size, size * 2);
-        SearchResponse accurateResponse = prepareSearch("idx_single_shard").addAggregation(
-            terms("terms").executionHint(randomExecutionHint())
-                .field(DOUBLE_FIELD_NAME)
-                .showTermDocCountError(true)
-                .size(10000)
-                .shardSize(10000)
-                .order(BucketOrder.aggregation("sortAgg", true))
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-                .subAggregation(sum("sortAgg").field(LONG_FIELD_NAME))
-        ).get();
-
-        assertNoFailures(accurateResponse);
-
-        SearchResponse testResponse = prepareSearch("idx_single_shard").addAggregation(
-            terms("terms").executionHint(randomExecutionHint())
-                .field(DOUBLE_FIELD_NAME)
-                .showTermDocCountError(true)
-                .size(size)
-                .shardSize(shardSize)
-                .order(BucketOrder.aggregation("sortAgg", true))
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-                .subAggregation(sum("sortAgg").field(LONG_FIELD_NAME))
-        ).get();
-
-        assertNoFailures(testResponse);
-
-        assertUnboundedDocCountError(size, accurateResponse, testResponse);
+        assertNoFailuresAndResponse(
+            prepareSearch("idx_single_shard").addAggregation(
+                terms("terms").executionHint(randomExecutionHint())
+                    .field(DOUBLE_FIELD_NAME)
+                    .showTermDocCountError(true)
+                    .size(10000)
+                    .shardSize(10000)
+                    .order(BucketOrder.aggregation("sortAgg", true))
+                    .collectMode(randomFrom(SubAggCollectionMode.values()))
+                    .subAggregation(sum("sortAgg").field(LONG_FIELD_NAME))
+            ),
+            accurateResponse -> assertNoFailuresAndResponse(
+                prepareSearch("idx_single_shard").addAggregation(
+                    terms("terms").executionHint(randomExecutionHint())
+                        .field(DOUBLE_FIELD_NAME)
+                        .showTermDocCountError(true)
+                        .size(size)
+                        .shardSize(shardSize)
+                        .order(BucketOrder.aggregation("sortAgg", true))
+                        .collectMode(randomFrom(SubAggCollectionMode.values()))
+                        .subAggregation(sum("sortAgg").field(LONG_FIELD_NAME))
+                ),
+                testResponse -> assertUnboundedDocCountError(size, accurateResponse, testResponse)
+            )
+        );
     }
 
     public void testDoubleValueFieldSubAggDesc() throws Exception {
         int size = randomIntBetween(1, 20);
         int shardSize = randomIntBetween(size, size * 2);
-        SearchResponse accurateResponse = prepareSearch("idx_single_shard").addAggregation(
-            terms("terms").executionHint(randomExecutionHint())
-                .field(DOUBLE_FIELD_NAME)
-                .showTermDocCountError(true)
-                .size(10000)
-                .shardSize(10000)
-                .order(BucketOrder.aggregation("sortAgg", false))
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-                .subAggregation(sum("sortAgg").field(LONG_FIELD_NAME))
-        ).get();
-
-        assertNoFailures(accurateResponse);
-
-        SearchResponse testResponse = prepareSearch("idx_single_shard").addAggregation(
-            terms("terms").executionHint(randomExecutionHint())
-                .field(DOUBLE_FIELD_NAME)
-                .showTermDocCountError(true)
-                .size(size)
-                .shardSize(shardSize)
-                .order(BucketOrder.aggregation("sortAgg", false))
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-                .subAggregation(sum("sortAgg").field(LONG_FIELD_NAME))
-        ).get();
-
-        assertNoFailures(testResponse);
-
-        assertUnboundedDocCountError(size, accurateResponse, testResponse);
+        assertNoFailuresAndResponse(
+            prepareSearch("idx_single_shard").addAggregation(
+                terms("terms").executionHint(randomExecutionHint())
+                    .field(DOUBLE_FIELD_NAME)
+                    .showTermDocCountError(true)
+                    .size(10000)
+                    .shardSize(10000)
+                    .order(BucketOrder.aggregation("sortAgg", false))
+                    .collectMode(randomFrom(SubAggCollectionMode.values()))
+                    .subAggregation(sum("sortAgg").field(LONG_FIELD_NAME))
+            ),
+            accurateResponse -> assertNoFailuresAndResponse(
+                prepareSearch("idx_single_shard").addAggregation(
+                    terms("terms").executionHint(randomExecutionHint())
+                        .field(DOUBLE_FIELD_NAME)
+                        .showTermDocCountError(true)
+                        .size(size)
+                        .shardSize(shardSize)
+                        .order(BucketOrder.aggregation("sortAgg", false))
+                        .collectMode(randomFrom(SubAggCollectionMode.values()))
+                        .subAggregation(sum("sortAgg").field(LONG_FIELD_NAME))
+                ),
+                testResponse -> assertUnboundedDocCountError(size, accurateResponse, testResponse)
+            )
+        );
     }
 
     /**
@@ -960,52 +912,54 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
      * 3 one-shard indices.
      */
     public void testFixedDocs() throws Exception {
-        SearchResponse response = prepareSearch("idx_fixed_docs_0", "idx_fixed_docs_1", "idx_fixed_docs_2").addAggregation(
-            terms("terms").executionHint(randomExecutionHint())
-                .field(STRING_FIELD_NAME)
-                .showTermDocCountError(true)
-                .size(5)
-                .shardSize(5)
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-        ).get();
-        assertNoFailures(response);
+        assertNoFailuresAndResponse(
+            prepareSearch("idx_fixed_docs_0", "idx_fixed_docs_1", "idx_fixed_docs_2").addAggregation(
+                terms("terms").executionHint(randomExecutionHint())
+                    .field(STRING_FIELD_NAME)
+                    .showTermDocCountError(true)
+                    .size(5)
+                    .shardSize(5)
+                    .collectMode(randomFrom(SubAggCollectionMode.values()))
+            ),
+            response -> {
+                Terms terms = response.getAggregations().get("terms");
+                assertThat(terms, notNullValue());
+                assertThat(terms.getDocCountError(), equalTo(46L));
+                List<? extends Bucket> buckets = terms.getBuckets();
+                assertThat(buckets, notNullValue());
+                assertThat(buckets.size(), equalTo(5));
 
-        Terms terms = response.getAggregations().get("terms");
-        assertThat(terms, notNullValue());
-        assertThat(terms.getDocCountError(), equalTo(46L));
-        List<? extends Bucket> buckets = terms.getBuckets();
-        assertThat(buckets, notNullValue());
-        assertThat(buckets.size(), equalTo(5));
+                Bucket bucket = buckets.get(0);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKey(), equalTo("A"));
+                assertThat(bucket.getDocCount(), equalTo(100L));
+                assertThat(bucket.getDocCountError(), equalTo(0L));
 
-        Bucket bucket = buckets.get(0);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKey(), equalTo("A"));
-        assertThat(bucket.getDocCount(), equalTo(100L));
-        assertThat(bucket.getDocCountError(), equalTo(0L));
+                bucket = buckets.get(1);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKey(), equalTo("Z"));
+                assertThat(bucket.getDocCount(), equalTo(52L));
+                assertThat(bucket.getDocCountError(), equalTo(2L));
 
-        bucket = buckets.get(1);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKey(), equalTo("Z"));
-        assertThat(bucket.getDocCount(), equalTo(52L));
-        assertThat(bucket.getDocCountError(), equalTo(2L));
+                bucket = buckets.get(2);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKey(), equalTo("C"));
+                assertThat(bucket.getDocCount(), equalTo(50L));
+                assertThat(bucket.getDocCountError(), equalTo(15L));
 
-        bucket = buckets.get(2);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKey(), equalTo("C"));
-        assertThat(bucket.getDocCount(), equalTo(50L));
-        assertThat(bucket.getDocCountError(), equalTo(15L));
+                bucket = buckets.get(3);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKey(), equalTo("G"));
+                assertThat(bucket.getDocCount(), equalTo(45L));
+                assertThat(bucket.getDocCountError(), equalTo(2L));
 
-        bucket = buckets.get(3);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKey(), equalTo("G"));
-        assertThat(bucket.getDocCount(), equalTo(45L));
-        assertThat(bucket.getDocCountError(), equalTo(2L));
-
-        bucket = buckets.get(4);
-        assertThat(bucket, notNullValue());
-        assertThat(bucket.getKey(), equalTo("B"));
-        assertThat(bucket.getDocCount(), equalTo(43L));
-        assertThat(bucket.getDocCountError(), equalTo(29L));
+                bucket = buckets.get(4);
+                assertThat(bucket, notNullValue());
+                assertThat(bucket.getKey(), equalTo("B"));
+                assertThat(bucket.getDocCount(), equalTo(43L));
+                assertThat(bucket.getDocCountError(), equalTo(29L));
+            }
+        );
     }
 
     /**
@@ -1013,16 +967,19 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
      * See https://github.com/elastic/elasticsearch/issues/40005 for more details
      */
     public void testIncrementalReduction() {
-        SearchResponse response = prepareSearch("idx_fixed_docs_3", "idx_fixed_docs_4", "idx_fixed_docs_5").addAggregation(
-            terms("terms").executionHint(randomExecutionHint())
-                .field(STRING_FIELD_NAME)
-                .showTermDocCountError(true)
-                .size(5)
-                .shardSize(5)
-                .collectMode(randomFrom(SubAggCollectionMode.values()))
-        ).get();
-        assertNoFailures(response);
-        Terms terms = response.getAggregations().get("terms");
-        assertThat(terms.getDocCountError(), equalTo(0L));
+        assertNoFailuresAndResponse(
+            prepareSearch("idx_fixed_docs_3", "idx_fixed_docs_4", "idx_fixed_docs_5").addAggregation(
+                terms("terms").executionHint(randomExecutionHint())
+                    .field(STRING_FIELD_NAME)
+                    .showTermDocCountError(true)
+                    .size(5)
+                    .shardSize(5)
+                    .collectMode(randomFrom(SubAggCollectionMode.values()))
+            ),
+            response -> {
+                Terms terms = response.getAggregations().get("terms");
+                assertThat(terms.getDocCountError(), equalTo(0L));
+            }
+        );
     }
 }


### PR DESCRIPTION
Remove explicit references from org.elasticsearch.search.aggregations.buckets