### PR TITLE
Resolve compile error in DenseVectorFieldMapper

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
@@ -12,7 +12,6 @@ import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.KnnVectorsReader;
 import org.apache.lucene.codecs.KnnVectorsWriter;
 import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat;
-import org.apache.lucene.codecs.lucene99.Lucene99ScalarQuantizedVectorsFormat;
 import org.apache.lucene.document.BinaryDocValuesField;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
@@ -1087,11 +1086,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
             format = defaultFormat;
         } else {
             HnswIndexOptions hnswIndexOptions = (HnswIndexOptions) indexOptions;
-            format = new Lucene99HnswVectorsFormat(
-                hnswIndexOptions.m,
-                hnswIndexOptions.efConstruction,
-                new Lucene99ScalarQuantizedVectorsFormat()
-            );
+            format = new Lucene99HnswVectorsFormat(hnswIndexOptions.m, hnswIndexOptions.efConstruction);
         }
         // It's legal to reuse the same format name as this is the same on-disk format.
         return new KnnVectorsFormat(format.getName()) {

--- a/server/src/main/java/org/elasticsearch/index/store/LuceneFilesExtensions.java
+++ b/server/src/main/java/org/elasticsearch/index/store/LuceneFilesExtensions.java
@@ -76,7 +76,10 @@ public enum LuceneFilesExtensions {
     // kNN vectors format
     VEC("vec", "Vector Data", false, true),
     VEX("vex", "Vector Index", false, true),
-    VEM("vem", "Vector Metadata", true, false);
+    VEM("vem", "Vector Metadata", true, false),
+    VEMF("vemf", "Flat Vector Metadata", true, false),
+    VEMQ("vemq", "Scalar Quantized Vector Metadata", true, false),
+    VEQ("veq", "Scalar Quantized Vector Data", false, true);
 
     /**
      * Allow plugin developers of custom codecs to opt out of the assertion in {@link #fromExtension}

--- a/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
@@ -977,7 +977,7 @@ public class DenseVectorFieldMapperTests extends MapperTestCase {
             + m
             + ", beamWidth="
             + efConstruction
-            + ", quantizer=Lucene99ScalarQuantizedVectorsFormat(name=Lucene99ScalarQuantizedVectorsFormat, quantile=null)"
+            + ", flatVectorFormat=Lucene99FlatVectorsFormat()"
             + ")";
         assertEquals(expectedString, knnVectorsFormat.toString());
     }


### PR DESCRIPTION
A change in Lucene99HnswVectorsFormat requires that we adapt our code, see https://github.com/apache/lucene/pull/12729
