### PR TITLE
[DOCS] Simplifies dense vector mapping in semantic search example

### DIFF
--- a/docs/reference/search/search-your-data/knn-search.asciidoc
+++ b/docs/reference/search/search-your-data/knn-search.asciidoc
@@ -903,8 +903,8 @@ the global top `k` matches across shards. You cannot set the
 To run an exact kNN search, use a `script_score` query with a vector function.
 
 . Explicitly map one or more `dense_vector` fields. If you don't intend to use
-the field for approximate kNN, omit the `index` mapping option or set it to
-`false`. This can significantly improve indexing speed.
+the field for approximate kNN, set the `index` mapping option to `false`. This 
+can significantly improve indexing speed.
 +
 [source,console]
 ----

--- a/docs/reference/search/search-your-data/knn-search.asciidoc
+++ b/docs/reference/search/search-your-data/knn-search.asciidoc
@@ -76,12 +76,10 @@ to search one or more `dense_vector` fields with indexing enabled.
 requires the following mapping options:
 +
 --
-* An `index` value of `true`.
-
 * A `similarity` value. This value determines the similarity metric used to
 score documents based on similarity between the query and document vector. For a
 list of available metrics, see the <<dense-vector-similarity,`similarity`>>
-parameter documentation.
+parameter documentation. The `similarity` setting defaults to `cosine`.
 
 [source,console]
 ----
@@ -92,13 +90,11 @@ PUT image-index
       "image-vector": {
         "type": "dense_vector",
         "dims": 3,
-        "index": true,
         "similarity": "l2_norm"
       },
       "title-vector": {
         "type": "dense_vector",
         "dims": 5,
-        "index": true,
         "similarity": "l2_norm"
       },
       "title": {
@@ -158,7 +154,7 @@ NOTE: Support for approximate kNN search was added in version 8.0. Before
 this, `dense_vector` fields did not support enabling `index` in the mapping.
 If you created an index prior to 8.0 containing `dense_vector` fields, then to
 support approximate kNN search the data must be reindexed using a new field
-mapping that sets `index: true`.
+mapping that sets `index: true` which is the default option.
 
 [discrete]
 [[tune-approximate-knn-for-speed-accuracy]]
@@ -199,9 +195,7 @@ PUT byte-image-index
       "byte-image-vector": {
         "type": "dense_vector",
         "element_type": "byte",
-        "dims": 2,
-        "index": true,
-        "similarity": "cosine"
+        "dims": 2
       },
       "title": {
         "type": "text"
@@ -516,9 +510,7 @@ PUT passage_vectors
                 "properties": {
                     "vector": {
                         "type": "dense_vector",
-                        "dims": 2,
-                        "index": true,
-                        "similarity": "cosine"
+                        "dims": 2
                     },
                     "text": {
                         "type": "text",
@@ -877,7 +869,6 @@ PUT image-index
       "image-vector": {
         "type": "dense_vector",
         "dims": 3,
-        "index": true,
         "similarity": "l2_norm",
         "index_options": {
           "type": "hnsw",

--- a/docs/reference/tab-widgets/semantic-search/field-mappings.asciidoc
+++ b/docs/reference/tab-widgets/semantic-search/field-mappings.asciidoc
@@ -63,9 +63,7 @@ PUT my-index
     "properties": {
       "my_embeddings.predicted_value": { <1>
         "type": "dense_vector", <2>
-        "dims": 384,<3>
-        "index": true,
-        "similarity": "cosine"
+        "dims": 384 <3>
       },
       "my_text_field": { <4>
         "type": "text" <5>


### PR DESCRIPTION
## Overview

In 8.11 the `dense vector` field type has been simplified and some of the settings now have sensible default values:
* `"index": true` is implicit,
* `similarity` defaults to `cosine`.

This PR adjusts the dense vector mapping example in the semantic search documentation and in. the kNN search docs to make it in line with the changes outlined above.

### Preview

* [Map a field for the text embeddings](https://elasticsearch_102080.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/semantic-search.html#semantic-search-field-mappings)
* [kNN search](https://elasticsearch_102080.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/knn-search.html)