### PR TITLE
Remove explicit SearchResponse references from `org.elasticsearch.search.fields`

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fields/SearchFieldsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fields/SearchFieldsIT.java
@@ -11,7 +11,6 @@ package org.elasticsearch.search.fields;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchRequestBuilder;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -61,8 +60,10 @@ import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDI
 import static org.elasticsearch.common.util.set.Sets.newHashSet;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertCheckedResponse;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -189,70 +190,70 @@ public class SearchFieldsIT extends ESIntegTestCase {
 
         indicesAdmin().prepareRefresh().get();
 
-        SearchResponse searchResponse = prepareSearch().setQuery(matchAllQuery()).addStoredField("field1").get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
-        assertThat(searchResponse.getHits().getHits().length, equalTo(1));
-        assertThat(searchResponse.getHits().getAt(0).getFields().size(), equalTo(1));
-        assertThat(searchResponse.getHits().getAt(0).getFields().get("field1").getValue().toString(), equalTo("value1"));
-
+        assertResponse(prepareSearch().setQuery(matchAllQuery()).addStoredField("field1"), response -> {
+            assertThat(response.getHits().getTotalHits().value, equalTo(1L));
+            assertThat(response.getHits().getHits().length, equalTo(1));
+            assertThat(response.getHits().getAt(0).getFields().size(), equalTo(1));
+            assertThat(response.getHits().getAt(0).getFields().get("field1").getValue().toString(), equalTo("value1"));
+        });
         // field2 is not stored, check that it is not extracted from source.
-        searchResponse = prepareSearch().setQuery(matchAllQuery()).addStoredField("field2").get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
-        assertThat(searchResponse.getHits().getHits().length, equalTo(1));
-        assertThat(searchResponse.getHits().getAt(0).getFields().size(), equalTo(0));
-        assertThat(searchResponse.getHits().getAt(0).getFields().get("field2"), nullValue());
-
-        searchResponse = prepareSearch().setQuery(matchAllQuery()).addStoredField("field3").get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
-        assertThat(searchResponse.getHits().getHits().length, equalTo(1));
-        assertThat(searchResponse.getHits().getAt(0).getFields().size(), equalTo(1));
-        assertThat(searchResponse.getHits().getAt(0).getFields().get("field3").getValue().toString(), equalTo("value3"));
-
-        searchResponse = prepareSearch().setQuery(matchAllQuery()).addStoredField("*3").get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
-        assertThat(searchResponse.getHits().getHits().length, equalTo(1));
-        assertThat(searchResponse.getHits().getAt(0).getFields().size(), equalTo(1));
-        assertThat(searchResponse.getHits().getAt(0).getFields().get("field3").getValue().toString(), equalTo("value3"));
-
-        searchResponse = prepareSearch().setQuery(matchAllQuery())
-            .addStoredField("*3")
-            .addStoredField("field1")
-            .addStoredField("field2")
-            .get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
-        assertThat(searchResponse.getHits().getHits().length, equalTo(1));
-        assertThat(searchResponse.getHits().getAt(0).getFields().size(), equalTo(2));
-        assertThat(searchResponse.getHits().getAt(0).getFields().get("field3").getValue().toString(), equalTo("value3"));
-        assertThat(searchResponse.getHits().getAt(0).getFields().get("field1").getValue().toString(), equalTo("value1"));
-
-        searchResponse = prepareSearch().setQuery(matchAllQuery()).addStoredField("field*").get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
-        assertThat(searchResponse.getHits().getHits().length, equalTo(1));
-        assertThat(searchResponse.getHits().getAt(0).getFields().size(), equalTo(2));
-        assertThat(searchResponse.getHits().getAt(0).getFields().get("field3").getValue().toString(), equalTo("value3"));
-        assertThat(searchResponse.getHits().getAt(0).getFields().get("field1").getValue().toString(), equalTo("value1"));
-
-        searchResponse = prepareSearch().setQuery(matchAllQuery()).addStoredField("f*3").get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
-        assertThat(searchResponse.getHits().getHits().length, equalTo(1));
-        assertThat(searchResponse.getHits().getAt(0).getFields().size(), equalTo(1));
-        assertThat(searchResponse.getHits().getAt(0).getFields().get("field3").getValue().toString(), equalTo("value3"));
-
-        searchResponse = prepareSearch().setQuery(matchAllQuery()).addStoredField("*").get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
-        assertThat(searchResponse.getHits().getHits().length, equalTo(1));
-        assertThat(searchResponse.getHits().getAt(0).getSourceAsMap(), nullValue());
-        assertThat(searchResponse.getHits().getAt(0).getFields().size(), equalTo(2));
-        assertThat(searchResponse.getHits().getAt(0).getFields().get("field1").getValue().toString(), equalTo("value1"));
-        assertThat(searchResponse.getHits().getAt(0).getFields().get("field3").getValue().toString(), equalTo("value3"));
-
-        searchResponse = prepareSearch().setQuery(matchAllQuery()).addStoredField("*").addStoredField("_source").get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
-        assertThat(searchResponse.getHits().getHits().length, equalTo(1));
-        assertThat(searchResponse.getHits().getAt(0).getSourceAsMap(), notNullValue());
-        assertThat(searchResponse.getHits().getAt(0).getFields().size(), equalTo(2));
-        assertThat(searchResponse.getHits().getAt(0).getFields().get("field1").getValue().toString(), equalTo("value1"));
-        assertThat(searchResponse.getHits().getAt(0).getFields().get("field3").getValue().toString(), equalTo("value3"));
+        assertResponse(prepareSearch().setQuery(matchAllQuery()).addStoredField("field2"), response -> {
+            assertThat(response.getHits().getTotalHits().value, equalTo(1L));
+            assertThat(response.getHits().getHits().length, equalTo(1));
+            assertThat(response.getHits().getAt(0).getFields().size(), equalTo(0));
+            assertThat(response.getHits().getAt(0).getFields().get("field2"), nullValue());
+        });
+        assertResponse(prepareSearch().setQuery(matchAllQuery()).addStoredField("field3"), response -> {
+            assertThat(response.getHits().getTotalHits().value, equalTo(1L));
+            assertThat(response.getHits().getHits().length, equalTo(1));
+            assertThat(response.getHits().getAt(0).getFields().size(), equalTo(1));
+            assertThat(response.getHits().getAt(0).getFields().get("field3").getValue().toString(), equalTo("value3"));
+        });
+        assertResponse(prepareSearch().setQuery(matchAllQuery()).addStoredField("*3"), response -> {
+            assertThat(response.getHits().getTotalHits().value, equalTo(1L));
+            assertThat(response.getHits().getHits().length, equalTo(1));
+            assertThat(response.getHits().getAt(0).getFields().size(), equalTo(1));
+            assertThat(response.getHits().getAt(0).getFields().get("field3").getValue().toString(), equalTo("value3"));
+        });
+        assertResponse(
+            prepareSearch().setQuery(matchAllQuery()).addStoredField("*3").addStoredField("field1").addStoredField("field2"),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(1L));
+                assertThat(response.getHits().getHits().length, equalTo(1));
+                assertThat(response.getHits().getAt(0).getFields().size(), equalTo(2));
+                assertThat(response.getHits().getAt(0).getFields().get("field3").getValue().toString(), equalTo("value3"));
+                assertThat(response.getHits().getAt(0).getFields().get("field1").getValue().toString(), equalTo("value1"));
+            }
+        );
+        assertResponse(prepareSearch().setQuery(matchAllQuery()).addStoredField("field*"), response -> {
+            assertThat(response.getHits().getTotalHits().value, equalTo(1L));
+            assertThat(response.getHits().getHits().length, equalTo(1));
+            assertThat(response.getHits().getAt(0).getFields().size(), equalTo(2));
+            assertThat(response.getHits().getAt(0).getFields().get("field3").getValue().toString(), equalTo("value3"));
+            assertThat(response.getHits().getAt(0).getFields().get("field1").getValue().toString(), equalTo("value1"));
+        });
+        assertResponse(prepareSearch().setQuery(matchAllQuery()).addStoredField("f*3"), response -> {
+            assertThat(response.getHits().getTotalHits().value, equalTo(1L));
+            assertThat(response.getHits().getHits().length, equalTo(1));
+            assertThat(response.getHits().getAt(0).getFields().size(), equalTo(1));
+            assertThat(response.getHits().getAt(0).getFields().get("field3").getValue().toString(), equalTo("value3"));
+        });
+        assertResponse(prepareSearch().setQuery(matchAllQuery()).addStoredField("*"), response -> {
+            assertThat(response.getHits().getTotalHits().value, equalTo(1L));
+            assertThat(response.getHits().getHits().length, equalTo(1));
+            assertThat(response.getHits().getAt(0).getSourceAsMap(), nullValue());
+            assertThat(response.getHits().getAt(0).getFields().size(), equalTo(2));
+            assertThat(response.getHits().getAt(0).getFields().get("field1").getValue().toString(), equalTo("value1"));
+            assertThat(response.getHits().getAt(0).getFields().get("field3").getValue().toString(), equalTo("value3"));
+        });
+        assertResponse(prepareSearch().setQuery(matchAllQuery()).addStoredField("*").addStoredField("_source"), response -> {
+            assertThat(response.getHits().getTotalHits().value, equalTo(1L));
+            assertThat(response.getHits().getHits().length, equalTo(1));
+            assertThat(response.getHits().getAt(0).getSourceAsMap(), notNullValue());
+            assertThat(response.getHits().getAt(0).getFields().size(), equalTo(2));
+            assertThat(response.getHits().getAt(0).getFields().get("field1").getValue().toString(), equalTo("value1"));
+            assertThat(response.getHits().getAt(0).getFields().get("field3").getValue().toString(), equalTo("value3"));
+        });
     }
 
     public void testScriptDocAndFields() throws Exception {
@@ -297,64 +298,68 @@ public class SearchFieldsIT extends ESIntegTestCase {
         indicesAdmin().refresh(new RefreshRequest()).actionGet();
 
         logger.info("running doc['num1'].value");
-        SearchResponse response = prepareSearch().setQuery(matchAllQuery())
-            .addSort("num1", SortOrder.ASC)
-            .addScriptField("sNum1", new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "doc['num1'].value", Collections.emptyMap()))
-            .addScriptField(
-                "sNum1_field",
-                new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "_fields['num1'].value", Collections.emptyMap())
-            )
-            .addScriptField(
-                "date1",
-                new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "doc['date'].date.millis", Collections.emptyMap())
-            )
-            .get();
-
-        assertNoFailures(response);
-
-        assertThat(response.getHits().getTotalHits().value, equalTo(3L));
-        assertFalse(response.getHits().getAt(0).hasSource());
-        assertThat(response.getHits().getAt(0).getId(), equalTo("1"));
-        Set<String> fields = new HashSet<>(response.getHits().getAt(0).getFields().keySet());
-        assertThat(fields, equalTo(newHashSet("sNum1", "sNum1_field", "date1")));
-        assertThat(response.getHits().getAt(0).getFields().get("sNum1").getValues().get(0), equalTo(1.0));
-        assertThat(response.getHits().getAt(0).getFields().get("sNum1_field").getValues().get(0), equalTo(1.0));
-        assertThat(response.getHits().getAt(0).getFields().get("date1").getValues().get(0), equalTo(0L));
-        assertThat(response.getHits().getAt(1).getId(), equalTo("2"));
-        fields = new HashSet<>(response.getHits().getAt(0).getFields().keySet());
-        assertThat(fields, equalTo(newHashSet("sNum1", "sNum1_field", "date1")));
-        assertThat(response.getHits().getAt(1).getFields().get("sNum1").getValues().get(0), equalTo(2.0));
-        assertThat(response.getHits().getAt(1).getFields().get("sNum1_field").getValues().get(0), equalTo(2.0));
-        assertThat(response.getHits().getAt(1).getFields().get("date1").getValues().get(0), equalTo(25000L));
-        assertThat(response.getHits().getAt(2).getId(), equalTo("3"));
-        fields = new HashSet<>(response.getHits().getAt(0).getFields().keySet());
-        assertThat(fields, equalTo(newHashSet("sNum1", "sNum1_field", "date1")));
-        assertThat(response.getHits().getAt(2).getFields().get("sNum1").getValues().get(0), equalTo(3.0));
-        assertThat(response.getHits().getAt(2).getFields().get("sNum1_field").getValues().get(0), equalTo(3.0));
-        assertThat(response.getHits().getAt(2).getFields().get("date1").getValues().get(0), equalTo(120000L));
-
+        assertNoFailuresAndResponse(
+            prepareSearch().setQuery(matchAllQuery())
+                .addSort("num1", SortOrder.ASC)
+                .addScriptField(
+                    "sNum1",
+                    new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "doc['num1'].value", Collections.emptyMap())
+                )
+                .addScriptField(
+                    "sNum1_field",
+                    new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "_fields['num1'].value", Collections.emptyMap())
+                )
+                .addScriptField(
+                    "date1",
+                    new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "doc['date'].date.millis", Collections.emptyMap())
+                ),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(3L));
+                assertFalse(response.getHits().getAt(0).hasSource());
+                assertThat(response.getHits().getAt(0).getId(), equalTo("1"));
+                Set<String> fields = new HashSet<>(response.getHits().getAt(0).getFields().keySet());
+                assertThat(fields, equalTo(newHashSet("sNum1", "sNum1_field", "date1")));
+                assertThat(response.getHits().getAt(0).getFields().get("sNum1").getValues().get(0), equalTo(1.0));
+                assertThat(response.getHits().getAt(0).getFields().get("sNum1_field").getValues().get(0), equalTo(1.0));
+                assertThat(response.getHits().getAt(0).getFields().get("date1").getValues().get(0), equalTo(0L));
+                assertThat(response.getHits().getAt(1).getId(), equalTo("2"));
+                fields = new HashSet<>(response.getHits().getAt(0).getFields().keySet());
+                assertThat(fields, equalTo(newHashSet("sNum1", "sNum1_field", "date1")));
+                assertThat(response.getHits().getAt(1).getFields().get("sNum1").getValues().get(0), equalTo(2.0));
+                assertThat(response.getHits().getAt(1).getFields().get("sNum1_field").getValues().get(0), equalTo(2.0));
+                assertThat(response.getHits().getAt(1).getFields().get("date1").getValues().get(0), equalTo(25000L));
+                assertThat(response.getHits().getAt(2).getId(), equalTo("3"));
+                fields = new HashSet<>(response.getHits().getAt(0).getFields().keySet());
+                assertThat(fields, equalTo(newHashSet("sNum1", "sNum1_field", "date1")));
+                assertThat(response.getHits().getAt(2).getFields().get("sNum1").getValues().get(0), equalTo(3.0));
+                assertThat(response.getHits().getAt(2).getFields().get("sNum1_field").getValues().get(0), equalTo(3.0));
+                assertThat(response.getHits().getAt(2).getFields().get("date1").getValues().get(0), equalTo(120000L));
+            }
+        );
         logger.info("running doc['num1'].value * factor");
-        response = prepareSearch().setQuery(matchAllQuery())
-            .addSort("num1", SortOrder.ASC)
-            .addScriptField(
-                "sNum1",
-                new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "doc['num1'].value * factor", Map.of("factor", 2.0))
-            )
-            .get();
-
-        assertThat(response.getHits().getTotalHits().value, equalTo(3L));
-        assertThat(response.getHits().getAt(0).getId(), equalTo("1"));
-        fields = new HashSet<>(response.getHits().getAt(0).getFields().keySet());
-        assertThat(fields, equalTo(singleton("sNum1")));
-        assertThat(response.getHits().getAt(0).getFields().get("sNum1").getValues().get(0), equalTo(2.0));
-        assertThat(response.getHits().getAt(1).getId(), equalTo("2"));
-        fields = new HashSet<>(response.getHits().getAt(0).getFields().keySet());
-        assertThat(fields, equalTo(singleton("sNum1")));
-        assertThat(response.getHits().getAt(1).getFields().get("sNum1").getValues().get(0), equalTo(4.0));
-        assertThat(response.getHits().getAt(2).getId(), equalTo("3"));
-        fields = new HashSet<>(response.getHits().getAt(0).getFields().keySet());
-        assertThat(fields, equalTo(singleton("sNum1")));
-        assertThat(response.getHits().getAt(2).getFields().get("sNum1").getValues().get(0), equalTo(6.0));
+        assertResponse(
+            prepareSearch().setQuery(matchAllQuery())
+                .addSort("num1", SortOrder.ASC)
+                .addScriptField(
+                    "sNum1",
+                    new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "doc['num1'].value * factor", Map.of("factor", 2.0))
+                ),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(3L));
+                assertThat(response.getHits().getAt(0).getId(), equalTo("1"));
+                Set<String> fields = new HashSet<>(response.getHits().getAt(0).getFields().keySet());
+                assertThat(fields, equalTo(singleton("sNum1")));
+                assertThat(response.getHits().getAt(0).getFields().get("sNum1").getValues().get(0), equalTo(2.0));
+                assertThat(response.getHits().getAt(1).getId(), equalTo("2"));
+                fields = new HashSet<>(response.getHits().getAt(0).getFields().keySet());
+                assertThat(fields, equalTo(singleton("sNum1")));
+                assertThat(response.getHits().getAt(1).getFields().get("sNum1").getValues().get(0), equalTo(4.0));
+                assertThat(response.getHits().getAt(2).getId(), equalTo("3"));
+                fields = new HashSet<>(response.getHits().getAt(0).getFields().keySet());
+                assertThat(fields, equalTo(singleton("sNum1")));
+                assertThat(response.getHits().getAt(2).getFields().get("sNum1").getValues().get(0), equalTo(6.0));
+            }
+        );
     }
 
     public void testScriptFieldWithNanos() throws Exception {
@@ -384,32 +389,32 @@ public class SearchFieldsIT extends ESIntegTestCase {
             client().prepareIndex("test").setId("2").setSource(jsonBuilder().startObject().field("date", date).endObject())
         );
 
-        SearchResponse response = prepareSearch().setQuery(matchAllQuery())
-            .addSort("date", SortOrder.ASC)
-            .addScriptField(
-                "date1",
-                new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "doc['date'].date.millis", Collections.emptyMap())
-            )
-            .addScriptField(
-                "date2",
-                new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "doc['date'].date.nanos", Collections.emptyMap())
-            )
-            .get();
+        assertNoFailuresAndResponse(
+            prepareSearch().setQuery(matchAllQuery())
+                .addSort("date", SortOrder.ASC)
+                .addScriptField(
+                    "date1",
+                    new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "doc['date'].date.millis", Collections.emptyMap())
+                )
+                .addScriptField(
+                    "date2",
+                    new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "doc['date'].date.nanos", Collections.emptyMap())
+                ),
+            response -> {
+                assertThat(response.getHits().getAt(0).getId(), is("1"));
+                assertThat(response.getHits().getAt(0).getFields().get("date1").getValues().get(0), equalTo(0L));
+                assertThat(response.getHits().getAt(0).getFields().get("date2").getValues().get(0), equalTo(0L));
+                assertThat(response.getHits().getAt(0).getSortValues()[0], equalTo(0L));
 
-        assertNoFailures(response);
-
-        assertThat(response.getHits().getAt(0).getId(), is("1"));
-        assertThat(response.getHits().getAt(0).getFields().get("date1").getValues().get(0), equalTo(0L));
-        assertThat(response.getHits().getAt(0).getFields().get("date2").getValues().get(0), equalTo(0L));
-        assertThat(response.getHits().getAt(0).getSortValues()[0], equalTo(0L));
-
-        assertThat(response.getHits().getAt(1).getId(), is("2"));
-        Instant instant = ZonedDateTime.parse(date).toInstant();
-        long dateAsNanos = DateUtils.toLong(instant);
-        long dateAsMillis = instant.toEpochMilli();
-        assertThat(response.getHits().getAt(1).getFields().get("date1").getValues().get(0), equalTo(dateAsMillis));
-        assertThat(response.getHits().getAt(1).getFields().get("date2").getValues().get(0), equalTo(dateAsNanos));
-        assertThat(response.getHits().getAt(1).getSortValues()[0], equalTo(dateAsNanos));
+                assertThat(response.getHits().getAt(1).getId(), is("2"));
+                Instant instant = ZonedDateTime.parse(date).toInstant();
+                long dateAsNanos = DateUtils.toLong(instant);
+                long dateAsMillis = instant.toEpochMilli();
+                assertThat(response.getHits().getAt(1).getFields().get("date1").getValues().get(0), equalTo(dateAsMillis));
+                assertThat(response.getHits().getAt(1).getFields().get("date2").getValues().get(0), equalTo(dateAsNanos));
+                assertThat(response.getHits().getAt(1).getSortValues()[0], equalTo(dateAsNanos));
+            }
+        );
     }
 
     public void testIdBasedScriptFields() throws Exception {
@@ -424,21 +429,21 @@ public class SearchFieldsIT extends ESIntegTestCase {
         }
         indexRandom(true, indexRequestBuilders);
 
-        SearchResponse response = prepareSearch().setQuery(matchAllQuery())
-            .addSort("num1", SortOrder.ASC)
-            .setSize(numDocs)
-            .addScriptField("id", new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "_fields._id.value", Collections.emptyMap()))
-            .get();
-
-        assertNoFailures(response);
-
-        assertThat(response.getHits().getTotalHits().value, equalTo((long) numDocs));
-        for (int i = 0; i < numDocs; i++) {
-            assertThat(response.getHits().getAt(i).getId(), equalTo(Integer.toString(i)));
-            Set<String> fields = new HashSet<>(response.getHits().getAt(i).getFields().keySet());
-            assertThat(fields, equalTo(singleton("id")));
-            assertThat(response.getHits().getAt(i).getFields().get("id").getValue(), equalTo(Integer.toString(i)));
-        }
+        assertNoFailuresAndResponse(
+            prepareSearch().setQuery(matchAllQuery())
+                .addSort("num1", SortOrder.ASC)
+                .setSize(numDocs)
+                .addScriptField("id", new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "_fields._id.value", Collections.emptyMap())),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo((long) numDocs));
+                for (int i = 0; i < numDocs; i++) {
+                    assertThat(response.getHits().getAt(i).getId(), equalTo(Integer.toString(i)));
+                    Set<String> fields = new HashSet<>(response.getHits().getAt(i).getFields().keySet());
+                    assertThat(fields, equalTo(singleton("id")));
+                    assertThat(response.getHits().getAt(i).getFields().get("id").getValue(), equalTo(Integer.toString(i)));
+                }
+            }
+        );
     }
 
     public void testScriptFieldUsingSource() throws Exception {
@@ -467,57 +472,63 @@ public class SearchFieldsIT extends ESIntegTestCase {
             .get();
         indicesAdmin().refresh(new RefreshRequest()).actionGet();
 
-        SearchResponse response = prepareSearch().setQuery(matchAllQuery())
-            .addScriptField("s_obj1", new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "_source.obj1", Collections.emptyMap()))
-            .addScriptField(
-                "s_obj1_test",
-                new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "_source.obj1.test", Collections.emptyMap())
-            )
-            .addScriptField("s_obj2", new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "_source.obj2", Collections.emptyMap()))
-            .addScriptField(
-                "s_obj2_arr2",
-                new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "_source.obj2.arr2", Collections.emptyMap())
-            )
-            .addScriptField("s_arr3", new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "_source.arr3", Collections.emptyMap()))
-            .get();
+        assertResponse(
+            prepareSearch().setQuery(matchAllQuery())
+                .addScriptField("s_obj1", new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "_source.obj1", Collections.emptyMap()))
+                .addScriptField(
+                    "s_obj1_test",
+                    new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "_source.obj1.test", Collections.emptyMap())
+                )
+                .addScriptField("s_obj2", new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "_source.obj2", Collections.emptyMap()))
+                .addScriptField(
+                    "s_obj2_arr2",
+                    new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "_source.obj2.arr2", Collections.emptyMap())
+                )
+                .addScriptField("s_arr3", new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "_source.arr3", Collections.emptyMap())),
+            response -> {
 
-        assertThat("Failures " + Arrays.toString(response.getShardFailures()), response.getShardFailures().length, equalTo(0));
+                assertThat("Failures " + Arrays.toString(response.getShardFailures()), response.getShardFailures().length, equalTo(0));
 
-        assertThat(response.getHits().getAt(0).field("s_obj1_test").getValue().toString(), equalTo("something"));
+                assertThat(response.getHits().getAt(0).field("s_obj1_test").getValue().toString(), equalTo("something"));
 
-        Map<String, Object> sObj1 = response.getHits().getAt(0).field("s_obj1").getValue();
-        assertThat(sObj1.get("test").toString(), equalTo("something"));
-        assertThat(response.getHits().getAt(0).field("s_obj1_test").getValue().toString(), equalTo("something"));
+                Map<String, Object> sObj1 = response.getHits().getAt(0).field("s_obj1").getValue();
+                assertThat(sObj1.get("test").toString(), equalTo("something"));
+                assertThat(response.getHits().getAt(0).field("s_obj1_test").getValue().toString(), equalTo("something"));
 
-        Map<String, Object> sObj2 = response.getHits().getAt(0).field("s_obj2").getValue();
-        List<?> sObj2Arr2 = (List<?>) sObj2.get("arr2");
-        assertThat(sObj2Arr2.size(), equalTo(2));
-        assertThat(sObj2Arr2.get(0).toString(), equalTo("arr_value1"));
-        assertThat(sObj2Arr2.get(1).toString(), equalTo("arr_value2"));
+                Map<String, Object> sObj2 = response.getHits().getAt(0).field("s_obj2").getValue();
+                List<?> sObj2Arr2 = (List<?>) sObj2.get("arr2");
+                assertThat(sObj2Arr2.size(), equalTo(2));
+                assertThat(sObj2Arr2.get(0).toString(), equalTo("arr_value1"));
+                assertThat(sObj2Arr2.get(1).toString(), equalTo("arr_value2"));
 
-        sObj2Arr2 = response.getHits().getAt(0).field("s_obj2_arr2").getValues();
-        assertThat(sObj2Arr2.size(), equalTo(2));
-        assertThat(sObj2Arr2.get(0).toString(), equalTo("arr_value1"));
-        assertThat(sObj2Arr2.get(1).toString(), equalTo("arr_value2"));
+                sObj2Arr2 = response.getHits().getAt(0).field("s_obj2_arr2").getValues();
+                assertThat(sObj2Arr2.size(), equalTo(2));
+                assertThat(sObj2Arr2.get(0).toString(), equalTo("arr_value1"));
+                assertThat(sObj2Arr2.get(1).toString(), equalTo("arr_value2"));
 
-        List<?> sObj2Arr3 = response.getHits().getAt(0).field("s_arr3").getValues();
-        assertThat(((Map<?, ?>) sObj2Arr3.get(0)).get("arr3_field1").toString(), equalTo("arr3_value1"));
+                List<?> sObj2Arr3 = response.getHits().getAt(0).field("s_arr3").getValues();
+                assertThat(((Map<?, ?>) sObj2Arr3.get(0)).get("arr3_field1").toString(), equalTo("arr3_value1"));
+            }
+        );
     }
 
     public void testScriptFieldsForNullReturn() throws Exception {
         client().prepareIndex("test").setId("1").setSource("foo", "bar").setRefreshPolicy("true").get();
 
-        SearchResponse response = prepareSearch().setQuery(matchAllQuery())
-            .addScriptField("test_script_1", new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "return null", Collections.emptyMap()))
-            .get();
-
-        assertNoFailures(response);
-
-        DocumentField fieldObj = response.getHits().getAt(0).field("test_script_1");
-        assertThat(fieldObj, notNullValue());
-        List<?> fieldValues = fieldObj.getValues();
-        assertThat(fieldValues, hasSize(1));
-        assertThat(fieldValues.get(0), nullValue());
+        assertNoFailuresAndResponse(
+            prepareSearch().setQuery(matchAllQuery())
+                .addScriptField(
+                    "test_script_1",
+                    new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "return null", Collections.emptyMap())
+                ),
+            response -> {
+                DocumentField fieldObj = response.getHits().getAt(0).field("test_script_1");
+                assertThat(fieldObj, notNullValue());
+                List<?> fieldValues = fieldObj.getValues();
+                assertThat(fieldValues, hasSize(1));
+                assertThat(fieldValues.get(0), nullValue());
+            }
+        );
     }
 
     public void testPartialFields() throws Exception {
@@ -624,49 +635,51 @@ public class SearchFieldsIT extends ESIntegTestCase {
 
         indicesAdmin().prepareRefresh().get();
 
-        SearchResponse searchResponse = prepareSearch().setQuery(matchAllQuery())
-            .addStoredField("byte_field")
-            .addStoredField("short_field")
-            .addStoredField("integer_field")
-            .addStoredField("long_field")
-            .addStoredField("float_field")
-            .addStoredField("double_field")
-            .addStoredField("date_field")
-            .addStoredField("boolean_field")
-            .addStoredField("binary_field")
-            .get();
+        assertCheckedResponse(
+            prepareSearch().setQuery(matchAllQuery())
+                .addStoredField("byte_field")
+                .addStoredField("short_field")
+                .addStoredField("integer_field")
+                .addStoredField("long_field")
+                .addStoredField("float_field")
+                .addStoredField("double_field")
+                .addStoredField("date_field")
+                .addStoredField("boolean_field")
+                .addStoredField("binary_field"),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(1L));
+                assertThat(response.getHits().getHits().length, equalTo(1));
+                Set<String> fields = new HashSet<>(response.getHits().getAt(0).getFields().keySet());
+                assertThat(
+                    fields,
+                    equalTo(
+                        newHashSet(
+                            "byte_field",
+                            "short_field",
+                            "integer_field",
+                            "long_field",
+                            "float_field",
+                            "double_field",
+                            "date_field",
+                            "boolean_field",
+                            "binary_field"
+                        )
+                    )
+                );
 
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
-        assertThat(searchResponse.getHits().getHits().length, equalTo(1));
-        Set<String> fields = new HashSet<>(searchResponse.getHits().getAt(0).getFields().keySet());
-        assertThat(
-            fields,
-            equalTo(
-                newHashSet(
-                    "byte_field",
-                    "short_field",
-                    "integer_field",
-                    "long_field",
-                    "float_field",
-                    "double_field",
-                    "date_field",
-                    "boolean_field",
-                    "binary_field"
-                )
-            )
+                SearchHit searchHit = response.getHits().getAt(0);
+                assertThat(searchHit.getFields().get("byte_field").getValue().toString(), equalTo("1"));
+                assertThat(searchHit.getFields().get("short_field").getValue().toString(), equalTo("2"));
+                assertThat(searchHit.getFields().get("integer_field").getValue(), equalTo((Object) 3));
+                assertThat(searchHit.getFields().get("long_field").getValue(), equalTo((Object) 4L));
+                assertThat(searchHit.getFields().get("float_field").getValue(), equalTo((Object) 5.0f));
+                assertThat(searchHit.getFields().get("double_field").getValue(), equalTo((Object) 6.0d));
+                String dateTime = DateFormatter.forPattern("date_optional_time").format(date);
+                assertThat(searchHit.getFields().get("date_field").getValue(), equalTo((Object) dateTime));
+                assertThat(searchHit.getFields().get("boolean_field").getValue(), equalTo((Object) Boolean.TRUE));
+                assertThat(searchHit.getFields().get("binary_field").getValue(), equalTo(new BytesArray("testing text".getBytes("UTF8"))));
+            }
         );
-
-        SearchHit searchHit = searchResponse.getHits().getAt(0);
-        assertThat(searchHit.getFields().get("byte_field").getValue().toString(), equalTo("1"));
-        assertThat(searchHit.getFields().get("short_field").getValue().toString(), equalTo("2"));
-        assertThat(searchHit.getFields().get("integer_field").getValue(), equalTo((Object) 3));
-        assertThat(searchHit.getFields().get("long_field").getValue(), equalTo((Object) 4L));
-        assertThat(searchHit.getFields().get("float_field").getValue(), equalTo((Object) 5.0f));
-        assertThat(searchHit.getFields().get("double_field").getValue(), equalTo((Object) 6.0d));
-        String dateTime = DateFormatter.forPattern("date_optional_time").format(date);
-        assertThat(searchHit.getFields().get("date_field").getValue(), equalTo((Object) dateTime));
-        assertThat(searchHit.getFields().get("boolean_field").getValue(), equalTo((Object) Boolean.TRUE));
-        assertThat(searchHit.getFields().get("binary_field").getValue(), equalTo(new BytesArray("testing text".getBytes("UTF8"))));
     }
 
     public void testSearchFieldsMetadata() throws Exception {
@@ -677,11 +690,11 @@ public class SearchFieldsIT extends ESIntegTestCase {
             .setRefreshPolicy(IMMEDIATE)
             .get();
 
-        SearchResponse searchResponse = prepareSearch("my-index").addStoredField("field1").addStoredField("_routing").get();
-
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
-        assertThat(searchResponse.getHits().getAt(0).field("field1"), nullValue());
-        assertThat(searchResponse.getHits().getAt(0).field("_routing").getValue().toString(), equalTo("1"));
+        assertResponse(prepareSearch("my-index").addStoredField("field1").addStoredField("_routing"), response -> {
+            assertThat(response.getHits().getTotalHits().value, equalTo(1L));
+            assertThat(response.getHits().getAt(0).field("field1"), nullValue());
+            assertThat(response.getHits().getAt(0).field("_routing").getValue().toString(), equalTo("1"));
+        });
     }
 
     public void testGetFieldsComplexField() throws Exception {
@@ -745,11 +758,12 @@ public class SearchFieldsIT extends ESIntegTestCase {
 
         String field = "field1.field2.field3.field4";
 
-        SearchResponse searchResponse = prepareSearch("my-index").addStoredField(field).get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
-        assertThat(searchResponse.getHits().getAt(0).field(field).getValues().size(), equalTo(2));
-        assertThat(searchResponse.getHits().getAt(0).field(field).getValues().get(0).toString(), equalTo("value1"));
-        assertThat(searchResponse.getHits().getAt(0).field(field).getValues().get(1).toString(), equalTo("value2"));
+        assertResponse(prepareSearch("my-index").addStoredField(field), response -> {
+            assertThat(response.getHits().getTotalHits().value, equalTo(1L));
+            assertThat(response.getHits().getAt(0).field(field).getValues().size(), equalTo(2));
+            assertThat(response.getHits().getAt(0).field(field).getValues().get(0).toString(), equalTo("value1"));
+            assertThat(response.getHits().getAt(0).field(field).getValues().get(1).toString(), equalTo("value2"));
+        });
     }
 
     // see #8203
@@ -757,12 +771,14 @@ public class SearchFieldsIT extends ESIntegTestCase {
         assertAcked(indicesAdmin().prepareCreate("test").setMapping("test_field", "type=keyword").get());
         indexRandom(true, client().prepareIndex("test").setId("1").setSource("test_field", "foobar"));
         refresh();
-        SearchResponse searchResponse = prepareSearch("test").setSource(
-            new SearchSourceBuilder().query(QueryBuilders.matchAllQuery()).docValueField("test_field")
-        ).get();
-        assertHitCount(searchResponse, 1);
-        Map<String, DocumentField> fields = searchResponse.getHits().getHits()[0].getFields();
-        assertThat(fields.get("test_field").getValue(), equalTo("foobar"));
+        assertResponse(
+            prepareSearch("test").setSource(new SearchSourceBuilder().query(QueryBuilders.matchAllQuery()).docValueField("test_field")),
+            response -> {
+                assertHitCount(response, 1);
+                Map<String, DocumentField> fields = response.getHits().getHits()[0].getFields();
+                assertThat(fields.get("test_field").getValue(), equalTo("foobar"));
+            }
+        );
     }
 
     public void testDocValueFields() throws Exception {
@@ -860,116 +876,116 @@ public class SearchFieldsIT extends ESIntegTestCase {
         if (randomBoolean()) {
             builder.addDocValueField("*_field");
         }
-        SearchResponse searchResponse = builder.get();
-
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
-        assertThat(searchResponse.getHits().getHits().length, equalTo(1));
-        Set<String> fields = new HashSet<>(searchResponse.getHits().getAt(0).getFields().keySet());
-        assertThat(
-            fields,
-            equalTo(
-                newHashSet(
-                    "byte_field",
-                    "short_field",
-                    "integer_field",
-                    "long_field",
-                    "float_field",
-                    "double_field",
-                    "date_field",
-                    "boolean_field",
-                    "text_field",
-                    "keyword_field",
-                    "binary_field",
-                    "ip_field"
+        assertResponse(builder, response -> {
+            assertThat(response.getHits().getTotalHits().value, equalTo(1L));
+            assertThat(response.getHits().getHits().length, equalTo(1));
+            Set<String> fields = new HashSet<>(response.getHits().getAt(0).getFields().keySet());
+            assertThat(
+                fields,
+                equalTo(
+                    newHashSet(
+                        "byte_field",
+                        "short_field",
+                        "integer_field",
+                        "long_field",
+                        "float_field",
+                        "double_field",
+                        "date_field",
+                        "boolean_field",
+                        "text_field",
+                        "keyword_field",
+                        "binary_field",
+                        "ip_field"
+                    )
                 )
-            )
-        );
+            );
 
-        assertThat(searchResponse.getHits().getAt(0).getFields().get("byte_field").getValues(), equalTo(List.of(1L)));
-        assertThat(searchResponse.getHits().getAt(0).getFields().get("short_field").getValues(), equalTo(List.of(2L)));
-        assertThat(searchResponse.getHits().getAt(0).getFields().get("integer_field").getValues(), equalTo(List.of(3L)));
-        assertThat(searchResponse.getHits().getAt(0).getFields().get("long_field").getValues(), equalTo(List.of(4L)));
-        assertThat(searchResponse.getHits().getAt(0).getFields().get("float_field").getValues(), equalTo(List.of(5.0)));
-        assertThat(searchResponse.getHits().getAt(0).getFields().get("double_field").getValues(), equalTo(List.of(6.0d)));
-        assertThat(
-            searchResponse.getHits().getAt(0).getFields().get("date_field").getValue(),
-            equalTo(DateFormatter.forPattern("date_optional_time").format(date))
-        );
-        assertThat(searchResponse.getHits().getAt(0).getFields().get("boolean_field").getValues(), equalTo(List.of(true)));
-        assertThat(searchResponse.getHits().getAt(0).getFields().get("text_field").getValues(), equalTo(List.of("foo")));
-        assertThat(searchResponse.getHits().getAt(0).getFields().get("keyword_field").getValues(), equalTo(List.of("foo")));
-        assertThat(searchResponse.getHits().getAt(0).getFields().get("binary_field").getValues(), equalTo(List.of("KmQ=")));
-        assertThat(searchResponse.getHits().getAt(0).getFields().get("ip_field").getValues(), equalTo(List.of("::1")));
-
-        builder = prepareSearch().setQuery(matchAllQuery()).addDocValueField("*field");
-        searchResponse = builder.get();
-
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
-        assertThat(searchResponse.getHits().getHits().length, equalTo(1));
-        fields = new HashSet<>(searchResponse.getHits().getAt(0).getFields().keySet());
-        assertThat(
-            fields,
-            equalTo(
-                newHashSet(
-                    "byte_field",
-                    "short_field",
-                    "integer_field",
-                    "long_field",
-                    "float_field",
-                    "double_field",
-                    "date_field",
-                    "boolean_field",
-                    "text_field",
-                    "keyword_field",
-                    "binary_field",
-                    "ip_field"
+            assertThat(response.getHits().getAt(0).getFields().get("byte_field").getValues(), equalTo(List.of(1L)));
+            assertThat(response.getHits().getAt(0).getFields().get("short_field").getValues(), equalTo(List.of(2L)));
+            assertThat(response.getHits().getAt(0).getFields().get("integer_field").getValues(), equalTo(List.of(3L)));
+            assertThat(response.getHits().getAt(0).getFields().get("long_field").getValues(), equalTo(List.of(4L)));
+            assertThat(response.getHits().getAt(0).getFields().get("float_field").getValues(), equalTo(List.of(5.0)));
+            assertThat(response.getHits().getAt(0).getFields().get("double_field").getValues(), equalTo(List.of(6.0d)));
+            assertThat(
+                response.getHits().getAt(0).getFields().get("date_field").getValue(),
+                equalTo(DateFormatter.forPattern("date_optional_time").format(date))
+            );
+            assertThat(response.getHits().getAt(0).getFields().get("boolean_field").getValues(), equalTo(List.of(true)));
+            assertThat(response.getHits().getAt(0).getFields().get("text_field").getValues(), equalTo(List.of("foo")));
+            assertThat(response.getHits().getAt(0).getFields().get("keyword_field").getValues(), equalTo(List.of("foo")));
+            assertThat(response.getHits().getAt(0).getFields().get("binary_field").getValues(), equalTo(List.of("KmQ=")));
+            assertThat(response.getHits().getAt(0).getFields().get("ip_field").getValues(), equalTo(List.of("::1")));
+        });
+        assertResponse(prepareSearch().setQuery(matchAllQuery()).addDocValueField("*field"), response -> {
+            assertThat(response.getHits().getTotalHits().value, equalTo(1L));
+            assertThat(response.getHits().getHits().length, equalTo(1));
+            Set<String> fields = new HashSet<>(response.getHits().getAt(0).getFields().keySet());
+            assertThat(
+                fields,
+                equalTo(
+                    newHashSet(
+                        "byte_field",
+                        "short_field",
+                        "integer_field",
+                        "long_field",
+                        "float_field",
+                        "double_field",
+                        "date_field",
+                        "boolean_field",
+                        "text_field",
+                        "keyword_field",
+                        "binary_field",
+                        "ip_field"
+                    )
                 )
-            )
-        );
+            );
 
-        assertThat(searchResponse.getHits().getAt(0).getFields().get("byte_field").getValues(), equalTo(List.of(1L)));
-        assertThat(searchResponse.getHits().getAt(0).getFields().get("short_field").getValues(), equalTo(List.of(2L)));
-        assertThat(searchResponse.getHits().getAt(0).getFields().get("integer_field").getValues(), equalTo(List.of(3L)));
-        assertThat(searchResponse.getHits().getAt(0).getFields().get("long_field").getValues(), equalTo(List.of(4L)));
-        assertThat(searchResponse.getHits().getAt(0).getFields().get("float_field").getValues(), equalTo(List.of(5.0)));
-        assertThat(searchResponse.getHits().getAt(0).getFields().get("double_field").getValues(), equalTo(List.of(6.0d)));
-        assertThat(
-            searchResponse.getHits().getAt(0).getFields().get("date_field").getValue(),
-            equalTo(DateFormatter.forPattern("date_optional_time").format(date))
-        );
-        assertThat(searchResponse.getHits().getAt(0).getFields().get("boolean_field").getValues(), equalTo(List.of(true)));
-        assertThat(searchResponse.getHits().getAt(0).getFields().get("text_field").getValues(), equalTo(List.of("foo")));
-        assertThat(searchResponse.getHits().getAt(0).getFields().get("keyword_field").getValues(), equalTo(List.of("foo")));
-        assertThat(searchResponse.getHits().getAt(0).getFields().get("binary_field").getValues(), equalTo(List.of("KmQ=")));
-        assertThat(searchResponse.getHits().getAt(0).getFields().get("ip_field").getValues(), equalTo(List.of("::1")));
-
-        builder = prepareSearch().setQuery(matchAllQuery())
-            .addDocValueField("byte_field", "#.0")
-            .addDocValueField("short_field", "#.0")
-            .addDocValueField("integer_field", "#.0")
-            .addDocValueField("long_field", "#.0")
-            .addDocValueField("float_field", "#.0")
-            .addDocValueField("double_field", "#.0")
-            .addDocValueField("date_field", "epoch_millis");
-        searchResponse = builder.get();
-
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
-        assertThat(searchResponse.getHits().getHits().length, equalTo(1));
-        fields = new HashSet<>(searchResponse.getHits().getAt(0).getFields().keySet());
-        assertThat(
-            fields,
-            equalTo(newHashSet("byte_field", "short_field", "integer_field", "long_field", "float_field", "double_field", "date_field"))
-        );
-
-        assertThat(searchResponse.getHits().getAt(0).getFields().get("byte_field").getValues(), equalTo(List.of("1.0")));
-        assertThat(searchResponse.getHits().getAt(0).getFields().get("short_field").getValues(), equalTo(List.of("2.0")));
-        assertThat(searchResponse.getHits().getAt(0).getFields().get("integer_field").getValues(), equalTo(List.of("3.0")));
-        assertThat(searchResponse.getHits().getAt(0).getFields().get("long_field").getValues(), equalTo(List.of("4.0")));
-        assertThat(searchResponse.getHits().getAt(0).getFields().get("float_field").getValues(), equalTo(List.of("5.0")));
-        assertThat(searchResponse.getHits().getAt(0).getFields().get("double_field").getValues(), equalTo(List.of("6.0")));
-        assertThat(
-            searchResponse.getHits().getAt(0).getFields().get("date_field").getValue(),
-            equalTo(DateFormatter.forPattern("epoch_millis").format(date))
+            assertThat(response.getHits().getAt(0).getFields().get("byte_field").getValues(), equalTo(List.of(1L)));
+            assertThat(response.getHits().getAt(0).getFields().get("short_field").getValues(), equalTo(List.of(2L)));
+            assertThat(response.getHits().getAt(0).getFields().get("integer_field").getValues(), equalTo(List.of(3L)));
+            assertThat(response.getHits().getAt(0).getFields().get("long_field").getValues(), equalTo(List.of(4L)));
+            assertThat(response.getHits().getAt(0).getFields().get("float_field").getValues(), equalTo(List.of(5.0)));
+            assertThat(response.getHits().getAt(0).getFields().get("double_field").getValues(), equalTo(List.of(6.0d)));
+            assertThat(
+                response.getHits().getAt(0).getFields().get("date_field").getValue(),
+                equalTo(DateFormatter.forPattern("date_optional_time").format(date))
+            );
+            assertThat(response.getHits().getAt(0).getFields().get("boolean_field").getValues(), equalTo(List.of(true)));
+            assertThat(response.getHits().getAt(0).getFields().get("text_field").getValues(), equalTo(List.of("foo")));
+            assertThat(response.getHits().getAt(0).getFields().get("keyword_field").getValues(), equalTo(List.of("foo")));
+            assertThat(response.getHits().getAt(0).getFields().get("binary_field").getValues(), equalTo(List.of("KmQ=")));
+            assertThat(response.getHits().getAt(0).getFields().get("ip_field").getValues(), equalTo(List.of("::1")));
+        });
+        assertResponse(
+            prepareSearch().setQuery(matchAllQuery())
+                .addDocValueField("byte_field", "#.0")
+                .addDocValueField("short_field", "#.0")
+                .addDocValueField("integer_field", "#.0")
+                .addDocValueField("long_field", "#.0")
+                .addDocValueField("float_field", "#.0")
+                .addDocValueField("double_field", "#.0")
+                .addDocValueField("date_field", "epoch_millis"),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(1L));
+                assertThat(response.getHits().getHits().length, equalTo(1));
+                Set<String> fields = new HashSet<>(response.getHits().getAt(0).getFields().keySet());
+                assertThat(
+                    fields,
+                    equalTo(
+                        newHashSet("byte_field", "short_field", "integer_field", "long_field", "float_field", "double_field", "date_field")
+                    )
+                );
+                assertThat(response.getHits().getAt(0).getFields().get("byte_field").getValues(), equalTo(List.of("1.0")));
+                assertThat(response.getHits().getAt(0).getFields().get("short_field").getValues(), equalTo(List.of("2.0")));
+                assertThat(response.getHits().getAt(0).getFields().get("integer_field").getValues(), equalTo(List.of("3.0")));
+                assertThat(response.getHits().getAt(0).getFields().get("long_field").getValues(), equalTo(List.of("4.0")));
+                assertThat(response.getHits().getAt(0).getFields().get("float_field").getValues(), equalTo(List.of("5.0")));
+                assertThat(response.getHits().getAt(0).getFields().get("double_field").getValues(), equalTo(List.of("6.0")));
+                assertThat(
+                    response.getHits().getAt(0).getFields().get("date_field").getValue(),
+                    equalTo(DateFormatter.forPattern("epoch_millis").format(date))
+                );
+            }
         );
     }
 
@@ -1021,18 +1037,18 @@ public class SearchFieldsIT extends ESIntegTestCase {
                 new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "doc['" + field + "']", Collections.emptyMap())
             );
         }
-        SearchResponse resp = req.get();
-        assertNoFailures(resp);
-        for (SearchHit hit : resp.getHits().getHits()) {
-            final int id = Integer.parseInt(hit.getId());
-            Map<String, DocumentField> fields = hit.getFields();
-            assertThat(fields.get("s").getValues(), equalTo(Collections.<Object>singletonList(Integer.toString(id))));
-            assertThat(fields.get("l").getValues(), equalTo(Collections.<Object>singletonList((long) id)));
-            assertThat(fields.get("d").getValues(), equalTo(Collections.<Object>singletonList((double) id)));
-            assertThat(fields.get("ms").getValues(), equalTo(Arrays.<Object>asList(Integer.toString(id), Integer.toString(id + 1))));
-            assertThat(fields.get("ml").getValues(), equalTo(Arrays.<Object>asList((long) id, id + 1L)));
-            assertThat(fields.get("md").getValues(), equalTo(Arrays.<Object>asList((double) id, id + 1d)));
-        }
+        assertNoFailuresAndResponse(req, response -> {
+            for (SearchHit hit : response.getHits().getHits()) {
+                final int id = Integer.parseInt(hit.getId());
+                Map<String, DocumentField> fields = hit.getFields();
+                assertThat(fields.get("s").getValues(), equalTo(Collections.<Object>singletonList(Integer.toString(id))));
+                assertThat(fields.get("l").getValues(), equalTo(Collections.<Object>singletonList((long) id)));
+                assertThat(fields.get("d").getValues(), equalTo(Collections.<Object>singletonList((double) id)));
+                assertThat(fields.get("ms").getValues(), equalTo(Arrays.<Object>asList(Integer.toString(id), Integer.toString(id + 1))));
+                assertThat(fields.get("ml").getValues(), equalTo(Arrays.<Object>asList((long) id, id + 1L)));
+                assertThat(fields.get("md").getValues(), equalTo(Arrays.<Object>asList((double) id, id + 1d)));
+            }
+        });
     }
 
     public void testDocValueFieldsWithFieldAlias() throws Exception {
@@ -1071,30 +1087,31 @@ public class SearchFieldsIT extends ESIntegTestCase {
         indexDoc("test", "1", "text_field", "foo", "date_field", formatter.format(date));
         refresh("test");
 
-        SearchRequestBuilder builder = prepareSearch().setQuery(matchAllQuery())
-            .addDocValueField("text_field_alias")
-            .addDocValueField("date_field_alias")
-            .addDocValueField("date_field");
-        SearchResponse searchResponse = builder.get();
+        assertNoFailuresAndResponse(
+            prepareSearch().setQuery(matchAllQuery())
+                .addDocValueField("text_field_alias")
+                .addDocValueField("date_field_alias")
+                .addDocValueField("date_field"),
+            response -> {
+                assertHitCount(response, 1);
+                SearchHit hit = response.getHits().getAt(0);
 
-        assertNoFailures(searchResponse);
-        assertHitCount(searchResponse, 1);
-        SearchHit hit = searchResponse.getHits().getAt(0);
+                Map<String, DocumentField> fields = hit.getFields();
+                assertThat(fields.keySet(), equalTo(newHashSet("text_field_alias", "date_field_alias", "date_field")));
 
-        Map<String, DocumentField> fields = hit.getFields();
-        assertThat(fields.keySet(), equalTo(newHashSet("text_field_alias", "date_field_alias", "date_field")));
+                DocumentField textFieldAlias = fields.get("text_field_alias");
+                assertThat(textFieldAlias.getName(), equalTo("text_field_alias"));
+                assertThat(textFieldAlias.getValue(), equalTo("foo"));
 
-        DocumentField textFieldAlias = fields.get("text_field_alias");
-        assertThat(textFieldAlias.getName(), equalTo("text_field_alias"));
-        assertThat(textFieldAlias.getValue(), equalTo("foo"));
+                DocumentField dateFieldAlias = fields.get("date_field_alias");
+                assertThat(dateFieldAlias.getName(), equalTo("date_field_alias"));
+                assertThat(dateFieldAlias.getValue(), equalTo("1990-12-29"));
 
-        DocumentField dateFieldAlias = fields.get("date_field_alias");
-        assertThat(dateFieldAlias.getName(), equalTo("date_field_alias"));
-        assertThat(dateFieldAlias.getValue(), equalTo("1990-12-29"));
-
-        DocumentField dateField = fields.get("date_field");
-        assertThat(dateField.getName(), equalTo("date_field"));
-        assertThat(dateField.getValue(), equalTo("1990-12-29"));
+                DocumentField dateField = fields.get("date_field");
+                assertThat(dateField.getName(), equalTo("date_field"));
+                assertThat(dateField.getValue(), equalTo("1990-12-29"));
+            }
+        );
     }
 
     public void testWildcardDocValueFieldsWithFieldAlias() throws Exception {
@@ -1133,27 +1150,28 @@ public class SearchFieldsIT extends ESIntegTestCase {
         indexDoc("test", "1", "text_field", "foo", "date_field", formatter.format(date));
         refresh("test");
 
-        SearchRequestBuilder builder = prepareSearch().setQuery(matchAllQuery()).addDocValueField("*alias").addDocValueField("date_field");
-        SearchResponse searchResponse = builder.get();
+        assertNoFailuresAndResponse(
+            prepareSearch().setQuery(matchAllQuery()).addDocValueField("*alias").addDocValueField("date_field"),
+            response -> {
+                assertHitCount(response, 1);
+                SearchHit hit = response.getHits().getAt(0);
 
-        assertNoFailures(searchResponse);
-        assertHitCount(searchResponse, 1);
-        SearchHit hit = searchResponse.getHits().getAt(0);
+                Map<String, DocumentField> fields = hit.getFields();
+                assertThat(fields.keySet(), equalTo(newHashSet("text_field_alias", "date_field_alias", "date_field")));
 
-        Map<String, DocumentField> fields = hit.getFields();
-        assertThat(fields.keySet(), equalTo(newHashSet("text_field_alias", "date_field_alias", "date_field")));
+                DocumentField textFieldAlias = fields.get("text_field_alias");
+                assertThat(textFieldAlias.getName(), equalTo("text_field_alias"));
+                assertThat(textFieldAlias.getValue(), equalTo("foo"));
 
-        DocumentField textFieldAlias = fields.get("text_field_alias");
-        assertThat(textFieldAlias.getName(), equalTo("text_field_alias"));
-        assertThat(textFieldAlias.getValue(), equalTo("foo"));
+                DocumentField dateFieldAlias = fields.get("date_field_alias");
+                assertThat(dateFieldAlias.getName(), equalTo("date_field_alias"));
+                assertThat(dateFieldAlias.getValue(), equalTo("1990-12-29"));
 
-        DocumentField dateFieldAlias = fields.get("date_field_alias");
-        assertThat(dateFieldAlias.getName(), equalTo("date_field_alias"));
-        assertThat(dateFieldAlias.getValue(), equalTo("1990-12-29"));
-
-        DocumentField dateField = fields.get("date_field");
-        assertThat(dateField.getName(), equalTo("date_field"));
-        assertThat(dateField.getValue(), equalTo("1990-12-29"));
+                DocumentField dateField = fields.get("date_field");
+                assertThat(dateField.getName(), equalTo("date_field"));
+                assertThat(dateField.getValue(), equalTo("1990-12-29"));
+            }
+        );
     }
 
     public void testStoredFieldsWithFieldAlias() throws Exception {
@@ -1185,18 +1203,19 @@ public class SearchFieldsIT extends ESIntegTestCase {
         indexDoc("test", "1", "field1", "value1", "field2", "value2");
         refresh("test");
 
-        SearchResponse searchResponse = prepareSearch().setQuery(matchAllQuery())
-            .addStoredField("field1-alias")
-            .addStoredField("field2-alias")
-            .get();
-        assertHitCount(searchResponse, 1L);
+        assertResponse(
+            prepareSearch().setQuery(matchAllQuery()).addStoredField("field1-alias").addStoredField("field2-alias"),
+            response -> {
+                assertHitCount(response, 1L);
 
-        SearchHit hit = searchResponse.getHits().getAt(0);
-        assertEquals(1, hit.getFields().size());
-        assertTrue(hit.getFields().containsKey("field1-alias"));
+                SearchHit hit = response.getHits().getAt(0);
+                assertEquals(1, hit.getFields().size());
+                assertTrue(hit.getFields().containsKey("field1-alias"));
 
-        DocumentField field = hit.getFields().get("field1-alias");
-        assertThat(field.getValue().toString(), equalTo("value1"));
+                DocumentField field = hit.getFields().get("field1-alias");
+                assertThat(field.getValue().toString(), equalTo("value1"));
+            }
+        );
     }
 
     public void testWildcardStoredFieldsWithFieldAlias() throws Exception {
@@ -1228,19 +1247,20 @@ public class SearchFieldsIT extends ESIntegTestCase {
         indexDoc("test", "1", "field1", "value1", "field2", "value2");
         refresh("test");
 
-        SearchResponse searchResponse = prepareSearch().setQuery(matchAllQuery()).addStoredField("field*").get();
-        assertHitCount(searchResponse, 1L);
+        assertResponse(prepareSearch().setQuery(matchAllQuery()).addStoredField("field*"), response -> {
+            assertHitCount(response, 1L);
 
-        SearchHit hit = searchResponse.getHits().getAt(0);
-        assertEquals(2, hit.getFields().size());
-        assertTrue(hit.getFields().containsKey("field1"));
-        assertTrue(hit.getFields().containsKey("field1-alias"));
+            SearchHit hit = response.getHits().getAt(0);
+            assertEquals(2, hit.getFields().size());
+            assertTrue(hit.getFields().containsKey("field1"));
+            assertTrue(hit.getFields().containsKey("field1-alias"));
 
-        DocumentField field = hit.getFields().get("field1");
-        assertThat(field.getValue().toString(), equalTo("value1"));
+            DocumentField field = hit.getFields().get("field1");
+            assertThat(field.getValue().toString(), equalTo("value1"));
 
-        DocumentField fieldAlias = hit.getFields().get("field1-alias");
-        assertThat(fieldAlias.getValue().toString(), equalTo("value1"));
+            DocumentField fieldAlias = hit.getFields().get("field1-alias");
+            assertThat(fieldAlias.getValue().toString(), equalTo("value1"));
+        });
     }
 
     public void testLoadMetadata() throws Exception {
@@ -1254,14 +1274,14 @@ public class SearchFieldsIT extends ESIntegTestCase {
                 .setSource(jsonBuilder().startObject().field("field1", "value").endObject())
         );
 
-        SearchResponse response = prepareSearch("test").addStoredField("field1").get();
-        assertNoFailures(response);
-        assertHitCount(response, 1);
+        assertNoFailuresAndResponse(prepareSearch("test").addStoredField("field1"), response -> {
+            assertHitCount(response, 1);
 
-        Map<String, DocumentField> fields = response.getHits().getAt(0).getMetadataFields();
+            Map<String, DocumentField> fields = response.getHits().getAt(0).getMetadataFields();
 
-        assertThat(fields.get("field1"), nullValue());
-        assertThat(fields.get("_routing").getValue().toString(), equalTo("1"));
-        assertThat(response.getHits().getAt(0).getDocumentFields().size(), equalTo(0));
+            assertThat(fields.get("field1"), nullValue());
+            assertThat(fields.get("_routing").getValue().toString(), equalTo("1"));
+            assertThat(response.getHits().getAt(0).getDocumentFields().size(), equalTo(0));
+        });
     }
 }


### PR DESCRIPTION
relates https://github.com/elastic/elasticsearch/issues/102030