### PR TITLE
Remove explicit SearchResponse references from `org.elasticsearch.search.functionscore`

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/functionscore/DecayFunctionScoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/functionscore/DecayFunctionScoreIT.java
@@ -8,12 +8,10 @@
 
 package org.elasticsearch.search.functionscore;
 
-import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.geo.GeoPoint;
@@ -48,8 +46,10 @@ import static org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders.
 import static org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders.linearDecayFunction;
 import static org.elasticsearch.search.builder.SearchSourceBuilder.searchSource;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertOrderedSearchHits;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHits;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.anyOf;
@@ -140,61 +140,65 @@ public class DecayFunctionScoreIT extends ESIntegTestCase {
         lonlat.add(20f);
         lonlat.add(11f);
 
-        ActionFuture<SearchResponse> response = client().search(
-            new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH).source(searchSource().query(baseQuery))
+        assertHitCount(
+            client().search(
+                new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH).source(searchSource().query(baseQuery))
+            ),
+            (numDummyDocs + 2)
         );
-        SearchResponse sr = response.actionGet();
-        SearchHits sh = sr.getHits();
-        assertThat(sh.getTotalHits().value, equalTo((long) (numDummyDocs + 2)));
 
-        response = client().search(
-            new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
-                .source(searchSource().query(functionScoreQuery(baseQuery, gaussDecayFunction("loc", lonlat, "1000km"))))
+        assertResponse(
+            client().search(
+                new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
+                    .source(searchSource().query(functionScoreQuery(baseQuery, gaussDecayFunction("loc", lonlat, "1000km"))))
+            ),
+            response -> {
+                assertHitCount(response, (numDummyDocs + 2));
+                assertThat(response.getHits().getAt(0).getId(), equalTo("1"));
+                assertThat(response.getHits().getAt(1).getId(), equalTo("2"));
+            }
         );
-        sr = response.actionGet();
-        sh = sr.getHits();
-        assertThat(sh.getTotalHits().value, equalTo((long) (numDummyDocs + 2)));
-
-        assertThat(sh.getAt(0).getId(), equalTo("1"));
-        assertThat(sh.getAt(1).getId(), equalTo("2"));
         // Test Exp
 
-        response = client().search(
-            new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH).source(searchSource().query(baseQuery))
+        assertHitCount(
+            client().search(
+                new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH).source(searchSource().query(baseQuery))
+            ),
+            (numDummyDocs + 2)
         );
-        sr = response.actionGet();
-        sh = sr.getHits();
-        assertThat(sh.getTotalHits().value, equalTo((long) (numDummyDocs + 2)));
 
-        response = client().search(
-            new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
-                .source(searchSource().query(functionScoreQuery(baseQuery, linearDecayFunction("loc", lonlat, "1000km"))))
+        assertResponse(
+            client().search(
+                new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
+                    .source(searchSource().query(functionScoreQuery(baseQuery, linearDecayFunction("loc", lonlat, "1000km"))))
+            ),
+            response -> {
+                assertHitCount(response, (numDummyDocs + 2));
+                assertThat(response.getHits().getAt(0).getId(), equalTo("1"));
+                assertThat(response.getHits().getAt(1).getId(), equalTo("2"));
+            }
         );
-        sr = response.actionGet();
-        sh = sr.getHits();
-        assertThat(sh.getTotalHits().value, equalTo((long) (numDummyDocs + 2)));
 
-        assertThat(sh.getAt(0).getId(), equalTo("1"));
-        assertThat(sh.getAt(1).getId(), equalTo("2"));
         // Test Lin
 
-        response = client().search(
-            new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH).source(searchSource().query(baseQuery))
+        assertHitCount(
+            client().search(
+                new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH).source(searchSource().query(baseQuery))
+            ),
+            (numDummyDocs + 2)
         );
-        sr = response.actionGet();
-        sh = sr.getHits();
-        assertThat(sh.getTotalHits().value, equalTo((long) (numDummyDocs + 2)));
 
-        response = client().search(
-            new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
-                .source(searchSource().query(functionScoreQuery(baseQuery, exponentialDecayFunction("loc", lonlat, "1000km"))))
+        assertResponse(
+            client().search(
+                new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
+                    .source(searchSource().query(functionScoreQuery(baseQuery, exponentialDecayFunction("loc", lonlat, "1000km"))))
+            ),
+            response -> {
+                assertHitCount(response, (numDummyDocs + 2));
+                assertThat(response.getHits().getAt(0).getId(), equalTo("1"));
+                assertThat(response.getHits().getAt(1).getId(), equalTo("2"));
+            }
         );
-        sr = response.actionGet();
-        sh = sr.getHits();
-        assertThat(sh.getTotalHits().value, equalTo((long) (numDummyDocs + 2)));
-
-        assertThat(sh.getAt(0).getId(), equalTo("1"));
-        assertThat(sh.getAt(1).getId(), equalTo("2"));
     }
 
     public void testDistanceScoreGeoLinGaussExpWithOffset() throws Exception {
@@ -245,67 +249,76 @@ public class DecayFunctionScoreIT extends ESIntegTestCase {
 
         // Test Gauss
 
-        ActionFuture<SearchResponse> response = client().search(
-            new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
-                .source(
-                    searchSource().size(numDummyDocs + 2)
-                        .query(
-                            functionScoreQuery(termQuery("test", "value"), gaussDecayFunction("num", 1.0, 5.0, 1.0)).boostMode(
-                                CombineFunction.REPLACE
+        assertResponse(
+            client().search(
+                new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
+                    .source(
+                        searchSource().size(numDummyDocs + 2)
+                            .query(
+                                functionScoreQuery(termQuery("test", "value"), gaussDecayFunction("num", 1.0, 5.0, 1.0)).boostMode(
+                                    CombineFunction.REPLACE
+                                )
                             )
-                        )
-                )
+                    )
+            ),
+            response -> {
+                SearchHits sh = response.getHits();
+                assertThat(sh.getTotalHits().value, equalTo((long) (numDummyDocs + 2)));
+                assertThat(sh.getAt(0).getId(), anyOf(equalTo("1"), equalTo("2")));
+                assertThat(sh.getAt(1).getId(), anyOf(equalTo("1"), equalTo("2")));
+                assertThat(sh.getAt(1).getScore(), equalTo(sh.getAt(0).getScore()));
+                for (int i = 0; i < numDummyDocs; i++) {
+                    assertThat(sh.getAt(i + 2).getId(), equalTo(Integer.toString(i + 3)));
+                }
+            }
         );
-        SearchResponse sr = response.actionGet();
-        SearchHits sh = sr.getHits();
-        assertThat(sh.getTotalHits().value, equalTo((long) (numDummyDocs + 2)));
-        assertThat(sh.getAt(0).getId(), anyOf(equalTo("1"), equalTo("2")));
-        assertThat(sh.getAt(1).getId(), anyOf(equalTo("1"), equalTo("2")));
-        assertThat(sh.getAt(1).getScore(), equalTo(sh.getAt(0).getScore()));
-        for (int i = 0; i < numDummyDocs; i++) {
-            assertThat(sh.getAt(i + 2).getId(), equalTo(Integer.toString(i + 3)));
-        }
 
         // Test Exp
 
-        response = client().search(
-            new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
-                .source(
-                    searchSource().size(numDummyDocs + 2)
-                        .query(
-                            functionScoreQuery(termQuery("test", "value"), exponentialDecayFunction("num", 1.0, 5.0, 1.0)).boostMode(
-                                CombineFunction.REPLACE
+        assertResponse(
+            client().search(
+                new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
+                    .source(
+                        searchSource().size(numDummyDocs + 2)
+                            .query(
+                                functionScoreQuery(termQuery("test", "value"), exponentialDecayFunction("num", 1.0, 5.0, 1.0)).boostMode(
+                                    CombineFunction.REPLACE
+                                )
                             )
-                        )
-                )
+                    )
+            ),
+            response -> {
+                SearchHits sh = response.getHits();
+                assertThat(sh.getTotalHits().value, equalTo((long) (numDummyDocs + 2)));
+                assertThat(sh.getAt(0).getId(), anyOf(equalTo("1"), equalTo("2")));
+                assertThat(sh.getAt(1).getId(), anyOf(equalTo("1"), equalTo("2")));
+                assertThat(sh.getAt(1).getScore(), equalTo(sh.getAt(0).getScore()));
+                for (int i = 0; i < numDummyDocs; i++) {
+                    assertThat(sh.getAt(i + 2).getId(), equalTo(Integer.toString(i + 3)));
+                }
+            }
         );
-        sr = response.actionGet();
-        sh = sr.getHits();
-        assertThat(sh.getTotalHits().value, equalTo((long) (numDummyDocs + 2)));
-        assertThat(sh.getAt(0).getId(), anyOf(equalTo("1"), equalTo("2")));
-        assertThat(sh.getAt(1).getId(), anyOf(equalTo("1"), equalTo("2")));
-        assertThat(sh.getAt(1).getScore(), equalTo(sh.getAt(0).getScore()));
-        for (int i = 0; i < numDummyDocs; i++) {
-            assertThat(sh.getAt(i + 2).getId(), equalTo(Integer.toString(i + 3)));
-        }
         // Test Lin
-        response = client().search(
-            new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
-                .source(
-                    searchSource().size(numDummyDocs + 2)
-                        .query(
-                            functionScoreQuery(termQuery("test", "value"), linearDecayFunction("num", 1.0, 20.0, 1.0)).boostMode(
-                                CombineFunction.REPLACE
+        assertResponse(
+            client().search(
+                new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
+                    .source(
+                        searchSource().size(numDummyDocs + 2)
+                            .query(
+                                functionScoreQuery(termQuery("test", "value"), linearDecayFunction("num", 1.0, 20.0, 1.0)).boostMode(
+                                    CombineFunction.REPLACE
+                                )
                             )
-                        )
-                )
+                    )
+            ),
+            response -> {
+                SearchHits sh = response.getHits();
+                assertThat(sh.getTotalHits().value, equalTo((long) (numDummyDocs + 2)));
+                assertThat(sh.getAt(0).getId(), anyOf(equalTo("1"), equalTo("2")));
+                assertThat(sh.getAt(1).getId(), anyOf(equalTo("1"), equalTo("2")));
+                assertThat(sh.getAt(1).getScore(), equalTo(sh.getAt(0).getScore()));
+            }
         );
-        sr = response.actionGet();
-        sh = sr.getHits();
-        assertThat(sh.getTotalHits().value, equalTo((long) (numDummyDocs + 2)));
-        assertThat(sh.getAt(0).getId(), anyOf(equalTo("1"), equalTo("2")));
-        assertThat(sh.getAt(1).getId(), anyOf(equalTo("1"), equalTo("2")));
-        assertThat(sh.getAt(1).getScore(), equalTo(sh.getAt(0).getScore()));
     }
 
     public void testBoostModeSettingWorks() throws Exception {
@@ -364,48 +377,56 @@ public class DecayFunctionScoreIT extends ESIntegTestCase {
         lonlat.add(20f);
         lonlat.add(11f);
 
-        ActionFuture<SearchResponse> response = client().search(
-            new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
-                .source(
-                    searchSource().query(
-                        functionScoreQuery(termQuery("test", "value"), gaussDecayFunction("loc", lonlat, "1000km")).boostMode(
-                            CombineFunction.MULTIPLY
+        assertResponse(
+            client().search(
+                new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
+                    .source(
+                        searchSource().query(
+                            functionScoreQuery(termQuery("test", "value"), gaussDecayFunction("loc", lonlat, "1000km")).boostMode(
+                                CombineFunction.MULTIPLY
+                            )
                         )
                     )
-                )
+            ),
+            response -> {
+                SearchHits sh = response.getHits();
+                assertThat(sh.getTotalHits().value, equalTo((long) (2)));
+                assertThat(sh.getAt(0).getId(), equalTo("1"));
+                assertThat(sh.getAt(1).getId(), equalTo("2"));
+            }
         );
-        SearchResponse sr = response.actionGet();
-        SearchHits sh = sr.getHits();
-        assertThat(sh.getTotalHits().value, equalTo((long) (2)));
-        assertThat(sh.getAt(0).getId(), equalTo("1"));
-        assertThat(sh.getAt(1).getId(), equalTo("2"));
-
         // Test Exp
-        response = client().search(
-            new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
-                .source(searchSource().query(termQuery("test", "value")))
+        assertResponse(
+            client().search(
+                new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
+                    .source(searchSource().query(termQuery("test", "value")))
+            ),
+            response -> {
+                SearchHits sh = response.getHits();
+                assertThat(sh.getTotalHits().value, equalTo((long) (2)));
+                assertThat(sh.getAt(0).getId(), equalTo("1"));
+                assertThat(sh.getAt(1).getId(), equalTo("2"));
+            }
         );
-        sr = response.actionGet();
-        sh = sr.getHits();
-        assertThat(sh.getTotalHits().value, equalTo((long) (2)));
-        assertThat(sh.getAt(0).getId(), equalTo("1"));
-        assertThat(sh.getAt(1).getId(), equalTo("2"));
 
-        response = client().search(
-            new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
-                .source(
-                    searchSource().query(
-                        functionScoreQuery(termQuery("test", "value"), gaussDecayFunction("loc", lonlat, "1000km")).boostMode(
-                            CombineFunction.REPLACE
+        assertResponse(
+            client().search(
+                new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
+                    .source(
+                        searchSource().query(
+                            functionScoreQuery(termQuery("test", "value"), gaussDecayFunction("loc", lonlat, "1000km")).boostMode(
+                                CombineFunction.REPLACE
+                            )
                         )
                     )
-                )
+            ),
+            response -> {
+                SearchHits sh = response.getHits();
+                assertThat(sh.getTotalHits().value, equalTo((long) (2)));
+                assertThat(sh.getAt(0).getId(), equalTo("2"));
+                assertThat(sh.getAt(1).getId(), equalTo("1"));
+            }
         );
-        sr = response.actionGet();
-        sh = sr.getHits();
-        assertThat(sh.getTotalHits().value, equalTo((long) (2)));
-        assertThat(sh.getAt(0).getId(), equalTo("2"));
-        assertThat(sh.getAt(1).getId(), equalTo("1"));
 
     }
 
@@ -446,34 +467,44 @@ public class DecayFunctionScoreIT extends ESIntegTestCase {
             ScoreFunctionBuilders.weightFactorFunction(randomIntBetween(1, 10))
         );
         GeoPoint point = new GeoPoint(20, 11);
-        ActionFuture<SearchResponse> response = client().search(
-            new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
-                .source(
-                    searchSource().query(
-                        functionScoreQuery(baseQueryBuilder, gaussDecayFunction("loc", point, "1000km")).boostMode(CombineFunction.REPLACE)
+        assertResponse(
+            client().search(
+                new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
+                    .source(
+                        searchSource().query(
+                            functionScoreQuery(baseQueryBuilder, gaussDecayFunction("loc", point, "1000km")).boostMode(
+                                CombineFunction.REPLACE
+                            )
+                        )
                     )
-                )
+            ),
+            response -> {
+                SearchHits sh = response.getHits();
+                assertThat(sh.getTotalHits().value, equalTo((long) (1)));
+                assertThat(sh.getAt(0).getId(), equalTo("1"));
+                assertThat((double) sh.getAt(0).getScore(), closeTo(1.0, 1.e-5));
+            }
         );
-        SearchResponse sr = response.actionGet();
-        SearchHits sh = sr.getHits();
-        assertThat(sh.getTotalHits().value, equalTo((long) (1)));
-        assertThat(sh.getAt(0).getId(), equalTo("1"));
-        assertThat((double) sh.getAt(0).getScore(), closeTo(1.0, 1.e-5));
         // this is equivalent to new GeoPoint(20, 11); just flipped so scores must be same
         float[] coords = { 11, 20 };
-        response = client().search(
-            new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
-                .source(
-                    searchSource().query(
-                        functionScoreQuery(baseQueryBuilder, gaussDecayFunction("loc", coords, "1000km")).boostMode(CombineFunction.REPLACE)
+        assertResponse(
+            client().search(
+                new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
+                    .source(
+                        searchSource().query(
+                            functionScoreQuery(baseQueryBuilder, gaussDecayFunction("loc", coords, "1000km")).boostMode(
+                                CombineFunction.REPLACE
+                            )
+                        )
                     )
-                )
+            ),
+            response -> {
+                SearchHits sh = response.getHits();
+                assertThat(sh.getTotalHits().value, equalTo((long) (1)));
+                assertThat(sh.getAt(0).getId(), equalTo("1"));
+                assertThat((double) sh.getAt(0).getScore(), closeTo(1.0f, 1.e-5));
+            }
         );
-        sr = response.actionGet();
-        sh = sr.getHits();
-        assertThat(sh.getTotalHits().value, equalTo((long) (1)));
-        assertThat(sh.getAt(0).getId(), equalTo("1"));
-        assertThat((double) sh.getAt(0).getScore(), closeTo(1.0f, 1.e-5));
     }
 
     public void testCombineModes() throws Exception {
@@ -505,95 +536,120 @@ public class DecayFunctionScoreIT extends ESIntegTestCase {
             ScoreFunctionBuilders.weightFactorFunction(2)
         );
         // decay score should return 0.5 for this function and baseQuery should return 2.0f as it's score
-        ActionFuture<SearchResponse> response = client().search(
-            new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
-                .source(
-                    searchSource().query(
-                        functionScoreQuery(baseQueryBuilder, gaussDecayFunction("num", 0.0, 1.0, null, 0.5)).boostMode(
-                            CombineFunction.MULTIPLY
+        assertResponse(
+            client().search(
+                new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
+                    .source(
+                        searchSource().query(
+                            functionScoreQuery(baseQueryBuilder, gaussDecayFunction("num", 0.0, 1.0, null, 0.5)).boostMode(
+                                CombineFunction.MULTIPLY
+                            )
                         )
                     )
-                )
+            ),
+            response -> {
+                SearchHits sh = response.getHits();
+                assertThat(sh.getTotalHits().value, equalTo((long) (1)));
+                assertThat(sh.getAt(0).getId(), equalTo("1"));
+                assertThat((double) sh.getAt(0).getScore(), closeTo(1.0, 1.e-5));
+            }
         );
-        SearchResponse sr = response.actionGet();
-        SearchHits sh = sr.getHits();
-        assertThat(sh.getTotalHits().value, equalTo((long) (1)));
-        assertThat(sh.getAt(0).getId(), equalTo("1"));
-        assertThat((double) sh.getAt(0).getScore(), closeTo(1.0, 1.e-5));
-
-        response = client().search(
-            new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
-                .source(
-                    searchSource().query(
-                        functionScoreQuery(baseQueryBuilder, gaussDecayFunction("num", 0.0, 1.0, null, 0.5)).boostMode(
-                            CombineFunction.REPLACE
+        assertResponse(
+            client().search(
+                new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
+                    .source(
+                        searchSource().query(
+                            functionScoreQuery(baseQueryBuilder, gaussDecayFunction("num", 0.0, 1.0, null, 0.5)).boostMode(
+                                CombineFunction.REPLACE
+                            )
                         )
                     )
-                )
+            ),
+            response -> {
+                SearchHits sh = response.getHits();
+                assertThat(sh.getTotalHits().value, equalTo((long) (1)));
+                assertThat(sh.getAt(0).getId(), equalTo("1"));
+                assertThat((double) sh.getAt(0).getScore(), closeTo(0.5, 1.e-5));
+            }
         );
-        sr = response.actionGet();
-        sh = sr.getHits();
-        assertThat(sh.getTotalHits().value, equalTo((long) (1)));
-        assertThat(sh.getAt(0).getId(), equalTo("1"));
-        assertThat((double) sh.getAt(0).getScore(), closeTo(0.5, 1.e-5));
-
-        response = client().search(
-            new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
-                .source(
-                    searchSource().query(
-                        functionScoreQuery(baseQueryBuilder, gaussDecayFunction("num", 0.0, 1.0, null, 0.5)).boostMode(CombineFunction.SUM)
+        assertResponse(
+            client().search(
+                new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
+                    .source(
+                        searchSource().query(
+                            functionScoreQuery(baseQueryBuilder, gaussDecayFunction("num", 0.0, 1.0, null, 0.5)).boostMode(
+                                CombineFunction.SUM
+                            )
+                        )
                     )
-                )
+            ),
+            response -> {
+                SearchHits sh = response.getHits();
+                assertThat(sh.getTotalHits().value, equalTo((long) (1)));
+                assertThat(sh.getAt(0).getId(), equalTo("1"));
+                assertThat((double) sh.getAt(0).getScore(), closeTo(2.0 + 0.5, 1.e-5));
+                logger.info(
+                    "--> Hit[0] {} Explanation:\n {}",
+                    response.getHits().getAt(0).getId(),
+                    response.getHits().getAt(0).getExplanation()
+                );
+            }
         );
-        sr = response.actionGet();
-        sh = sr.getHits();
-        assertThat(sh.getTotalHits().value, equalTo((long) (1)));
-        assertThat(sh.getAt(0).getId(), equalTo("1"));
-        assertThat((double) sh.getAt(0).getScore(), closeTo(2.0 + 0.5, 1.e-5));
-        logger.info("--> Hit[0] {} Explanation:\n {}", sr.getHits().getAt(0).getId(), sr.getHits().getAt(0).getExplanation());
 
-        response = client().search(
-            new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
-                .source(
-                    searchSource().query(
-                        functionScoreQuery(baseQueryBuilder, gaussDecayFunction("num", 0.0, 1.0, null, 0.5)).boostMode(CombineFunction.AVG)
+        assertResponse(
+            client().search(
+                new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
+                    .source(
+                        searchSource().query(
+                            functionScoreQuery(baseQueryBuilder, gaussDecayFunction("num", 0.0, 1.0, null, 0.5)).boostMode(
+                                CombineFunction.AVG
+                            )
+                        )
                     )
-                )
+            ),
+            response -> {
+                SearchHits sh = response.getHits();
+                assertThat(sh.getTotalHits().value, equalTo((long) (1)));
+                assertThat(sh.getAt(0).getId(), equalTo("1"));
+                assertThat((double) sh.getAt(0).getScore(), closeTo((2.0 + 0.5) / 2, 1.e-5));
+            }
         );
-        sr = response.actionGet();
-        sh = sr.getHits();
-        assertThat(sh.getTotalHits().value, equalTo((long) (1)));
-        assertThat(sh.getAt(0).getId(), equalTo("1"));
-        assertThat((double) sh.getAt(0).getScore(), closeTo((2.0 + 0.5) / 2, 1.e-5));
-
-        response = client().search(
-            new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
-                .source(
-                    searchSource().query(
-                        functionScoreQuery(baseQueryBuilder, gaussDecayFunction("num", 0.0, 1.0, null, 0.5)).boostMode(CombineFunction.MIN)
+        assertResponse(
+            client().search(
+                new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
+                    .source(
+                        searchSource().query(
+                            functionScoreQuery(baseQueryBuilder, gaussDecayFunction("num", 0.0, 1.0, null, 0.5)).boostMode(
+                                CombineFunction.MIN
+                            )
+                        )
                     )
-                )
+            ),
+            response -> {
+                SearchHits sh = response.getHits();
+                assertThat(sh.getTotalHits().value, equalTo((long) (1)));
+                assertThat(sh.getAt(0).getId(), equalTo("1"));
+                assertThat((double) sh.getAt(0).getScore(), closeTo(0.5, 1.e-5));
+            }
         );
-        sr = response.actionGet();
-        sh = sr.getHits();
-        assertThat(sh.getTotalHits().value, equalTo((long) (1)));
-        assertThat(sh.getAt(0).getId(), equalTo("1"));
-        assertThat((double) sh.getAt(0).getScore(), closeTo(0.5, 1.e-5));
-
-        response = client().search(
-            new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
-                .source(
-                    searchSource().query(
-                        functionScoreQuery(baseQueryBuilder, gaussDecayFunction("num", 0.0, 1.0, null, 0.5)).boostMode(CombineFunction.MAX)
+        assertResponse(
+            client().search(
+                new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
+                    .source(
+                        searchSource().query(
+                            functionScoreQuery(baseQueryBuilder, gaussDecayFunction("num", 0.0, 1.0, null, 0.5)).boostMode(
+                                CombineFunction.MAX
+                            )
+                        )
                     )
-                )
+            ),
+            response -> {
+                SearchHits sh = response.getHits();
+                assertThat(sh.getTotalHits().value, equalTo((long) (1)));
+                assertThat(sh.getAt(0).getId(), equalTo("1"));
+                assertThat((double) sh.getAt(0).getScore(), closeTo(2.0, 1.e-5));
+            }
         );
-        sr = response.actionGet();
-        sh = sr.getHits();
-        assertThat(sh.getTotalHits().value, equalTo((long) (1)));
-        assertThat(sh.getAt(0).getId(), equalTo("1"));
-        assertThat((double) sh.getAt(0).getScore(), closeTo(2.0, 1.e-5));
-
     }
 
     public void testExceptionThrownIfScaleLE0() throws Exception {
@@ -623,18 +679,18 @@ public class DecayFunctionScoreIT extends ESIntegTestCase {
         ).actionGet();
         refresh();
 
-        ActionFuture<SearchResponse> response = client().search(
-            new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
-                .source(
-                    searchSource().query(functionScoreQuery(termQuery("test", "value"), gaussDecayFunction("num1", "2013-05-28", "-1d")))
-                )
+        SearchPhaseExecutionException e = expectThrows(
+            SearchPhaseExecutionException.class,
+            () -> client().search(
+                new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
+                    .source(
+                        searchSource().query(
+                            functionScoreQuery(termQuery("test", "value"), gaussDecayFunction("num1", "2013-05-28", "-1d"))
+                        )
+                    )
+            ).actionGet()
         );
-        try {
-            response.actionGet();
-            fail("Expected SearchPhaseExecutionException");
-        } catch (SearchPhaseExecutionException e) {
-            assertThat(e.getMessage(), is("all shards failed"));
-        }
+        assertThat(e.getMessage(), is("all shards failed"));
     }
 
     public void testParseDateMath() throws Exception {
@@ -670,24 +726,23 @@ public class DecayFunctionScoreIT extends ESIntegTestCase {
         ).actionGet();
         refresh();
 
-        SearchResponse sr = client().search(
-            new SearchRequest(new String[] {}).source(
-                searchSource().query(functionScoreQuery(termQuery("test", "value"), gaussDecayFunction("num1", "now", "2d")))
-            )
-        ).get();
+        assertNoFailuresAndResponse(
+            client().search(
+                new SearchRequest(new String[] {}).source(
+                    searchSource().query(functionScoreQuery(termQuery("test", "value"), gaussDecayFunction("num1", "now", "2d")))
+                )
+            ),
+            response -> assertOrderedSearchHits(response, "1", "2")
+        );
 
-        assertNoFailures(sr);
-        assertOrderedSearchHits(sr, "1", "2");
-
-        sr = client().search(
-            new SearchRequest(new String[] {}).source(
-                searchSource().query(functionScoreQuery(termQuery("test", "value"), gaussDecayFunction("num1", "now-1d", "2d")))
-            )
-        ).get();
-
-        assertNoFailures(sr);
-        assertOrderedSearchHits(sr, "2", "1");
-
+        assertNoFailuresAndResponse(
+            client().search(
+                new SearchRequest(new String[] {}).source(
+                    searchSource().query(functionScoreQuery(termQuery("test", "value"), gaussDecayFunction("num1", "now-1d", "2d")))
+                )
+            ),
+            response -> assertOrderedSearchHits(response, "2", "1")
+        );
     }
 
     public void testValueMissingLin() throws Exception {
@@ -729,32 +784,31 @@ public class DecayFunctionScoreIT extends ESIntegTestCase {
 
         refresh();
 
-        ActionFuture<SearchResponse> response = client().search(
-            new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
-                .source(
-                    searchSource().query(
-                        functionScoreQuery(
-                            baseQuery,
-                            new FilterFunctionBuilder[] {
-                                new FilterFunctionBuilder(linearDecayFunction("num1", "2013-05-28", "+3d")),
-                                new FilterFunctionBuilder(linearDecayFunction("num2", "0.0", "1")) }
-                        ).scoreMode(FunctionScoreQuery.ScoreMode.MULTIPLY)
+        assertNoFailuresAndResponse(
+            client().search(
+                new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
+                    .source(
+                        searchSource().query(
+                            functionScoreQuery(
+                                baseQuery,
+                                new FilterFunctionBuilder[] {
+                                    new FilterFunctionBuilder(linearDecayFunction("num1", "2013-05-28", "+3d")),
+                                    new FilterFunctionBuilder(linearDecayFunction("num2", "0.0", "1")) }
+                            ).scoreMode(FunctionScoreQuery.ScoreMode.MULTIPLY)
+                        )
                     )
-                )
+            ),
+            response -> {
+                SearchHits sh = response.getHits();
+                assertThat(sh.getHits().length, equalTo(4));
+                double[] scores = new double[4];
+                for (int i = 0; i < sh.getHits().length; i++) {
+                    scores[Integer.parseInt(sh.getAt(i).getId()) - 1] = sh.getAt(i).getScore();
+                }
+                assertThat(scores[0], lessThan(scores[1]));
+                assertThat(scores[2], lessThan(scores[3]));
+            }
         );
-
-        SearchResponse sr = response.actionGet();
-
-        assertNoFailures(sr);
-        SearchHits sh = sr.getHits();
-        assertThat(sh.getHits().length, equalTo(4));
-        double[] scores = new double[4];
-        for (int i = 0; i < sh.getHits().length; i++) {
-            scores[Integer.parseInt(sh.getAt(i).getId()) - 1] = sh.getAt(i).getScore();
-        }
-        assertThat(scores[0], lessThan(scores[1]));
-        assertThat(scores[2], lessThan(scores[3]));
-
     }
 
     public void testDateWithoutOrigin() throws Exception {
@@ -810,32 +864,32 @@ public class DecayFunctionScoreIT extends ESIntegTestCase {
 
         refresh();
 
-        ActionFuture<SearchResponse> response = client().search(
-            new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
-                .source(
-                    searchSource().query(
-                        functionScoreQuery(
-                            QueryBuilders.matchAllQuery(),
-                            new FilterFunctionBuilder[] {
-                                new FilterFunctionBuilder(linearDecayFunction("num1", null, "7000d")),
-                                new FilterFunctionBuilder(gaussDecayFunction("num1", null, "1d")),
-                                new FilterFunctionBuilder(exponentialDecayFunction("num1", null, "7000d")) }
-                        ).scoreMode(FunctionScoreQuery.ScoreMode.MULTIPLY)
+        assertNoFailuresAndResponse(
+            client().search(
+                new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
+                    .source(
+                        searchSource().query(
+                            functionScoreQuery(
+                                QueryBuilders.matchAllQuery(),
+                                new FilterFunctionBuilder[] {
+                                    new FilterFunctionBuilder(linearDecayFunction("num1", null, "7000d")),
+                                    new FilterFunctionBuilder(gaussDecayFunction("num1", null, "1d")),
+                                    new FilterFunctionBuilder(exponentialDecayFunction("num1", null, "7000d")) }
+                            ).scoreMode(FunctionScoreQuery.ScoreMode.MULTIPLY)
+                        )
                     )
-                )
+            ),
+            response -> {
+                SearchHits sh = response.getHits();
+                assertThat(sh.getHits().length, equalTo(3));
+                double[] scores = new double[4];
+                for (int i = 0; i < sh.getHits().length; i++) {
+                    scores[Integer.parseInt(sh.getAt(i).getId()) - 1] = sh.getAt(i).getScore();
+                }
+                assertThat(scores[1], lessThan(scores[0]));
+                assertThat(scores[2], lessThan(scores[1]));
+            }
         );
-
-        SearchResponse sr = response.actionGet();
-        assertNoFailures(sr);
-        SearchHits sh = sr.getHits();
-        assertThat(sh.getHits().length, equalTo(3));
-        double[] scores = new double[4];
-        for (int i = 0; i < sh.getHits().length; i++) {
-            scores[Integer.parseInt(sh.getAt(i).getId()) - 1] = sh.getAt(i).getScore();
-        }
-        assertThat(scores[1], lessThan(scores[0]));
-        assertThat(scores[2], lessThan(scores[1]));
-
     }
 
     public void testManyDocsLin() throws Exception {
@@ -891,33 +945,34 @@ public class DecayFunctionScoreIT extends ESIntegTestCase {
         List<Float> lonlat = new ArrayList<>();
         lonlat.add(100f);
         lonlat.add(110f);
-        ActionFuture<SearchResponse> response = client().search(
-            new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
-                .source(
-                    searchSource().size(numDocs)
-                        .query(
-                            functionScoreQuery(
-                                termQuery("test", "value"),
-                                new FilterFunctionBuilder[] {
-                                    new FilterFunctionBuilder(linearDecayFunction("date", "2013-05-30", "+15d")),
-                                    new FilterFunctionBuilder(linearDecayFunction("geo", lonlat, "1000km")),
-                                    new FilterFunctionBuilder(linearDecayFunction("num", numDocs, numDocs / 2.0)) }
-                            ).scoreMode(ScoreMode.MULTIPLY).boostMode(CombineFunction.REPLACE)
-                        )
-                )
+        assertNoFailuresAndResponse(
+            client().search(
+                new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
+                    .source(
+                        searchSource().size(numDocs)
+                            .query(
+                                functionScoreQuery(
+                                    termQuery("test", "value"),
+                                    new FilterFunctionBuilder[] {
+                                        new FilterFunctionBuilder(linearDecayFunction("date", "2013-05-30", "+15d")),
+                                        new FilterFunctionBuilder(linearDecayFunction("geo", lonlat, "1000km")),
+                                        new FilterFunctionBuilder(linearDecayFunction("num", numDocs, numDocs / 2.0)) }
+                                ).scoreMode(ScoreMode.MULTIPLY).boostMode(CombineFunction.REPLACE)
+                            )
+                    )
+            ),
+            response -> {
+                SearchHits sh = response.getHits();
+                assertThat(sh.getHits().length, equalTo(numDocs));
+                double[] scores = new double[numDocs];
+                for (int i = 0; i < numDocs; i++) {
+                    scores[Integer.parseInt(sh.getAt(i).getId())] = sh.getAt(i).getScore();
+                }
+                for (int i = 0; i < numDocs - 1; i++) {
+                    assertThat(scores[i], lessThan(scores[i + 1]));
+                }
+            }
         );
-
-        SearchResponse sr = response.actionGet();
-        assertNoFailures(sr);
-        SearchHits sh = sr.getHits();
-        assertThat(sh.getHits().length, equalTo(numDocs));
-        double[] scores = new double[numDocs];
-        for (int i = 0; i < numDocs; i++) {
-            scores[Integer.parseInt(sh.getAt(i).getId())] = sh.getAt(i).getScore();
-        }
-        for (int i = 0; i < numDocs - 1; i++) {
-            assertThat(scores[i], lessThan(scores[i + 1]));
-        }
     }
 
     public void testParsingExceptionIfFieldDoesNotExist() throws Exception {
@@ -953,23 +1008,22 @@ public class DecayFunctionScoreIT extends ESIntegTestCase {
         List<Float> lonlat = new ArrayList<>();
         lonlat.add(100f);
         lonlat.add(110f);
-        ActionFuture<SearchResponse> response = client().search(
-            new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
-                .source(
-                    searchSource().size(numDocs)
-                        .query(
-                            functionScoreQuery(termQuery("test", "value"), linearDecayFunction("type.geo", lonlat, "1000km")).scoreMode(
-                                FunctionScoreQuery.ScoreMode.MULTIPLY
+
+        SearchPhaseExecutionException e = expectThrows(
+            SearchPhaseExecutionException.class,
+            () -> client().search(
+                new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
+                    .source(
+                        searchSource().size(numDocs)
+                            .query(
+                                functionScoreQuery(termQuery("test", "value"), linearDecayFunction("type.geo", lonlat, "1000km")).scoreMode(
+                                    FunctionScoreQuery.ScoreMode.MULTIPLY
+                                )
                             )
-                        )
-                )
+                    )
+            ).actionGet()
         );
-        try {
-            response.actionGet();
-            fail("Expected SearchPhaseExecutionException");
-        } catch (SearchPhaseExecutionException e) {
-            assertThat(e.getMessage(), is("all shards failed"));
-        }
+        assertThat(e.getMessage(), is("all shards failed"));
     }
 
     public void testParsingExceptionIfFieldTypeDoesNotMatch() throws Exception {
@@ -996,20 +1050,20 @@ public class DecayFunctionScoreIT extends ESIntegTestCase {
         ).actionGet();
         refresh();
         // so, we indexed a string field, but now we try to score a num field
-        ActionFuture<SearchResponse> response = client().search(
-            new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
-                .source(
-                    searchSource().query(
-                        functionScoreQuery(termQuery("test", "value"), linearDecayFunction("num", 1.0, 0.5)).scoreMode(ScoreMode.MULTIPLY)
+        SearchPhaseExecutionException e = expectThrows(
+            SearchPhaseExecutionException.class,
+            () -> client().search(
+                new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
+                    .source(
+                        searchSource().query(
+                            functionScoreQuery(termQuery("test", "value"), linearDecayFunction("num", 1.0, 0.5)).scoreMode(
+                                ScoreMode.MULTIPLY
+                            )
+                        )
                     )
-                )
+            ).actionGet()
         );
-        try {
-            response.actionGet();
-            fail("Expected SearchPhaseExecutionException");
-        } catch (SearchPhaseExecutionException e) {
-            assertThat(e.getMessage(), is("all shards failed"));
-        }
+        assertThat(e.getMessage(), is("all shards failed"));
     }
 
     public void testNoQueryGiven() throws Exception {
@@ -1033,15 +1087,17 @@ public class DecayFunctionScoreIT extends ESIntegTestCase {
             .actionGet();
         refresh();
         // so, we indexed a string field, but now we try to score a num field
-        ActionFuture<SearchResponse> response = client().search(
-            new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
-                .source(
-                    searchSource().query(
-                        functionScoreQuery(linearDecayFunction("num", 1, 0.5)).scoreMode(FunctionScoreQuery.ScoreMode.MULTIPLY)
+        assertResponse(
+            client().search(
+                new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
+                    .source(
+                        searchSource().query(
+                            functionScoreQuery(linearDecayFunction("num", 1, 0.5)).scoreMode(FunctionScoreQuery.ScoreMode.MULTIPLY)
+                        )
                     )
-                )
+            ),
+            response -> {}
         );
-        response.actionGet();
     }
 
     public void testMultiFieldOptions() throws Exception {
@@ -1099,41 +1155,47 @@ public class DecayFunctionScoreIT extends ESIntegTestCase {
 
         indexRandom(true, doc1, doc2);
 
-        ActionFuture<SearchResponse> response = client().search(new SearchRequest(new String[] {}).source(searchSource().query(baseQuery)));
-        SearchResponse sr = response.actionGet();
-        assertSearchHits(sr, "1", "2");
-        SearchHits sh = sr.getHits();
-        assertThat(sh.getTotalHits().value, equalTo((long) (2)));
+        assertResponse(client().search(new SearchRequest(new String[] {}).source(searchSource().query(baseQuery))), response -> {
+            assertSearchHits(response, "1", "2");
+            SearchHits sh = response.getHits();
+            assertThat(sh.getTotalHits().value, equalTo((long) (2)));
+        });
 
         List<Float> lonlat = new ArrayList<>();
         lonlat.add(20f);
         lonlat.add(10f);
-        response = client().search(
-            new SearchRequest(new String[] {}).source(
-                searchSource().query(
-                    functionScoreQuery(baseQuery, gaussDecayFunction("loc", lonlat, "1000km").setMultiValueMode(MultiValueMode.MIN))
+        assertResponse(
+            client().search(
+                new SearchRequest(new String[] {}).source(
+                    searchSource().query(
+                        functionScoreQuery(baseQuery, gaussDecayFunction("loc", lonlat, "1000km").setMultiValueMode(MultiValueMode.MIN))
+                    )
                 )
-            )
-        );
-        sr = response.actionGet();
-        assertSearchHits(sr, "1", "2");
-        sh = sr.getHits();
+            ),
+            response -> {
+                assertSearchHits(response, "1", "2");
+                SearchHits sh = response.getHits();
 
-        assertThat(sh.getAt(0).getId(), equalTo("1"));
-        assertThat(sh.getAt(1).getId(), equalTo("2"));
-        response = client().search(
-            new SearchRequest(new String[] {}).source(
-                searchSource().query(
-                    functionScoreQuery(baseQuery, gaussDecayFunction("loc", lonlat, "1000km").setMultiValueMode(MultiValueMode.MAX))
+                assertThat(sh.getAt(0).getId(), equalTo("1"));
+                assertThat(sh.getAt(1).getId(), equalTo("2"));
+            }
+        );
+        assertResponse(
+            client().search(
+                new SearchRequest(new String[] {}).source(
+                    searchSource().query(
+                        functionScoreQuery(baseQuery, gaussDecayFunction("loc", lonlat, "1000km").setMultiValueMode(MultiValueMode.MAX))
+                    )
                 )
-            )
-        );
-        sr = response.actionGet();
-        assertSearchHits(sr, "1", "2");
-        sh = sr.getHits();
+            ),
+            response -> {
+                assertSearchHits(response, "1", "2");
+                SearchHits sh = response.getHits();
 
-        assertThat(sh.getAt(0).getId(), equalTo("2"));
-        assertThat(sh.getAt(1).getId(), equalTo("1"));
+                assertThat(sh.getAt(0).getId(), equalTo("2"));
+                assertThat(sh.getAt(1).getId(), equalTo("1"));
+            }
+        );
 
         // Now test AVG and SUM
 
@@ -1149,30 +1211,36 @@ public class DecayFunctionScoreIT extends ESIntegTestCase {
             .setSource(jsonBuilder().startObject().field("test", "value").field("num", 1.0).endObject());
 
         indexRandom(true, doc1, doc2);
-        response = client().search(
-            new SearchRequest(new String[] {}).source(
-                searchSource().query(
-                    functionScoreQuery(baseQuery, linearDecayFunction("num", "0", "10").setMultiValueMode(MultiValueMode.SUM))
+        assertResponse(
+            client().search(
+                new SearchRequest(new String[] {}).source(
+                    searchSource().query(
+                        functionScoreQuery(baseQuery, linearDecayFunction("num", "0", "10").setMultiValueMode(MultiValueMode.SUM))
+                    )
                 )
-            )
-        );
-        sr = response.actionGet();
-        assertSearchHits(sr, "1", "2");
-        sh = sr.getHits();
+            ),
+            response -> {
+                assertSearchHits(response, "1", "2");
+                SearchHits sh = response.getHits();
 
-        assertThat(sh.getAt(0).getId(), equalTo("2"));
-        assertThat(sh.getAt(1).getId(), equalTo("1"));
-        assertThat(1.0 - sh.getAt(0).getScore(), closeTo((1.0 - sh.getAt(1).getScore()) / 3.0, 1.e-6d));
-        response = client().search(
-            new SearchRequest(new String[] {}).source(
-                searchSource().query(
-                    functionScoreQuery(baseQuery, linearDecayFunction("num", "0", "10").setMultiValueMode(MultiValueMode.AVG))
-                )
-            )
+                assertThat(sh.getAt(0).getId(), equalTo("2"));
+                assertThat(sh.getAt(1).getId(), equalTo("1"));
+                assertThat(1.0 - sh.getAt(0).getScore(), closeTo((1.0 - sh.getAt(1).getScore()) / 3.0, 1.e-6d));
+            }
         );
-        sr = response.actionGet();
-        assertSearchHits(sr, "1", "2");
-        sh = sr.getHits();
-        assertThat((double) (sh.getAt(0).getScore()), closeTo((sh.getAt(1).getScore()), 1.e-6d));
+        assertResponse(
+            client().search(
+                new SearchRequest(new String[] {}).source(
+                    searchSource().query(
+                        functionScoreQuery(baseQuery, linearDecayFunction("num", "0", "10").setMultiValueMode(MultiValueMode.AVG))
+                    )
+                )
+            ),
+            response -> {
+                assertSearchHits(response, "1", "2");
+                SearchHits sh = response.getHits();
+                assertThat((double) (sh.getAt(0).getScore()), closeTo((sh.getAt(1).getScore()), 1.e-6d));
+            }
+        );
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/functionscore/ExplainableScriptIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/functionscore/ExplainableScriptIT.java
@@ -12,7 +12,6 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.Explanation;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.common.lucene.search.function.CombineFunction;
 import org.elasticsearch.common.settings.Settings;
@@ -41,12 +40,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 
 import static org.elasticsearch.index.query.QueryBuilders.functionScoreQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 import static org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders.scriptFunction;
 import static org.elasticsearch.search.builder.SearchSourceBuilder.searchSource;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -112,7 +112,7 @@ public class ExplainableScriptIT extends ESIntegTestCase {
         return Arrays.asList(ExplainableScriptPlugin.class);
     }
 
-    public void testExplainScript() throws InterruptedException, IOException {
+    public void testExplainScript() throws InterruptedException, IOException, ExecutionException {
         List<IndexRequestBuilder> indexRequests = new ArrayList<>();
         for (int i = 0; i < 20; i++) {
             indexRequests.add(
@@ -124,28 +124,30 @@ public class ExplainableScriptIT extends ESIntegTestCase {
         indexRandom(true, true, indexRequests);
         client().admin().indices().prepareRefresh().get();
         ensureYellow();
-        SearchResponse response = client().search(
-            new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
-                .source(
-                    searchSource().explain(true)
-                        .query(
-                            functionScoreQuery(
-                                termQuery("text", "text"),
-                                scriptFunction(new Script(ScriptType.INLINE, "test", "explainable_script", Collections.emptyMap()))
-                            ).boostMode(CombineFunction.REPLACE)
-                        )
-                )
-        ).actionGet();
-
-        assertNoFailures(response);
-        SearchHits hits = response.getHits();
-        assertThat(hits.getTotalHits().value, equalTo(20L));
-        int idCounter = 19;
-        for (SearchHit hit : hits.getHits()) {
-            assertThat(hit.getId(), equalTo(Integer.toString(idCounter)));
-            assertThat(hit.getExplanation().toString(), containsString(Double.toString(idCounter)));
-            assertThat(hit.getExplanation().getDetails().length, equalTo(2));
-            idCounter--;
-        }
+        assertNoFailuresAndResponse(
+            client().search(
+                new SearchRequest(new String[] {}).searchType(SearchType.QUERY_THEN_FETCH)
+                    .source(
+                        searchSource().explain(true)
+                            .query(
+                                functionScoreQuery(
+                                    termQuery("text", "text"),
+                                    scriptFunction(new Script(ScriptType.INLINE, "test", "explainable_script", Collections.emptyMap()))
+                                ).boostMode(CombineFunction.REPLACE)
+                            )
+                    )
+            ),
+            response -> {
+                SearchHits hits = response.getHits();
+                assertThat(hits.getTotalHits().value, equalTo(20L));
+                int idCounter = 19;
+                for (SearchHit hit : hits.getHits()) {
+                    assertThat(hit.getId(), equalTo(Integer.toString(idCounter)));
+                    assertThat(hit.getExplanation().toString(), containsString(Double.toString(idCounter)));
+                    assertThat(hit.getExplanation().getDetails().length, equalTo(2));
+                    idCounter--;
+                }
+            }
+        );
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/functionscore/FunctionScoreFieldValueIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/functionscore/FunctionScoreFieldValueIT.java
@@ -9,9 +9,9 @@
 package org.elasticsearch.search.functionscore;
 
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.lucene.search.function.FieldValueFactorFunction;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 
 import java.io.IOException;
 
@@ -20,8 +20,8 @@ import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.index.query.QueryBuilders.simpleQueryStringQuery;
 import static org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders.fieldValueFactorFunction;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertOrderedSearchHits;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 
 /**
@@ -88,10 +88,11 @@ public class FunctionScoreFieldValueIT extends ESIntegTestCase {
 
         // doc 3 doesn't have a "test" field, so an exception will be thrown
         try {
-            SearchResponse response = prepareSearch("test").setExplain(randomBoolean())
-                .setQuery(functionScoreQuery(matchAllQuery(), fieldValueFactorFunction("test")))
-                .get();
-            assertFailures(response);
+            assertResponse(
+                prepareSearch("test").setExplain(randomBoolean())
+                    .setQuery(functionScoreQuery(matchAllQuery(), fieldValueFactorFunction("test"))),
+                ElasticsearchAssertions::assertFailures
+            );
         } catch (SearchPhaseExecutionException e) {
             // We are expecting an exception, because 3 has no field
         }
@@ -111,30 +112,32 @@ public class FunctionScoreFieldValueIT extends ESIntegTestCase {
         );
 
         // field is not mapped but we're defaulting it to 100 so all documents should have the same score
-        SearchResponse response = prepareSearch("test").setExplain(randomBoolean())
-            .setQuery(
-                functionScoreQuery(
-                    matchAllQuery(),
-                    fieldValueFactorFunction("notmapped").modifier(FieldValueFactorFunction.Modifier.RECIPROCAL).missing(100)
-                )
-            )
-            .get();
-        assertEquals(response.getHits().getAt(0).getScore(), response.getHits().getAt(2).getScore(), 0);
+        assertResponse(
+            prepareSearch("test").setExplain(randomBoolean())
+                .setQuery(
+                    functionScoreQuery(
+                        matchAllQuery(),
+                        fieldValueFactorFunction("notmapped").modifier(FieldValueFactorFunction.Modifier.RECIPROCAL).missing(100)
+                    )
+                ),
+            response -> assertEquals(response.getHits().getAt(0).getScore(), response.getHits().getAt(2).getScore(), 0)
+        );
 
         client().prepareIndex("test").setId("2").setSource("test", -1, "body", "foo").get();
         refresh();
 
         // -1 divided by 0 is infinity, which should provoke an exception.
         try {
-            response = prepareSearch("test").setExplain(randomBoolean())
-                .setQuery(
-                    functionScoreQuery(
-                        simpleQueryStringQuery("foo"),
-                        fieldValueFactorFunction("test").modifier(FieldValueFactorFunction.Modifier.RECIPROCAL).factor(0)
-                    )
-                )
-                .get();
-            assertFailures(response);
+            assertResponse(
+                prepareSearch("test").setExplain(randomBoolean())
+                    .setQuery(
+                        functionScoreQuery(
+                            simpleQueryStringQuery("foo"),
+                            fieldValueFactorFunction("test").modifier(FieldValueFactorFunction.Modifier.RECIPROCAL).factor(0)
+                        )
+                    ),
+                ElasticsearchAssertions::assertFailures
+            );
         } catch (SearchPhaseExecutionException e) {
             // This is fine, the query will throw an exception if executed
             // locally, instead of just having failures

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/functionscore/FunctionScoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/functionscore/FunctionScoreIT.java
@@ -41,6 +41,8 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.search.builder.SearchSourceBuilder.searchSource;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -76,7 +78,7 @@ public class FunctionScoreIT extends ESIntegTestCase {
         }
     }
 
-    public void testScriptScoresNested() throws IOException {
+    public void testScriptScoresNested() throws Exception {
         createIndex(INDEX);
         index(INDEX, "1", jsonBuilder().startObject().field("dummy_field", 1).endObject());
         refresh();
@@ -84,39 +86,46 @@ public class FunctionScoreIT extends ESIntegTestCase {
         Script scriptOne = new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "1", Collections.emptyMap());
         Script scriptTwo = new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "get score value", Collections.emptyMap());
 
-        SearchResponse response = client().search(
-            new SearchRequest(new String[] {}).source(
-                searchSource().query(
-                    functionScoreQuery(
-                        functionScoreQuery(functionScoreQuery(scriptFunction(scriptOne)), scriptFunction(scriptTwo)),
-                        scriptFunction(scriptTwo)
+        assertNoFailuresAndResponse(
+            client().search(
+                new SearchRequest(new String[] {}).source(
+                    searchSource().query(
+                        functionScoreQuery(
+                            functionScoreQuery(functionScoreQuery(scriptFunction(scriptOne)), scriptFunction(scriptTwo)),
+                            scriptFunction(scriptTwo)
+                        )
                     )
                 )
-            )
-        ).actionGet();
-        assertNoFailures(response);
-        assertThat(response.getHits().getAt(0).getScore(), equalTo(1.0f));
+            ),
+            response -> assertThat(response.getHits().getAt(0).getScore(), equalTo(1.0f))
+        );
     }
 
-    public void testScriptScoresWithAgg() throws IOException {
+    public void testScriptScoresWithAgg() throws Exception {
         createIndex(INDEX);
         index(INDEX, "1", jsonBuilder().startObject().field("dummy_field", 1).endObject());
         refresh();
 
         Script script = new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "get score value", Collections.emptyMap());
 
-        SearchResponse response = client().search(
-            new SearchRequest(new String[] {}).source(
-                searchSource().query(functionScoreQuery(scriptFunction(script))).aggregation(terms("score_agg").script(script))
-            )
-        ).actionGet();
-        assertNoFailures(response);
-        assertThat(response.getHits().getAt(0).getScore(), equalTo(1.0f));
-        assertThat(((Terms) response.getAggregations().asMap().get("score_agg")).getBuckets().get(0).getKeyAsString(), equalTo("1.0"));
-        assertThat(((Terms) response.getAggregations().asMap().get("score_agg")).getBuckets().get(0).getDocCount(), is(1L));
+        assertNoFailuresAndResponse(
+            client().search(
+                new SearchRequest(new String[] {}).source(
+                    searchSource().query(functionScoreQuery(scriptFunction(script))).aggregation(terms("score_agg").script(script))
+                )
+            ),
+            response -> {
+                assertThat(response.getHits().getAt(0).getScore(), equalTo(1.0f));
+                assertThat(
+                    ((Terms) response.getAggregations().asMap().get("score_agg")).getBuckets().get(0).getKeyAsString(),
+                    equalTo("1.0")
+                );
+                assertThat(((Terms) response.getAggregations().asMap().get("score_agg")).getBuckets().get(0).getDocCount(), is(1L));
+            }
+        );
     }
 
-    public void testMinScoreFunctionScoreBasic() throws IOException {
+    public void testMinScoreFunctionScoreBasic() throws Exception {
         float score = randomValueOtherThanMany((f) -> Float.compare(f, 0) < 0, ESTestCase::randomFloat);
         float minScore = randomValueOtherThanMany((f) -> Float.compare(f, 0) < 0, ESTestCase::randomFloat);
         index(
@@ -130,34 +139,42 @@ public class FunctionScoreIT extends ESIntegTestCase {
         ensureYellow();
 
         Script script = new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "doc['random_score']", Collections.emptyMap());
-        SearchResponse searchResponse = client().search(
-            new SearchRequest(new String[] {}).source(
-                searchSource().query(functionScoreQuery(scriptFunction(script)).setMinScore(minScore))
-            )
-        ).actionGet();
-        if (score < minScore) {
-            assertThat(searchResponse.getHits().getTotalHits().value, is(0L));
-        } else {
-            assertThat(searchResponse.getHits().getTotalHits().value, is(1L));
-        }
-
-        searchResponse = client().search(
-            new SearchRequest(new String[] {}).source(
-                searchSource().query(
-                    functionScoreQuery(
-                        new MatchAllQueryBuilder(),
-                        new FilterFunctionBuilder[] {
-                            new FilterFunctionBuilder(scriptFunction(script)),
-                            new FilterFunctionBuilder(scriptFunction(script)) }
-                    ).scoreMode(FunctionScoreQuery.ScoreMode.AVG).setMinScore(minScore)
+        assertResponse(
+            client().search(
+                new SearchRequest(new String[] {}).source(
+                    searchSource().query(functionScoreQuery(scriptFunction(script)).setMinScore(minScore))
                 )
-            )
-        ).actionGet();
-        if (score < minScore) {
-            assertThat(searchResponse.getHits().getTotalHits().value, is(0L));
-        } else {
-            assertThat(searchResponse.getHits().getTotalHits().value, is(1L));
-        }
+            ),
+            response -> {
+                if (score < minScore) {
+                    assertThat(response.getHits().getTotalHits().value, is(0L));
+                } else {
+                    assertThat(response.getHits().getTotalHits().value, is(1L));
+                }
+            }
+        );
+
+        assertResponse(
+            client().search(
+                new SearchRequest(new String[] {}).source(
+                    searchSource().query(
+                        functionScoreQuery(
+                            new MatchAllQueryBuilder(),
+                            new FilterFunctionBuilder[] {
+                                new FilterFunctionBuilder(scriptFunction(script)),
+                                new FilterFunctionBuilder(scriptFunction(script)) }
+                        ).scoreMode(FunctionScoreQuery.ScoreMode.AVG).setMinScore(minScore)
+                    )
+                )
+            ),
+            response -> {
+                if (score < minScore) {
+                    assertThat(response.getHits().getTotalHits().value, is(0L));
+                } else {
+                    assertThat(response.getHits().getTotalHits().value, is(1L));
+                }
+            }
+        );
     }
 
     public void testMinScoreFunctionScoreManyDocsAndRandomMinScore() throws IOException, ExecutionException, InterruptedException {
@@ -178,26 +195,33 @@ public class FunctionScoreIT extends ESIntegTestCase {
             numMatchingDocs = numDocs;
         }
 
-        SearchResponse searchResponse = client().search(
-            new SearchRequest(new String[] {}).source(
-                searchSource().query(functionScoreQuery(scriptFunction(script)).setMinScore(minScore)).size(numDocs)
-            )
-        ).actionGet();
-        assertMinScoreSearchResponses(numDocs, searchResponse, numMatchingDocs);
+        final int finalNumMatchingDocs = numMatchingDocs;
 
-        searchResponse = client().search(
-            new SearchRequest(new String[] {}).source(
-                searchSource().query(
-                    functionScoreQuery(
-                        new MatchAllQueryBuilder(),
-                        new FilterFunctionBuilder[] {
-                            new FilterFunctionBuilder(scriptFunction(script)),
-                            new FilterFunctionBuilder(scriptFunction(script)) }
-                    ).scoreMode(FunctionScoreQuery.ScoreMode.AVG).setMinScore(minScore)
-                ).size(numDocs)
-            )
-        ).actionGet();
-        assertMinScoreSearchResponses(numDocs, searchResponse, numMatchingDocs);
+        assertResponse(
+            client().search(
+                new SearchRequest(new String[] {}).source(
+                    searchSource().query(functionScoreQuery(scriptFunction(script)).setMinScore(minScore)).size(numDocs)
+                )
+            ),
+            response -> assertMinScoreSearchResponses(numDocs, response, finalNumMatchingDocs)
+        );
+
+        assertResponse(
+            client().search(
+                new SearchRequest(new String[] {}).source(
+                    searchSource().query(
+                        functionScoreQuery(
+                            new MatchAllQueryBuilder(),
+                            new FilterFunctionBuilder[] {
+                                new FilterFunctionBuilder(scriptFunction(script)),
+                                new FilterFunctionBuilder(scriptFunction(script)) }
+                        ).scoreMode(FunctionScoreQuery.ScoreMode.AVG).setMinScore(minScore)
+                    ).size(numDocs)
+                )
+            ),
+            response -> assertMinScoreSearchResponses(numDocs, response, finalNumMatchingDocs)
+        );
+
     }
 
     protected void assertMinScoreSearchResponses(int numDocs, SearchResponse searchResponse, int numMatchingDocs) {
@@ -216,35 +240,38 @@ public class FunctionScoreIT extends ESIntegTestCase {
         index("test", "1", jsonBuilder().startObject().field("text", "test text").endObject());
         refresh();
 
-        SearchResponse termQuery = client().search(
-            new SearchRequest(new String[] {}).source(searchSource().explain(true).query(termQuery("text", "text")))
-        ).get();
-        assertNoFailures(termQuery);
-        assertThat(termQuery.getHits().getTotalHits().value, equalTo(1L));
-        float termQueryScore = termQuery.getHits().getAt(0).getScore();
-
+        float[] termQueryScore = new float[1];
+        assertNoFailuresAndResponse(
+            client().search(new SearchRequest(new String[] {}).source(searchSource().explain(true).query(termQuery("text", "text")))),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(1L));
+                termQueryScore[0] = response.getHits().getAt(0).getScore();
+            }
+        );
         for (CombineFunction combineFunction : CombineFunction.values()) {
-            testMinScoreApplied(combineFunction, termQueryScore);
+            testMinScoreApplied(combineFunction, termQueryScore[0]);
         }
     }
 
     protected void testMinScoreApplied(CombineFunction boostMode, float expectedScore) throws InterruptedException, ExecutionException {
-        SearchResponse response = client().search(
-            new SearchRequest(new String[] {}).source(
-                searchSource().explain(true).query(functionScoreQuery(termQuery("text", "text")).boostMode(boostMode).setMinScore(0.1f))
-            )
-        ).get();
-        assertNoFailures(response);
-        assertThat(response.getHits().getTotalHits().value, equalTo(1L));
-        assertThat(response.getHits().getAt(0).getScore(), equalTo(expectedScore));
-
-        response = client().search(
-            new SearchRequest(new String[] {}).source(
-                searchSource().explain(true).query(functionScoreQuery(termQuery("text", "text")).boostMode(boostMode).setMinScore(2f))
-            )
-        ).get();
-
-        assertNoFailures(response);
-        assertThat(response.getHits().getTotalHits().value, equalTo(0L));
+        assertNoFailuresAndResponse(
+            client().search(
+                new SearchRequest(new String[] {}).source(
+                    searchSource().explain(true).query(functionScoreQuery(termQuery("text", "text")).boostMode(boostMode).setMinScore(0.1f))
+                )
+            ),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(1L));
+                assertThat(response.getHits().getAt(0).getScore(), equalTo(expectedScore));
+            }
+        );
+        assertNoFailuresAndResponse(
+            client().search(
+                new SearchRequest(new String[] {}).source(
+                    searchSource().explain(true).query(functionScoreQuery(termQuery("text", "text")).boostMode(boostMode).setMinScore(2f))
+                )
+            ),
+            response -> assertThat(response.getHits().getTotalHits().value, equalTo(0L))
+        );
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/functionscore/QueryRescorerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/functionscore/QueryRescorerIT.java
@@ -49,6 +49,8 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFirs
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFourthHit;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSecondHit;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertThirdHit;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.hasId;
@@ -72,29 +74,31 @@ public class QueryRescorerIT extends ESIntegTestCase {
 
         int numShards = getNumShards("test").numPrimaries;
         for (int j = 0; j < iters; j++) {
-            SearchResponse searchResponse = prepareSearch().setQuery(QueryBuilders.matchAllQuery())
-                .setRescorer(
-                    new QueryRescorerBuilder(
-                        functionScoreQuery(matchAllQuery(), ScoreFunctionBuilders.weightFactorFunction(100)).boostMode(
-                            CombineFunction.REPLACE
-                        ).queryName("hello world")
-                    ).setQueryWeight(0.0f).setRescoreQueryWeight(1.0f),
-                    1
-                )
-                .setSize(randomIntBetween(2, 10))
-                .get();
-            assertNoFailures(searchResponse);
-            assertFirstHit(searchResponse, hasScore(100.f));
-            int numDocsWith100AsAScore = 0;
-            for (int i = 0; i < searchResponse.getHits().getHits().length; i++) {
-                float score = searchResponse.getHits().getHits()[i].getScore();
-                if (score == 100f) {
-                    numDocsWith100AsAScore += 1;
+            assertNoFailuresAndResponse(
+                prepareSearch().setQuery(QueryBuilders.matchAllQuery())
+                    .setRescorer(
+                        new QueryRescorerBuilder(
+                            functionScoreQuery(matchAllQuery(), ScoreFunctionBuilders.weightFactorFunction(100)).boostMode(
+                                CombineFunction.REPLACE
+                            ).queryName("hello world")
+                        ).setQueryWeight(0.0f).setRescoreQueryWeight(1.0f),
+                        1
+                    )
+                    .setSize(randomIntBetween(2, 10)),
+                response -> {
+                    assertFirstHit(response, hasScore(100.f));
+                    int numDocsWith100AsAScore = 0;
+                    for (int i = 0; i < response.getHits().getHits().length; i++) {
+                        float score = response.getHits().getHits()[i].getScore();
+                        if (score == 100f) {
+                            numDocsWith100AsAScore += 1;
+                        }
+                    }
+                    assertThat(response.getHits().getMaxScore(), equalTo(response.getHits().getHits()[0].getScore()));
+                    // we cannot assert that they are equal since some shards might not have docs at all
+                    assertThat(numDocsWith100AsAScore, lessThanOrEqualTo(numShards));
                 }
-            }
-            assertThat(searchResponse.getHits().getMaxScore(), equalTo(searchResponse.getHits().getHits()[0].getScore()));
-            // we cannot assert that they are equal since some shards might not have docs at all
-            assertThat(numDocsWith100AsAScore, lessThanOrEqualTo(numShards));
+            );
         }
     }
 
@@ -121,39 +125,41 @@ public class QueryRescorerIT extends ESIntegTestCase {
             .setSource("field1", "quick huge brown", "field2", "the quick lazy huge brown fox jumps over the tree")
             .get();
         refresh();
-        SearchResponse searchResponse = prepareSearch().setQuery(
-            QueryBuilders.matchQuery("field1", "the quick brown").operator(Operator.OR)
-        )
-            .setRescorer(
-                new QueryRescorerBuilder(matchPhraseQuery("field1", "quick brown").slop(2).boost(4.0f)).setRescoreQueryWeight(2),
-                5
-            )
-            .get();
-
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(3L));
-        assertThat(searchResponse.getHits().getMaxScore(), equalTo(searchResponse.getHits().getHits()[0].getScore()));
-        assertThat(searchResponse.getHits().getHits()[0].getId(), equalTo("1"));
-        assertThat(searchResponse.getHits().getHits()[1].getId(), equalTo("3"));
-        assertThat(searchResponse.getHits().getHits()[2].getId(), equalTo("2"));
-
-        searchResponse = prepareSearch().setQuery(QueryBuilders.matchQuery("field1", "the quick brown").operator(Operator.OR))
-            .setRescorer(new QueryRescorerBuilder(matchPhraseQuery("field1", "the quick brown").slop(3)), 5)
-            .get();
-
-        assertHitCount(searchResponse, 3);
-        assertFirstHit(searchResponse, hasId("1"));
-        assertSecondHit(searchResponse, hasId("2"));
-        assertThirdHit(searchResponse, hasId("3"));
-
-        searchResponse = prepareSearch().setQuery(QueryBuilders.matchQuery("field1", "the quick brown").operator(Operator.OR))
-            .setRescorer(new QueryRescorerBuilder(matchPhraseQuery("field1", "the quick brown")), 5)
-            .get();
-
-        assertHitCount(searchResponse, 3);
-        assertThat(searchResponse.getHits().getMaxScore(), equalTo(searchResponse.getHits().getHits()[0].getScore()));
-        assertFirstHit(searchResponse, hasId("1"));
-        assertSecondHit(searchResponse, hasId("2"));
-        assertThirdHit(searchResponse, hasId("3"));
+        assertResponse(
+            prepareSearch().setQuery(QueryBuilders.matchQuery("field1", "the quick brown").operator(Operator.OR))
+                .setRescorer(
+                    new QueryRescorerBuilder(matchPhraseQuery("field1", "quick brown").slop(2).boost(4.0f)).setRescoreQueryWeight(2),
+                    5
+                ),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(3L));
+                assertThat(response.getHits().getMaxScore(), equalTo(response.getHits().getHits()[0].getScore()));
+                assertThat(response.getHits().getHits()[0].getId(), equalTo("1"));
+                assertThat(response.getHits().getHits()[1].getId(), equalTo("3"));
+                assertThat(response.getHits().getHits()[2].getId(), equalTo("2"));
+            }
+        );
+        assertResponse(
+            prepareSearch().setQuery(QueryBuilders.matchQuery("field1", "the quick brown").operator(Operator.OR))
+                .setRescorer(new QueryRescorerBuilder(matchPhraseQuery("field1", "the quick brown").slop(3)), 5),
+            response -> {
+                assertHitCount(response, 3);
+                assertFirstHit(response, hasId("1"));
+                assertSecondHit(response, hasId("2"));
+                assertThirdHit(response, hasId("3"));
+            }
+        );
+        assertResponse(
+            prepareSearch().setQuery(QueryBuilders.matchQuery("field1", "the quick brown").operator(Operator.OR))
+                .setRescorer(new QueryRescorerBuilder(matchPhraseQuery("field1", "the quick brown")), 5),
+            response -> {
+                assertHitCount(response, 3);
+                assertThat(response.getHits().getMaxScore(), equalTo(response.getHits().getHits()[0].getScore()));
+                assertFirstHit(response, hasId("1"));
+                assertSecondHit(response, hasId("2"));
+                assertThirdHit(response, hasId("3"));
+            }
+        );
     }
 
     public void testMoreDocs() throws Exception {
@@ -189,62 +195,61 @@ public class QueryRescorerIT extends ESIntegTestCase {
         client().prepareIndex("test").setId("11").setSource("field1", "2st street boston massachusetts").get();
         client().prepareIndex("test").setId("12").setSource("field1", "3st street boston massachusetts").get();
         indicesAdmin().prepareRefresh("test").get();
-        SearchResponse searchResponse = prepareSearch().setQuery(
-            QueryBuilders.matchQuery("field1", "lexington avenue massachusetts").operator(Operator.OR)
-        )
-            .setFrom(0)
-            .setSize(5)
-            .setRescorer(
-                new QueryRescorerBuilder(matchPhraseQuery("field1", "lexington avenue massachusetts").slop(3)).setQueryWeight(0.6f)
-                    .setRescoreQueryWeight(2.0f),
-                20
-            )
-            .get();
+        assertResponse(
+            prepareSearch().setQuery(QueryBuilders.matchQuery("field1", "lexington avenue massachusetts").operator(Operator.OR))
+                .setFrom(0)
+                .setSize(5)
+                .setRescorer(
+                    new QueryRescorerBuilder(matchPhraseQuery("field1", "lexington avenue massachusetts").slop(3)).setQueryWeight(0.6f)
+                        .setRescoreQueryWeight(2.0f),
+                    20
+                ),
+            response -> {
+                assertThat(response.getHits().getHits().length, equalTo(5));
+                assertHitCount(response, 9);
+                assertFirstHit(response, hasId("2"));
+                assertSecondHit(response, hasId("6"));
+                assertThirdHit(response, hasId("3"));
+            }
+        );
 
-        assertThat(searchResponse.getHits().getHits().length, equalTo(5));
-        assertHitCount(searchResponse, 9);
-        assertFirstHit(searchResponse, hasId("2"));
-        assertSecondHit(searchResponse, hasId("6"));
-        assertThirdHit(searchResponse, hasId("3"));
-
-        searchResponse = prepareSearch().setQuery(
-            QueryBuilders.matchQuery("field1", "lexington avenue massachusetts").operator(Operator.OR)
-        )
-            .setFrom(0)
-            .setSize(5)
-            .setSearchType(SearchType.DFS_QUERY_THEN_FETCH)
-            .setRescorer(
-                new QueryRescorerBuilder(matchPhraseQuery("field1", "lexington avenue massachusetts").slop(3)).setQueryWeight(0.6f)
-                    .setRescoreQueryWeight(2.0f),
-                20
-            )
-            .get();
-
-        assertThat(searchResponse.getHits().getHits().length, equalTo(5));
-        assertHitCount(searchResponse, 9);
-        assertThat(searchResponse.getHits().getMaxScore(), equalTo(searchResponse.getHits().getHits()[0].getScore()));
-        assertFirstHit(searchResponse, hasId("2"));
-        assertSecondHit(searchResponse, hasId("6"));
-        assertThirdHit(searchResponse, hasId("3"));
-
+        assertResponse(
+            prepareSearch().setQuery(QueryBuilders.matchQuery("field1", "lexington avenue massachusetts").operator(Operator.OR))
+                .setFrom(0)
+                .setSize(5)
+                .setSearchType(SearchType.DFS_QUERY_THEN_FETCH)
+                .setRescorer(
+                    new QueryRescorerBuilder(matchPhraseQuery("field1", "lexington avenue massachusetts").slop(3)).setQueryWeight(0.6f)
+                        .setRescoreQueryWeight(2.0f),
+                    20
+                ),
+            response -> {
+                assertThat(response.getHits().getHits().length, equalTo(5));
+                assertHitCount(response, 9);
+                assertThat(response.getHits().getMaxScore(), equalTo(response.getHits().getHits()[0].getScore()));
+                assertFirstHit(response, hasId("2"));
+                assertSecondHit(response, hasId("6"));
+                assertThirdHit(response, hasId("3"));
+            }
+        );
         // Make sure non-zero from works:
-        searchResponse = prepareSearch().setQuery(
-            QueryBuilders.matchQuery("field1", "lexington avenue massachusetts").operator(Operator.OR)
-        )
-            .setFrom(2)
-            .setSize(5)
-            .setSearchType(SearchType.DFS_QUERY_THEN_FETCH)
-            .setRescorer(
-                new QueryRescorerBuilder(matchPhraseQuery("field1", "lexington avenue massachusetts").slop(3)).setQueryWeight(0.6f)
-                    .setRescoreQueryWeight(2.0f),
-                20
-            )
-            .get();
-
-        assertThat(searchResponse.getHits().getHits().length, equalTo(5));
-        assertHitCount(searchResponse, 9);
-        assertThat(searchResponse.getHits().getMaxScore(), greaterThan(searchResponse.getHits().getHits()[0].getScore()));
-        assertFirstHit(searchResponse, hasId("3"));
+        assertResponse(
+            prepareSearch().setQuery(QueryBuilders.matchQuery("field1", "lexington avenue massachusetts").operator(Operator.OR))
+                .setFrom(2)
+                .setSize(5)
+                .setSearchType(SearchType.DFS_QUERY_THEN_FETCH)
+                .setRescorer(
+                    new QueryRescorerBuilder(matchPhraseQuery("field1", "lexington avenue massachusetts").slop(3)).setQueryWeight(0.6f)
+                        .setRescoreQueryWeight(2.0f),
+                    20
+                ),
+            response -> {
+                assertThat(response.getHits().getHits().length, equalTo(5));
+                assertHitCount(response, 9);
+                assertThat(response.getHits().getMaxScore(), greaterThan(response.getHits().getHits()[0].getScore()));
+                assertFirstHit(response, hasId("3"));
+            }
+        );
     }
 
     // Tests a rescore window smaller than number of hits:
@@ -272,56 +277,59 @@ public class QueryRescorerIT extends ESIntegTestCase {
         client().prepareIndex("test").setId("2").setSource("field1", "lexington avenue boston massachusetts road").get();
         indicesAdmin().prepareRefresh("test").get();
 
-        SearchResponse searchResponse = prepareSearch().setQuery(QueryBuilders.matchQuery("field1", "massachusetts"))
-            .setFrom(0)
-            .setSize(5)
-            .get();
-        assertThat(searchResponse.getHits().getHits().length, equalTo(4));
-        assertHitCount(searchResponse, 4);
-        assertThat(searchResponse.getHits().getMaxScore(), equalTo(searchResponse.getHits().getHits()[0].getScore()));
-        assertFirstHit(searchResponse, hasId("3"));
-        assertSecondHit(searchResponse, hasId("6"));
-        assertThirdHit(searchResponse, hasId("1"));
-        assertFourthHit(searchResponse, hasId("2"));
+        assertResponse(prepareSearch().setQuery(QueryBuilders.matchQuery("field1", "massachusetts")).setFrom(0).setSize(5), response -> {
+            assertThat(response.getHits().getHits().length, equalTo(4));
+            assertHitCount(response, 4);
+            assertThat(response.getHits().getMaxScore(), equalTo(response.getHits().getHits()[0].getScore()));
+            assertFirstHit(response, hasId("3"));
+            assertSecondHit(response, hasId("6"));
+            assertThirdHit(response, hasId("1"));
+            assertFourthHit(response, hasId("2"));
+        });
 
         // Now, rescore only top 2 hits w/ proximity:
-        searchResponse = prepareSearch().setQuery(QueryBuilders.matchQuery("field1", "massachusetts"))
-            .setFrom(0)
-            .setSize(5)
-            .setRescorer(
-                new QueryRescorerBuilder(matchPhraseQuery("field1", "lexington avenue massachusetts").slop(3)).setQueryWeight(0.6f)
-                    .setRescoreQueryWeight(2.0f),
-                2
-            )
-            .get();
-        // Only top 2 hits were re-ordered:
-        assertThat(searchResponse.getHits().getHits().length, equalTo(4));
-        assertHitCount(searchResponse, 4);
-        assertThat(searchResponse.getHits().getMaxScore(), equalTo(searchResponse.getHits().getHits()[0].getScore()));
-        assertFirstHit(searchResponse, hasId("6"));
-        assertSecondHit(searchResponse, hasId("3"));
-        assertThirdHit(searchResponse, hasId("1"));
-        assertFourthHit(searchResponse, hasId("2"));
+        assertResponse(
+            prepareSearch().setQuery(QueryBuilders.matchQuery("field1", "massachusetts"))
+                .setFrom(0)
+                .setSize(5)
+                .setRescorer(
+                    new QueryRescorerBuilder(matchPhraseQuery("field1", "lexington avenue massachusetts").slop(3)).setQueryWeight(0.6f)
+                        .setRescoreQueryWeight(2.0f),
+                    2
+                ),
+            response -> {
+                // Only top 2 hits were re-ordered:
+                assertThat(response.getHits().getHits().length, equalTo(4));
+                assertHitCount(response, 4);
+                assertThat(response.getHits().getMaxScore(), equalTo(response.getHits().getHits()[0].getScore()));
+                assertFirstHit(response, hasId("6"));
+                assertSecondHit(response, hasId("3"));
+                assertThirdHit(response, hasId("1"));
+                assertFourthHit(response, hasId("2"));
+            }
+        );
 
         // Now, rescore only top 3 hits w/ proximity:
-        searchResponse = prepareSearch().setQuery(QueryBuilders.matchQuery("field1", "massachusetts"))
-            .setFrom(0)
-            .setSize(5)
-            .setRescorer(
-                new QueryRescorerBuilder(matchPhraseQuery("field1", "lexington avenue massachusetts").slop(3)).setQueryWeight(0.6f)
-                    .setRescoreQueryWeight(2.0f),
-                3
-            )
-            .get();
-
-        // Only top 3 hits were re-ordered:
-        assertThat(searchResponse.getHits().getHits().length, equalTo(4));
-        assertHitCount(searchResponse, 4);
-        assertThat(searchResponse.getHits().getMaxScore(), equalTo(searchResponse.getHits().getHits()[0].getScore()));
-        assertFirstHit(searchResponse, hasId("1"));
-        assertSecondHit(searchResponse, hasId("6"));
-        assertThirdHit(searchResponse, hasId("3"));
-        assertFourthHit(searchResponse, hasId("2"));
+        assertResponse(
+            prepareSearch().setQuery(QueryBuilders.matchQuery("field1", "massachusetts"))
+                .setFrom(0)
+                .setSize(5)
+                .setRescorer(
+                    new QueryRescorerBuilder(matchPhraseQuery("field1", "lexington avenue massachusetts").slop(3)).setQueryWeight(0.6f)
+                        .setRescoreQueryWeight(2.0f),
+                    3
+                ),
+            response -> {
+                // Only top 3 hits were re-ordered:
+                assertThat(response.getHits().getHits().length, equalTo(4));
+                assertHitCount(response, 4);
+                assertThat(response.getHits().getMaxScore(), equalTo(response.getHits().getHits()[0].getScore()));
+                assertFirstHit(response, hasId("1"));
+                assertSecondHit(response, hasId("6"));
+                assertThirdHit(response, hasId("3"));
+                assertFourthHit(response, hasId("2"));
+            }
+        );
     }
 
     // Tests a rescorer that penalizes the scores:
@@ -349,35 +357,37 @@ public class QueryRescorerIT extends ESIntegTestCase {
         client().prepareIndex("test").setId("2").setSource("field1", "lexington avenue boston massachusetts road").get();
         indicesAdmin().prepareRefresh("test").get();
 
-        SearchResponse searchResponse = prepareSearch().setQuery(QueryBuilders.matchQuery("field1", "massachusetts").operator(Operator.OR))
-            .setFrom(0)
-            .setSize(5)
-            .get();
-        assertThat(searchResponse.getHits().getHits().length, equalTo(4));
-        assertHitCount(searchResponse, 4);
-        assertThat(searchResponse.getHits().getMaxScore(), equalTo(searchResponse.getHits().getHits()[0].getScore()));
-        assertFirstHit(searchResponse, hasId("3"));
-        assertSecondHit(searchResponse, hasId("6"));
-        assertThirdHit(searchResponse, hasId("1"));
-        assertFourthHit(searchResponse, hasId("2"));
-
+        assertResponse(
+            prepareSearch().setQuery(QueryBuilders.matchQuery("field1", "massachusetts").operator(Operator.OR)).setFrom(0).setSize(5),
+            response -> {
+                assertThat(response.getHits().getHits().length, equalTo(4));
+                assertHitCount(response, 4);
+                assertThat(response.getHits().getMaxScore(), equalTo(response.getHits().getHits()[0].getScore()));
+                assertFirstHit(response, hasId("3"));
+                assertSecondHit(response, hasId("6"));
+                assertThirdHit(response, hasId("1"));
+                assertFourthHit(response, hasId("2"));
+            }
+        );
         // Now, penalizing rescore (nothing matches the rescore query):
-        searchResponse = prepareSearch().setQuery(QueryBuilders.matchQuery("field1", "massachusetts").operator(Operator.OR))
-            .setFrom(0)
-            .setSize(5)
-            .setRescorer(
-                new QueryRescorerBuilder(matchPhraseQuery("field1", "lexington avenue massachusetts").slop(3)).setQueryWeight(1.0f)
-                    .setRescoreQueryWeight(-1f),
-                3
-            )
-            .get();
-
-        // 6 and 1 got worse, and then the hit (2) outside the rescore window were sorted ahead:
-        assertThat(searchResponse.getHits().getMaxScore(), equalTo(searchResponse.getHits().getHits()[0].getScore()));
-        assertFirstHit(searchResponse, hasId("3"));
-        assertSecondHit(searchResponse, hasId("2"));
-        assertThirdHit(searchResponse, hasId("6"));
-        assertFourthHit(searchResponse, hasId("1"));
+        assertResponse(
+            prepareSearch().setQuery(QueryBuilders.matchQuery("field1", "massachusetts").operator(Operator.OR))
+                .setFrom(0)
+                .setSize(5)
+                .setRescorer(
+                    new QueryRescorerBuilder(matchPhraseQuery("field1", "lexington avenue massachusetts").slop(3)).setQueryWeight(1.0f)
+                        .setRescoreQueryWeight(-1f),
+                    3
+                ),
+            response -> {
+                // 6 and 1 got worse, and then the hit (2) outside the rescore window were sorted ahead:
+                assertThat(response.getHits().getMaxScore(), equalTo(response.getHits().getHits()[0].getScore()));
+                assertFirstHit(response, hasId("3"));
+                assertSecondHit(response, hasId("2"));
+                assertThirdHit(response, hasId("6"));
+                assertFourthHit(response, hasId("1"));
+            }
+        );
     }
 
     // Comparator that sorts hits and rescored hits in the same way.
@@ -430,43 +440,46 @@ public class QueryRescorerIT extends ESIntegTestCase {
             int rescoreWindow = between(1, 3) * resultSize;
             String intToEnglish = English.intToEnglish(between(0, numDocs - 1));
             String query = intToEnglish.split(" ")[0];
-            SearchResponse rescored = prepareSearch().setSearchType(SearchType.QUERY_THEN_FETCH)
-                .setPreference("test") // ensure we hit the same shards for tie-breaking
-                .setQuery(QueryBuilders.matchQuery("field1", query).operator(Operator.OR))
-                .setFrom(0)
-                .setSize(resultSize)
-                .setRescorer(
-                    new QueryRescorerBuilder(constantScoreQuery(matchPhraseQuery("field1", intToEnglish).slop(3))).setQueryWeight(1.0f)
-                        // no weight - so we basically use the same score as the actual query
-                        .setRescoreQueryWeight(0.0f),
-                    rescoreWindow
-                )
-                .get();
 
-            SearchResponse plain = prepareSearch().setSearchType(SearchType.QUERY_THEN_FETCH)
-                .setPreference("test") // ensure we hit the same shards for tie-breaking
-                .setQuery(QueryBuilders.matchQuery("field1", query).operator(Operator.OR))
-                .setFrom(0)
-                .setSize(resultSize)
-                .get();
+            assertResponse(
+                prepareSearch().setSearchType(SearchType.QUERY_THEN_FETCH)
+                    .setPreference("test") // ensure we hit the same shards for tie-breaking
+                    .setQuery(QueryBuilders.matchQuery("field1", query).operator(Operator.OR))
+                    .setFrom(0)
+                    .setSize(resultSize),
+                plain -> {
+                    assertResponse(
+                        prepareSearch().setSearchType(SearchType.QUERY_THEN_FETCH)
+                            .setPreference("test") // ensure we hit the same shards for tie-breaking
+                            .setQuery(QueryBuilders.matchQuery("field1", query).operator(Operator.OR))
+                            .setFrom(0)
+                            .setSize(resultSize)
+                            .setRescorer(
+                                new QueryRescorerBuilder(constantScoreQuery(matchPhraseQuery("field1", intToEnglish).slop(3)))
+                                    .setQueryWeight(1.0f)
+                                    // no weight - so we basically use the same score as the actual query
+                                    .setRescoreQueryWeight(0.0f),
+                                rescoreWindow
+                            ),
+                        rescored -> assertEquivalent(query, plain, rescored)
+                    );  // check equivalence
 
-            // check equivalence
-            assertEquivalent(query, plain, rescored);
-
-            rescored = prepareSearch().setSearchType(SearchType.QUERY_THEN_FETCH)
-                .setPreference("test") // ensure we hit the same shards for tie-breaking
-                .setQuery(QueryBuilders.matchQuery("field1", query).operator(Operator.OR))
-                .setFrom(0)
-                .setSize(resultSize)
-                .setRescorer(
-                    new QueryRescorerBuilder(constantScoreQuery(matchPhraseQuery("field1", "not in the index").slop(3))).setQueryWeight(
-                        1.0f
-                    ).setRescoreQueryWeight(1.0f),
-                    rescoreWindow
-                )
-                .get();
-            // check equivalence
-            assertEquivalent(query, plain, rescored);
+                    assertResponse(
+                        prepareSearch().setSearchType(SearchType.QUERY_THEN_FETCH)
+                            .setPreference("test") // ensure we hit the same shards for tie-breaking
+                            .setQuery(QueryBuilders.matchQuery("field1", query).operator(Operator.OR))
+                            .setFrom(0)
+                            .setSize(resultSize)
+                            .setRescorer(
+                                new QueryRescorerBuilder(constantScoreQuery(matchPhraseQuery("field1", "not in the index").slop(3)))
+                                    .setQueryWeight(1.0f)
+                                    .setRescoreQueryWeight(1.0f),
+                                rescoreWindow
+                            ),
+                        rescored -> assertEquivalent(query, plain, rescored)
+                    );  // check equivalence
+                }
+            );
         }
     }
 
@@ -495,39 +508,42 @@ public class QueryRescorerIT extends ESIntegTestCase {
         refresh();
 
         {
-            SearchResponse searchResponse = prepareSearch().setSearchType(SearchType.DFS_QUERY_THEN_FETCH)
-                .setQuery(QueryBuilders.matchQuery("field1", "the quick brown").operator(Operator.OR))
-                .setRescorer(
-                    new QueryRescorerBuilder(matchPhraseQuery("field1", "the quick brown").slop(2).boost(4.0f)).setQueryWeight(0.5f)
-                        .setRescoreQueryWeight(0.4f),
-                    5
-                )
-                .setExplain(true)
-                .get();
-            assertHitCount(searchResponse, 3);
-            assertFirstHit(searchResponse, hasId("1"));
-            assertSecondHit(searchResponse, hasId("2"));
-            assertThirdHit(searchResponse, hasId("3"));
+            assertResponse(
+                prepareSearch().setSearchType(SearchType.DFS_QUERY_THEN_FETCH)
+                    .setQuery(QueryBuilders.matchQuery("field1", "the quick brown").operator(Operator.OR))
+                    .setRescorer(
+                        new QueryRescorerBuilder(matchPhraseQuery("field1", "the quick brown").slop(2).boost(4.0f)).setQueryWeight(0.5f)
+                            .setRescoreQueryWeight(0.4f),
+                        5
+                    )
+                    .setExplain(true),
+                response -> {
+                    assertHitCount(response, 3);
+                    assertFirstHit(response, hasId("1"));
+                    assertSecondHit(response, hasId("2"));
+                    assertThirdHit(response, hasId("3"));
 
-            for (int i = 0; i < 3; i++) {
-                assertThat(searchResponse.getHits().getAt(i).getExplanation(), notNullValue());
-                assertThat(searchResponse.getHits().getAt(i).getExplanation().isMatch(), equalTo(true));
-                assertThat(searchResponse.getHits().getAt(i).getExplanation().getDetails().length, equalTo(2));
-                assertThat(searchResponse.getHits().getAt(i).getExplanation().getDetails()[0].isMatch(), equalTo(true));
-                if (i == 2) {
-                    assertThat(searchResponse.getHits().getAt(i).getExplanation().getDetails()[1].getValue(), equalTo(0.5f));
-                } else {
-                    assertThat(searchResponse.getHits().getAt(i).getExplanation().getDescription(), equalTo("sum of:"));
-                    assertThat(
-                        searchResponse.getHits().getAt(i).getExplanation().getDetails()[0].getDetails()[1].getValue(),
-                        equalTo(0.5f)
-                    );
-                    assertThat(
-                        searchResponse.getHits().getAt(i).getExplanation().getDetails()[1].getDetails()[1].getValue(),
-                        equalTo(0.4f)
-                    );
+                    for (int i = 0; i < 3; i++) {
+                        assertThat(response.getHits().getAt(i).getExplanation(), notNullValue());
+                        assertThat(response.getHits().getAt(i).getExplanation().isMatch(), equalTo(true));
+                        assertThat(response.getHits().getAt(i).getExplanation().getDetails().length, equalTo(2));
+                        assertThat(response.getHits().getAt(i).getExplanation().getDetails()[0].isMatch(), equalTo(true));
+                        if (i == 2) {
+                            assertThat(response.getHits().getAt(i).getExplanation().getDetails()[1].getValue(), equalTo(0.5f));
+                        } else {
+                            assertThat(response.getHits().getAt(i).getExplanation().getDescription(), equalTo("sum of:"));
+                            assertThat(
+                                response.getHits().getAt(i).getExplanation().getDetails()[0].getDetails()[1].getValue(),
+                                equalTo(0.5f)
+                            );
+                            assertThat(
+                                response.getHits().getAt(i).getExplanation().getDetails()[1].getDetails()[1].getValue(),
+                                equalTo(0.4f)
+                            );
+                        }
+                    }
                 }
-            }
+            );
         }
 
         String[] scoreModes = new String[] { "max", "min", "avg", "total", "multiply", "" };
@@ -540,21 +556,26 @@ public class QueryRescorerIT extends ESIntegTestCase {
             if ("".equals(scoreModes[innerMode]) == false) {
                 innerRescoreQuery.setScoreMode(QueryRescoreMode.fromString(scoreModes[innerMode]));
             }
+            final int finalInnerMode = innerMode;
+            assertResponse(
+                prepareSearch().setSearchType(SearchType.DFS_QUERY_THEN_FETCH)
+                    .setQuery(QueryBuilders.matchQuery("field1", "the quick brown").operator(Operator.OR))
+                    .setRescorer(innerRescoreQuery, 5)
+                    .setExplain(true),
+                response -> {
+                    assertHitCount(response, 3);
+                    assertFirstHit(response, hasId("1"));
+                    assertSecondHit(response, hasId("2"));
+                    assertThirdHit(response, hasId("3"));
 
-            SearchResponse searchResponse = prepareSearch().setSearchType(SearchType.DFS_QUERY_THEN_FETCH)
-                .setQuery(QueryBuilders.matchQuery("field1", "the quick brown").operator(Operator.OR))
-                .setRescorer(innerRescoreQuery, 5)
-                .setExplain(true)
-                .get();
-            assertHitCount(searchResponse, 3);
-            assertFirstHit(searchResponse, hasId("1"));
-            assertSecondHit(searchResponse, hasId("2"));
-            assertThirdHit(searchResponse, hasId("3"));
-
-            for (int j = 0; j < 3; j++) {
-                assertThat(searchResponse.getHits().getAt(j).getExplanation().getDescription(), equalTo(descriptionModes[innerMode]));
-            }
-
+                    for (int j = 0; j < 3; j++) {
+                        assertThat(
+                            response.getHits().getAt(j).getExplanation().getDescription(),
+                            equalTo(descriptionModes[finalInnerMode])
+                        );
+                    }
+                }
+            );
             for (int outerMode = 0; outerMode < scoreModes.length; outerMode++) {
                 QueryRescorerBuilder outerRescoreQuery = new QueryRescorerBuilder(matchQuery("field1", "the quick brown").boost(4.0f))
                     .setQueryWeight(0.5f)
@@ -563,23 +584,29 @@ public class QueryRescorerIT extends ESIntegTestCase {
                 if ("".equals(scoreModes[outerMode]) == false) {
                     outerRescoreQuery.setScoreMode(QueryRescoreMode.fromString(scoreModes[outerMode]));
                 }
+                final int finalOuterMode = outerMode;
+                assertResponse(
+                    prepareSearch().setSearchType(SearchType.DFS_QUERY_THEN_FETCH)
+                        .setQuery(QueryBuilders.matchQuery("field1", "the quick brown").operator(Operator.OR))
+                        .addRescorer(innerRescoreQuery, 5)
+                        .addRescorer(outerRescoreQuery.windowSize(10))
+                        .setExplain(true),
+                    response -> {
+                        assertHitCount(response, 3);
+                        assertFirstHit(response, hasId("1"));
+                        assertSecondHit(response, hasId("2"));
+                        assertThirdHit(response, hasId("3"));
 
-                searchResponse = prepareSearch().setSearchType(SearchType.DFS_QUERY_THEN_FETCH)
-                    .setQuery(QueryBuilders.matchQuery("field1", "the quick brown").operator(Operator.OR))
-                    .addRescorer(innerRescoreQuery, 5)
-                    .addRescorer(outerRescoreQuery.windowSize(10))
-                    .setExplain(true)
-                    .get();
-                assertHitCount(searchResponse, 3);
-                assertFirstHit(searchResponse, hasId("1"));
-                assertSecondHit(searchResponse, hasId("2"));
-                assertThirdHit(searchResponse, hasId("3"));
-
-                for (int j = 0; j < 3; j++) {
-                    Explanation explanation = searchResponse.getHits().getAt(j).getExplanation();
-                    assertThat(explanation.getDescription(), equalTo(descriptionModes[outerMode]));
-                    assertThat(explanation.getDetails()[0].getDetails()[0].getDescription(), equalTo(descriptionModes[innerMode]));
-                }
+                        for (int j = 0; j < 3; j++) {
+                            Explanation explanation = response.getHits().getAt(j).getExplanation();
+                            assertThat(explanation.getDescription(), equalTo(descriptionModes[finalOuterMode]));
+                            assertThat(
+                                explanation.getDetails()[0].getDetails()[0].getDescription(),
+                                equalTo(descriptionModes[finalInnerMode])
+                            );
+                        }
+                    }
+                );
             }
         }
     }
@@ -617,58 +644,66 @@ public class QueryRescorerIT extends ESIntegTestCase {
                 if ("".equals(scoreMode) == false) {
                     rescoreQuery.setScoreMode(QueryRescoreMode.fromString(scoreMode));
                 }
+                final int finalI = i;
+                assertResponse(
+                    prepareSearch().setPreference("test") // ensure we hit the same shards for tie-breaking
+                        .setFrom(0)
+                        .setSize(10)
+                        .setQuery(query)
+                        .setRescorer(rescoreQuery, 50),
+                    rescored -> {
+                        assertHitCount(rescored, 4);
 
-                SearchResponse rescored = prepareSearch().setPreference("test") // ensure we hit the same shards for tie-breaking
-                    .setFrom(0)
-                    .setSize(10)
-                    .setQuery(query)
-                    .setRescorer(rescoreQuery, 50)
-                    .get();
-
-                assertHitCount(rescored, 4);
-
-                assertThat(rescored.getHits().getMaxScore(), equalTo(rescored.getHits().getHits()[0].getScore()));
-                if ("total".equals(scoreMode) || "".equals(scoreMode)) {
-                    assertFirstHit(rescored, hasId(String.valueOf(i + 1)));
-                    assertSecondHit(rescored, hasId(String.valueOf(i)));
-                    assertThirdHit(rescored, hasId(String.valueOf(i + 2)));
-                    assertThat(rescored.getHits().getHits()[0].getScore(), equalTo(3.0f * primaryWeight + 7.0f * secondaryWeight));
-                    assertThat(rescored.getHits().getHits()[1].getScore(), equalTo(2.0f * primaryWeight + 5.0f * secondaryWeight));
-                    assertThat(rescored.getHits().getHits()[2].getScore(), equalTo(5.0f * primaryWeight));
-                    assertThat(rescored.getHits().getHits()[3].getScore(), equalTo(0.2f * primaryWeight + 0.0f * secondaryWeight));
-                } else if ("max".equals(scoreMode)) {
-                    assertFirstHit(rescored, hasId(String.valueOf(i + 1)));
-                    assertSecondHit(rescored, hasId(String.valueOf(i)));
-                    assertThirdHit(rescored, hasId(String.valueOf(i + 2)));
-                    assertThat(rescored.getHits().getHits()[0].getScore(), equalTo(7.0f * secondaryWeight));
-                    assertThat(rescored.getHits().getHits()[1].getScore(), equalTo(5.0f * secondaryWeight));
-                    assertThat(rescored.getHits().getHits()[2].getScore(), equalTo(5.0f * primaryWeight));
-                    assertThat(rescored.getHits().getHits()[3].getScore(), equalTo(0.2f * primaryWeight));
-                } else if ("min".equals(scoreMode)) {
-                    assertFirstHit(rescored, hasId(String.valueOf(i + 2)));
-                    assertSecondHit(rescored, hasId(String.valueOf(i + 1)));
-                    assertThirdHit(rescored, hasId(String.valueOf(i)));
-                    assertThat(rescored.getHits().getHits()[0].getScore(), equalTo(5.0f * primaryWeight));
-                    assertThat(rescored.getHits().getHits()[1].getScore(), equalTo(3.0f * primaryWeight));
-                    assertThat(rescored.getHits().getHits()[2].getScore(), equalTo(2.0f * primaryWeight));
-                    assertThat(rescored.getHits().getHits()[3].getScore(), equalTo(0.0f * secondaryWeight));
-                } else if ("avg".equals(scoreMode)) {
-                    assertFirstHit(rescored, hasId(String.valueOf(i + 1)));
-                    assertSecondHit(rescored, hasId(String.valueOf(i + 2)));
-                    assertThirdHit(rescored, hasId(String.valueOf(i)));
-                    assertThat(rescored.getHits().getHits()[0].getScore(), equalTo((3.0f * primaryWeight + 7.0f * secondaryWeight) / 2.0f));
-                    assertThat(rescored.getHits().getHits()[1].getScore(), equalTo(5.0f * primaryWeight));
-                    assertThat(rescored.getHits().getHits()[2].getScore(), equalTo((2.0f * primaryWeight + 5.0f * secondaryWeight) / 2.0f));
-                    assertThat(rescored.getHits().getHits()[3].getScore(), equalTo((0.2f * primaryWeight) / 2.0f));
-                } else if ("multiply".equals(scoreMode)) {
-                    assertFirstHit(rescored, hasId(String.valueOf(i + 1)));
-                    assertSecondHit(rescored, hasId(String.valueOf(i)));
-                    assertThirdHit(rescored, hasId(String.valueOf(i + 2)));
-                    assertThat(rescored.getHits().getHits()[0].getScore(), equalTo(3.0f * primaryWeight * 7.0f * secondaryWeight));
-                    assertThat(rescored.getHits().getHits()[1].getScore(), equalTo(2.0f * primaryWeight * 5.0f * secondaryWeight));
-                    assertThat(rescored.getHits().getHits()[2].getScore(), equalTo(5.0f * primaryWeight));
-                    assertThat(rescored.getHits().getHits()[3].getScore(), equalTo(0.2f * primaryWeight * 0.0f * secondaryWeight));
-                }
+                        assertThat(rescored.getHits().getMaxScore(), equalTo(rescored.getHits().getHits()[0].getScore()));
+                        if ("total".equals(scoreMode) || "".equals(scoreMode)) {
+                            assertFirstHit(rescored, hasId(String.valueOf(finalI + 1)));
+                            assertSecondHit(rescored, hasId(String.valueOf(finalI)));
+                            assertThirdHit(rescored, hasId(String.valueOf(finalI + 2)));
+                            assertThat(rescored.getHits().getHits()[0].getScore(), equalTo(3.0f * primaryWeight + 7.0f * secondaryWeight));
+                            assertThat(rescored.getHits().getHits()[1].getScore(), equalTo(2.0f * primaryWeight + 5.0f * secondaryWeight));
+                            assertThat(rescored.getHits().getHits()[2].getScore(), equalTo(5.0f * primaryWeight));
+                            assertThat(rescored.getHits().getHits()[3].getScore(), equalTo(0.2f * primaryWeight + 0.0f * secondaryWeight));
+                        } else if ("max".equals(scoreMode)) {
+                            assertFirstHit(rescored, hasId(String.valueOf(finalI + 1)));
+                            assertSecondHit(rescored, hasId(String.valueOf(finalI)));
+                            assertThirdHit(rescored, hasId(String.valueOf(finalI + 2)));
+                            assertThat(rescored.getHits().getHits()[0].getScore(), equalTo(7.0f * secondaryWeight));
+                            assertThat(rescored.getHits().getHits()[1].getScore(), equalTo(5.0f * secondaryWeight));
+                            assertThat(rescored.getHits().getHits()[2].getScore(), equalTo(5.0f * primaryWeight));
+                            assertThat(rescored.getHits().getHits()[3].getScore(), equalTo(0.2f * primaryWeight));
+                        } else if ("min".equals(scoreMode)) {
+                            assertFirstHit(rescored, hasId(String.valueOf(finalI + 2)));
+                            assertSecondHit(rescored, hasId(String.valueOf(finalI + 1)));
+                            assertThirdHit(rescored, hasId(String.valueOf(finalI)));
+                            assertThat(rescored.getHits().getHits()[0].getScore(), equalTo(5.0f * primaryWeight));
+                            assertThat(rescored.getHits().getHits()[1].getScore(), equalTo(3.0f * primaryWeight));
+                            assertThat(rescored.getHits().getHits()[2].getScore(), equalTo(2.0f * primaryWeight));
+                            assertThat(rescored.getHits().getHits()[3].getScore(), equalTo(0.0f * secondaryWeight));
+                        } else if ("avg".equals(scoreMode)) {
+                            assertFirstHit(rescored, hasId(String.valueOf(finalI + 1)));
+                            assertSecondHit(rescored, hasId(String.valueOf(finalI + 2)));
+                            assertThirdHit(rescored, hasId(String.valueOf(finalI)));
+                            assertThat(
+                                rescored.getHits().getHits()[0].getScore(),
+                                equalTo((3.0f * primaryWeight + 7.0f * secondaryWeight) / 2.0f)
+                            );
+                            assertThat(rescored.getHits().getHits()[1].getScore(), equalTo(5.0f * primaryWeight));
+                            assertThat(
+                                rescored.getHits().getHits()[2].getScore(),
+                                equalTo((2.0f * primaryWeight + 5.0f * secondaryWeight) / 2.0f)
+                            );
+                            assertThat(rescored.getHits().getHits()[3].getScore(), equalTo((0.2f * primaryWeight) / 2.0f));
+                        } else if ("multiply".equals(scoreMode)) {
+                            assertFirstHit(rescored, hasId(String.valueOf(finalI + 1)));
+                            assertSecondHit(rescored, hasId(String.valueOf(finalI)));
+                            assertThirdHit(rescored, hasId(String.valueOf(finalI + 2)));
+                            assertThat(rescored.getHits().getHits()[0].getScore(), equalTo(3.0f * primaryWeight * 7.0f * secondaryWeight));
+                            assertThat(rescored.getHits().getHits()[1].getScore(), equalTo(2.0f * primaryWeight * 5.0f * secondaryWeight));
+                            assertThat(rescored.getHits().getHits()[2].getScore(), equalTo(5.0f * primaryWeight));
+                            assertThat(rescored.getHits().getHits()[3].getScore(), equalTo(0.2f * primaryWeight * 0.0f * secondaryWeight));
+                        }
+                    }
+                );
             }
         }
     }
@@ -688,13 +723,16 @@ public class QueryRescorerIT extends ESIntegTestCase {
         // First set the rescore window large enough that both rescores take effect
         SearchRequestBuilder request = prepareSearch();
         request.addRescorer(eightIsGreat, numDocs).addRescorer(sevenIsBetter, numDocs);
-        SearchResponse response = request.get();
-        assertFirstHit(response, hasId("7"));
-        assertSecondHit(response, hasId("8"));
+        assertResponse(request, response -> {
+            assertFirstHit(response, hasId("7"));
+            assertSecondHit(response, hasId("8"));
+        });
 
         // Now squash the second rescore window so it never gets to see a seven
-        response = request.setSize(1).clearRescorers().addRescorer(eightIsGreat, numDocs).addRescorer(sevenIsBetter, 1).get();
-        assertFirstHit(response, hasId("8"));
+        assertResponse(
+            request.setSize(1).clearRescorers().addRescorer(eightIsGreat, numDocs).addRescorer(sevenIsBetter, 1),
+            response -> assertFirstHit(response, hasId("8"))
+        );
         // We have no idea what the second hit will be because we didn't get a chance to look for seven
 
         // Now use one rescore to drag the number we're looking for into the window of another
@@ -709,11 +747,12 @@ public class QueryRescorerIT extends ESIntegTestCase {
             )
         ).setScoreMode(QueryRescoreMode.Total);
         request.clearRescorers().addRescorer(ninetyIsGood, numDocs).addRescorer(oneToo, 10);
-        response = request.setSize(2).get();
-        assertThat(response.getHits().getMaxScore(), equalTo(response.getHits().getHits()[0].getScore()));
-        assertFirstHit(response, hasId("91"));
-        assertFirstHit(response, hasScore(2001.0f));
-        assertSecondHit(response, hasScore(1001.0f)); // Not sure which one it is but it is ninety something
+        assertResponse(request.setSize(2), response -> {
+            assertThat(response.getHits().getMaxScore(), equalTo(response.getHits().getHits()[0].getScore()));
+            assertFirstHit(response, hasId("91"));
+            assertFirstHit(response, hasScore(2001.0f));
+            assertSecondHit(response, hasScore(1001.0f)); // Not sure which one it is but it is ninety something
+        });
     }
 
     private int indexRandomNumbers(String analyzer) throws Exception {
@@ -797,14 +836,17 @@ public class QueryRescorerIT extends ESIntegTestCase {
         assertNotNull(exc.getCause());
         assertThat(exc.getCause().getMessage(), containsString("Cannot use [sort] option in conjunction with [rescore]."));
 
-        SearchResponse resp = prepareSearch().addSort(SortBuilders.scoreSort())
-            .setTrackScores(true)
-            .addRescorer(new QueryRescorerBuilder(matchAllQuery()).setRescoreQueryWeight(100.0f), 50)
-            .get();
-        assertThat(resp.getHits().getTotalHits().value, equalTo(5L));
-        assertThat(resp.getHits().getHits().length, equalTo(5));
-        for (SearchHit hit : resp.getHits().getHits()) {
-            assertThat(hit.getScore(), equalTo(101f));
-        }
+        assertResponse(
+            prepareSearch().addSort(SortBuilders.scoreSort())
+                .setTrackScores(true)
+                .addRescorer(new QueryRescorerBuilder(matchAllQuery()).setRescoreQueryWeight(100.0f), 50),
+            response -> {
+                assertThat(response.getHits().getTotalHits().value, equalTo(5L));
+                assertThat(response.getHits().getHits().length, equalTo(5));
+                for (SearchHit hit : response.getHits().getHits()) {
+                    assertThat(hit.getScore(), equalTo(101f));
+                }
+            }
+        );
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/functionscore/RandomScoreFunctionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/functionscore/RandomScoreFunctionIT.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.search.functionscore;
 
 import org.apache.lucene.util.ArrayUtil;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.mapper.SeqNoFieldMapper;
 import org.elasticsearch.index.query.functionscore.FunctionScoreQueryBuilder;
@@ -37,6 +36,8 @@ import static org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders.
 import static org.elasticsearch.script.MockScriptPlugin.NAME;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
@@ -97,35 +98,39 @@ public class RandomScoreFunctionIT extends ESIntegTestCase {
                 preference = randomRealisticUnicodeOfLengthBetween(1, 10);
             }
             int innerIters = scaledRandomIntBetween(2, 5);
-            SearchHit[] hits = null;
+            final SearchHit[][] hits = new SearchHit[1][];
             for (int i = 0; i < innerIters; i++) {
-                SearchResponse searchResponse = prepareSearch().setSize(docCount) // get all docs otherwise we are prone to tie-breaking
-                    .setPreference(preference)
-                    .setQuery(functionScoreQuery(matchAllQuery(), randomFunction().seed(seed).setField("foo")))
-                    .get();
-                assertThat(
-                    "Failures " + Arrays.toString(searchResponse.getShardFailures()),
-                    searchResponse.getShardFailures().length,
-                    CoreMatchers.equalTo(0)
-                );
-                final int hitCount = searchResponse.getHits().getHits().length;
-                final SearchHit[] currentHits = searchResponse.getHits().getHits();
-                ArrayUtil.timSort(currentHits, (o1, o2) -> {
-                    // for tie-breaking we have to resort here since if the score is
-                    // identical we rely on collection order which might change.
-                    int cmp = Float.compare(o1.getScore(), o2.getScore());
-                    return cmp == 0 ? o1.getId().compareTo(o2.getId()) : cmp;
-                });
-                if (i == 0) {
-                    assertThat(hits, nullValue());
-                    hits = currentHits;
-                } else {
-                    assertThat(hits.length, equalTo(searchResponse.getHits().getHits().length));
-                    for (int j = 0; j < hitCount; j++) {
-                        assertThat("" + j, currentHits[j].getScore(), equalTo(hits[j].getScore()));
-                        assertThat("" + j, currentHits[j].getId(), equalTo(hits[j].getId()));
+                final int finalI = i;
+                assertResponse(
+                    prepareSearch().setSize(docCount) // get all docs otherwise we are prone to tie-breaking
+                        .setPreference(preference)
+                        .setQuery(functionScoreQuery(matchAllQuery(), randomFunction().seed(seed).setField("foo"))),
+                    response -> {
+                        assertThat(
+                            "Failures " + Arrays.toString(response.getShardFailures()),
+                            response.getShardFailures().length,
+                            CoreMatchers.equalTo(0)
+                        );
+                        final int hitCount = response.getHits().getHits().length;
+                        final SearchHit[] currentHits = response.getHits().getHits();
+                        ArrayUtil.timSort(currentHits, (o1, o2) -> {
+                            // for tie-breaking we have to resort here since if the score is
+                            // identical we rely on collection order which might change.
+                            int cmp = Float.compare(o1.getScore(), o2.getScore());
+                            return cmp == 0 ? o1.getId().compareTo(o2.getId()) : cmp;
+                        });
+                        if (finalI == 0) {
+                            assertThat(hits[0], nullValue());
+                            hits[0] = currentHits;
+                        } else {
+                            assertThat(hits[0].length, equalTo(response.getHits().getHits().length));
+                            for (int j = 0; j < hitCount; j++) {
+                                assertThat("" + j, currentHits[j].getScore(), equalTo(hits[0][j].getScore()));
+                                assertThat("" + j, currentHits[j].getId(), equalTo(hits[0][j].getId()));
+                            }
+                        }
                     }
-                }
+                );
 
                 // randomly change some docs to get them in different segments
                 int numDocsToChange = randomIntBetween(20, 50);
@@ -165,73 +170,88 @@ public class RandomScoreFunctionIT extends ESIntegTestCase {
 
         // Test for accessing _score
         Script script = new Script(ScriptType.INLINE, NAME, "log(doc['index'].value + (factor * _score))", params);
-        SearchResponse resp = prepareSearch("test").setQuery(
-            functionScoreQuery(
-                matchQuery("body", "foo"),
-                new FunctionScoreQueryBuilder.FilterFunctionBuilder[] {
-                    new FunctionScoreQueryBuilder.FilterFunctionBuilder(fieldValueFactorFunction("index").factor(2)),
-                    new FunctionScoreQueryBuilder.FilterFunctionBuilder(scriptFunction(script)) }
-            )
-        ).get();
-        assertNoFailures(resp);
-        SearchHit firstHit = resp.getHits().getAt(0);
-        assertThat(firstHit.getScore(), greaterThan(1f));
+        assertNoFailuresAndResponse(
+            prepareSearch("test").setQuery(
+                functionScoreQuery(
+                    matchQuery("body", "foo"),
+                    new FunctionScoreQueryBuilder.FilterFunctionBuilder[] {
+                        new FunctionScoreQueryBuilder.FilterFunctionBuilder(fieldValueFactorFunction("index").factor(2)),
+                        new FunctionScoreQueryBuilder.FilterFunctionBuilder(scriptFunction(script)) }
+                )
+            ),
+            response -> {
+                SearchHit firstHit = response.getHits().getAt(0);
+                assertThat(firstHit.getScore(), greaterThan(1f));
+            }
+        );
 
         // Test for accessing _score.intValue()
         script = new Script(ScriptType.INLINE, NAME, "log(doc['index'].value + (factor * _score.intValue()))", params);
-        resp = prepareSearch("test").setQuery(
-            functionScoreQuery(
-                matchQuery("body", "foo"),
-                new FunctionScoreQueryBuilder.FilterFunctionBuilder[] {
-                    new FunctionScoreQueryBuilder.FilterFunctionBuilder(fieldValueFactorFunction("index").factor(2)),
-                    new FunctionScoreQueryBuilder.FilterFunctionBuilder(scriptFunction(script)) }
-            )
-        ).get();
-        assertNoFailures(resp);
-        firstHit = resp.getHits().getAt(0);
-        assertThat(firstHit.getScore(), greaterThan(1f));
+        assertNoFailuresAndResponse(
+            prepareSearch("test").setQuery(
+                functionScoreQuery(
+                    matchQuery("body", "foo"),
+                    new FunctionScoreQueryBuilder.FilterFunctionBuilder[] {
+                        new FunctionScoreQueryBuilder.FilterFunctionBuilder(fieldValueFactorFunction("index").factor(2)),
+                        new FunctionScoreQueryBuilder.FilterFunctionBuilder(scriptFunction(script)) }
+                )
+            ),
+            response -> {
+                SearchHit firstHit = response.getHits().getAt(0);
+                assertThat(firstHit.getScore(), greaterThan(1f));
+            }
+        );
 
         // Test for accessing _score.longValue()
         script = new Script(ScriptType.INLINE, NAME, "log(doc['index'].value + (factor * _score.longValue()))", params);
-        resp = prepareSearch("test").setQuery(
-            functionScoreQuery(
-                matchQuery("body", "foo"),
-                new FunctionScoreQueryBuilder.FilterFunctionBuilder[] {
-                    new FunctionScoreQueryBuilder.FilterFunctionBuilder(fieldValueFactorFunction("index").factor(2)),
-                    new FunctionScoreQueryBuilder.FilterFunctionBuilder(scriptFunction(script)) }
-            )
-        ).get();
-        assertNoFailures(resp);
-        firstHit = resp.getHits().getAt(0);
-        assertThat(firstHit.getScore(), greaterThan(1f));
+        assertNoFailuresAndResponse(
+            prepareSearch("test").setQuery(
+                functionScoreQuery(
+                    matchQuery("body", "foo"),
+                    new FunctionScoreQueryBuilder.FilterFunctionBuilder[] {
+                        new FunctionScoreQueryBuilder.FilterFunctionBuilder(fieldValueFactorFunction("index").factor(2)),
+                        new FunctionScoreQueryBuilder.FilterFunctionBuilder(scriptFunction(script)) }
+                )
+            ),
+            response -> {
+                SearchHit firstHit = response.getHits().getAt(0);
+                assertThat(firstHit.getScore(), greaterThan(1f));
+            }
+        );
 
         // Test for accessing _score.floatValue()
         script = new Script(ScriptType.INLINE, NAME, "log(doc['index'].value + (factor * _score.floatValue()))", params);
-        resp = prepareSearch("test").setQuery(
-            functionScoreQuery(
-                matchQuery("body", "foo"),
-                new FunctionScoreQueryBuilder.FilterFunctionBuilder[] {
-                    new FunctionScoreQueryBuilder.FilterFunctionBuilder(fieldValueFactorFunction("index").factor(2)),
-                    new FunctionScoreQueryBuilder.FilterFunctionBuilder(scriptFunction(script)) }
-            )
-        ).get();
-        assertNoFailures(resp);
-        firstHit = resp.getHits().getAt(0);
-        assertThat(firstHit.getScore(), greaterThan(1f));
+        assertNoFailuresAndResponse(
+            prepareSearch("test").setQuery(
+                functionScoreQuery(
+                    matchQuery("body", "foo"),
+                    new FunctionScoreQueryBuilder.FilterFunctionBuilder[] {
+                        new FunctionScoreQueryBuilder.FilterFunctionBuilder(fieldValueFactorFunction("index").factor(2)),
+                        new FunctionScoreQueryBuilder.FilterFunctionBuilder(scriptFunction(script)) }
+                )
+            ),
+            response -> {
+                SearchHit firstHit = response.getHits().getAt(0);
+                assertThat(firstHit.getScore(), greaterThan(1f));
+            }
+        );
 
         // Test for accessing _score.doubleValue()
         script = new Script(ScriptType.INLINE, NAME, "log(doc['index'].value + (factor * _score.doubleValue()))", params);
-        resp = prepareSearch("test").setQuery(
-            functionScoreQuery(
-                matchQuery("body", "foo"),
-                new FunctionScoreQueryBuilder.FilterFunctionBuilder[] {
-                    new FunctionScoreQueryBuilder.FilterFunctionBuilder(fieldValueFactorFunction("index").factor(2)),
-                    new FunctionScoreQueryBuilder.FilterFunctionBuilder(scriptFunction(script)) }
-            )
-        ).get();
-        assertNoFailures(resp);
-        firstHit = resp.getHits().getAt(0);
-        assertThat(firstHit.getScore(), greaterThan(1f));
+        assertNoFailuresAndResponse(
+            prepareSearch("test").setQuery(
+                functionScoreQuery(
+                    matchQuery("body", "foo"),
+                    new FunctionScoreQueryBuilder.FilterFunctionBuilder[] {
+                        new FunctionScoreQueryBuilder.FilterFunctionBuilder(fieldValueFactorFunction("index").factor(2)),
+                        new FunctionScoreQueryBuilder.FilterFunctionBuilder(scriptFunction(script)) }
+                )
+            ),
+            response -> {
+                SearchHit firstHit = response.getHits().getAt(0);
+                assertThat(firstHit.getScore(), greaterThan(1f));
+            }
+        );
     }
 
     public void testSeedReportedInExplain() throws Exception {
@@ -243,28 +263,33 @@ public class RandomScoreFunctionIT extends ESIntegTestCase {
 
         int seed = 12345678;
 
-        SearchResponse resp = prepareSearch("test").setQuery(
-            functionScoreQuery(matchAllQuery(), randomFunction().seed(seed).setField(SeqNoFieldMapper.NAME))
-        ).setExplain(true).get();
-        assertNoFailures(resp);
-        assertEquals(1, resp.getHits().getTotalHits().value);
-        SearchHit firstHit = resp.getHits().getAt(0);
-        assertThat(firstHit.getExplanation().toString(), containsString("" + seed));
+        assertNoFailuresAndResponse(
+            prepareSearch("test").setQuery(functionScoreQuery(matchAllQuery(), randomFunction().seed(seed).setField(SeqNoFieldMapper.NAME)))
+                .setExplain(true),
+            response -> {
+                assertNoFailures(response);
+                assertEquals(1, response.getHits().getTotalHits().value);
+                SearchHit firstHit = response.getHits().getAt(0);
+                assertThat(firstHit.getExplanation().toString(), containsString("" + seed));
+            }
+        );
     }
 
     public void testNoDocs() throws Exception {
         createIndex("test");
         ensureGreen();
 
-        SearchResponse resp = prepareSearch("test").setQuery(
-            functionScoreQuery(matchAllQuery(), randomFunction().seed(1234).setField(SeqNoFieldMapper.NAME))
-        ).get();
-        assertNoFailures(resp);
-        assertEquals(0, resp.getHits().getTotalHits().value);
+        assertNoFailuresAndResponse(
+            prepareSearch("test").setQuery(
+                functionScoreQuery(matchAllQuery(), randomFunction().seed(1234).setField(SeqNoFieldMapper.NAME))
+            ),
+            response -> assertEquals(0, response.getHits().getTotalHits().value)
+        );
 
-        resp = prepareSearch("test").setQuery(functionScoreQuery(matchAllQuery(), randomFunction())).get();
-        assertNoFailures(resp);
-        assertEquals(0, resp.getHits().getTotalHits().value);
+        assertNoFailuresAndResponse(
+            prepareSearch("test").setQuery(functionScoreQuery(matchAllQuery(), randomFunction())),
+            response -> assertEquals(0, response.getHits().getTotalHits().value)
+        );
     }
 
     public void testScoreRange() throws Exception {
@@ -280,14 +305,14 @@ public class RandomScoreFunctionIT extends ESIntegTestCase {
         refresh();
         int iters = scaledRandomIntBetween(10, 20);
         for (int i = 0; i < iters; ++i) {
-            SearchResponse searchResponse = prepareSearch().setQuery(functionScoreQuery(matchAllQuery(), randomFunction()))
-                .setSize(docCount)
-                .get();
-
-            assertNoFailures(searchResponse);
-            for (SearchHit hit : searchResponse.getHits().getHits()) {
-                assertThat(hit.getScore(), allOf(greaterThanOrEqualTo(0.0f), lessThanOrEqualTo(1.0f)));
-            }
+            assertNoFailuresAndResponse(
+                prepareSearch().setQuery(functionScoreQuery(matchAllQuery(), randomFunction())).setSize(docCount),
+                response -> {
+                    for (SearchHit hit : response.getHits().getHits()) {
+                        assertThat(hit.getScore(), allOf(greaterThanOrEqualTo(0.0f), lessThanOrEqualTo(1.0f)));
+                    }
+                }
+            );
         }
     }
 
@@ -338,10 +363,10 @@ public class RandomScoreFunctionIT extends ESIntegTestCase {
 
         for (int i = 0; i < count; i++) {
 
-            SearchResponse searchResponse = prepareSearch().setQuery(functionScoreQuery(matchAllQuery(), new RandomScoreFunctionBuilder()))
-                .get();
-
-            matrix[Integer.valueOf(searchResponse.getHits().getAt(0).getId())]++;
+            assertResponse(
+                prepareSearch().setQuery(functionScoreQuery(matchAllQuery(), new RandomScoreFunctionBuilder())),
+                response -> matrix[Integer.valueOf(response.getHits().getAt(0).getId())]++
+            );
         }
 
         int filled = 0;


### PR DESCRIPTION
relates https://github.com/elastic/elasticsearch/issues/102030