### PR TITLE
Removing Version.CURRENT from geo ip

### DIFF
--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/IngestGeoIpPlugin.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/IngestGeoIpPlugin.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.ingest.geoip;
 
 import org.apache.lucene.util.SetOnce;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.client.internal.Client;
@@ -65,6 +64,14 @@ import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 public class IngestGeoIpPlugin extends Plugin implements IngestPlugin, SystemIndexPlugin, Closeable, PersistentTaskPlugin, ActionPlugin {
     public static final Setting<Long> CACHE_SIZE = Setting.longSetting("ingest.geoip.cache_size", 1000, 0, Setting.Property.NodeScope);
     private static final int GEOIP_INDEX_MAPPINGS_VERSION = 1;
+    /**
+     * No longer used for determining the age of mappings, but system index descriptor
+     * code requires <em>something</em> be set. We use a value that can be parsed by
+     * old nodes in mixed-version clusters, just in case any old code exists that
+     * tries to parse <code>version</code> from index metadata, and that will indicate
+     * to these old nodes that the mappings are newer than they are.
+     */
+    private static final String LEGACY_VERSION_FIELD_VALUE = "8.12.0";
 
     private final SetOnce<IngestService> ingestService = new SetOnce<>();
     private final SetOnce<DatabaseNodeService> databaseRegistry = new SetOnce<>();
@@ -204,7 +211,7 @@ public class IngestGeoIpPlugin extends Plugin implements IngestPlugin, SystemInd
             return jsonBuilder().startObject()
                 .startObject(SINGLE_MAPPING_NAME)
                 .startObject("_meta")
-                .field("version", Version.CURRENT)
+                .field("version", LEGACY_VERSION_FIELD_VALUE)
                 .field(SystemIndexDescriptor.VERSION_META_KEY, GEOIP_INDEX_MAPPINGS_VERSION)
                 .endObject()
                 .field("dynamic", "strict")


### PR DESCRIPTION
Previously, we put a version field in the _meta block for the `geoip_databases` system index mapping. The value of this field was the current version of Elasticsearch. It was used by the system to know if mappings were up to date. We're now putting a numeric version into the managed_index_mappings_version field in the _meta block for the `geoip_databases` system index mapping for the same purpose to get away from using the elasticsearch version. This will only be updated when the mapping changes.
We have to leave the version in place since it could be read by an older node in a mixed cluster. In order to make it clear that this is no longer in use going forward, I've frozen the value of version to "8.12.0". That way any older node will recognize it as newer.
This is nearly identical to the change for watcher in #102045.