### PR TITLE
Misc. small search cleanups

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/QueryPhaseResultConsumer.java
+++ b/server/src/main/java/org/elasticsearch/action/search/QueryPhaseResultConsumer.java
@@ -39,7 +39,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-import static java.util.stream.Collectors.toCollection;
 import static org.elasticsearch.action.search.SearchPhaseController.getTopDocsSize;
 import static org.elasticsearch.action.search.SearchPhaseController.mergeTopDocs;
 import static org.elasticsearch.action.search.SearchPhaseController.setShardIndex;
@@ -106,7 +105,7 @@ public class QueryPhaseResultConsumer extends ArraySearchPhaseResults<SearchPhas
 
     @Override
     public void close() {
-        Releasables.close(pendingMerges);
+        pendingMerges.close();
     }
 
     @Override
@@ -269,12 +268,9 @@ public class QueryPhaseResultConsumer extends ArraySearchPhaseResults<SearchPhas
                 assert circuitBreakerBytes >= 0;
             }
 
-            List<Releasable> toRelease = buffer.stream().<Releasable>map(b -> b::releaseAggs).collect(toCollection(ArrayList::new));
-            toRelease.add(() -> {
-                circuitBreaker.addWithoutBreaking(-circuitBreakerBytes);
-                circuitBreakerBytes = 0;
-            });
-            Releasables.close(toRelease);
+            releaseBuffer();
+            circuitBreaker.addWithoutBreaking(-circuitBreakerBytes);
+            circuitBreakerBytes = 0;
 
             if (hasPendingMerges()) {
                 // This is a theoretically unreachable exception.
@@ -350,8 +346,7 @@ public class QueryPhaseResultConsumer extends ArraySearchPhaseResults<SearchPhas
                             addEstimateAndMaybeBreak(aggsSize);
                         } catch (Exception exc) {
                             result.releaseAggs();
-                            buffer.forEach(QuerySearchResult::releaseAggs);
-                            buffer.clear();
+                            releaseBuffer();
                             onMergeFailure(exc);
                             next.run();
                             return;
@@ -377,6 +372,11 @@ public class QueryPhaseResultConsumer extends ArraySearchPhaseResults<SearchPhas
             if (executeNextImmediately) {
                 next.run();
             }
+        }
+
+        private void releaseBuffer() {
+            buffer.forEach(QuerySearchResult::releaseAggs);
+            buffer.clear();
         }
 
         private synchronized void onMergeFailure(Exception exc) {

--- a/server/src/main/java/org/elasticsearch/search/fetch/ShardFetchRequest.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/ShardFetchRequest.java
@@ -37,7 +37,8 @@ public class ShardFetchRequest extends TransportRequest {
 
     private final int[] docIds;
 
-    private ScoreDoc lastEmittedDoc;
+    @Nullable
+    private final ScoreDoc lastEmittedDoc;
 
     public ShardFetchRequest(ShardSearchContextId contextId, List<Integer> docIds, ScoreDoc lastEmittedDoc) {
         this.contextId = contextId;
@@ -60,6 +61,8 @@ public class ShardFetchRequest extends TransportRequest {
             lastEmittedDoc = Lucene.readScoreDoc(in);
         } else if (flag != 0) {
             throw new IOException("Unknown flag: " + flag);
+        } else {
+            lastEmittedDoc = null;
         }
     }
 

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/TransportSubmitAsyncSearchAction.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/TransportSubmitAsyncSearchAction.java
@@ -24,7 +24,6 @@ import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.search.SearchService;
-import org.elasticsearch.search.aggregations.AggregationReduceContext;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.transport.TransportService;
@@ -37,16 +36,13 @@ import org.elasticsearch.xpack.core.search.action.SubmitAsyncSearchAction;
 import org.elasticsearch.xpack.core.search.action.SubmitAsyncSearchRequest;
 
 import java.util.Map;
-import java.util.function.BiFunction;
-import java.util.function.Function;
-import java.util.function.Supplier;
 
 import static org.elasticsearch.xpack.core.ClientHelper.ASYNC_SEARCH_ORIGIN;
 
 public class TransportSubmitAsyncSearchAction extends HandledTransportAction<SubmitAsyncSearchRequest, AsyncSearchResponse> {
     private final ClusterService clusterService;
     private final NodeClient nodeClient;
-    private final BiFunction<Supplier<Boolean>, SearchRequest, AggregationReduceContext> requestToAggReduceContextBuilder;
+    private final SearchService searchService;
     private final TransportSearchAction searchAction;
     private final ThreadContext threadContext;
     private final AsyncTaskIndexService<AsyncSearchResponse> store;
@@ -72,10 +68,7 @@ public class TransportSubmitAsyncSearchAction extends HandledTransportAction<Sub
         );
         this.clusterService = clusterService;
         this.nodeClient = nodeClient;
-        this.requestToAggReduceContextBuilder = (task, request) -> searchService.aggReduceContextBuilder(
-            task,
-            request.source().aggregations()
-        ).forFinalReduction();
+        this.searchService = searchService;
         this.searchAction = searchAction;
         this.threadContext = transportService.getThreadPool().getThreadContext();
         this.store = new AsyncTaskIndexService<>(
@@ -162,12 +155,11 @@ public class TransportSubmitAsyncSearchAction extends HandledTransportAction<Sub
             nodeClient.threadPool().getThreadContext(),
             clusterService.state()
         );
-        SearchRequest searchRequest = new SearchRequest(request.getSearchRequest()) {
+        var originalSearchRequest = request.getSearchRequest();
+        SearchRequest searchRequest = new SearchRequest(originalSearchRequest) {
             @Override
             public AsyncSearchTask createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> taskHeaders) {
                 AsyncExecutionId searchId = new AsyncExecutionId(docID, new TaskId(nodeClient.getLocalNodeId(), id));
-                Function<Supplier<Boolean>, Supplier<AggregationReduceContext>> aggReduceContextSupplierFactory =
-                    isCancelled -> () -> requestToAggReduceContextBuilder.apply(isCancelled, request.getSearchRequest());
                 return new AsyncSearchTask(
                     id,
                     type,
@@ -180,7 +172,8 @@ public class TransportSubmitAsyncSearchAction extends HandledTransportAction<Sub
                     searchId,
                     store.getClientWithOrigin(),
                     nodeClient.threadPool(),
-                    aggReduceContextSupplierFactory
+                    isCancelled -> () -> searchService.aggReduceContextBuilder(isCancelled, originalSearchRequest.source().aggregations())
+                        .forFinalReduction()
                 );
             }
         };


### PR DESCRIPTION
Couple small things from investigating ref-counting that individually don't deserve their own PRs.
* make `ShardFetchRequest` immutable
* simplify away redundant lambda field (this neither saved memory nor did it make the code any easier to read)
* dry up buffer release in a search phase and avoid allocating a list during closing to both make it faster and less allocation heavy for larger searches
* avoid getting (in the sense of getter call) a ref counted variable repeatedly, just get it once and manage it from there to make the ref counting easier to follow 