### PR TITLE
Adding "not" in the error message for attempts to load text fields when synthetic source is enabled (#102118)

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -994,7 +994,7 @@ public class TextFieldMapper extends FieldMapper {
                 throw new IllegalArgumentException(
                     "fetching values from a text field ["
                         + name()
-                        + "] is supported because synthetic _source is enabled and we don't have a way to load the fields"
+                        + "] is not supported because synthetic _source is enabled and we don't have a way to load the fields"
                 );
             }
             return new SourceValueFetcherSortedBinaryIndexFieldData.Builder(


### PR DESCRIPTION
Backports https://github.com/elastic/elasticsearch/pull/102118

(cherry picked from commit 4701abaa673a8c3aad64faa3dcbef404517a1010)