### PR TITLE
[DOCS] Update ES|QL getting started for demo environment

### DIFF
--- a/docs/reference/esql/esql-get-started.asciidoc
+++ b/docs/reference/esql/esql-get-started.asciidoc
@@ -7,50 +7,14 @@
 
 This guide shows how you can use {esql} to query and aggregate your data.
 
-TIP: To get started with {esql} without setting up your own deployment, visit
-the public {esql} demo environment at
-https://esql.demo.elastic.co/[esql.demo.elastic.co]. It comes with preloaded
-data sets and sample queries.
-
 [discrete]
 [[esql-getting-started-prerequisites]]
 === Prerequisites
 
-To follow along with the queries in this getting started guide, first ingest
-some sample data using the following requests:
+To follow along with the queries in this guide, you can either set up your own
+deployment, or use Elastic's public {esql} demo environment.
 
-[source,console]
-----
-PUT sample_data
-{
-  "mappings": {
-    "properties": {
-      "client.ip": {
-        "type": "ip"
-      },
-      "message": {
-        "type": "keyword"
-      }
-    }
-  }
-}
-
-PUT sample_data/_bulk
-{"index": {}}
-{"@timestamp": "2023-10-23T12:15:03.360Z", "client.ip": "172.21.2.162", "message": "Connected to 10.1.0.3", "event.duration": 3450233}
-{"index": {}}
-{"@timestamp": "2023-10-23T12:27:28.948Z", "client.ip": "172.21.2.113", "message": "Connected to 10.1.0.2", "event.duration": 2764889}
-{"index": {}}
-{"@timestamp": "2023-10-23T13:33:34.937Z", "client.ip": "172.21.0.5", "message": "Disconnected", "event.duration": 1232382}
-{"index": {}}
-{"@timestamp": "2023-10-23T13:51:54.732Z", "client.ip": "172.21.3.15", "message": "Connection error", "event.duration": 725448}
-{"index": {}}
-{"@timestamp": "2023-10-23T13:52:55.015Z", "client.ip": "172.21.3.15", "message": "Connection error", "event.duration": 8268153}
-{"index": {}}
-{"@timestamp": "2023-10-23T13:53:55.832Z", "client.ip": "172.21.3.15", "message": "Connection error", "event.duration": 5033755}
-{"index": {}}
-{"@timestamp": "2023-10-23T13:55:01.543Z", "client.ip": "172.21.3.15", "message": "Connected to 10.1.0.1", "event.duration": 1756467}
-----
+include::{es-repo-dir}/tab-widgets/esql/esql-getting-started-widget-sample-data.asciidoc[]
 
 [discrete]
 [[esql-getting-started-running-queries]]
@@ -58,7 +22,7 @@ PUT sample_data/_bulk
 
 In {kib}, you can use Console or Discover to run {esql} queries:
 
-include::{es-repo-dir}/tab-widgets/esql/esql-getting-started-widget.asciidoc[]
+include::{es-repo-dir}/tab-widgets/esql/esql-getting-started-widget-discover-console.asciidoc[]
 
 [discrete]
 [[esql-getting-started-first-query]]
@@ -300,57 +264,9 @@ image::images/esql/esql-enrich.png[align="center"]
 
 Before you can use `ENRICH`, you first need to
 <<esql-create-enrich-policy,create>> and <<esql-execute-enrich-policy,execute>>
-an <<esql-enrich-policy,enrich policy>>. The following requests create and
-execute a policy that links an IP address to an environment ("Development",
-"QA", or "Production"):
+an <<esql-enrich-policy,enrich policy>>. 
 
-[source,console]
-----
-PUT clientips
-{
-  "mappings": {
-    "properties": {
-      "client.ip": {
-        "type": "keyword"
-      },
-      "env": {
-        "type": "keyword"
-      }
-    }
-  }
-}
-
-PUT clientips/_bulk
-{ "index" : {}}
-{ "client.ip": "172.21.0.5", "env": "Development" }
-{ "index" : {}}
-{ "client.ip": "172.21.2.113", "env": "QA" }
-{ "index" : {}}
-{ "client.ip": "172.21.2.162", "env": "QA" }
-{ "index" : {}}
-{ "client.ip": "172.21.3.15", "env": "Production" }
-{ "index" : {}}
-{ "client.ip": "172.21.3.16", "env": "Production" }
-
-PUT /_enrich/policy/clientip_policy
-{
-  "match": {
-    "indices": "clientips",
-    "match_field": "client.ip",
-    "enrich_fields": ["env"]
-  }
-}
-
-PUT /_enrich/policy/clientip_policy/_execute
-----
-
-////
-[source,console]
-----
-DELETE /_enrich/policy/clientip_policy
-----
-// TEST[continued]
-////
+include::{es-repo-dir}/tab-widgets/esql/esql-getting-started-widget-enrich-policy.asciidoc[]
 
 After creating and executing a policy, you can use it with the `ENRICH`
 command:

--- a/docs/reference/tab-widgets/esql/esql-getting-started-discover-console.asciidoc
+++ b/docs/reference/tab-widgets/esql/esql-getting-started-discover-console.asciidoc
@@ -34,6 +34,9 @@ FROM sample_data
 
 include::../../esql/esql-kibana.asciidoc[tag=esql-mode]
 
+Adjust the time filter so it includes the timestamps in the sample data (October
+23rd, 2023).
+
 After switching to {esql} mode, the query bar shows a sample query. You can
 replace this query with the queries in this getting started guide.
 

--- a/docs/reference/tab-widgets/esql/esql-getting-started-enrich-policy.asciidoc
+++ b/docs/reference/tab-widgets/esql/esql-getting-started-enrich-policy.asciidoc
@@ -1,0 +1,65 @@
+// tag::own-deployment[]
+
+The following requests create and execute a policy called `clientip_policy`. The
+policy links an IP address to an environment ("Development", "QA", or
+"Production"):
+
+[source,console]
+----
+PUT clientips
+{
+  "mappings": {
+    "properties": {
+      "client.ip": {
+        "type": "keyword"
+      },
+      "env": {
+        "type": "keyword"
+      }
+    }
+  }
+}
+
+PUT clientips/_bulk
+{ "index" : {}}
+{ "client.ip": "172.21.0.5", "env": "Development" }
+{ "index" : {}}
+{ "client.ip": "172.21.2.113", "env": "QA" }
+{ "index" : {}}
+{ "client.ip": "172.21.2.162", "env": "QA" }
+{ "index" : {}}
+{ "client.ip": "172.21.3.15", "env": "Production" }
+{ "index" : {}}
+{ "client.ip": "172.21.3.16", "env": "Production" }
+
+PUT /_enrich/policy/clientip_policy
+{
+  "match": {
+    "indices": "clientips",
+    "match_field": "client.ip",
+    "enrich_fields": ["env"]
+  }
+}
+
+PUT /_enrich/policy/clientip_policy/_execute
+----
+
+////
+[source,console]
+----
+DELETE /_enrich/policy/clientip_policy
+----
+// TEST[continued]
+////
+
+// end::own-deployment[]
+
+
+// tag::demo-env[]
+
+On the demo environment at https://esql.demo.elastic.co/[esql.demo.elastic.co],
+an enrich policy called `clientip_policy` has already been created an executed.
+The policy links an IP address to an environment ("Development", "QA", or
+"Production")
+
+// end::demo-env[]

--- a/docs/reference/tab-widgets/esql/esql-getting-started-sample-data.asciidoc
+++ b/docs/reference/tab-widgets/esql/esql-getting-started-sample-data.asciidoc
@@ -1,0 +1,48 @@
+// tag::own-deployment[]
+
+First ingest some sample data. In {kib}, open the main menu and select *Dev
+Tools*. Run the the following two requests:
+
+[source,console]
+----
+PUT sample_data
+{
+  "mappings": {
+    "properties": {
+      "client.ip": {
+        "type": "ip"
+      },
+      "message": {
+        "type": "keyword"
+      }
+    }
+  }
+}
+
+PUT sample_data/_bulk
+{"index": {}}
+{"@timestamp": "2023-10-23T12:15:03.360Z", "client.ip": "172.21.2.162", "message": "Connected to 10.1.0.3", "event.duration": 3450233}
+{"index": {}}
+{"@timestamp": "2023-10-23T12:27:28.948Z", "client.ip": "172.21.2.113", "message": "Connected to 10.1.0.2", "event.duration": 2764889}
+{"index": {}}
+{"@timestamp": "2023-10-23T13:33:34.937Z", "client.ip": "172.21.0.5", "message": "Disconnected", "event.duration": 1232382}
+{"index": {}}
+{"@timestamp": "2023-10-23T13:51:54.732Z", "client.ip": "172.21.3.15", "message": "Connection error", "event.duration": 725448}
+{"index": {}}
+{"@timestamp": "2023-10-23T13:52:55.015Z", "client.ip": "172.21.3.15", "message": "Connection error", "event.duration": 8268153}
+{"index": {}}
+{"@timestamp": "2023-10-23T13:53:55.832Z", "client.ip": "172.21.3.15", "message": "Connection error", "event.duration": 5033755}
+{"index": {}}
+{"@timestamp": "2023-10-23T13:55:01.543Z", "client.ip": "172.21.3.15", "message": "Connected to 10.1.0.1", "event.duration": 1756467}
+----
+
+// end::own-deployment[]
+
+
+// tag::demo-env[]
+
+The data set used in this guide has been preloaded into the Elastic {esql}
+public demo environment. Visit
+https://esql.demo.elastic.co/[esql.demo.elastic.co] to start using it.
+
+// end::demo-env[]

--- a/docs/reference/tab-widgets/esql/esql-getting-started-widget-discover-console.asciidoc
+++ b/docs/reference/tab-widgets/esql/esql-getting-started-widget-discover-console.asciidoc
@@ -1,6 +1,6 @@
 ++++
-<div class="tabs" data-tab-group="model">
-  <div role="tablist" aria-label="model">
+<div class="tabs" data-tab-group="discover-console">
+  <div role="tablist" aria-label="discover-console">
     <button role="tab"
             aria-selected="true"
             aria-controls="esql-tab-console"
@@ -20,7 +20,7 @@
        aria-labelledby="esql-console">
 ++++
 
-include::esql-getting-started.asciidoc[tag=console]
+include::esql-getting-started-discover-console.asciidoc[tag=console]
 
 ++++
   </div>
@@ -31,7 +31,7 @@ include::esql-getting-started.asciidoc[tag=console]
        hidden="">
 ++++
 
-include::esql-getting-started.asciidoc[tag=discover]
+include::esql-getting-started-discover-console.asciidoc[tag=discover]
 
 ++++
   </div>

--- a/docs/reference/tab-widgets/esql/esql-getting-started-widget-enrich-policy.asciidoc
+++ b/docs/reference/tab-widgets/esql/esql-getting-started-widget-enrich-policy.asciidoc
@@ -1,0 +1,39 @@
+++++
+<div class="tabs" data-tab-group="demo-env">
+  <div role="tablist" aria-label="demo-env">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="esql-enrich-tab-own-deployment"
+            id="esql-enrich-own-deployment">
+      Own deployment
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="esql-enrich-tab-demo-env"
+            id="esql-enrich-demo-env">
+      Demo environment
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="esql-enrich-tab-own-deployment"
+       aria-labelledby="esql-enrich-own-deployment">
+++++
+
+include::esql-getting-started-enrich-policy.asciidoc[tag=own-deployment]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="esql-enrich-tab-demo-env"
+       aria-labelledby="esql-enrich-demo-env"
+       hidden="">
+++++
+
+include::esql-getting-started-enrich-policy.asciidoc[tag=demo-env]
+
+++++
+  </div>
+</div>
+++++

--- a/docs/reference/tab-widgets/esql/esql-getting-started-widget-sample-data.asciidoc
+++ b/docs/reference/tab-widgets/esql/esql-getting-started-widget-sample-data.asciidoc
@@ -1,0 +1,39 @@
+++++
+<div class="tabs" data-tab-group="demo-env">
+  <div role="tablist" aria-label="demo-env">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="esql-tab-own-deployment"
+            id="esql-own-deployment">
+      Own deployment
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="esql-tab-demo-env"
+            id="esql-demo-env">
+      Demo environment
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="esql-tab-own-deployment"
+       aria-labelledby="esql-own-deployment">
+++++
+
+include::esql-getting-started-sample-data.asciidoc[tag=own-deployment]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="esql-tab-demo-env"
+       aria-labelledby="esql-demo-env"
+       hidden="">
+++++
+
+include::esql-getting-started-sample-data.asciidoc[tag=demo-env]
+
+++++
+  </div>
+</div>
+++++


### PR DESCRIPTION
The ES|QL getting started data set and enrich policy have been loaded into the ES|QL demo environment at https://esql.demo.elastic.co , making it easier for users to get started with ES|QL without having to spin up their own deployment.

This PR updates the getting started instructions accordingly, by letting users choose between their own environment or the demo environment using tabbed widgets.