### PR TITLE
Reduce static footprint of Painless

### DIFF
--- a/modules/lang-painless/spi/src/main/java/org/elasticsearch/painless/spi/Whitelist.java
+++ b/modules/lang-painless/spi/src/main/java/org/elasticsearch/painless/spi/Whitelist.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.painless.spi;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -47,11 +46,10 @@ public final class Whitelist {
         List<WhitelistClassBinding> whitelistClassBindings,
         List<WhitelistInstanceBinding> whitelistInstanceBindings
     ) {
-
         this.classLoader = Objects.requireNonNull(classLoader);
-        this.whitelistClasses = Collections.unmodifiableList(Objects.requireNonNull(whitelistClasses));
-        this.whitelistImportedMethods = Collections.unmodifiableList(Objects.requireNonNull(whitelistImportedMethods));
-        this.whitelistClassBindings = Collections.unmodifiableList(Objects.requireNonNull(whitelistClassBindings));
-        this.whitelistInstanceBindings = Collections.unmodifiableList(Objects.requireNonNull(whitelistInstanceBindings));
+        this.whitelistClasses = List.copyOf(whitelistClasses);
+        this.whitelistImportedMethods = List.copyOf(whitelistImportedMethods);
+        this.whitelistClassBindings = List.copyOf(whitelistClassBindings);
+        this.whitelistInstanceBindings = List.copyOf(whitelistInstanceBindings);
     }
 }

--- a/modules/lang-painless/spi/src/main/java/org/elasticsearch/painless/spi/WhitelistClass.java
+++ b/modules/lang-painless/spi/src/main/java/org/elasticsearch/painless/spi/WhitelistClass.java
@@ -8,11 +8,10 @@
 
 package org.elasticsearch.painless.spi;
 
-import java.util.AbstractMap;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -59,23 +58,12 @@ public final class WhitelistClass {
         List<WhitelistField> whitelistFields,
         List<Object> painlessAnnotations
     ) {
-
         this.origin = Objects.requireNonNull(origin);
         this.javaClassName = Objects.requireNonNull(javaClassName);
-
-        this.whitelistConstructors = Collections.unmodifiableList(Objects.requireNonNull(whitelistConstructors));
-        this.whitelistMethods = Collections.unmodifiableList(Objects.requireNonNull(whitelistMethods));
-        this.whitelistFields = Collections.unmodifiableList(Objects.requireNonNull(whitelistFields));
-
-        if (painlessAnnotations.isEmpty()) {
-            this.painlessAnnotations = Collections.emptyMap();
-        } else {
-            this.painlessAnnotations = Collections.unmodifiableMap(
-                Objects.requireNonNull(painlessAnnotations)
-                    .stream()
-                    .map(painlessAnnotation -> new AbstractMap.SimpleEntry<>(painlessAnnotation.getClass(), painlessAnnotation))
-                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))
-            );
-        }
+        this.whitelistConstructors = List.copyOf(whitelistConstructors);
+        this.whitelistMethods = List.copyOf(whitelistMethods);
+        this.whitelistFields = List.copyOf(whitelistFields);
+        this.painlessAnnotations = painlessAnnotations.stream()
+            .collect(Collectors.toUnmodifiableMap(Object::getClass, Function.identity()));
     }
 }

--- a/modules/lang-painless/spi/src/main/java/org/elasticsearch/painless/spi/WhitelistField.java
+++ b/modules/lang-painless/spi/src/main/java/org/elasticsearch/painless/spi/WhitelistField.java
@@ -8,11 +8,10 @@
 
 package org.elasticsearch.painless.spi;
 
-import java.util.AbstractMap;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -39,16 +38,7 @@ public class WhitelistField {
         this.origin = Objects.requireNonNull(origin);
         this.fieldName = Objects.requireNonNull(fieldName);
         this.canonicalTypeNameParameter = Objects.requireNonNull(canonicalTypeNameParameter);
-
-        if (painlessAnnotations.isEmpty()) {
-            this.painlessAnnotations = Collections.emptyMap();
-        } else {
-            this.painlessAnnotations = Collections.unmodifiableMap(
-                Objects.requireNonNull(painlessAnnotations)
-                    .stream()
-                    .map(painlessAnnotation -> new AbstractMap.SimpleEntry<>(painlessAnnotation.getClass(), painlessAnnotation))
-                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))
-            );
-        }
+        this.painlessAnnotations = painlessAnnotations.stream()
+            .collect(Collectors.toUnmodifiableMap(Object::getClass, Function.identity()));
     }
 }

--- a/modules/lang-painless/spi/src/main/java/org/elasticsearch/painless/spi/WhitelistMethod.java
+++ b/modules/lang-painless/spi/src/main/java/org/elasticsearch/painless/spi/WhitelistMethod.java
@@ -8,11 +8,10 @@
 
 package org.elasticsearch.painless.spi;
 
-import java.util.AbstractMap;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -69,22 +68,12 @@ public class WhitelistMethod {
         List<String> canonicalTypeNameParameters,
         List<Object> painlessAnnotations
     ) {
-
         this.origin = Objects.requireNonNull(origin);
         this.augmentedCanonicalClassName = augmentedCanonicalClassName;
         this.methodName = methodName;
         this.returnCanonicalTypeName = Objects.requireNonNull(returnCanonicalTypeName);
-        this.canonicalTypeNameParameters = Collections.unmodifiableList(Objects.requireNonNull(canonicalTypeNameParameters));
-
-        if (painlessAnnotations.isEmpty()) {
-            this.painlessAnnotations = Collections.emptyMap();
-        } else {
-            this.painlessAnnotations = Collections.unmodifiableMap(
-                Objects.requireNonNull(painlessAnnotations)
-                    .stream()
-                    .map(painlessAnnotation -> new AbstractMap.SimpleEntry<>(painlessAnnotation.getClass(), painlessAnnotation))
-                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))
-            );
-        }
+        this.canonicalTypeNameParameters = List.copyOf(canonicalTypeNameParameters);
+        this.painlessAnnotations = painlessAnnotations.stream()
+            .collect(Collectors.toUnmodifiableMap(Object::getClass, Function.identity()));
     }
 }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/lookup/PainlessClass.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/lookup/PainlessClass.java
@@ -45,7 +45,7 @@ public final class PainlessClass {
         this.staticFields = Map.copyOf(staticFields);
         this.fields = Map.copyOf(fields);
         this.functionalInterfaceMethod = functionalInterfaceMethod;
-        this.annotations = annotations;
+        this.annotations = Map.copyOf(annotations);
 
         this.getterMethodHandles = Map.copyOf(getterMethodHandles);
         this.setterMethodHandles = Map.copyOf(setterMethodHandles);

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/lookup/PainlessLookupBuilder.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/lookup/PainlessLookupBuilder.java
@@ -1680,6 +1680,7 @@ public final class PainlessLookupBuilder {
             );
         }
 
+        classesToDirectSubClasses.replaceAll((key, set) -> Set.copyOf(set)); // save some memory, especially when set is empty
         return new PainlessLookup(
             javaClassNamesToClasses,
             canonicalClassNamesToClasses,


### PR DESCRIPTION
Many empty lists+sets+maps here that we can save. Found this in a heap dump I investigated and seems we can save about 3Mb of heap use from this plus it mostly saves code.
