### PR TITLE
Normalize vectors indexed with dot_product similarity

### DIFF
--- a/docs/changelog/102155.yaml
+++ b/docs/changelog/102155.yaml
@@ -1,0 +1,5 @@
+pr: 102155
+summary: Normalize vectors indexed with `dot_product` similarity
+area: Vector Search
+type: enhancement
+issues: []

--- a/docs/reference/how-to/knn-search.asciidoc
+++ b/docs/reference/how-to/knn-search.asciidoc
@@ -21,8 +21,8 @@ options.
 The `cosine` option accepts any float vector and computes the cosine
 similarity. While this is convenient for testing, it's not the most efficient
 approach. Instead, we recommend using the `dot_product` option to compute the
-similarity. To use `dot_product`, all vectors need to be normalized in advance
-to have length 1. The `dot_product` option is significantly faster, since it
+similarity. When using `dot_product`, all vectors are normalized during index to have
+a magnitude of 1. The `dot_product` option is significantly faster, since it
 avoids performing extra vector length computations during the search.
 
 [discrete]

--- a/docs/reference/mapping/types/dense-vector.asciidoc
+++ b/docs/reference/mapping/types/dense-vector.asciidoc
@@ -160,9 +160,9 @@ Computes the dot product of two unit vectors. This option provides an optimized 
 to perform cosine similarity. The constraints and computed score are defined
 by `element_type`.
 +
-When `element_type` is `float`, all vectors must be unit length, including both
-document and query vectors. The document `_score` is computed as
-`(1 + dot_product(query, vector)) / 2`.
+When `element_type` is `float`, all vectors are automatically converted to unit length, including both
+document and query vectors. Consequently, `dot_product` does not allow vectors with a zero magnitude.
+The document `_score` is computed as `(1 + dot_product(query, vector)) / 2`.
 +
 When `element_type` is `byte`, all vectors must have the same
 length including both document and query vectors or results will be inaccurate.
@@ -172,9 +172,9 @@ where `dims` is the number of dimensions per vector.
 
 `cosine`:::
 Computes the cosine similarity. Note that the most efficient way to perform
-cosine similarity is to normalize all vectors to unit length, and instead use
+cosine similarity is to have all vectors normalized to unit length, and instead use
 `dot_product`. You should only use `cosine` if you need to preserve the
-original vectors and cannot normalize them in advance. The document `_score`
+original vectors and cannot allow Elasticsearch to normalize them. The document `_score`
 is computed as `(1 + cosine(query, vector)) / 2`. The `cosine` similarity does
 not allow vectors with zero magnitude, since cosine is not defined in this
 case.

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/40_knn_search.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/40_knn_search.yml
@@ -436,3 +436,122 @@ setup:
   - length: {hits.hits: 1}
   - match: {hits.hits.0._id: "2"}
   - close_to: {hits.hits.0._score: {value: 33686.29, error: 0.01}}
+---
+"kNN search with dot-product auto-normalized":
+  - skip:
+      features: close_to
+      version: ' - 8.11.99'
+      reason: 'dense_vector auto-normalized dot_product in 8.12'
+
+  - do:
+      indices.create:
+        index: test_dot_product
+        body:
+          mappings:
+            properties:
+              name:
+                type: keyword
+              dot_product_vector:
+                type: dense_vector
+                dims: 5
+                index: true
+                similarity: dot_product
+              cosine_vector:
+                type: dense_vector
+                dims: 5
+                index: true
+                similarity: cosine
+
+  - do:
+      index:
+        index: test_dot_product
+        id: "1"
+        body:
+          name: cow.jpg
+          dot_product_vector: [ 230.0, 300.33, -34.8988, 15.555, -200.0 ]
+          cosine_vector: [ 230.0, 300.33, -34.8988, 15.555, -200.0 ]
+
+  - do:
+      index:
+        index: test_dot_product
+        id: "2"
+        body:
+          name: moose.jpg
+          dot_product_vector: [ -0.5, 100.0, -13, 14.8, -156.0 ]
+          cosine_vector: [ -0.5, 100.0, -13, 14.8, -156.0 ]
+
+  - do:
+      index:
+        index: test_dot_product
+        id: "3"
+        body:
+          name: rabbit.jpg
+          dot_product_vector: [ 0.5, 111.3, -13.0, 14.8, -156.0 ]
+          cosine_vector: [ 0.5, 111.3, -13.0, 14.8, -156.0 ]
+
+  - do:
+      indices.refresh: { }
+
+  - do:
+      search:
+        index: test_dot_product
+        body:
+          fields: [ "name" ]
+          knn:
+            field: dot_product_vector
+            query_vector: [-0.5, 90.0, -10, 14.8, -156.0]
+            k: 2
+            num_candidates: 3
+
+  - match: {hits.total.value: 2}
+  - match: {hits.hits.0._id: "2"}
+  - set: { hits.hits.0._score: score_0 }
+  - match: {hits.hits.0.fields.name.0: "moose.jpg"}
+  - match: {hits.hits.1._id: "3"}
+  - set: { hits.hits.1._score: score_1 }
+  - match: {hits.hits.1.fields.name.0: "rabbit.jpg"}
+
+  - do:
+      search:
+        index: test_dot_product
+        body:
+          fields: [ "name" ]
+          knn:
+            field: cosine_vector
+            query_vector: [ -0.5, 90.0, -10, 14.8, -156.0 ]
+            k: 2
+            num_candidates: 3
+
+  - match: {hits.total.value: 2}
+  - match: {hits.hits.0._id: "2"}
+  - close_to: { hits.hits.0._score: { value: $score_0, error: 0.00001 } }
+  - match: {hits.hits.0.fields.name.0: "moose.jpg"}
+  - match: {hits.hits.1._id: "3"}
+  - close_to: { hits.hits.1._score: { value: $score_1, error: 0.00001 } }
+  - match: {hits.hits.1.fields.name.0: "rabbit.jpg"}
+---
+"kNN search fails with non-normalized dot-product in older versions":
+  - skip:
+      version: '8.11.99 - '
+      reason: 'dense_vector auto-normalized dot_product in 8.12'
+
+  - do:
+      indices.create:
+        index: test_failing_dot_product
+        body:
+          mappings:
+            properties:
+              dot_product_vector:
+                type: dense_vector
+                dims: 5
+                index: true
+                similarity: dot_product
+
+  - do:
+      catch: bad_request
+      index:
+        index: test_failing_dot_product
+        id: "1"
+        body:
+          name: cow.jpg
+          dot_product_vector: [ 230.0, 300.33, -34.8988, 15.555, -200.0 ]

--- a/server/src/main/java/org/elasticsearch/index/IndexVersions.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersions.java
@@ -87,6 +87,7 @@ public class IndexVersions {
     public static final IndexVersion NEW_SPARSE_VECTOR = def(8_500_001, Version.LUCENE_9_7_0);
     public static final IndexVersion SPARSE_VECTOR_IN_FIELD_NAMES_SUPPORT = def(8_500_002, Version.LUCENE_9_7_0);
     public static final IndexVersion UPGRADE_LUCENE_9_8 = def(8_500_003, Version.LUCENE_9_8_0);
+    public static final IndexVersion NORMALIZE_DOT_PRODUCT = def(8_500_004, Version.LUCENE_9_8_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
@@ -342,7 +342,7 @@ public class DenseVectorFieldMapperTests extends MapperTestCase {
                 b -> b.field("type", "dense_vector").field("dims", 3).field("index", true).field("similarity", VectorSimilarity.DOT_PRODUCT)
             )
         );
-        float[] vector = { -12.1f, 2.7f, -4 };
+        float[] vector = { 0f, 0f, 0f };
         DocumentParsingException e = expectThrows(
             DocumentParsingException.class,
             () -> mapper.parse(source(b -> b.array("field", vector)))
@@ -351,23 +351,7 @@ public class DenseVectorFieldMapperTests extends MapperTestCase {
         assertThat(
             e.getCause().getMessage(),
             containsString(
-                "The [dot_product] similarity can only be used with unit-length vectors. Preview of invalid vector: [-12.1, 2.7, -4.0]"
-            )
-        );
-
-        DocumentMapper mapperWithLargerDim = createDocumentMapper(
-            fieldMapping(
-                b -> b.field("type", "dense_vector").field("dims", 6).field("index", true).field("similarity", VectorSimilarity.DOT_PRODUCT)
-            )
-        );
-        float[] largerVector = { -12.1f, 2.7f, -4, 1.05f, 10.0f, 29.9f };
-        e = expectThrows(DocumentParsingException.class, () -> mapperWithLargerDim.parse(source(b -> b.array("field", largerVector))));
-        assertNotNull(e.getCause());
-        assertThat(
-            e.getCause().getMessage(),
-            containsString(
-                "The [dot_product] similarity can only be used with unit-length vectors. "
-                    + "Preview of invalid vector: [-12.1, 2.7, -4.0, 1.05, 10.0, ...]"
+                "The [dot_product] similarity does not support vectors with zero magnitude. Preview of invalid vector: [0.0, 0.0, 0.0]"
             )
         );
     }
@@ -571,7 +555,7 @@ public class DenseVectorFieldMapperTests extends MapperTestCase {
         assertNull(denseVectorFieldType.getSimilarity());
     }
 
-    public void testtParamsBeforeIndexByDefault() throws Exception {
+    public void testParamsBeforeIndexByDefault() throws Exception {
         DocumentMapper documentMapper = createDocumentMapper(INDEXED_BY_DEFAULT_PREVIOUS_INDEX_VERSION, fieldMapping(b -> {
             b.field("type", "dense_vector").field("dims", 3).field("index", true).field("similarity", "dot_product");
         }));

--- a/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldTypeTests.java
@@ -185,9 +185,9 @@ public class DenseVectorFieldTypeTests extends FieldTypeTestCase {
         );
         e = expectThrows(
             IllegalArgumentException.class,
-            () -> dotProductField.createKnnQuery(new float[] { 0.3f, 0.1f, 1.0f }, 10, null, null, null)
+            () -> dotProductField.createKnnQuery(new float[] { 0.0f, 0.0f, 0.0f }, 10, null, null, null)
         );
-        assertThat(e.getMessage(), containsString("The [dot_product] similarity can only be used with unit-length vectors."));
+        assertThat(e.getMessage(), containsString("The [dot_product] similarity does not support vectors with zero magnitude."));
 
         DenseVectorFieldType cosineField = new DenseVectorFieldType(
             "f",

--- a/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/CloseToAssertion.java
+++ b/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/CloseToAssertion.java
@@ -36,14 +36,14 @@ public class CloseToAssertion extends Assertion {
                 throw new IllegalArgumentException("expected a map with value and error but got a map with " + map.size() + " fields");
             }
             Object valObj = map.get("value");
-            if (valObj instanceof Number == false) {
-                throw new IllegalArgumentException("value is missing or not a number");
+            if (valObj == null) {
+                throw new IllegalArgumentException("value is missing");
             }
             Object errObj = map.get("error");
             if (errObj instanceof Number == false) {
                 throw new IllegalArgumentException("error is missing or not a number");
             }
-            return new CloseToAssertion(location, fieldValueTuple.v1(), ((Number) valObj).doubleValue(), ((Number) errObj).doubleValue());
+            return new CloseToAssertion(location, fieldValueTuple.v1(), valObj, ((Number) errObj).doubleValue());
         } else {
             throw new IllegalArgumentException(
                 "expected a map with value and error but got " + fieldValueTuple.v2().getClass().getSimpleName()
@@ -56,7 +56,7 @@ public class CloseToAssertion extends Assertion {
 
     private final double error;
 
-    public CloseToAssertion(XContentLocation location, String field, Double expectedValue, Double error) {
+    public CloseToAssertion(XContentLocation location, String field, Object expectedValue, Double error) {
         super(location, field, expectedValue);
         this.error = error;
     }
@@ -69,9 +69,9 @@ public class CloseToAssertion extends Assertion {
     protected void doAssert(Object actualValue, Object expectedValue) {
         logger.trace("assert that [{}] is close to [{}] with error [{}] (field [{}])", actualValue, expectedValue, error, getField());
         if (actualValue instanceof Number actualValueNumber) {
-            assertThat(actualValueNumber.doubleValue(), closeTo((Double) expectedValue, error));
+            assertThat(actualValueNumber.doubleValue(), closeTo(((Number) expectedValue).doubleValue(), error));
         } else {
-            throw new AssertionError("excpected a value close to " + expectedValue + " but got " + actualValue + ", which is not a number");
+            throw new AssertionError("expected a value close to " + expectedValue + " but got " + actualValue + ", which is not a number");
         }
     }
 }

--- a/test/yaml-rest-runner/src/test/java/org/elasticsearch/test/rest/yaml/section/AssertionTests.java
+++ b/test/yaml-rest-runner/src/test/java/org/elasticsearch/test/rest/yaml/section/AssertionTests.java
@@ -169,7 +169,7 @@ public class AssertionTests extends AbstractClientYamlTestFragmentParserTestCase
 
         parser = createParser(YamlXContent.yamlXContent, "{ field: { foo: 13, bar: 15 } }");
         exception = expectThrows(IllegalArgumentException.class, () -> CloseToAssertion.parse(parser));
-        assertThat(exception.getMessage(), equalTo("value is missing or not a number"));
+        assertThat(exception.getMessage(), equalTo("value is missing"));
     }
 
     public void testExists() throws IOException {


### PR DESCRIPTION
`dot_product` requires vectors to be unit-length. Previously, we would check that vectors were unit-length and throw if they were not.

Instead, we will now auto-normalize vectors as they are indexed.

`cosine` will continue to behave as usual, not normalizing the vectors.

closes: https://github.com/elastic/elasticsearch/issues/98935