### PR TITLE
[8.10] default run_ml_inference should be true (#102151)

### DIFF
--- a/docs/changelog/102151.yaml
+++ b/docs/changelog/102151.yaml
@@ -1,0 +1,5 @@
+pr: 102151
+summary: Default `run_ml_inference` should be true
+area: Application
+type: bug
+issues: []

--- a/x-pack/plugin/core/template-resources/src/main/resources/entsearch/connector/elastic-connectors-mappings.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/entsearch/connector/elastic-connectors-mappings.json
@@ -9,7 +9,7 @@
         "pipeline": {
           "default_name": "ent-search-generic-ingestion",
           "default_extract_binary_content": true,
-          "default_run_ml_inference": false,
+          "default_run_ml_inference": true,
           "default_reduce_whitespace": true
         },
         "version": ${xpack.application.connector.template.version}


### PR DESCRIPTION
Backports the following commits to 8.10:
 - default run_ml_inference should be true (#102151)