### PR TITLE
[8.11] [DOCS] More ES|QL limitations (#101972)

### DIFF
--- a/docs/reference/esql/esql-limitations.asciidoc
+++ b/docs/reference/esql/esql-limitations.asciidoc
@@ -57,6 +57,7 @@ include::processing-commands/limit.asciidoc[tag=limitation]
 ** `completion`
 ** `dense_vector`
 ** `double_range`
+** `flattened`
 ** `float_range`
 ** `histogram`
 ** `integer_range`
@@ -156,6 +157,12 @@ include::esql-process-data-with-dissect-grok.asciidoc[tag=grok-limitations]
 return `null` when applied to a multivalued field, unless documented otherwise.
 Work around this limitation by converting the field to single value with one of
 the <<esql-mv-functions,multivalue functions>>.
+
+[discrete]
+[[esql-limitations-timezone]]
+=== Timezone support
+
+{esql} only supports the UTC timezone.
 
 [discrete]
 [[esql-limitations-kibana]]

--- a/docs/reference/esql/esql-query-api.asciidoc
+++ b/docs/reference/esql/esql-query-api.asciidoc
@@ -68,11 +68,6 @@ responses. See <<esql-rest-columnar>>.
 `query`::
 (Required, object) {esql} query to run. For syntax, refer to <<esql-syntax>>.
 
-[[esql-search-api-time-zone]]
-`time_zone`::
-(Optional, string) ISO-8601 time zone ID for the search. Several {esql}
-date/time functions use this time zone. Defaults to `Z` (UTC).
-
 [discrete]
 [role="child_attributes"]
 [[esql-query-api-response-body]]


### PR DESCRIPTION
Backports the following commits to 8.11:
 - [DOCS] More ES|QL limitations (#101972)