### PR TITLE
More linearizable register docs

### DIFF
--- a/docs/reference/snapshot-restore/apis/repo-analysis-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/repo-analysis-api.asciidoc
@@ -141,8 +141,9 @@ between versions. The request parameters and response format depend on details
 of the implementation so may also be different in newer versions.
 
 The analysis comprises a number of blob-level tasks, as set by the `blob_count`
-parameter. The blob-level tasks are distributed over the data and
-master-eligible nodes in the cluster for execution.
+parameter, and a number of compare-and-exchange operations on linearizable
+registers. These tasks are distributed over the data and master-eligible nodes
+in the cluster for execution.
 
 For most blob-level tasks, the executing node first writes a blob to the
 repository, and then instructs some of the other nodes in the cluster to


### PR DESCRIPTION
In 8.12 users can configure the number of register operations performed
by repository analysis, but this configuration is not available in
earlier versions. Nonetheless, we should at least mention that
repository analysis does some register operations. This commit backports
the few relevant lines of the docs changes from #102051 to earlier
branches.

Relates #102050