### PR TITLE
Avoid eagerly resolving dependencies when configuring packaging tests

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/DistroTestPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/DistroTestPlugin.java
@@ -101,7 +101,7 @@ public class DistroTestPlugin implements Plugin<Project> {
                 addDistributionSysprop(t, DISTRIBUTION_SYSPROP, distribution::getFilepath);
                 addDistributionSysprop(t, EXAMPLE_PLUGIN_SYSPROP, () -> examplePlugin.getSingleFile().toString());
                 t.exclude("**/PackageUpgradeTests.class");
-            }, distribution.getArchiveDependencies(), examplePlugin.getDependencies());
+            }, distribution, examplePlugin.getDependencies());
 
             if (distribution.getPlatform() == Platform.WINDOWS) {
                 windowsTestTasks.add(destructiveTask);
@@ -235,6 +235,7 @@ public class DistroTestPlugin implements Plugin<Project> {
                 d.setBundledJdk(bundledJdk);
             }
             d.setVersion(version);
+            d.setPreferArchive(true);
         });
 
         // Allow us to gracefully omit building Docker distributions if Docker is not available on the system.


### PR DESCRIPTION
The current implementation of `Distribution.getArchiveDependencies()` would cause a bunch of task resolution to happen. Avoid this by simply relying on the fact that `Distribution` is `Buildable` and simply resolve different dependencies based on requested configuration.