### PR TITLE
Move LeakTracker to production code and use it in assertions around QuerySearchContext

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
@@ -94,13 +94,14 @@ public class QueryPhase {
             if (searchTimedOut) {
                 break;
             }
-            RankSearchContext rankSearchContext = new RankSearchContext(searchContext, rankQuery, rankShardContext.windowSize());
-            QueryPhase.addCollectorsAndSearch(rankSearchContext);
-            QuerySearchResult rrfQuerySearchResult = rankSearchContext.queryResult();
-            rrfRankResults.add(rrfQuerySearchResult.topDocs().topDocs);
-            serviceTimeEWMA += rrfQuerySearchResult.serviceTimeEWMA();
-            nodeQueueSize = Math.max(nodeQueueSize, rrfQuerySearchResult.nodeQueueSize());
-            searchTimedOut = rrfQuerySearchResult.searchTimedOut();
+            try (RankSearchContext rankSearchContext = new RankSearchContext(searchContext, rankQuery, rankShardContext.windowSize())) {
+                QueryPhase.addCollectorsAndSearch(rankSearchContext);
+                QuerySearchResult rrfQuerySearchResult = rankSearchContext.queryResult();
+                rrfRankResults.add(rrfQuerySearchResult.topDocs().topDocs);
+                serviceTimeEWMA += rrfQuerySearchResult.serviceTimeEWMA();
+                nodeQueueSize = Math.max(nodeQueueSize, rrfQuerySearchResult.nodeQueueSize());
+                searchTimedOut = rrfQuerySearchResult.searchTimedOut();
+            }
         }
 
         querySearchResult.setRankShardResult(rankShardContext.combine(rrfRankResults));

--- a/server/src/main/java/org/elasticsearch/search/rank/RankSearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/rank/RankSearchContext.java
@@ -64,6 +64,7 @@ public class RankSearchContext extends SearchContext {
         this.rankQuery = parent.buildFilteredQuery(rankQuery);
         this.windowSize = windowSize;
         this.querySearchResult = new QuerySearchResult(parent.readerContext().id(), parent.shardTarget(), parent.request());
+        this.addReleasable(querySearchResult::decRef);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/action/search/DfsQueryPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/DfsQueryPhaseTests.java
@@ -81,30 +81,38 @@ public class DfsQueryPhaseTests extends ESTestCase {
                         new SearchShardTarget("node1", new ShardId("test", "na", 0), null),
                         null
                     );
-                    queryResult.topDocs(
-                        new TopDocsAndMaxScore(
-                            new TopDocs(new TotalHits(1, TotalHits.Relation.EQUAL_TO), new ScoreDoc[] { new ScoreDoc(42, 1.0F) }),
-                            2.0F
-                        ),
-                        new DocValueFormat[0]
-                    );
-                    queryResult.size(2); // the size of the result set
-                    listener.onResponse(queryResult);
+                    try {
+                        queryResult.topDocs(
+                            new TopDocsAndMaxScore(
+                                new TopDocs(new TotalHits(1, TotalHits.Relation.EQUAL_TO), new ScoreDoc[] { new ScoreDoc(42, 1.0F) }),
+                                2.0F
+                            ),
+                            new DocValueFormat[0]
+                        );
+                        queryResult.size(2); // the size of the result set
+                        listener.onResponse(queryResult);
+                    } finally {
+                        queryResult.decRef();
+                    }
                 } else if (request.contextId().getId() == 2) {
                     QuerySearchResult queryResult = new QuerySearchResult(
                         new ShardSearchContextId("", 123),
                         new SearchShardTarget("node2", new ShardId("test", "na", 0), null),
                         null
                     );
-                    queryResult.topDocs(
-                        new TopDocsAndMaxScore(
-                            new TopDocs(new TotalHits(1, TotalHits.Relation.EQUAL_TO), new ScoreDoc[] { new ScoreDoc(84, 2.0F) }),
-                            2.0F
-                        ),
-                        new DocValueFormat[0]
-                    );
-                    queryResult.size(2); // the size of the result set
-                    listener.onResponse(queryResult);
+                    try {
+                        queryResult.topDocs(
+                            new TopDocsAndMaxScore(
+                                new TopDocs(new TotalHits(1, TotalHits.Relation.EQUAL_TO), new ScoreDoc[] { new ScoreDoc(84, 2.0F) }),
+                                2.0F
+                            ),
+                            new DocValueFormat[0]
+                        );
+                        queryResult.size(2); // the size of the result set
+                        listener.onResponse(queryResult);
+                    } finally {
+                        queryResult.decRef();
+                    }
                 } else {
                     fail("no such request ID: " + request.contextId());
                 }
@@ -172,15 +180,19 @@ public class DfsQueryPhaseTests extends ESTestCase {
                         new SearchShardTarget("node1", new ShardId("test", "na", 0), null),
                         null
                     );
-                    queryResult.topDocs(
-                        new TopDocsAndMaxScore(
-                            new TopDocs(new TotalHits(1, TotalHits.Relation.EQUAL_TO), new ScoreDoc[] { new ScoreDoc(42, 1.0F) }),
-                            2.0F
-                        ),
-                        new DocValueFormat[0]
-                    );
-                    queryResult.size(2); // the size of the result set
-                    listener.onResponse(queryResult);
+                    try {
+                        queryResult.topDocs(
+                            new TopDocsAndMaxScore(
+                                new TopDocs(new TotalHits(1, TotalHits.Relation.EQUAL_TO), new ScoreDoc[] { new ScoreDoc(42, 1.0F) }),
+                                2.0F
+                            ),
+                            new DocValueFormat[0]
+                        );
+                        queryResult.size(2); // the size of the result set
+                        listener.onResponse(queryResult);
+                    } finally {
+                        queryResult.decRef();
+                    }
                 } else if (request.contextId().getId() == 2) {
                     listener.onFailure(new MockDirectoryWrapper.FakeIOException());
                 } else {
@@ -252,15 +264,19 @@ public class DfsQueryPhaseTests extends ESTestCase {
                         new SearchShardTarget("node1", new ShardId("test", "na", 0), null),
                         null
                     );
-                    queryResult.topDocs(
-                        new TopDocsAndMaxScore(
-                            new TopDocs(new TotalHits(1, TotalHits.Relation.EQUAL_TO), new ScoreDoc[] { new ScoreDoc(42, 1.0F) }),
-                            2.0F
-                        ),
-                        new DocValueFormat[0]
-                    );
-                    queryResult.size(2); // the size of the result set
-                    listener.onResponse(queryResult);
+                    try {
+                        queryResult.topDocs(
+                            new TopDocsAndMaxScore(
+                                new TopDocs(new TotalHits(1, TotalHits.Relation.EQUAL_TO), new ScoreDoc[] { new ScoreDoc(42, 1.0F) }),
+                                2.0F
+                            ),
+                            new DocValueFormat[0]
+                        );
+                        queryResult.size(2); // the size of the result set
+                        listener.onResponse(queryResult);
+                    } finally {
+                        queryResult.decRef();
+                    }
                 } else if (request.contextId().getId() == 2) {
                     throw new UncheckedIOException(new MockDirectoryWrapper.FakeIOException());
                 } else {

--- a/server/src/test/java/org/elasticsearch/action/search/FetchSearchPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/FetchSearchPhaseTests.java
@@ -76,8 +76,12 @@ public class FetchSearchPhaseTests extends ESTestCase {
             SearchHits hits = new SearchHits(new SearchHit[] { new SearchHit(42) }, new TotalHits(1, TotalHits.Relation.EQUAL_TO), 1.0F);
             fetchResult.shardResult(hits, fetchProfile(profiled));
             QueryFetchSearchResult fetchSearchResult = new QueryFetchSearchResult(queryResult, fetchResult);
-            fetchSearchResult.setShardIndex(0);
-            results.consumeResult(fetchSearchResult, () -> {});
+            try {
+                fetchSearchResult.setShardIndex(0);
+                results.consumeResult(fetchSearchResult, () -> {});
+            } finally {
+                fetchSearchResult.decRef();
+            }
             numHits = 1;
         } else {
             numHits = 0;
@@ -135,33 +139,42 @@ public class FetchSearchPhaseTests extends ESTestCase {
 
         ShardSearchContextId ctx1 = new ShardSearchContextId(UUIDs.base64UUID(), 123);
         SearchShardTarget shard1Target = new SearchShardTarget("node1", new ShardId("test", "na", 0), null);
+        SearchShardTarget shard2Target = new SearchShardTarget("node2", new ShardId("test", "na", 1), null);
         QuerySearchResult queryResult = new QuerySearchResult(ctx1, shard1Target, null);
-        queryResult.topDocs(
-            new TopDocsAndMaxScore(
-                new TopDocs(new TotalHits(1, TotalHits.Relation.EQUAL_TO), new ScoreDoc[] { new ScoreDoc(42, 1.0F) }),
-                2.0F
-            ),
-            new DocValueFormat[0]
-        );
-        queryResult.size(resultSetSize); // the size of the result set
-        queryResult.setShardIndex(0);
-        addProfiling(profiled, queryResult);
-        results.consumeResult(queryResult, () -> {});
+        try {
+            queryResult.topDocs(
+                new TopDocsAndMaxScore(
+                    new TopDocs(new TotalHits(1, TotalHits.Relation.EQUAL_TO), new ScoreDoc[] { new ScoreDoc(42, 1.0F) }),
+                    2.0F
+                ),
+                new DocValueFormat[0]
+            );
+            queryResult.size(resultSetSize); // the size of the result set
+            queryResult.setShardIndex(0);
+            addProfiling(profiled, queryResult);
+            results.consumeResult(queryResult, () -> {});
+
+        } finally {
+            queryResult.decRef();
+        }
 
         final ShardSearchContextId ctx2 = new ShardSearchContextId(UUIDs.base64UUID(), 321);
-        SearchShardTarget shard2Target = new SearchShardTarget("node2", new ShardId("test", "na", 1), null);
-        queryResult = new QuerySearchResult(ctx2, shard2Target, null);
-        queryResult.topDocs(
-            new TopDocsAndMaxScore(
-                new TopDocs(new TotalHits(1, TotalHits.Relation.EQUAL_TO), new ScoreDoc[] { new ScoreDoc(84, 2.0F) }),
-                2.0F
-            ),
-            new DocValueFormat[0]
-        );
-        queryResult.size(resultSetSize);
-        queryResult.setShardIndex(1);
-        addProfiling(profiled, queryResult);
-        results.consumeResult(queryResult, () -> {});
+        try {
+            queryResult = new QuerySearchResult(ctx2, shard2Target, null);
+            queryResult.topDocs(
+                new TopDocsAndMaxScore(
+                    new TopDocs(new TotalHits(1, TotalHits.Relation.EQUAL_TO), new ScoreDoc[] { new ScoreDoc(84, 2.0F) }),
+                    2.0F
+                ),
+                new DocValueFormat[0]
+            );
+            queryResult.size(resultSetSize);
+            queryResult.setShardIndex(1);
+            addProfiling(profiled, queryResult);
+            results.consumeResult(queryResult, () -> {});
+        } finally {
+            queryResult.decRef();
+        }
 
         mockSearchPhaseContext.searchTransport = new SearchTransportService(null, null, null) {
             @Override
@@ -228,31 +241,39 @@ public class FetchSearchPhaseTests extends ESTestCase {
         final ShardSearchContextId ctx = new ShardSearchContextId(UUIDs.base64UUID(), 123);
         SearchShardTarget shard1Target = new SearchShardTarget("node1", new ShardId("test", "na", 0), null);
         QuerySearchResult queryResult = new QuerySearchResult(ctx, shard1Target, null);
-        queryResult.topDocs(
-            new TopDocsAndMaxScore(
-                new TopDocs(new TotalHits(1, TotalHits.Relation.EQUAL_TO), new ScoreDoc[] { new ScoreDoc(42, 1.0F) }),
-                2.0F
-            ),
-            new DocValueFormat[0]
-        );
-        queryResult.size(resultSetSize); // the size of the result set
-        queryResult.setShardIndex(0);
-        addProfiling(profiled, queryResult);
-        results.consumeResult(queryResult, () -> {});
+        try {
+            queryResult.topDocs(
+                new TopDocsAndMaxScore(
+                    new TopDocs(new TotalHits(1, TotalHits.Relation.EQUAL_TO), new ScoreDoc[] { new ScoreDoc(42, 1.0F) }),
+                    2.0F
+                ),
+                new DocValueFormat[0]
+            );
+            queryResult.size(resultSetSize); // the size of the result set
+            queryResult.setShardIndex(0);
+            addProfiling(profiled, queryResult);
+            results.consumeResult(queryResult, () -> {});
+        } finally {
+            queryResult.decRef();
+        }
 
         SearchShardTarget shard2Target = new SearchShardTarget("node2", new ShardId("test", "na", 1), null);
         queryResult = new QuerySearchResult(new ShardSearchContextId("", 321), shard2Target, null);
-        queryResult.topDocs(
-            new TopDocsAndMaxScore(
-                new TopDocs(new TotalHits(1, TotalHits.Relation.EQUAL_TO), new ScoreDoc[] { new ScoreDoc(84, 2.0F) }),
-                2.0F
-            ),
-            new DocValueFormat[0]
-        );
-        queryResult.size(resultSetSize);
-        queryResult.setShardIndex(1);
-        addProfiling(profiled, queryResult);
-        results.consumeResult(queryResult, () -> {});
+        try {
+            queryResult.topDocs(
+                new TopDocsAndMaxScore(
+                    new TopDocs(new TotalHits(1, TotalHits.Relation.EQUAL_TO), new ScoreDoc[] { new ScoreDoc(84, 2.0F) }),
+                    2.0F
+                ),
+                new DocValueFormat[0]
+            );
+            queryResult.size(resultSetSize);
+            queryResult.setShardIndex(1);
+            addProfiling(profiled, queryResult);
+            results.consumeResult(queryResult, () -> {});
+        } finally {
+            queryResult.decRef();
+        }
 
         mockSearchPhaseContext.searchTransport = new SearchTransportService(null, null, null) {
             @Override
@@ -345,10 +366,14 @@ public class FetchSearchPhaseTests extends ESTestCase {
                 ),
                 new DocValueFormat[0]
             );
-            queryResult.size(resultSetSize); // the size of the result set
-            queryResult.setShardIndex(i);
-            addProfiling(profiled, queryResult);
-            results.consumeResult(queryResult, () -> {});
+            try {
+                queryResult.size(resultSetSize); // the size of the result set
+                queryResult.setShardIndex(i);
+                addProfiling(profiled, queryResult);
+                results.consumeResult(queryResult, () -> {});
+            } finally {
+                queryResult.decRef();
+            }
         }
         mockSearchPhaseContext.searchTransport = new SearchTransportService(null, null, null) {
             @Override
@@ -437,32 +462,39 @@ public class FetchSearchPhaseTests extends ESTestCase {
         boolean profiled = randomBoolean();
 
         SearchShardTarget shard1Target = new SearchShardTarget("node1", new ShardId("test", "na", 0), null);
-        QuerySearchResult queryResult = new QuerySearchResult(new ShardSearchContextId("", 123), shard1Target, null);
-        queryResult.topDocs(
-            new TopDocsAndMaxScore(
-                new TopDocs(new TotalHits(1, TotalHits.Relation.EQUAL_TO), new ScoreDoc[] { new ScoreDoc(42, 1.0F) }),
-                2.0F
-            ),
-            new DocValueFormat[0]
-        );
-        queryResult.size(resultSetSize); // the size of the result set
-        queryResult.setShardIndex(0);
-        addProfiling(profiled, queryResult);
-        results.consumeResult(queryResult, () -> {});
-
         SearchShardTarget shard2Target = new SearchShardTarget("node1", new ShardId("test", "na", 0), null);
-        queryResult = new QuerySearchResult(new ShardSearchContextId("", 321), shard2Target, null);
-        queryResult.topDocs(
-            new TopDocsAndMaxScore(
-                new TopDocs(new TotalHits(1, TotalHits.Relation.EQUAL_TO), new ScoreDoc[] { new ScoreDoc(84, 2.0F) }),
-                2.0F
-            ),
-            new DocValueFormat[0]
-        );
-        queryResult.size(resultSetSize);
-        queryResult.setShardIndex(1);
-        addProfiling(profiled, queryResult);
-        results.consumeResult(queryResult, () -> {});
+        QuerySearchResult queryResult = new QuerySearchResult(new ShardSearchContextId("", 123), shard1Target, null);
+        try {
+            queryResult.topDocs(
+                new TopDocsAndMaxScore(
+                    new TopDocs(new TotalHits(1, TotalHits.Relation.EQUAL_TO), new ScoreDoc[] { new ScoreDoc(42, 1.0F) }),
+                    2.0F
+                ),
+                new DocValueFormat[0]
+            );
+            queryResult.size(resultSetSize); // the size of the result set
+            queryResult.setShardIndex(0);
+            addProfiling(profiled, queryResult);
+            results.consumeResult(queryResult, () -> {});
+        } finally {
+            queryResult.decRef();
+        }
+        try {
+            queryResult = new QuerySearchResult(new ShardSearchContextId("", 321), shard2Target, null);
+            queryResult.topDocs(
+                new TopDocsAndMaxScore(
+                    new TopDocs(new TotalHits(1, TotalHits.Relation.EQUAL_TO), new ScoreDoc[] { new ScoreDoc(84, 2.0F) }),
+                    2.0F
+                ),
+                new DocValueFormat[0]
+            );
+            queryResult.size(resultSetSize);
+            queryResult.setShardIndex(1);
+            addProfiling(profiled, queryResult);
+            results.consumeResult(queryResult, () -> {});
+        } finally {
+            queryResult.decRef();
+        }
 
         AtomicInteger numFetches = new AtomicInteger(0);
         mockSearchPhaseContext.searchTransport = new SearchTransportService(null, null, null) {
@@ -527,32 +559,39 @@ public class FetchSearchPhaseTests extends ESTestCase {
         final ShardSearchContextId ctx1 = new ShardSearchContextId(UUIDs.base64UUID(), 123);
         SearchShardTarget shard1Target = new SearchShardTarget("node1", new ShardId("test", "na", 0), null);
         QuerySearchResult queryResult = new QuerySearchResult(ctx1, shard1Target, null);
-        queryResult.topDocs(
-            new TopDocsAndMaxScore(
-                new TopDocs(new TotalHits(1, TotalHits.Relation.EQUAL_TO), new ScoreDoc[] { new ScoreDoc(42, 1.0F) }),
-                2.0F
-            ),
-            new DocValueFormat[0]
-        );
-        queryResult.size(resultSetSize); // the size of the result set
-        queryResult.setShardIndex(0);
-        addProfiling(profiled, queryResult);
-        results.consumeResult(queryResult, () -> {});
-
+        try {
+            queryResult.topDocs(
+                new TopDocsAndMaxScore(
+                    new TopDocs(new TotalHits(1, TotalHits.Relation.EQUAL_TO), new ScoreDoc[] { new ScoreDoc(42, 1.0F) }),
+                    2.0F
+                ),
+                new DocValueFormat[0]
+            );
+            queryResult.size(resultSetSize); // the size of the result set
+            queryResult.setShardIndex(0);
+            addProfiling(profiled, queryResult);
+            results.consumeResult(queryResult, () -> {});
+        } finally {
+            queryResult.decRef();
+        }
         final ShardSearchContextId ctx2 = new ShardSearchContextId(UUIDs.base64UUID(), 321);
         SearchShardTarget shard2Target = new SearchShardTarget("node2", new ShardId("test", "na", 1), null);
         queryResult = new QuerySearchResult(ctx2, shard2Target, null);
-        queryResult.topDocs(
-            new TopDocsAndMaxScore(
-                new TopDocs(new TotalHits(1, TotalHits.Relation.EQUAL_TO), new ScoreDoc[] { new ScoreDoc(84, 2.0F) }),
-                2.0F
-            ),
-            new DocValueFormat[0]
-        );
-        queryResult.size(resultSetSize);
-        queryResult.setShardIndex(1);
-        addProfiling(profiled, queryResult);
-        results.consumeResult(queryResult, () -> {});
+        try {
+            queryResult.topDocs(
+                new TopDocsAndMaxScore(
+                    new TopDocs(new TotalHits(1, TotalHits.Relation.EQUAL_TO), new ScoreDoc[] { new ScoreDoc(84, 2.0F) }),
+                    2.0F
+                ),
+                new DocValueFormat[0]
+            );
+            queryResult.size(resultSetSize);
+            queryResult.setShardIndex(1);
+            addProfiling(profiled, queryResult);
+            results.consumeResult(queryResult, () -> {});
+        } finally {
+            queryResult.decRef();
+        }
 
         mockSearchPhaseContext.searchTransport = new SearchTransportService(null, null, null) {
             @Override

--- a/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
@@ -382,16 +382,24 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
                             new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()),
                             result
                         );
-                        SearchPhaseResult searchPhaseResult = result.get();
-                        List<Integer> intCursors = new ArrayList<>(1);
-                        intCursors.add(0);
-                        ShardFetchRequest req = new ShardFetchRequest(searchPhaseResult.getContextId(), intCursors, null/* not a scroll */);
-                        PlainActionFuture<FetchSearchResult> listener = new PlainActionFuture<>();
-                        service.executeFetchPhase(req, new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()), listener);
-                        listener.get();
-                        if (useScroll) {
-                            // have to free context since this test does not remove the index from IndicesService.
-                            service.freeReaderContext(searchPhaseResult.getContextId());
+                        final SearchPhaseResult searchPhaseResult = result.get();
+                        try {
+                            List<Integer> intCursors = new ArrayList<>(1);
+                            intCursors.add(0);
+                            ShardFetchRequest req = new ShardFetchRequest(
+                                searchPhaseResult.getContextId(),
+                                intCursors,
+                                null/* not a scroll */
+                            );
+                            PlainActionFuture<FetchSearchResult> listener = new PlainActionFuture<>();
+                            service.executeFetchPhase(req, new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()), listener);
+                            listener.get().decRef();
+                            if (useScroll) {
+                                // have to free context since this test does not remove the index from IndicesService.
+                                service.freeReaderContext(searchPhaseResult.getContextId());
+                            }
+                        } finally {
+                            searchPhaseResult.decRef();
                         }
                     } catch (ExecutionException ex) {
                         assertThat(ex.getCause(), instanceOf(RuntimeException.class));
@@ -1046,6 +1054,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
                     // make sure that the wrapper is called when the query is actually executed
                     assertEquals(6, numWrapInvocations.get());
                 } finally {
+                    searchPhaseResult.decRef();
                     latch.countDown();
                 }
             }
@@ -1360,6 +1369,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
                         assertNotNull(result.queryResult().topDocs());
                         assertNotNull(result.queryResult().aggregations());
                     } finally {
+                        result.decRef();
                         latch.countDown();
                     }
                 }
@@ -1390,6 +1400,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
                         assertNotNull(result.queryResult().topDocs());
                         assertNotNull(result.queryResult().aggregations());
                     } finally {
+                        result.decRef();
                         latch.countDown();
                     }
                 }
@@ -1418,6 +1429,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
                         assertThat(result, instanceOf(QuerySearchResult.class));
                         assertTrue(result.queryResult().isNull());
                     } finally {
+                        result.decRef();
                         latch.countDown();
                     }
                 }
@@ -1558,6 +1570,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
             @Override
             public void onResponse(SearchPhaseResult searchPhaseResult) {
                 service.freeReaderContext(searchPhaseResult.getContextId());
+                searchPhaseResult.decRef();
                 latch1.countDown();
             }
 
@@ -1602,6 +1615,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
                     fail("Search not cancelled early");
                 } finally {
                     service.freeReaderContext(searchPhaseResult.getContextId());
+                    searchPhaseResult.decRef();
                     latch3.countDown();
                 }
             }
@@ -1728,7 +1742,11 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
         );
         service.executeQueryPhase(request, task, future);
         SearchPhaseResult searchPhaseResult = future.actionGet();
-        assertEquals(1, searchPhaseResult.queryResult().getTotalHits().value);
+        try {
+            assertEquals(1, searchPhaseResult.queryResult().getTotalHits().value);
+        } finally {
+            searchPhaseResult.decRef();
+        }
     }
 
     public void testWaitOnRefreshFailsWithRefreshesDisabled() {
@@ -1907,7 +1925,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
             plainActionFuture
         );
 
-        plainActionFuture.actionGet();
+        plainActionFuture.actionGet().decRef();
         assertThat(((TestRewriteCounterQueryBuilder) request.source().query()).asyncRewriteCount, equalTo(1));
         final ShardSearchContextId contextId = context.id();
         assertTrue(service.freeReaderContext(contextId));
@@ -2068,114 +2086,37 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
         try (ReaderContext readerContext = createReaderContext(indexService, indexShard)) {
             SearchShardTask task = new SearchShardTask(0, "type", "action", "description", null, emptyMap());
             {
-                SearchContext searchContext = service.createContext(readerContext, request, task, ResultsType.DFS, true);
-                ContextIndexSearcher searcher = searchContext.searcher();
-                assertNotNull(searcher.getExecutor());
-
-                final int maxPoolSize = executor.getMaximumPoolSize();
-                assertEquals(
-                    "Sanity check to ensure this isn't the default of 1 when pool size is unset",
-                    configuredMaxPoolSize,
-                    maxPoolSize
-                );
-
-                final int expectedSlices = ContextIndexSearcher.computeSlices(searcher.getIndexReader().leaves(), maxPoolSize, 1).length;
-                assertNotEquals("Sanity check to ensure this isn't the default of 1 when pool size is unset", 1, expectedSlices);
-
-                final long priorExecutorTaskCount = executor.getCompletedTaskCount();
-                searcher.search(termQuery, new TotalHitCountCollectorManager());
-                assertBusy(
-                    () -> assertEquals(
-                        "DFS supports parallel collection, so the number of slices should be > 1.",
-                        expectedSlices,
-                        executor.getCompletedTaskCount() - priorExecutorTaskCount
-                    )
-                );
-            }
-            {
-                SearchContext searchContext = service.createContext(readerContext, request, task, ResultsType.QUERY, true);
-                ContextIndexSearcher searcher = searchContext.searcher();
-                assertNotNull(searcher.getExecutor());
-
-                final int maxPoolSize = executor.getMaximumPoolSize();
-                assertEquals(
-                    "Sanity check to ensure this isn't the default of 1 when pool size is unset",
-                    configuredMaxPoolSize,
-                    maxPoolSize
-                );
-
-                final int expectedSlices = ContextIndexSearcher.computeSlices(searcher.getIndexReader().leaves(), maxPoolSize, 1).length;
-                assertNotEquals("Sanity check to ensure this isn't the default of 1 when pool size is unset", 1, expectedSlices);
-
-                final long priorExecutorTaskCount = executor.getCompletedTaskCount();
-                searcher.search(termQuery, new TotalHitCountCollectorManager());
-                assertBusy(
-                    () -> assertEquals(
-                        "QUERY supports parallel collection when enabled, so the number of slices should be > 1.",
-                        expectedSlices,
-                        executor.getCompletedTaskCount() - priorExecutorTaskCount
-                    )
-                );
-            }
-            {
-                SearchContext searchContext = service.createContext(readerContext, request, task, ResultsType.FETCH, true);
-                ContextIndexSearcher searcher = searchContext.searcher();
-                assertNotNull(searcher.getExecutor());
-                final long priorExecutorTaskCount = executor.getCompletedTaskCount();
-                searcher.search(termQuery, new TotalHitCountCollectorManager());
-                assertBusy(
-                    () -> assertEquals(
-                        "The number of slices should be 1 as FETCH does not support parallel collection.",
-                        1,
-                        executor.getCompletedTaskCount() - priorExecutorTaskCount
-                    )
-                );
-            }
-            {
-                SearchContext searchContext = service.createContext(readerContext, request, task, ResultsType.NONE, true);
-                ContextIndexSearcher searcher = searchContext.searcher();
-                assertNotNull(searcher.getExecutor());
-                final long priorExecutorTaskCount = executor.getCompletedTaskCount();
-                searcher.search(termQuery, new TotalHitCountCollectorManager());
-                assertBusy(
-                    () -> assertEquals(
-                        "The number of slices should be 1 as NONE does not support parallel collection.",
-                        1,
-                        executor.getCompletedTaskCount() - priorExecutorTaskCount
-                    )
-                );
-            }
-
-            try {
-                ClusterUpdateSettingsResponse response = client().admin()
-                    .cluster()
-                    .prepareUpdateSettings()
-                    .setPersistentSettings(Settings.builder().put(QUERY_PHASE_PARALLEL_COLLECTION_ENABLED.getKey(), false).build())
-                    .get();
-                assertTrue(response.isAcknowledged());
-                {
-                    SearchContext searchContext = service.createContext(readerContext, request, task, ResultsType.QUERY, true);
+                try (SearchContext searchContext = service.createContext(readerContext, request, task, ResultsType.DFS, true)) {
                     ContextIndexSearcher searcher = searchContext.searcher();
                     assertNotNull(searcher.getExecutor());
+
+                    final int maxPoolSize = executor.getMaximumPoolSize();
+                    assertEquals(
+                        "Sanity check to ensure this isn't the default of 1 when pool size is unset",
+                        configuredMaxPoolSize,
+                        maxPoolSize
+                    );
+
+                    final int expectedSlices = ContextIndexSearcher.computeSlices(
+                        searcher.getIndexReader().leaves(),
+                        maxPoolSize,
+                        1
+                    ).length;
+                    assertNotEquals("Sanity check to ensure this isn't the default of 1 when pool size is unset", 1, expectedSlices);
+
                     final long priorExecutorTaskCount = executor.getCompletedTaskCount();
                     searcher.search(termQuery, new TotalHitCountCollectorManager());
                     assertBusy(
                         () -> assertEquals(
-                            "The number of slices should be 1 when QUERY parallel collection is disabled.",
-                            1,
+                            "DFS supports parallel collection, so the number of slices should be > 1.",
+                            expectedSlices,
                             executor.getCompletedTaskCount() - priorExecutorTaskCount
                         )
                     );
                 }
-            } finally {
-                // Reset to the original default setting and check to ensure it takes effect.
-                client().admin()
-                    .cluster()
-                    .prepareUpdateSettings()
-                    .setPersistentSettings(Settings.builder().putNull(QUERY_PHASE_PARALLEL_COLLECTION_ENABLED.getKey()).build())
-                    .get();
-                {
-                    SearchContext searchContext = service.createContext(readerContext, request, task, ResultsType.QUERY, true);
+            }
+            {
+                try (SearchContext searchContext = service.createContext(readerContext, request, task, ResultsType.QUERY, true)) {
                     ContextIndexSearcher searcher = searchContext.searcher();
                     assertNotNull(searcher.getExecutor());
 
@@ -2202,6 +2143,97 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
                             executor.getCompletedTaskCount() - priorExecutorTaskCount
                         )
                     );
+                }
+            }
+            {
+                try (SearchContext searchContext = service.createContext(readerContext, request, task, ResultsType.FETCH, true)) {
+                    ContextIndexSearcher searcher = searchContext.searcher();
+                    assertNotNull(searcher.getExecutor());
+                    final long priorExecutorTaskCount = executor.getCompletedTaskCount();
+                    searcher.search(termQuery, new TotalHitCountCollectorManager());
+                    assertBusy(
+                        () -> assertEquals(
+                            "The number of slices should be 1 as FETCH does not support parallel collection.",
+                            1,
+                            executor.getCompletedTaskCount() - priorExecutorTaskCount
+                        )
+                    );
+                }
+            }
+            {
+                try (SearchContext searchContext = service.createContext(readerContext, request, task, ResultsType.NONE, true)) {
+                    ContextIndexSearcher searcher = searchContext.searcher();
+                    assertNotNull(searcher.getExecutor());
+                    final long priorExecutorTaskCount = executor.getCompletedTaskCount();
+                    searcher.search(termQuery, new TotalHitCountCollectorManager());
+                    assertBusy(
+                        () -> assertEquals(
+                            "The number of slices should be 1 as NONE does not support parallel collection.",
+                            1,
+                            executor.getCompletedTaskCount() - priorExecutorTaskCount
+                        )
+                    );
+                }
+            }
+
+            try {
+                ClusterUpdateSettingsResponse response = client().admin()
+                    .cluster()
+                    .prepareUpdateSettings()
+                    .setPersistentSettings(Settings.builder().put(QUERY_PHASE_PARALLEL_COLLECTION_ENABLED.getKey(), false).build())
+                    .get();
+                assertTrue(response.isAcknowledged());
+                {
+                    try (SearchContext searchContext = service.createContext(readerContext, request, task, ResultsType.QUERY, true)) {
+                        ContextIndexSearcher searcher = searchContext.searcher();
+                        assertNotNull(searcher.getExecutor());
+                        final long priorExecutorTaskCount = executor.getCompletedTaskCount();
+                        searcher.search(termQuery, new TotalHitCountCollectorManager());
+                        assertBusy(
+                            () -> assertEquals(
+                                "The number of slices should be 1 when QUERY parallel collection is disabled.",
+                                1,
+                                executor.getCompletedTaskCount() - priorExecutorTaskCount
+                            )
+                        );
+                    }
+                }
+            } finally {
+                // Reset to the original default setting and check to ensure it takes effect.
+                client().admin()
+                    .cluster()
+                    .prepareUpdateSettings()
+                    .setPersistentSettings(Settings.builder().putNull(QUERY_PHASE_PARALLEL_COLLECTION_ENABLED.getKey()).build())
+                    .get();
+                {
+                    try (SearchContext searchContext = service.createContext(readerContext, request, task, ResultsType.QUERY, true)) {
+                        ContextIndexSearcher searcher = searchContext.searcher();
+                        assertNotNull(searcher.getExecutor());
+
+                        final int maxPoolSize = executor.getMaximumPoolSize();
+                        assertEquals(
+                            "Sanity check to ensure this isn't the default of 1 when pool size is unset",
+                            configuredMaxPoolSize,
+                            maxPoolSize
+                        );
+
+                        final int expectedSlices = ContextIndexSearcher.computeSlices(
+                            searcher.getIndexReader().leaves(),
+                            maxPoolSize,
+                            1
+                        ).length;
+                        assertNotEquals("Sanity check to ensure this isn't the default of 1 when pool size is unset", 1, expectedSlices);
+
+                        final long priorExecutorTaskCount = executor.getCompletedTaskCount();
+                        searcher.search(termQuery, new TotalHitCountCollectorManager());
+                        assertBusy(
+                            () -> assertEquals(
+                                "QUERY supports parallel collection when enabled, so the number of slices should be > 1.",
+                                expectedSlices,
+                                executor.getCompletedTaskCount() - priorExecutorTaskCount
+                            )
+                        );
+                    }
                 }
             }
         }

--- a/test/framework/src/main/java/org/elasticsearch/search/MockSearchService.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/MockSearchService.java
@@ -132,7 +132,12 @@ public class MockSearchService extends SearchService {
         boolean includeAggregations
     ) throws IOException {
         SearchContext searchContext = super.createContext(readerContext, request, task, resultsType, includeAggregations);
-        onCreateSearchContext.accept(searchContext);
+        try {
+            onCreateSearchContext.accept(searchContext);
+        } catch (Exception e) {
+            searchContext.close();
+            throw e;
+        }
         return searchContext;
     }
 


### PR DESCRIPTION
Part of the ref counted search hits effort requires us to correctly ref count `FetchSearchPhase`. This doesn't commit moves us one step in the direction of doing so by adding testing that ensure that `QuerySearchContext` is ref counted correctly and fixes one production code spot where it wasn't (albeit that spot worked out for other reasons anyways). This is done by moving the leak tracker to production code and making use of it selectively in case assertions are enabled.

Mostly test changes here, review with `?w=1` for easier readability :)