### PR TITLE
Fix failing tests due to new query to string format

### DIFF
--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldTypeTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldTypeTests.java
@@ -35,6 +35,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static org.hamcrest.Matchers.containsString;
+
 public class ScaledFloatFieldTypeTests extends FieldTypeTestCase {
 
     public void testTermQuery() {
@@ -136,40 +138,19 @@ public class ScaledFloatFieldTypeTests extends FieldTypeTestCase {
     public void testRoundsUpperBoundCorrectly() {
         ScaledFloatFieldMapper.ScaledFloatFieldType ft = new ScaledFloatFieldMapper.ScaledFloatFieldType("scaled_float", 100);
         Query scaledFloatQ = ft.rangeQuery(null, 0.1, true, false, MOCK_CONTEXT);
-        assertEquals(
-            "IndexOrDocValuesQuery(indexQuery=scaled_float:[-9223372036854775808 TO 9], dvQuery=scaled_float:[-9223372036854775808 TO 9])",
-            scaledFloatQ.toString()
-        );
+        assertThat(scaledFloatQ.toString(), containsString("scaled_float:[-9223372036854775808 TO 9]"));
         scaledFloatQ = ft.rangeQuery(null, 0.1, true, true, MOCK_CONTEXT);
-        assertEquals(
-            "IndexOrDocValuesQuery(indexQuery=scaled_float:[-9223372036854775808 TO 10], dvQuery=scaled_float:[-9223372036854775808 TO 10])",
-            scaledFloatQ.toString()
-        );
+        assertThat(scaledFloatQ.toString(), containsString("scaled_float:[-9223372036854775808 TO 10]"));
         scaledFloatQ = ft.rangeQuery(null, 0.095, true, false, MOCK_CONTEXT);
-        assertEquals(
-            "IndexOrDocValuesQuery(indexQuery=scaled_float:[-9223372036854775808 TO 9], dvQuery=scaled_float:[-9223372036854775808 TO 9])",
-            scaledFloatQ.toString()
-        );
+        assertThat(scaledFloatQ.toString(), containsString("scaled_float:[-9223372036854775808 TO 9]"));
         scaledFloatQ = ft.rangeQuery(null, 0.095, true, true, MOCK_CONTEXT);
-        assertEquals(
-            "IndexOrDocValuesQuery(indexQuery=scaled_float:[-9223372036854775808 TO 9], dvQuery=scaled_float:[-9223372036854775808 TO 9])",
-            scaledFloatQ.toString()
-        );
+        assertThat(scaledFloatQ.toString(), containsString("scaled_float:[-9223372036854775808 TO 9]"));
         scaledFloatQ = ft.rangeQuery(null, 0.105, true, false, MOCK_CONTEXT);
-        assertEquals(
-            "IndexOrDocValuesQuery(indexQuery=scaled_float:[-9223372036854775808 TO 10], dvQuery=scaled_float:[-9223372036854775808 TO 10])",
-            scaledFloatQ.toString()
-        );
+        assertThat(scaledFloatQ.toString(), containsString("scaled_float:[-9223372036854775808 TO 10]"));
         scaledFloatQ = ft.rangeQuery(null, 0.105, true, true, MOCK_CONTEXT);
-        assertEquals(
-            "IndexOrDocValuesQuery(indexQuery=scaled_float:[-9223372036854775808 TO 10], dvQuery=scaled_float:[-9223372036854775808 TO 10])",
-            scaledFloatQ.toString()
-        );
+        assertThat(scaledFloatQ.toString(), containsString("scaled_float:[-9223372036854775808 TO 10]"));
         scaledFloatQ = ft.rangeQuery(null, 79.99, true, true, MOCK_CONTEXT);
-        assertEquals(
-            "IndexOrDocValuesQuery(indexQuery=scaled_float:[-9223372036854775808 TO 7999], dvQuery=scaled_float:[-9223372036854775808 TO 7999])",
-            scaledFloatQ.toString()
-        );
+        assertThat(scaledFloatQ.toString(), containsString("scaled_float:[-9223372036854775808 TO 7999]"));
     }
 
     public void testRoundsLowerBoundCorrectly() {

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldTypeTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldTypeTests.java
@@ -136,35 +136,74 @@ public class ScaledFloatFieldTypeTests extends FieldTypeTestCase {
     public void testRoundsUpperBoundCorrectly() {
         ScaledFloatFieldMapper.ScaledFloatFieldType ft = new ScaledFloatFieldMapper.ScaledFloatFieldType("scaled_float", 100);
         Query scaledFloatQ = ft.rangeQuery(null, 0.1, true, false, MOCK_CONTEXT);
-        assertEquals("scaled_float:[-9223372036854775808 TO 9]", scaledFloatQ.toString());
+        assertEquals(
+            "IndexOrDocValuesQuery(indexQuery=scaled_float:[-9223372036854775808 TO 9], dvQuery=scaled_float:[-9223372036854775808 TO 9])",
+            scaledFloatQ.toString()
+        );
         scaledFloatQ = ft.rangeQuery(null, 0.1, true, true, MOCK_CONTEXT);
-        assertEquals("scaled_float:[-9223372036854775808 TO 10]", scaledFloatQ.toString());
+        assertEquals(
+            "IndexOrDocValuesQuery(indexQuery=scaled_float:[-9223372036854775808 TO 10], dvQuery=scaled_float:[-9223372036854775808 TO 10])",
+            scaledFloatQ.toString()
+        );
         scaledFloatQ = ft.rangeQuery(null, 0.095, true, false, MOCK_CONTEXT);
-        assertEquals("scaled_float:[-9223372036854775808 TO 9]", scaledFloatQ.toString());
+        assertEquals(
+            "IndexOrDocValuesQuery(indexQuery=scaled_float:[-9223372036854775808 TO 9], dvQuery=scaled_float:[-9223372036854775808 TO 9])",
+            scaledFloatQ.toString()
+        );
         scaledFloatQ = ft.rangeQuery(null, 0.095, true, true, MOCK_CONTEXT);
-        assertEquals("scaled_float:[-9223372036854775808 TO 9]", scaledFloatQ.toString());
+        assertEquals(
+            "IndexOrDocValuesQuery(indexQuery=scaled_float:[-9223372036854775808 TO 9], dvQuery=scaled_float:[-9223372036854775808 TO 9])",
+            scaledFloatQ.toString()
+        );
         scaledFloatQ = ft.rangeQuery(null, 0.105, true, false, MOCK_CONTEXT);
-        assertEquals("scaled_float:[-9223372036854775808 TO 10]", scaledFloatQ.toString());
+        assertEquals(
+            "IndexOrDocValuesQuery(indexQuery=scaled_float:[-9223372036854775808 TO 10], dvQuery=scaled_float:[-9223372036854775808 TO 10])",
+            scaledFloatQ.toString()
+        );
         scaledFloatQ = ft.rangeQuery(null, 0.105, true, true, MOCK_CONTEXT);
-        assertEquals("scaled_float:[-9223372036854775808 TO 10]", scaledFloatQ.toString());
+        assertEquals(
+            "IndexOrDocValuesQuery(indexQuery=scaled_float:[-9223372036854775808 TO 10], dvQuery=scaled_float:[-9223372036854775808 TO 10])",
+            scaledFloatQ.toString()
+        );
         scaledFloatQ = ft.rangeQuery(null, 79.99, true, true, MOCK_CONTEXT);
-        assertEquals("scaled_float:[-9223372036854775808 TO 7999]", scaledFloatQ.toString());
+        assertEquals(
+            "IndexOrDocValuesQuery(indexQuery=scaled_float:[-9223372036854775808 TO 7999], dvQuery=scaled_float:[-9223372036854775808 TO 7999])",
+            scaledFloatQ.toString()
+        );
     }
 
     public void testRoundsLowerBoundCorrectly() {
         ScaledFloatFieldMapper.ScaledFloatFieldType ft = new ScaledFloatFieldMapper.ScaledFloatFieldType("scaled_float", 100);
         Query scaledFloatQ = ft.rangeQuery(-0.1, null, false, true, MOCK_CONTEXT);
-        assertEquals("scaled_float:[-9 TO 9223372036854775807]", scaledFloatQ.toString());
+        assertEquals(
+            "IndexOrDocValuesQuery(indexQuery=scaled_float:[-9 TO 9223372036854775807], dvQuery=scaled_float:[-9 TO 9223372036854775807])",
+            scaledFloatQ.toString()
+        );
         scaledFloatQ = ft.rangeQuery(-0.1, null, true, true, MOCK_CONTEXT);
-        assertEquals("scaled_float:[-10 TO 9223372036854775807]", scaledFloatQ.toString());
+        assertEquals(
+            "IndexOrDocValuesQuery(indexQuery=scaled_float:[-10 TO 9223372036854775807], dvQuery=scaled_float:[-10 TO 9223372036854775807])",
+            scaledFloatQ.toString()
+        );
         scaledFloatQ = ft.rangeQuery(-0.095, null, false, true, MOCK_CONTEXT);
-        assertEquals("scaled_float:[-9 TO 9223372036854775807]", scaledFloatQ.toString());
+        assertEquals(
+            "IndexOrDocValuesQuery(indexQuery=scaled_float:[-9 TO 9223372036854775807], dvQuery=scaled_float:[-9 TO 9223372036854775807])",
+            scaledFloatQ.toString()
+        );
         scaledFloatQ = ft.rangeQuery(-0.095, null, true, true, MOCK_CONTEXT);
-        assertEquals("scaled_float:[-9 TO 9223372036854775807]", scaledFloatQ.toString());
+        assertEquals(
+            "IndexOrDocValuesQuery(indexQuery=scaled_float:[-9 TO 9223372036854775807], dvQuery=scaled_float:[-9 TO 9223372036854775807])",
+            scaledFloatQ.toString()
+        );
         scaledFloatQ = ft.rangeQuery(-0.105, null, false, true, MOCK_CONTEXT);
-        assertEquals("scaled_float:[-10 TO 9223372036854775807]", scaledFloatQ.toString());
+        assertEquals(
+            "IndexOrDocValuesQuery(indexQuery=scaled_float:[-10 TO 9223372036854775807], dvQuery=scaled_float:[-10 TO 9223372036854775807])",
+            scaledFloatQ.toString()
+        );
         scaledFloatQ = ft.rangeQuery(-0.105, null, true, true, MOCK_CONTEXT);
-        assertEquals("scaled_float:[-10 TO 9223372036854775807]", scaledFloatQ.toString());
+        assertEquals(
+            "IndexOrDocValuesQuery(indexQuery=scaled_float:[-10 TO 9223372036854775807], dvQuery=scaled_float:[-10 TO 9223372036854775807])",
+            scaledFloatQ.toString()
+        );
     }
 
     public void testValueForSearch() {

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldTypeTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldTypeTests.java
@@ -156,35 +156,17 @@ public class ScaledFloatFieldTypeTests extends FieldTypeTestCase {
     public void testRoundsLowerBoundCorrectly() {
         ScaledFloatFieldMapper.ScaledFloatFieldType ft = new ScaledFloatFieldMapper.ScaledFloatFieldType("scaled_float", 100);
         Query scaledFloatQ = ft.rangeQuery(-0.1, null, false, true, MOCK_CONTEXT);
-        assertEquals(
-            "IndexOrDocValuesQuery(indexQuery=scaled_float:[-9 TO 9223372036854775807], dvQuery=scaled_float:[-9 TO 9223372036854775807])",
-            scaledFloatQ.toString()
-        );
+        assertThat(scaledFloatQ.toString(), containsString("scaled_float:[-9 TO 9223372036854775807]"));
         scaledFloatQ = ft.rangeQuery(-0.1, null, true, true, MOCK_CONTEXT);
-        assertEquals(
-            "IndexOrDocValuesQuery(indexQuery=scaled_float:[-10 TO 9223372036854775807], dvQuery=scaled_float:[-10 TO 9223372036854775807])",
-            scaledFloatQ.toString()
-        );
+        assertThat(scaledFloatQ.toString(), containsString("scaled_float:[-10 TO 9223372036854775807]"));
         scaledFloatQ = ft.rangeQuery(-0.095, null, false, true, MOCK_CONTEXT);
-        assertEquals(
-            "IndexOrDocValuesQuery(indexQuery=scaled_float:[-9 TO 9223372036854775807], dvQuery=scaled_float:[-9 TO 9223372036854775807])",
-            scaledFloatQ.toString()
-        );
+        assertThat(scaledFloatQ.toString(), containsString("scaled_float:[-9 TO 9223372036854775807]"));
         scaledFloatQ = ft.rangeQuery(-0.095, null, true, true, MOCK_CONTEXT);
-        assertEquals(
-            "IndexOrDocValuesQuery(indexQuery=scaled_float:[-9 TO 9223372036854775807], dvQuery=scaled_float:[-9 TO 9223372036854775807])",
-            scaledFloatQ.toString()
-        );
+        assertThat(scaledFloatQ.toString(), containsString("scaled_float:[-9 TO 9223372036854775807]"));
         scaledFloatQ = ft.rangeQuery(-0.105, null, false, true, MOCK_CONTEXT);
-        assertEquals(
-            "IndexOrDocValuesQuery(indexQuery=scaled_float:[-10 TO 9223372036854775807], dvQuery=scaled_float:[-10 TO 9223372036854775807])",
-            scaledFloatQ.toString()
-        );
+        assertThat(scaledFloatQ.toString(), containsString("scaled_float:[-10 TO 9223372036854775807]"));
         scaledFloatQ = ft.rangeQuery(-0.105, null, true, true, MOCK_CONTEXT);
-        assertEquals(
-            "IndexOrDocValuesQuery(indexQuery=scaled_float:[-10 TO 9223372036854775807], dvQuery=scaled_float:[-10 TO 9223372036854775807])",
-            scaledFloatQ.toString()
-        );
+        assertThat(scaledFloatQ.toString(), containsString("scaled_float:[-10 TO 9223372036854775807]"));
     }
 
     public void testValueForSearch() {

--- a/server/src/internalClusterTest/java/org/elasticsearch/validate/SimpleValidateQueryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/validate/SimpleValidateQueryIT.java
@@ -219,7 +219,10 @@ public class SimpleValidateQueryIT extends ESIntegTestCase {
 
         long twoMonthsAgo = now.minus(2, ChronoUnit.MONTHS).truncatedTo(ChronoUnit.DAYS).toEpochSecond() * 1000;
         long rangeEnd = (now.plus(1, ChronoUnit.DAYS).truncatedTo(ChronoUnit.DAYS).toEpochSecond() * 1000) - 1;
-        assertThat(response.getQueryExplanation().get(0).getExplanation(), equalTo("past:[" + twoMonthsAgo + " TO " + rangeEnd + "]"));
+        assertThat(
+            response.getQueryExplanation().get(0).getExplanation(),
+            containsString("past:[" + twoMonthsAgo + " TO " + rangeEnd + "]")
+        );
         assertThat(response.isValid(), equalTo(true));
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldTypeTests.java
@@ -233,12 +233,18 @@ public class RangeFieldTypeTests extends FieldTypeTestCase {
 
         RangeFieldType fieldType = new RangeFieldType("field", formatter);
         final Query query = fieldType.rangeQuery(from, to, true, true, relation, null, fieldType.dateMathParser(), context);
-        assertEquals("field:<ranges:[1465975790000 : 1466062190999]>", query.toString());
+        assertEquals(
+            "IndexOrDocValuesQuery(indexQuery=field:<ranges:[1465975790000 : 1466062190999]>, dvQuery=BinaryDocValuesRangeQuery(fieldName=,from=1465975790000,to=1466062190999))",
+            query.toString()
+        );
 
         // compare lower and upper bounds with what we would get on a `date` field
         DateFieldType dateFieldType = new DateFieldType("field", DateFieldMapper.Resolution.MILLISECONDS, formatter);
         final Query queryOnDateField = dateFieldType.rangeQuery(from, to, true, true, relation, null, fieldType.dateMathParser(), context);
-        assertEquals("field:[1465975790000 TO 1466062190999]", queryOnDateField.toString());
+        assertEquals(
+            "IndexOrDocValuesQuery(indexQuery=field:[1465975790000 TO 1466062190999], dvQuery=field:[1465975790000 TO 1466062190999])",
+            queryOnDateField.toString()
+        );
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldTypeTests.java
@@ -233,18 +233,12 @@ public class RangeFieldTypeTests extends FieldTypeTestCase {
 
         RangeFieldType fieldType = new RangeFieldType("field", formatter);
         final Query query = fieldType.rangeQuery(from, to, true, true, relation, null, fieldType.dateMathParser(), context);
-        assertEquals(
-            "IndexOrDocValuesQuery(indexQuery=field:<ranges:[1465975790000 : 1466062190999]>, dvQuery=BinaryDocValuesRangeQuery(fieldName=,from=1465975790000,to=1466062190999))",
-            query.toString()
-        );
+        assertThat(query.toString(), containsString("field:<ranges:[1465975790000 : 1466062190999]>"));
 
         // compare lower and upper bounds with what we would get on a `date` field
         DateFieldType dateFieldType = new DateFieldType("field", DateFieldMapper.Resolution.MILLISECONDS, formatter);
         final Query queryOnDateField = dateFieldType.rangeQuery(from, to, true, true, relation, null, fieldType.dateMathParser(), context);
-        assertEquals(
-            "IndexOrDocValuesQuery(indexQuery=field:[1465975790000 TO 1466062190999], dvQuery=field:[1465975790000 TO 1466062190999])",
-            queryOnDateField.toString()
-        );
+        assertThat(queryOnDateField.toString(), containsString("field:[1465975790000 TO 1466062190999]"));
     }
 
     /**

--- a/test/framework/src/main/java/org/elasticsearch/search/geo/GeoDistanceQueryBuilderTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/geo/GeoDistanceQueryBuilderTestCase.java
@@ -325,9 +325,9 @@ public abstract class GeoDistanceQueryBuilderTestCase extends AbstractQueryTestC
         // so we cannot access its fields directly to check and have to use toString() here instead.
         double qLat = GeoEncodingUtils.decodeLatitude(GeoEncodingUtils.encodeLatitude(lat));
         double qLon = GeoEncodingUtils.decodeLongitude(GeoEncodingUtils.encodeLongitude(lon));
-        assertEquals(
+        assertThat(
             parsedQuery.toString(),
-            "mapped_geo_point:" + qLat + "," + qLon + " +/- " + distanceUnit.toMeters(distance) + " meters"
+            containsString("mapped_geo_point:" + qLat + "," + qLon + " +/- " + distanceUnit.toMeters(distance) + " meters")
         );
     }
 


### PR DESCRIPTION
There have been some changes around range query toString format. This commit adjusts tests expecting particular outputs from the previous Lucene version