### PR TITLE
[Query Rules] Fix error message when rule query rulesets do not exist

### DIFF
--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/RuleQueryBuilder.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/RuleQueryBuilder.java
@@ -8,10 +8,13 @@ package org.elasticsearch.xpack.application.rules;
 
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.SetOnce;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.get.GetRequest;
+import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.OriginSettingClient;
 import org.elasticsearch.common.ParsingException;
@@ -19,6 +22,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.logging.HeaderWarning;
+import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.query.AbstractQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryRewriteContext;
@@ -209,18 +213,35 @@ public class RuleQueryBuilder extends AbstractQueryBuilder<RuleQueryBuilder> {
 
         queryRewriteContext.registerAsyncAction((client, listener) -> {
             Client clientWithOrigin = new OriginSettingClient(client, ENT_SEARCH_ORIGIN);
-            clientWithOrigin.get(getRequest, listener.delegateFailureAndWrap((l, getResponse) -> {
-                if (getResponse.isExists() == false) {
-                    throw new ResourceNotFoundException("query ruleset " + rulesetId + " not found");
+            clientWithOrigin.get(getRequest, new ActionListener<>() {
+                @Override
+                public void onResponse(GetResponse getResponse) {
+                    if (getResponse.isExists() == false) {
+                        throw new ResourceNotFoundException("query ruleset " + rulesetId + " not found");
+                    }
+                    QueryRuleset queryRuleset = QueryRuleset.fromXContentBytes(
+                        rulesetId,
+                        getResponse.getSourceAsBytesRef(),
+                        XContentType.JSON
+                    );
+                    for (QueryRule rule : queryRuleset.rules()) {
+                        rule.applyRule(appliedRules, matchCriteria);
+                    }
+                    pinnedIdsSetOnce.set(appliedRules.pinnedIds().stream().distinct().toList());
+                    pinnedDocsSetOnce.set(appliedRules.pinnedDocs().stream().distinct().toList());
+                    listener.onResponse(null);
                 }
-                QueryRuleset queryRuleset = QueryRuleset.fromXContentBytes(rulesetId, getResponse.getSourceAsBytesRef(), XContentType.JSON);
-                for (QueryRule rule : queryRuleset.rules()) {
-                    rule.applyRule(appliedRules, matchCriteria);
+
+                @Override
+                public void onFailure(Exception e) {
+                    Throwable cause = ExceptionsHelper.unwrapCause(e);
+                    if (cause instanceof IndexNotFoundException) {
+                        listener.onFailure(new ResourceNotFoundException("query ruleset " + rulesetId + " not found"));
+                    } else {
+                        listener.onFailure(e);
+                    }
                 }
-                pinnedIdsSetOnce.set(appliedRules.pinnedIds().stream().distinct().toList());
-                pinnedDocsSetOnce.set(appliedRules.pinnedDocs().stream().distinct().toList());
-                listener.onResponse(null);
-            }));
+            });
         });
 
         QueryBuilder newOrganicQuery = organicQuery.rewrite(queryRewriteContext);


### PR DESCRIPTION
Fixes an issue, where if you execute a `rule_query` when the query rules system index does not exist, we no longer display an index not found exception for the system index but rather nicely package it into a ruleset not found exception. 

Example request: 
```
PUT foo

GET foo/_search
{
  "query": {
    "rule_query": {
      "organic": {
          "match_all": {}
      },
      "ruleset_id": "foo",
      "match_criteria": {
        "foo": "bar"
      }
    }
  }
}
```

Previous error: 
```
{
  "error": {
    "root_cause": [
      {
        "type": "index_not_found_exception",
        "reason": "no such index [.query-rules]",
        "resource.type": "index_or_alias",
        "resource.id": ".query-rules",
        "index_uuid": "_na_",
        "index": ".query-rules"
      }
    ],
    "type": "index_not_found_exception",
    "reason": "no such index [.query-rules]",
    "resource.type": "index_or_alias",
    "resource.id": ".query-rules",
    "index_uuid": "_na_",
    "index": ".query-rules"
  },
  "status": 404
}
```

New error: 
```
{
  "error": {
    "root_cause": [
      {
        "type": "resource_not_found_exception",
        "reason": "query ruleset foo not found"
      }
    ],
    "type": "resource_not_found_exception",
    "reason": "query ruleset foo not found"
  },
  "status": 404
}
```