### PR TITLE
Track blocks in AsyncOperator

### DIFF
--- a/docs/changelog/102188.yaml
+++ b/docs/changelog/102188.yaml
@@ -1,0 +1,5 @@
+pr: 102188
+summary: Track blocks in `AsyncOperator`
+area: ES|QL
+type: enhancement
+issues: []

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/AsyncOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/AsyncOperatorTests.java
@@ -8,22 +8,27 @@
 package org.elasticsearch.compute.operator;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.SubscribableListener;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
-import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.LongVector;
+import org.elasticsearch.compute.data.MockBlockFactory;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.FixedExecutorBuilder;
 import org.elasticsearch.threadpool.TestThreadPool;
@@ -36,8 +41,11 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.LongStream;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
 public class AsyncOperatorTests extends ESTestCase {
@@ -80,16 +88,17 @@ public class AsyncOperatorTests extends ESTestCase {
 
             @Override
             protected Page createPage(int positionOffset, int length) {
-                LongVector.Builder builder = LongVector.newVectorBuilder(length);
-                for (int i = 0; i < length; i++) {
-                    builder.appendLong(ids.get(currentPosition++));
+                try (LongVector.Builder builder = blockFactory.newLongVectorBuilder(length)) {
+                    for (int i = 0; i < length; i++) {
+                        builder.appendLong(ids.get(currentPosition++));
+                    }
+                    return new Page(builder.build().asBlock());
                 }
-                return new Page(builder.build().asBlock());
             }
         };
         int maxConcurrentRequests = randomIntBetween(1, 10);
         AsyncOperator asyncOperator = new AsyncOperator(maxConcurrentRequests) {
-            final LookupService lookupService = new LookupService(threadPool, dict, maxConcurrentRequests);
+            final LookupService lookupService = new LookupService(threadPool, driverContext.blockFactory(), dict, maxConcurrentRequests);
 
             @Override
             protected void performAsync(Page inputPage, ActionListener<Page> listener) {
@@ -97,25 +106,27 @@ public class AsyncOperatorTests extends ESTestCase {
             }
 
             @Override
-            public void close() {
+            public void doClose() {
 
             }
         };
         Iterator<Long> it = ids.iterator();
         SinkOperator outputOperator = new PageConsumerOperator(page -> {
-            assertThat(page.getBlockCount(), equalTo(2));
-            LongBlock b1 = page.getBlock(0);
-            BytesRefBlock b2 = page.getBlock(1);
-            BytesRef scratch = new BytesRef();
-            for (int i = 0; i < page.getPositionCount(); i++) {
-                assertTrue(it.hasNext());
-                long key = b1.getLong(i);
-                assertThat(key, equalTo(it.next()));
-                String v = dict.get(key);
-                if (v == null) {
-                    assertTrue(b2.isNull(i));
-                } else {
-                    assertThat(b2.getBytesRef(i, scratch), equalTo(new BytesRef(v)));
+            try (Releasable ignored = page::releaseBlocks) {
+                assertThat(page.getBlockCount(), equalTo(2));
+                LongBlock b1 = page.getBlock(0);
+                BytesRefBlock b2 = page.getBlock(1);
+                BytesRef scratch = new BytesRef();
+                for (int i = 0; i < page.getPositionCount(); i++) {
+                    assertTrue(it.hasNext());
+                    long key = b1.getLong(i);
+                    assertThat(key, equalTo(it.next()));
+                    String v = dict.get(key);
+                    if (v == null) {
+                        assertTrue(b2.isNull(i));
+                    } else {
+                        assertThat(b2.getBytesRef(i, scratch), equalTo(new BytesRef(v)));
+                    }
                 }
             }
         });
@@ -126,6 +137,7 @@ public class AsyncOperatorTests extends ESTestCase {
     }
 
     public void testStatus() {
+        DriverContext driverContext = driverContext();
         Map<Page, ActionListener<Page>> handlers = new HashMap<>();
         AsyncOperator operator = new AsyncOperator(2) {
             @Override
@@ -134,36 +146,95 @@ public class AsyncOperatorTests extends ESTestCase {
             }
 
             @Override
-            public void close() {
+            protected void doClose() {
 
             }
         };
         assertTrue(operator.isBlocked().isDone());
         assertTrue(operator.needsInput());
 
-        Page page1 = new Page(Block.constantNullBlock(1));
+        Page page1 = new Page(driverContext.blockFactory().newConstantNullBlock(1));
         operator.addInput(page1);
         assertFalse(operator.isBlocked().isDone());
         SubscribableListener<Void> blocked1 = operator.isBlocked();
         assertTrue(operator.needsInput());
 
-        Page page2 = new Page(Block.constantNullBlock(2));
+        Page page2 = new Page(driverContext.blockFactory().newConstantNullBlock(2));
         operator.addInput(page2);
         assertFalse(operator.needsInput()); // reached the max outstanding requests
         assertFalse(operator.isBlocked().isDone());
         assertThat(operator.isBlocked(), equalTo(blocked1));
 
-        Page page3 = new Page(Block.constantNullBlock(3));
+        Page page3 = new Page(driverContext.blockFactory().newConstantNullBlock(3));
         handlers.remove(page1).onResponse(page3);
+        page1.releaseBlocks();
         assertFalse(operator.needsInput()); // still have 2 outstanding requests
         assertTrue(operator.isBlocked().isDone());
         assertTrue(blocked1.isDone());
-
         assertThat(operator.getOutput(), equalTo(page3));
+        page3.releaseBlocks();
+
         assertTrue(operator.needsInput());
         assertFalse(operator.isBlocked().isDone());
+        Page page4 = new Page(driverContext.blockFactory().newConstantNullBlock(3));
+        handlers.remove(page2).onResponse(page4);
+        page2.releaseBlocks();
+        assertThat(operator.getOutput(), equalTo(page4));
+        page4.releaseBlocks();
 
         operator.close();
+    }
+
+    public void testFailure() throws Exception {
+        DriverContext driverContext = driverContext();
+        final SequenceLongBlockSourceOperator sourceOperator = new SequenceLongBlockSourceOperator(
+            driverContext.blockFactory(),
+            LongStream.range(0, 100 * 1024)
+        );
+        int maxConcurrentRequests = randomIntBetween(1, 10);
+        AtomicBoolean failed = new AtomicBoolean();
+        AsyncOperator asyncOperator = new AsyncOperator(maxConcurrentRequests) {
+            @Override
+            protected void performAsync(Page inputPage, ActionListener<Page> listener) {
+                ActionRunnable<Page> command = new ActionRunnable<>(listener) {
+                    @Override
+                    protected void doRun() {
+                        if (randomInt(100) < 10) {
+                            failed.set(true);
+                            throw new ElasticsearchException("simulated");
+                        }
+                        int positionCount = inputPage.getBlock(0).getPositionCount();
+                        IntBlock block = driverContext.blockFactory().newConstantIntBlockWith(between(1, 100), positionCount);
+                        listener.onResponse(inputPage.appendPage(new Page(block)));
+                    }
+                };
+                if (randomBoolean()) {
+                    command.run();
+                } else {
+                    TimeValue delay = TimeValue.timeValueMillis(randomIntBetween(0, 50));
+                    threadPool.schedule(command, delay, threadPool.executor(ESQL_TEST_EXECUTOR));
+                }
+            }
+
+            @Override
+            protected void doClose() {
+
+            }
+        };
+        SinkOperator outputOperator = new PageConsumerOperator(Page::releaseBlocks);
+        PlainActionFuture<Void> future = new PlainActionFuture<>();
+        Driver driver = new Driver(driverContext, sourceOperator, List.of(asyncOperator), outputOperator, () -> {});
+        Driver.start(threadPool.getThreadContext(), threadPool.executor(ESQL_TEST_EXECUTOR), driver, between(1, 1000), future);
+        assertBusy(() -> {
+            assertTrue(asyncOperator.isFinished());
+            assertTrue(future.isDone());
+        });
+        if (failed.get()) {
+            ElasticsearchException error = expectThrows(ElasticsearchException.class, future::actionGet);
+            assertThat(error.getMessage(), containsString("simulated"));
+        } else {
+            future.actionGet();
+        }
     }
 
     static class LookupService {
@@ -171,10 +242,12 @@ public class AsyncOperatorTests extends ESTestCase {
         private final Map<Long, String> dict;
         private final int maxConcurrentRequests;
         private final AtomicInteger pendingRequests = new AtomicInteger();
+        private final BlockFactory blockFactory;
 
-        LookupService(ThreadPool threadPool, Map<Long, String> dict, int maxConcurrentRequests) {
+        LookupService(ThreadPool threadPool, BlockFactory blockFactory, Map<Long, String> dict, int maxConcurrentRequests) {
             this.threadPool = threadPool;
             this.dict = dict;
+            this.blockFactory = blockFactory;
             this.maxConcurrentRequests = maxConcurrentRequests;
         }
 
@@ -184,20 +257,21 @@ public class AsyncOperatorTests extends ESTestCase {
             ActionRunnable<Page> command = new ActionRunnable<>(listener) {
                 @Override
                 protected void doRun() {
-                    LongBlock ids = input.getBlock(0);
-                    BytesRefBlock.Builder builder = BytesRefBlock.newBlockBuilder(ids.getPositionCount());
-                    for (int i = 0; i < ids.getPositionCount(); i++) {
-                        String v = dict.get(ids.getLong(i));
-                        if (v != null) {
-                            builder.appendBytesRef(new BytesRef(v));
-                        } else {
-                            builder.appendNull();
-                        }
-                    }
                     int current = pendingRequests.decrementAndGet();
                     assert current >= 0 : "pending requests must be non-negative";
-                    Page result = input.appendBlock(builder.build());
-                    listener.onResponse(result);
+                    LongBlock ids = input.getBlock(0);
+                    try (BytesRefBlock.Builder builder = blockFactory.newBytesRefBlockBuilder(ids.getPositionCount())) {
+                        for (int i = 0; i < ids.getPositionCount(); i++) {
+                            String v = dict.get(ids.getLong(i));
+                            if (v != null) {
+                                builder.appendBytesRef(new BytesRef(v));
+                            } else {
+                                builder.appendNull();
+                            }
+                        }
+                        Page result = input.appendPage(new Page(builder.build()));
+                        listener.onResponse(result);
+                    }
                 }
             };
             TimeValue delay = TimeValue.timeValueMillis(randomIntBetween(0, 50));
@@ -205,13 +279,30 @@ public class AsyncOperatorTests extends ESTestCase {
         }
     }
 
-    /**
-     * A {@link DriverContext} with a nonBreakingBigArrays.
-     */
-    DriverContext driverContext() {
-        return new DriverContext(
-            new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, new NoneCircuitBreakerService()).withCircuitBreaking(),
-            BlockFactory.getNonBreakingInstance()
-        );
+    protected DriverContext driverContext() {
+        BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, ByteSizeValue.ofGb(1)).withCircuitBreaking();
+        CircuitBreaker breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
+        breakers.add(breaker);
+        BlockFactory factory = new MockBlockFactory(breaker, bigArrays);
+        blockFactories.add(factory);
+        return new DriverContext(bigArrays, factory);
+    }
+
+    private final List<CircuitBreaker> breakers = new ArrayList<>();
+    private final List<BlockFactory> blockFactories = new ArrayList<>();
+
+    @After
+    public void allBreakersEmpty() throws Exception {
+        // first check that all big arrays are released, which can affect breakers
+        MockBigArrays.ensureAllArraysAreReleased();
+
+        for (CircuitBreaker breaker : breakers) {
+            for (var factory : blockFactories) {
+                if (factory instanceof MockBlockFactory mockBlockFactory) {
+                    mockBlockFactory.ensureAllBlocksAreReleased();
+                }
+            }
+            assertThat("Unexpected used in breaker: " + breaker, breaker.getUsed(), equalTo(0L));
+        }
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/DriverTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/DriverTests.java
@@ -127,7 +127,7 @@ public class DriverTests extends ESTestCase {
         }
 
         @Override
-        public void close() {
+        protected void doClose() {
 
         }
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/EnrichLookupOperator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/EnrichLookupOperator.java
@@ -106,7 +106,7 @@ public final class EnrichLookupOperator extends AsyncOperator {
     }
 
     @Override
-    public void close() {
+    protected void doClose() {
         // TODO: Maybe create a sub-task as the parent task of all the lookup tasks
         // then cancel it when this operator terminates early (e.g., have enough result).
     }


### PR DESCRIPTION
Spin-off from #102184

This PR tracks blocks in AsyncOperator and its subclasses. We might consider replacing the internal queue of AsyncOperator with an exchange buffer. However, this requires work in planning and introduces an ordered exchange buffer. 