### PR TITLE
Exception from consumer must fail RefCountingListener

### DIFF
--- a/docs/changelog/102191.yaml
+++ b/docs/changelog/102191.yaml
@@ -1,5 +1,0 @@
-pr: 102191
-summary: Exception from consumer must fail `RefCountingListener`
-area: Distributed
-type: bug
-issues: []

--- a/docs/changelog/102191.yaml
+++ b/docs/changelog/102191.yaml
@@ -1,0 +1,5 @@
+pr: 102191
+summary: Exception from consumer must fail `RefCountingListener`
+area: Distributed
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/support/RefCountingListener.java
+++ b/server/src/main/java/org/elasticsearch/action/support/RefCountingListener.java
@@ -187,10 +187,12 @@ public final class RefCountingListener implements Releasable {
                     if (acquiredConsumer == null) {
                         assert false : "already closed";
                     } else {
-                        acquiredConsumer.accept(response);
+                        try {
+                            acquiredConsumer.accept(response);
+                        } catch (Exception e) {
+                            addException(e);
+                        }
                     }
-                } catch (Exception e) {
-                    addException(e);
                 }
             }
 


### PR DESCRIPTION
If the last listener acquired from a `RefCountingListener` was acquired
using `acquire(Consumer)`, and the provided consumer throws an
exception, then the exception was lost and the outer listener completes
successfully. This commit makes sure to capture exceptions from all
consumers.