### PR TITLE
Minor cleanups of org.elasticsearch.search.aggregations package

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/InternalOrder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/InternalOrder.java
@@ -388,7 +388,6 @@ public abstract class InternalOrder extends BucketOrder {
     /**
      * @return compare by {@link Bucket#getKey()} that will be in the bucket once it is reduced
      */
-    @SuppressWarnings("unchecked")
     private static Comparator<DelayedBucket<? extends Bucket>> comparingDelayedKeys() {
         return DelayedBucket::compareKey;
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/MultiBucketCollector.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/MultiBucketCollector.java
@@ -183,17 +183,16 @@ public class MultiBucketCollector extends BucketCollector {
                 );
             }
         }
-        switch (leafCollectors.size()) {
-            case 0:
+        return switch (leafCollectors.size()) {
+            case 0 -> {
                 if (terminateIfNoop) {
                     throw new CollectionTerminatedException();
                 }
-                return LeafBucketCollector.NO_OP_COLLECTOR;
-            case 1:
-                return leafCollectors.get(0);
-            default:
-                return new MultiLeafBucketCollector(leafCollectors, cacheScores);
-        }
+                yield LeafBucketCollector.NO_OP_COLLECTOR;
+            }
+            case 1 -> leafCollectors.get(0);
+            default -> new MultiLeafBucketCollector(leafCollectors, cacheScores);
+        };
     }
 
     private static class MultiLeafBucketCollector extends LeafBucketCollector {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/TopBucketBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/TopBucketBuilder.java
@@ -102,7 +102,7 @@ public abstract class TopBucketBuilder<B extends InternalMultiBucketAggregation.
             if (size >= ArrayUtil.MAX_ARRAY_LENGTH) {
                 throw new IllegalArgumentException("can't reduce more than [" + ArrayUtil.MAX_ARRAY_LENGTH + "] buckets");
             }
-            queue = new PriorityQueue<DelayedBucket<B>>(size) {
+            queue = new PriorityQueue<>(size) {
                 private final Comparator<DelayedBucket<? extends Bucket>> comparator = order.delayedBucketComparator();
 
                 @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/BestBucketsDeferringCollector.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/BestBucketsDeferringCollector.java
@@ -40,11 +40,7 @@ import java.util.function.LongUnaryOperator;
  * this collector.
  */
 public class BestBucketsDeferringCollector extends DeferringBucketCollector {
-    static class Entry {
-        final AggregationExecutionContext aggCtx;
-        final PackedLongValues docDeltas;
-        final PackedLongValues buckets;
-
+    record Entry(AggregationExecutionContext aggCtx, PackedLongValues docDeltas, PackedLongValues buckets) {
         Entry(AggregationExecutionContext aggCtx, PackedLongValues docDeltas, PackedLongValues buckets) {
             this.aggCtx = Objects.requireNonNull(aggCtx);
             this.docDeltas = Objects.requireNonNull(docDeltas);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregator.java
@@ -256,22 +256,19 @@ public final class CompositeAggregator extends BucketsAggregator implements Size
     /** Return true if the provided field may have multiple values per document in the leaf **/
     private static boolean isMaybeMultivalued(LeafReaderContext context, SortField sortField) throws IOException {
         SortField.Type type = IndexSortConfig.getSortFieldType(sortField);
-        switch (type) {
-            case STRING:
+        return switch (type) {
+            case STRING -> {
                 final SortedSetDocValues v1 = context.reader().getSortedSetDocValues(sortField.getField());
-                return v1 != null && DocValues.unwrapSingleton(v1) == null;
-
-            case DOUBLE:
-            case FLOAT:
-            case LONG:
-            case INT:
+                yield v1 != null && DocValues.unwrapSingleton(v1) == null;
+            }
+            case DOUBLE, FLOAT, LONG, INT -> {
                 final SortedNumericDocValues v2 = context.reader().getSortedNumericDocValues(sortField.getField());
-                return v2 != null && DocValues.unwrapSingleton(v2) == null;
-
-            default:
+                yield v2 != null && DocValues.unwrapSingleton(v2) == null;
+            }
+            default ->
                 // we have no clue whether the field is multi-valued or not so we assume it is.
-                return true;
-        }
+                true;
+        };
     }
 
     /**
@@ -631,13 +628,5 @@ public final class CompositeAggregator extends BucketsAggregator implements Size
         }
     }
 
-    private static class Entry {
-        final AggregationExecutionContext aggCtx;
-        final DocIdSet docIdSet;
-
-        Entry(AggregationExecutionContext aggCtx, DocIdSet docIdSet) {
-            this.aggCtx = aggCtx;
-            this.docIdSet = docIdSet;
-        }
-    }
+    private record Entry(AggregationExecutionContext aggCtx, DocIdSet docIdSet) {}
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeValuesCollectorQueue.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeValuesCollectorQueue.java
@@ -29,7 +29,7 @@ import static org.elasticsearch.core.Types.forciblyCast;
  */
 final class CompositeValuesCollectorQueue extends PriorityQueue<Integer> implements Releasable {
     private class Slot {
-        int value;
+        final int value;
 
         Slot(int initial) {
             this.value = initial;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/InternalComposite.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/InternalComposite.java
@@ -628,10 +628,10 @@ public class InternalComposite extends InternalMultiBucketAggregation<InternalCo
 
         @Override
         public Set<Entry<String, Object>> entrySet() {
-            return new AbstractSet<Entry<String, Object>>() {
+            return new AbstractSet<>() {
                 @Override
                 public Iterator<Entry<String, Object>> iterator() {
-                    return new Iterator<Entry<String, Object>>() {
+                    return new Iterator<>() {
                         int pos = 0;
 
                         @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/LongValuesSource.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/LongValuesSource.java
@@ -43,7 +43,7 @@ class LongValuesSource extends SingleDimensionValuesSource<Long> {
     private final CheckedFunction<LeafReaderContext, SortedNumericDocValues, IOException> docValuesFunc;
     private final LongUnaryOperator rounding;
 
-    private BitArray bits;
+    private final BitArray bits;
     private LongArray values;
     private long currentValue;
     private boolean missingCurrentValue;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FiltersAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FiltersAggregator.java
@@ -140,7 +140,7 @@ public abstract class FiltersAggregator extends BucketsAggregator {
         Map<String, Object> metadata
     ) throws IOException {
         FilterByFilterAggregator.AdapterBuilder<FilterByFilterAggregator> filterByFilterBuilder =
-            new FilterByFilterAggregator.AdapterBuilder<FilterByFilterAggregator>(
+            new FilterByFilterAggregator.AdapterBuilder<>(
                 name,
                 keyed,
                 keyedBucket,
@@ -214,7 +214,7 @@ public abstract class FiltersAggregator extends BucketsAggregator {
             (offsetInOwningOrd, docCount, subAggregationResults) -> {
                 if (offsetInOwningOrd < filters.size()) {
                     return new InternalFilters.InternalBucket(
-                        filters.get(offsetInOwningOrd).key().toString(),
+                        filters.get(offsetInOwningOrd).key(),
                         docCount,
                         subAggregationResults,
                         keyed,
@@ -232,13 +232,7 @@ public abstract class FiltersAggregator extends BucketsAggregator {
         InternalAggregations subAggs = buildEmptySubAggregations();
         List<InternalFilters.InternalBucket> buckets = new ArrayList<>(filters.size() + (otherBucketKey == null ? 0 : 1));
         for (QueryToFilterAdapter filter : filters) {
-            InternalFilters.InternalBucket bucket = new InternalFilters.InternalBucket(
-                filter.key().toString(),
-                0,
-                subAggs,
-                keyed,
-                keyedBucket
-            );
+            InternalFilters.InternalBucket bucket = new InternalFilters.InternalBucket(filter.key(), 0, subAggs, keyed, keyedBucket);
             buckets.add(bucket);
         }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoTileUtils.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoTileUtils.java
@@ -203,7 +203,7 @@ public final class GeoTileUtils {
     public static String stringEncode(long hash) {
         final int[] res = parseHash(hash);
         validateZXY(res[0], res[1], res[2]);
-        return "" + res[0] + "/" + res[1] + "/" + res[2];
+        return res[0] + "/" + res[1] + "/" + res[2];
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateIntervalWrapper.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateIntervalWrapper.java
@@ -79,7 +79,7 @@ public class DateIntervalWrapper implements ToXContentFragment, Writeable {
             return preferredName;
         }
 
-        private String preferredName;
+        private final String preferredName;
 
         IntervalTypeEnum(String preferredName) {
             this.preferredName = preferredName;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/ParsedVariableWidthHistogram.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/ParsedVariableWidthHistogram.java
@@ -36,7 +36,7 @@ public class ParsedVariableWidthHistogram extends ParsedMultiBucketAggregation<P
         return buckets;
     }
 
-    private static ObjectParser<ParsedVariableWidthHistogram, Void> PARSER = new ObjectParser<>(
+    private static final ObjectParser<ParsedVariableWidthHistogram, Void> PARSER = new ObjectParser<>(
         ParsedVariableWidthHistogram.class.getSimpleName(),
         true,
         ParsedVariableWidthHistogram::new

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/VariableWidthHistogramAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/VariableWidthHistogramAggregator.java
@@ -82,7 +82,7 @@ public class VariableWidthHistogramAggregator extends DeferableBucketAggregator 
 
         private DoubleArray buffer;
         private int bufferSize;
-        private int bufferLimit;
+        private final int bufferLimit;
         private MergeBucketsPhase mergeBucketsPhase;
 
         BufferValuesPhase(int bufferLimit) {
@@ -97,7 +97,7 @@ public class VariableWidthHistogramAggregator extends DeferableBucketAggregator 
             if (bufferSize < bufferLimit) {
                 // Add to the buffer i.e store the doc in a new bucket
                 buffer = bigArrays().grow(buffer, bufferSize + 1);
-                buffer.set((long) bufferSize, val);
+                buffer.set(bufferSize, val);
                 collectBucket(sub, doc, bufferSize);
                 bufferSize += 1;
             }
@@ -432,7 +432,6 @@ public class VariableWidthHistogramAggregator extends DeferableBucketAggregator 
     // Aggregation parameters
     private final int numBuckets;
     private final int shardSize;
-    private final int bufferLimit;
 
     private CollectionPhase collector;
 
@@ -455,9 +454,8 @@ public class VariableWidthHistogramAggregator extends DeferableBucketAggregator 
         this.valuesSource = (ValuesSource.Numeric) valuesSourceConfig.getValuesSource();
         this.formatter = valuesSourceConfig.format();
         this.shardSize = shardSize;
-        this.bufferLimit = initialBuffer;
 
-        collector = new BufferValuesPhase(this.bufferLimit);
+        collector = new BufferValuesPhase(initialBuffer);
 
         String scoringAgg = subAggsNeedScore();
         String nestedAgg = descendsFromNestedAggregator(parent);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregator.java
@@ -383,8 +383,16 @@ public abstract class RangeAggregator extends BucketsAggregator {
             return null;
         }
         boolean wholeNumbersOnly = false == ((ValuesSource.Numeric) valuesSourceConfig.getValuesSource()).isFloatingPoint();
-        FilterByFilterAggregator.AdapterBuilder<FromFilters<?>> filterByFilterBuilder = new FilterByFilterAggregator.AdapterBuilder<
-            FromFilters<?>>(name, false, false, null, context, parent, cardinality, metadata) {
+        FilterByFilterAggregator.AdapterBuilder<FromFilters<?>> filterByFilterBuilder = new FilterByFilterAggregator.AdapterBuilder<>(
+            name,
+            false,
+            false,
+            null,
+            context,
+            parent,
+            cardinality,
+            metadata
+        ) {
             @Override
             protected FromFilters<?> adapt(CheckedFunction<AggregatorFactories, FilterByFilterAggregator, IOException> delegate)
                 throws IOException {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/BestDocsDeferringCollector.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/BestDocsDeferringCollector.java
@@ -45,7 +45,7 @@ public class BestDocsDeferringCollector extends DeferringBucketCollector impleme
     private final List<PerSegmentCollects> entries = new ArrayList<>();
     private BucketCollector deferred;
     private ObjectArray<PerParentBucketSamples> perBucketSamples;
-    private int shardSize;
+    private final int shardSize;
     private PerSegmentCollects perSegCollector;
     private final BigArrays bigArrays;
     private final Consumer<Long> circuitBreakerConsumer;
@@ -210,7 +210,7 @@ public class BestDocsDeferringCollector extends DeferringBucketCollector impleme
     }
 
     class PerSegmentCollects extends Scorable {
-        private AggregationExecutionContext aggCtx;
+        private final AggregationExecutionContext aggCtx;
         int maxDocId = Integer.MIN_VALUE;
         private float currentScore;
         private int currentDocId = -1;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractInternalTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractInternalTerms.java
@@ -204,7 +204,7 @@ public abstract class AbstractInternalTerms<A extends AbstractInternalTerms<A, B
             if (lastBucket != null && cmp.compare(top.current(), lastBucket) != 0) {
                 // the key changed so bundle up the last key's worth of buckets
                 boolean shouldContinue = sink.apply(
-                    new DelayedBucket<B>(AbstractInternalTerms.this::reduceBucket, reduceContext, sameTermBuckets)
+                    new DelayedBucket<>(AbstractInternalTerms.this::reduceBucket, reduceContext, sameTermBuckets)
                 );
                 if (false == shouldContinue) {
                     return;
@@ -228,7 +228,7 @@ public abstract class AbstractInternalTerms<A extends AbstractInternalTerms<A, B
         }
 
         if (sameTermBuckets.isEmpty() == false) {
-            sink.apply(new DelayedBucket<B>(AbstractInternalTerms.this::reduceBucket, reduceContext, sameTermBuckets));
+            sink.apply(new DelayedBucket<>(AbstractInternalTerms.this::reduceBucket, reduceContext, sameTermBuckets));
         }
     }
 
@@ -249,7 +249,7 @@ public abstract class AbstractInternalTerms<A extends AbstractInternalTerms<A, B
         }
         for (List<B> sameTermBuckets : bucketMap.values()) {
             boolean shouldContinue = sink.apply(
-                new DelayedBucket<B>(AbstractInternalTerms.this::reduceBucket, reduceContext, sameTermBuckets)
+                new DelayedBucket<>(AbstractInternalTerms.this::reduceBucket, reduceContext, sameTermBuckets)
             );
             if (false == shouldContinue) {
                 return;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/IncludeExclude.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/IncludeExclude.java
@@ -170,7 +170,7 @@ public class IncludeExclude implements Writeable, ToXContentFragment {
         private Set<Long> valids;
         private Set<Long> invalids;
 
-        private Long spare = new Long(0);
+        private final Long spare = new Long(0);
 
         private SetBackedLongFilter(int numValids, int numInvalids) {
             if (numValids > 0) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongKeyedBucketOrds.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongKeyedBucketOrds.java
@@ -130,8 +130,8 @@ public abstract class LongKeyedBucketOrds implements Releasable {
             }
         }
         Iterator<Long> toReturn = new Iterator<>() {
-            Iterator<Long> wrapped = keySet.iterator();
-            long filterOrd = owningBucketOrd;
+            final Iterator<Long> wrapped = keySet.iterator();
+            final long filterOrd = owningBucketOrd;
             long next;
             boolean hasNext = true;
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsAggregatorFromFilters.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsAggregatorFromFilters.java
@@ -69,16 +69,7 @@ public class StringTermsAggregatorFromFilters extends AdaptingAggregator {
             return null;
         }
         FilterByFilterAggregator.AdapterBuilder<StringTermsAggregatorFromFilters> filterByFilterBuilder =
-            new FilterByFilterAggregator.AdapterBuilder<StringTermsAggregatorFromFilters>(
-                name,
-                false,
-                false,
-                null,
-                context,
-                parent,
-                cardinality,
-                metadata
-            ) {
+            new FilterByFilterAggregator.AdapterBuilder<>(name, false, false, null, context, parent, cardinality, metadata) {
                 @Override
                 protected StringTermsAggregatorFromFilters adapt(
                     CheckedFunction<AggregatorFactories, FilterByFilterAggregator, IOException> delegate
@@ -164,7 +155,7 @@ public class StringTermsAggregatorFromFilters extends AdaptingAggregator {
         }
         TermsEnum terms = valuesSupplier.get().termsEnum();
         if (filters.getBuckets().size() > bucketCountThresholds.getShardSize()) {
-            PriorityQueue<OrdBucket> queue = new PriorityQueue<OrdBucket>(bucketCountThresholds.getShardSize()) {
+            PriorityQueue<OrdBucket> queue = new PriorityQueue<>(bucketCountThresholds.getShardSize()) {
                 private final Comparator<Bucket> comparator = order.comparator();
 
                 @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorFactory.java
@@ -468,7 +468,7 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
                     && ordinalsValuesSource.supportsGlobalOrdinalsMapping()
                     &&
                 // we use the static COLLECT_SEGMENT_ORDS to allow tests to force specific optimizations
-                    (COLLECT_SEGMENT_ORDS != null ? COLLECT_SEGMENT_ORDS.booleanValue() : ratio <= 0.5 && maxOrd <= 2048)) {
+                    (COLLECT_SEGMENT_ORDS != null ? COLLECT_SEGMENT_ORDS : ratio <= 0.5 && maxOrd <= 2048)) {
                     /*
                      * We can use the low cardinality execution mode iff this aggregator:
                      *  - has no sub-aggregator AND
@@ -505,7 +505,7 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
                      * is only possible if we're collecting from a single
                      * bucket.
                      */
-                    remapGlobalOrds = REMAP_GLOBAL_ORDS.booleanValue();
+                    remapGlobalOrds = REMAP_GLOBAL_ORDS;
                 } else {
                     remapGlobalOrds = true;
                     if (includeExclude == null

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregatorFactory.java
@@ -111,7 +111,7 @@ public class CardinalityAggregatorFactory extends ValuesSourceAggregatorFactory 
             }
         }
 
-        boolean isHeuristicBased;
+        final boolean isHeuristicBased;
 
         ExecutionMode(boolean isHeuristicBased) {
             this.isHeuristicBased = isHeuristicBased;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/HDRPercentileRanksAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/HDRPercentileRanksAggregator.java
@@ -54,7 +54,7 @@ class HDRPercentileRanksAggregator extends AbstractHDRPercentilesAggregator {
         if (state == null) {
             return Double.NaN;
         } else {
-            return InternalHDRPercentileRanks.percentileRank(state, Double.valueOf(name));
+            return InternalHDRPercentileRanks.percentileRank(state, Double.parseDouble(name));
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/HyperLogLogPlusPlus.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/HyperLogLogPlusPlus.java
@@ -244,7 +244,7 @@ public final class HyperLogLogPlusPlus extends AbstractHyperLogLogPlusPlus {
 
         private final HyperLogLog hll;
         int pos;
-        long start;
+        final long start;
         private byte value;
 
         HyperLogLogIterator(HyperLogLog hll, long bucket) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedPercentiles.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedPercentiles.java
@@ -111,7 +111,7 @@ public abstract class ParsedPercentiles extends ParsedAggregation implements Ite
                         } else if (token == XContentParser.Token.VALUE_STRING) {
                             int i = parser.currentName().indexOf("_as_string");
                             if (i > 0) {
-                                double key = Double.valueOf(parser.currentName().substring(0, i));
+                                double key = Double.parseDouble(parser.currentName().substring(0, i));
                                 aggregation.addPercentileAsString(key, parser.text());
                             } else {
                                 aggregation.addPercentile(Double.valueOf(parser.currentName()), Double.valueOf(parser.text()));

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricAggregator.java
@@ -158,7 +158,6 @@ class ScriptedMetricAggregator extends MetricsAggregator {
 
     private class State {
         private final ScriptedMetricAggContexts.MapScript.LeafFactory mapScript;
-        private final Map<String, Object> mapScriptParamsForState;
         private final Map<String, Object> combineScriptParamsForState;
         private final Map<String, Object> aggState;
         private MapScript leafMapScript;
@@ -166,7 +165,7 @@ class ScriptedMetricAggregator extends MetricsAggregator {
         State() {
             // Its possible for building the initial state to mutate the parameters as a side effect
             Map<String, Object> aggParamsForState = ScriptedMetricAggregatorFactory.deepCopyParams(aggParams);
-            mapScriptParamsForState = ScriptedMetricAggregatorFactory.mergeParams(aggParamsForState, mapScriptParams);
+            Map<String, Object> mapScriptParamsForState = ScriptedMetricAggregatorFactory.mergeParams(aggParamsForState, mapScriptParams);
             combineScriptParamsForState = ScriptedMetricAggregatorFactory.mergeParams(aggParamsForState, combineScriptParams);
             aggState = newInitialState(ScriptedMetricAggregatorFactory.mergeParams(aggParamsForState, initScriptParams));
             mapScript = mapScriptFactory.newFactory(

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentileRanksAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentileRanksAggregator.java
@@ -54,7 +54,7 @@ class TDigestPercentileRanksAggregator extends AbstractTDigestPercentilesAggrega
         if (state == null) {
             return Double.NaN;
         } else {
-            return InternalTDigestPercentileRanks.percentileRank(state, Double.valueOf(name));
+            return InternalTDigestPercentileRanks.percentileRank(state, Double.parseDouble(name));
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/MovAvgPipelineAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/MovAvgPipelineAggregationBuilder.java
@@ -37,7 +37,7 @@ public class MovAvgPipelineAggregationBuilder extends AbstractPipelineAggregatio
     public static final String MOVING_AVG_AGG_DEPRECATION_MSG = "Moving Average aggregation usage is not supported. "
         + "Use the [moving_fn] aggregation instead.";
 
-    public static ParseField NAME_V7 = new ParseField("moving_avg").withAllDeprecated(MOVING_AVG_AGG_DEPRECATION_MSG)
+    public static final ParseField NAME_V7 = new ParseField("moving_avg").withAllDeprecated(MOVING_AVG_AGG_DEPRECATION_MSG)
         .forRestApiVersion(RestApiVersion.equalTo(RestApiVersion.V_7));
 
     public static final ContextParser<String, MovAvgPipelineAggregationBuilder> PARSER = (parser, name) -> {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/PipelineAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/PipelineAggregator.java
@@ -92,9 +92,9 @@ public abstract class PipelineAggregator {
         }
     }
 
-    private String name;
-    private String[] bucketsPaths;
-    private Map<String, Object> metadata;
+    private final String name;
+    private final String[] bucketsPaths;
+    private final Map<String, Object> metadata;
 
     protected PipelineAggregator(String name, String[] bucketsPaths, Map<String, Object> metadata) {
         this.name = name;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/SerialDiffPipelineAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/SerialDiffPipelineAggregator.java
@@ -28,9 +28,9 @@ import java.util.stream.StreamSupport;
 import static org.elasticsearch.search.aggregations.pipeline.BucketHelpers.resolveBucketValue;
 
 public class SerialDiffPipelineAggregator extends PipelineAggregator {
-    private DocValueFormat formatter;
-    private GapPolicy gapPolicy;
-    private int lag;
+    private final DocValueFormat formatter;
+    private final GapPolicy gapPolicy;
+    private final int lag;
 
     SerialDiffPipelineAggregator(
         String name,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/CoreValuesSourceType.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/CoreValuesSourceType.java
@@ -338,14 +338,10 @@ public enum CoreValuesSourceType implements ValuesSourceType {
                             @Override
                             public QueryVisitor getSubVisitor(BooleanClause.Occur occur, Query parent) {
                                 // Only extract bounds queries that must filter the results
-                                switch (occur) {
-                                    case MUST:
-                                    case FILTER:
-                                        return this;
-
-                                    default:
-                                        return QueryVisitor.EMPTY_VISITOR;
-                                }
+                                return switch (occur) {
+                                    case MUST, FILTER -> this;
+                                    default -> QueryVisitor.EMPTY_VISITOR;
+                                };
                             };
 
                             @Override
@@ -450,5 +446,5 @@ public enum CoreValuesSourceType implements ValuesSourceType {
     }
 
     /** List containing all members of the enumeration. */
-    public static List<ValuesSourceType> ALL_CORE = Arrays.asList(CoreValuesSourceType.values());
+    public static final List<ValuesSourceType> ALL_CORE = Arrays.asList(CoreValuesSourceType.values());
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/FieldContext.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/FieldContext.java
@@ -14,37 +14,22 @@ import org.elasticsearch.index.mapper.MappedFieldType;
  * Used by all field data based aggregators. This determine the context of the field data the aggregators are operating
  * in. It holds both the field names and the index field datas that are associated with them.
  */
-public class FieldContext {
-
-    private final String field;
-    private final IndexFieldData<?> indexFieldData;
-    private final MappedFieldType fieldType;
+public record FieldContext(String field, IndexFieldData<?> indexFieldData, MappedFieldType fieldType) {
 
     /**
      * Constructs a field data context for the given field and its index field data
      *
-     * @param field             The name of the field
-     * @param indexFieldData    The index field data of the field
+     * @param field          The name of the field
+     * @param indexFieldData The index field data of the field
      */
-    public FieldContext(String field, IndexFieldData<?> indexFieldData, MappedFieldType fieldType) {
-        this.field = field;
-        this.indexFieldData = indexFieldData;
-        this.fieldType = fieldType;
-    }
-
-    public String field() {
-        return field;
-    }
+    public FieldContext {}
 
     /**
      * @return The index field datas in this context
      */
+    @Override
     public IndexFieldData<?> indexFieldData() {
         return indexFieldData;
-    }
-
-    public MappedFieldType fieldType() {
-        return fieldType;
     }
 
     public String getTypeName() {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/MultiValuesSourceAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/MultiValuesSourceAggregationBuilder.java
@@ -96,7 +96,6 @@ public abstract class MultiValuesSourceAggregationBuilder<AB extends MultiValues
     /**
      * Read from a stream.
      */
-    @SuppressWarnings("unchecked")
     private void read(StreamInput in) throws IOException {
         fields = in.readMap(MultiValuesSourceFieldConfig::new);
         userValueTypeHint = in.readOptionalWriteable(ValueType::readFromStream);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/SamplingContext.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/SamplingContext.java
@@ -21,7 +21,7 @@ import java.util.Optional;
  * This provides information around the current sampling context for aggregations
  */
 public record SamplingContext(double probability, int seed) {
-    public static SamplingContext NONE = new SamplingContext(1.0, 0);
+    public static final SamplingContext NONE = new SamplingContext(1.0, 0);
 
     public boolean isSampled() {
         return probability < 1.0;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValueType.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValueType.java
@@ -69,7 +69,7 @@ public enum ValueType implements Writeable {
         return valuesSourceType;
     }
 
-    private static Set<ValueType> numericValueTypes = Set.of(
+    private static final Set<ValueType> numericValueTypes = Set.of(
         ValueType.DOUBLE,
         ValueType.DATE,
         ValueType.LONG,
@@ -77,7 +77,7 @@ public enum ValueType implements Writeable {
         ValueType.NUMERIC,
         ValueType.BOOLEAN
     );
-    private static Set<ValueType> stringValueTypes = Set.of(ValueType.STRING, ValueType.IP);
+    private static final Set<ValueType> stringValueTypes = Set.of(ValueType.STRING, ValueType.IP);
 
     /**
      * This is a bit of a hack to mirror the old {@link ValueType} behavior, which would allow a rough compatibility between types.  This

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceRegistry.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceRegistry.java
@@ -58,7 +58,7 @@ public class ValuesSourceRegistry {
 
     public static class Builder {
         private final AggregationUsageService.Builder usageServiceBuilder;
-        private Map<RegistryKey<?>, List<Map.Entry<ValuesSourceType, ?>>> aggregatorRegistry = new HashMap<>();
+        private final Map<RegistryKey<?>, List<Map.Entry<ValuesSourceType, ?>>> aggregatorRegistry = new HashMap<>();
 
         public Builder() {
             this.usageServiceBuilder = new AggregationUsageService.Builder();

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/values/ScriptDoubleValues.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/values/ScriptDoubleValues.java
@@ -81,7 +81,7 @@ public class ScriptDoubleValues extends SortingNumericDoubleValues implements Sc
             // that scripts return the same internal representation as regular fields, so boolean
             // values in scripts need to be converted to a number, and the value formatter will
             // make sure of using true/false in the key_as_string field
-            return ((Boolean) o).booleanValue() ? 1.0 : 0.0;
+            return (Boolean) o ? 1.0 : 0.0;
         } else {
             throw AggregationErrors.unsupportedScriptValue(o == null ? "null" : o.toString());
         }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/values/ScriptLongValues.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/values/ScriptLongValues.java
@@ -83,7 +83,7 @@ public class ScriptLongValues extends AbstractSortingNumericDocValues implements
             // that scripts return the same internal representation as regular fields, so boolean
             // values in scripts need to be converted to a number, and the value formatter will
             // make sure of using true/false in the key_as_string field
-            return ((Boolean) o).booleanValue() ? 1L : 0L;
+            return (Boolean) o ? 1L : 0L;
         } else {
             throw AggregationErrors.unsupportedScriptValue(o == null ? "null" : o.toString());
         }


### PR DESCRIPTION
* Converted a few classes to records.
* Use diamond operator to make statements shorter.
* Replaced switched with enhanced switch
* Made some fields final
* Removed unnecessary casts.