### PR TITLE
ES|QL: Fix layout management for duplicate stats + mv_expand

### DIFF
--- a/docs/changelog/102199.yaml
+++ b/docs/changelog/102199.yaml
@@ -1,0 +1,6 @@
+pr: 102199
+summary: "ES|QL: Fix layout management for duplicate stats + `mv_expand`"
+area: ES|QL
+type: bug
+issues:
+ - 102120

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/mv_expand.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/mv_expand.csv-spec
@@ -252,3 +252,20 @@ emp_no:integer  | first_name:keyword | generate_mv:keyword
 10001           | Georgi             | foo
 10002           | Bezalel            | foo
 ;
+
+
+// see https://github.com/elastic/elasticsearch/issues/102120
+expandAfterDuplicateAggs
+row a = 1 |  stats  a = count(*), b = count(*) | mv_expand b;
+
+a:long | b:long 
+1      | 1
+;
+
+
+expandAfterDuplicateAggsAndEval
+row a = 1 |  stats  a = count(*), b = count(*) | eval c = 2 | mv_expand b;
+
+a:long | b:long | c:integer
+1      | 1      | 2
+;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/mv_expand.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/mv_expand.csv-spec
@@ -255,7 +255,7 @@ emp_no:integer  | first_name:keyword | generate_mv:keyword
 
 
 // see https://github.com/elastic/elasticsearch/issues/102120
-expandAfterDuplicateAggs
+expandAfterDuplicateAggs#[skip:-8.11.99]
 row a = 1 |  stats  a = count(*), b = count(*) | mv_expand b;
 
 a:long | b:long 
@@ -263,7 +263,7 @@ a:long | b:long
 ;
 
 
-expandAfterDuplicateAggsAndEval
+expandAfterDuplicateAggsAndEval#[skip:-8.11.99]
 row a = 1 |  stats  a = count(*), b = count(*) | eval c = 2 | mv_expand b;
 
 a:long | b:long | c:integer

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/Layout.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/Layout.java
@@ -108,16 +108,27 @@ public interface Layout {
             int numberOfChannels = 0;
             for (ChannelSet set : channels) {
                 int channel = numberOfChannels++;
-                for (NameId id : set.nameIds) {
-                    ChannelAndType next = new ChannelAndType(channel, set.type);
-                    ChannelAndType prev = layout.put(id, next);
-                    // Do allow multiple name to point to the same channel - see https://github.com/elastic/elasticsearch/pull/100238
-                    // if (prev != null) {
-                    // throw new IllegalArgumentException("Name [" + id + "] is on two channels [" + prev + "] and [" + next + "]");
-                    // }
+                if (set != null) {
+                    for (NameId id : set.nameIds) {
+                        ChannelAndType next = new ChannelAndType(channel, set.type);
+                        ChannelAndType prev = layout.put(id, next);
+                        // Do allow multiple name to point to the same channel - see https://github.com/elastic/elasticsearch/pull/100238
+                        // if (prev != null) {
+                        // throw new IllegalArgumentException("Name [" + id + "] is on two channels [" + prev + "] and [" + next + "]");
+                        // }
+                    }
                 }
             }
             return new DefaultLayout(Collections.unmodifiableMap(layout), numberOfChannels);
+        }
+
+        public void replace(NameId id, NameId id1) {
+            for (ChannelSet channel : this.channels) {
+                if (channel != null && channel.nameIds.contains(id)) {
+                    channel.nameIds.remove(id);
+                    channel.nameIds.add(id1);
+                }
+            }
         }
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/Layout.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/Layout.java
@@ -108,6 +108,8 @@ public interface Layout {
             int numberOfChannels = 0;
             for (ChannelSet set : channels) {
                 int channel = numberOfChannels++;
+                // the set can be null in case of multiple aggs with the same expression (eg. STATS a = count(*), b = count(*))
+                // This is a specific case of what is described in the comment below
                 if (set != null) {
                     for (NameId id : set.nameIds) {
                         ChannelAndType next = new ChannelAndType(channel, set.type);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -616,14 +616,13 @@ public class LocalExecutionPlanner {
         List<Attribute> childOutput = mvExpandExec.child().output();
         int blockSize = 5000;// TODO estimate row size and use context.pageSize()
 
-        Layout.Builder layout = new Layout.Builder();
+        Layout.Builder layout = source.layout.builder();
         List<Layout.ChannelSet> inverse = source.layout.inverse();
         var expandedName = mvExpandExec.expanded().name();
         for (int index = 0; index < inverse.size(); index++) {
-            if (childOutput.get(index).name().equals(expandedName)) {
-                layout.append(mvExpandExec.expanded());
-            } else {
-                layout.append(inverse.get(index));
+            Attribute prev = childOutput.get(index);
+            if (prev.name().equals(expandedName)) {
+                layout.replace(prev.id(), mvExpandExec.expanded().id());
             }
         }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -622,6 +622,8 @@ public class LocalExecutionPlanner {
         for (int index = 0; index < inverse.size(); index++) {
             Attribute prev = childOutput.get(index);
             if (prev.name().equals(expandedName)) {
+                // the layout looks the same, but it's actually not:
+                // the new field loses some of the properties of the original one, eg. it could no longer be foldable
                 layout.replace(prev.id(), mvExpandExec.expanded().id());
             }
         }


### PR DESCRIPTION
Fixes #102120 

In case of multiple aggs with the same expression, the layout has multiple entries pointing to the same position.
MV_EXPAND planning did not manage this situation properly, this change fixes the problem