### PR TITLE
Fix ShardSearchFailure reason

### DIFF
--- a/docs/changelog/102200.yaml
+++ b/docs/changelog/102200.yaml
@@ -1,0 +1,5 @@
+pr: 102200
+summary: Fix `ShardSearchFailure` reason
+area: Machine Learning
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/search/ShardSearchFailure.java
+++ b/server/src/main/java/org/elasticsearch/action/search/ShardSearchFailure.java
@@ -25,6 +25,7 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 
@@ -61,7 +62,7 @@ public class ShardSearchFailure extends ShardOperationFailedException {
         super(
             shardTarget == null ? null : shardTarget.getFullyQualifiedIndexName(),
             shardTarget == null ? -1 : shardTarget.getShardId().getId(),
-            ExceptionsHelper.unwrapCause(e).getMessage(),
+            Objects.toString(ExceptionsHelper.unwrapCause(e).getMessage(), ""),
             ExceptionsHelper.status(ExceptionsHelper.unwrapCause(e)),
             ExceptionsHelper.unwrapCause(e)
         );

--- a/server/src/main/java/org/elasticsearch/action/search/ShardSearchFailure.java
+++ b/server/src/main/java/org/elasticsearch/action/search/ShardSearchFailure.java
@@ -61,7 +61,7 @@ public class ShardSearchFailure extends ShardOperationFailedException {
         super(
             shardTarget == null ? null : shardTarget.getFullyQualifiedIndexName(),
             shardTarget == null ? -1 : shardTarget.getShardId().getId(),
-            e.getMessage(),
+            ExceptionsHelper.unwrapCause(e).getMessage(),
             ExceptionsHelper.status(ExceptionsHelper.unwrapCause(e)),
             ExceptionsHelper.unwrapCause(e)
         );

--- a/server/src/main/java/org/elasticsearch/action/search/ShardSearchFailure.java
+++ b/server/src/main/java/org/elasticsearch/action/search/ShardSearchFailure.java
@@ -61,7 +61,7 @@ public class ShardSearchFailure extends ShardOperationFailedException {
         super(
             shardTarget == null ? null : shardTarget.getFullyQualifiedIndexName(),
             shardTarget == null ? -1 : shardTarget.getShardId().getId(),
-            ExceptionsHelper.stackTrace(e),
+            e.getMessage(),
             ExceptionsHelper.status(ExceptionsHelper.unwrapCause(e)),
             ExceptionsHelper.unwrapCause(e)
         );

--- a/x-pack/plugin/graph/src/internalClusterTest/java/org/elasticsearch/xpack/graph/test/GraphTests.java
+++ b/x-pack/plugin/graph/src/internalClusterTest/java/org/elasticsearch/xpack/graph/test/GraphTests.java
@@ -44,7 +44,6 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAllS
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.mockito.ArgumentMatchers.contains;
 
 public class GraphTests extends ESSingleNodeTestCase {
 

--- a/x-pack/plugin/graph/src/internalClusterTest/java/org/elasticsearch/xpack/graph/test/GraphTests.java
+++ b/x-pack/plugin/graph/src/internalClusterTest/java/org/elasticsearch/xpack/graph/test/GraphTests.java
@@ -42,7 +42,9 @@ import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAllSuccessful;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.mockito.ArgumentMatchers.contains;
 
 public class GraphTests extends ESSingleNodeTestCase {
 
@@ -280,7 +282,7 @@ public class GraphTests extends ESSingleNodeTestCase {
         }
         assertNotNull(expectedError);
         String message = expectedError.toString();
-        assertTrue(message.contains("Sample diversifying key must be a single valued-field"));
+        assertThat(message, containsString("Sample diversifying key must be a single valued-field"));
     }
 
     public void testMappedAndUnmappedQueryCrawl() {

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/SecurityClearScrollTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/SecurityClearScrollTests.java
@@ -128,7 +128,7 @@ public class SecurityClearScrollTests extends SecurityIntegTestCase {
                 SearchPhaseExecutionException.class,
                 () -> client().prepareSearchScroll(scrollId).get()
             );
-            assertThat(expectedException.toString(), containsString("SearchContextMissingException"));
+            assertThat(expectedException.toString(), containsString("No search context found"));
         }
     }
 


### PR DESCRIPTION
Currently, the reason field of a `ShardSearchFailure` is filled with a stack trace, causing the stack trace to end up in the Kibana user interface, see: https://github.com/elastic/ml-team/issues/1057

If I understand correctly, `reason`s should be human readable, hence this fix.