### PR TITLE
Pull out some single-reference objects for node constructions into separate methods

### DIFF
--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -254,7 +254,17 @@ class NodeConstruction {
             SearchModule searchModule = constructor.createSearchModule(settingsModule.getSettings(), threadPool);
             constructor.createClientAndRegistries(settingsModule.getSettings(), threadPool, searchModule);
 
-            constructor.construct(threadPool, settingsModule, searchModule, serviceProvider, forbidPrivateIndexSettings);
+            ScriptService scriptService = constructor.createScriptService(settingsModule, threadPool, serviceProvider);
+
+            constructor.construct(
+                threadPool,
+                settingsModule,
+                searchModule,
+                scriptService,
+                constructor.createAnalysisRegistry(),
+                serviceProvider,
+                forbidPrivateIndexSettings
+            );
 
             return constructor;
         } catch (IOException e) {
@@ -545,54 +555,59 @@ class NodeConstruction {
         });
     }
 
-    private void construct(
-        ThreadPool threadPool,
-        SettingsModule settingsModule,
-        SearchModule searchModule,
-        NodeServiceProvider serviceProvider,
-        boolean forbidPrivateIndexSettings
-    ) throws IOException {
-
+    private ScriptService createScriptService(SettingsModule settingsModule, ThreadPool threadPool, NodeServiceProvider serviceProvider) {
         Settings settings = settingsModule.getSettings();
+        ScriptModule scriptModule = new ScriptModule(settings, pluginsService.filterPlugins(ScriptPlugin.class).toList());
 
-        final ResourceWatcherService resourceWatcherService = new ResourceWatcherService(settings, threadPool);
-        resourcesToClose.add(resourceWatcherService);
-
-        final Set<String> taskHeaders = Stream.concat(
-            pluginsService.filterPlugins(ActionPlugin.class).flatMap(p -> p.getTaskHeaders().stream()),
-            Task.HEADERS_TO_COPY.stream()
-        ).collect(Collectors.toSet());
-
-        final TelemetryProvider telemetryProvider = getSinglePlugin(TelemetryPlugin.class).map(p -> p.getTelemetryProvider(settings))
-            .orElse(TelemetryProvider.NOOP);
-
-        final Tracer tracer = telemetryProvider.getTracer();
-
-        final TaskManager taskManager = new TaskManager(settings, threadPool, taskHeaders, tracer);
-
-        final ScriptModule scriptModule = new ScriptModule(settings, pluginsService.filterPlugins(ScriptPlugin.class).toList());
-        final ScriptService scriptService = serviceProvider.newScriptService(
+        ScriptService scriptService = serviceProvider.newScriptService(
             pluginsService,
             settings,
             scriptModule.engines,
             scriptModule.contexts,
             threadPool::absoluteTimeInMillis
         );
-        AnalysisModule analysisModule = new AnalysisModule(
+        ScriptModule.registerClusterSettingsListeners(scriptService, settingsModule.getClusterSettings());
+        modules.add(b -> {
+            b.bind(ScriptService.class).toInstance(scriptService);
+            b.bind(UpdateHelper.class).toInstance(new UpdateHelper(scriptService));
+        });
+
+        return scriptService;
+    }
+
+    private AnalysisRegistry createAnalysisRegistry() throws IOException {
+        AnalysisRegistry registry = new AnalysisModule(
             environment,
             pluginsService.filterPlugins(AnalysisPlugin.class).toList(),
             pluginsService.getStablePluginRegistry()
-        );
+        ).getAnalysisRegistry();
+        modules.bindToInstance(AnalysisRegistry.class, registry);
+        return registry;
+    }
 
-        ScriptModule.registerClusterSettingsListeners(scriptService, settingsModule.getClusterSettings());
-        final NetworkService networkService = new NetworkService(
-            pluginsService.filterPlugins(DiscoveryPlugin.class)
-                .map(d -> d.getCustomNameResolver(environment.settings()))
-                .filter(Objects::nonNull)
-                .toList()
-        );
+    private void construct(
+        ThreadPool threadPool,
+        SettingsModule settingsModule,
+        SearchModule searchModule,
+        ScriptService scriptService,
+        AnalysisRegistry analysisRegistry,
+        NodeServiceProvider serviceProvider,
+        boolean forbidPrivateIndexSettings
+    ) throws IOException {
 
-        List<ClusterPlugin> clusterPlugins = pluginsService.filterPlugins(ClusterPlugin.class).toList();
+        Settings settings = settingsModule.getSettings();
+
+        final TelemetryProvider telemetryProvider = getSinglePlugin(TelemetryPlugin.class).map(p -> p.getTelemetryProvider(settings))
+            .orElse(TelemetryProvider.NOOP);
+
+        final Tracer tracer = telemetryProvider.getTracer();
+
+        Set<String> taskHeaders = Stream.concat(
+            pluginsService.filterPlugins(ActionPlugin.class).flatMap(p -> p.getTaskHeaders().stream()),
+            Task.HEADERS_TO_COPY.stream()
+        ).collect(Collectors.toSet());
+        final TaskManager taskManager = new TaskManager(settings, threadPool, taskHeaders, tracer);
+
         final ClusterService clusterService = new ClusterService(settings, settingsModule.getClusterSettings(), threadPool, taskManager);
         clusterService.addStateApplier(scriptService);
         resourcesToClose.add(clusterService);
@@ -611,7 +626,7 @@ class NodeConstruction {
             threadPool,
             environment,
             scriptService,
-            analysisModule.getAnalysisRegistry(),
+            analysisRegistry,
             pluginsService.filterPlugins(IngestPlugin.class).toList(),
             client,
             IngestService.createGrokThreadWatchdog(environment, threadPool),
@@ -625,14 +640,8 @@ class NodeConstruction {
             threadPool,
             client
         );
-        final UsageService usageService = new UsageService();
 
-        final List<SystemIndices.Feature> features = pluginsService.filterPlugins(SystemIndexPlugin.class).map(plugin -> {
-            SystemIndices.validateFeatureName(plugin.getFeatureName(), plugin.getClass().getCanonicalName());
-            return SystemIndices.Feature.fromSystemIndexPlugin(plugin, settings);
-        }).toList();
-        final SystemIndices systemIndices = new SystemIndices(features);
-        final ExecutorSelector executorSelector = systemIndices.getExecutorSelector();
+        SystemIndices systemIndices = createSystemIndices(settings);
 
         final MonitorService monitorService = new MonitorService(settings, nodeEnvironment, threadPool);
         final FsHealthService fsHealthService = new FsHealthService(
@@ -652,7 +661,7 @@ class NodeConstruction {
         final ClusterModule clusterModule = new ClusterModule(
             settings,
             clusterService,
-            clusterPlugins,
+            pluginsService.filterPlugins(ClusterPlugin.class).toList(),
             clusterInfoService,
             snapshotsInfoService,
             threadPool,
@@ -737,7 +746,7 @@ class NodeConstruction {
             pluginsService,
             nodeEnvironment,
             xContentRegistry,
-            analysisModule.getAnalysisRegistry(),
+            analysisRegistry,
             clusterModule.getIndexNameExpressionResolver(),
             indicesModule.getMapperRegistry(),
             namedWriteableRegistry,
@@ -819,7 +828,7 @@ class NodeConstruction {
             client,
             clusterService,
             threadPool,
-            resourceWatcherService,
+            createResourceWatcherService(settings, threadPool),
             scriptService,
             xContentRegistry,
             environment,
@@ -872,7 +881,7 @@ class NodeConstruction {
             pluginsService.filterPlugins(ActionPlugin.class).toList(),
             client,
             circuitBreakerService,
-            usageService,
+            createUsageService(),
             systemIndices,
             tracer,
             clusterService,
@@ -881,6 +890,12 @@ class NodeConstruction {
         );
         modules.add(actionModule);
 
+        final NetworkService networkService = new NetworkService(
+            pluginsService.filterPlugins(DiscoveryPlugin.class)
+                .map(d -> d.getCustomNameResolver(environment.settings()))
+                .filter(Objects::nonNull)
+                .toList()
+        );
         final RestController restController = actionModule.getRestController();
         final NetworkModule networkModule = new NetworkModule(
             settings,
@@ -1047,7 +1062,7 @@ class NodeConstruction {
             searchModule.getFetchPhase(),
             responseCollectorService,
             circuitBreakerService,
-            executorSelector,
+            systemIndices.getExecutorSelector(),
             tracer
         );
 
@@ -1132,15 +1147,11 @@ class NodeConstruction {
 
         modules.add(b -> {
             b.bind(NodeService.class).toInstance(nodeService);
-            b.bind(ResourceWatcherService.class).toInstance(resourceWatcherService);
             b.bind(CircuitBreakerService.class).toInstance(circuitBreakerService);
             b.bind(BigArrays.class).toInstance(bigArrays);
             b.bind(PageCacheRecycler.class).toInstance(pageCacheRecycler);
-            b.bind(ScriptService.class).toInstance(scriptService);
-            b.bind(AnalysisRegistry.class).toInstance(analysisModule.getAnalysisRegistry());
             b.bind(IngestService.class).toInstance(ingestService);
             b.bind(IndexingPressure.class).toInstance(indexingLimits);
-            b.bind(UsageService.class).toInstance(usageService);
             b.bind(AggregationUsageService.class).toInstance(searchModule.getValuesSourceRegistry().getUsageService());
             b.bind(MetadataUpgrader.class).toInstance(metadataUpgrader);
             b.bind(MetaStateService.class).toInstance(metaStateService);
@@ -1156,7 +1167,6 @@ class NodeConstruction {
             b.bind(Transport.class).toInstance(transport);
             b.bind(TransportService.class).toInstance(transportService);
             b.bind(NetworkService.class).toInstance(networkService);
-            b.bind(UpdateHelper.class).toInstance(new UpdateHelper(scriptService));
             b.bind(IndexMetadataVerifier.class).toInstance(indexMetadataVerifier);
             b.bind(ClusterInfoService.class).toInstance(clusterInfoService);
             b.bind(SnapshotsInfoService.class).toInstance(snapshotsInfoService);
@@ -1175,9 +1185,7 @@ class NodeConstruction {
             b.bind(RerouteService.class).toInstance(rerouteService);
             b.bind(ShardLimitValidator.class).toInstance(shardLimitValidator);
             b.bind(FsHealthService.class).toInstance(fsHealthService);
-            b.bind(SystemIndices.class).toInstance(systemIndices);
             b.bind(PluginShutdownService.class).toInstance(pluginShutdownService);
-            b.bind(ExecutorSelector.class).toInstance(executorSelector);
             b.bind(IndexSettingProviders.class).toInstance(indexSettingProviders);
             b.bind(DesiredNodesSettingsValidator.class).toInstance(new DesiredNodesSettingsValidator());
             b.bind(HealthNodeTaskExecutor.class).toInstance(healthNodeTaskExecutor);
@@ -1197,6 +1205,33 @@ class NodeConstruction {
         injector = modules.createInjector();
 
         postInjection(clusterModule, actionModule, clusterService, transportService, featureService);
+    }
+
+    private UsageService createUsageService() {
+        UsageService usageService = new UsageService();
+        modules.bindToInstance(UsageService.class, usageService);
+        return usageService;
+    }
+
+    private SystemIndices createSystemIndices(Settings settings) {
+        List<SystemIndices.Feature> features = pluginsService.filterPlugins(SystemIndexPlugin.class).map(plugin -> {
+            SystemIndices.validateFeatureName(plugin.getFeatureName(), plugin.getClass().getCanonicalName());
+            return SystemIndices.Feature.fromSystemIndexPlugin(plugin, settings);
+        }).toList();
+
+        SystemIndices systemIndices = new SystemIndices(features);
+        modules.add(b -> {
+            b.bind(SystemIndices.class).toInstance(systemIndices);
+            b.bind(ExecutorSelector.class).toInstance(systemIndices.getExecutorSelector());
+        });
+        return systemIndices;
+    }
+
+    private ResourceWatcherService createResourceWatcherService(Settings settings, ThreadPool threadPool) {
+        ResourceWatcherService resourceWatcherService = new ResourceWatcherService(settings, threadPool);
+        resourcesToClose.add(resourceWatcherService);
+        modules.bindToInstance(ResourceWatcherService.class, resourceWatcherService);
+        return resourceWatcherService;
     }
 
     private Module loadDiagnosticServices(


### PR DESCRIPTION
Some objects are only referenced once, apart from injection binding. Pull these out into separate methods and inline them.