### PR TITLE
Reinstate recovery planner plugin construction to the main construction method

### DIFF
--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -1016,7 +1016,7 @@ class NodeConstruction {
             compatibilityVersions,
             featureService
         );
-        this.nodeService = new NodeService(
+        nodeService = new NodeService(
             settings,
             threadPool,
             monitorService,
@@ -1102,8 +1102,8 @@ class NodeConstruction {
             loadDiagnosticServices(settings, discoveryModule.getCoordinator(), clusterService, transportService, featureService, threadPool)
         );
 
+        RecoveryPlannerService recoveryPlannerService = getRecoveryPlannerService(threadPool, clusterService, repositoryService);
         modules.add(b -> {
-            RecoveryPlannerService recoveryPlannerService = getRecoveryPlannerService(threadPool, clusterService, repositoryService);
             serviceProvider.processRecoverySettings(pluginsService, settingsModule.getClusterSettings(), recoverySettings);
             SnapshotFilesProvider snapshotFilesProvider = new SnapshotFilesProvider(repositoryService);
             var peerRecovery = new PeerRecoverySourceService(


### PR DESCRIPTION
`getRecoveryPlannerService` was incorrectly moved to inside a module binding by #101123, where it is called whilst holding a lock.

This shouldn't actually affect anything, but we should aim to keep things as functionally close as they were beforehand.