### PR TITLE
Change some uses of node version id to getPre811NodeVersionId

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
@@ -1047,7 +1047,7 @@ public class ClusterState implements ChunkedToXContent, Diffable<ClusterState> {
         TransportVersion tv;
         if (node.getVersion().before(Version.V_8_8_0)) {
             // 1-to-1 mapping between Version and TransportVersion
-            tv = TransportVersion.fromId(node.getVersion().id);
+            tv = TransportVersion.fromId(node.getPre811VersionId().getAsInt());
         } else {
             // use the lowest value it could be for now
             tv = INFERRED_TRANSPORT_VERSION;

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinRequest.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinRequest.java
@@ -76,7 +76,10 @@ public class JoinRequest extends TransportRequest {
         } else {
             // there's a 1-1 mapping from Version to TransportVersion before 8.8.0
             // no known mapping versions here
-            compatibilityVersions = new CompatibilityVersions(TransportVersion.fromId(sourceNode.getVersion().id), Map.of());
+            compatibilityVersions = new CompatibilityVersions(
+                TransportVersion.fromId(sourceNode.getPre811VersionId().getAsInt()),
+                Map.of()
+            );
         }
         if (in.getTransportVersion().onOrAfter(TransportVersions.CLUSTER_FEATURES_ADDED)) {
             features = in.readCollectionAsSet(StreamInput::readString);

--- a/server/src/test/java/org/elasticsearch/cluster/service/TransportVersionsFixupListenerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/service/TransportVersionsFixupListenerTests.java
@@ -49,8 +49,7 @@ import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 
 public class TransportVersionsFixupListenerTests extends ESTestCase {
 
-    // TODO: replace with real constants when 8.8.0 is released
-    private static final Version NEXT_VERSION = Version.fromString("8.8.1");
+    private static final Version NEXT_VERSION = Version.V_8_8_1;
     private static final TransportVersion NEXT_TRANSPORT_VERSION = TransportVersion.fromId(NEXT_VERSION.id);
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Use the 'official' method rather than accessing id directly