### PR TITLE
Drop assertion that enforces `search_shards` action to be called from `search_coordination` thread pool

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchShardsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchShardsAction.java
@@ -79,7 +79,6 @@ public class TransportSearchShardsAction extends HandledTransportAction<SearchSh
 
     @Override
     protected void doExecute(Task task, SearchShardsRequest searchShardsRequest, ActionListener<SearchShardsResponse> listener) {
-        assert ThreadPool.assertCurrentThreadPool(ThreadPool.Names.SEARCH_COORDINATION);
         final long relativeStartNanos = System.nanoTime();
         SearchRequest original = new SearchRequest(searchShardsRequest.indices()).indicesOptions(searchShardsRequest.indicesOptions())
             .routing(searchShardsRequest.routing())


### PR DESCRIPTION
Now, that `search_shards` API is about to be called from transform code, the assertion requiring the `search_shards` API to be called from `search_coordination` thread pool seems overly restrictive.
This PR removes this assertion.

Relates https://github.com/elastic/elasticsearch/issues/100486