### PR TITLE
Fix nesting of linearizable register docs

### DIFF
--- a/docs/reference/snapshot-restore/repository-azure.asciidoc
+++ b/docs/reference/snapshot-restore/repository-azure.asciidoc
@@ -259,7 +259,6 @@ permitted in container names.
 * Container names must be from 3 through 63 characters long.
 
 [[repository-azure-linearizable-registers]]
-[discrete]
 ==== Linearizable register implementation
 
 The linearizable register implementation for Azure repositories is based on

--- a/docs/reference/snapshot-restore/repository-gcs.asciidoc
+++ b/docs/reference/snapshot-restore/repository-gcs.asciidoc
@@ -277,7 +277,6 @@ The service account used to access the bucket must have the "Writer" access to t
 5. The service account must be configured as a "User" with "Writer" access.
 
 [[repository-gcs-linearizable-registers]]
-[discrete]
 ==== Linearizable register implementation
 
 The linearizable register implementation for GCS repositories is based on GCS's

--- a/docs/reference/snapshot-restore/repository-s3.asciidoc
+++ b/docs/reference/snapshot-restore/repository-s3.asciidoc
@@ -558,7 +558,6 @@ collecting the logs needed by your supplier, set the logger settings back to
 and <<cluster-update-settings>> for more information.
 
 [[repository-s3-linearizable-registers]]
-[discrete]
 ==== Linearizable register implementation
 
 The linearizable register implementation for S3 repositories is based on the

--- a/docs/reference/snapshot-restore/repository-shared-file-system.asciidoc
+++ b/docs/reference/snapshot-restore/repository-shared-file-system.asciidoc
@@ -86,7 +86,6 @@ the same numeric UID and GID, or else update your NFS configuration to account
 for the variance in numeric IDs across nodes.
 
 [[repository-fs-linearizable-registers]]
-[discrete]
 ==== Linearizable register implementation
 
 The linearizable register implementation for shared filesystem repositories is


### PR DESCRIPTION
Removes the `[discrete]` line from the docs introduced in #102050 so
that these subsections are nested at the right level.