### PR TITLE
Remove explicit SearchResponse references from `org.elasticsearch.search.stats`

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/stats/FieldUsageStatsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/stats/FieldUsageStatsIT.java
@@ -11,7 +11,6 @@ package org.elasticsearch.search.stats;
 import org.elasticsearch.action.admin.indices.stats.FieldUsageShardResponse;
 import org.elasticsearch.action.admin.indices.stats.FieldUsageStatsAction;
 import org.elasticsearch.action.admin.indices.stats.FieldUsageStatsRequest;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -30,6 +29,7 @@ import java.util.concurrent.ExecutionException;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAllSuccessful;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 
 public class FieldUsageStatsIT extends ESIntegTestCase {
 
@@ -73,16 +73,18 @@ public class FieldUsageStatsIT extends ESIntegTestCase {
         assertFalse(stats.hasField("field2"));
         assertFalse(stats.hasField("date_field"));
 
-        SearchResponse searchResponse = prepareSearch().setSearchType(SearchType.DEFAULT)
-            .setQuery(QueryBuilders.termQuery("field", "value"))
-            .addAggregation(AggregationBuilders.terms("agg1").field("field.keyword"))
-            .addAggregation(AggregationBuilders.filter("agg2", QueryBuilders.spanTermQuery("field2", "value2")))
-            .setSize(between(5, 100))
-            .setPreference("fixed")
-            .get();
-
-        assertHitCount(searchResponse, 30);
-        assertAllSuccessful(searchResponse);
+        assertResponse(
+            prepareSearch().setSearchType(SearchType.DEFAULT)
+                .setQuery(QueryBuilders.termQuery("field", "value"))
+                .addAggregation(AggregationBuilders.terms("agg1").field("field.keyword"))
+                .addAggregation(AggregationBuilders.filter("agg2", QueryBuilders.spanTermQuery("field2", "value2")))
+                .setSize(between(5, 100))
+                .setPreference("fixed"),
+            response -> {
+                assertHitCount(response, 30);
+                assertAllSuccessful(response);
+            }
+        );
 
         stats = aggregated(client().execute(FieldUsageStatsAction.INSTANCE, new FieldUsageStatsRequest()).get().getStats().get("test"));
         logger.info("Stats after first query: {}", stats);

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/stats/SearchStatsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/stats/SearchStatsIT.java
@@ -11,7 +11,6 @@ package org.elasticsearch.search.stats;
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
 import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsResponse;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.routing.GroupShardsIterator;
 import org.elasticsearch.cluster.routing.ShardIterator;
@@ -39,7 +38,8 @@ import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAllSuccessful;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -103,16 +103,22 @@ public class SearchStatsIT extends ESIntegTestCase {
         refresh();
         int iters = scaledRandomIntBetween(100, 150);
         for (int i = 0; i < iters; i++) {
-            SearchResponse searchResponse = internalCluster().coordOnlyNodeClient()
-                .prepareSearch()
-                .setQuery(QueryBuilders.termQuery("field", "value"))
-                .setStats("group1", "group2")
-                .highlighter(new HighlightBuilder().field("field"))
-                .addScriptField("script1", new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "_source.field", Collections.emptyMap()))
-                .setSize(100)
-                .get();
-            assertHitCount(searchResponse, docsTest1 + docsTest2);
-            assertAllSuccessful(searchResponse);
+            assertResponse(
+                internalCluster().coordOnlyNodeClient()
+                    .prepareSearch()
+                    .setQuery(QueryBuilders.termQuery("field", "value"))
+                    .setStats("group1", "group2")
+                    .highlighter(new HighlightBuilder().field("field"))
+                    .addScriptField(
+                        "script1",
+                        new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "_source.field", Collections.emptyMap())
+                    )
+                    .setSize(100),
+                response -> {
+                    assertHitCount(response, docsTest1 + docsTest2);
+                    assertAllSuccessful(response);
+                }
+            );
         }
 
         IndicesStatsResponse indicesStats = indicesAdmin().prepareStats().get();
@@ -188,11 +194,15 @@ public class SearchStatsIT extends ESIntegTestCase {
         assertThat(indicesStats.getTotal().getSearch().getOpenContexts(), equalTo(0L));
 
         int size = scaledRandomIntBetween(1, docs);
-        SearchResponse searchResponse = prepareSearch().setQuery(matchAllQuery())
-            .setSize(size)
-            .setScroll(TimeValue.timeValueMinutes(2))
-            .get();
-        assertNoFailures(searchResponse);
+        final String[] scroll = new String[1];
+        final int[] total = new int[1];
+        assertNoFailuresAndResponse(
+            prepareSearch().setQuery(matchAllQuery()).setSize(size).setScroll(TimeValue.timeValueMinutes(2)),
+            response -> {
+                scroll[0] = response.getScrollId();
+                total[0] = response.getHits().getHits().length;
+            }
+        );
 
         // refresh the stats now that scroll contexts are opened
         indicesStats = indicesAdmin().prepareStats(index).get();
@@ -202,11 +212,14 @@ public class SearchStatsIT extends ESIntegTestCase {
 
         int hits = 0;
         while (true) {
-            if (searchResponse.getHits().getHits().length == 0) {
+            if (total[0] == 0) {
                 break;
             }
-            hits += searchResponse.getHits().getHits().length;
-            searchResponse = client().prepareSearchScroll(searchResponse.getScrollId()).setScroll(TimeValue.timeValueMinutes(2)).get();
+            hits += total[0];
+            assertResponse(client().prepareSearchScroll(scroll[0]).setScroll(TimeValue.timeValueMinutes(2)), response -> {
+                scroll[0] = response.getScrollId();
+                total[0] = response.getHits().getHits().length;
+            });
         }
         long expected = 0;
 
@@ -220,7 +233,7 @@ public class SearchStatsIT extends ESIntegTestCase {
         assertEquals(hits, docs * numAssignedShards(index));
         assertThat(stats.getQueryCount(), greaterThanOrEqualTo(expected));
 
-        clearScroll(searchResponse.getScrollId());
+        clearScroll(scroll[0]);
 
         indicesStats = indicesAdmin().prepareStats().get();
         stats = indicesStats.getTotal().getSearch().getTotal();


### PR DESCRIPTION
relates https://github.com/elastic/elasticsearch/issues/102030
