### PR TITLE
[ML] Record the time of job state changes

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -165,6 +165,7 @@ public class TransportVersions {
     public static final TransportVersion REPO_ANALYSIS_REGISTER_OP_COUNT_ADDED = def(8_534_00_0);
     public static final TransportVersion ML_TRAINED_MODEL_PREFIX_STRINGS_ADDED = def(8_535_00_0);
     public static final TransportVersion COUNTED_KEYWORD_ADDED = def(8_536_00_0);
+    public static final TransportVersion ML_STATE_CHANGE_TIMESTAMPS = def(8_537_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/persistent/UpdatePersistentTaskStatusAction.java
+++ b/server/src/main/java/org/elasticsearch/persistent/UpdatePersistentTaskStatusAction.java
@@ -66,12 +66,24 @@ public class UpdatePersistentTaskStatusAction extends ActionType<PersistentTaskR
             this.taskId = taskId;
         }
 
+        public String getTaskId() {
+            return taskId;
+        }
+
         public void setAllocationId(long allocationId) {
             this.allocationId = allocationId;
         }
 
+        public long getAllocationId() {
+            return allocationId;
+        }
+
         public void setState(PersistentTaskState state) {
             this.state = state;
+        }
+
+        public PersistentTaskState getState() {
+            return state;
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlTasks.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlTasks.java
@@ -22,6 +22,7 @@ import org.elasticsearch.xpack.core.ml.job.snapshot.upgrade.SnapshotUpgradeState
 import org.elasticsearch.xpack.core.ml.job.snapshot.upgrade.SnapshotUpgradeTaskState;
 import org.elasticsearch.xpack.core.ml.utils.MemoryTrackedTaskState;
 
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
@@ -194,6 +195,17 @@ public final class MlTasks {
         return jobState;
     }
 
+    public static Instant getLastJobTaskStateChangeTime(String jobId, @Nullable PersistentTasksCustomMetadata tasks) {
+        PersistentTasksCustomMetadata.PersistentTask<?> task = getJobTask(jobId, tasks);
+        if (task != null) {
+            JobTaskState jobTaskState = (JobTaskState) task.getState();
+            if (jobTaskState != null) {
+                return jobTaskState.getLastStateChangeTime();
+            }
+        }
+        return null;
+    }
+
     public static SnapshotUpgradeState getSnapshotUpgradeState(
         String jobId,
         String snapshotId,
@@ -258,6 +270,17 @@ public final class MlTasks {
             }
         }
         return state;
+    }
+
+    public static Instant getLastDataFrameAnalyticsTaskStateChangeTime(String analyticsId, @Nullable PersistentTasksCustomMetadata tasks) {
+        PersistentTasksCustomMetadata.PersistentTask<?> task = getDataFrameAnalyticsTask(analyticsId, tasks);
+        if (task != null) {
+            DataFrameAnalyticsTaskState taskState = (DataFrameAnalyticsTaskState) task.getState();
+            if (taskState != null) {
+                return taskState.getLastStateChangeTime();
+            }
+        }
+        return null;
     }
 
     /**

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsTaskState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsTaskState.java
@@ -6,42 +6,57 @@
  */
 package org.elasticsearch.xpack.core.ml.dataframe;
 
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.persistent.PersistentTaskState;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
+import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xpack.core.common.time.TimeUtils;
 import org.elasticsearch.xpack.core.ml.MlTasks;
+import org.elasticsearch.xpack.core.ml.utils.MlTaskState;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Objects;
 
-public class DataFrameAnalyticsTaskState implements PersistentTaskState {
+import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
+
+public class DataFrameAnalyticsTaskState implements PersistentTaskState, MlTaskState {
 
     public static final String NAME = MlTasks.DATA_FRAME_ANALYTICS_TASK_NAME;
 
-    private static ParseField STATE = new ParseField("state");
-    private static ParseField ALLOCATION_ID = new ParseField("allocation_id");
-    private static ParseField REASON = new ParseField("reason");
+    private static final ParseField STATE = new ParseField("state");
+    private static final ParseField ALLOCATION_ID = new ParseField("allocation_id");
+    private static final ParseField REASON = new ParseField("reason");
+    private static final ParseField LAST_STATE_CHANGE_TIME = new ParseField("last_state_change_time");
 
     private final DataFrameAnalyticsState state;
     private final long allocationId;
     private final String reason;
+    private final Instant lastStateChangeTime;
 
     private static final ConstructingObjectParser<DataFrameAnalyticsTaskState, Void> PARSER = new ConstructingObjectParser<>(
         NAME,
         true,
-        a -> new DataFrameAnalyticsTaskState((DataFrameAnalyticsState) a[0], (long) a[1], (String) a[2])
+        a -> new DataFrameAnalyticsTaskState((DataFrameAnalyticsState) a[0], (long) a[1], (String) a[2], (Instant) a[3])
     );
 
     static {
         PARSER.declareString(ConstructingObjectParser.constructorArg(), DataFrameAnalyticsState::fromString, STATE);
         PARSER.declareLong(ConstructingObjectParser.constructorArg(), ALLOCATION_ID);
         PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), REASON);
+        PARSER.declareField(
+            optionalConstructorArg(),
+            p -> TimeUtils.parseTimeFieldToInstant(p, LAST_STATE_CHANGE_TIME.getPreferredName()),
+            LAST_STATE_CHANGE_TIME,
+            ObjectParser.ValueType.VALUE
+        );
     }
 
     public static DataFrameAnalyticsTaskState fromXContent(XContentParser parser) {
@@ -52,25 +67,47 @@ public class DataFrameAnalyticsTaskState implements PersistentTaskState {
         }
     }
 
-    public DataFrameAnalyticsTaskState(DataFrameAnalyticsState state, long allocationId, @Nullable String reason) {
+    public DataFrameAnalyticsTaskState(
+        DataFrameAnalyticsState state,
+        long allocationId,
+        @Nullable String reason,
+        @Nullable Instant lastStateChangeTime
+    ) {
         this.state = Objects.requireNonNull(state);
         this.allocationId = allocationId;
         this.reason = reason;
+        // Round to millisecond to avoid serialization round trip differences
+        this.lastStateChangeTime = (lastStateChangeTime != null) ? Instant.ofEpochMilli(lastStateChangeTime.toEpochMilli()) : null;
     }
 
     public DataFrameAnalyticsTaskState(StreamInput in) throws IOException {
         this.state = DataFrameAnalyticsState.fromStream(in);
         this.allocationId = in.readLong();
         this.reason = in.readOptionalString();
+        if (in.getTransportVersion().onOrAfter(TransportVersions.ML_STATE_CHANGE_TIMESTAMPS)) {
+            lastStateChangeTime = in.readOptionalInstant();
+        } else {
+            lastStateChangeTime = null;
+        }
     }
 
     public DataFrameAnalyticsState getState() {
         return state;
     }
 
+    public long getAllocationId() {
+        return allocationId;
+    }
+
     @Nullable
     public String getReason() {
         return reason;
+    }
+
+    @Override
+    @Nullable
+    public Instant getLastStateChangeTime() {
+        return lastStateChangeTime;
     }
 
     public boolean isStatusStale(PersistentTasksCustomMetadata.PersistentTask<?> task) {
@@ -87,6 +124,9 @@ public class DataFrameAnalyticsTaskState implements PersistentTaskState {
         state.writeTo(out);
         out.writeLong(allocationId);
         out.writeOptionalString(reason);
+        if (out.getTransportVersion().onOrAfter(TransportVersions.ML_STATE_CHANGE_TIMESTAMPS)) {
+            out.writeOptionalInstant(lastStateChangeTime);
+        }
     }
 
     @Override
@@ -97,6 +137,13 @@ public class DataFrameAnalyticsTaskState implements PersistentTaskState {
         if (reason != null) {
             builder.field(REASON.getPreferredName(), reason);
         }
+        if (lastStateChangeTime != null) {
+            builder.timeField(
+                LAST_STATE_CHANGE_TIME.getPreferredName(),
+                LAST_STATE_CHANGE_TIME.getPreferredName() + "_string",
+                lastStateChangeTime.toEpochMilli()
+            );
+        }
         builder.endObject();
         return builder;
     }
@@ -106,11 +153,14 @@ public class DataFrameAnalyticsTaskState implements PersistentTaskState {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         DataFrameAnalyticsTaskState that = (DataFrameAnalyticsTaskState) o;
-        return allocationId == that.allocationId && state == that.state && Objects.equals(reason, that.reason);
+        return allocationId == that.allocationId
+            && state == that.state
+            && Objects.equals(reason, that.reason)
+            && Objects.equals(lastStateChangeTime, that.lastStateChangeTime);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(state, allocationId, reason);
+        return Objects.hash(state, allocationId, reason, lastStateChangeTime);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/JobTaskState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/JobTaskState.java
@@ -6,41 +6,53 @@
  */
 package org.elasticsearch.xpack.core.ml.job.config;
 
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.persistent.PersistentTaskState;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata.PersistentTask;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
+import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xpack.core.common.time.TimeUtils;
 import org.elasticsearch.xpack.core.ml.MlTasks;
+import org.elasticsearch.xpack.core.ml.utils.MlTaskState;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Objects;
 
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
 
-public class JobTaskState implements PersistentTaskState {
+public class JobTaskState implements PersistentTaskState, MlTaskState {
 
     public static final String NAME = MlTasks.JOB_TASK_NAME;
 
-    private static ParseField STATE = new ParseField("state");
-    private static ParseField ALLOCATION_ID = new ParseField("allocation_id");
-    private static ParseField REASON = new ParseField("reason");
+    private static final ParseField STATE = new ParseField("state");
+    private static final ParseField ALLOCATION_ID = new ParseField("allocation_id");
+    private static final ParseField REASON = new ParseField("reason");
+    private static final ParseField LAST_STATE_CHANGE_TIME = new ParseField("last_state_change_time");
 
     private static final ConstructingObjectParser<JobTaskState, Void> PARSER = new ConstructingObjectParser<>(
         NAME,
         true,
-        args -> new JobTaskState((JobState) args[0], (Long) args[1], (String) args[2])
+        args -> new JobTaskState((JobState) args[0], (Long) args[1], (String) args[2], (Instant) args[3])
     );
 
     static {
         PARSER.declareString(constructorArg(), JobState::fromString, STATE);
         PARSER.declareLong(constructorArg(), ALLOCATION_ID);
         PARSER.declareString(optionalConstructorArg(), REASON);
+        PARSER.declareField(
+            optionalConstructorArg(),
+            p -> TimeUtils.parseTimeFieldToInstant(p, LAST_STATE_CHANGE_TIME.getPreferredName()),
+            LAST_STATE_CHANGE_TIME,
+            ObjectParser.ValueType.VALUE
+        );
     }
 
     public static JobTaskState fromXContent(XContentParser parser) {
@@ -54,26 +66,44 @@ public class JobTaskState implements PersistentTaskState {
     private final JobState state;
     private final long allocationId;
     private final String reason;
+    private final Instant lastStateChangeTime;
 
-    public JobTaskState(JobState state, long allocationId, @Nullable String reason) {
+    public JobTaskState(JobState state, long allocationId, @Nullable String reason, @Nullable Instant lastStateChangeTime) {
         this.state = Objects.requireNonNull(state);
         this.allocationId = allocationId;
         this.reason = reason;
+        // Round to millisecond to avoid serialization round trip differences
+        this.lastStateChangeTime = (lastStateChangeTime != null) ? Instant.ofEpochMilli(lastStateChangeTime.toEpochMilli()) : null;
     }
 
     public JobTaskState(StreamInput in) throws IOException {
         state = JobState.fromStream(in);
         allocationId = in.readLong();
         reason = in.readOptionalString();
+        if (in.getTransportVersion().onOrAfter(TransportVersions.ML_STATE_CHANGE_TIMESTAMPS)) {
+            lastStateChangeTime = in.readOptionalInstant();
+        } else {
+            lastStateChangeTime = null;
+        }
     }
 
     public JobState getState() {
         return state;
     }
 
+    public long getAllocationId() {
+        return allocationId;
+    }
+
     @Nullable
     public String getReason() {
         return reason;
+    }
+
+    @Override
+    @Nullable
+    public Instant getLastStateChangeTime() {
+        return lastStateChangeTime;
     }
 
     /**
@@ -101,6 +131,9 @@ public class JobTaskState implements PersistentTaskState {
         state.writeTo(out);
         out.writeLong(allocationId);
         out.writeOptionalString(reason);
+        if (out.getTransportVersion().onOrAfter(TransportVersions.ML_STATE_CHANGE_TIMESTAMPS)) {
+            out.writeOptionalInstant(lastStateChangeTime);
+        }
     }
 
     @Override
@@ -111,6 +144,13 @@ public class JobTaskState implements PersistentTaskState {
         if (reason != null) {
             builder.field(REASON.getPreferredName(), reason);
         }
+        if (lastStateChangeTime != null) {
+            builder.timeField(
+                LAST_STATE_CHANGE_TIME.getPreferredName(),
+                LAST_STATE_CHANGE_TIME.getPreferredName() + "_string",
+                lastStateChangeTime.toEpochMilli()
+            );
+        }
         builder.endObject();
         return builder;
     }
@@ -120,11 +160,14 @@ public class JobTaskState implements PersistentTaskState {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         JobTaskState that = (JobTaskState) o;
-        return state == that.state && Objects.equals(allocationId, that.allocationId) && Objects.equals(reason, that.reason);
+        return state == that.state
+            && Objects.equals(allocationId, that.allocationId)
+            && Objects.equals(reason, that.reason)
+            && Objects.equals(lastStateChangeTime, that.lastStateChangeTime);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(state, allocationId, reason);
+        return Objects.hash(state, allocationId, reason, lastStateChangeTime);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/MlTaskState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/MlTaskState.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.ml.utils;
+
+import org.elasticsearch.core.Nullable;
+
+import java.time.Instant;
+
+public interface MlTaskState {
+
+    /**
+     * The time of the last state change.
+     */
+    @Nullable
+    Instant getLastStateChangeTime();
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/MlTasksTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/MlTasksTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.xpack.core.ml.job.snapshot.upgrade.SnapshotUpgradeTaskP
 import org.elasticsearch.xpack.core.ml.job.snapshot.upgrade.SnapshotUpgradeTaskState;
 
 import java.net.InetAddress;
+import java.time.Instant;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -50,7 +51,10 @@ public class MlTasksTests extends ESTestCase {
         );
         assertEquals(JobState.OPENING, MlTasks.getJobState("foo", tasksBuilder.build()));
 
-        tasksBuilder.updateTaskState(MlTasks.jobTaskId("foo"), new JobTaskState(JobState.OPENED, tasksBuilder.getLastAllocationId(), null));
+        tasksBuilder.updateTaskState(
+            MlTasks.jobTaskId("foo"),
+            new JobTaskState(JobState.OPENED, tasksBuilder.getLastAllocationId(), null, Instant.now())
+        );
         assertEquals(JobState.OPENED, MlTasks.getJobState("foo", tasksBuilder.build()));
     }
 
@@ -327,7 +331,7 @@ public class MlTasksTests extends ESTestCase {
             new OpenJobAction.JobParams("foo-1"),
             new PersistentTasksCustomMetadata.Assignment("node-1", "test assignment")
         );
-        tasksBuilder.updateTaskState(MlTasks.jobTaskId("job-1"), new JobTaskState(JobState.FAILED, 1, "testing"));
+        tasksBuilder.updateTaskState(MlTasks.jobTaskId("job-1"), new JobTaskState(JobState.FAILED, 1, "testing", Instant.now()));
         tasksBuilder.addTask(
             MlTasks.jobTaskId("job-2"),
             MlTasks.JOB_TASK_NAME,
@@ -335,7 +339,7 @@ public class MlTasksTests extends ESTestCase {
             new PersistentTasksCustomMetadata.Assignment("node-1", "test assignment")
         );
         if (randomBoolean()) {
-            tasksBuilder.updateTaskState(MlTasks.jobTaskId("job-2"), new JobTaskState(JobState.OPENED, 2, "testing"));
+            tasksBuilder.updateTaskState(MlTasks.jobTaskId("job-2"), new JobTaskState(JobState.OPENED, 2, "testing", Instant.now()));
         }
         tasksBuilder.addTask(
             MlTasks.jobTaskId("job-3"),
@@ -344,7 +348,7 @@ public class MlTasksTests extends ESTestCase {
             new PersistentTasksCustomMetadata.Assignment("node-2", "test assignment")
         );
         if (randomBoolean()) {
-            tasksBuilder.updateTaskState(MlTasks.jobTaskId("job-3"), new JobTaskState(JobState.FAILED, 3, "testing"));
+            tasksBuilder.updateTaskState(MlTasks.jobTaskId("job-3"), new JobTaskState(JobState.FAILED, 3, "testing", Instant.now()));
         }
 
         assertThat(MlTasks.nonFailedJobTasksOnNode(tasksBuilder.build(), "node-1"), contains(hasProperty("id", equalTo("job-job-2"))));
@@ -514,7 +518,7 @@ public class MlTasksTests extends ESTestCase {
         if (state != null) {
             builder.updateTaskState(
                 MlTasks.dataFrameAnalyticsTaskId(jobId),
-                new DataFrameAnalyticsTaskState(state, builder.getLastAllocationId() - (isStale ? 1 : 0), null)
+                new DataFrameAnalyticsTaskState(state, builder.getLastAllocationId() - (isStale ? 1 : 0), null, Instant.now())
             );
         }
         PersistentTasksCustomMetadata tasks = builder.build();

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsTaskStateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsTaskStateTests.java
@@ -16,7 +16,12 @@ public class DataFrameAnalyticsTaskStateTests extends AbstractXContentSerializin
 
     @Override
     protected DataFrameAnalyticsTaskState createTestInstance() {
-        return new DataFrameAnalyticsTaskState(randomFrom(DataFrameAnalyticsState.values()), randomLong(), randomAlphaOfLength(10));
+        return new DataFrameAnalyticsTaskState(
+            randomFrom(DataFrameAnalyticsState.values()),
+            randomLong(),
+            randomAlphaOfLength(10),
+            randomInstant()
+        );
     }
 
     @Override

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/BasicDistributedJobsIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/BasicDistributedJobsIT.java
@@ -45,6 +45,8 @@ import org.elasticsearch.xpack.ml.MachineLearning;
 import org.elasticsearch.xpack.ml.support.BaseMlIntegTestCase;
 
 import java.io.IOException;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -74,6 +76,7 @@ public class BasicDistributedJobsIT extends BaseMlIntegTestCase {
         OpenJobAction.Request openJobRequest = new OpenJobAction.Request(job.getId());
         client().execute(OpenJobAction.INSTANCE, openJobRequest).actionGet();
         awaitJobOpenedAndAssigned(job.getId(), null);
+        assertRecentLastTaskStateChangeTime(MlTasks.jobTaskId(job.getId()), Duration.of(10, ChronoUnit.SECONDS), null);
 
         setMlIndicesDelayedNodeLeftTimeoutToZero();
 

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/BasicDistributedJobsIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/BasicDistributedJobsIT.java
@@ -84,11 +84,13 @@ public class BasicDistributedJobsIT extends BaseMlIntegTestCase {
         internalCluster().stopRandomDataNode();
         ensureStableCluster(3);
         awaitJobOpenedAndAssigned(job.getId(), null);
+        assertRecentLastTaskStateChangeTime(MlTasks.jobTaskId(job.getId()), Duration.of(10, ChronoUnit.SECONDS), null);
 
         ensureGreen(); // replicas must be assigned, otherwise we could lose a whole index
         internalCluster().stopRandomDataNode();
         ensureStableCluster(2);
         awaitJobOpenedAndAssigned(job.getId(), null);
+        assertRecentLastTaskStateChangeTime(MlTasks.jobTaskId(job.getId()), Duration.of(10, ChronoUnit.SECONDS), null);
     }
 
     @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/82591")

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DataFrameAnalyticsConfigProviderIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DataFrameAnalyticsConfigProviderIT.java
@@ -32,6 +32,7 @@ import org.elasticsearch.xpack.ml.dataframe.persistence.DataFrameAnalyticsConfig
 import org.elasticsearch.xpack.ml.notifications.DataFrameAnalyticsAuditor;
 import org.junit.Before;
 
+import java.time.Instant;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
@@ -383,7 +384,7 @@ public class DataFrameAnalyticsConfigProviderIT extends MlSingleNodeTestCase {
         );
         builder.updateTaskState(
             MlTasks.dataFrameAnalyticsTaskId(analyticsId),
-            new DataFrameAnalyticsTaskState(analyticsState, builder.getLastAllocationId(), null)
+            new DataFrameAnalyticsTaskState(analyticsState, builder.getLastAllocationId(), null, Instant.now())
         );
         PersistentTasksCustomMetadata tasks = builder.build();
 

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/IndexLayoutIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/IndexLayoutIT.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.ml.integration;
 
 import org.elasticsearch.client.internal.OriginSettingClient;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.xpack.core.ml.MlTasks;
 import org.elasticsearch.xpack.core.ml.action.CloseJobAction;
 import org.elasticsearch.xpack.core.ml.action.GetJobsStatsAction;
 import org.elasticsearch.xpack.core.ml.action.OpenJobAction;
@@ -21,6 +22,8 @@ import org.elasticsearch.xpack.core.ml.job.config.JobState;
 import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
 import org.elasticsearch.xpack.ml.support.BaseMlIntegTestCase;
 
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
@@ -44,6 +47,7 @@ public class IndexLayoutIT extends BaseMlIntegTestCase {
                 .actionGet();
             assertEquals(statsResponse.getResponse().results().get(0).getState(), JobState.OPENED);
         });
+        assertRecentLastTaskStateChangeTime(MlTasks.jobTaskId(jobId), Duration.of(10, ChronoUnit.SECONDS), null);
         assertBusy(() -> {
             GetJobsStatsAction.Response statsResponse = client().execute(
                 GetJobsStatsAction.INSTANCE,
@@ -51,6 +55,7 @@ public class IndexLayoutIT extends BaseMlIntegTestCase {
             ).actionGet();
             assertEquals(statsResponse.getResponse().results().get(0).getState(), JobState.OPENED);
         });
+        assertRecentLastTaskStateChangeTime(MlTasks.jobTaskId(jobId2), Duration.of(10, ChronoUnit.SECONDS), null);
 
         OriginSettingClient client = new OriginSettingClient(client(), ML_ORIGIN);
         assertThat(

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/JobsAndModelsIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/JobsAndModelsIT.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.json.JsonXContent;
+import org.elasticsearch.xpack.core.ml.MlTasks;
 import org.elasticsearch.xpack.core.ml.action.CloseJobAction;
 import org.elasticsearch.xpack.core.ml.action.GetJobsStatsAction;
 import org.elasticsearch.xpack.core.ml.action.GetTrainedModelsStatsAction;
@@ -36,6 +37,8 @@ import org.elasticsearch.xpack.ml.inference.nlp.tokenizers.BertTokenizer;
 import org.elasticsearch.xpack.ml.inference.persistence.TrainedModelDefinitionDoc;
 import org.elasticsearch.xpack.ml.support.BaseMlIntegTestCase;
 
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Set;
 
@@ -230,6 +233,8 @@ public class JobsAndModelsIT extends BaseMlIntegTestCase {
 
             assertThat(jobStats.getNode(), is(not(equalTo(modelStats.getDeploymentStats().getNodeStats().get(0).getNode()))));
         });
+
+        assertRecentLastTaskStateChangeTime(MlTasks.jobTaskId(jobId), Duration.of(10, ChronoUnit.SECONDS), null);
 
         // Clean up
         client().execute(CloseJobAction.INSTANCE, new CloseJobAction.Request(jobId).setForce(true)).actionGet();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportCloseJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportCloseJobAction.java
@@ -52,6 +52,7 @@ import org.elasticsearch.xpack.ml.job.persistence.JobConfigProvider;
 import org.elasticsearch.xpack.ml.job.task.JobTask;
 import org.elasticsearch.xpack.ml.notifications.AnomalyDetectionAuditor;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -425,7 +426,7 @@ public class TransportCloseJobAction extends TransportTasksAction<
         JobTask jobTask,
         ActionListener<CloseJobAction.Response> listener
     ) {
-        JobTaskState taskState = new JobTaskState(JobState.CLOSING, jobTask.getAllocationId(), "close job (api)");
+        JobTaskState taskState = new JobTaskState(JobState.CLOSING, jobTask.getAllocationId(), "close job (api)", Instant.now());
         jobTask.updatePersistentTaskState(taskState, ActionListener.wrap(task -> {
             // we need to fork because we are now on a network threadpool and closeJob method may take a while to complete:
             threadPool.executor(MachineLearning.UTILITY_THREAD_POOL_NAME).execute(new AbstractRunnable() {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsAction.java
@@ -83,6 +83,7 @@ import org.elasticsearch.xpack.ml.notifications.DataFrameAnalyticsAuditor;
 import org.elasticsearch.xpack.ml.process.MlMemoryTracker;
 import org.elasticsearch.xpack.ml.task.AbstractJobPersistentTasksExecutor;
 
+import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -788,7 +789,8 @@ public class TransportStartDataFrameAnalyticsAction extends TransportMasterNodeA
             DataFrameAnalyticsTaskState startedState = new DataFrameAnalyticsTaskState(
                 DataFrameAnalyticsState.STARTED,
                 task.getAllocationId(),
-                null
+                null,
+                Instant.now()
             );
             task.updatePersistentTaskState(
                 startedState,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStopDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStopDataFrameAnalyticsAction.java
@@ -47,6 +47,7 @@ import org.elasticsearch.xpack.ml.dataframe.DataFrameAnalyticsTask;
 import org.elasticsearch.xpack.ml.dataframe.persistence.DataFrameAnalyticsConfigProvider;
 import org.elasticsearch.xpack.ml.notifications.DataFrameAnalyticsAuditor;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -385,7 +386,8 @@ public class TransportStopDataFrameAnalyticsAction extends TransportTasksAction<
         DataFrameAnalyticsTaskState stoppingState = new DataFrameAnalyticsTaskState(
             DataFrameAnalyticsState.STOPPING,
             task.getAllocationId(),
-            null
+            null,
+            Instant.now()
         );
         task.updatePersistentTaskState(stoppingState, ActionListener.wrap(pTask -> {
             threadPool.executor(MachineLearning.UTILITY_THREAD_POOL_NAME).execute(new AbstractRunnable() {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsTask.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsTask.java
@@ -45,6 +45,7 @@ import org.elasticsearch.xpack.ml.dataframe.steps.DataFrameAnalyticsStep;
 import org.elasticsearch.xpack.ml.notifications.DataFrameAnalyticsAuditor;
 import org.elasticsearch.xpack.ml.utils.persistence.MlParserUtils;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -178,7 +179,8 @@ public class DataFrameAnalyticsTask extends LicensedAllocatedPersistentTask impl
             DataFrameAnalyticsTaskState newTaskState = new DataFrameAnalyticsTaskState(
                 DataFrameAnalyticsState.FAILED,
                 getAllocationId(),
-                reason
+                reason,
+                Instant.now()
             );
             updatePersistentTaskState(newTaskState, ActionListener.wrap(updatedTask -> {
                 String message = Messages.getMessage(

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManager.java
@@ -81,6 +81,7 @@ import org.elasticsearch.xpack.ml.process.NativeStorageProvider;
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.Iterator;
@@ -1000,7 +1001,7 @@ public class AutodetectProcessManager implements ClusterStateListener {
     }
 
     void setJobState(JobTask jobTask, JobState state, String reason) {
-        JobTaskState jobTaskState = new JobTaskState(state, jobTask.getAllocationId(), reason);
+        JobTaskState jobTaskState = new JobTaskState(state, jobTask.getAllocationId(), reason, Instant.now());
         jobTask.updatePersistentTaskState(
             jobTaskState,
             ActionListener.wrap(
@@ -1019,7 +1020,7 @@ public class AutodetectProcessManager implements ClusterStateListener {
     }
 
     void setJobState(JobTask jobTask, JobState state, String reason, CheckedConsumer<Exception, IOException> handler) {
-        JobTaskState jobTaskState = new JobTaskState(state, jobTask.getAllocationId(), reason);
+        JobTaskState jobTaskState = new JobTaskState(state, jobTask.getAllocationId(), reason, Instant.now());
         jobTask.updatePersistentTaskState(jobTaskState, ActionListener.wrap(persistentTask -> {
             try {
                 handler.accept(null);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutor.java
@@ -61,6 +61,7 @@ import org.elasticsearch.xpack.ml.notifications.AnomalyDetectionAuditor;
 import org.elasticsearch.xpack.ml.process.MlMemoryTracker;
 import org.elasticsearch.xpack.ml.task.AbstractJobPersistentTasksExecutor;
 
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -344,7 +345,7 @@ public class OpenJobPersistentTasksExecutor extends AbstractJobPersistentTasksEx
     private void failTask(JobTask jobTask, String reason) {
         String jobId = jobTask.getJobId();
         auditor.error(jobId, reason);
-        JobTaskState failedState = new JobTaskState(JobState.FAILED, jobTask.getAllocationId(), reason);
+        JobTaskState failedState = new JobTaskState(JobState.FAILED, jobTask.getAllocationId(), reason, Instant.now());
         jobTask.updatePersistentTaskState(failedState, ActionListener.wrap(r -> {
             logger.debug("[{}] updated task state to failed", jobId);
             stopAssociatedDatafeedForFailedJob(jobId);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlLifeCycleServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlLifeCycleServiceTests.java
@@ -147,7 +147,7 @@ public class MlLifeCycleServiceTests extends ESTestCase {
             new OpenJobAction.JobParams("job-1"),
             new PersistentTasksCustomMetadata.Assignment("node-1", "test assignment")
         );
-        tasksBuilder.updateTaskState(MlTasks.jobTaskId("job-1"), new JobTaskState(JobState.FAILED, 1, "testing"));
+        tasksBuilder.updateTaskState(MlTasks.jobTaskId("job-1"), new JobTaskState(JobState.FAILED, 1, "testing", Instant.now()));
         tasksBuilder.addTask(
             MlTasks.dataFrameAnalyticsTaskId("job-2"),
             MlTasks.DATA_FRAME_ANALYTICS_TASK_NAME,
@@ -156,7 +156,7 @@ public class MlLifeCycleServiceTests extends ESTestCase {
         );
         tasksBuilder.updateTaskState(
             MlTasks.dataFrameAnalyticsTaskId("job-2"),
-            new DataFrameAnalyticsTaskState(DataFrameAnalyticsState.FAILED, 2, "testing")
+            new DataFrameAnalyticsTaskState(DataFrameAnalyticsState.FAILED, 2, "testing", Instant.now())
         );
         tasksBuilder.addTask(
             MlTasks.snapshotUpgradeTaskId("job-3", "snapshot-3"),

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportStopDataFrameAnalyticsActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportStopDataFrameAnalyticsActionTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsState;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsTaskState;
 import org.elasticsearch.xpack.ml.action.TransportStopDataFrameAnalyticsAction.AnalyticsByTaskState;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -84,7 +85,7 @@ public class TransportStopDataFrameAnalyticsActionTests extends ESTestCase {
         if (state != null) {
             builder.updateTaskState(
                 MlTasks.dataFrameAnalyticsTaskId(analyticsId),
-                new DataFrameAnalyticsTaskState(state, builder.getLastAllocationId(), null)
+                new DataFrameAnalyticsTaskState(state, builder.getLastAllocationId(), null, Instant.now())
             );
         }
     }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingResourceTrackerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingResourceTrackerTests.java
@@ -32,6 +32,7 @@ import org.elasticsearch.xpack.ml.process.MlMemoryTracker;
 import org.elasticsearch.xpack.ml.utils.NativeMemoryCalculator;
 
 import java.net.InetAddress;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -178,7 +179,7 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
                         1,
                         AWAITING_LAZY_ASSIGNMENT
                     ),
-                    new JobTaskState(JobState.FAILED, 1, "a nasty bug")
+                    new JobTaskState(JobState.FAILED, 1, "a nasty bug", Instant.now())
                 )
             ),
             List.of(),

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlMemoryAutoscalingDeciderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlMemoryAutoscalingDeciderTests.java
@@ -48,6 +48,7 @@ import org.elasticsearch.xpack.ml.process.MlMemoryTracker;
 import org.elasticsearch.xpack.ml.utils.NativeMemoryCalculator;
 import org.junit.Before;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -1406,7 +1407,7 @@ public class MlMemoryAutoscalingDeciderTests extends ESTestCase {
         if (jobState != null) {
             builder.updateTaskState(
                 MlTasks.dataFrameAnalyticsTaskId(jobId),
-                new DataFrameAnalyticsTaskState(jobState, builder.getLastAllocationId(), null)
+                new DataFrameAnalyticsTaskState(jobState, builder.getLastAllocationId(), null, Instant.now())
             );
         }
     }
@@ -1419,7 +1420,10 @@ public class MlMemoryAutoscalingDeciderTests extends ESTestCase {
             nodeId == null ? AWAITING_LAZY_ASSIGNMENT : new PersistentTasksCustomMetadata.Assignment(nodeId, "test assignment")
         );
         if (jobState != null) {
-            builder.updateTaskState(MlTasks.jobTaskId(jobId), new JobTaskState(jobState, builder.getLastAllocationId(), null));
+            builder.updateTaskState(
+                MlTasks.jobTaskId(jobId),
+                new JobTaskState(jobState, builder.getLastAllocationId(), null, Instant.now())
+            );
         }
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedNodeSelectorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedNodeSelectorTests.java
@@ -43,6 +43,7 @@ import org.elasticsearch.xpack.core.ml.job.config.JobTaskState;
 import org.junit.Before;
 
 import java.net.InetAddress;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -441,7 +442,7 @@ public class DatafeedNodeSelectorTests extends ESTestCase {
         PersistentTasksCustomMetadata.Builder tasksBuilder = PersistentTasksCustomMetadata.builder();
         addJobTask(job.getId(), nodeId, JobState.OPENED, tasksBuilder);
         // Set to lower allocationId, so job task is stale:
-        tasksBuilder.updateTaskState(MlTasks.jobTaskId(job.getId()), new JobTaskState(JobState.OPENED, 0, null));
+        tasksBuilder.updateTaskState(MlTasks.jobTaskId(job.getId()), new JobTaskState(JobState.OPENED, 0, null, Instant.now()));
         tasks = tasksBuilder.build();
 
         givenClusterState("foo", 1, 0);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/JobNodeSelectorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/JobNodeSelectorTests.java
@@ -38,6 +38,7 @@ import org.elasticsearch.xpack.ml.support.BaseMlIntegTestCase;
 import org.junit.Before;
 
 import java.net.InetAddress;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -1429,7 +1430,7 @@ public class JobNodeSelectorTests extends ESTestCase {
         if (state != null) {
             builder.updateTaskState(
                 MlTasks.dataFrameAnalyticsTaskId(id),
-                new DataFrameAnalyticsTaskState(state, builder.getLastAllocationId() - (isStale ? 1 : 0), null)
+                new DataFrameAnalyticsTaskState(state, builder.getLastAllocationId() - (isStale ? 1 : 0), null, Instant.now())
             );
         }
     }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/config/JobTaskStateTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/config/JobTaskStateTests.java
@@ -16,7 +16,7 @@ public class JobTaskStateTests extends AbstractXContentSerializingTestCase<JobTa
 
     @Override
     protected JobTaskState createTestInstance() {
-        return new JobTaskState(randomFrom(JobState.values()), randomLong(), randomAlphaOfLength(10));
+        return new JobTaskState(randomFrom(JobState.values()), randomLong(), randomAlphaOfLength(10), randomInstant());
     }
 
     @Override

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManagerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManagerTests.java
@@ -268,7 +268,12 @@ public class AutodetectProcessManagerTests extends ESTestCase {
         manager.openJob(jobTask, clusterState, DEFAULT_MASTER_NODE_TIMEOUT, (e, b) -> {});
         assertEquals(1, manager.numberOfOpenJobs());
         assertTrue(manager.jobHasActiveAutodetectProcess(jobTask));
-        verify(jobTask).updatePersistentTaskState(eq(new JobTaskState(JobState.OPENED, 1L, null)), any());
+        ArgumentCaptor<JobTaskState> captor = ArgumentCaptor.forClass(JobTaskState.class);
+        verify(jobTask).updatePersistentTaskState(captor.capture(), any());
+        JobTaskState state = captor.getValue();
+        assertThat(state.getState(), equalTo(JobState.OPENED));
+        assertThat(state.getAllocationId(), equalTo(1L));
+        assertNull(state.getReason());
     }
 
     public void testOpenJob_withoutVersion() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutorTests.java
@@ -64,6 +64,7 @@ import org.elasticsearch.xpack.ml.job.process.autodetect.AutodetectProcessManage
 import org.elasticsearch.xpack.ml.process.MlMemoryTracker;
 import org.junit.Before;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -238,7 +239,7 @@ public class OpenJobPersistentTasksExecutorTests extends ESTestCase {
         if (jobState != null) {
             builder.updateTaskState(
                 MlTasks.jobTaskId(jobId),
-                new JobTaskState(jobState, builder.getLastAllocationId() - (isStale ? 1 : 0), null)
+                new JobTaskState(jobState, builder.getLastAllocationId() - (isStale ? 1 : 0), null, Instant.now())
             );
         }
     }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/support/BaseMlIntegTestCase.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/support/BaseMlIntegTestCase.java
@@ -12,6 +12,9 @@ import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksRequest;
 import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksResponse;
 import org.elasticsearch.action.admin.cluster.node.tasks.list.TransportListTasksAction;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateAction;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.action.admin.indices.recovery.RecoveryResponse;
 import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
 import org.elasticsearch.action.bulk.BulkItemResponse;
@@ -36,6 +39,7 @@ import org.elasticsearch.indices.recovery.RecoveryState;
 import org.elasticsearch.ingest.common.IngestCommonPlugin;
 import org.elasticsearch.license.LicenseSettings;
 import org.elasticsearch.persistent.PersistentTasksClusterService;
+import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.reindex.ReindexPlugin;
 import org.elasticsearch.script.IngestScript;
@@ -76,6 +80,7 @@ import org.elasticsearch.xpack.core.ml.job.config.Detector;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.config.JobState;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.DataCounts;
+import org.elasticsearch.xpack.core.ml.utils.MlTaskState;
 import org.elasticsearch.xpack.ilm.IndexLifecycle;
 import org.elasticsearch.xpack.ml.LocalStateMachineLearning;
 import org.elasticsearch.xpack.ml.MachineLearning;
@@ -86,6 +91,8 @@ import org.elasticsearch.xpack.wildcard.Wildcard;
 import org.junit.After;
 import org.junit.Before;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -104,6 +111,7 @@ import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -505,6 +513,31 @@ public abstract class BaseMlIntegTestCase extends ESIntegTestCase {
             jobNode.set(jobStats.getNode().getName());
         });
         return jobNode.get();
+    }
+
+    protected void assertRecentLastTaskStateChangeTime(String taskId, Duration howRecent, String queryNode) {
+        ClusterStateRequest csRequest = new ClusterStateRequest().clear().metadata(true);
+        ClusterStateResponse csResponse = client(queryNode).execute(ClusterStateAction.INSTANCE, csRequest).actionGet();
+        PersistentTasksCustomMetadata tasks = csResponse.getState().getMetadata().custom(PersistentTasksCustomMetadata.TYPE);
+        assertNotNull(tasks);
+        PersistentTasksCustomMetadata.PersistentTask<?> task = tasks.getTask(taskId);
+        assertNotNull(task);
+        assertThat(task.getState(), instanceOf(MlTaskState.class));
+        MlTaskState state = (MlTaskState) task.getState();
+        assertNotNull(state.getLastStateChangeTime());
+        Instant now = Instant.now();
+        assertTrue(
+            "["
+                + taskId
+                + " has last state change time ["
+                + state.getLastStateChangeTime()
+                + "] that is more than ["
+                + howRecent
+                + "] behind current time ["
+                + now
+                + "]",
+            state.getLastStateChangeTime().isAfter(now.minus(howRecent))
+        );
     }
 
     /**


### PR DESCRIPTION
It's useful to know whether jobs have been failed for long periods of time or just failed recently, as this may affect the recommended course of action for recovery or cleanup.

To help with that, this change adds a last changed time to the task state for ML jobs. The task state contains more than just the job state. It also contains the allocation ID and assignment reason. Therefore it is not a perfect record of when a job entered the failed state. However, we would expect that jobs will not be moved around after failing, so it's pretty good.

Due to the distinction between job state and task state this new information is not exposed in the standard stats responses. It is available to developers looking for detailed support information within the task states in cluster state.