### PR TITLE
[8.9] Fix nesting of linearizable register docs (#102218)

### DIFF
--- a/docs/reference/snapshot-restore/repository-azure.asciidoc
+++ b/docs/reference/snapshot-restore/repository-azure.asciidoc
@@ -259,7 +259,6 @@ permitted in container names.
 * Container names must be from 3 through 63 characters long.
 
 [[repository-azure-linearizable-registers]]
-[discrete]
 ==== Linearizable register implementation
 
 The linearizable register implementation for Azure repositories is based on

--- a/docs/reference/snapshot-restore/repository-gcs.asciidoc
+++ b/docs/reference/snapshot-restore/repository-gcs.asciidoc
@@ -277,7 +277,6 @@ The service account used to access the bucket must have the "Writer" access to t
 5. The service account must be configured as a "User" with "Writer" access.
 
 [[repository-gcs-linearizable-registers]]
-[discrete]
 ==== Linearizable register implementation
 
 The linearizable register implementation for GCS repositories is based on GCS's

--- a/docs/reference/snapshot-restore/repository-s3.asciidoc
+++ b/docs/reference/snapshot-restore/repository-s3.asciidoc
@@ -528,7 +528,6 @@ by the `elasticsearch` user. By default, {es} runs as user `elasticsearch` using
 If the symlink exists, it will be used by default by all S3 repositories that don't have explicit `client` credentials.
 
 [[repository-s3-linearizable-registers]]
-[discrete]
 ==== Linearizable register implementation
 
 The linearizable register implementation for S3 repositories is based on the

--- a/docs/reference/snapshot-restore/repository-shared-file-system.asciidoc
+++ b/docs/reference/snapshot-restore/repository-shared-file-system.asciidoc
@@ -86,7 +86,6 @@ the same numeric UID and GID, or else update your NFS configuration to account
 for the variance in numeric IDs across nodes.
 
 [[repository-fs-linearizable-registers]]
-[discrete]
 ==== Linearizable register implementation
 
 The linearizable register implementation for shared filesystem repositories is


### PR DESCRIPTION
Backports the following commits to 8.9:
 - Fix nesting of linearizable register docs (#102218)