### PR TITLE
[ILM] Fix downsample to skip already downsampled indices

### DIFF
--- a/docs/changelog/102250.yaml
+++ b/docs/changelog/102250.yaml
@@ -1,0 +1,6 @@
+pr: 102250
+summary: "[ILM] Fix downsample to skip already downsampled indices"
+area: ILM+SLM
+type: bug
+issues:
+ - 102249

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/DownsampleAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/DownsampleAction.java
@@ -6,6 +6,8 @@
  */
 package org.elasticsearch.xpack.core.ilm;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.downsample.DownsampleConfig;
 import org.elasticsearch.client.internal.Client;
@@ -32,6 +34,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
+import static org.elasticsearch.action.downsample.DownsampleConfig.generateDownsampleIndexName;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
 
@@ -39,6 +42,8 @@ import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstr
  * A {@link LifecycleAction} which calls {@link org.elasticsearch.action.downsample.DownsampleAction} on an index
  */
 public class DownsampleAction implements LifecycleAction {
+
+    private static final Logger logger = LogManager.getLogger(DownsampleAction.class);
 
     public static final String NAME = "downsample";
     public static final String DOWNSAMPLED_INDEX_PREFIX = "downsample-";
@@ -155,7 +160,30 @@ public class DownsampleAction implements LifecycleAction {
             (index, clusterState) -> {
                 IndexMetadata indexMetadata = clusterState.metadata().index(index);
                 assert indexMetadata != null : "invalid cluster metadata. index [" + index.getName() + "] metadata not found";
-                return IndexSettings.MODE.get(indexMetadata.getSettings()) == IndexMode.TIME_SERIES;
+                if (IndexSettings.MODE.get(indexMetadata.getSettings()) != IndexMode.TIME_SERIES) {
+                    return false;
+                }
+
+                if (index.getName().equals(generateDownsampleIndexName(DOWNSAMPLED_INDEX_PREFIX, indexMetadata, fixedInterval))) {
+                    var downsampleStatus = IndexMetadata.INDEX_DOWNSAMPLE_STATUS.get(indexMetadata.getSettings());
+                    if (downsampleStatus == IndexMetadata.DownsampleTaskStatus.UNKNOWN) {
+                        // This isn't a downsample index, but it has the name of our target downsample index - very bad, we'll skip the
+                        // downsample action to avoid blocking the lifecycle of this index - if there
+                        // is another downsample action configured in the next phase, it'll be able to proceed successfully
+                        logger.warn(
+                            "index [{}] as part of policy [{}] cannot be downsampled at interval [{}] in phase [{}] because it has"
+                                + " the name of the target downsample index and is itself not a downsampled index. Skipping the downsample "
+                                + "action.",
+                            index.getName(),
+                            indexMetadata.getLifecyclePolicyName(),
+                            fixedInterval,
+                            phase
+                        );
+                    }
+                    return false;
+                }
+
+                return true;
             }
         );
 

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/DownsampleActionIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/DownsampleActionIT.java
@@ -490,6 +490,111 @@ public class DownsampleActionIT extends ESRestTestCase {
         }
     }
 
+    public void testDownsampleTwiceSameInterval() throws Exception {
+        // Create the ILM policy
+        Request request = new Request("PUT", "_ilm/policy/" + policy);
+        request.setJsonEntity("""
+            {
+                "policy": {
+                    "phases": {
+                        "warm": {
+                            "actions": {
+                                "downsample": {
+                                    "fixed_interval" : "5m"
+                                }
+                            }
+                        },
+                        "cold": {
+                            "min_age": "365d",
+                            "actions": {}
+                        }
+                    }
+                }
+            }
+            """);
+        assertOK(client().performRequest(request));
+
+        // Create a template
+        Request createIndexTemplateRequest = new Request("POST", "/_index_template/" + dataStream);
+        createIndexTemplateRequest.setJsonEntity(
+            Strings.format(TEMPLATE, dataStream, "2006-01-08T23:40:53.384Z", "2021-01-08T23:40:53.384Z", policy)
+        );
+        assertOK(client().performRequest(createIndexTemplateRequest));
+
+        index(client(), dataStream, true, null, "@timestamp", "2020-01-01T05:10:00Z", "volume", 11.0, "metricset", randomAlphaOfLength(5));
+
+        String firstBackingIndex = getBackingIndices(client(), dataStream).get(0);
+        logger.info("--> firstBackingIndex: {}", firstBackingIndex);
+        assertBusy(
+            () -> assertThat(
+                "index must wait in the " + CheckNotDataStreamWriteIndexStep.NAME + " until it is not the write index anymore",
+                explainIndex(client(), firstBackingIndex).get("step"),
+                is(CheckNotDataStreamWriteIndexStep.NAME)
+            ),
+            30,
+            TimeUnit.SECONDS
+        );
+
+        // before we rollover, update template to not contain time boundaries anymore (rollover is blocked otherwise due to index time
+        // boundaries overlapping after rollover)
+        Request updateIndexTemplateRequest = new Request("POST", "/_index_template/" + dataStream);
+        updateIndexTemplateRequest.setJsonEntity(Strings.format(TEMPLATE_NO_TIME_BOUNDARIES, dataStream, policy));
+        assertOK(client().performRequest(updateIndexTemplateRequest));
+
+        // Manual rollover the original index such that it's not the write index in the data stream anymore
+        rolloverMaxOneDocCondition(client(), dataStream);
+
+        String downsampleIndexName = "downsample-5m-" + firstBackingIndex;
+        // wait for the downsample index to get to the end of the warm phase
+        assertBusy(() -> {
+            assertThat(indexExists(downsampleIndexName), is(true));
+            assertThat(indexExists(firstBackingIndex), is(false));
+
+            assertThat(explainIndex(client(), downsampleIndexName).get("step"), is(PhaseCompleteStep.NAME));
+            assertThat(explainIndex(client(), downsampleIndexName).get("phase"), is("warm"));
+
+            Map<String, Object> settings = getOnlyIndexSettings(client(), downsampleIndexName);
+            assertEquals(firstBackingIndex, settings.get(IndexMetadata.INDEX_DOWNSAMPLE_ORIGIN_NAME.getKey()));
+            assertEquals(firstBackingIndex, settings.get(IndexMetadata.INDEX_DOWNSAMPLE_SOURCE_NAME.getKey()));
+            assertEquals(DownsampleTaskStatus.SUCCESS.toString(), settings.get(IndexMetadata.INDEX_DOWNSAMPLE_STATUS.getKey()));
+            assertEquals(policy, settings.get(LifecycleSettings.LIFECYCLE_NAME_SETTING.getKey()));
+        }, 60, TimeUnit.SECONDS);
+
+        // update the policy to now contain the downsample action in cold, whilst not existing in warm anymore (this will have our already
+        // downsampled index attempt to go through the downsample action again when in cold)
+
+        Request updatePolicyRequest = new Request("PUT", "_ilm/policy/" + policy);
+        updatePolicyRequest.setJsonEntity("""
+            {
+                "policy": {
+                    "phases": {
+                        "warm": {
+                            "actions": {
+                            }
+                        },
+                        "cold": {
+                            "min_age": "0ms",
+                            "actions": {
+                               "downsample": {
+                                  "fixed_interval" : "5m"
+                               }
+                            }
+                        }
+                    }
+                }
+            }
+            """);
+        assertOK(client().performRequest(updatePolicyRequest));
+
+        // the downsample index (already part of the data stream as we created it in the warm phase previously) should continue to exist and
+        // reach the cold/complete/complete step
+        assertBusy(() -> {
+            assertThat(indexExists(downsampleIndexName), is(true));
+            assertThat(explainIndex(client(), downsampleIndexName).get("step"), is(PhaseCompleteStep.NAME));
+            assertThat(explainIndex(client(), downsampleIndexName).get("phase"), is("cold"));
+        }, 60, TimeUnit.SECONDS);
+    }
+
     /**
      * Gets the generated rollup index name for a given index by looking at newly created indices that match the rollup index name pattern
      *


### PR DESCRIPTION
This fixes a bug in ILM where if an ILM policy is updated such that the next phase (e.g. warm) contains the downsample action from the previous phase (e.g. hot), whilst the managed index is waiting to enter the next phase (e.g. warm), if the managed index was already downsampled in hot it would get deleted in the warm phase.

Fixes https://github.com/elastic/elasticsearch/issues/102249