### PR TITLE
Improve logging in testSeqNoCASLinearizability

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/versioning/ConcurrentSeqNoVersioningIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/versioning/ConcurrentSeqNoVersioningIT.java
@@ -7,20 +7,22 @@
  */
 package org.elasticsearch.versioning;
 
+import org.apache.logging.log4j.Level;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.cluster.coordination.LinearizabilityChecker;
 import org.elasticsearch.cluster.coordination.LinearizabilityChecker.LinearizabilityCheckAborted;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
-import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.ReferenceDocs;
 import org.elasticsearch.common.io.stream.InputStreamStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.OutputStreamStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.logging.ChunkedLoggingStream;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.discovery.AbstractDisruptionTestCase;
@@ -30,7 +32,7 @@ import org.elasticsearch.test.disruption.ServiceDisruptionScheme;
 
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.util.ArrayList;
+import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
@@ -435,16 +437,27 @@ public class ConcurrentSeqNoVersioningIT extends AbstractDisruptionTestCase {
             } catch (LinearizabilityCheckAborted e) {
                 logger.warn("linearizability check check was aborted", e);
             } finally {
-                // implicitly test that we can serialize all histories.
-                String serializedHistory = base64Serialize(history);
-                if (linearizable == false) {
-                    // we dump base64 encoded data, since the nature of this test is that it does not reproduce even with same seed.
-                    logger.error(
-                        "Linearizability check failed. Spec: {}, initial version: {}, serialized history: {}",
-                        spec,
-                        initialVersion,
-                        serializedHistory
-                    );
+                try {
+                    if (linearizable) {
+                        // ensure that we can serialize all histories.
+                        writeHistory(new OutputStreamStreamOutput(OutputStream.nullOutputStream()), history);
+                    } else {
+                        logger.error("Linearizability check failed. Spec: {}, initial version: {}", spec, initialVersion);
+                        // we dump base64 encoded data, since the nature of this test is that it does not reproduce even with same seed.
+                        try (
+                            var chunkedLoggingStream = ChunkedLoggingStream.create(
+                                logger,
+                                Level.ERROR,
+                                "unlinearizable history",
+                                ReferenceDocs.LOGGING // any old docs link will do
+                            );
+                            var output = new OutputStreamStreamOutput(chunkedLoggingStream)
+                        ) {
+                            writeHistory(output, history);
+                        }
+                    }
+                } catch (IOException e) {
+                    logger.error("failure writing out history", e);
                 }
             }
             assertTrue("Must be linearizable", linearizable);
@@ -623,31 +636,15 @@ public class ConcurrentSeqNoVersioningIT extends AbstractDisruptionTestCase {
         return input -> new FailureHistoryOutput();
     }
 
-    private String base64Serialize(LinearizabilityChecker.History history) {
-        BytesStreamOutput output = new BytesStreamOutput();
-        try {
-            List<LinearizabilityChecker.Event> events = history.copyEvents();
-            output.writeInt(events.size());
-            for (LinearizabilityChecker.Event event : events) {
-                writeEvent(event, output);
-            }
-            output.close();
-            return Base64.getEncoder().encodeToString(BytesReference.toBytes(output.bytes()));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+    private static void writeHistory(StreamOutput output, LinearizabilityChecker.History history) throws IOException {
+        output.writeCollection(history.copyEvents(), ConcurrentSeqNoVersioningIT::writeEvent);
     }
 
     private static LinearizabilityChecker.History readHistory(StreamInput input) throws IOException {
-        int size = input.readInt();
-        List<LinearizabilityChecker.Event> events = new ArrayList<>(size);
-        for (int i = 0; i < size; ++i) {
-            events.add(readEvent(input));
-        }
-        return new LinearizabilityChecker.History(events);
+        return new LinearizabilityChecker.History(input.readCollectionAsList(ConcurrentSeqNoVersioningIT::readEvent));
     }
 
-    private static void writeEvent(LinearizabilityChecker.Event event, BytesStreamOutput output) throws IOException {
+    private static void writeEvent(StreamOutput output, LinearizabilityChecker.Event event) throws IOException {
         output.writeEnum(event.type());
         output.writeNamedWriteable((NamedWriteable) event.value());
         output.writeInt(event.id());

--- a/server/src/internalClusterTest/java/org/elasticsearch/versioning/ConcurrentSeqNoVersioningIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/versioning/ConcurrentSeqNoVersioningIT.java
@@ -458,6 +458,7 @@ public class ConcurrentSeqNoVersioningIT extends AbstractDisruptionTestCase {
                     }
                 } catch (IOException e) {
                     logger.error("failure writing out history", e);
+                    fail(e);
                 }
             }
             assertTrue("Must be linearizable", linearizable);


### PR DESCRIPTION
Today we log a base64-representation of an unlinearizable history in a
single log message, but this risks truncation. This commit moves to
using `ChunkedLoggingStream` to split the data up across multiple log
lines.