### PR TITLE
[Usage API] Count all the data streams that have lifecycle

### DIFF
--- a/docs/changelog/102259.yaml
+++ b/docs/changelog/102259.yaml
@@ -1,0 +1,5 @@
+pr: 102259
+summary: "[Usage API] Count all the data streams that have lifecycle"
+area: Data streams
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/core/action/DataStreamLifecycleUsageTransportActionIT.java
+++ b/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/core/action/DataStreamLifecycleUsageTransportActionIT.java
@@ -71,7 +71,8 @@ public class DataStreamLifecycleUsageTransportActionIT extends ESIntegTestCase {
     @SuppressWarnings("unchecked")
     public void testAction() throws Exception {
         assertUsageResults(0, 0, 0, 0.0, true);
-        AtomicLong count = new AtomicLong(0);
+        AtomicLong totalCount = new AtomicLong(0);
+        AtomicLong countLifecycleWithRetention = new AtomicLong(0);
         AtomicLong totalRetentionTimes = new AtomicLong(0);
         AtomicLong minRetention = new AtomicLong(Long.MAX_VALUE);
         AtomicLong maxRetention = new AtomicLong(Long.MIN_VALUE);
@@ -94,11 +95,13 @@ public class DataStreamLifecycleUsageTransportActionIT extends ESIntegTestCase {
                 if (hasLifecycle) {
                     if (randomBoolean()) {
                         lifecycle = new DataStreamLifecycle(null, null, null);
+                        totalCount.incrementAndGet();
                     } else {
                         long retentionMillis = randomLongBetween(1000, 100000);
                         boolean isEnabled = randomBoolean();
                         if (isEnabled) {
-                            count.incrementAndGet();
+                            totalCount.incrementAndGet();
+                            countLifecycleWithRetention.incrementAndGet();
                             totalRetentionTimes.addAndGet(retentionMillis);
 
                             if (retentionMillis < minRetention.get()) {
@@ -141,9 +144,11 @@ public class DataStreamLifecycleUsageTransportActionIT extends ESIntegTestCase {
         });
         int expectedMinimumRetention = minRetention.get() == Long.MAX_VALUE ? 0 : minRetention.intValue();
         int expectedMaximumRetention = maxRetention.get() == Long.MIN_VALUE ? 0 : maxRetention.intValue();
-        double expectedAverageRetention = count.get() == 0 ? 0.0 : totalRetentionTimes.doubleValue() / count.get();
+        double expectedAverageRetention = totalCount.get() == 0
+            ? 0.0
+            : totalRetentionTimes.doubleValue() / countLifecycleWithRetention.get();
         assertUsageResults(
-            count.intValue(),
+            totalCount.intValue(),
             expectedMinimumRetention,
             expectedMaximumRetention,
             expectedAverageRetention,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/DataStreamLifecycleUsageTransportAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/DataStreamLifecycleUsageTransportAction.java
@@ -16,6 +16,7 @@ import org.elasticsearch.cluster.metadata.DataStreamLifecycle;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.protocol.xpack.XPackUsageRequest;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -24,7 +25,6 @@ import org.elasticsearch.xpack.core.datastreams.DataStreamLifecycleFeatureSetUsa
 
 import java.util.Collection;
 import java.util.LongSummaryStatistics;
-import java.util.stream.Collectors;
 
 public class DataStreamLifecycleUsageTransportAction extends XPackUsageFeatureTransportAction {
 
@@ -54,26 +54,44 @@ public class DataStreamLifecycleUsageTransportAction extends XPackUsageFeatureTr
         ActionListener<XPackUsageFeatureResponse> listener
     ) {
         final Collection<DataStream> dataStreams = state.metadata().dataStreams().values();
-        LongSummaryStatistics retentionStats = dataStreams.stream()
-            .filter(ds -> ds.getLifecycle() != null && ds.getLifecycle().isEnabled())
-            .filter(ds -> ds.getLifecycle().getEffectiveDataRetention() != null)
-            .collect(Collectors.summarizingLong(ds -> ds.getLifecycle().getEffectiveDataRetention().getMillis()));
-        long dataStreamsWithLifecycles = retentionStats.getCount();
-        long minRetention = dataStreamsWithLifecycles == 0 ? 0 : retentionStats.getMin();
-        long maxRetention = dataStreamsWithLifecycles == 0 ? 0 : retentionStats.getMax();
-        double averageRetention = retentionStats.getAverage();
+        Tuple<Long, LongSummaryStatistics> stats = calculateStats(dataStreams);
+
+        long minRetention = stats.v1() == 0 ? 0 : stats.v2().getMin();
+        long maxRetention = stats.v1() == 0 ? 0 : stats.v2().getMax();
+        double averageRetention = stats.v2().getAverage();
         RolloverConfiguration rolloverConfiguration = clusterService.getClusterSettings()
             .get(DataStreamLifecycle.CLUSTER_LIFECYCLE_DEFAULT_ROLLOVER_SETTING);
         String rolloverConfigString = rolloverConfiguration.toString();
-        final DataStreamLifecycleFeatureSetUsage.LifecycleStats stats = new DataStreamLifecycleFeatureSetUsage.LifecycleStats(
-            dataStreamsWithLifecycles,
+        final DataStreamLifecycleFeatureSetUsage.LifecycleStats lifecycleStats = new DataStreamLifecycleFeatureSetUsage.LifecycleStats(
+            stats.v1(),
             minRetention,
             maxRetention,
             averageRetention,
             DataStreamLifecycle.CLUSTER_LIFECYCLE_DEFAULT_ROLLOVER_SETTING.getDefault(null).toString().equals(rolloverConfigString)
         );
 
-        final DataStreamLifecycleFeatureSetUsage usage = new DataStreamLifecycleFeatureSetUsage(stats);
+        final DataStreamLifecycleFeatureSetUsage usage = new DataStreamLifecycleFeatureSetUsage(lifecycleStats);
         listener.onResponse(new XPackUsageFeatureResponse(usage));
     }
+
+    /**
+     * Counts the number of data streams that have a lifecycle configured (and enabled) and for
+     * the data streams that have a lifecycle it computes the min/max/average summary of the effective
+     * configured retention.
+     */
+    public static Tuple<Long, LongSummaryStatistics> calculateStats(Collection<DataStream> dataStreams) {
+        long dataStreamsWithLifecycles = 0;
+        LongSummaryStatistics retentionStats = new LongSummaryStatistics();
+        for (DataStream dataStream : dataStreams) {
+            if (dataStream.getLifecycle() != null && dataStream.getLifecycle().isEnabled()) {
+                dataStreamsWithLifecycles++;
+                if (dataStream.getLifecycle().getEffectiveDataRetention() != null) {
+                    retentionStats.accept(dataStream.getLifecycle().getEffectiveDataRetention().getMillis());
+                }
+            }
+        }
+        return new Tuple<>(dataStreamsWithLifecycles, retentionStats);
+    }
+
+    private record Result(long dataStreamsWithLifecycles, LongSummaryStatistics retentionStats) {}
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/DataStreamLifecycleUsageTransportAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/DataStreamLifecycleUsageTransportAction.java
@@ -92,6 +92,4 @@ public class DataStreamLifecycleUsageTransportAction extends XPackUsageFeatureTr
         }
         return new Tuple<>(dataStreamsWithLifecycles, retentionStats);
     }
-
-    private record Result(long dataStreamsWithLifecycles, LongSummaryStatistics retentionStats) {}
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/datastreams/DataStreamLifecycleFeatureSetUsageTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/datastreams/DataStreamLifecycleFeatureSetUsageTests.java
@@ -7,9 +7,22 @@
 
 package org.elasticsearch.xpack.core.datastreams;
 
+import org.elasticsearch.cluster.metadata.DataStream;
+import org.elasticsearch.cluster.metadata.DataStreamLifecycle;
+import org.elasticsearch.cluster.metadata.DataStreamTestHelper;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.test.ESTestCase;
+
+import java.util.List;
+import java.util.LongSummaryStatistics;
+import java.util.UUID;
+
+import static org.elasticsearch.xpack.core.action.DataStreamLifecycleUsageTransportAction.calculateStats;
+import static org.hamcrest.Matchers.is;
 
 public class DataStreamLifecycleFeatureSetUsageTests extends AbstractWireSerializingTestCase<DataStreamLifecycleFeatureSetUsage> {
 
@@ -81,6 +94,61 @@ public class DataStreamLifecycleFeatureSetUsageTests extends AbstractWireSeriali
             );
             default -> throw new RuntimeException("unreachable");
         };
+    }
+
+    public void testLifecycleStats() {
+        List<DataStream> dataStreams = List.of(
+            DataStreamTestHelper.newInstance(
+                randomAlphaOfLength(10),
+                List.of(new Index(randomAlphaOfLength(10), UUID.randomUUID().toString())),
+                1L,
+                null,
+                false,
+                new DataStreamLifecycle()
+            ),
+            DataStreamTestHelper.newInstance(
+                randomAlphaOfLength(10),
+                List.of(new Index(randomAlphaOfLength(10), UUID.randomUUID().toString())),
+                1L,
+                null,
+                false,
+                new DataStreamLifecycle(new DataStreamLifecycle.Retention(TimeValue.timeValueMillis(1000)), null, true)
+            ),
+            DataStreamTestHelper.newInstance(
+                randomAlphaOfLength(10),
+                List.of(new Index(randomAlphaOfLength(10), UUID.randomUUID().toString())),
+                1L,
+                null,
+                false,
+                new DataStreamLifecycle(new DataStreamLifecycle.Retention(TimeValue.timeValueMillis(100)), null, true)
+            ),
+            DataStreamTestHelper.newInstance(
+                randomAlphaOfLength(10),
+                List.of(new Index(randomAlphaOfLength(10), UUID.randomUUID().toString())),
+                1L,
+                null,
+                false,
+                new DataStreamLifecycle(new DataStreamLifecycle.Retention(TimeValue.timeValueMillis(5000)), null, false)
+            ),
+            DataStreamTestHelper.newInstance(
+                randomAlphaOfLength(10),
+                List.of(new Index(randomAlphaOfLength(10), UUID.randomUUID().toString())),
+                1L,
+                null,
+                false,
+                null
+            )
+        );
+
+        Tuple<Long, LongSummaryStatistics> stats = calculateStats(dataStreams);
+        // 3 data streams with an enabled lifecycle
+        assertThat(stats.v1(), is(3L));
+        LongSummaryStatistics longSummaryStatistics = stats.v2();
+        assertThat(longSummaryStatistics.getMax(), is(1000));
+        assertThat(longSummaryStatistics.getMin(), is(100));
+        // only counting the ones with an effective retention in the summary statistics
+        assertThat(longSummaryStatistics.getCount(), is(2));
+        assertThat(longSummaryStatistics.getAverage(), is(550));
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/datastreams/DataStreamLifecycleFeatureSetUsageTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/datastreams/DataStreamLifecycleFeatureSetUsageTests.java
@@ -144,11 +144,11 @@ public class DataStreamLifecycleFeatureSetUsageTests extends AbstractWireSeriali
         // 3 data streams with an enabled lifecycle
         assertThat(stats.v1(), is(3L));
         LongSummaryStatistics longSummaryStatistics = stats.v2();
-        assertThat(longSummaryStatistics.getMax(), is(1000));
-        assertThat(longSummaryStatistics.getMin(), is(100));
+        assertThat(longSummaryStatistics.getMax(), is(1000L));
+        assertThat(longSummaryStatistics.getMin(), is(100L));
         // only counting the ones with an effective retention in the summary statistics
-        assertThat(longSummaryStatistics.getCount(), is(2));
-        assertThat(longSummaryStatistics.getAverage(), is(550));
+        assertThat(longSummaryStatistics.getCount(), is(2L));
+        assertThat(longSummaryStatistics.getAverage(), is(550.0));
     }
 
     @Override


### PR DESCRIPTION
Previously we, inadvertently, counted only the data streams that have a lifecycle with a configured retention.
This fixes the DSL usage stats to count all the data streams that have a configured lifecycle (that is enabled).