### PR TITLE
[8.11] [ci] Add a way to trigger the entire regular PR pipeline via comment (#102256)

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -11,10 +11,7 @@
       "set_commit_status": false,
       "build_on_commit": true,
       "build_on_comment": true,
-      "trigger_comment_regex": "buildkite\\W+elasticsearch-ci.+",
-      "labels": [
-        "buildkite-opt-in"
-      ],
+      "trigger_comment_regex": "(run\\W+elasticsearch-ci.+)|(^\\s*(buildkite\\s*)?test\\s+this(\\s+please)?)",
       "cancel_intermediate_builds": true,
       "cancel_intermediate_builds_on_comment": false
     },

--- a/.buildkite/scripts/pull-request/pipeline.test.ts
+++ b/.buildkite/scripts/pull-request/pipeline.test.ts
@@ -12,21 +12,28 @@ describe("generatePipelines", () => {
     process.env["GITHUB_PR_TRIGGER_COMMENT"] = "";
   });
 
-  test("should generate correct pipelines with a non-docs change", () => {
-    const pipelines = generatePipelines(`${import.meta.dir}/mocks/pipelines`, ["build.gradle", "docs/README.asciidoc"]);
+  // Helper for testing pipeline generations that should be the same when using the overall ci trigger comment "buildkite test this"
+  const testWithTriggerCheck = (directory: string, changedFiles?: string[]) => {
+    const pipelines = generatePipelines(directory, changedFiles);
     expect(pipelines).toMatchSnapshot();
+
+    process.env["GITHUB_PR_TRIGGER_COMMENT"] = "buildkite test this";
+    const pipelinesWithTriggerComment = generatePipelines(directory, changedFiles);
+    expect(pipelinesWithTriggerComment).toEqual(pipelines);
+  };
+
+  test("should generate correct pipelines with a non-docs change", () => {
+    testWithTriggerCheck(`${import.meta.dir}/mocks/pipelines`, ["build.gradle", "docs/README.asciidoc"]);
   });
 
   test("should generate correct pipelines with only docs changes", () => {
-    const pipelines = generatePipelines(`${import.meta.dir}/mocks/pipelines`, ["docs/README.asciidoc"]);
-    expect(pipelines).toMatchSnapshot();
+    testWithTriggerCheck(`${import.meta.dir}/mocks/pipelines`, ["docs/README.asciidoc"]);
   });
 
   test("should generate correct pipelines with full BWC expansion", () => {
     process.env["GITHUB_PR_LABELS"] = "test-full-bwc";
 
-    const pipelines = generatePipelines(`${import.meta.dir}/mocks/pipelines`, ["build.gradle"]);
-    expect(pipelines).toMatchSnapshot();
+    testWithTriggerCheck(`${import.meta.dir}/mocks/pipelines`, ["build.gradle"]);
   });
 
   test("should generate correct pipeline when using a trigger comment for it", () => {

--- a/.buildkite/scripts/pull-request/pipeline.ts
+++ b/.buildkite/scripts/pull-request/pipeline.ts
@@ -144,8 +144,12 @@ export const generatePipelines = (
     (pipeline) => changedFilesIncludedCheck(pipeline, changedFiles),
   ];
 
-  // When triggering via comment, we ONLY want to run pipelines that match the trigger phrase, regardless of labels, etc
-  if (process.env["GITHUB_PR_TRIGGER_COMMENT"]) {
+  // When triggering via the "run elasticsearch-ci/step-name" comment, we ONLY want to run pipelines that match the trigger phrase, regardless of labels, etc
+  // However, if we're using the overall CI trigger "[buildkite] test this [please]", we should use the regular filters above
+  if (
+    process.env["GITHUB_PR_TRIGGER_COMMENT"] &&
+    !process.env["GITHUB_PR_TRIGGER_COMMENT"].match(/^\s*(buildkite\s*)?test\s+this(\s+please)?/i)
+  ) {
     filters = [triggerCommentCheck];
   }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.11`:
 - [[ci] Add a way to trigger the entire regular PR pipeline via comment (#102256)](https://github.com/elastic/elasticsearch/pull/102256)

<!--- Backport version: 9.2.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)