### PR TITLE
[DRAFT] Use IndexVersion as version value in NodeMetadata

### DIFF
--- a/docs/changelog/102266.yaml
+++ b/docs/changelog/102266.yaml
@@ -1,0 +1,5 @@
+pr: 102266
+summary: "[DRAFT] Use `IndexVersion` as version value in `NodeMetadata`"
+area: Infra/Core
+type: enhancement
+issues: []

--- a/server/src/internalClusterTest/java/org/elasticsearch/env/NodeEnvironmentIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/env/NodeEnvironmentIT.java
@@ -126,7 +126,7 @@ public class NodeEnvironmentIT extends ESIntegTestCase {
         );
         assertThat(
             illegalStateException.getMessage(),
-            allOf(startsWith("cannot downgrade a node from version ["), endsWith("] to version [" + Build.current().version() + "]"))
+            allOf(startsWith("cannot downgrade a node using index version ["), endsWith("] to version [" + Build.current().version() + "]"))
         );
     }
 
@@ -137,7 +137,7 @@ public class NodeEnvironmentIT extends ESIntegTestCase {
         assertThat(
             illegalStateException.getMessage(),
             allOf(
-                startsWith("cannot upgrade a node from version ["),
+                startsWith("cannot upgrade a node using index version ["),
                 endsWith(
                     "] directly to version ["
                         + Build.current().version()

--- a/server/src/internalClusterTest/java/org/elasticsearch/gateway/GatewayIndexStateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/gateway/GatewayIndexStateIT.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.gateway;
 
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
@@ -34,6 +33,7 @@ import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.env.NodeMetadata;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.indices.IndexClosedException;
@@ -575,7 +575,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
                     .putCustom(IndexGraveyard.TYPE, IndexGraveyard.builder().addTombstone(metadata.index("test").getIndex()).build())
                     .build()
             );
-            NodeMetadata.FORMAT.writeAndCleanup(new NodeMetadata(nodeId, Version.CURRENT, metadata.oldestIndexVersion()), paths);
+            NodeMetadata.FORMAT.writeAndCleanup(new NodeMetadata(nodeId, IndexVersion.current(), metadata.oldestIndexVersion()), paths);
         });
 
         ensureGreen();

--- a/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -638,7 +638,7 @@ public final class NodeEnvironment implements Closeable {
         }
 
         metadata = metadata.upgradeToCurrentVersion();
-        assert metadata.nodeVersion().equals(Version.CURRENT) : metadata.nodeVersion() + " != " + Version.CURRENT;
+        assert metadata.nodeIndexVersion().equals(IndexVersion.current()) : metadata.nodeVersion() + " != " + Version.CURRENT;
 
         return metadata;
     }

--- a/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -630,7 +630,7 @@ public final class NodeEnvironment implements Closeable {
                 assert nodeIds.isEmpty() : nodeIds;
                 // If we couldn't find legacy metadata, we set the latest index version to this version. This happens
                 // when we are starting a new node and there are no indices to worry about.
-                metadata = new NodeMetadata(generateNodeId(settings), Version.CURRENT, IndexVersion.current());
+                metadata = new NodeMetadata(generateNodeId(settings), IndexVersion.current(), IndexVersion.current());
             } else {
                 assert nodeIds.equals(Collections.singleton(legacyMetadata.nodeId())) : nodeIds + " doesn't match " + legacyMetadata;
                 metadata = legacyMetadata;

--- a/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -525,19 +525,18 @@ public final class NodeEnvironment implements Closeable {
 
         if (metadata.oldestIndexVersion().isLegacyIndexVersion()) {
 
-            // TODO[wrb]: update message
             throw new IllegalStateException(
                 "Cannot start this node because it holds metadata for indices with version ["
                     + metadata.oldestIndexVersion()
                     + "] with which this node of version ["
                     + Build.current().version()
-                    + "] is incompatible. Revert this node to version ["
+                    + "] is incompatible. Revert this node to one with index versions ["
                     + metadata.previousNodeIndexVersion()
                     + "] and delete any indices with versions earlier than ["
                     + IndexVersions.MINIMUM_COMPATIBLE
                     + "] before upgrading to version ["
                     + Build.current().version()
-                    + "]. If all such indices have already been deleted, revert this node to version ["
+                    + "]. If all such indices have already been deleted, revert this node to one with index version ["
                     + metadata.previousNodeIndexVersion()
                     + "] and wait for it to join the cluster to clean up any older indices from its metadata."
             );

--- a/server/src/main/java/org/elasticsearch/env/NodeMetadata.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeMetadata.java
@@ -54,11 +54,6 @@ public final class NodeMetadata {
         this.oldestIndexVersion = Objects.requireNonNull(oldestIndexVersion);
     }
 
-    @Deprecated
-    public NodeMetadata(final String nodeId, final Version nodeVersion, final IndexVersion oldestIndexVersion) {
-        this(nodeId, IndexVersion.fromId(nodeVersion.id()), oldestIndexVersion);
-    }
-
     public NodeMetadata(final String nodeId, final IndexVersion nodeIndexVersion, final IndexVersion oldestIndexVersion) {
         this(nodeId, nodeIndexVersion, nodeIndexVersion, oldestIndexVersion);
     }

--- a/server/src/main/java/org/elasticsearch/env/NodeMetadata.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeMetadata.java
@@ -98,11 +98,6 @@ public final class NodeMetadata {
         return nodeId;
     }
 
-    @Deprecated
-    public Version nodeVersion() {
-        return Version.fromId(nodeIndexVersion.id());
-    }
-
     public IndexVersion nodeIndexVersion() {
         return nodeIndexVersion;
     }
@@ -113,10 +108,6 @@ public final class NodeMetadata {
      * the current version of the node ({@link NodeMetadata#upgradeToCurrentVersion()} before storing the node metadata again on disk.
      * In doing so, {@code previousNodeVersion} refers to the previously last known version that this node was started on.
      */
-    public Version previousNodeVersion() {
-        return Version.fromId(previousNodeIndexVersion.id());
-    }
-
     public IndexVersion previousNodeIndexVersion() {
         return previousNodeIndexVersion;
     }

--- a/server/src/main/java/org/elasticsearch/env/NodeMetadata.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeMetadata.java
@@ -116,9 +116,8 @@ public final class NodeMetadata {
             : "version is required in the node metadata from v9 onwards";
 
         if (nodeIndexVersion.before(IndexVersions.MINIMUM_IN_PLACE_UPGRADE_COMPATIBLE)) {
-            // TODO[wrb]: fix message
             throw new IllegalStateException(
-                "cannot upgrade a node from version ["
+                "cannot upgrade a node using index version ["
                     + nodeIndexVersion
                     + "] directly to version ["
                     + Build.current().version()
@@ -130,9 +129,8 @@ public final class NodeMetadata {
         }
 
         if (nodeIndexVersion.after(IndexVersion.current())) {
-            // TODO[wrb]: fix message
             throw new IllegalStateException(
-                "cannot downgrade a node from version [" + nodeIndexVersion + "] to version [" + Build.current().version() + "]"
+                "cannot downgrade a node using index version [" + nodeIndexVersion + "] to version [" + Build.current().version() + "]"
             );
         }
     }

--- a/server/src/main/java/org/elasticsearch/env/OverrideNodeVersionCommand.java
+++ b/server/src/main/java/org/elasticsearch/env/OverrideNodeVersionCommand.java
@@ -90,7 +90,7 @@ public class OverrideNodeVersionCommand extends ElasticsearchNodeCommand {
             ).replace("V_NEW", nodeMetadata.nodeIndexVersion().toString()).replace("V_CUR", Version.CURRENT.toString())
         );
 
-        PersistedClusterStateService.overrideVersion(Version.CURRENT, paths);
+        PersistedClusterStateService.overrideVersion(IndexVersion.current(), paths);
 
         terminal.println(SUCCESS_MESSAGE);
     }

--- a/server/src/main/java/org/elasticsearch/env/OverrideNodeVersionCommand.java
+++ b/server/src/main/java/org/elasticsearch/env/OverrideNodeVersionCommand.java
@@ -15,6 +15,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.cli.Terminal;
 import org.elasticsearch.cluster.coordination.ElasticsearchNodeCommand;
 import org.elasticsearch.gateway.PersistedClusterStateService;
+import org.elasticsearch.index.IndexVersion;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -80,12 +81,13 @@ public class OverrideNodeVersionCommand extends ElasticsearchNodeCommand {
             // ok, means the version change is not supported
         }
 
+        // TODO[wrb]: fix up versions here
         confirm(
             terminal,
-            (nodeMetadata.nodeVersion().before(Version.CURRENT) ? TOO_OLD_MESSAGE : TOO_NEW_MESSAGE).replace(
+            (nodeMetadata.nodeIndexVersion().before(IndexVersion.current()) ? TOO_OLD_MESSAGE : TOO_NEW_MESSAGE).replace(
                 "V_OLD",
-                nodeMetadata.nodeVersion().toString()
-            ).replace("V_NEW", nodeMetadata.nodeVersion().toString()).replace("V_CUR", Version.CURRENT.toString())
+                nodeMetadata.nodeIndexVersion().toString()
+            ).replace("V_NEW", nodeMetadata.nodeIndexVersion().toString()).replace("V_CUR", Version.CURRENT.toString())
         );
 
         PersistedClusterStateService.overrideVersion(Version.CURRENT, paths);

--- a/server/src/main/java/org/elasticsearch/env/OverrideNodeVersionCommand.java
+++ b/server/src/main/java/org/elasticsearch/env/OverrideNodeVersionCommand.java
@@ -71,7 +71,7 @@ public class OverrideNodeVersionCommand extends ElasticsearchNodeCommand {
             nodeMetadata.upgradeToCurrentVersion();
             throw new ElasticsearchException(
                 "found ["
-                    + nodeMetadata
+                    + nodeMetadata.nodeIndexVersion()
                     + "] which is compatible with current version ["
                     + Version.CURRENT
                     + "], so there is no need to override the version checks"

--- a/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
+++ b/server/src/main/java/org/elasticsearch/gateway/GatewayMetaState.java
@@ -14,7 +14,6 @@ import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.coordination.CoordinationMetadata;
@@ -36,6 +35,7 @@ import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.core.UpdateForV9;
 import org.elasticsearch.env.NodeMetadata;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.plugins.ClusterCoordinationPlugin;
@@ -222,7 +222,11 @@ public class GatewayMetaState implements Closeable {
             }
             // write legacy node metadata to prevent accidental downgrades from spawning empty cluster state
             NodeMetadata.FORMAT.writeAndCleanup(
-                new NodeMetadata(persistedClusterStateService.getNodeId(), Version.CURRENT, clusterState.metadata().oldestIndexVersion()),
+                new NodeMetadata(
+                    persistedClusterStateService.getNodeId(),
+                    IndexVersion.current(),
+                    clusterState.metadata().oldestIndexVersion()
+                ),
                 persistedClusterStateService.getDataPaths()
             );
             success = true;
@@ -260,7 +264,11 @@ public class GatewayMetaState implements Closeable {
             metaStateService.deleteAll();
             // write legacy node metadata to prevent downgrades from spawning empty cluster state
             NodeMetadata.FORMAT.writeAndCleanup(
-                new NodeMetadata(persistedClusterStateService.getNodeId(), Version.CURRENT, clusterState.metadata().oldestIndexVersion()),
+                new NodeMetadata(
+                    persistedClusterStateService.getNodeId(),
+                    IndexVersion.current(),
+                    clusterState.metadata().oldestIndexVersion()
+                ),
                 persistedClusterStateService.getDataPaths()
             );
         }

--- a/server/src/main/java/org/elasticsearch/gateway/PersistedClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/gateway/PersistedClusterStateService.java
@@ -379,10 +379,6 @@ public class PersistedClusterStateService {
         return new NodeMetadata(nodeId, nodeIndexVersion, oldestIndexVersion);
     }
 
-    public static void overrideVersion(Version version, Path... dataPaths) throws IOException {
-        overrideVersion(IndexVersion.fromId(version.id), dataPaths);
-    }
-
     /**
      * Overrides the version field for the metadata in the given data path
      */
@@ -851,7 +847,7 @@ public class PersistedClusterStateService {
             final Map<String, String> commitData = Maps.newMapWithExpectedSize(COMMIT_DATA_SIZE);
             commitData.put(CURRENT_TERM_KEY, Long.toString(currentTerm));
             commitData.put(LAST_ACCEPTED_VERSION_KEY, Long.toString(lastAcceptedVersion));
-            commitData.put(NODE_VERSION_KEY, Integer.toString(Version.CURRENT.id));
+            commitData.put(NODE_VERSION_KEY, Integer.toString(IndexVersion.current().id()));
             commitData.put(OLDEST_INDEX_VERSION_KEY, Integer.toString(oldestIndexVersion.id()));
             commitData.put(NODE_ID_KEY, nodeId);
             commitData.put(CLUSTER_UUID_KEY, clusterUUID);

--- a/server/src/main/java/org/elasticsearch/index/IndexVersions.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersions.java
@@ -130,7 +130,7 @@ public class IndexVersions {
         Map<Integer, String> versionIdFields = new HashMap<>();
         NavigableMap<Integer, IndexVersion> builder = new TreeMap<>();
 
-        Set<String> ignore = Set.of("ZERO", "MINIMUM_COMPATIBLE");
+        Set<String> ignore = Set.of("ZERO", "MINIMUM_COMPATIBLE", "MINIMUM_IN_PLACE_UPGRADE_COMPATIBLE");
 
         for (Field declaredField : cls.getFields()) {
             if (declaredField.getType().equals(IndexVersion.class)) {

--- a/server/src/main/java/org/elasticsearch/index/IndexVersions.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersions.java
@@ -114,6 +114,7 @@ public class IndexVersions {
      */
 
     public static final IndexVersion MINIMUM_COMPATIBLE = V_7_0_0;
+    public static final IndexVersion MINIMUM_IN_PLACE_UPGRADE_COMPATIBLE = V_7_17_0;
 
     static final NavigableMap<Integer, IndexVersion> VERSION_IDS = getAllVersionIds(IndexVersions.class);
     static final IndexVersion LATEST_DEFINED;

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -12,7 +12,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.ElasticsearchTimeoutException;
-import org.elasticsearch.Version;
 import org.elasticsearch.bootstrap.BootstrapCheck;
 import org.elasticsearch.bootstrap.BootstrapContext;
 import org.elasticsearch.client.internal.Client;
@@ -54,6 +53,7 @@ import org.elasticsearch.gateway.MetaStateService;
 import org.elasticsearch.gateway.PersistedClusterStateService;
 import org.elasticsearch.health.HealthPeriodicLogger;
 import org.elasticsearch.http.HttpServerTransport;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.cluster.IndicesClusterStateService;
 import org.elasticsearch.indices.recovery.PeerRecoverySourceService;
@@ -328,7 +328,7 @@ public class Node implements Closeable {
                     nodeEnvironment.nodeDataPaths()
                 );
                 assert nodeMetadata != null;
-                assert nodeMetadata.nodeVersion().equals(Version.CURRENT);
+                assert nodeMetadata.nodeIndexVersion().equals(IndexVersion.current());
                 assert nodeMetadata.nodeId().equals(localNodeFactory.getNode().getId());
             } catch (IOException e) {
                 assert false : e;

--- a/server/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
+++ b/server/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
@@ -41,7 +41,6 @@ import org.elasticsearch.test.IndexSettingsModule;
 import org.elasticsearch.test.MockLogAppender;
 import org.elasticsearch.test.NodeRoles;
 import org.elasticsearch.test.junit.annotations.TestLogging;
-import org.hamcrest.Matchers;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -595,6 +594,7 @@ public class NodeEnvironmentTests extends ESTestCase {
                 () -> checkForIndexCompatibility(logger, env.dataPaths())
             );
 
+            // TODO[wrb]: got to get rid of Version in this test if we can
             assertThat(
                 ex.getMessage(),
                 allOf(
@@ -602,7 +602,7 @@ public class NodeEnvironmentTests extends ESTestCase {
                     containsString("it holds metadata for indices with version [" + oldIndexVersion + "]"),
                     containsString(
                         "Revert this node to version ["
-                            + (previousNodeVersion.major == Version.V_8_0_0.major ? Version.V_7_17_0 : previousNodeVersion)
+                            + (previousNodeVersion.major == Version.V_8_0_0.major ? Version.V_7_17_0 : previousNodeVersion).id()
                             + "]"
                     )
                 )
@@ -645,20 +645,6 @@ public class NodeEnvironmentTests extends ESTestCase {
 
         assertTrue(Files.exists(symLinkPath));
         env.close();
-    }
-
-    public void testGetBestDowngradeVersion() {
-        assertThat(NodeEnvironment.getBestDowngradeVersion("7.17.0"), Matchers.equalTo("7.17.0"));
-        assertThat(NodeEnvironment.getBestDowngradeVersion("7.17.5"), Matchers.equalTo("7.17.5"));
-        assertThat(NodeEnvironment.getBestDowngradeVersion("7.17.1234"), Matchers.equalTo("7.17.1234"));
-        assertThat(NodeEnvironment.getBestDowngradeVersion("7.18.0"), Matchers.equalTo("7.18.0"));
-        assertThat(NodeEnvironment.getBestDowngradeVersion("7.17.x"), Matchers.equalTo("7.17.0"));
-        assertThat(NodeEnvironment.getBestDowngradeVersion("7.17.5-SNAPSHOT"), Matchers.equalTo("7.17.0"));
-        assertThat(NodeEnvironment.getBestDowngradeVersion("7.17.6b"), Matchers.equalTo("7.17.0"));
-        assertThat(NodeEnvironment.getBestDowngradeVersion("7.16.0"), Matchers.equalTo("7.17.0"));
-        // when we get to version 7.2147483648.0 we will have to rethink our approach, but for now we return 7.17.0 with an integer overflow
-        assertThat(NodeEnvironment.getBestDowngradeVersion("7." + Integer.MAX_VALUE + "0.0"), Matchers.equalTo("7.17.0"));
-        assertThat(NodeEnvironment.getBestDowngradeVersion("foo"), Matchers.equalTo("7.17.0"));
     }
 
     private void verifyFailsOnShardData(Settings settings, Path indexPath, String shardDataDirName) {

--- a/server/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
+++ b/server/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
@@ -628,7 +628,7 @@ public class NodeEnvironmentTests extends ESTestCase {
             assertThat(
                 ex.getMessage(),
                 allOf(
-                    startsWith("cannot upgrade a node from version [" + oldVersion + "] directly"),
+                    startsWith("cannot upgrade a node from version [" + oldVersion.id() + "] directly"),
                     containsString("upgrade to version [" + Build.current().minWireCompatVersion())
                 )
             );

--- a/server/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
+++ b/server/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
@@ -628,7 +628,7 @@ public class NodeEnvironmentTests extends ESTestCase {
             assertThat(
                 ex.getMessage(),
                 allOf(
-                    startsWith("cannot upgrade a node from version [" + oldVersion.id() + "] directly"),
+                    startsWith("cannot upgrade a node using index version [" + oldVersion.id() + "] directly"),
                     containsString("upgrade to version [" + Build.current().minWireCompatVersion())
                 )
             );

--- a/server/src/test/java/org/elasticsearch/env/NodeMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/env/NodeMetadataTests.java
@@ -100,7 +100,7 @@ public class NodeMetadataTests extends ESTestCase {
             ),
             IndexVersion.current()
         ).upgradeToCurrentVersion();
-        assertThat(nodeMetadata.nodeVersion(), equalTo(Version.CURRENT));
+        assertThat(nodeMetadata.nodeIndexVersion(), equalTo(IndexVersion.current()));
         assertThat(nodeMetadata.nodeId(), equalTo(nodeId));
     }
 
@@ -114,7 +114,7 @@ public class NodeMetadataTests extends ESTestCase {
         assertThat(
             illegalStateException.getMessage(),
             startsWith(
-                "cannot upgrade a node from version [" + Version.V_EMPTY + "] directly to version [" + Build.current().version() + "]"
+                "cannot upgrade a node from version [" + IndexVersions.ZERO + "] directly to version [" + Build.current().version() + "]"
             )
         );
     }
@@ -155,7 +155,7 @@ public class NodeMetadataTests extends ESTestCase {
         final Version version = VersionUtils.randomVersionBetween(random(), Version.CURRENT.minimumCompatibilityVersion(), Version.V_8_0_0);
 
         final NodeMetadata nodeMetadata = new NodeMetadata(nodeId, version, IndexVersion.current()).upgradeToCurrentVersion();
-        assertThat(nodeMetadata.nodeVersion(), equalTo(Version.CURRENT));
+        assertThat(nodeMetadata.nodeIndexVersion(), equalTo(IndexVersion.current()));
         assertThat(nodeMetadata.previousNodeVersion(), equalTo(version));
     }
 

--- a/server/src/test/java/org/elasticsearch/env/NodeMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/env/NodeMetadataTests.java
@@ -87,7 +87,7 @@ public class NodeMetadataTests extends ESTestCase {
         Files.copy(resource, stateDir.resolve(NodeMetadata.FORMAT.getStateFileName(between(0, Integer.MAX_VALUE))));
         final NodeMetadata nodeMetadata = NodeMetadata.FORMAT.loadLatestState(logger, xContentRegistry(), tempDir);
         assertThat(nodeMetadata.nodeId(), equalTo("y6VUVMSaStO4Tz-B5BxcOw"));
-        assertThat(nodeMetadata.nodeVersion(), equalTo(Version.V_EMPTY));
+        assertThat(nodeMetadata.nodeIndexVersion(), equalTo(IndexVersions.ZERO));
     }
 
     public void testUpgradesLegitimateVersions() {
@@ -152,11 +152,15 @@ public class NodeMetadataTests extends ESTestCase {
 
     public void testUpgradeMarksPreviousVersion() {
         final String nodeId = randomAlphaOfLength(10);
-        final Version version = VersionUtils.randomVersionBetween(random(), Version.CURRENT.minimumCompatibilityVersion(), Version.V_8_0_0);
+        final IndexVersion version = IndexVersionUtils.randomVersionBetween(
+            random(),
+            IndexVersions.MINIMUM_IN_PLACE_UPGRADE_COMPATIBLE,
+            IndexVersions.V_8_0_0
+        );
 
         final NodeMetadata nodeMetadata = new NodeMetadata(nodeId, version, IndexVersion.current()).upgradeToCurrentVersion();
         assertThat(nodeMetadata.nodeIndexVersion(), equalTo(IndexVersion.current()));
-        assertThat(nodeMetadata.previousNodeVersion(), equalTo(version));
+        assertThat(nodeMetadata.previousNodeIndexVersion(), equalTo(version));
     }
 
     public static IndexVersion tooNewVersion() {

--- a/server/src/test/java/org/elasticsearch/env/NodeMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/env/NodeMetadataTests.java
@@ -114,7 +114,11 @@ public class NodeMetadataTests extends ESTestCase {
         assertThat(
             illegalStateException.getMessage(),
             startsWith(
-                "cannot upgrade a node using index version [" + IndexVersions.ZERO + "] directly to version [" + Build.current().version() + "]"
+                "cannot upgrade a node using index version ["
+                    + IndexVersions.ZERO
+                    + "] directly to version ["
+                    + Build.current().version()
+                    + "]"
             )
         );
     }

--- a/server/src/test/java/org/elasticsearch/env/NodeMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/env/NodeMetadataTests.java
@@ -114,7 +114,7 @@ public class NodeMetadataTests extends ESTestCase {
         assertThat(
             illegalStateException.getMessage(),
             startsWith(
-                "cannot upgrade a node from version [" + IndexVersions.ZERO + "] directly to version [" + Build.current().version() + "]"
+                "cannot upgrade a node using index version [" + IndexVersions.ZERO + "] directly to version [" + Build.current().version() + "]"
             )
         );
     }
@@ -126,7 +126,7 @@ public class NodeMetadataTests extends ESTestCase {
         );
         assertThat(
             illegalStateException.getMessage(),
-            allOf(startsWith("cannot downgrade a node from version ["), endsWith("] to version [" + Build.current().version() + "]"))
+            allOf(startsWith("cannot downgrade a node using index version ["), endsWith("] to version [" + Build.current().version() + "]"))
         );
     }
 
@@ -138,7 +138,7 @@ public class NodeMetadataTests extends ESTestCase {
         assertThat(
             illegalStateException.getMessage(),
             allOf(
-                startsWith("cannot upgrade a node from version ["),
+                startsWith("cannot upgrade a node using index version ["),
                 endsWith(
                     "] directly to version ["
                         + Build.current().version()

--- a/server/src/test/java/org/elasticsearch/env/OverrideNodeVersionCommandTests.java
+++ b/server/src/test/java/org/elasticsearch/env/OverrideNodeVersionCommandTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.gateway.PersistedClusterStateService;
 import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.After;
 import org.junit.Before;
@@ -96,7 +97,9 @@ public class OverrideNodeVersionCommandTests extends ESTestCase {
     }
 
     public void testFailsIfUnnecessary() throws IOException {
-        final Version nodeVersion = Version.fromId(between(Version.CURRENT.minimumCompatibilityVersion().id, Version.CURRENT.id));
+        final IndexVersion nodeVersion = IndexVersion.fromId(
+            between(IndexVersions.MINIMUM_IN_PLACE_UPGRADE_COMPATIBLE.id(), IndexVersion.current().id())
+        );
         PersistedClusterStateService.overrideVersion(nodeVersion, dataPaths);
         final MockTerminal mockTerminal = MockTerminal.create();
         final ElasticsearchException elasticsearchException = expectThrows(
@@ -185,7 +188,7 @@ public class OverrideNodeVersionCommandTests extends ESTestCase {
         expectThrows(IllegalStateException.class, () -> mockTerminal.readText(""));
 
         final NodeMetadata nodeMetadata = PersistedClusterStateService.nodeMetadata(dataPaths);
-        assertThat(nodeMetadata.nodeVersion(), equalTo(Version.CURRENT));
+        assertThat(nodeMetadata.nodeIndexVersion(), equalTo(IndexVersion.current()));
     }
 
     public void testOverwritesIfTooNew() throws Exception {
@@ -207,6 +210,6 @@ public class OverrideNodeVersionCommandTests extends ESTestCase {
         expectThrows(IllegalStateException.class, () -> mockTerminal.readText(""));
 
         final NodeMetadata nodeMetadata = PersistedClusterStateService.nodeMetadata(dataPaths);
-        assertThat(nodeMetadata.nodeVersion(), equalTo(Version.CURRENT));
+        assertThat(nodeMetadata.nodeIndexVersion(), equalTo(IndexVersion.current()));
     }
 }

--- a/server/src/test/java/org/elasticsearch/env/OverrideNodeVersionCommandTests.java
+++ b/server/src/test/java/org/elasticsearch/env/OverrideNodeVersionCommandTests.java
@@ -107,7 +107,7 @@ public class OverrideNodeVersionCommandTests extends ESTestCase {
             allOf(
                 containsString("compatible with current version"),
                 containsString(Version.CURRENT.toString()),
-                containsString(nodeVersion.toString())
+                containsString(String.valueOf(nodeVersion.id()))
             )
         );
         expectThrows(IllegalStateException.class, () -> mockTerminal.readText(""));

--- a/server/src/test/java/org/elasticsearch/env/OverrideNodeVersionCommandTests.java
+++ b/server/src/test/java/org/elasticsearch/env/OverrideNodeVersionCommandTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.gateway.PersistedClusterStateService;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.After;
 import org.junit.Before;
@@ -114,7 +115,7 @@ public class OverrideNodeVersionCommandTests extends ESTestCase {
     }
 
     public void testWarnsIfTooOld() throws Exception {
-        final Version nodeVersion = NodeMetadataTests.tooOldVersion();
+        final IndexVersion nodeVersion = NodeMetadataTests.tooOldVersion();
         PersistedClusterStateService.overrideVersion(nodeVersion, dataPaths);
         final MockTerminal mockTerminal = MockTerminal.create();
         mockTerminal.addTextInput("n");
@@ -136,11 +137,11 @@ public class OverrideNodeVersionCommandTests extends ESTestCase {
         expectThrows(IllegalStateException.class, () -> mockTerminal.readText(""));
 
         final NodeMetadata nodeMetadata = PersistedClusterStateService.nodeMetadata(dataPaths);
-        assertThat(nodeMetadata.nodeVersion(), equalTo(nodeVersion));
+        assertThat(nodeMetadata.nodeIndexVersion(), equalTo(nodeVersion));
     }
 
     public void testWarnsIfTooNew() throws Exception {
-        final Version nodeVersion = NodeMetadataTests.tooNewVersion();
+        final IndexVersion nodeVersion = NodeMetadataTests.tooNewVersion();
         PersistedClusterStateService.overrideVersion(nodeVersion, dataPaths);
         final MockTerminal mockTerminal = MockTerminal.create();
         mockTerminal.addTextInput(randomFrom("yy", "Yy", "n", "yes", "true", "N", "no"));
@@ -161,11 +162,11 @@ public class OverrideNodeVersionCommandTests extends ESTestCase {
         expectThrows(IllegalStateException.class, () -> mockTerminal.readText(""));
 
         final NodeMetadata nodeMetadata = PersistedClusterStateService.nodeMetadata(dataPaths);
-        assertThat(nodeMetadata.nodeVersion(), equalTo(nodeVersion));
+        assertThat(nodeMetadata.nodeIndexVersion(), equalTo(nodeVersion));
     }
 
     public void testOverwritesIfTooOld() throws Exception {
-        final Version nodeVersion = NodeMetadataTests.tooOldVersion();
+        final IndexVersion nodeVersion = NodeMetadataTests.tooOldVersion();
         PersistedClusterStateService.overrideVersion(nodeVersion, dataPaths);
         final MockTerminal mockTerminal = MockTerminal.create();
         mockTerminal.addTextInput(randomFrom("y", "Y"));
@@ -188,7 +189,7 @@ public class OverrideNodeVersionCommandTests extends ESTestCase {
     }
 
     public void testOverwritesIfTooNew() throws Exception {
-        final Version nodeVersion = NodeMetadataTests.tooNewVersion();
+        final IndexVersion nodeVersion = NodeMetadataTests.tooNewVersion();
         PersistedClusterStateService.overrideVersion(nodeVersion, dataPaths);
         final MockTerminal mockTerminal = MockTerminal.create();
         mockTerminal.addTextInput(randomFrom("y", "Y"));
@@ -199,7 +200,7 @@ public class OverrideNodeVersionCommandTests extends ESTestCase {
                 containsString("data loss"),
                 containsString("You should not use this tool"),
                 containsString(Version.CURRENT.toString()),
-                containsString(nodeVersion.toString()),
+                containsString(String.valueOf(nodeVersion.id())),
                 containsString(OverrideNodeVersionCommand.SUCCESS_MESSAGE)
             )
         );

--- a/server/src/test/java/org/elasticsearch/gateway/PersistedClusterStateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/PersistedClusterStateServiceTests.java
@@ -34,7 +34,6 @@ import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.store.NIOFSDirectory;
 import org.apache.lucene.tests.mockfile.ExtrasFS;
 import org.apache.lucene.util.Bits;
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.coordination.CoordinationMetadata;
@@ -1439,13 +1438,13 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
 
             }
             NodeMetadata prevMetadata = PersistedClusterStateService.nodeMetadata(persistedClusterStateService.getDataPaths());
-            assertEquals(Version.CURRENT, prevMetadata.nodeVersion());
-            PersistedClusterStateService.overrideVersion(Version.V_8_0_0, persistedClusterStateService.getDataPaths());
+            assertEquals(IndexVersion.current(), prevMetadata.nodeIndexVersion());
+            PersistedClusterStateService.overrideVersion(IndexVersions.V_8_0_0, persistedClusterStateService.getDataPaths());
             NodeMetadata metadata = PersistedClusterStateService.nodeMetadata(persistedClusterStateService.getDataPaths());
-            assertEquals(Version.V_8_0_0, metadata.nodeVersion());
+            assertEquals(IndexVersions.V_8_0_0, metadata.nodeIndexVersion());
             for (Path p : persistedClusterStateService.getDataPaths()) {
                 NodeMetadata individualMetadata = PersistedClusterStateService.nodeMetadata(p);
-                assertEquals(Version.V_8_0_0, individualMetadata.nodeVersion());
+                assertEquals(IndexVersions.V_8_0_0, individualMetadata.nodeIndexVersion());
             }
         }
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/SecurityImplicitBehaviorBootstrapCheck.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/SecurityImplicitBehaviorBootstrapCheck.java
@@ -7,11 +7,12 @@
 
 package org.elasticsearch.xpack.security;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.bootstrap.BootstrapCheck;
 import org.elasticsearch.bootstrap.BootstrapContext;
 import org.elasticsearch.common.ReferenceDocs;
 import org.elasticsearch.env.NodeMetadata;
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.license.ClusterStateLicenseService;
 import org.elasticsearch.license.License;
 import org.elasticsearch.license.LicenseService;
@@ -34,9 +35,9 @@ public class SecurityImplicitBehaviorBootstrapCheck implements BootstrapCheck {
         }
         if (licenseService instanceof ClusterStateLicenseService clusterStateLicenseService) {
             final License license = clusterStateLicenseService.getLicense(context.metadata());
-            final Version lastKnownVersion = nodeMetadata.previousNodeVersion();
+            final IndexVersion lastKnownVersion = nodeMetadata.previousNodeIndexVersion();
             // pre v7.2.0 nodes have Version.EMPTY and its id is 0, so Version#before handles this successfully
-            if (lastKnownVersion.before(Version.V_8_0_0)
+            if (lastKnownVersion.before(IndexVersions.V_8_0_0)
                 && XPackSettings.SECURITY_ENABLED.exists(context.settings()) == false
                 && (license.operationMode() == License.OperationMode.BASIC || license.operationMode() == License.OperationMode.TRIAL)) {
                 return BootstrapCheckResult.failure(

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityImplicitBehaviorBootstrapCheckTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityImplicitBehaviorBootstrapCheckTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.security;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.bootstrap.BootstrapCheck;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.ReferenceDocs;
@@ -15,13 +14,14 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.env.NodeMetadata;
 import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.license.ClusterStateLicenseService;
 import org.elasticsearch.license.License;
 import org.elasticsearch.license.LicensesMetadata;
 import org.elasticsearch.license.TestUtils;
 import org.elasticsearch.license.internal.TrialLicenseVersion;
 import org.elasticsearch.test.AbstractBootstrapCheckTestCase;
-import org.elasticsearch.test.VersionUtils;
+import org.elasticsearch.test.index.IndexVersionUtils;
 import org.elasticsearch.xpack.core.XPackSettings;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -32,9 +32,9 @@ import static org.mockito.Mockito.when;
 public class SecurityImplicitBehaviorBootstrapCheckTests extends AbstractBootstrapCheckTestCase {
 
     public void testFailureUpgradeFrom7xWithImplicitSecuritySettings() throws Exception {
-        final Version previousVersion = randomValueOtherThan(
-            Version.V_8_0_0,
-            () -> VersionUtils.randomVersionBetween(random(), Version.CURRENT.minimumCompatibilityVersion(), Version.V_8_0_0)
+        final IndexVersion previousVersion = randomValueOtherThan(
+            IndexVersions.V_8_0_0,
+            () -> IndexVersionUtils.randomVersionBetween(random(), IndexVersions.MINIMUM_IN_PLACE_UPGRADE_COMPATIBLE, IndexVersions.V_8_0_0)
         );
         NodeMetadata nodeMetadata = new NodeMetadata(randomAlphaOfLength(10), previousVersion, IndexVersion.current());
         nodeMetadata = nodeMetadata.upgradeToCurrentVersion();
@@ -67,9 +67,9 @@ public class SecurityImplicitBehaviorBootstrapCheckTests extends AbstractBootstr
     }
 
     public void testUpgradeFrom7xWithImplicitSecuritySettingsOnGoldPlus() throws Exception {
-        final Version previousVersion = randomValueOtherThan(
-            Version.V_8_0_0,
-            () -> VersionUtils.randomVersionBetween(random(), Version.CURRENT.minimumCompatibilityVersion(), Version.V_8_0_0)
+        final IndexVersion previousVersion = randomValueOtherThan(
+            IndexVersions.V_8_0_0,
+            () -> IndexVersionUtils.randomVersionBetween(random(), IndexVersions.MINIMUM_IN_PLACE_UPGRADE_COMPATIBLE, IndexVersions.V_8_0_0)
         );
         NodeMetadata nodeMetadata = new NodeMetadata(randomAlphaOfLength(10), previousVersion, IndexVersion.current());
         nodeMetadata = nodeMetadata.upgradeToCurrentVersion();
@@ -88,9 +88,9 @@ public class SecurityImplicitBehaviorBootstrapCheckTests extends AbstractBootstr
     }
 
     public void testUpgradeFrom7xWithExplicitSecuritySettings() throws Exception {
-        final Version previousVersion = randomValueOtherThan(
-            Version.V_8_0_0,
-            () -> VersionUtils.randomVersionBetween(random(), Version.CURRENT.minimumCompatibilityVersion(), Version.V_8_0_0)
+        final IndexVersion previousVersion = randomValueOtherThan(
+            IndexVersions.V_8_0_0,
+            () -> IndexVersionUtils.randomVersionBetween(random(), IndexVersions.MINIMUM_IN_PLACE_UPGRADE_COMPATIBLE, IndexVersions.V_8_0_0)
         );
         NodeMetadata nodeMetadata = new NodeMetadata(randomAlphaOfLength(10), previousVersion, IndexVersion.current());
         nodeMetadata = nodeMetadata.upgradeToCurrentVersion();
@@ -105,7 +105,7 @@ public class SecurityImplicitBehaviorBootstrapCheckTests extends AbstractBootstr
     }
 
     public void testUpgradeFrom8xWithImplicitSecuritySettings() throws Exception {
-        final Version previousVersion = VersionUtils.randomVersionBetween(random(), Version.V_8_0_0, null);
+        final IndexVersion previousVersion = IndexVersionUtils.randomVersionBetween(random(), IndexVersions.V_8_0_0, null);
         NodeMetadata nodeMetadata = new NodeMetadata(randomAlphaOfLength(10), previousVersion, IndexVersion.current());
         nodeMetadata = nodeMetadata.upgradeToCurrentVersion();
         ClusterStateLicenseService licenseService = mock(ClusterStateLicenseService.class);
@@ -119,7 +119,7 @@ public class SecurityImplicitBehaviorBootstrapCheckTests extends AbstractBootstr
     }
 
     public void testUpgradeFrom8xWithExplicitSecuritySettings() throws Exception {
-        final Version previousVersion = VersionUtils.randomVersionBetween(random(), Version.V_8_0_0, null);
+        final IndexVersion previousVersion = IndexVersionUtils.randomVersionBetween(random(), IndexVersions.V_8_0_0, null);
         NodeMetadata nodeMetadata = new NodeMetadata(randomAlphaOfLength(10), previousVersion, IndexVersion.current());
         nodeMetadata = nodeMetadata.upgradeToCurrentVersion();
         ClusterStateLicenseService licenseService = mock(ClusterStateLicenseService.class);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
@@ -10,7 +10,6 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchSecurityException;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionModule;
 import org.elasticsearch.client.internal.Client;
@@ -189,7 +188,7 @@ public class SecurityTests extends ESTestCase {
 
     private Collection<Object> createComponentsUtil(Settings settings) throws Exception {
         Environment env = TestEnvironment.newEnvironment(settings);
-        NodeMetadata nodeMetadata = new NodeMetadata(randomAlphaOfLength(8), Version.CURRENT, IndexVersion.current());
+        NodeMetadata nodeMetadata = new NodeMetadata(randomAlphaOfLength(8), IndexVersion.current(), IndexVersion.current());
         ThreadPool threadPool = mock(ThreadPool.class);
         ClusterService clusterService = mock(ClusterService.class);
         settings = Security.additionalSettings(settings, true);


### PR DESCRIPTION
This is a possible alternative to #102185 which makes it much more likely that our downgrade barriers won't change.

NodeMetadata that's been persisted on disk since the creation of IndexVersion will have version IDs written from Version, but since the IDs from detached index versions are higher than the 8.12 version IDs, I don't think there will be a bwc problem.
