### PR TITLE
Only log node shutting down once

### DIFF
--- a/server/src/main/java/org/elasticsearch/readiness/ReadinessService.java
+++ b/server/src/main/java/org/elasticsearch/readiness/ReadinessService.java
@@ -242,8 +242,11 @@ public class ReadinessService extends AbstractLifecycleComponent implements Clus
         this.shuttingDown = shutdownNodeIds.contains(clusterState.nodes().getLocalNodeId());
 
         if (shuttingDown) {
-            setReady(false);
-            logger.info("marking node as not ready because it's shutting down");
+            // only disable the probe and log if the probe is running
+            if (ready()) {
+                setReady(false);
+                logger.info("marking node as not ready because it's shutting down");
+            }
         } else {
             if (clusterState.nodes().getLocalNodeId().equals(clusterState.nodes().getMasterNodeId())) {
                 setReady(fileSettingsApplied);


### PR DESCRIPTION
When a node begins shutting down, the readiness service detects this and presents the node as not ready. However, any cluster state update that occurs after that again causes the readiness service to log a message that it is shutting down. This commit guards the log message and setting the service as not ready.