### PR TITLE
Minor tweak for free space reporting

### DIFF
--- a/server/src/main/java/org/elasticsearch/env/Environment.java
+++ b/server/src/main/java/org/elasticsearch/env/Environment.java
@@ -326,11 +326,7 @@ public class Environment {
 
     public static long getUsableSpace(Path path) throws IOException {
         long freeSpaceInBytes = Environment.getFileStore(path).getUsableSpace();
-
-        /* See: https://bugs.openjdk.java.net/browse/JDK-8162520 */
-        if (freeSpaceInBytes < 0) {
-            freeSpaceInBytes = Long.MAX_VALUE;
-        }
+        assert freeSpaceInBytes >= 0;
         return freeSpaceInBytes;
     }
 

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBytes.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBytes.java
@@ -134,7 +134,7 @@ public class SharedBytes extends AbstractRefCounted {
         if (usableSpace > fileSize) {
             return p;
         } else {
-            throw new IOException("Not enough free space for cache file of size [" + fileSize + "] in path [" + path + "]");
+            throw new IOException("Not enough free space [" + usableSpace + "] for cache file of size [" + fileSize + "] in path [" + path + "]");
         }
     }
 

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBytes.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBytes.java
@@ -134,7 +134,9 @@ public class SharedBytes extends AbstractRefCounted {
         if (usableSpace > fileSize) {
             return p;
         } else {
-            throw new IOException("Not enough free space [" + usableSpace + "] for cache file of size [" + fileSize + "] in path [" + path + "]");
+            throw new IOException(
+                "Not enough free space [" + usableSpace + "] for cache file of size [" + fileSize + "] in path [" + path + "]"
+            );
         }
     }
 


### PR DESCRIPTION
This PR adds free space size in error message. It also removes the special handling of negative size since the JDK bug is fixed.

