### PR TITLE
Improve failure handling in ContinuousComputation

### DIFF
--- a/docs/changelog/102281.yaml
+++ b/docs/changelog/102281.yaml
@@ -1,0 +1,5 @@
+pr: 102281
+summary: Improve failure handling in `ContinuousComputation`
+area: Allocation
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocator.java
@@ -100,7 +100,7 @@ public class DesiredBalanceShardsAllocator implements ShardsAllocator {
         this.reconciler = reconciler;
         this.desiredBalanceComputer = desiredBalanceComputer;
         this.desiredBalanceReconciler = new DesiredBalanceReconciler(clusterService.getClusterSettings(), threadPool);
-        this.desiredBalanceComputation = new ContinuousComputation<>(threadPool) {
+        this.desiredBalanceComputation = new ContinuousComputation<>(threadPool.generic()) {
 
             @Override
             protected void processInput(DesiredBalanceInput desiredBalanceInput) {
@@ -141,7 +141,7 @@ public class DesiredBalanceShardsAllocator implements ShardsAllocator {
 
             @Override
             public String toString() {
-                return "DesiredBalanceShardsAllocator#updateDesiredBalanceAndReroute";
+                return "DesiredBalanceShardsAllocator#allocate";
             }
         };
         this.queue = new PendingListenersQueue();

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/ContinuousComputationTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/ContinuousComputationTests.java
@@ -167,8 +167,9 @@ public class ContinuousComputationTests extends ESTestCase {
             }
         };
 
-        final var mockLogAppender = new MockLogAppender();
-        mockLogAppender.addExpectation(
+        MockLogAppender.assertThatLogger(
+            () -> computation.onNewInput(input1),
+            ContinuousComputation.class,
             new MockLogAppender.SeenEventExpectation(
                 "error log",
                 ContinuousComputation.class.getCanonicalName(),
@@ -176,11 +177,6 @@ public class ContinuousComputationTests extends ESTestCase {
                 "unexpected error processing [test computation]"
             )
         );
-
-        try (var ignored = mockLogAppender.capturing(ContinuousComputation.class)) {
-            computation.onNewInput(input1);
-            mockLogAppender.assertAllExpectationsMatched();
-        }
 
         // check that both inputs were processed
         assertEquals(1, failureCount.get());

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/ContinuousComputationTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/ContinuousComputationTests.java
@@ -8,7 +8,9 @@
 
 package org.elasticsearch.cluster.routing.allocation.allocator;
 
+import org.apache.logging.log4j.Level;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockLogAppender;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.AfterClass;
@@ -19,11 +21,11 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertEquals;
 
 public class ContinuousComputationTests extends ESTestCase {
 
@@ -46,7 +48,7 @@ public class ContinuousComputationTests extends ESTestCase {
     public void testConcurrency() throws Exception {
 
         final var result = new AtomicReference<Integer>();
-        final var computation = new ContinuousComputation<Integer>(threadPool) {
+        final var computation = new ContinuousComputation<Integer>(threadPool.generic()) {
 
             public final Semaphore executePermit = new Semaphore(1);
 
@@ -94,7 +96,7 @@ public class ContinuousComputationTests extends ESTestCase {
         final var finalInput = new Object();
 
         final var result = new AtomicReference<Object>();
-        final var computation = new ContinuousComputation<Object>(threadPool) {
+        final var computation = new ContinuousComputation<Object>(threadPool.generic()) {
             @Override
             protected void processInput(Object input) {
                 assertNotEquals(input, skippedInput);
@@ -133,5 +135,58 @@ public class ContinuousComputationTests extends ESTestCase {
         assertThat(result.get(), equalTo(finalInput));
         await.run();
         assertBusy(() -> assertFalse(computation.isActive()));
+    }
+
+    public void testFailureHandling() {
+        final var input1 = new Object();
+        final var input2 = new Object();
+
+        final var failureCount = new AtomicInteger();
+
+        final var computation = new ContinuousComputation<>(r -> {
+            try {
+                r.run();
+            } catch (AssertionError e) {
+                assertEquals("simulated", asInstanceOf(RuntimeException.class, e.getCause()).getMessage());
+                failureCount.incrementAndGet();
+            }
+        }) {
+            @Override
+            protected void processInput(Object input) {
+                if (input == input1) {
+                    onNewInput(input2);
+                }
+                throw new RuntimeException("simulated");
+            }
+
+            @Override
+            public String toString() {
+                return "test computation";
+            }
+        };
+
+        final var mockLogAppender = new MockLogAppender();
+        mockLogAppender.addExpectation(
+            new MockLogAppender.SeenEventExpectation(
+                "error log",
+                ContinuousComputation.class.getCanonicalName(),
+                Level.ERROR,
+                "unexpected error processing [test computation]"
+            )
+        );
+
+        try (var ignored = mockLogAppender.capturing(ContinuousComputation.class)) {
+            computation.onNewInput(input1);
+            mockLogAppender.assertAllExpectationsMatched();
+        }
+
+        // check that both inputs were processed
+        assertEquals(2, failureCount.get());
+
+        // check that the computation still accepts and processes new inputs
+        computation.onNewInput(input2);
+        assertEquals(3, failureCount.get());
+        computation.onNewInput(input1);
+        assertEquals(5, failureCount.get());
     }
 }


### PR DESCRIPTION
Today we assert that processing an input (e.g. computing an updated
shard balance) doesn't throw an exception, but if an exception were to
occur in production then we don't even log anything, we just silently
stop processing anything else.

This commit adds an error log and a `finally` block to ensure that we
carry on trying to process new inputs even if one of them throws an
exception.