### PR TITLE
Consider duplicate stacktraces in custom index

### DIFF
--- a/docs/changelog/102292.yaml
+++ b/docs/changelog/102292.yaml
@@ -1,0 +1,5 @@
+pr: 102292
+summary: Consider duplicate stacktraces in custom index
+area: Application
+type: enhancement
+issues: []

--- a/x-pack/plugin/mapper-counted-keyword/src/main/java/org/elasticsearch/xpack/countedkeyword/CountedTermsAggregationBuilder.java
+++ b/x-pack/plugin/mapper-counted-keyword/src/main/java/org/elasticsearch/xpack/countedkeyword/CountedTermsAggregationBuilder.java
@@ -30,10 +30,12 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
 
-class CountedTermsAggregationBuilder extends ValuesSourceAggregationBuilder<CountedTermsAggregationBuilder> {
+public class CountedTermsAggregationBuilder extends ValuesSourceAggregationBuilder<CountedTermsAggregationBuilder> {
     public static final String NAME = "counted_terms";
-    public static final ValuesSourceRegistry.RegistryKey<CountedTermsAggregatorSupplier> REGISTRY_KEY =
-        new ValuesSourceRegistry.RegistryKey<>(NAME, CountedTermsAggregatorSupplier.class);
+    static final ValuesSourceRegistry.RegistryKey<CountedTermsAggregatorSupplier> REGISTRY_KEY = new ValuesSourceRegistry.RegistryKey<>(
+        NAME,
+        CountedTermsAggregatorSupplier.class
+    );
 
     public static final ParseField REQUIRED_SIZE_FIELD_NAME = new ParseField("size");
 
@@ -50,7 +52,7 @@ class CountedTermsAggregationBuilder extends ValuesSourceAggregationBuilder<Coun
     // see TermsAggregationBuilder.DEFAULT_BUCKET_COUNT_THRESHOLDS
     private TermsAggregator.BucketCountThresholds bucketCountThresholds = new TermsAggregator.BucketCountThresholds(1, 0, 10, -1);
 
-    protected CountedTermsAggregationBuilder(String name) {
+    public CountedTermsAggregationBuilder(String name) {
         super(name);
     }
 

--- a/x-pack/plugin/profiling/build.gradle
+++ b/x-pack/plugin/profiling/build.gradle
@@ -17,6 +17,7 @@ esplugin {
 
 dependencies {
   compileOnly project(path: xpackModule('core'))
+  compileOnly project(path: xpackModule('mapper-counted-keyword'))
   testImplementation(testArtifact(project(xpackModule('core'))))
   testImplementation project(path: xpackModule('mapper-unsigned-long'))
   testImplementation project(path: xpackModule('mapper-version'))

--- a/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/GetStackTracesActionIT.java
+++ b/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/GetStackTracesActionIT.java
@@ -44,10 +44,11 @@ public class GetStackTracesActionIT extends ProfilingTestCase {
 
         GetStackTracesRequest request = new GetStackTracesRequest(null, query, "apm-test-*", "transaction.profiler_stack_trace_ids");
         GetStackTracesResponse response = client().execute(GetStackTracesAction.INSTANCE, request).get();
-        assertEquals(39, response.getTotalFrames());
+        assertEquals(43, response.getTotalFrames());
 
         assertNotNull(response.getStackTraceEvents());
-        assertEquals(1L, (long) response.getStackTraceEvents().get("Ce77w10WeIDow3kd1jowlA"));
+        assertEquals(3L, (long) response.getStackTraceEvents().get("Ce77w10WeIDow3kd1jowlA"));
+        assertEquals(2L, (long) response.getStackTraceEvents().get("JvISdnJ47BQ01489cwF9DA"));
 
         assertNotNull(response.getStackTraces());
         // just do a high-level spot check. Decoding is tested in unit-tests

--- a/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/ProfilingTestCase.java
+++ b/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/ProfilingTestCase.java
@@ -24,6 +24,7 @@ import org.elasticsearch.transport.netty4.Netty4Plugin;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.ilm.LifecycleSettings;
+import org.elasticsearch.xpack.countedkeyword.CountedKeywordMapperPlugin;
 import org.elasticsearch.xpack.ilm.IndexLifecycle;
 import org.elasticsearch.xpack.unsignedlong.UnsignedLongMapperPlugin;
 import org.elasticsearch.xpack.versionfield.VersionFieldPlugin;
@@ -45,6 +46,7 @@ public abstract class ProfilingTestCase extends ESIntegTestCase {
             LocalStateProfilingXPackPlugin.class,
             IndexLifecycle.class,
             UnsignedLongMapperPlugin.class,
+            CountedKeywordMapperPlugin.class,
             VersionFieldPlugin.class,
             getTestTransportPlugin()
         );

--- a/x-pack/plugin/profiling/src/internalClusterTest/resources/data/apm-test.ndjson
+++ b/x-pack/plugin/profiling/src/internalClusterTest/resources/data/apm-test.ndjson
@@ -1,2 +1,2 @@
 {"create": {"_index": "apm-test-001"}}
-{"@timestamp": "1698624000", "transaction.name":  "encodeSha1", "transaction.profiler_stack_trace_ids": "Ce77w10WeIDow3kd1jowlA"}
+{"@timestamp": "1698624000", "transaction.name":  "encodeSha1", "transaction.profiler_stack_trace_ids": ["Ce77w10WeIDow3kd1jowlA", "JvISdnJ47BQ01489cwF9DA", "JvISdnJ47BQ01489cwF9DA", "Ce77w10WeIDow3kd1jowlA", "Ce77w10WeIDow3kd1jowlA"]}

--- a/x-pack/plugin/profiling/src/internalClusterTest/resources/indices/apm-test.json
+++ b/x-pack/plugin/profiling/src/internalClusterTest/resources/indices/apm-test.json
@@ -13,7 +13,7 @@
           "type": "date"
         },
         "transaction.profiler_stack_trace_ids": {
-          "type": "keyword"
+          "type": "counted_keyword"
         },
         "transaction.name": {
           "type": "keyword"

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStackTracesAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStackTracesAction.java
@@ -40,6 +40,7 @@ import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.ObjectPath;
+import org.elasticsearch.xpack.countedkeyword.CountedTermsAggregationBuilder;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -184,8 +185,7 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
             .addAggregation(new MinAggregationBuilder("min_time").field("@timestamp"))
             .addAggregation(new MaxAggregationBuilder("max_time").field("@timestamp"))
             .addAggregation(
-                // TODO: Replace this with a CountedTermsAggregationBuilder when #101826 is merged.
-                new TermsAggregationBuilder("group_by")
+                new CountedTermsAggregationBuilder("group_by")
                     // 'size' should be max 100k, but might be slightly more. Better be on the safe side.
                     .size(150_000)
                     .field(request.getStackTraceIds())


### PR DESCRIPTION
With this commit we consider also duplicate stacktraces in custom indices for profiling events. We achieve that by using the recently introduced `counted_terms` aggregation (requires that the respective field is mapped as `counted_keyword`).

Relates #101826
Relates #102020