### PR TITLE
Additional minor cleanup of org.elasticsearch.search.aggregations package

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorBase.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorBase.java
@@ -267,8 +267,8 @@ public abstract class AggregatorBase extends Aggregator {
     public Aggregator subAggregator(String aggName) {
         if (subAggregatorbyName == null) {
             subAggregatorbyName = Maps.newMapWithExpectedSize(subAggregators.length);
-            for (int i = 0; i < subAggregators.length; i++) {
-                subAggregatorbyName.put(subAggregators[i].name(), subAggregators[i]);
+            for (Aggregator subAggregator : subAggregators) {
+                subAggregatorbyName.put(subAggregator.name(), subAggregator);
             }
         }
         return subAggregatorbyName.get(aggName);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/InternalOrder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/InternalOrder.java
@@ -289,7 +289,7 @@ public abstract class InternalOrder extends BucketOrder {
         @Override
         public <T extends Bucket> Comparator<T> partiallyBuiltBucketComparator(ToLongFunction<T> ordinalReader, Aggregator aggregator) {
             Comparator<Bucket> comparator = comparator();
-            return (lhs, rhs) -> comparator.compare(lhs, rhs);
+            return comparator::compare;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/BucketsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/BucketsAggregator.java
@@ -223,9 +223,9 @@ public abstract class BucketsAggregator extends AggregatorBase {
         }
         InternalAggregations[] results = buildSubAggsForBuckets(bucketOrdsToCollect);
         s = 0;
-        for (int r = 0; r < buckets.length; r++) {
-            for (int b = 0; b < buckets[r].length; b++) {
-                setAggs.accept(buckets[r][b], results[s++]);
+        for (B[] bucket : buckets) {
+            for (int b = 0; b < bucket.length; b++) {
+                setAggs.accept(bucket[b], results[s++]);
             }
         }
     }
@@ -330,8 +330,8 @@ public abstract class BucketsAggregator extends AggregatorBase {
         }
         long[] bucketOrdsToCollect = new long[(int) totalOrdsToCollect];
         int b = 0;
-        for (int ordIdx = 0; ordIdx < owningBucketOrds.length; ordIdx++) {
-            LongKeyedBucketOrds.BucketOrdsEnum ordsEnum = bucketOrds.ordsEnum(owningBucketOrds[ordIdx]);
+        for (long owningBucketOrd : owningBucketOrds) {
+            LongKeyedBucketOrds.BucketOrdsEnum ordsEnum = bucketOrds.ordsEnum(owningBucketOrd);
             while (ordsEnum.next()) {
                 bucketOrdsToCollect[b++] = ordsEnum.ord();
             }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeValuesCollectorQueue.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeValuesCollectorQueue.java
@@ -83,7 +83,7 @@ final class CompositeValuesCollectorQueue extends PriorityQueue<Integer> impleme
         // tracking the highest competitive value.
         if (arrays[0] instanceof GlobalOrdinalValuesSource globalOrdinalValuesSource) {
             if (shouldApplyGlobalOrdinalDynamicPruningForLeadingSource(sources, size, indexReader)) {
-                competitiveBoundsChangedListener = topSlot -> globalOrdinalValuesSource.updateHighestCompetitiveValue(topSlot);
+                competitiveBoundsChangedListener = globalOrdinalValuesSource::updateHighestCompetitiveValue;
             } else {
                 competitiveBoundsChangedListener = null;
             }
@@ -207,8 +207,8 @@ final class CompositeValuesCollectorQueue extends PriorityQueue<Integer> impleme
      * Copies the current value in <code>slot</code>.
      */
     private void copyCurrent(int slot, long value) {
-        for (int i = 0; i < arrays.length; i++) {
-            arrays[i].copyCurrent(slot);
+        for (SingleDimensionValuesSource<?> array : arrays) {
+            array.copyCurrent(slot);
         }
         docCounts = bigArrays.grow(docCounts, slot + 1);
         docCounts.set(slot, value);
@@ -238,12 +238,12 @@ final class CompositeValuesCollectorQueue extends PriorityQueue<Integer> impleme
      */
     boolean equals(int slot1, int slot2) {
         assert slot2 != CANDIDATE_SLOT;
-        for (int i = 0; i < arrays.length; i++) {
+        for (SingleDimensionValuesSource<?> array : arrays) {
             final int cmp;
             if (slot1 == CANDIDATE_SLOT) {
-                cmp = arrays[i].compareCurrent(slot2);
+                cmp = array.compareCurrent(slot2);
             } else {
-                cmp = arrays[i].compare(slot1, slot2);
+                cmp = array.compare(slot1, slot2);
             }
             if (cmp != 0) {
                 return false;
@@ -257,8 +257,8 @@ final class CompositeValuesCollectorQueue extends PriorityQueue<Integer> impleme
      */
     int hashCode(int slot) {
         int result = 1;
-        for (int i = 0; i < arrays.length; i++) {
-            result = 31 * result + (slot == CANDIDATE_SLOT ? arrays[i].hashCodeCurrent() : arrays[i].hashCode(slot));
+        for (SingleDimensionValuesSource<?> array : arrays) {
+            result = 31 * result + (slot == CANDIDATE_SLOT ? array.hashCodeCurrent() : array.hashCode(slot));
         }
         return result;
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/ParsedComposite.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/ParsedComposite.java
@@ -32,7 +32,7 @@ public class ParsedComposite extends ParsedMultiBucketAggregation<ParsedComposit
             new ParseField("after_key"),
             ObjectParser.ValueType.OBJECT
         );
-        declareMultiBucketAggregationFields(PARSER, parser -> ParsedComposite.ParsedBucket.fromXContent(parser), parser -> null);
+        declareMultiBucketAggregationFields(PARSER, ParsedBucket::fromXContent, parser -> null);
     }
 
     private Map<String, Object> afterKey;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoGridAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoGridAggregationBuilder.java
@@ -64,7 +64,7 @@ public abstract class GeoGridAggregationBuilder extends ValuesSourceAggregationB
         parser.declareInt(GeoGridAggregationBuilder::size, FIELD_SIZE);
         parser.declareInt(GeoGridAggregationBuilder::shardSize, FIELD_SHARD_SIZE);
         parser.declareField(
-            (p, builder, context) -> { builder.setGeoBoundingBox(GeoBoundingBox.parseBoundingBox(p)); },
+            (p, builder, context) -> builder.setGeoBoundingBox(GeoBoundingBox.parseBoundingBox(p)),
             GeoBoundingBox.BOUNDS_FIELD,
             org.elasticsearch.xcontent.ObjectParser.ValueType.OBJECT
         );

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregator.java
@@ -555,8 +555,7 @@ public abstract class RangeAggregator extends BucketsAggregator {
     public InternalAggregation buildEmptyAggregation() {
         InternalAggregations subAggs = buildEmptySubAggregations();
         List<org.elasticsearch.search.aggregations.bucket.range.Range.Bucket> buckets = new ArrayList<>(ranges.length);
-        for (int i = 0; i < ranges.length; i++) {
-            Range range = ranges[i];
+        for (Range range : ranges) {
             org.elasticsearch.search.aggregations.bucket.range.Range.Bucket bucket = rangeFactory.createBucket(
                 range.key,
                 range.originalFrom,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractInternalTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractInternalTerms.java
@@ -300,7 +300,7 @@ public abstract class AbstractInternalTerms<A extends AbstractInternalTerms<A, B
             TopBucketBuilder<B> top = TopBucketBuilder.build(
                 getRequiredSize(),
                 getOrder(),
-                removed -> { otherDocCount[0] += removed.getDocCount(); }
+                removed -> otherDocCount[0] += removed.getDocCount()
             );
             thisReduceOrder = reduceBuckets(aggregations, reduceContext, bucket -> {
                 if (bucket.getDocCount() >= getMinDocCount()) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalSignificantTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalSignificantTerms.java
@@ -213,11 +213,7 @@ public abstract class InternalSignificantTerms<A extends InternalSignificantTerm
             @SuppressWarnings("unchecked")
             InternalSignificantTerms<A, B> terms = (InternalSignificantTerms<A, B>) aggregation;
             for (B bucket : terms.getBuckets()) {
-                List<B> existingBuckets = buckets.get(bucket.getKeyAsString());
-                if (existingBuckets == null) {
-                    existingBuckets = new ArrayList<>(aggregations.size());
-                    buckets.put(bucket.getKeyAsString(), existingBuckets);
-                }
+                List<B> existingBuckets = buckets.computeIfAbsent(bucket.getKeyAsString(), k -> new ArrayList<>(aggregations.size()));
                 // Adjust the buckets with the global stats representing the
                 // total size of the pots from which the stats are drawn
                 existingBuckets.add(

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsAggregatorFromFilters.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsAggregatorFromFilters.java
@@ -186,7 +186,7 @@ public class StringTermsAggregatorFromFilters extends AdaptingAggregator {
                 for (OrdBucket b : queue) {
                     buckets.add(buildBucket(b, terms));
                 }
-                Collections.sort(buckets, reduceOrder.comparator());
+                buckets.sort(reduceOrder.comparator());
             } else {
                 /*
                  * Note for the curious: you can just use a for loop to iterate
@@ -208,7 +208,7 @@ public class StringTermsAggregatorFromFilters extends AdaptingAggregator {
                 }
                 buckets.add(buildBucket(b, terms));
             }
-            Collections.sort(buckets, reduceOrder.comparator());
+            buckets.sort(reduceOrder.comparator());
         }
         return new StringTerms(
             filters.getName(),

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractHyperLogLogPlusPlus.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractHyperLogLogPlusPlus.java
@@ -81,12 +81,7 @@ public abstract class AbstractHyperLogLogPlusPlus extends AbstractCardinalityAlg
             AbstractHyperLogLog.RunLenIterator iterator = getHyperLogLog(bucketOrd);
             while (iterator.next()) {
                 byte runLength = iterator.value();
-                Integer numOccurances = values.get(runLength);
-                if (numOccurances == null) {
-                    values.put(runLength, 1);
-                } else {
-                    values.put(runLength, numOccurances + 1);
-                }
+                values.merge(runLength, 1, Integer::sum);
             }
             return values;
         }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractInternalHDRPercentiles.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractInternalHDRPercentiles.java
@@ -121,7 +121,7 @@ abstract class AbstractInternalHDRPercentiles extends InternalNumericMetricsAggr
 
     @Override
     public Iterable<String> valueNames() {
-        return Arrays.stream(getKeys()).mapToObj(d -> String.valueOf(d)).toList();
+        return Arrays.stream(getKeys()).mapToObj(String::valueOf).toList();
     }
 
     public DocValueFormat formatter() {
@@ -210,9 +210,9 @@ abstract class AbstractInternalHDRPercentiles extends InternalNumericMetricsAggr
         DoubleHistogram state = getState();
         if (keyed) {
             builder.startObject(CommonFields.VALUES.getPreferredName());
-            for (int i = 0; i < keys.length; ++i) {
-                String key = String.valueOf(keys[i]);
-                double value = value(keys[i]);
+            for (double v : keys) {
+                String key = String.valueOf(v);
+                double value = value(v);
                 builder.field(key, state.getTotalCount() == 0 ? null : value);
                 if (format != DocValueFormat.RAW && state.getTotalCount() > 0) {
                     builder.field(key + "_as_string", format.format(value).toString());
@@ -221,10 +221,10 @@ abstract class AbstractInternalHDRPercentiles extends InternalNumericMetricsAggr
             builder.endObject();
         } else {
             builder.startArray(CommonFields.VALUES.getPreferredName());
-            for (int i = 0; i < keys.length; i++) {
-                double value = value(keys[i]);
+            for (double key : keys) {
+                double value = value(key);
                 builder.startObject();
-                builder.field(CommonFields.KEY.getPreferredName(), keys[i]);
+                builder.field(CommonFields.KEY.getPreferredName(), key);
                 builder.field(CommonFields.VALUE.getPreferredName(), state.getTotalCount() == 0 ? null : value);
                 if (format != DocValueFormat.RAW && state.getTotalCount() > 0) {
                     builder.field(CommonFields.VALUE_AS_STRING.getPreferredName(), format.format(value).toString());

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractInternalTDigestPercentiles.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractInternalTDigestPercentiles.java
@@ -101,7 +101,7 @@ abstract class AbstractInternalTDigestPercentiles extends InternalNumericMetrics
 
     @Override
     public Iterable<String> valueNames() {
-        return Arrays.stream(getKeys()).mapToObj(d -> String.valueOf(d)).toList();
+        return Arrays.stream(getKeys()).mapToObj(String::valueOf).toList();
     }
 
     public abstract double value(double key);
@@ -188,9 +188,9 @@ abstract class AbstractInternalTDigestPercentiles extends InternalNumericMetrics
         TDigestState state = getState();
         if (keyed) {
             builder.startObject(CommonFields.VALUES.getPreferredName());
-            for (int i = 0; i < keys.length; ++i) {
-                String key = String.valueOf(keys[i]);
-                double value = value(keys[i]);
+            for (double v : keys) {
+                String key = String.valueOf(v);
+                double value = value(v);
                 builder.field(key, state.size() == 0 ? null : value);
                 if (format != DocValueFormat.RAW && state.size() > 0) {
                     builder.field(key + "_as_string", format.format(value).toString());
@@ -199,10 +199,10 @@ abstract class AbstractInternalTDigestPercentiles extends InternalNumericMetrics
             builder.endObject();
         } else {
             builder.startArray(CommonFields.VALUES.getPreferredName());
-            for (int i = 0; i < keys.length; i++) {
-                double value = value(keys[i]);
+            for (double key : keys) {
+                double value = value(key);
                 builder.startObject();
-                builder.field(CommonFields.KEY.getPreferredName(), keys[i]);
+                builder.field(CommonFields.KEY.getPreferredName(), key);
                 builder.field(CommonFields.VALUE.getPreferredName(), state.size() == 0 ? null : value);
                 if (format != DocValueFormat.RAW && state.size() > 0) {
                     builder.field(CommonFields.VALUE_AS_STRING.getPreferredName(), format.format(value).toString());

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedGeoBounds.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedGeoBounds.java
@@ -80,11 +80,7 @@ public class ParsedGeoBounds extends ParsedAggregation implements GeoBounds {
 
     static {
         declareAggregationFields(PARSER);
-        PARSER.declareObject(
-            (agg, bbox) -> { agg.geoBoundingBox = new GeoBoundingBox(bbox.v1(), bbox.v2()); },
-            BOUNDS_PARSER,
-            BOUNDS_FIELD
-        );
+        PARSER.declareObject((agg, bbox) -> agg.geoBoundingBox = new GeoBoundingBox(bbox.v1(), bbox.v2()), BOUNDS_PARSER, BOUNDS_FIELD);
 
         BOUNDS_PARSER.declareObject(constructorArg(), GEO_POINT_PARSER, TOP_LEFT_FIELD);
         BOUNDS_PARSER.declareObject(constructorArg(), GEO_POINT_PARSER, BOTTOM_RIGHT_FIELD);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedHDRPercentiles.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedHDRPercentiles.java
@@ -52,6 +52,6 @@ public class ParsedHDRPercentiles extends ParsedPercentiles implements Percentil
 
     @Override
     public Iterable<String> valueNames() {
-        return percentiles.keySet().stream().map(d -> d.toString()).toList();
+        return percentiles.keySet().stream().map(Object::toString).toList();
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedPercentileRanks.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedPercentileRanks.java
@@ -31,7 +31,7 @@ abstract class ParsedPercentileRanks extends ParsedPercentiles implements Percen
 
     @Override
     public Iterable<String> valueNames() {
-        return percentiles.keySet().stream().map(d -> d.toString()).toList();
+        return percentiles.keySet().stream().map(Object::toString).toList();
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedTDigestPercentiles.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ParsedTDigestPercentiles.java
@@ -37,7 +37,7 @@ public class ParsedTDigestPercentiles extends ParsedPercentiles implements Perce
 
     @Override
     public Iterable<String> valueNames() {
-        return percentiles.keySet().stream().map(d -> d.toString()).toList();
+        return percentiles.keySet().stream().map(Object::toString).toList();
     }
 
     private static final ObjectParser<ParsedTDigestPercentiles, Void> PARSER = new ObjectParser<>(

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregationBuilder.java
@@ -272,9 +272,7 @@ public class TopHitsAggregationBuilder extends AbstractAggregationBuilder<TopHit
         if (this.sorts == null) {
             this.sorts = new ArrayList<>();
         }
-        for (SortBuilder<?> sort : sorts) {
-            this.sorts.add(sort);
-        }
+        this.sorts.addAll(sorts);
         return this;
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/InternalPercentilesBucket.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/InternalPercentilesBucket.java
@@ -126,7 +126,7 @@ public class InternalPercentilesBucket extends InternalNumericMetricsAggregation
 
     @Override
     public Iterable<String> valueNames() {
-        return Arrays.stream(percents).mapToObj(d -> String.valueOf(d)).toList();
+        return Arrays.stream(percents).mapToObj(String::valueOf).toList();
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/MovingFunctions.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/MovingFunctions.java
@@ -174,7 +174,7 @@ public class MovingFunctions {
 
         int counter = 0;
 
-        Double last;
+        double last;
         for (double v : values) {
             if (Double.isNaN(v) == false) {
                 last = v;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/ParsedPercentilesBucket.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/ParsedPercentilesBucket.java
@@ -57,7 +57,7 @@ public class ParsedPercentilesBucket extends ParsedPercentiles implements Percen
 
     @Override
     public Iterable<String> valueNames() {
-        return percentiles.keySet().stream().map(d -> d.toString()).toList();
+        return percentiles.keySet().stream().map(Object::toString).toList();
     }
 
     @Override


### PR DESCRIPTION
* Convert Collections.sort() to List.sort()
* Use Collections.addAll() instead of manually invoking add()
* Use Map.merge() / Map.computIfAbsent()
* Use primitive double over Double
* Replace some lambdas with method references.
* Replaces for loops with index variable to use foreach iteration style for loops.