### PR TITLE
[Stack Monitoring] Add logstash host.ip mapping

### DIFF
--- a/x-pack/plugin/core/template-resources/src/main/resources/monitoring-logstash-mb.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/monitoring-logstash-mb.json
@@ -523,6 +523,9 @@
             "name": {
               "type": "keyword",
               "ignore_above": 1024
+            },
+            "ip": {
+              "type": "ip"
             }
           }
         },

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java
@@ -77,7 +77,7 @@ public class MonitoringTemplateRegistry extends IndexTemplateRegistry {
      * writes monitoring data in ECS format as of 8.0. These templates define the ECS schema as well as alias fields for the old monitoring
      * mappings that point to the corresponding ECS fields.
      */
-    public static final int STACK_MONITORING_REGISTRY_VERSION = 8_00_00_99 + 9;
+    public static final int STACK_MONITORING_REGISTRY_VERSION = 8_00_00_99 + 10;
     private static final String STACK_MONITORING_REGISTRY_VERSION_VARIABLE = "xpack.stack.monitoring.template.release.version";
     private static final String STACK_TEMPLATE_VERSION = "8";
     private static final String STACK_TEMPLATE_VERSION_VARIABLE = "xpack.stack.monitoring.template.version";


### PR DESCRIPTION
### Summary
Add missing logstash `host.ip` mapping in the Stack Monitoring `.monitoring-logstash-mb` mappings

Corresponding integration package change https://github.com/elastic/integrations/pull/8526