### PR TITLE
Using the newer template API for simulate ingest yaml rest tests

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/simulate.ingest/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/simulate.ingest/10_basic.yml
@@ -144,13 +144,14 @@ setup:
   - match: { acknowledged: true }
 
   - do:
-      indices.put_template:
+      indices.put_index_template:
         name: my-template
         body:
           index_patterns: index-*
-          settings:
-            default_pipeline: "my-pipeline"
-            final_pipeline: "my-final-pipeline"
+          template:
+            settings:
+              default_pipeline: "my-pipeline"
+              final_pipeline: "my-final-pipeline"
 
   - do:
       headers:
@@ -208,12 +209,13 @@ setup:
   - match: { acknowledged: true }
 
   - do:
-      indices.put_template:
+      indices.put_index_template:
         name: my-template
         body:
           index_patterns: index-*
-          settings:
-            default_pipeline: "my-pipeline"
+          template:
+            settings:
+              default_pipeline: "my-pipeline"
 
   - do:
       catch: "request"


### PR DESCRIPTION
This changes the simulate ingest yaml rest tests to use the non-deprecated templates API so that it works when the old API is not available.