### PR TITLE
ESQL: Fix single value query

### DIFF
--- a/docs/changelog/102317.yaml
+++ b/docs/changelog/102317.yaml
@@ -1,0 +1,6 @@
+pr: 102317
+summary: "ESQL: Fix single value query"
+area: ES|QL
+type: bug
+issues:
+ - 102298


### PR DESCRIPTION
This fixes the lucene query that we use to push "is this a single valued field?" into lucene. In particular, it was erroniously turning itself into a noop any time it saw a field that could have either 0 or 1 value per document. It's right and good for the query to noop itself only when a field can only have 1 value per document. This adds logic to check for that.

Closes #102298
