### PR TITLE
Enable the failure store feature flag for non-snapshot docs tests

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -72,6 +72,10 @@ testClusters.matching { it.name == "yamlRestTest"}.configureEach {
     setting 'xpack.license.self_generated.type', 'trial'
     setting 'indices.lifecycle.history_index_enabled', 'false'
     keystorePassword 'keystore-password'
+    if (BuildParams.isSnapshotBuild() == false) {
+//      systemProperty 'es.failure_store_feature_flag_enabled', 'true'
+      requiresFeature 'es.failure_store_feature_flag_enabled', new Version(8, 12, 0)
+    }
   }
 
   // debug ccr test failures:

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -73,7 +73,6 @@ testClusters.matching { it.name == "yamlRestTest"}.configureEach {
     setting 'indices.lifecycle.history_index_enabled', 'false'
     keystorePassword 'keystore-password'
     if (BuildParams.isSnapshotBuild() == false) {
-//      systemProperty 'es.failure_store_feature_flag_enabled', 'true'
       requiresFeature 'es.failure_store_feature_flag_enabled', new Version(8, 12, 0)
     }
   }


### PR DESCRIPTION
This PR enables the new failure store feature flag on the docs test clusters if the build is part of a non-snapshot build. This ensures that the docs build does not fail because of missing fields on the API responses.

Fixes #102284