### PR TITLE
[Profiling] Add TopN functions API

### DIFF
--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetTopNFunctionsAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetTopNFunctionsAction.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.profiling;
+
+import org.elasticsearch.action.ActionType;
+
+public final class GetTopNFunctionsAction extends ActionType<GetTopNFunctionsResponse> {
+    public static final GetTopNFunctionsAction INSTANCE = new GetTopNFunctionsAction();
+    public static final String NAME = "indices:data/read/profiling/topn/functions";
+
+    private GetTopNFunctionsAction() {
+        super(NAME, GetTopNFunctionsResponse::new);
+    }
+}

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetTopNFunctionsAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetTopNFunctionsAction.java
@@ -7,12 +7,13 @@
 package org.elasticsearch.xpack.profiling;
 
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.common.io.stream.Writeable;
 
 public final class GetTopNFunctionsAction extends ActionType<GetTopNFunctionsResponse> {
     public static final GetTopNFunctionsAction INSTANCE = new GetTopNFunctionsAction();
     public static final String NAME = "indices:data/read/profiling/topn/functions";
 
     private GetTopNFunctionsAction() {
-        super(NAME, GetTopNFunctionsResponse::new);
+        super(NAME, Writeable.Reader.localOnly());
     }
 }

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetTopNFunctionsResponse.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetTopNFunctionsResponse.java
@@ -79,6 +79,7 @@ public class GetTopNFunctionsResponse extends ActionResponse implements ChunkedT
             Iterators.single((b, p) -> b.field("TotalCount", totalCount)),
             Iterators.single((b, p) -> b.field("SelfCPU", selfCPU)),
             Iterators.single((b, p) -> b.field("TotalCPU", totalCPU)),
+            ChunkedToXContentHelper.array("TopN", Iterators.map(topNFunctions.iterator(), e -> (b, p) -> b.value(e))),
             ChunkedToXContentHelper.endObject()
         );
     }

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetTopNFunctionsResponse.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetTopNFunctionsResponse.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.profiling;
+
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.common.collect.Iterators;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ChunkedToXContentHelper;
+import org.elasticsearch.common.xcontent.ChunkedToXContentObject;
+import org.elasticsearch.xcontent.ToXContent;
+
+import java.io.IOException;
+import java.util.Iterator;
+
+public class GetTopNFunctionsResponse extends ActionResponse implements ChunkedToXContentObject {
+    private final int size;
+    private final double samplingRate;
+
+    public GetTopNFunctionsResponse(StreamInput in) throws IOException {
+        this.size = in.readInt();
+        this.samplingRate = in.readDouble();
+    }
+
+    public GetTopNFunctionsResponse(int size, double samplingRate) {
+        this.size = size;
+        this.samplingRate = samplingRate;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeInt(this.size);
+        out.writeDouble(this.samplingRate);
+    }
+
+    public int getSize() {
+        return size;
+    }
+
+    public double getSamplingRate() {
+        return samplingRate;
+    }
+
+    @Override
+    public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
+        return Iterators.concat(
+            ChunkedToXContentHelper.startObject(),
+            Iterators.single((b, p) -> b.field("Size", size)),
+            Iterators.single((b, p) -> b.field("SamplingRate", samplingRate)),
+            ChunkedToXContentHelper.endObject()
+        );
+    }
+}

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetTopNFunctionsResponse.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetTopNFunctionsResponse.java
@@ -17,41 +17,68 @@ import org.elasticsearch.xcontent.ToXContent;
 
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.List;
 
 public class GetTopNFunctionsResponse extends ActionResponse implements ChunkedToXContentObject {
-    private final int size;
     private final double samplingRate;
+    private final long totalCount;
+    private final long selfCPU;
+    private final long totalCPU;
+    private final List<TopNFunction> topNFunctions;
 
     public GetTopNFunctionsResponse(StreamInput in) throws IOException {
-        this.size = in.readInt();
         this.samplingRate = in.readDouble();
+        this.totalCount = in.readLong();
+        this.selfCPU = in.readLong();
+        this.totalCPU = in.readLong();
+        this.topNFunctions = in.readCollectionAsList(TopNFunction::new);
     }
 
-    public GetTopNFunctionsResponse(int size, double samplingRate) {
-        this.size = size;
+    public GetTopNFunctionsResponse(double samplingRate, long totalCount, long selfCPU, long totalCPU, List<TopNFunction> topNFunctions) {
         this.samplingRate = samplingRate;
+        this.totalCount = totalCount;
+        this.selfCPU = selfCPU;
+        this.totalCPU = totalCPU;
+        this.topNFunctions = topNFunctions;
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeInt(this.size);
         out.writeDouble(this.samplingRate);
-    }
-
-    public int getSize() {
-        return size;
+        out.writeLong(this.totalCount);
+        out.writeLong(this.selfCPU);
+        out.writeLong(this.totalCPU);
+        out.writeCollection(this.topNFunctions);
     }
 
     public double getSamplingRate() {
         return samplingRate;
     }
 
+    public long getTotalCount() {
+        return totalCount;
+    }
+
+    public long getSelfCPU() {
+        return selfCPU;
+    }
+
+    public long getTotalCPU() {
+        return totalCPU;
+    }
+
+    public List<TopNFunction> getTopN() {
+        return topNFunctions;
+    }
+
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
         return Iterators.concat(
             ChunkedToXContentHelper.startObject(),
-            Iterators.single((b, p) -> b.field("Size", size)),
             Iterators.single((b, p) -> b.field("SamplingRate", samplingRate)),
+            Iterators.single((b, p) -> b.field("TotalCount", totalCount)),
+            Iterators.single((b, p) -> b.field("SelfCPU", selfCPU)),
+            Iterators.single((b, p) -> b.field("TotalCPU", totalCPU)),
             ChunkedToXContentHelper.endObject()
         );
     }

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/ProfilingPlugin.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/ProfilingPlugin.java
@@ -131,6 +131,7 @@ public class ProfilingPlugin extends Plugin implements ActionPlugin {
         if (enabled) {
             handlers.add(new RestGetStackTracesAction());
             handlers.add(new RestGetFlamegraphAction());
+            handlers.add(new RestGetTopNFunctionsAction());
         }
         return Collections.unmodifiableList(handlers);
     }
@@ -165,6 +166,7 @@ public class ProfilingPlugin extends Plugin implements ActionPlugin {
         return List.of(
             new ActionHandler<>(GetStackTracesAction.INSTANCE, TransportGetStackTracesAction.class),
             new ActionHandler<>(GetFlamegraphAction.INSTANCE, TransportGetFlamegraphAction.class),
+            new ActionHandler<>(GetTopNFunctionsAction.INSTANCE, TransportGetTopNFunctionsAction.class),
             new ActionHandler<>(GetStatusAction.INSTANCE, TransportGetStatusAction.class),
             new ActionHandler<>(XPackUsageFeatureAction.UNIVERSAL_PROFILING, ProfilingUsageTransportAction.class),
             new ActionHandler<>(XPackInfoFeatureAction.UNIVERSAL_PROFILING, ProfilingInfoTransportAction.class)

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/RestGetTopNFunctionsAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/RestGetTopNFunctionsAction.java
@@ -9,6 +9,8 @@ package org.elasticsearch.xpack.profiling;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.Scope;
+import org.elasticsearch.rest.ServerlessScope;
 import org.elasticsearch.rest.action.RestActionListener;
 import org.elasticsearch.rest.action.RestCancellableNodeClient;
 import org.elasticsearch.rest.action.RestChunkedToXContentListener;
@@ -18,6 +20,7 @@ import java.util.List;
 
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 
+@ServerlessScope(Scope.PUBLIC)
 public class RestGetTopNFunctionsAction extends BaseRestHandler {
     @Override
     public List<Route> routes() {

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/RestGetTopNFunctionsAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/RestGetTopNFunctionsAction.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.profiling;
+
+import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestActionListener;
+import org.elasticsearch.rest.action.RestCancellableNodeClient;
+import org.elasticsearch.rest.action.RestChunkedToXContentListener;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.elasticsearch.rest.RestRequest.Method.POST;
+
+public class RestGetTopNFunctionsAction extends BaseRestHandler {
+    @Override
+    public List<Route> routes() {
+        return List.of(new Route(POST, "/_profiling/topn/functions"));
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        GetStackTracesRequest getStackTracesRequest = new GetStackTracesRequest();
+        request.applyContentParser(getStackTracesRequest::parseXContent);
+        // enforce server-side adjustment of sample counts for top N functions
+        getStackTracesRequest.setAdjustSampleCount(true);
+
+        return channel -> {
+            RestActionListener<GetTopNFunctionsResponse> listener = new RestChunkedToXContentListener<>(channel);
+            RestCancellableNodeClient cancelClient = new RestCancellableNodeClient(client, request.getHttpChannel());
+            cancelClient.execute(GetTopNFunctionsAction.INSTANCE, getStackTracesRequest, listener);
+        };
+    }
+
+    @Override
+    public String getName() {
+        return "get_topn_functions_action";
+    }
+}

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/RestGetTopNFunctionsAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/RestGetTopNFunctionsAction.java
@@ -11,9 +11,8 @@ import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.Scope;
 import org.elasticsearch.rest.ServerlessScope;
-import org.elasticsearch.rest.action.RestActionListener;
 import org.elasticsearch.rest.action.RestCancellableNodeClient;
-import org.elasticsearch.rest.action.RestChunkedToXContentListener;
+import org.elasticsearch.rest.action.RestRefCountedChunkedToXContentListener;
 
 import java.io.IOException;
 import java.util.List;
@@ -35,9 +34,12 @@ public class RestGetTopNFunctionsAction extends BaseRestHandler {
         getStackTracesRequest.setAdjustSampleCount(true);
 
         return channel -> {
-            RestActionListener<GetTopNFunctionsResponse> listener = new RestChunkedToXContentListener<>(channel);
             RestCancellableNodeClient cancelClient = new RestCancellableNodeClient(client, request.getHttpChannel());
-            cancelClient.execute(GetTopNFunctionsAction.INSTANCE, getStackTracesRequest, listener);
+            cancelClient.execute(
+                GetTopNFunctionsAction.INSTANCE,
+                getStackTracesRequest,
+                new RestRefCountedChunkedToXContentListener<>(channel)
+            );
         };
     }
 

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/StackFrameMetadata.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/StackFrameMetadata.java
@@ -7,13 +7,16 @@
 
 package org.elasticsearch.xpack.profiling;
 
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.util.Objects;
 
-final class StackFrameMetadata implements ToXContentObject {
+final class StackFrameMetadata implements Writeable, ToXContentObject {
     String frameID;
     String fileID;
     int frameType;
@@ -24,6 +27,19 @@ final class StackFrameMetadata implements ToXContentObject {
     String sourceFilename;
     int sourceLine;
     String exeFilename;
+
+    StackFrameMetadata(StreamInput in) throws IOException {
+        this.frameID = in.readString();
+        this.fileID = in.readString();
+        this.frameType = in.readInt();
+        this.inline = in.readBoolean();
+        this.addressOrLine = in.readInt();
+        this.functionName = in.readString();
+        this.functionOffset = in.readInt();
+        this.sourceFilename = in.readString();
+        this.sourceLine = in.readInt();
+        this.exeFilename = in.readString();
+    }
 
     StackFrameMetadata(
         String frameID,
@@ -47,6 +63,20 @@ final class StackFrameMetadata implements ToXContentObject {
         this.sourceFilename = sourceFilename;
         this.sourceLine = sourceLine;
         this.exeFilename = exeFilename;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(this.frameID);
+        out.writeString(this.fileID);
+        out.writeInt(this.frameType);
+        out.writeBoolean(this.inline);
+        out.writeInt(this.addressOrLine);
+        out.writeString(this.functionName);
+        out.writeInt(this.functionOffset);
+        out.writeString(this.sourceFilename);
+        out.writeInt(this.sourceLine);
+        out.writeString(this.exeFilename);
     }
 
     @Override

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/StackFrameMetadata.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/StackFrameMetadata.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.profiling;
+
+import org.elasticsearch.xcontent.ToXContentObject;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Objects;
+
+final class StackFrameMetadata implements ToXContentObject {
+    String frameID;
+    String fileID;
+    int frameType;
+    boolean inline;
+    int addressOrLine;
+    String functionName;
+    int functionOffset;
+    String sourceFilename;
+    int sourceLine;
+    String exeFilename;
+
+    StackFrameMetadata(
+        String frameID,
+        String fileID,
+        int frameType,
+        boolean inline,
+        int addressOrLine,
+        String functionName,
+        int functionOffset,
+        String sourceFilename,
+        int sourceLine,
+        String exeFilename
+    ) {
+        this.frameID = frameID;
+        this.fileID = fileID;
+        this.frameType = frameType;
+        this.inline = inline;
+        this.addressOrLine = addressOrLine;
+        this.functionName = functionName;
+        this.functionOffset = functionOffset;
+        this.sourceFilename = sourceFilename;
+        this.sourceLine = sourceLine;
+        this.exeFilename = exeFilename;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field("FrameID", this.frameID);
+        builder.field("FileID", this.fileID);
+        builder.field("FrameType", this.frameType);
+        builder.field("Inline", this.inline);
+        builder.field("AddressOrLine", this.addressOrLine);
+        builder.field("FunctionName", this.functionName);
+        builder.field("FunctionOffset", this.functionOffset);
+        builder.field("SourceFilename", this.sourceFilename);
+        builder.field("SourceLine", this.sourceLine);
+        builder.field("ExeFileName", this.exeFilename);
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        StackFrameMetadata that = (StackFrameMetadata) o;
+        return Objects.equals(frameID, that.frameID)
+            && Objects.equals(fileID, that.fileID)
+            && Objects.equals(frameType, that.frameType)
+            && Objects.equals(inline, that.inline)
+            && Objects.equals(addressOrLine, that.addressOrLine)
+            && Objects.equals(functionName, that.functionName)
+            && Objects.equals(functionOffset, that.functionOffset)
+            && Objects.equals(sourceFilename, that.sourceFilename)
+            && Objects.equals(sourceLine, that.sourceLine)
+            && Objects.equals(exeFilename, that.exeFilename);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+            frameID,
+            fileID,
+            frameType,
+            inline,
+            addressOrLine,
+            functionName,
+            functionOffset,
+            sourceFilename,
+            sourceLine,
+            exeFilename
+        );
+    }
+}

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TopNFunction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TopNFunction.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.profiling;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.xcontent.ToXContentObject;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Objects;
+
+final class TopNFunction implements Writeable, ToXContentObject, Comparable<TopNFunction> {
+    String id;
+    int rank;
+    StackFrameMetadata metadata;
+    long exclusiveCount;
+    long inclusiveCount;
+
+    TopNFunction(StreamInput in) throws IOException {
+        this.id = in.readString();
+        this.rank = in.readInt();
+        this.exclusiveCount = in.readLong();
+        this.inclusiveCount = in.readLong();
+        this.metadata = new StackFrameMetadata(in);
+    }
+
+    TopNFunction(String id, StackFrameMetadata metadata) {
+        this.id = id;
+        this.metadata = metadata;
+    }
+
+    TopNFunction(String id, int rank, StackFrameMetadata metadata, long exclusiveCount, long inclusiveCount) {
+        this.id = id;
+        this.rank = rank;
+        this.metadata = metadata;
+        this.exclusiveCount = exclusiveCount;
+        this.inclusiveCount = inclusiveCount;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(this.id);
+        out.writeInt(this.rank);
+        out.writeLong(this.exclusiveCount);
+        out.writeLong(this.inclusiveCount);
+        this.metadata.writeTo(out);
+    }
+
+    public String getId() {
+        return this.id;
+    }
+
+    public int getRank() {
+        return this.rank;
+    }
+
+    public StackFrameMetadata getMetadata() {
+        return this.metadata;
+    }
+
+    public long getCountExclusive() {
+        return this.exclusiveCount;
+    }
+
+    public long getCountInclusive() {
+        return this.inclusiveCount;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field("Id", this.id);
+        builder.field("Rank", this.rank);
+        builder.field("Frame", this.metadata);
+        builder.field("CountExclusive", this.exclusiveCount);
+        builder.field("CountInclusive", this.inclusiveCount);
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TopNFunction that = (TopNFunction) o;
+        return Objects.equals(id, that.id)
+            && Objects.equals(rank, that.rank)
+            && Objects.equals(metadata, that.metadata)
+            && Objects.equals(exclusiveCount, that.exclusiveCount)
+            && Objects.equals(inclusiveCount, that.inclusiveCount);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, rank, metadata, exclusiveCount, inclusiveCount);
+    }
+
+    @Override
+    public int compareTo(TopNFunction that) {
+        if (this.exclusiveCount > that.exclusiveCount) {
+            return 1;
+        }
+        if (this.exclusiveCount < that.exclusiveCount) {
+            return -1;
+        }
+        return this.id.compareTo(that.id);
+    }
+}

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetTopNFunctionsAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetTopNFunctionsAction.java
@@ -11,12 +11,11 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.ParentTaskAssigningClient;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
 
@@ -37,13 +36,7 @@ public class TransportGetTopNFunctionsAction extends HandledTransportAction<GetS
 
     @Inject
     public TransportGetTopNFunctionsAction(NodeClient nodeClient, TransportService transportService, ActionFilters actionFilters) {
-        super(
-            GetTopNFunctionsAction.NAME,
-            transportService,
-            actionFilters,
-            GetStackTracesRequest::new,
-            EsExecutors.DIRECT_EXECUTOR_SERVICE
-        );
+        super(GetTopNFunctionsAction.NAME, actionFilters, transportService.getTaskManager());
         this.nodeClient = nodeClient;
         this.transportService = transportService;
     }

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetTopNFunctionsAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetTopNFunctionsAction.java
@@ -68,7 +68,7 @@ public class TransportGetTopNFunctionsAction extends HandledTransportAction<GetS
         }
 
         for (Map.Entry<String, StackTrace> st : response.getStackTraces().entrySet()) {
-            Set<String> frameGroupsPerStackTrace = new HashSet<String>();
+            Set<String> frameGroupsPerStackTrace = new HashSet<>();
             String stackTraceId = st.getKey();
             StackTrace stackTrace = st.getValue();
             long samples = response.getStackTraceEvents().getOrDefault(stackTraceId, 0L);

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetTopNFunctionsAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetTopNFunctionsAction.java
@@ -84,6 +84,13 @@ public class TransportGetTopNFunctionsAction extends HandledTransportAction<GetS
                 String executable = response.getExecutables().getOrDefault(fileId, "");
 
                 for (Frame frame : stackFrame.frames()) {
+                    // The samples associated with a frame provide the total number of
+                    // traces in which that frame has appeared at least once. However, a
+                    // frame may appear multiple times in a trace, and thus to avoid
+                    // counting it multiple times we need to record the frames seen so
+                    // far in each trace. Instead of using the entire frame information
+                    // to determine if a frame has already been seen within a given
+                    // stacktrace, we use the frame group ID for a frame.
                     String frameGroupId = FrameGroupID.create(fileId, addressOrLine, executable, frame.fileName(), frame.functionName());
                     if (builder.setCurrentTopNFunction(frameGroupId) == false) {
                         builder.addTopNFunction(
@@ -107,6 +114,7 @@ public class TransportGetTopNFunctionsAction extends HandledTransportAction<GetS
                         builder.addToCurrentInclusiveCount(samples);
                     }
                     if (i == frameCount - 1) {
+                        // Leaf frame: sum up counts for exclusive CPU.
                         builder.addToCurrentExclusiveCount(samples);
                     }
                 }

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetTopNFunctionsAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetTopNFunctionsAction.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.profiling;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.client.internal.ParentTaskAssigningClient;
+import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.transport.TransportService;
+
+public class TransportGetTopNFunctionsAction extends HandledTransportAction<GetStackTracesRequest, GetTopNFunctionsResponse> {
+    private static final Logger log = LogManager.getLogger(TransportGetTopNFunctionsAction.class);
+
+    private final NodeClient nodeClient;
+    private final TransportService transportService;
+
+    @Inject
+    public TransportGetTopNFunctionsAction(NodeClient nodeClient, TransportService transportService, ActionFilters actionFilters) {
+        super(
+            GetTopNFunctionsAction.NAME,
+            transportService,
+            actionFilters,
+            GetStackTracesRequest::new,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE
+        );
+        this.nodeClient = nodeClient;
+        this.transportService = transportService;
+    }
+
+    @Override
+    protected void doExecute(Task task, GetStackTracesRequest request, ActionListener<GetTopNFunctionsResponse> listener) {
+        Client client = new ParentTaskAssigningClient(this.nodeClient, transportService.getLocalNode(), task);
+        StopWatch watch = new StopWatch("getTopNFunctionsAction");
+        client.execute(GetStackTracesAction.INSTANCE, request, new ActionListener<>() {
+            @Override
+            public void onResponse(GetStackTracesResponse response) {
+                long responseStart = System.nanoTime();
+                try {
+                    StopWatch processingWatch = new StopWatch("Processing response");
+                    GetTopNFunctionsResponse topNFunctionsResponse = buildTopNFunctions(response);
+                    log.debug(() -> watch.report() + " " + processingWatch.report());
+                    listener.onResponse(topNFunctionsResponse);
+                } catch (Exception ex) {
+                    listener.onFailure(ex);
+                }
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                listener.onFailure(e);
+            }
+        });
+    }
+
+    static GetTopNFunctionsResponse buildTopNFunctions(GetStackTracesResponse response) {
+        TopNFunctionsBuilder builder = new TopNFunctionsBuilder(0, response.getSamplingRate());
+        if (response.getTotalFrames() == 0) {
+            return builder.build();
+        }
+
+        return builder.build();
+    }
+
+    private static class TopNFunctionsBuilder {
+        private int size = 0;
+        private final double samplingRate;
+
+        TopNFunctionsBuilder(int frames, double samplingRate) {
+            this.samplingRate = samplingRate;
+        }
+
+        public GetTopNFunctionsResponse build() {
+            return new GetTopNFunctionsResponse(size, samplingRate);
+        }
+    }
+}

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetTopNFunctionsAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetTopNFunctionsAction.java
@@ -53,7 +53,6 @@ public class TransportGetTopNFunctionsAction extends HandledTransportAction<GetS
         Client client = new ParentTaskAssigningClient(this.nodeClient, transportService.getLocalNode(), task);
         StopWatch watch = new StopWatch("getTopNFunctionsAction");
         client.execute(GetStackTracesAction.INSTANCE, request, ActionListener.wrap(searchResponse -> {
-            long responseStart = System.nanoTime();
             StopWatch processingWatch = new StopWatch("Processing response");
             GetTopNFunctionsResponse topNFunctionsResponse = buildTopNFunctions(searchResponse);
             log.debug(() -> watch.report() + " " + processingWatch.report());

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/StackFrameMetadataTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/StackFrameMetadataTests.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.profiling;
+
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.EqualsHashCodeTestUtils;
+import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentFactory;
+import org.elasticsearch.xcontent.XContentType;
+
+import java.io.IOException;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
+
+public class StackFrameMetadataTests extends ESTestCase {
+    public void testToXContent() throws IOException {
+        XContentType contentType = randomFrom(XContentType.values());
+        XContentBuilder expectedRequest = XContentFactory.contentBuilder(contentType)
+            .startObject()
+            .field("FrameID", "VZbhUAtQEfdUptXfb8HvNgAAAAAAsbAE")
+            .field("FileID", "6tVKI4mSYDEJ-ABAIpYXcg")
+            .field("FrameType", 1)
+            .field("Inline", false)
+            .field("AddressOrLine", 23)
+            .field("FunctionName", "PyDict_GetItemWithError")
+            .field("FunctionOffset", 2567)
+            .field("SourceFilename", "/build/python3.9-RNBry6/python3.9-3.9.2/Objects/dictobject.c")
+            .field("SourceLine", 1456)
+            .field("ExeFileName", "python3.9")
+            .endObject();
+
+        XContentBuilder actualRequest = XContentFactory.contentBuilder(contentType);
+        StackFrameMetadata stackTraceMetadata = new StackFrameMetadata(
+            "VZbhUAtQEfdUptXfb8HvNgAAAAAAsbAE",
+            "6tVKI4mSYDEJ-ABAIpYXcg",
+            1,
+            false,
+            23,
+            "PyDict_GetItemWithError",
+            2567,
+            "/build/python3.9-RNBry6/python3.9-3.9.2/Objects/dictobject.c",
+            1456,
+            "python3.9"
+        );
+        stackTraceMetadata.toXContent(actualRequest, ToXContent.EMPTY_PARAMS);
+
+        assertToXContentEquivalent(BytesReference.bytes(expectedRequest), BytesReference.bytes(actualRequest), contentType);
+    }
+
+    public void testEquality() {
+        StackFrameMetadata metadata = new StackFrameMetadata(
+            "VZbhUAtQEfdUptXfb8HvNgAAAAAAsbAE",
+            "6tVKI4mSYDEJ-ABAIpYXcg",
+            1,
+            false,
+            23,
+            "PyDict_GetItemWithError",
+            2567,
+            "/build/python3.9-RNBry6/python3.9-3.9.2/Objects/dictobject.c",
+            1456,
+            "python3.9"
+        );
+        EqualsHashCodeTestUtils.checkEqualsAndHashCode(
+            metadata,
+            (o -> new StackFrameMetadata(
+                o.frameID,
+                o.fileID,
+                o.frameType,
+                o.inline,
+                o.addressOrLine,
+                o.functionName,
+                o.functionOffset,
+                o.sourceFilename,
+                o.sourceLine,
+                o.exeFilename
+            ))
+        );
+    }
+}

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/StackFrameTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/StackFrameTests.java
@@ -62,6 +62,5 @@ public class StackFrameTests extends ESTestCase {
             frame,
             (o -> new StackFrame(o.fileName, o.functionName, o.functionOffset, o.lineNumber))
         );
-
     }
 }

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/TopNFunctionTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/TopNFunctionTests.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.profiling;
+
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.EqualsHashCodeTestUtils;
+import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentFactory;
+import org.elasticsearch.xcontent.XContentType;
+
+import java.io.IOException;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
+
+public class TopNFunctionTests extends ESTestCase {
+    public void testToXContent() throws IOException {
+        StackFrameMetadata metadata = new StackFrameMetadata(
+            "VZbhUAtQEfdUptXfb8HvNgAAAAAAsbAE",
+            "6tVKI4mSYDEJ-ABAIpYXcg",
+            1,
+            false,
+            23,
+            "PyDict_GetItemWithError",
+            2567,
+            "/build/python3.9-RNBry6/python3.9-3.9.2/Objects/dictobject.c",
+            1456,
+            "python3.9"
+        );
+        String frameGroupID = FrameGroupID.create(
+            metadata.fileID,
+            metadata.addressOrLine,
+            metadata.exeFilename,
+            metadata.sourceFilename,
+            metadata.functionName
+        );
+
+        XContentType contentType = randomFrom(XContentType.values());
+        XContentBuilder expectedRequest = XContentFactory.contentBuilder(contentType)
+            .startObject()
+            .field("Id", frameGroupID)
+            .field("Rank", 1)
+            .field("Frame", metadata)
+            .field("CountExclusive", 1)
+            .field("CountInclusive", 10)
+            .endObject();
+
+        XContentBuilder actualRequest = XContentFactory.contentBuilder(contentType);
+        TopNFunction topNFunction = new TopNFunction(frameGroupID.toString(), 1, metadata, 1, 10);
+        topNFunction.toXContent(actualRequest, ToXContent.EMPTY_PARAMS);
+
+        assertToXContentEquivalent(BytesReference.bytes(expectedRequest), BytesReference.bytes(actualRequest), contentType);
+    }
+
+    public void testEquality() {
+        StackFrameMetadata metadata = new StackFrameMetadata(
+            "VZbhUAtQEfdUptXfb8HvNgAAAAAAsbAE",
+            "6tVKI4mSYDEJ-ABAIpYXcg",
+            1,
+            false,
+            23,
+            "PyDict_GetItemWithError",
+            2567,
+            "/build/python3.9-RNBry6/python3.9-3.9.2/Objects/dictobject.c",
+            1456,
+            "python3.9"
+        );
+        String frameGroupID = FrameGroupID.create(
+            metadata.fileID,
+            metadata.addressOrLine,
+            metadata.exeFilename,
+            metadata.sourceFilename,
+            metadata.functionName
+        );
+        TopNFunction topNFunction = new TopNFunction(frameGroupID, 1, metadata, 1, 10);
+        EqualsHashCodeTestUtils.checkEqualsAndHashCode(
+            topNFunction,
+            (o -> new TopNFunction(o.id, o.rank, o.metadata, o.exclusiveCount, o.inclusiveCount))
+        );
+    }
+}

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/TransportGetFlamegraphActionTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/TransportGetFlamegraphActionTests.java
@@ -118,7 +118,6 @@ public class TransportGetFlamegraphActionTests extends ESTestCase {
         assertEquals(1L, response.getSelfCPU());
         assertEquals(10L, response.getTotalCPU());
         assertEquals(1L, response.getTotalSamples());
-
     }
 
     public void testCreateEmptyFlamegraphWithRootNode() {

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/TransportGetTopNFunctionsActionTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/TransportGetTopNFunctionsActionTests.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.profiling;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class TransportGetTopNFunctionsActionTests extends ESTestCase {
+    public void testCreateTopNFunctions() {
+        GetStackTracesResponse stacktraces = new GetStackTracesResponse(
+            Map.of(
+                "2buqP1GpF-TXYmL4USW8gA",
+                new StackTrace(
+                    List.of(12784352, 19334053, 19336161, 18795859, 18622708, 18619213, 12989721, 13658842, 16339645),
+                    List.of(
+                        "fr28zxcZ2UDasxYuu6dV-w",
+                        "fr28zxcZ2UDasxYuu6dV-w",
+                        "fr28zxcZ2UDasxYuu6dV-w",
+                        "fr28zxcZ2UDasxYuu6dV-w",
+                        "fr28zxcZ2UDasxYuu6dV-w",
+                        "fr28zxcZ2UDasxYuu6dV-w",
+                        "fr28zxcZ2UDasxYuu6dV-w",
+                        "fr28zxcZ2UDasxYuu6dV-w",
+                        "fr28zxcZ2UDasxYuu6dV-w"
+                    ),
+                    List.of(
+                        "fr28zxcZ2UDasxYuu6dV-wAAAAAAwxLg",
+                        "fr28zxcZ2UDasxYuu6dV-wAAAAABJwOl",
+                        "fr28zxcZ2UDasxYuu6dV-wAAAAABJwvh",
+                        "fr28zxcZ2UDasxYuu6dV-wAAAAABHs1T",
+                        "fr28zxcZ2UDasxYuu6dV-wAAAAABHCj0",
+                        "fr28zxcZ2UDasxYuu6dV-wAAAAABHBtN",
+                        "fr28zxcZ2UDasxYuu6dV-wAAAAAAxjUZ",
+                        "fr28zxcZ2UDasxYuu6dV-wAAAAAA0Gra",
+                        "fr28zxcZ2UDasxYuu6dV-wAAAAAA-VK9"
+                    ),
+                    List.of(3, 3, 3, 3, 3, 3, 3, 3, 3)
+                )
+            ),
+            Map.of(),
+            Map.of("fr28zxcZ2UDasxYuu6dV-w", "containerd"),
+            Map.of("2buqP1GpF-TXYmL4USW8gA", 1L),
+            9,
+            1.0d,
+            1
+        );
+
+        GetTopNFunctionsResponse response = TransportGetTopNFunctionsAction.buildTopNFunctions(stacktraces);
+        assertNotNull(response);
+        assertEquals(1.0d, response.getSamplingRate(), 0.001d);
+        assertEquals(1, response.getTotalCount());
+        assertEquals(1, response.getSelfCPU());
+        assertEquals(9, response.getTotalCPU());
+
+        List<TopNFunction> topNFunctions = response.getTopN();
+        assertNotNull(topNFunctions);
+        assertEquals(9, topNFunctions.size());
+
+        List<String> ids = topNFunctions.stream().map(fn -> fn.id).collect(Collectors.toList());
+        List<Integer> ranks = topNFunctions.stream().map(fn -> fn.rank).collect(Collectors.toList());
+        List<Long> exclusiveCounts = topNFunctions.stream().map(fn -> fn.exclusiveCount).collect(Collectors.toList());
+        List<Long> inclusiveCounts = topNFunctions.stream().map(fn -> fn.inclusiveCount).collect(Collectors.toList());
+        List<String> frameIDs = topNFunctions.stream().map(fn -> fn.metadata.frameID).collect(Collectors.toList());
+        List<String> fileIDs = topNFunctions.stream().map(fn -> fn.metadata.fileID).collect(Collectors.toList());
+        List<Integer> frameTypes = topNFunctions.stream().map(fn -> fn.metadata.frameType).collect(Collectors.toList());
+        List<Boolean> inlines = topNFunctions.stream().map(fn -> fn.metadata.inline).collect(Collectors.toList());
+        List<Integer> addressOrLines = topNFunctions.stream().map(fn -> fn.metadata.addressOrLine).collect(Collectors.toList());
+        List<String> functionNames = topNFunctions.stream().map(fn -> fn.metadata.functionName).collect(Collectors.toList());
+        List<Integer> functionOffsets = topNFunctions.stream().map(fn -> fn.metadata.functionOffset).collect(Collectors.toList());
+        List<String> sourceFilenames = topNFunctions.stream().map(fn -> fn.metadata.sourceFilename).collect(Collectors.toList());
+        List<Integer> sourceLines = topNFunctions.stream().map(fn -> fn.metadata.sourceLine).collect(Collectors.toList());
+        List<String> exeFilenames = topNFunctions.stream().map(fn -> fn.metadata.exeFilename).collect(Collectors.toList());
+
+        assertEquals(
+            List.of("178196121", "181192637", "181190529", "180652335", "180479184", "180475689", "175515318", "174846197", "174640828"),
+            ids
+        );
+        assertEquals(List.of(1, 2, 3, 4, 5, 6, 7, 8, 9), ranks);
+        assertEquals(List.of(1L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L), exclusiveCounts);
+        assertEquals(List.of(1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L), inclusiveCounts);
+        assertEquals(
+            List.of(
+                "fr28zxcZ2UDasxYuu6dV-wAAAAAA-VK9",
+                "fr28zxcZ2UDasxYuu6dV-wAAAAABJwvh",
+                "fr28zxcZ2UDasxYuu6dV-wAAAAABJwOl",
+                "fr28zxcZ2UDasxYuu6dV-wAAAAABHs1T",
+                "fr28zxcZ2UDasxYuu6dV-wAAAAABHCj0",
+                "fr28zxcZ2UDasxYuu6dV-wAAAAABHBtN",
+                "fr28zxcZ2UDasxYuu6dV-wAAAAAA0Gra",
+                "fr28zxcZ2UDasxYuu6dV-wAAAAAAxjUZ",
+                "fr28zxcZ2UDasxYuu6dV-wAAAAAAwxLg"
+            ),
+            frameIDs
+        );
+        assertEquals(
+            List.of(
+                "fr28zxcZ2UDasxYuu6dV-w",
+                "fr28zxcZ2UDasxYuu6dV-w",
+                "fr28zxcZ2UDasxYuu6dV-w",
+                "fr28zxcZ2UDasxYuu6dV-w",
+                "fr28zxcZ2UDasxYuu6dV-w",
+                "fr28zxcZ2UDasxYuu6dV-w",
+                "fr28zxcZ2UDasxYuu6dV-w",
+                "fr28zxcZ2UDasxYuu6dV-w",
+                "fr28zxcZ2UDasxYuu6dV-w"
+            ),
+            fileIDs
+        );
+        assertEquals(List.of(3, 3, 3, 3, 3, 3, 3, 3, 3), frameTypes);
+        assertEquals(List.of(false, false, false, false, false, false, false, false, false), inlines);
+        assertEquals(List.of(16339645, 19336161, 19334053, 18795859, 18622708, 18619213, 13658842, 12989721, 12784352), addressOrLines);
+        assertEquals(List.of("", "", "", "", "", "", "", "", ""), functionNames);
+        assertEquals(List.of(0, 0, 0, 0, 0, 0, 0, 0, 0), functionOffsets);
+        assertEquals(List.of("", "", "", "", "", "", "", "", ""), sourceFilenames);
+        assertEquals(List.of(0, 0, 0, 0, 0, 0, 0, 0, 0), sourceLines);
+        assertEquals(
+            List.of(
+                "containerd",
+                "containerd",
+                "containerd",
+                "containerd",
+                "containerd",
+                "containerd",
+                "containerd",
+                "containerd",
+                "containerd"
+            ),
+            exeFilenames
+        );
+    }
+
+    public void testCreateEmptyTopNFunctions() {
+        GetStackTracesResponse stacktraces = new GetStackTracesResponse(Map.of(), Map.of(), Map.of(), Map.of(), 0, 1.0d, 0);
+        GetTopNFunctionsResponse response = TransportGetTopNFunctionsAction.buildTopNFunctions(stacktraces);
+        assertNotNull(response);
+        assertEquals(1.0d, response.getSamplingRate(), 0.001d);
+        assertEquals(0, response.getTotalCount());
+        assertEquals(0, response.getSelfCPU());
+        assertEquals(0, response.getTotalCPU());
+
+        List<TopNFunction> topNFunctions = response.getTopN();
+        assertNotNull(topNFunctions);
+        assertEquals(0, topNFunctions.size());
+    }
+}


### PR DESCRIPTION
This PR adds a new API call `/_profiling/topn/functions` that builds on top of the existing `/_profiling/stacktraces` API, but moves all computation for TopN functions from Kibana to Elasticsearch.

**Note**: this PR is currently in draft and is incomplete (awaiting serialization/deserialization for nested objects).

At least two Kibana PRs are required to integrate this new API (https://github.com/elastic/kibana/pull/171151 is already pending).