### PR TITLE
Account for the minimum G1 region size on G1OverLimitStrategy

### DIFF
--- a/docs/changelog/102329.yaml
+++ b/docs/changelog/102329.yaml
@@ -1,0 +1,5 @@
+pr: 102329
+summary: Account for the minimum G1 region size on G1OverLimitStrategy
+area: Distributed
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerService.java
+++ b/server/src/main/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerService.java
@@ -580,7 +580,8 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
             } else if (regionSize > ByteSizeUnit.MB.toBytes(32)) {
                 regionSize = ByteSizeUnit.MB.toBytes(32);
             }
-            return regionSize;
+            // elasticsearch overrides the region size for small heaps so the smallest region size possible is 4MiB
+            return Math.max(ByteSizeUnit.MB.toBytes(4), regionSize);
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerServiceTests.java
@@ -464,7 +464,7 @@ public class HierarchyCircuitBreakerServiceTests extends ESTestCase {
 
         assertThat(
             HierarchyCircuitBreakerService.G1OverLimitStrategy.fallbackRegionSize(JvmInfo.jvmInfo()),
-            equalTo(JvmInfo.jvmInfo().getG1RegionSize())
+            equalTo(Math.max(ByteSizeUnit.MB.toBytes(4), JvmInfo.jvmInfo().getG1RegionSize()))
         );
     }
 


### PR DESCRIPTION
The G1OverLimitStrategy tries to read the region size from the `JVMInfo`, but in case the information is not there it takes the value from a fallback option that uses the same algorithm that the JDK to compute the regions size. This is ok but Elasticsearch overrides the region size for small heaps so the minimum allow is 4MiB. 

This PR updates the fallback option to take into account the minimum G1 region size.