### PR TITLE
Fix mistake when removing the High level rest Client in CCSDuelIT

### DIFF
--- a/qa/multi-cluster-search/src/test/java/org/elasticsearch/search/CCSDuelIT.java
+++ b/qa/multi-cluster-search/src/test/java/org/elasticsearch/search/CCSDuelIT.java
@@ -874,7 +874,7 @@ public class CCSDuelIT extends ESRestTestCase {
             assertNull(response.evaluate("aggregations"));
             assertNull(response.evaluate("suggest"));
             assertThat(response.evaluateArraySize("hits.hits"), greaterThan(0));
-            assertThat(response.evaluate("_shards.failed"), greaterThan(2));
+            assertThat(response.evaluate("_shards.failed"), greaterThanOrEqualTo(2));
         }, compareAsyncAndSyncResponses);
     }
 


### PR DESCRIPTION
Mistake when migrating the condition, tis `greaterThanOrEqualTo` instead of `greaterThan`: https://github.com/elastic/elasticsearch/blob/25b80acb38932134e0b40926bf11b7bb0949e8fa/qa/multi-cluster-search/src/test/java/org/elasticsearch/search/CCSDuelIT.java#L886

fixes: https://github.com/elastic/elasticsearch/issues/102316