### PR TITLE
Yet more logging for S3SnapshotRepoTestKitIT

### DIFF
--- a/x-pack/plugin/snapshot-repo-test-kit/qa/s3/build.gradle
+++ b/x-pack/plugin/snapshot-repo-test-kit/qa/s3/build.gradle
@@ -69,6 +69,12 @@ testClusters.matching { it.name == "javaRestTest" }.configureEach {
     println "Using an external service to test " + project.name
   }
   setting 'xpack.security.enabled', 'false'
+
+  // Additional tracing related to investigation into https://github.com/elastic/elasticsearch/issues/102294
+  setting 'logger.org.elasticsearch.repositories.s3', 'TRACE'
+  setting 'logger.org.elasticsearch.repositories.blobstore.testkit', 'TRACE'
+  setting 'logger.com.amazonaws.request', 'DEBUG'
+  setting 'logger.org.apache.http.wire', 'DEBUG'
 }
 
 tasks.register("s3ThirdPartyTest") {

--- a/x-pack/plugin/snapshot-repo-test-kit/qa/s3/src/javaRestTest/java/org/elasticsearch/repositories/blobstore/testkit/S3SnapshotRepoTestKitIT.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/qa/s3/src/javaRestTest/java/org/elasticsearch/repositories/blobstore/testkit/S3SnapshotRepoTestKitIT.java
@@ -7,7 +7,6 @@
 package org.elasticsearch.repositories.blobstore.testkit;
 
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.test.junit.annotations.TestIssueLogging;
 
 import static org.hamcrest.Matchers.blankOrNullString;
 import static org.hamcrest.Matchers.not;
@@ -31,10 +30,6 @@ public class S3SnapshotRepoTestKitIT extends AbstractSnapshotRepoTestKitRestTest
     }
 
     @Override
-    @TestIssueLogging(
-        issueUrl = "https://github.com/elastic/elasticsearch/issues/102294",
-        value = "org.elasticsearch.repositories.s3:TRACE,org.elasticsearch.repositories.blobstore.testkit:TRACE"
-    )
     public void testRepositoryAnalysis() throws Exception {
         super.testRepositoryAnalysis();
     }


### PR DESCRIPTION
Moves the logging added in #102299 onto the test cluster where it
belongs, and adds wire logging to this test suite too.

Relates #102294