### PR TITLE
Fix AsyncOperatorTests#testFailure

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/AsyncOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/AsyncOperator.java
@@ -166,6 +166,7 @@ public abstract class AsyncOperator implements Operator {
 
     @Override
     public boolean isFinished() {
+        checkFailure();
         return finished && checkpoint.getPersistedCheckpoint() == checkpoint.getMaxSeqNo();
     }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/AsyncOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/AsyncOperatorTests.java
@@ -185,7 +185,6 @@ public class AsyncOperatorTests extends ESTestCase {
         operator.close();
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/102264")
     public void testFailure() throws Exception {
         DriverContext driverContext = driverContext();
         final SequenceLongBlockSourceOperator sourceOperator = new SequenceLongBlockSourceOperator(
@@ -226,15 +225,17 @@ public class AsyncOperatorTests extends ESTestCase {
         PlainActionFuture<Void> future = new PlainActionFuture<>();
         Driver driver = new Driver(driverContext, sourceOperator, List.of(asyncOperator), outputOperator, () -> {});
         Driver.start(threadPool.getThreadContext(), threadPool.executor(ESQL_TEST_EXECUTOR), driver, between(1, 1000), future);
-        assertBusy(() -> {
-            assertTrue(asyncOperator.isFinished());
-            assertTrue(future.isDone());
-        });
+        assertBusy(() -> assertTrue(future.isDone()));
         if (failed.get()) {
             ElasticsearchException error = expectThrows(ElasticsearchException.class, future::actionGet);
             assertThat(error.getMessage(), containsString("simulated"));
+            error = expectThrows(ElasticsearchException.class, asyncOperator::isFinished);
+            assertThat(error.getMessage(), containsString("simulated"));
+            error = expectThrows(ElasticsearchException.class, asyncOperator::getOutput);
+            assertThat(error.getMessage(), containsString("simulated"));
         } else {
-            future.actionGet();
+            assertTrue(asyncOperator.isFinished());
+            assertNull(asyncOperator.getOutput());
         }
     }
 


### PR DESCRIPTION
There is a bug in the test where we check the failed flag immediately after the Driver starts, instead of waiting until the Driver has completed. Also, we should check for failure in the AsyncOperator.

Closes #102264