### PR TITLE
Fix references of ESQL enrich lookup requests

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/InboundHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/InboundHandler.java
@@ -263,47 +263,20 @@ public class InboundHandler {
                 assert ignoreDeserializationErrors : e;
                 throw e;
             }
-            boolean success = false;
             try {
                 request.remoteAddress(channel.getRemoteAddress());
                 assert requestId > 0;
                 request.setRequestId(requestId);
                 verifyRequestReadFully(stream, requestId, action);
-                var wrappedChannel = new TransportChannel() {
-                    @Override
-                    public String getProfileName() {
-                        return transportChannel.getProfileName();
-                    }
-
-                    @Override
-                    public String getChannelType() {
-                        return transportChannel.getChannelType();
-                    }
-
-                    @Override
-                    public void sendResponse(TransportResponse response) throws IOException {
-                        transportChannel.sendResponse(response);
-                        request.decRef();
-                    }
-
-                    @Override
-                    public void sendResponse(Exception exception) throws IOException {
-                        request.decRef();
-                        transportChannel.sendResponse(exception);
-                    }
-                };
                 if (reg.getExecutor() == EsExecutors.DIRECT_EXECUTOR_SERVICE) {
                     try (var ignored = threadPool.getThreadContext().newTraceContext()) {
-                        doHandleRequest(reg, request, wrappedChannel);
+                        doHandleRequest(reg, request, transportChannel);
                     }
                 } else {
-                    handleRequestForking(request, reg, wrappedChannel);
+                    handleRequestForking(request, reg, transportChannel);
                 }
-                success = true;
             } finally {
-                if (success == false) {
-                    request.decRef();
-                }
+                request.decRef();
             }
         } catch (Exception e) {
             sendErrorResponse(action, transportChannel, e);
@@ -319,28 +292,42 @@ public class InboundHandler {
     }
 
     private <T extends TransportRequest> void handleRequestForking(T request, RequestHandlerRegistry<T> reg, TransportChannel channel) {
-        reg.getExecutor().execute(threadPool.getThreadContext().preserveContextWithTracing(new AbstractRunnable() {
-            @Override
-            protected void doRun() {
-                doHandleRequest(reg, request, channel);
-            }
+        boolean success = false;
+        request.incRef();
+        try {
+            reg.getExecutor().execute(threadPool.getThreadContext().preserveContextWithTracing(new AbstractRunnable() {
+                @Override
+                protected void doRun() {
+                    doHandleRequest(reg, request, channel);
+                }
 
-            @Override
-            public boolean isForceExecution() {
-                return reg.isForceExecution();
-            }
+                @Override
+                public boolean isForceExecution() {
+                    return reg.isForceExecution();
+                }
 
-            @Override
-            public void onRejection(Exception e) {
-                sendErrorResponse(reg.getAction(), channel, e);
-            }
+                @Override
+                public void onRejection(Exception e) {
+                    sendErrorResponse(reg.getAction(), channel, e);
+                }
 
-            @Override
-            public void onFailure(Exception e) {
-                assert false : e; // shouldn't get here ever, no failures other than rejection by the thread-pool expected
-                sendErrorResponse(reg.getAction(), channel, e);
+                @Override
+                public void onFailure(Exception e) {
+                    assert false : e; // shouldn't get here ever, no failures other than rejection by the thread-pool expected
+                    sendErrorResponse(reg.getAction(), channel, e);
+                }
+
+                @Override
+                public void onAfter() {
+                    request.decRef();
+                }
+            }));
+            success = true;
+        } finally {
+            if (success == false) {
+                request.decRef();
             }
-        }));
+        }
     }
 
     private void handleHandshakeRequest(TcpChannel channel, InboundMessage message) throws IOException {

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EnrichIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EnrichIT.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.action;
 
+import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.client.internal.Client;
@@ -59,6 +60,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
+@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/pull/102184")
 public class EnrichIT extends AbstractEsqlIntegTestCase {
 
     @Override

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EnrichIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EnrichIT.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.esql.action;
 
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.client.internal.Client;
@@ -60,7 +59,6 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/pull/102184")
 public class EnrichIT extends AbstractEsqlIntegTestCase {
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/EnrichLookupService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/EnrichLookupService.java
@@ -335,7 +335,8 @@ public class EnrichLookupService {
     private class TransportHandler implements TransportRequestHandler<LookupRequest> {
         @Override
         public void messageReceived(LookupRequest request, TransportChannel channel, Task task) {
-            ActionListener<LookupResponse> listener = new ChannelActionListener<>(channel);
+            request.incRef();
+            ActionListener<LookupResponse> listener = ActionListener.runBefore(new ChannelActionListener<>(channel), request::decRef);
             doLookup(
                 request.sessionId,
                 (CancellableTask) task,


### PR DESCRIPTION
The EnrichIT suite failed because enrich lookup requests are released while a driver is still executing. While we can extend the lifecycle of the transport requests, this PR extends the lifecycle of enrich lookup requests only to minimize the impact of the fix.