### PR TITLE
Retry CCR assertTotalHitCount on 404

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -1485,8 +1485,9 @@ public abstract class ESRestTestCase extends ESTestCase {
         return runningTasks;
     }
 
-    public static void assertOK(Response response) {
+    public static Response assertOK(Response response) {
         assertThat(response.getStatusLine().getStatusCode(), anyOf(equalTo(200), equalTo(201)));
+        return response;
     }
 
     public static ObjectPath assertOKAndCreateObjectPath(Response response) throws IOException {

--- a/x-pack/qa/rolling-upgrade-multi-cluster/src/test/java/org/elasticsearch/upgrades/CcrRollingUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade-multi-cluster/src/test/java/org/elasticsearch/upgrades/CcrRollingUpgradeIT.java
@@ -88,7 +88,6 @@ public class CcrRollingUpgradeIT extends AbstractMultiClusterUpgradeTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/102000")
     public void testAutoFollowing() throws Exception {
         String leaderIndex1 = "logs-20200101";
         String leaderIndex2 = "logs-20200102";
@@ -372,7 +371,8 @@ public class CcrRollingUpgradeIT extends AbstractMultiClusterUpgradeTestCase {
     private static void verifyTotalHitCount(final String index, final int expectedTotalHits, final RestClient client) throws IOException {
         final Request request = new Request("GET", "/" + index + "/_search");
         request.addParameter(TOTAL_HITS_AS_INT_PARAM, "true");
-        Map<?, ?> response = toMap(client.performRequest(request));
+        request.addParameter("ignore", "404"); // If index not found, trip the assertOK (i.e. retry an assertBusy) rather than throwing
+        Map<?, ?> response = toMap(assertOK(client.performRequest(request)));
         final int totalHits = (int) XContentMapValues.extractValue("hits.total", response);
         assertThat(totalHits, equalTo(expectedTotalHits));
     }


### PR DESCRIPTION
Some CCR tests check for leader/follower sync by performing a search on
the follower, but it's possible the follower index does not even exist
which today receives a 404 that maps onto a `ResponseException`. If we
expect the indices to be in sync already then this should fail the test,
whereas if we are retrying in an `assertBusy()` then this should trigger
a retry. Either way we should map a 404 onto an `AssertionError` rather
than a `ResponseException`. That's what this commit does.

Closes #102000