### PR TITLE
Extract constant for ?ignore pseudo-parameter

### DIFF
--- a/client/rest/src/main/java/org/elasticsearch/client/RestClient.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/RestClient.java
@@ -87,6 +87,7 @@ import javax.net.ssl.SSLHandshakeException;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singletonList;
+import static org.elasticsearch.client.RestClient.IGNORE_RESPONSE_CODES_PARAM;
 
 /**
  * Client that connects to an Elasticsearch cluster through HTTP.
@@ -106,6 +107,9 @@ import static java.util.Collections.singletonList;
  * Requests can be traced by enabling trace logging for "tracer". The trace logger outputs requests and responses in curl format.
  */
 public class RestClient implements Closeable {
+
+    public static final String IGNORE_RESPONSE_CODES_PARAM = "ignore";
+
     private static final Log logger = LogFactory.getLog(RestClient.class);
 
     private final CloseableHttpAsyncClient client;
@@ -780,8 +784,8 @@ public class RestClient implements Closeable {
             this.request = request;
             Map<String, String> params = new HashMap<>(request.getParameters());
             params.putAll(request.getOptions().getParameters());
-            // ignore is a special parameter supported by the clients, shouldn't be sent to es
-            String ignoreString = params.remove("ignore");
+            // IGNORE_RESPONSE_CODES_PARAM is a special parameter supported by the clients, shouldn't be sent to es
+            String ignoreString = params.remove(IGNORE_RESPONSE_CODES_PARAM);
             this.ignoreErrorCodes = getIgnoreErrorCodes(ignoreString, request.getMethod());
             URI uri = buildUri(pathPrefix, request.getEndpoint(), params);
             this.httpRequest = createHttpRequest(request.getMethod(), uri, request.getEntity(), compressionEnabled);

--- a/client/rest/src/test/java/org/elasticsearch/client/RestClientSingleHostTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/RestClientSingleHostTests.java
@@ -275,6 +275,7 @@ public class RestClientSingleHostTests extends RestClientTestCase {
                 try {
                     Request request = new Request(method, "/" + errorStatusCode);
                     if (false == ignoreParam.isEmpty()) {
+                        // literal "ignore" rather than IGNORE_RESPONSE_CODES_PARAM since this is something on which callers might rely
                         request.addParameter("ignore", ignoreParam);
                     }
                     Response response = restClient.performRequest(request);
@@ -568,6 +569,7 @@ public class RestClientSingleHostTests extends RestClientTestCase {
             if (randomBoolean()) {
                 ignore += "," + randomFrom(RestClientTestUtil.getAllErrorStatusCodes());
             }
+            // literal "ignore" rather than IGNORE_RESPONSE_CODES_PARAM since this is something on which callers might rely
             request.addParameter("ignore", ignore);
         }
         URI uri = uriBuilder.build();

--- a/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/restspec/ClientYamlSuiteRestSpec.java
+++ b/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/restspec/ClientYamlSuiteRestSpec.java
@@ -24,6 +24,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import static org.elasticsearch.client.RestClient.IGNORE_RESPONSE_CODES_PARAM;
+
 /**
  * Holds the specification used to turn {@code do} actions in the YAML suite into REST api calls.
  */
@@ -69,7 +71,7 @@ public class ClientYamlSuiteRestSpec {
      * that they influence the client behaviour and don't get sent to Elasticsearch
      */
     public boolean isClientParameter(String name) {
-        return "ignore".equals(name);
+        return IGNORE_RESPONSE_CODES_PARAM.equals(name);
     }
 
     /**

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/PublishableHttpResource.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/http/PublishableHttpResource.java
@@ -27,9 +27,11 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
+import static java.util.stream.Collectors.joining;
+import static org.elasticsearch.client.RestClient.IGNORE_RESPONSE_CODES_PARAM;
 import static org.elasticsearch.core.Strings.format;
+import static org.elasticsearch.rest.RestStatus.NOT_FOUND;
 
 /**
  * {@code PublishableHttpResource} represents an {@link HttpResource} that is a single file or object that can be checked <em>and</em>
@@ -254,7 +256,7 @@ public abstract class PublishableHttpResource extends HttpResource {
 
         // avoid exists and DNE parameters from being an exception by default
         final Set<Integer> expectedResponseCodes = Sets.union(exists, doesNotExist);
-        request.addParameter("ignore", expectedResponseCodes.stream().map(i -> i.toString()).collect(Collectors.joining(",")));
+        request.addParameter(IGNORE_RESPONSE_CODES_PARAM, expectedResponseCodes.stream().map(Object::toString).collect(joining(",")));
 
         client.performRequestAsync(request, new ResponseListener() {
 
@@ -436,9 +438,9 @@ public abstract class PublishableHttpResource extends HttpResource {
         final Request request = new Request("DELETE", resourceBasePath + "/" + resourceName);
         addDefaultParameters(request);
 
-        if (false == defaultParameters.containsKey("ignore")) {
+        if (false == defaultParameters.containsKey(IGNORE_RESPONSE_CODES_PARAM)) {
             // avoid 404 being an exception by default
-            request.addParameter("ignore", Integer.toString(RestStatus.NOT_FOUND.getStatus()));
+            request.addParameter(IGNORE_RESPONSE_CODES_PARAM, Integer.toString(NOT_FOUND.getStatus()));
         }
 
         client.performRequestAsync(request, new ResponseListener() {

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/AbstractPublishableHttpResourceTestCase.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/AbstractPublishableHttpResourceTestCase.java
@@ -30,8 +30,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
+import static java.util.stream.Collectors.joining;
+import static org.elasticsearch.client.RestClient.IGNORE_RESPONSE_CODES_PARAM;
 import static org.elasticsearch.xpack.monitoring.exporter.http.AsyncHttpResourceHelper.mockBooleanActionListener;
 import static org.elasticsearch.xpack.monitoring.exporter.http.AsyncHttpResourceHelper.mockPublishResultActionListener;
 import static org.elasticsearch.xpack.monitoring.exporter.http.AsyncHttpResourceHelper.whenPerformRequestAsyncWith;
@@ -443,7 +444,7 @@ public abstract class AbstractPublishableHttpResourceTestCase extends ESTestCase
         final Set<Integer> statusCodes = Sets.union(exists, doesNotExist);
         final Map<String, String> parametersWithIgnore = new HashMap<>(parameters);
 
-        parametersWithIgnore.putIfAbsent("ignore", statusCodes.stream().map(i -> i.toString()).collect(Collectors.joining(",")));
+        parametersWithIgnore.putIfAbsent(IGNORE_RESPONSE_CODES_PARAM, statusCodes.stream().map(Object::toString).collect(joining(",")));
 
         return parametersWithIgnore;
     }
@@ -451,7 +452,7 @@ public abstract class AbstractPublishableHttpResourceTestCase extends ESTestCase
     protected Map<String, String> deleteParameters(final Map<String, String> parameters) {
         final Map<String, String> parametersWithIgnore = new HashMap<>(parameters);
 
-        parametersWithIgnore.putIfAbsent("ignore", "404");
+        parametersWithIgnore.putIfAbsent(IGNORE_RESPONSE_CODES_PARAM, Integer.toString(RestStatus.NOT_FOUND.getStatus()));
 
         return parametersWithIgnore;
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/test/TestSecurityClient.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/test/TestSecurityClient.java
@@ -25,6 +25,7 @@ import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.xcontent.XContentParserUtils;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Tuple;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xcontent.ObjectPath;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -51,6 +52,7 @@ import java.util.stream.Collectors;
 
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.elasticsearch.test.rest.ESRestTestCase.entityAsMap;
+import static org.elasticsearch.test.rest.ESRestTestCase.setIgnoredErrorResponseCodes;
 
 public class TestSecurityClient {
 
@@ -395,7 +397,7 @@ public class TestSecurityClient {
         final Request request = new Request(HttpDelete.METHOD_NAME, endpoint);
         // This API returns 404 (with the same body as a 200 response) if there's nothing to delete.
         // RestClient will throw an exception on 404, but we don't want that, we want to parse the body and return it
-        request.addParameter("ignore", "404");
+        setIgnoredErrorResponseCodes(request, RestStatus.NOT_FOUND);
         request.setJsonEntity(requestBody);
         final Map<String, Object> responseBody = entityAsMap(execute(request));
         final List<Map<String, ?>> errors = (List<Map<String, ?>>) responseBody.get("error_details");

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
@@ -19,6 +19,7 @@ import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.transform.TransformField;
@@ -618,7 +619,7 @@ public abstract class TransformRestTestCase extends ESRestTestCase {
     protected static void deleteTransform(String transformId, boolean ignoreNotFound, boolean deleteDestIndex) throws IOException {
         Request request = new Request("DELETE", getTransformEndpoint() + transformId);
         if (ignoreNotFound) {
-            request.addParameter("ignore", "404");
+            setIgnoredErrorResponseCodes(request, RestStatus.NOT_FOUND);
         }
         if (deleteDestIndex) {
             request.addParameter(TransformField.DELETE_DEST_INDEX.getPreferredName(), Boolean.TRUE.toString());

--- a/x-pack/qa/rolling-upgrade-basic/src/test/java/org/elasticsearch/upgrades/BasicLicenseUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade-basic/src/test/java/org/elasticsearch/upgrades/BasicLicenseUpgradeIT.java
@@ -8,6 +8,7 @@ package org.elasticsearch.upgrades;
 
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
+import org.elasticsearch.rest.RestStatus;
 
 import java.util.Map;
 
@@ -28,7 +29,7 @@ public class BasicLicenseUpgradeIT extends AbstractUpgradeTestCase {
         final Request request = new Request("GET", "/_license");
         // This avoids throwing a ResponseException when the license is not ready yet
         // allowing to retry the check using assertBusy
-        request.addParameter("ignore", "404");
+        setIgnoredErrorResponseCodes(request, RestStatus.NOT_FOUND);
         Response licenseResponse = client().performRequest(request);
         assertOK(licenseResponse);
         Map<String, Object> licenseResponseMap = entityAsMap(licenseResponse);
@@ -42,7 +43,7 @@ public class BasicLicenseUpgradeIT extends AbstractUpgradeTestCase {
         final Request request = new Request("GET", "/_license");
         // This avoids throwing a ResponseException when the license is not ready yet
         // allowing to retry the check using assertBusy
-        request.addParameter("ignore", "404");
+        setIgnoredErrorResponseCodes(request, RestStatus.NOT_FOUND);
         Response licenseResponse = client().performRequest(request);
         assertOK(licenseResponse);
         Map<String, Object> licenseResponseMap = entityAsMap(licenseResponse);

--- a/x-pack/qa/rolling-upgrade-multi-cluster/src/test/java/org/elasticsearch/upgrades/CcrRollingUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade-multi-cluster/src/test/java/org/elasticsearch/upgrades/CcrRollingUpgradeIT.java
@@ -371,7 +371,7 @@ public class CcrRollingUpgradeIT extends AbstractMultiClusterUpgradeTestCase {
     private static void verifyTotalHitCount(final String index, final int expectedTotalHits, final RestClient client) throws IOException {
         final Request request = new Request("GET", "/" + index + "/_search");
         request.addParameter(TOTAL_HITS_AS_INT_PARAM, "true");
-        request.addParameter("ignore", "404"); // If index not found, trip the assertOK (i.e. retry an assertBusy) rather than throwing
+        setIgnoredErrorResponseCodes(request, RestStatus.NOT_FOUND); // trip the assertOK (i.e. retry an assertBusy) rather than throwing
         Map<?, ?> response = toMap(assertOK(client.performRequest(request)));
         final int totalHits = (int) XContentMapValues.extractValue("hits.total", response);
         assertThat(totalHits, equalTo(expectedTotalHits));


### PR DESCRIPTION
Today `RestClient` interprets an `?ignore=` request parameter as an
indication that certain HTTP response codes should be considered
successful and not raise a `ResponseException`. This commit replaces the
magic literal `"ignore"` with a constant and adds a utility to specify
the ignored codes as `RestStatus` values.