### PR TITLE
Remove exception mangling around LoggingTaskListener

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractBaseReindexRestHandler.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractBaseReindexRestHandler.java
@@ -11,7 +11,7 @@ package org.elasticsearch.reindex;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.ActiveShardCount;
-import org.elasticsearch.action.support.ListenableActionFuture;
+import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.index.reindex.AbstractBulkByScrollRequest;
@@ -64,9 +64,9 @@ public abstract class AbstractBaseReindexRestHandler<
         if (validationException != null) {
             throw validationException;
         }
-        final var responseFuture = new ListenableActionFuture<BulkByScrollResponse>();
-        final var task = client.executeLocally(action, internal, responseFuture);
-        responseFuture.addListener(new LoggingTaskListener<>(task));
+        final var responseListener = new SubscribableListener<BulkByScrollResponse>();
+        final var task = client.executeLocally(action, internal, responseListener);
+        responseListener.addListener(new LoggingTaskListener<>(task));
         return sendTask(client.getLocalNodeId(), task);
     }
 

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestForceMergeAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestForceMergeAction.java
@@ -13,7 +13,7 @@ import org.elasticsearch.action.admin.indices.forcemerge.ForceMergeAction;
 import org.elasticsearch.action.admin.indices.forcemerge.ForceMergeRequest;
 import org.elasticsearch.action.admin.indices.forcemerge.ForceMergeResponse;
 import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.action.support.ListenableActionFuture;
+import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.rest.BaseRestHandler;
@@ -65,9 +65,9 @@ public class RestForceMergeAction extends BaseRestHandler {
             if (validationException != null) {
                 throw validationException;
             }
-            final var responseFuture = new ListenableActionFuture<ForceMergeResponse>();
-            final var task = client.executeLocally(ForceMergeAction.INSTANCE, mergeRequest, responseFuture);
-            responseFuture.addListener(new LoggingTaskListener<>(task));
+            final var responseListener = new SubscribableListener<ForceMergeResponse>();
+            final var task = client.executeLocally(ForceMergeAction.INSTANCE, mergeRequest, responseListener);
+            responseListener.addListener(new LoggingTaskListener<>(task));
             return sendTask(client.getLocalNodeId(), task);
         }
     }

--- a/server/src/main/java/org/elasticsearch/tasks/LoggingTaskListener.java
+++ b/server/src/main/java/org/elasticsearch/tasks/LoggingTaskListener.java
@@ -31,7 +31,6 @@ public final class LoggingTaskListener<Response> implements ActionListener<Respo
     @Override
     public void onResponse(Response response) {
         logger.info("{} finished with response {}", task.getId(), response);
-
     }
 
     @Override


### PR DESCRIPTION
Replaces `ListenableActionFuture` with `SubscribableListener` at both
call sites.