### PR TITLE
Migrate JoinValidationService to TransportVersion

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinValidationService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinValidationService.java
@@ -12,7 +12,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.Version;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.cluster.ClusterState;
@@ -30,6 +30,7 @@ import org.elasticsearch.core.AbstractRefCounted;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.RefCounted;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.core.UpdateForV9;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.node.NodeClosedException;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -148,10 +149,23 @@ public class JoinValidationService {
     }
 
     public void validateJoin(DiscoveryNode discoveryNode, ActionListener<Void> listener) {
-        if (discoveryNode.getVersion().onOrAfter(Version.V_8_3_0)) {
+        // This node isn't in the cluster yet so ClusterState#getMinTransportVersion() doesn't apply, we must obtain a specific connection
+        // so we can check its transport version to decide how to proceed.
+
+        final Transport.Connection connection;
+        try {
+            connection = transportService.getConnection(discoveryNode);
+            assert connection != null;
+        } catch (Exception e) {
+            assert e instanceof NodeNotConnectedException : e;
+            listener.onFailure(e);
+            return;
+        }
+
+        if (connection.getTransportVersion().onOrAfter(TransportVersions.V_8_3_0)) {
             if (executeRefs.tryIncRef()) {
                 try {
-                    execute(new JoinValidation(discoveryNode, listener));
+                    execute(new JoinValidation(discoveryNode, connection, listener));
                 } finally {
                     executeRefs.decRef();
                 }
@@ -159,39 +173,44 @@ public class JoinValidationService {
                 listener.onFailure(new NodeClosedException(transportService.getLocalNode()));
             }
         } else {
-            final var responseHandler = TransportResponseHandler.empty(responseExecutor, listener.delegateResponse((l, e) -> {
-                logger.warn(() -> "failed to validate incoming join request from node [" + discoveryNode + "]", e);
-                listener.onFailure(
-                    new IllegalStateException(
-                        String.format(
-                            Locale.ROOT,
-                            "failure when sending a join validation request from [%s] to [%s]",
-                            transportService.getLocalNode().descriptionWithoutAttributes(),
-                            discoveryNode.descriptionWithoutAttributes()
-                        ),
-                        e
-                    )
-                );
-            }));
-            final var clusterState = clusterStateSupplier.get();
-            if (clusterState != null) {
-                assert clusterState.nodes().isLocalNodeElectedMaster();
-                transportService.sendRequest(
-                    discoveryNode,
-                    JOIN_VALIDATE_ACTION_NAME,
-                    new ValidateJoinRequest(clusterState),
-                    REQUEST_OPTIONS,
-                    responseHandler
-                );
-            } else {
-                transportService.sendRequest(
-                    discoveryNode,
-                    JoinHelper.JOIN_PING_ACTION_NAME,
-                    TransportRequest.Empty.INSTANCE,
-                    REQUEST_OPTIONS,
-                    responseHandler
-                );
-            }
+            legacyValidateJoin(discoveryNode, listener, connection);
+        }
+    }
+
+    @UpdateForV9
+    private void legacyValidateJoin(DiscoveryNode discoveryNode, ActionListener<Void> listener, Transport.Connection connection) {
+        final var responseHandler = TransportResponseHandler.empty(responseExecutor, listener.delegateResponse((l, e) -> {
+            logger.warn(() -> "failed to validate incoming join request from node [" + discoveryNode + "]", e);
+            listener.onFailure(
+                new IllegalStateException(
+                    String.format(
+                        Locale.ROOT,
+                        "failure when sending a join validation request from [%s] to [%s]",
+                        transportService.getLocalNode().descriptionWithoutAttributes(),
+                        discoveryNode.descriptionWithoutAttributes()
+                    ),
+                    e
+                )
+            );
+        }));
+        final var clusterState = clusterStateSupplier.get();
+        if (clusterState != null) {
+            assert clusterState.nodes().isLocalNodeElectedMaster();
+            transportService.sendRequest(
+                connection,
+                JOIN_VALIDATE_ACTION_NAME,
+                new ValidateJoinRequest(clusterState),
+                REQUEST_OPTIONS,
+                responseHandler
+            );
+        } else {
+            transportService.sendRequest(
+                connection,
+                JoinHelper.JOIN_PING_ACTION_NAME,
+                TransportRequest.Empty.INSTANCE,
+                REQUEST_OPTIONS,
+                responseHandler
+            );
         }
     }
 
@@ -312,27 +331,22 @@ public class JoinValidationService {
 
     private class JoinValidation extends ActionRunnable<Void> {
         private final DiscoveryNode discoveryNode;
+        private final Transport.Connection connection;
 
-        JoinValidation(DiscoveryNode discoveryNode, ActionListener<Void> listener) {
+        JoinValidation(DiscoveryNode discoveryNode, Transport.Connection connection, ActionListener<Void> listener) {
             super(listener);
             this.discoveryNode = discoveryNode;
+            this.connection = connection;
         }
 
         @Override
-        protected void doRun() throws Exception {
-            assert discoveryNode.getVersion().onOrAfter(Version.V_8_3_0) : discoveryNode.getVersion();
+        protected void doRun() {
+            assert connection.getTransportVersion().onOrAfter(TransportVersions.V_8_3_0) : discoveryNode.getVersion();
             // NB these things never run concurrently to each other, or to the cache cleaner (see IMPLEMENTATION NOTES above) so it is safe
             // to do these (non-atomic) things to the (unsynchronized) statesByVersion map.
-            Transport.Connection connection;
-            try {
-                connection = transportService.getConnection(discoveryNode);
-            } catch (NodeNotConnectedException e) {
-                listener.onFailure(e);
-                return;
-            }
-            var version = connection.getTransportVersion();
-            var cachedBytes = statesByVersion.get(version);
-            var bytes = maybeSerializeClusterState(cachedBytes, discoveryNode, version);
+            var transportVersion = connection.getTransportVersion();
+            var cachedBytes = statesByVersion.get(transportVersion);
+            var bytes = maybeSerializeClusterState(cachedBytes, discoveryNode, transportVersion);
             if (bytes == null) {
                 // Normally if we're not the master then the Coordinator sends a ping message just to validate connectivity instead of
                 // getting here. But if we were the master when the Coordinator checked then we might not be the master any more, so we
@@ -354,7 +368,7 @@ public class JoinValidationService {
             transportService.sendRequest(
                 connection,
                 JOIN_VALIDATE_ACTION_NAME,
-                new BytesTransportRequest(bytes, version),
+                new BytesTransportRequest(bytes, transportVersion),
                 REQUEST_OPTIONS,
                 new CleanableResponseHandler<>(
                     listener.map(ignored -> null),


### PR DESCRIPTION
We introduced a new join validation protocol in version 8.3, effectively
a different transport protocol. However today we are still checking the
node's release version when deciding which validation protocol to use.
This commit migrates to using the `TransportVersion` of the relevant
connection.