### PR TITLE
Add missing spaces in concatenated strings

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessExecuteAction.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessExecuteAction.java
@@ -437,7 +437,7 @@ public class PainlessExecuteAction {
 
         @Override
         public String toString() {
-            return "Request{" + "script=" + script + "context=" + context + ", contextSetup=" + contextSetup + '}';
+            return "Request{" + "script=" + script + ", context=" + context + ", contextSetup=" + contextSetup + '}';
         }
 
         static boolean needDocumentAndIndex(ScriptContext<?> scriptContext) {

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessExecuteAction.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessExecuteAction.java
@@ -448,7 +448,7 @@ public class PainlessExecuteAction {
 
     public static class Response extends ActionResponse implements ToXContentObject {
 
-        private Object result;
+        private final Object result;
 
         Response(Object result) {
             this.result = result;

--- a/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobStore.java
+++ b/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureBlobStore.java
@@ -542,7 +542,7 @@ public class AzureBlobStore implements BlobStore {
             }
             // This flux is subscribed by a downstream operator that finally queues the
             // buffers into netty output queue. Sadly we are not able to get a signal once
-            // the buffer has been flushed, so we have to allocate those and let the GC to
+            // the buffer has been flushed, so we have to allocate those and let the GC
             // reclaim them (see MonoSendMany). Additionally, that very same operator requests
             // 128 elements (that's hardcoded) once it's subscribed (later on, it requests
             // by 64 elements), that's why we provide 64kb buffers.
@@ -566,7 +566,7 @@ public class AzureBlobStore implements BlobStore {
                 }
                 if (numOfBytesRead == -1 && currentTotalLength.get() < length) {
                     throw new IllegalStateException(
-                        "InputStream provided" + currentTotalLength + " bytes, less than the expected" + length + " bytes"
+                        "InputStream provided " + currentTotalLength + " bytes, less than the expected " + length + " bytes"
                     );
                 }
                 return ByteBuffer.wrap(buffer);

--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobContainer.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobContainer.java
@@ -500,7 +500,7 @@ class S3BlobContainer extends AbstractBlobContainer {
 
             if (bytesCount != blobSize) {
                 throw new IOException(
-                    "Failed to execute multipart upload for [" + blobName + "], expected " + blobSize + "bytes sent but got " + bytesCount
+                    "Failed to execute multipart upload for [" + blobName + "], expected " + blobSize + " bytes sent but got " + bytesCount
                 );
             }
 

--- a/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
@@ -724,7 +724,7 @@ public abstract class TransportReplicationAction<
             }
         }
 
-        protected void responseWithFailure(Exception e) {
+        private void responseWithFailure(Exception e) {
             setPhase(task, "finished");
             onCompletionListener.onFailure(e);
         }
@@ -1183,8 +1183,8 @@ public abstract class TransportReplicationAction<
     }
 
     public static class ReplicaResponse extends ActionResponse implements ReplicationOperation.ReplicaResponse {
-        private long localCheckpoint;
-        private long globalCheckpoint;
+        private final long localCheckpoint;
+        private final long globalCheckpoint;
 
         ReplicaResponse(StreamInput in) throws IOException {
             super(in);

--- a/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/TransportReplicationAction.java
@@ -441,7 +441,7 @@ public abstract class TransportReplicationAction<
                     // it is safe to execute primary phase on relocation target as there are no more in-flight operations where primary
                     // phase is executed on local shard and all subsequent operations are executed on relocation target as primary phase.
                     final ShardRouting primary = primaryShardReference.routingEntry();
-                    assert primary.relocating() : "indexShard is marked as relocated but routing isn't" + primary;
+                    assert primary.relocating() : "indexShard is marked as relocated but routing isn't " + primary;
                     final Writeable.Reader<Response> reader = TransportReplicationAction.this::newResponseInstance;
                     DiscoveryNode relocatingNode = clusterState.nodes().get(primary.relocatingNodeId());
                     transportService.sendRequest(
@@ -1001,7 +1001,7 @@ public abstract class TransportReplicationAction<
         void retry(Exception failure) {
             assert failure != null;
             if (observer.isTimedOut()) {
-                // we running as a last attempt after a timeout has happened. don't retry
+                // running as a last attempt after a timeout has happened. don't retry
                 finishAsFailed(failure);
                 return;
             }
@@ -1305,7 +1305,7 @@ public abstract class TransportReplicationAction<
         private final String targetAllocationID;
         private final long primaryTerm;
         private final R request;
-        // Indicates if this primary shard request originated by a reroute on this local node.
+        // Indicates if this primary shard request originated by a rerouting on this local node.
         private final boolean sentFromLocalReroute;
         // Indicates if this local reroute was initiated by the NodeClient executing a transport action. This
         // is only true if sentFromLocalReroute is true.

--- a/server/src/main/java/org/elasticsearch/cluster/health/ClusterShardHealth.java
+++ b/server/src/main/java/org/elasticsearch/cluster/health/ClusterShardHealth.java
@@ -193,7 +193,7 @@ public final class ClusterShardHealth implements Writeable, ToXContentFragment {
      *
      * An inactive primary shard in an index should cause the cluster health to be RED to make it visible that some of the existing data is
      * unavailable. In case of index creation, snapshot restore or index shrinking, which are unexceptional events in the cluster lifecycle,
-     * cluster health should not turn RED for the time where primaries are still in the initializing state but go to YELLOW instead.
+     * cluster health should not turn RED for the time when primaries are still in the initializing state but go to YELLOW instead.
      * However, in case of exceptional events, for example when the primary shard cannot be assigned to a node or initialization fails at
      * some point, cluster health should still turn RED.
      *
@@ -203,7 +203,7 @@ public final class ClusterShardHealth implements Writeable, ToXContentFragment {
         assert shardRouting.primary() : "cannot invoke on a replica shard: " + shardRouting;
         assert shardRouting.active() == false : "cannot invoke on an active shard: " + shardRouting;
         assert shardRouting.unassignedInfo() != null : "cannot invoke on a shard with no UnassignedInfo: " + shardRouting;
-        assert shardRouting.recoverySource() != null : "cannot invoke on a shard that has no recovery source" + shardRouting;
+        assert shardRouting.recoverySource() != null : "cannot invoke on a shard that has no recovery source: " + shardRouting;
         final UnassignedInfo unassignedInfo = shardRouting.unassignedInfo();
         RecoverySource.Type recoveryType = shardRouting.recoverySource().getType();
         if (unassignedInfo.getLastAllocationStatus() != AllocationStatus.DECIDERS_NO

--- a/server/src/main/java/org/elasticsearch/cluster/routing/ShardRouting.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/ShardRouting.java
@@ -108,27 +108,27 @@ public final class ShardRouting implements Writeable, ToXContentObject {
                 assert currentNodeId == null : state + " shard must not be assigned to a node " + this;
                 assert relocatingNodeId == null : state + " shard must not be relocating to a node " + this;
                 assert unassignedInfo != null : state + " shard must be created with unassigned info " + this;
-                assert recoverySource != null : state + " shard must be created with a recovery source" + this;
-                assert primary ^ recoverySource == PeerRecoverySource.INSTANCE : "replica shards always recover from primary" + this;
+                assert recoverySource != null : state + " shard must be created with a recovery source " + this;
+                assert primary ^ recoverySource == PeerRecoverySource.INSTANCE : "replica shards always recover from primary " + this;
             }
             case INITIALIZING -> {
                 assert currentNodeId != null : state + " shard must be assigned to a node " + this;
                 // relocatingNodeId is not set for initializing shard but set for relocating shard counterpart
                 // unassignedInfo is kept after starting unassigned shard but not present for relocating shard counterpart
-                assert recoverySource != null : state + "shard must be created with a recovery source" + this;
-                assert primary || recoverySource == PeerRecoverySource.INSTANCE : "replica shards always recover from primary" + this;
+                assert recoverySource != null : state + " shard must be created with a recovery source " + this;
+                assert primary || recoverySource == PeerRecoverySource.INSTANCE : "replica shards always recover from primary " + this;
             }
             case STARTED -> {
                 assert currentNodeId != null : state + " shard must be assigned to a node " + this;
                 assert relocatingNodeId == null : state + " shard must not be relocating to a node " + this;
                 assert unassignedInfo == null : state + " shard must be created without unassigned info " + this;
-                assert recoverySource == null : state + " shard must be created without a recovery source" + this;
+                assert recoverySource == null : state + " shard must be created without a recovery source " + this;
             }
             case RELOCATING -> {
                 assert currentNodeId != null : state + " shard must be assigned to a node " + this;
                 assert relocatingNodeId != null : state + " shard must be relocating to a node " + this;
                 assert unassignedInfo == null : state + " shard must be created without unassigned info " + this;
-                assert recoverySource == null : state + " shard must be created without a recovery source" + this;
+                assert recoverySource == null : state + " shard must be created without a recovery source " + this;
             }
         }
         return true;
@@ -221,7 +221,7 @@ public final class ShardRouting implements Writeable, ToXContentObject {
     }
 
     /**
-     * Returns <code>true</code> iff the this shard is currently
+     * Returns <code>true</code> iff the shard is currently
      * {@link ShardRoutingState#STARTED started} or
      * {@link ShardRoutingState#RELOCATING relocating} to another node.
      * Otherwise <code>false</code>
@@ -238,7 +238,7 @@ public final class ShardRouting implements Writeable, ToXContentObject {
     }
 
     /**
-     * Returns <code>true</code> iff the this shard is currently relocating to
+     * Returns <code>true</code> iff the shard is currently relocating to
      * another node. Otherwise <code>false</code>
      *
      * @see ShardRoutingState#RELOCATING
@@ -248,7 +248,7 @@ public final class ShardRouting implements Writeable, ToXContentObject {
     }
 
     /**
-     * Returns <code>true</code> iff this shard is assigned to a node ie. not
+     * Returns <code>true</code> iff this shard is assigned to a node i.e. not
      * {@link ShardRoutingState#UNASSIGNED unassigned}. Otherwise <code>false</code>
      */
     public boolean assignedToNode() {
@@ -674,7 +674,7 @@ public final class ShardRouting implements Writeable, ToXContentObject {
      * returns true if this routing has the same allocation ID as another.
      * <p>
      * Note: if both shard routing has a null as their {@link #allocationId()}, this method returns false as the routing describe
-     * no allocation at all..
+     * no allocation at all.
      **/
     public boolean isSameAllocation(ShardRouting other) {
         boolean b = this.allocationId != null && other.allocationId != null && this.allocationId.getId().equals(other.allocationId.getId());

--- a/server/src/main/java/org/elasticsearch/common/settings/SettingsModule.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/SettingsModule.java
@@ -94,7 +94,7 @@ public class SettingsModule implements Module {
                 for (String word : ("Since elasticsearch 5.x index level settings can NOT be set on the nodes configuration like "
                     + "the elasticsearch.yaml, in system properties or command line arguments."
                     + "In order to upgrade all indices the settings must be updated via the /${index}/_settings API. "
-                    + "Unless all settings are dynamic all indices must be closed in order to apply the upgrade"
+                    + "Unless all settings are dynamic all indices must be closed in order to apply the upgrade. "
                     + "Indices created in the future should use index templates to set default values.").split(" ")) {
                     if (count + word.length() > 85) {
                         builder.append(System.lineSeparator());
@@ -143,7 +143,7 @@ public class SettingsModule implements Module {
 
     /**
      * Registers a new setting. This method should be used by plugins in order to expose any custom settings the plugin defines.
-     * Unless a setting is registered the setting is unusable. If a setting is never the less specified the node will reject
+     * Unless a setting is registered the setting is unusable. If a setting is nevertheless specified the node will reject
      * the setting during startup.
      */
     private void registerSetting(Setting<?> setting) {

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -2430,7 +2430,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
             return RepositoryData.EMPTY;
         }
         try {
-            final String snapshotsIndexBlobName = INDEX_FILE_PREFIX + Long.toString(indexGen);
+            final String snapshotsIndexBlobName = INDEX_FILE_PREFIX + indexGen;
 
             // EMPTY is safe here because RepositoryData#fromXContent calls namedObject
             try (

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -219,7 +219,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
     private static final String VIRTUAL_DATA_BLOB_PREFIX = "v__";
 
     /**
-     * When set to true metadata files are stored in compressed format. This setting doesn’t affect index
+     * When set to true metadata files are stored in compressed format. This setting doesn't affect index
      * files that are already compressed by default. Changing the setting does not invalidate existing files since reads
      * do not observe the setting, instead they examine the file to see if it is compressed or not.
      */
@@ -362,7 +362,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
     /**
      * Flag that is set to {@code true} if this instance is started with {@link #metadata} that has a higher value for
      * {@link RepositoryMetadata#pendingGeneration()} than for {@link RepositoryMetadata#generation()} indicating a full cluster restart
-     * potentially accounting for the the last {@code index-N} write in the cluster state.
+     * potentially accounting for the last {@code index-N} write in the cluster state.
      * Note: While it is true that this value could also be set to {@code true} for an instance on a node that is just joining the cluster
      * during a new {@code index-N} write, this does not present a problem. The node will still load the correct {@link RepositoryData} in
      * all cases and simply do a redundant listing of the repository contents if it tries to load {@link RepositoryData} and falls back
@@ -1003,7 +1003,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
          *
          * @param indexId       Index that the snapshot was removed from
          * @param shardId       Shard id that the snapshot was removed from
-         * @param newGeneration Id of the new index-${uuid} blob that does not include the snapshot any more
+         * @param newGeneration Id of the new index-${uuid} blob that does not include the snapshot anymore
          * @param blobsToDelete Blob names in the shard directory that have become unreferenced in the new shard generation
          */
         private record ShardSnapshotMetaDeleteResult(
@@ -1269,7 +1269,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 /**
                  * Delete snapshot from shard level metadata.
                  *
-                 * @param indexGeneration generation to write the new shard level level metadata to. If negative a uuid id shard generation
+                 * @param indexGeneration generation to write the new shard level metadata to. If negative a uuid id shard generation
                  *                        should be used
                  */
                 private ShardSnapshotMetaDeleteResult deleteFromShardSnapshotMeta(
@@ -1508,7 +1508,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                     try {
                         return newRepositoryData.getGenId() > Long.parseLong(blob.substring(INDEX_FILE_PREFIX.length()));
                     } catch (NumberFormatException nfe) {
-                        // odd case of an extra file with the index- prefix that we can't identify
+                        // odd case of an extra file with the "index-" prefix that we can't identify
                         return false;
                     }
                 }
@@ -1810,7 +1810,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
             } catch (NoSuchFileException ex) {
                 failure = new SnapshotMissingException(metadata.name(), snapshotId, ex);
             } catch (IOException | NotXContentException ex) {
-                failure = new SnapshotException(metadata.name(), snapshotId, "failed to get snapshot info" + snapshotId, ex);
+                failure = new SnapshotException(metadata.name(), snapshotId, "failed to get snapshot info " + snapshotId, ex);
             } catch (Exception e) {
                 failure = e instanceof SnapshotException
                     ? e
@@ -2188,7 +2188,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
     }
 
     private ClusterState getClusterStateWithUpdatedRepositoryGeneration(ClusterState currentState, RepositoryData repoData) {
-        // In theory we might have failed over to a different master which initialized the repo and then failed back to this node, so we
+        // In theory, we might have failed over to a different master which initialized the repo and then failed back to this node, so we
         // must check the repository generation in the cluster state is still unknown here.
         final RepositoryMetadata repoMetadata = getRepoMetadata(currentState);
         if (repoMetadata.generation() != RepositoryData.UNKNOWN_REPO_GEN) {
@@ -2900,7 +2900,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
             // and because the index.latest blob will never be deleted and re-written.
             return listBlobsToGetLatestIndexId();
         } catch (UnsupportedOperationException e) {
-            // If its a read-only repository, listing blobs by prefix may not be supported (e.g. a URL repository),
+            // If it's a read-only repository, listing blobs by prefix may not be supported (e.g. a URL repository),
             // in this case, try reading the latest index generation from the index.latest blob
             try {
                 return readSnapshotIndexLatestBlob();
@@ -2942,7 +2942,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 latest = Math.max(latest, curr);
             } catch (NumberFormatException nfe) {
                 // the index- blob wasn't of the format index-N where N is a number,
-                // no idea what this blob is but it doesn't belong in the repository!
+                // no idea what this blob is, but it doesn't belong in the repository!
                 logger.warn("[{}] Unknown blob in the repository: {}", metadata.name(), blobName);
             }
         }
@@ -3767,7 +3767,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
     }
 
     /**
-     * @return whether this repository performs overwrites atomically. In practice we only overwrite the `index.latest` blob so this
+     * @return whether this repository performs overwrites atomically. In practice, we only overwrite the `index.latest` blob so this
      * is not very important, but the repository analyzer does test that overwrites happen atomically. It will skip those tests if the
      * repository overrides this method to indicate that it does not support atomic overwrites.
      */

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/RareTermsAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/RareTermsAggregationBuilder.java
@@ -140,7 +140,7 @@ public class RareTermsAggregationBuilder extends ValuesSourceAggregationBuilder<
         // TODO review: what size cap should we put on this?
         if (maxDocCount > MAX_MAX_DOC_COUNT) {
             throw new IllegalArgumentException(
-                "[" + MAX_DOC_COUNT_FIELD_NAME.getPreferredName() + "] must be smaller" + "than " + MAX_MAX_DOC_COUNT + "in [" + name + "]"
+                "[" + MAX_DOC_COUNT_FIELD_NAME.getPreferredName() + "] must be smaller than " + MAX_MAX_DOC_COUNT + " in [" + name + "]"
             );
         }
         this.maxDocCount = (int) maxDocCount;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/SerialDiffPipelineAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/SerialDiffPipelineAggregationBuilder.java
@@ -150,7 +150,7 @@ public class SerialDiffPipelineAggregationBuilder extends AbstractPipelineAggreg
                     if (lag <= 0) {
                         throw new ParsingException(
                             parser.getTokenLocation(),
-                            "Lag must be a positive, non-zero integer.  Value supplied was"
+                            "Lag must be a positive, non-zero integer. Value supplied was "
                                 + lag
                                 + " in ["
                                 + reducerName

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/SerialDiffPipelineAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/SerialDiffPipelineAggregationBuilder.java
@@ -172,7 +172,7 @@ public class SerialDiffPipelineAggregationBuilder extends AbstractPipelineAggreg
                         String path = parser.text();
                         paths.add(path);
                     }
-                    bucketsPaths = paths.toArray(new String[paths.size()]);
+                    bucketsPaths = paths.toArray(new String[0]);
                 } else {
                     throw new ParsingException(
                         parser.getTokenLocation(),

--- a/test/framework/src/main/java/org/elasticsearch/test/ClusterServiceUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ClusterServiceUtils.java
@@ -96,7 +96,7 @@ public class ClusterServiceUtils {
 
             @Override
             public void onFailure(Exception e) {
-                fail("unexpected exception" + e);
+                fail("unexpected exception " + e);
             }
         });
         try {

--- a/test/logger-usage/src/main/java/org/elasticsearch/test/loggerusage/ESLoggerUsageChecker.java
+++ b/test/logger-usage/src/main/java/org/elasticsearch/test/loggerusage/ESLoggerUsageChecker.java
@@ -295,7 +295,7 @@ public class ESLoggerUsageChecker {
                                             throw new IllegalStateException(
                                                 "Constructor invoked on "
                                                     + objectType
-                                                    + " that is not supported by logger usage checker"
+                                                    + " that is not supported by logger usage checker "
                                                     + new WrongLoggerUsage(
                                                         className,
                                                         methodNode.name,

--- a/test/logger-usage/src/main/java/org/elasticsearch/test/loggerusage/ESLoggerUsageChecker.java
+++ b/test/logger-usage/src/main/java/org/elasticsearch/test/loggerusage/ESLoggerUsageChecker.java
@@ -116,7 +116,7 @@ public class ESLoggerUsageChecker {
          */
         public String getErrorLines() {
             String fullClassName = Type.getObjectType(className).getClassName();
-            String simpleClassName = fullClassName.substring(fullClassName.lastIndexOf(".") + 1, fullClassName.length());
+            String simpleClassName = fullClassName.substring(fullClassName.lastIndexOf(".") + 1);
             int innerClassIndex = simpleClassName.indexOf("$");
             if (innerClassIndex > 0) {
                 simpleClassName = simpleClassName.substring(0, innerClassIndex);

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/index/engine/FollowingEngineAssertions.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/index/engine/FollowingEngineAssertions.java
@@ -25,7 +25,7 @@ final class FollowingEngineAssertions {
          */
         assert operation.seqNo() != SequenceNumbers.UNASSIGNED_SEQ_NO;
         assert (operation.origin() == Engine.Operation.Origin.PRIMARY) == (operation.versionType() == VersionType.EXTERNAL)
-            : "invalid version_type in a following engine; version_type=" + operation.versionType() + "origin=" + operation.origin();
+            : "invalid version_type in a following engine: version_type=" + operation.versionType() + ", origin=" + operation.origin();
         return true;
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/RealmSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/RealmSettings.java
@@ -60,7 +60,7 @@ public class RealmSettings {
                         + v
                         + "] for ["
                         + key
-                        + "]. Fixed-string suffix must begin with a letter and followed by either letters or digits and"
+                        + "]. Fixed-string suffix must begin with a letter and followed by either letters or digits and "
                         + "the total length must be between 1 and 10 characters (inclusive)."
                 );
             }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/RealmSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/RealmSettings.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Function;
@@ -214,14 +215,12 @@ public class RealmSettings {
         }
         // verify that domain assignment does not refer to unknown realms
         if (false == unknownRealms.isEmpty()) {
-            final StringBuilder undefinedRealmsErrorMessageBuilder = new StringBuilder("Undefined realms ").append(unknownRealms)
-                .append(" cannot be assigned to domains");
-            throw new IllegalArgumentException(undefinedRealmsErrorMessageBuilder.toString());
+            throw new IllegalArgumentException("Undefined realms " + unknownRealms + " cannot be assigned to domains");
         }
         return realmToDomainsMap.entrySet()
             .stream()
             .map(e -> Map.entry(e.getKey(), e.getValue().stream().findAny().get()))
-            .collect(Collectors.toUnmodifiableMap(e -> e.getKey(), e -> e.getValue()));
+            .collect(Collectors.toUnmodifiableMap(Entry::getKey, Entry::getValue));
     }
 
     /**

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/PolicyStepsRegistry.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/PolicyStepsRegistry.java
@@ -42,7 +42,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -268,16 +267,7 @@ public class PolicyStepsRegistry {
             String phaseDefNonNull = Objects.requireNonNullElse(phaseDef, InitializePolicyContextStep.INITIALIZATION_PHASE);
             return parseStepsFromPhase(policy, currentPhase, phaseDefNonNull).stream().map(Step::getKey).collect(Collectors.toSet());
         } catch (IOException e) {
-            logger.trace(
-                () -> String.format(
-                    Locale.ROOT,
-                    "unable to parse steps for policy [{}], phase [{}], and phase definition [{}]",
-                    policy,
-                    currentPhase,
-                    phaseDef
-                ),
-                e
-            );
+            logger.trace("unable to parse steps for policy [{}], phase [{}], and phase definition [{}]", policy, currentPhase, phaseDef, e);
             return null;
         }
     }

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/PolicyStepsRegistry.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/PolicyStepsRegistry.java
@@ -208,7 +208,7 @@ public class PolicyStepsRegistry {
         final String policyName = indexMetadata.getLifecyclePolicyName();
         final LifecyclePolicyMetadata policyMetadata = lifecyclePolicyMap.get(policyName);
         if (policyMetadata == null) {
-            throw new IllegalArgumentException("the policy [" + policyName + "] for index" + index + " does not exist");
+            throw new IllegalArgumentException("the policy [" + policyName + "] for index " + index + " does not exist");
         }
         final LifecyclePolicySecurityClient policyClient = new LifecyclePolicySecurityClient(
             client,
@@ -248,7 +248,7 @@ public class PolicyStepsRegistry {
     /*
      * Parses the step keys from the {@code phaseDef} for the given phase.
      * ILM makes use of some implicit steps that belong to actions that we automatically inject
-     * (eg. unfollow and migrate) or special purpose steps like the phase `complete` step.
+     * (e.g. unfollow and migrate) or special purpose steps like the phase `complete` step.
      *
      * The {@code phaseDef} is *mostly* a valid json we store in the lifecycle execution state. However,
      * we have a few of exceptional cases:

--- a/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateDoubleMetricFieldMapper.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateDoubleMetricFieldMapper.java
@@ -154,7 +154,7 @@ public class AggregateDoubleMetricFieldMapper extends FieldMapper {
             try {
                 return Metric.valueOf(o.toString());
             } catch (IllegalArgumentException e) {
-                throw new IllegalArgumentException("Metric [" + o.toString() + "] is not supported.", e);
+                throw new IllegalArgumentException("Metric [" + o + "] is not supported.", e);
             }
         }, m -> toType(m).defaultMetric, XContentBuilder::field, Objects::toString);
 

--- a/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateDoubleMetricFieldMapper.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateDoubleMetricFieldMapper.java
@@ -241,7 +241,7 @@ public class AggregateDoubleMetricFieldMapper extends FieldMapper {
             EnumMap<Metric, NumberFieldMapper.NumberFieldType> metricFields = metricMappers.entrySet()
                 .stream()
                 .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().fieldType(), (l, r) -> {
-                    throw new IllegalArgumentException("Duplicate keys " + l + "and " + r + ".");
+                    throw new IllegalArgumentException("Duplicate keys " + l + " and " + r + ".");
                 }, () -> new EnumMap<>(Metric.class)));
 
             AggregateDoubleMetricFieldType metricFieldType = new AggregateDoubleMetricFieldType(
@@ -599,7 +599,7 @@ public class AggregateDoubleMetricFieldMapper extends FieldMapper {
 
                 token = subParser.nextToken();
                 // Make sure that the value is a number. Probably this will change when
-                // new aggregate metric types are added (histogram, cardinality etc)
+                // new aggregate metric types are added (histogram, cardinality, etc.)
                 ensureExpectedToken(XContentParser.Token.VALUE_NUMBER, token, subParser);
                 NumberFieldMapper delegateFieldMapper = metricFieldMappers.get(metric);
                 // Delegate parsing the field to a numeric field mapper

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportKillProcessAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportKillProcessAction.java
@@ -119,7 +119,7 @@ public class TransportKillProcessAction extends TransportTasksAction<
         if (jobTasks.stream().allMatch(t -> nodes.get(t.getExecutorNode()) == null)) {
             listener.onFailure(
                 ExceptionsHelper.conflictStatusException(
-                    "Cannot kill process for job {} as" + "executor node {} cannot be found",
+                    "Cannot kill process for job {} as executor node {} cannot be found",
                     request.getJobId(),
                     jobTasks.get(0).getExecutorNode()
                 )

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectAuthenticator.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectAuthenticator.java
@@ -206,7 +206,7 @@ public class OpenIdConnectAuthenticator {
                 ErrorObject error = ((AuthenticationErrorResponse) authenticationResponse).getErrorObject();
                 listener.onFailure(
                     new ElasticsearchSecurityException(
-                        "OpenID Connect Provider response indicates authentication failure" + "Code=[{}], Description=[{}]",
+                        "OpenID Connect Provider response indicates authentication failure Code=[{}], Description=[{}]",
                         error.getCode(),
                         error.getDescription()
                     )
@@ -480,15 +480,13 @@ public class OpenIdConnectAuthenticator {
                 } else if (ContentType.parse(contentHeader.getValue()).getMimeType().equals("application/jwt")) {
                     // TODO Handle validating possibly signed responses
                     claimsListener.onFailure(
-                        new IllegalStateException(
-                            "Unable to parse Userinfo Response. Signed/encrypted JWTs are" + "not currently supported"
-                        )
+                        new IllegalStateException("Unable to parse Userinfo Response. Signed/encrypted JWTs are not currently supported")
                     );
                 } else {
                     claimsListener.onFailure(
                         new IllegalStateException(
                             "Unable to parse Userinfo Response. Content type was expected to "
-                                + "be [application/json] or [appliation/jwt] but was ["
+                                + "be [application/json] or [application/jwt] but was ["
                                 + contentHeader.getValue()
                                 + "]"
                         )

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectAuthenticator.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectAuthenticator.java
@@ -140,7 +140,7 @@ public class OpenIdConnectAuthenticator {
     private final OpenIdConnectProviderConfiguration opConfig;
     private final RelyingPartyConfiguration rpConfig;
     private final SSLService sslService;
-    private AtomicReference<IDTokenValidator> idTokenValidator = new AtomicReference<>();
+    private final AtomicReference<IDTokenValidator> idTokenValidator = new AtomicReference<>();
     private final CloseableHttpAsyncClient httpClient;
     private final ResourceWatcherService watcherService;
 
@@ -417,7 +417,7 @@ public class OpenIdConnectAuthenticator {
             final HttpGet httpGet = new HttpGet(opConfig.getUserinfoEndpoint());
             httpGet.setHeader("Authorization", "Bearer " + accessToken.getValue());
             AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                httpClient.execute(httpGet, new FutureCallback<HttpResponse>() {
+                httpClient.execute(httpGet, new FutureCallback<>() {
                     @Override
                     public void completed(HttpResponse result) {
                         handleUserinfoResponse(result, verifiedIdTokenClaims, claimsListener);
@@ -589,7 +589,7 @@ public class OpenIdConnectAuthenticator {
             SpecialPermission.check();
             AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
 
-                httpClient.execute(httpPost, new FutureCallback<HttpResponse>() {
+                httpClient.execute(httpPost, new FutureCallback<>() {
                     @Override
                     public void completed(HttpResponse result) {
                         handleTokenResponse(result, tokensListener);
@@ -980,7 +980,7 @@ public class OpenIdConnectAuthenticator {
             try {
                 final HttpGet httpGet = new HttpGet(jwkSetPath.toURI());
                 AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                    httpClient.execute(httpGet, new FutureCallback<HttpResponse>() {
+                    httpClient.execute(httpGet, new FutureCallback<>() {
                         @Override
                         public void completed(HttpResponse result) {
                             try {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectRealm.java
@@ -188,7 +188,7 @@ public class OpenIdConnectRealm extends Realm implements Releasable {
         final String principal = principalAttribute.getClaimValue(claims);
         if (Strings.isNullOrEmpty(principal)) {
             authResultListener.onResponse(
-                AuthenticationResult.unsuccessful(principalAttribute + "not found in " + claims.toJSONObject(), null)
+                AuthenticationResult.unsuccessful(principalAttribute + " not found in " + claims.toJSONObject(), null)
             );
             return;
         }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectRealm.java
@@ -251,7 +251,7 @@ public class OpenIdConnectRealm extends Realm implements Releasable {
         }
         final ClientID clientId = new ClientID(require(config, RP_CLIENT_ID));
         final SecureString clientSecret = config.getSetting(RP_CLIENT_SECRET);
-        if (clientSecret.length() == 0) {
+        if (clientSecret.isEmpty()) {
             throw new SettingsException(
                 "The configuration setting [" + RealmSettings.getFullSettingKey(config, RP_CLIENT_SECRET) + "] is required"
             );

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlObjectHandler.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlObjectHandler.java
@@ -247,7 +247,7 @@ public class SamlObjectHandler {
     private ElasticsearchSecurityException samlSignatureException(List<Credential> credentials, String signature, Exception cause) {
         logger.warn(
             "The XML Signature of this SAML message cannot be validated. Please verify that the saml realm uses the correct SAML"
-                + "metadata file/URL for this Identity Provider"
+                + " metadata file/URL for this Identity Provider"
         );
         final String msg = "SAML Signature [{}] could not be validated against [{}]";
         return samlException(msg, cause, signature, describeCredentials(credentials));
@@ -256,7 +256,7 @@ public class SamlObjectHandler {
     private ElasticsearchSecurityException samlSignatureException(List<Credential> credentials, String signature) {
         logger.warn(
             "The XML Signature of this SAML message cannot be validated. Please verify that the saml realm uses the correct SAML"
-                + "metadata file/URL for this Identity Provider"
+                + " metadata file/URL for this Identity Provider"
         );
         final String msg = "SAML Signature [{}] could not be validated against [{}]";
         return samlException(msg, signature, describeCredentials(credentials));

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlRealm.java
@@ -569,7 +569,7 @@ public final class SamlRealm extends Realm implements Releasable {
         final String principal = resolveSingleValueAttribute(attributes, principalAttribute, PRINCIPAL_ATTRIBUTE.name(config));
         if (Strings.isNullOrEmpty(principal)) {
             final String msg = principalAttribute
-                + " not found in saml attributes"
+                + " not found in SAML attributes "
                 + attributes.attributes()
                 + " or NameID ["
                 + attributes.name()
@@ -824,7 +824,7 @@ public final class SamlRealm extends Realm implements Releasable {
         if (descriptor == null) {
             /*
              * If the descriptor is null, we haven't found a metadata file with that entity id in it. This could be caused by 2 things:
-             * 1. We didn't find any metadata file (e.g. the metadata is loaded over http, and the request returned an error
+             * 1. We didn't find any metadata file (e.g. the metadata is loaded over http, and the request returned an error)
              * 2. The file does exist, but doesn't contain the entity.
              * In either case it's worth refreshing the metadata again to see if it's now correct because it's possible that the problem
              *    has been resolved (although if metadata is loaded from a local file we monitor it for changes anyway, so this refresh

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlRealm.java
@@ -239,7 +239,7 @@ public final class SamlRealm extends Realm implements Releasable {
         );
 
         // the metadata resolver needs to be destroyed since it runs a timer task in the background and destroying stops it!
-        realm.releasables.add(() -> metadataResolver.destroy());
+        realm.releasables.add(metadataResolver::destroy);
 
         return realm;
     }
@@ -618,7 +618,7 @@ public final class SamlRealm extends Realm implements Releasable {
         UserRoleMapper.UserData userData = new UserRoleMapper.UserData(principal, dn, groups, userMeta, config);
         logger.debug("SAML attribute mapping = [{}]", userData);
         roleMapper.resolveRoles(userData, wrappedListener.delegateFailureAndWrap((l, roles) -> {
-            final User user = new User(principal, roles.toArray(new String[roles.size()]), name, mail, userMeta, true);
+            final User user = new User(principal, roles.toArray(new String[0]), name, mail, userMeta, true);
             logger.debug("SAML user = [{}]", user);
             l.onResponse(AuthenticationResult.success(user));
         }));
@@ -748,7 +748,7 @@ public final class SamlRealm extends Realm implements Releasable {
         protected byte[] fetchMetadata() throws ResolverException {
             try {
                 return AccessController.doPrivileged(
-                    (PrivilegedExceptionAction<byte[]>) () -> PrivilegedHTTPMetadataResolver.super.fetchMetadata()
+                    (PrivilegedExceptionAction<byte[]>) PrivilegedHTTPMetadataResolver.super::fetchMetadata
                 );
             } catch (final PrivilegedActionException e) {
                 throw (ResolverException) e.getCause();

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/enrollment/ExternalEnrollmentTokenGenerator.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/enrollment/ExternalEnrollmentTokenGenerator.java
@@ -46,7 +46,7 @@ public class ExternalEnrollmentTokenGenerator extends BaseEnrollmentTokenGenerat
     private final SSLService sslService;
     private final CommandLineHttpClient client;
 
-    public ExternalEnrollmentTokenGenerator(Environment environment) throws MalformedURLException {
+    public ExternalEnrollmentTokenGenerator(Environment environment) {
         this(environment, new CommandLineHttpClient(environment));
     }
 
@@ -138,9 +138,7 @@ public class ExternalEnrollmentTokenGenerator extends BaseEnrollmentTokenGenerat
         final int httpCode = httpResponseApiKey.getHttpStatus();
 
         if (httpCode != HttpURLConnection.HTTP_OK) {
-            logger.error(
-                "Error " + httpCode + " when calling GET " + createApiKeyUrl + ". ResponseBody: " + httpResponseApiKey.getResponseBody()
-            );
+            logger.error("Error {} when calling POST {}. ResponseBody: {}", httpCode, createApiKeyUrl, httpResponseApiKey.getResponseBody());
             throw new IllegalStateException("Unexpected response code [" + httpCode + "] from calling POST " + createApiKeyUrl);
         }
 
@@ -158,19 +156,16 @@ public class ExternalEnrollmentTokenGenerator extends BaseEnrollmentTokenGenerat
         final int httpCode = httpResponseHttp.getHttpStatus();
 
         if (httpCode != HttpURLConnection.HTTP_OK) {
-            logger.error(
-                "Error " + httpCode + " when calling GET " + httpInfoUrl + ". ResponseBody: " + httpResponseHttp.getResponseBody()
-            );
+            logger.error("Error {} when calling GET {}. ResponseBody: {}", httpCode, httpInfoUrl, httpResponseHttp.getResponseBody());
             throw new IllegalStateException("Unexpected response code [" + httpCode + "] from calling GET " + httpInfoUrl);
         }
 
         final List<String> addresses = getBoundAddresses(httpResponseHttp.getResponseBody());
         if (addresses.isEmpty()) {
             logger.error(
-                "No bound addresses found in response from calling GET "
-                    + httpInfoUrl
-                    + ". ResponseBody: "
-                    + httpResponseHttp.getResponseBody()
+                "No bound addresses found in response from calling GET {}. ResponseBody: {}",
+                httpInfoUrl,
+                httpResponseHttp.getResponseBody()
             );
             throw new IllegalStateException("No bound addresses found in response from calling GET " + httpInfoUrl);
         }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/enrollment/ExternalEnrollmentTokenGenerator.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/enrollment/ExternalEnrollmentTokenGenerator.java
@@ -140,7 +140,7 @@ public class ExternalEnrollmentTokenGenerator extends BaseEnrollmentTokenGenerat
 
         if (httpCode != HttpURLConnection.HTTP_OK) {
             logger.error(
-                "Error " + httpCode + "when calling GET " + createApiKeyUrl + ". ResponseBody: " + httpResponseApiKey.getResponseBody()
+                "Error " + httpCode + " when calling GET " + createApiKeyUrl + ". ResponseBody: " + httpResponseApiKey.getResponseBody()
             );
             throw new IllegalStateException("Unexpected response code [" + httpCode + "] from calling POST " + createApiKeyUrl);
         }
@@ -159,7 +159,9 @@ public class ExternalEnrollmentTokenGenerator extends BaseEnrollmentTokenGenerat
         final int httpCode = httpResponseHttp.getHttpStatus();
 
         if (httpCode != HttpURLConnection.HTTP_OK) {
-            logger.error("Error " + httpCode + "when calling GET " + httpInfoUrl + ". ResponseBody: " + httpResponseHttp.getResponseBody());
+            logger.error(
+                "Error " + httpCode + " when calling GET " + httpInfoUrl + ". ResponseBody: " + httpResponseHttp.getResponseBody()
+            );
             throw new IllegalStateException("Unexpected response code [" + httpCode + "] from calling GET " + httpInfoUrl);
         }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/enrollment/ExternalEnrollmentTokenGenerator.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/enrollment/ExternalEnrollmentTokenGenerator.java
@@ -100,8 +100,7 @@ public class ExternalEnrollmentTokenGenerator extends BaseEnrollmentTokenGenerat
         nodesInfo = (Map<?, ?>) nodesInfo.get("nodes");
         Map<?, ?> nodeInfo = (Map<?, ?>) nodesInfo.values().iterator().next();
         Map<?, ?> http = (Map<?, ?>) nodeInfo.get("http");
-        final List<String> addresses = new ArrayList<>();
-        addresses.addAll((Collection<? extends String>) http.get("bound_address"));
+        final List<String> addresses = new ArrayList<>((Collection<? extends String>) http.get("bound_address"));
         addresses.add(getIpFromPublishAddress((String) http.get("publish_address")));
         return addresses;
     }
@@ -166,7 +165,7 @@ public class ExternalEnrollmentTokenGenerator extends BaseEnrollmentTokenGenerat
         }
 
         final List<String> addresses = getBoundAddresses(httpResponseHttp.getResponseBody());
-        if (addresses == null || addresses.isEmpty()) {
+        if (addresses.isEmpty()) {
             logger.error(
                 "No bound addresses found in response from calling GET "
                     + httpInfoUrl

--- a/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/JdbcDatabaseMetaData.java
+++ b/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/JdbcDatabaseMetaData.java
@@ -221,10 +221,10 @@ class JdbcDatabaseMetaData implements DatabaseMetaData, JdbcWrapper {
     @Override
     public String getTimeDateFunctions() throws SQLException {
         // https://docs.microsoft.com/en-us/sql/odbc/reference/appendixes/time-date-and-interval-functions?view=sql-server-2017
-        return "DAYNAME,DAYOFMONTH,DAYOFWEEK,DAYOFYEAR"
+        return "DAYNAME,DAYOFMONTH,DAYOFWEEK,DAYOFYEAR,"
             + "EXTRACT,"
             + "HOUR,"
-            + "MINUTE,MONTH,MONTHNAME"
+            + "MINUTE,MONTH,MONTHNAME,"
             + "QUARTER,"
             + "SECOND,"
             + "WEEK,"
@@ -783,7 +783,7 @@ class JdbcDatabaseMetaData implements DatabaseMetaData, JdbcWrapper {
     public ResultSet getColumns(String catalog, String schemaPattern, String tableNamePattern, String columnNamePattern)
         throws SQLException {
         PreparedStatement ps = con.prepareStatement("SYS COLUMNS CATALOG ? TABLE LIKE ? ESCAPE '\\' LIKE ? ESCAPE '\\'");
-        // NB: catalog is not a pattern hence why null is send instead
+        // NB: catalog is not a pattern hence why null is sent instead
         ps.setString(1, catalog != null ? catalog.trim() : null);
         ps.setString(2, tableNamePattern != null ? tableNamePattern.trim() : WILDCARD);
         ps.setString(3, columnNamePattern != null ? columnNamePattern.trim() : WILDCARD);

--- a/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/JdbcDatabaseMetaData.java
+++ b/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/JdbcDatabaseMetaData.java
@@ -1213,7 +1213,7 @@ class JdbcDatabaseMetaData implements DatabaseMetaData, JdbcWrapper {
         for (int i = 0; i < data.length; i++) {
             data[i] = new Object[4];
             data[i][0] = info[i].name;
-            data[i][1] = Integer.valueOf(-1);
+            data[i][1] = -1;
             data[i][2] = EMPTY;
             data[i][3] = EMPTY;
         }

--- a/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/TypeUtils.java
+++ b/x-pack/plugin/sql/jdbc/src/main/java/org/elasticsearch/xpack/sql/jdbc/TypeUtils.java
@@ -135,7 +135,7 @@ final class TypeUtils {
 
     static SQLType asSqlType(int sqlType) throws SQLException {
         for (JDBCType jdbcType : JDBCType.class.getEnumConstants()) {
-            if (sqlType == jdbcType.getVendorTypeNumber().intValue()) {
+            if (sqlType == jdbcType.getVendorTypeNumber()) {
                 return jdbcType;
             }
         }
@@ -147,7 +147,7 @@ final class TypeUtils {
         if (sqlType instanceof EsType) {
             return (EsType) sqlType;
         }
-        EsType dataType = SQL_TO_TYPE.get(Integer.valueOf(sqlType.getVendorTypeNumber()));
+        EsType dataType = SQL_TO_TYPE.get(sqlType.getVendorTypeNumber());
         if (dataType == null) {
             throw new SQLFeatureNotSupportedException("Unsupported SQL type [" + sqlType + "]");
         }
@@ -155,7 +155,7 @@ final class TypeUtils {
     }
 
     static EsType of(int sqlType) throws SQLException {
-        EsType dataType = SQL_TO_TYPE.get(Integer.valueOf(sqlType));
+        EsType dataType = SQL_TO_TYPE.get(sqlType);
         if (dataType == null) {
             throw new SQLFeatureNotSupportedException("Unsupported SQL type [" + sqlType + "]");
         }
@@ -184,7 +184,7 @@ final class TypeUtils {
         return dataType == EsType.KEYWORD || dataType == EsType.TEXT;
     }
 
-    static EsType of(Class<? extends Object> clazz) throws SQLException {
+    static EsType of(Class<?> clazz) throws SQLException {
         EsType dataType = CLASS_TO_TYPE.get(clazz);
 
         if (dataType == null) {

--- a/x-pack/plugin/sql/jdbc/src/test/java/org/elasticsearch/xpack/sql/jdbc/JdbcDatabaseMetaDataTests.java
+++ b/x-pack/plugin/sql/jdbc/src/test/java/org/elasticsearch/xpack/sql/jdbc/JdbcDatabaseMetaDataTests.java
@@ -12,7 +12,9 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.List;
 import java.util.Properties;
+import java.util.Set;
 
 public class JdbcDatabaseMetaDataTests extends ESTestCase {
 
@@ -98,6 +100,22 @@ public class JdbcDatabaseMetaDataTests extends ESTestCase {
         testEmptySet(() -> md.getFunctions(null, null, null));
     }
 
+    public void testGetNumericFunctions() throws Exception {
+        assertEquals(23, countValues(md.getNumericFunctions()));
+    }
+
+    public void testGetStringFunctions() throws Exception {
+        assertEquals(21, countValues(md.getStringFunctions()));
+    }
+
+    public void testGetSystemFunctions() throws Exception {
+        assertEquals(3, countValues(md.getSystemFunctions()));
+    }
+
+    public void testGetTimeDateFunctions() throws Exception {
+        assertEquals(13, countValues(md.getTimeDateFunctions()));
+    }
+
     public void testGetFunctionColumns() throws Exception {
         testEmptySet(() -> md.getFunctionColumns(null, null, null, null));
     }
@@ -116,6 +134,15 @@ public class JdbcDatabaseMetaDataTests extends ESTestCase {
             assertNotNull(result);
             assertFalse(result.next());
         }
+    }
+
+    /**
+     * Returns the number of values in a comma-separated list
+     */
+    private static int countValues(String commaSeparated) {
+        List<String> values = List.of(commaSeparated.split(","));
+        assertEquals("Duplicate values found: " + values, Set.copyOf(values).size(), values.size());
+        return values.size();
     }
 
     public void testGetClientInfoProperties() throws Exception {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
@@ -368,7 +368,7 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
         }, listener::onFailure);
 
         Instant instantOfTrigger = Instant.ofEpochMilli(now);
-        // If we are not on the initial batch checkpoint and its the first pass of whatever continuous checkpoint we are on,
+        // If we are not on the initial batch checkpoint and it's the first pass of whatever continuous checkpoint we are on,
         // we should verify if there are local changes based on the sync config. If not, do not proceed further and exit.
         if (context.getCheckpoint() > 0 && initialRun()) {
             checkpointProvider.sourceHasChanged(getLastCheckpoint(), ActionListener.wrap(hasChanged -> {
@@ -493,7 +493,7 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
             }
             // paranoia: we are not expecting dbq to fail for other reasons
             if (bulkByScrollResponse.getBulkFailures().size() > 0 || bulkByScrollResponse.getSearchFailures().size() > 0) {
-                assert false : "delete by query failed unexpectedly" + bulkByScrollResponse;
+                assert false : "delete by query failed unexpectedly " + bulkByScrollResponse;
                 listener.onFailure(
                     new RetentionPolicyException(
                         "found failures when deleting documents as part of the retention policy. Response: [{}]",
@@ -715,11 +715,11 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
         if (indexerState.equals(IndexerState.STOPPED)) {
             // If we are going to stop after the state is saved, we should NOT persist `shouldStopAtCheckpoint: true` as this may
             // cause problems if the task starts up again.
-            // Additionally, we don't have to worry about inconsistency with the ClusterState (if it is persisted there) as the
+            // Additionally, we don't have to worry about inconsistency with the ClusterState (if it is persisted there) as
             // when we stop, we mark the task as complete and that state goes away.
             shouldStopAtCheckpoint = false;
 
-            // We don't want adjust the stored taskState because as soon as it is `STOPPED` a user could call
+            // We don't want to adjust the stored taskState because as soon as it is `STOPPED` a user could call
             // .start again.
             taskState = TransformTaskState.STOPPED;
         }
@@ -901,7 +901,7 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
 
             context.setShouldStopAtCheckpoint(shouldStopAtCheckpoint);
         }
-        // in case of throttling the indexer might wait for the next search, fast forward, so stop listeners do not wait to long
+        // in case of throttling the indexer might wait for the next search, fast-forward, so stop listeners do not wait to long
         runSearchImmediately();
         return true;
     }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
@@ -854,7 +854,7 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
                 CountDownLatch latch = new CountDownLatch(1);
                 logger.debug("[{}] persisting stop at checkpoint", getJobId());
 
-                persistState(newTransformState, ActionListener.running(() -> latch.countDown()));
+                persistState(newTransformState, ActionListener.running(latch::countDown));
 
                 if (latch.await(PERSIST_STOP_AT_CHECKPOINT_TIMEOUT_SEC, TimeUnit.SECONDS) == false) {
                     logger.error(


### PR DESCRIPTION
This PR fixes missing spaces in concatenated strings, like `"script=" + script + "context=" + context` or `"InputStream provided" + currentTotalLength + " bytes,`.
These were mostly in logging and assert messages. But there was one real bug too - see `JdbcDatabaseMetaData`.

I also took the liberty to do some minor code cleanup in the affected classes.
This is in the second commit. Please let me know if you would prefer it removed from the PR.