### PR TITLE
[Transform] Pass source query to FieldCapabilitiesAction (as index_filter) for better performance

### DIFF
--- a/docs/changelog/102379.yaml
+++ b/docs/changelog/102379.yaml
@@ -1,5 +1,5 @@
 pr: 102379
-summary: Pass source query to `FieldCapabilitiesAction` (as index_filter) for better
+summary: Pass source query to `_field_caps` (as `index_filter`) when deducing destination index mappings for better
   performance
 area: Transform
 type: enhancement

--- a/docs/changelog/102379.yaml
+++ b/docs/changelog/102379.yaml
@@ -1,0 +1,6 @@
+pr: 102379
+summary: Pass source query to `FieldCapabilitiesAction` (as index_filter) for better
+  performance
+area: Transform
+type: enhancement
+issues: []

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformPivotRestIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformPivotRestIT.java
@@ -1123,8 +1123,24 @@ public class TransformPivotRestIT extends TransformRestTestCase {
         assertEquals(11, totalStars, 0);
     }
 
-    @SuppressWarnings("unchecked")
     public void testPreviewTransform() throws Exception {
+        testPreviewTransform("");
+    }
+
+    public void testPreviewTransformWithQuery() throws Exception {
+        testPreviewTransform("""
+            ,
+            "query": {
+              "range": {
+                "timestamp": {
+                  "gte": 123456789
+                }
+              }
+            }""");
+    }
+
+    @SuppressWarnings("unchecked")
+    private void testPreviewTransform(String queryJson) throws Exception {
         setupDataAccessRole(DATA_ACCESS_ROLE, REVIEWS_INDEX_NAME);
         final Request createPreviewRequest = createRequestWithAuth(
             "POST",
@@ -1136,6 +1152,7 @@ public class TransformPivotRestIT extends TransformRestTestCase {
             {
               "source": {
                 "index": "%s"
+                %s
               },
               "pivot": {
                 "group_by": {
@@ -1159,7 +1176,7 @@ public class TransformPivotRestIT extends TransformRestTestCase {
                   }
                 }
               }
-            }""", REVIEWS_INDEX_NAME);
+            }""", REVIEWS_INDEX_NAME, queryJson);
 
         createPreviewRequest.setJsonEntity(config);
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/Pivot.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/Pivot.java
@@ -97,7 +97,15 @@ public class Pivot extends AbstractCompositeAggFunction {
             listener.onResponse(emptyMap());
             return;
         }
-        SchemaUtil.deduceMappings(client, headers, config, sourceConfig.getIndex(), sourceConfig.getRuntimeMappings(), listener);
+        SchemaUtil.deduceMappings(
+            client,
+            headers,
+            config,
+            sourceConfig.getIndex(),
+            sourceConfig.getQueryConfig().getQuery(),
+            sourceConfig.getRuntimeMappings(),
+            listener
+        );
     }
 
     /**

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/SchemaUtil.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/SchemaUtil.java
@@ -17,6 +17,7 @@ import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
+import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.PipelineAggregationBuilder;
 import org.elasticsearch.xpack.core.ClientHelper;
@@ -89,6 +90,7 @@ public final class SchemaUtil {
      * @param client Client from which to make requests against the cluster
      * @param config The PivotConfig for which to deduce destination mapping
      * @param sourceIndex Source index that contains the data to pivot
+     * @param sourceQuery Source index query to apply
      * @param runtimeMappings Source runtime mappings
      * @param listener Listener to alert on success or failure.
      */
@@ -97,6 +99,7 @@ public final class SchemaUtil {
         final Map<String, String> headers,
         final PivotConfig config,
         final String[] sourceIndex,
+        final QueryBuilder sourceQuery,
         final Map<String, Object> runtimeMappings,
         final ActionListener<Map<String, String>> listener
     ) {
@@ -145,6 +148,7 @@ public final class SchemaUtil {
             client,
             headers,
             sourceIndex,
+            sourceQuery,
             allFieldNames.values().stream().filter(Objects::nonNull).toArray(String[]::new),
             runtimeMappings,
             ActionListener.wrap(
@@ -248,6 +252,7 @@ public final class SchemaUtil {
         Client client,
         Map<String, String> headers,
         String[] index,
+        QueryBuilder query,
         String[] fields,
         Map<String, Object> runtimeMappings,
         ActionListener<Map<String, String>> listener
@@ -257,6 +262,7 @@ public final class SchemaUtil {
             return;
         }
         FieldCapabilitiesRequest fieldCapabilitiesRequest = new FieldCapabilitiesRequest().indices(index)
+            .indexFilter(query)
             .fields(fields)
             .runtimeFields(runtimeMappings)
             .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationSchemaAndResultTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationSchemaAndResultTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse;
 import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
@@ -147,7 +148,15 @@ public class AggregationSchemaAndResultTests extends ESTestCase {
             .count();
 
         this.<Map<String, String>>assertAsync(
-            listener -> SchemaUtil.deduceMappings(client, emptyMap(), pivotConfig, new String[] { "source-index" }, emptyMap(), listener),
+            listener -> SchemaUtil.deduceMappings(
+                client,
+                emptyMap(),
+                pivotConfig,
+                new String[] { "source-index" },
+                QueryBuilders.matchAllQuery(),
+                emptyMap(),
+                listener
+            ),
             mappings -> {
                 assertEquals("Mappings were: " + mappings, numGroupsWithoutScripts + 15, mappings.size());
                 assertEquals("long", mappings.get("max_rating"));
@@ -219,7 +228,15 @@ public class AggregationSchemaAndResultTests extends ESTestCase {
             .count();
 
         this.<Map<String, String>>assertAsync(
-            listener -> SchemaUtil.deduceMappings(client, emptyMap(), pivotConfig, new String[] { "source-index" }, emptyMap(), listener),
+            listener -> SchemaUtil.deduceMappings(
+                client,
+                emptyMap(),
+                pivotConfig,
+                new String[] { "source-index" },
+                QueryBuilders.matchAllQuery(),
+                emptyMap(),
+                listener
+            ),
             mappings -> {
                 assertEquals(numGroupsWithoutScripts + 12, mappings.size());
                 assertEquals("long", mappings.get("filter_1"));

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/SchemaUtilTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/SchemaUtilTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.action.fieldcaps.FieldCapabilitiesRequest;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse;
 import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.client.NoOpClient;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -104,6 +105,7 @@ public class SchemaUtilTests extends ESTestCase {
                     client,
                     emptyMap(),
                     new String[] { "index-1", "index-2" },
+                    QueryBuilders.matchAllQuery(),
                     null,
                     emptyMap(),
                     listener
@@ -120,6 +122,7 @@ public class SchemaUtilTests extends ESTestCase {
                     client,
                     emptyMap(),
                     new String[] { "index-1", "index-2" },
+                    QueryBuilders.matchAllQuery(),
                     new String[] {},
                     emptyMap(),
                     listener
@@ -136,6 +139,7 @@ public class SchemaUtilTests extends ESTestCase {
                     client,
                     emptyMap(),
                     null,
+                    QueryBuilders.matchAllQuery(),
                     new String[] { "field-1", "field-2" },
                     emptyMap(),
                     listener
@@ -152,6 +156,7 @@ public class SchemaUtilTests extends ESTestCase {
                     client,
                     emptyMap(),
                     new String[] {},
+                    QueryBuilders.matchAllQuery(),
                     new String[] { "field-1", "field-2" },
                     emptyMap(),
                     listener
@@ -168,6 +173,7 @@ public class SchemaUtilTests extends ESTestCase {
                     client,
                     emptyMap(),
                     new String[] { "index-1", "index-2" },
+                    QueryBuilders.matchAllQuery(),
                     new String[] { "field-1", "field-2" },
                     emptyMap(),
                     listener
@@ -196,6 +202,7 @@ public class SchemaUtilTests extends ESTestCase {
                     client,
                     emptyMap(),
                     new String[] { "index-1", "index-2" },
+                    QueryBuilders.matchAllQuery(),
                     new String[] { "field-1", "field-2" },
                     runtimeMappings,
                     listener


### PR DESCRIPTION
Transforms can be configured to search incredibly broad index patterns. These cause the lower level actions used by transforms to iterate huge numbers of shards unless measures are taken to restrict which shards are considered using information available in cluster state.

This PR fixes this problem for the `FieldCapabilitiesAction` which is used by the transform in order to collect source indices mappings.

Relates https://github.com/elastic/elasticsearch/issues/101049