### PR TITLE
Avoid failing search request due to max clause count when searching all fields

### DIFF
--- a/docs/changelog/102385.yaml
+++ b/docs/changelog/102385.yaml
@@ -1,0 +1,5 @@
+pr: 102385
+summary: Avoid failing search request due to max clause count when searching all fields
+area: Search
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/search/QueryParserHelper.java
+++ b/server/src/main/java/org/elasticsearch/index/search/QueryParserHelper.java
@@ -120,6 +120,9 @@ public final class QueryParserHelper {
         String fieldSuffix
     ) {
         Set<String> allFields = context.getMatchingFieldNames(fieldOrPattern);
+        // avoid failing search request when using the default value for index.query.default_field (*)
+        int limit = Regex.isMatchAllPattern(fieldOrPattern) ? IndexSearcher.getMaxClauseCount() : Integer.MAX_VALUE;
+
         Map<String, Float> fields = new HashMap<>();
 
         for (String fieldName : allFields) {
@@ -147,6 +150,9 @@ public final class QueryParserHelper {
 
             float w = fields.getOrDefault(fieldName, 1.0F);
             fields.put(fieldName, w * weight);
+            if (fields.size() >= limit) {
+                break;
+            }
         }
         return fields;
     }


### PR DESCRIPTION
This is a POC for #102378

The way the limit is applied isn't completely deterministic. It's not based on which fields are added first as the order of the fields gets lost when converting to a map here:

https://github.com/elastic/elasticsearch/blob/588eabe185ad319c0268a13480465966cef058cd/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java#L47

And again when compacting the map via `Map.copyOf` here:

https://github.com/elastic/elasticsearch/blob/588eabe185ad319c0268a13480465966cef058cd/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java#L93-L94

We could change that, for example, by storing an additional List of the field names that preserves the order from the mappings.