### PR TITLE
CCS with minimize_roundtrips performs incremental merges of each SearchResponse

### DIFF
--- a/docs/changelog/102389.yaml
+++ b/docs/changelog/102389.yaml
@@ -1,0 +1,5 @@
+pr: 102389
+summary: CCS with `minimize_roundtrips` performs incremental merges of each `SearchResponse`
+area: Search
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/search/SearchResponseMerger.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchResponseMerger.java
@@ -16,7 +16,6 @@ import org.apache.lucene.search.TopFieldDocs;
 import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.search.SearchPhaseController.TopDocsStats;
-import org.elasticsearch.action.search.SearchResponse.Clusters;
 import org.elasticsearch.action.search.TransportSearchAction.SearchTimeProvider;
 import org.elasticsearch.common.lucene.search.TopDocsAndMaxScore;
 import org.elasticsearch.index.shard.ShardId;
@@ -72,6 +71,7 @@ import static org.elasticsearch.action.search.SearchPhaseController.mergeTopDocs
 // from the remote clusters in the fetch phase. This would be identical to the removed QueryAndFetch strategy except that only the remote
 // cluster response would have the fetch results.
 final class SearchResponseMerger {
+
     final int from;
     final int size;
     final int trackTotalHitsUpTo;
@@ -130,7 +130,7 @@ final class SearchResponseMerger {
 
     /**
      * Add a search response to the list of responses to be merged together into one.
-     * Merges currently happen at once when all responses are available and {@link #getMergedResponse(Clusters)} )} is called.
+     * Merges currently happen at once when all responses are available and {@link #getMergedResponse()} )} is called.
      * That may change in the future as it's possible to introduce incremental merges as responses come in if necessary.
      */
     synchronized void add(SearchResponse searchResponse) {
@@ -141,7 +141,7 @@ final class SearchResponseMerger {
         // do an incremental merge, as the CCSActionListener will call getMergedResponse to create the final response
         // after this method returns
         if (progressListener != null && progressListener != SearchProgressListener.NOOP && numExpectedResponses != numResponses()) {
-            progressListener.notifyCcsReduce(getMergedResponse(clusters));
+            progressListener.notifyCcsReduce(getMergedResponse());
         }
     }
 
@@ -153,8 +153,7 @@ final class SearchResponseMerger {
      * Returns the merged response. To be called once all responses have been added through {@link #add(SearchResponse)}
      * so that all responses are merged into a single one.
      */
-    /// MP TODO: remove clusters arg and use the one passed into the ctor
-    synchronized SearchResponse getMergedResponse(Clusters clusters) {
+    synchronized SearchResponse getMergedResponse() {
         // if the search is only across remote clusters, none of them are available, and all of them have skip_unavailable set to true,
         // we end up calling merge without anything to merge, we just return an empty search response
         if (searchResponses.size() == 0) {

--- a/server/src/main/java/org/elasticsearch/action/search/SearchResponseMerger.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchResponseMerger.java
@@ -94,6 +94,20 @@ final class SearchResponseMerger {
         this(from, size, trackTotalHitsUpTo, searchTimeProvider, aggReduceContextBuilder, clusters, progressListener, -1);
     }
 
+    /**
+     *
+     * @param from
+     * @param size
+     * @param trackTotalHitsUpTo
+     * @param searchTimeProvider
+     * @param aggReduceContextBuilder
+     * @param clusters
+     * @param progressListener
+     * @param numTotalClusters Specify the total number of clusters to turn on an optimization where an incremental
+     *                         merge will not be done in the add method for the last search response to come in
+     *                         (since the user of the Merger object is going to call {getMergedResponse} after
+     *                         all have been added.
+     */
     SearchResponseMerger(
         int from,
         int size,

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -792,7 +792,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
 
             @Override
             SearchResponse createFinalResponse() {
-                return searchResponseMerger.getMergedResponse(clusters);
+                return searchResponseMerger.getMergedResponse();
             }
         };
     }

--- a/server/src/test/java/org/elasticsearch/action/search/SearchResponseMergerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchResponseMergerTests.java
@@ -111,12 +111,12 @@ public class SearchResponseMergerTests extends ESTestCase {
                 0,
                 randomNonNegativeLong(),
                 ShardSearchFailure.EMPTY_ARRAY,
-                SearchResponseTests.randomClusters()
+                SearchResponse.Clusters.EMPTY
             );
             addResponse(merger, searchResponse);
         }
         awaitResponsesAdded();
-        SearchResponse searchResponse = merger.getMergedResponse(SearchResponse.Clusters.EMPTY);
+        SearchResponse searchResponse = merger.getMergedResponse();
         assertEquals(TimeUnit.NANOSECONDS.toMillis(currentRelativeTime), searchResponse.getTook().millis());
     }
 
@@ -181,7 +181,7 @@ public class SearchResponseMergerTests extends ESTestCase {
         }
         awaitResponsesAdded();
         assertEquals(numResponses, merger.numResponses());
-        SearchResponse mergedResponse = merger.getMergedResponse(clusters);
+        SearchResponse mergedResponse = merger.getMergedResponse();
         assertSame(clusters, mergedResponse.getClusters());
         assertEquals(numResponses, mergedResponse.getTotalShards());
         assertEquals(numResponses, mergedResponse.getSuccessfulShards());
@@ -239,7 +239,7 @@ public class SearchResponseMergerTests extends ESTestCase {
         }
         awaitResponsesAdded();
         assertEquals(numResponses, merger.numResponses());
-        SearchResponse mergedResponse = merger.getMergedResponse(clusters);
+        SearchResponse mergedResponse = merger.getMergedResponse();
         assertSame(clusters, mergedResponse.getClusters());
         assertEquals(numResponses, mergedResponse.getTotalShards());
         assertEquals(numResponses, mergedResponse.getSuccessfulShards());
@@ -287,7 +287,7 @@ public class SearchResponseMergerTests extends ESTestCase {
         }
         awaitResponsesAdded();
         assertEquals(numResponses, merger.numResponses());
-        ShardSearchFailure[] shardFailures = merger.getMergedResponse(SearchResponse.Clusters.EMPTY).getShardFailures();
+        ShardSearchFailure[] shardFailures = merger.getMergedResponse().getShardFailures();
         assertThat(Arrays.asList(shardFailures), containsInAnyOrder(expectedFailures.toArray(ShardSearchFailure.EMPTY_ARRAY)));
     }
 
@@ -323,7 +323,7 @@ public class SearchResponseMergerTests extends ESTestCase {
         }
         awaitResponsesAdded();
         assertEquals(numResponses, merger.numResponses());
-        SearchResponse mergedResponse = merger.getMergedResponse(clusters);
+        SearchResponse mergedResponse = merger.getMergedResponse();
         assertSame(clusters, mergedResponse.getClusters());
         assertEquals(numResponses, mergedResponse.getTotalShards());
         assertEquals(numResponses, mergedResponse.getSuccessfulShards());
@@ -398,9 +398,8 @@ public class SearchResponseMergerTests extends ESTestCase {
         }
         awaitResponsesAdded();
         assertEquals(numResponses, searchResponseMerger.numResponses());
-        SearchResponse.Clusters clusters = SearchResponseTests.randomClusters();
-        SearchResponse mergedResponse = searchResponseMerger.getMergedResponse(clusters);
-        assertSame(clusters, mergedResponse.getClusters());
+        SearchResponse mergedResponse = searchResponseMerger.getMergedResponse();
+        assertSame(SearchResponse.Clusters.EMPTY, mergedResponse.getClusters());
         assertEquals(numResponses, mergedResponse.getTotalShards());
         assertEquals(numResponses, mergedResponse.getSuccessfulShards());
         assertEquals(0, mergedResponse.getSkippedShards());
@@ -476,7 +475,7 @@ public class SearchResponseMergerTests extends ESTestCase {
         }
         awaitResponsesAdded();
         assertEquals(numResponses, searchResponseMerger.numResponses());
-        SearchResponse mergedResponse = searchResponseMerger.getMergedResponse(clusters);
+        SearchResponse mergedResponse = searchResponseMerger.getMergedResponse();
         assertSame(clusters, mergedResponse.getClusters());
         assertEquals(numResponses, mergedResponse.getTotalShards());
         assertEquals(numResponses, mergedResponse.getSuccessfulShards());
@@ -542,7 +541,7 @@ public class SearchResponseMergerTests extends ESTestCase {
             );
             searchResponseMerger.add(searchResponse);
         }
-        SearchResponse searchResponse = searchResponseMerger.getMergedResponse(clusters);
+        SearchResponse searchResponse = searchResponseMerger.getMergedResponse();
         Max mergedMax = searchResponse.getAggregations().get("field1");
         assertEquals(mergedMax.getValueAsString(), "2021-05-01T00:00:00.000Z");
     }
@@ -611,7 +610,7 @@ public class SearchResponseMergerTests extends ESTestCase {
         }
         awaitResponsesAdded();
         assertEquals(numResponses, searchResponseMerger.numResponses());
-        SearchResponse mergedResponse = searchResponseMerger.getMergedResponse(clusters);
+        SearchResponse mergedResponse = searchResponseMerger.getMergedResponse();
         assertSame(clusters, mergedResponse.getClusters());
         assertEquals(numResponses, mergedResponse.getTotalShards());
         assertEquals(numResponses, mergedResponse.getSuccessfulShards());
@@ -783,7 +782,7 @@ public class SearchResponseMergerTests extends ESTestCase {
 
         awaitResponsesAdded();
         assertEquals(numResponses, searchResponseMerger.numResponses());
-        SearchResponse searchResponse = searchResponseMerger.getMergedResponse(clusters);
+        SearchResponse searchResponse = searchResponseMerger.getMergedResponse();
 
         assertEquals(TimeUnit.NANOSECONDS.toMillis(currentRelativeTime), searchResponse.getTook().millis());
         assertEquals(expectedTotal, searchResponse.getTotalShards());
@@ -861,7 +860,7 @@ public class SearchResponseMergerTests extends ESTestCase {
             progressListener
         );
         assertEquals(0, merger.numResponses());
-        SearchResponse response = merger.getMergedResponse(clusters);
+        SearchResponse response = merger.getMergedResponse();
         assertSame(clusters, response.getClusters());
         assertEquals(TimeUnit.NANOSECONDS.toMillis(currentRelativeTime), response.getTook().millis());
         assertEquals(0, response.getTotalShards());
@@ -958,7 +957,7 @@ public class SearchResponseMergerTests extends ESTestCase {
             merger.add(searchResponse);
         }
         assertEquals(2, merger.numResponses());
-        SearchResponse mergedResponse = merger.getMergedResponse(clusters);
+        SearchResponse mergedResponse = merger.getMergedResponse();
         assertEquals(10, mergedResponse.getHits().getTotalHits().value);
         assertEquals(10, mergedResponse.getHits().getHits().length);
         assertEquals(2, mergedResponse.getTotalShards());
@@ -1018,7 +1017,7 @@ public class SearchResponseMergerTests extends ESTestCase {
             SearchResponse incrementalSearchResponse = incrementalResponses.get(i);
             assertEquals(expectedTotalHits, incrementalSearchResponse.getHits().getTotalHits());
         }
-        SearchResponse mergedResponse = merger.getMergedResponse(clusters);
+        SearchResponse mergedResponse = merger.getMergedResponse();
         assertEquals(expectedTotalHits, mergedResponse.getHits().getTotalHits());
     }
 
@@ -1129,7 +1128,7 @@ public class SearchResponseMergerTests extends ESTestCase {
         assertEquals(0, incrementalResponses.size());
         searchResponseMergerWithProgListener.add(firstResponse);
         assertEquals(1, incrementalResponses.size());
-        assertEquals(Strings.toString(searchResponseMerger1.getMergedResponse(clusters)), Strings.toString(incrementalResponses.get(0)));
+        assertEquals(Strings.toString(searchResponseMerger1.getMergedResponse()), Strings.toString(incrementalResponses.get(0)));
 
         SearchResponse secondResponse = responses.get(1);
         searchResponseMerger2.add(secondResponse);
@@ -1138,7 +1137,7 @@ public class SearchResponseMergerTests extends ESTestCase {
         assertEquals(1, incrementalResponses.size());
         searchResponseMergerWithProgListener.add(secondResponse);
         assertEquals(2, incrementalResponses.size());
-        assertEquals(Strings.toString(searchResponseMerger2.getMergedResponse(clusters)), Strings.toString(incrementalResponses.get(1)));
+        assertEquals(Strings.toString(searchResponseMerger2.getMergedResponse()), Strings.toString(incrementalResponses.get(1)));
 
         SearchResponse thirdResponse = responses.get(2);
         searchResponseMerger3.add(thirdResponse);
@@ -1146,7 +1145,7 @@ public class SearchResponseMergerTests extends ESTestCase {
         assertEquals(2, incrementalResponses.size());
         searchResponseMergerWithProgListener.add(thirdResponse);
         assertEquals(3, incrementalResponses.size());
-        assertEquals(Strings.toString(searchResponseMerger3.getMergedResponse(clusters)), Strings.toString(incrementalResponses.get(2)));
+        assertEquals(Strings.toString(searchResponseMerger3.getMergedResponse()), Strings.toString(incrementalResponses.get(2)));
 
         SearchResponse fourthResponse = responses.get(3);
         searchResponseMerger4.add(fourthResponse);
@@ -1159,8 +1158,8 @@ public class SearchResponseMergerTests extends ESTestCase {
             assertEquals(4, incrementalResponses.size());
         }
 
-        SearchResponse finalWithNoIncrementalReductions = searchResponseMerger4.getMergedResponse(clusters);
-        SearchResponse finalWithIncrementalReductions = searchResponseMergerWithProgListener.getMergedResponse(clusters);
+        SearchResponse finalWithNoIncrementalReductions = searchResponseMerger4.getMergedResponse();
+        SearchResponse finalWithIncrementalReductions = searchResponseMergerWithProgListener.getMergedResponse();
         assertEquals(Strings.toString(finalWithNoIncrementalReductions), Strings.toString(finalWithIncrementalReductions));
     }
 

--- a/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
@@ -533,6 +533,7 @@ public class TransportSearchActionTests extends ESTestCase {
                 emptyReduceContextBuilder(),
                 remoteClusterService,
                 threadPool,
+                null,  /// MP TODO: need to add SearchProgressListener to some of these tests (or a new one)
                 listener,
                 (r, l) -> setOnce.set(Tuple.tuple(r, l))
             );
@@ -599,6 +600,7 @@ public class TransportSearchActionTests extends ESTestCase {
                     emptyReduceContextBuilder(),
                     remoteClusterService,
                     threadPool,
+                    null,
                     listener,
                     (r, l) -> setOnce.set(Tuple.tuple(r, l))
                 );
@@ -641,6 +643,7 @@ public class TransportSearchActionTests extends ESTestCase {
                     emptyReduceContextBuilder(),
                     remoteClusterService,
                     threadPool,
+                    null,
                     listener,
                     (r, l) -> setOnce.set(Tuple.tuple(r, l))
                 );
@@ -701,6 +704,7 @@ public class TransportSearchActionTests extends ESTestCase {
                     emptyReduceContextBuilder(),
                     remoteClusterService,
                     threadPool,
+                    null,
                     listener,
                     (r, l) -> setOnce.set(Tuple.tuple(r, l))
                 );
@@ -747,6 +751,7 @@ public class TransportSearchActionTests extends ESTestCase {
                     emptyReduceContextBuilder(),
                     remoteClusterService,
                     threadPool,
+                    null,
                     listener,
                     (r, l) -> setOnce.set(Tuple.tuple(r, l))
                 );
@@ -811,6 +816,7 @@ public class TransportSearchActionTests extends ESTestCase {
                     emptyReduceContextBuilder(),
                     remoteClusterService,
                     threadPool,
+                    null,
                     listener,
                     (r, l) -> setOnce.set(Tuple.tuple(r, l))
                 );
@@ -1061,7 +1067,10 @@ public class TransportSearchActionTests extends ESTestCase {
             SearchResponseMerger merger = TransportSearchAction.createSearchResponseMerger(
                 source,
                 timeProvider,
-                emptyReduceContextBuilder()
+                emptyReduceContextBuilder(),
+                SearchResponse.Clusters.EMPTY, // MP: TODO: change this?
+                null,  // TODO: add SearchProgressListener?
+                null
             );
             assertEquals(0, merger.from);
             assertEquals(10, merger.size);
@@ -1071,7 +1080,14 @@ public class TransportSearchActionTests extends ESTestCase {
             assertNull(source.trackTotalHitsUpTo());
         }
         {
-            SearchResponseMerger merger = TransportSearchAction.createSearchResponseMerger(null, timeProvider, emptyReduceContextBuilder());
+            SearchResponseMerger merger = TransportSearchAction.createSearchResponseMerger(
+                null,
+                timeProvider,
+                emptyReduceContextBuilder(),
+                SearchResponse.Clusters.EMPTY, // MP: TODO: change this?
+                null,  // TODO: add SearchProgressListener?
+                null
+            );
             assertEquals(0, merger.from);
             assertEquals(10, merger.size);
             assertEquals(SearchContext.DEFAULT_TRACK_TOTAL_HITS_UP_TO, merger.trackTotalHitsUpTo);
@@ -1087,7 +1103,10 @@ public class TransportSearchActionTests extends ESTestCase {
             SearchResponseMerger merger = TransportSearchAction.createSearchResponseMerger(
                 source,
                 timeProvider,
-                emptyReduceContextBuilder()
+                emptyReduceContextBuilder(),
+                SearchResponse.Clusters.EMPTY, // MP: TODO: change this?
+                null,  // TODO: add SearchProgressListener?
+                null
             );
             assertEquals(0, source.from());
             assertEquals(originalFrom + originalSize, source.size());

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/AsyncSearchTask.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/AsyncSearchTask.java
@@ -484,6 +484,19 @@ final class AsyncSearchTask extends SearchTask implements AsyncTask {
             searchResponse.get().updatePartialResponse(shards.size(), totalHits, () -> aggregations, reducePhase);
         }
 
+        /**
+         * Called when a full reduction is done as part of CCS minimize_roundtrip=true.
+         * This may or may not be the final response. The final response (once all clusters have
+         * responded) will be sent to the ActionListener.onResponse callback below.
+         * @param response SearchResponse with fully merged aggs and tophits based on CCS responses
+         *                 received so far
+         */
+        @Override
+        public void onCcsReduce(SearchResponse response) {
+            // this is only used for MRT=true, so not passing to the MRT=false delegate
+            searchResponse.get().updatePartialResponse(response);
+        }
+
         @Override
         public void onResponse(SearchResponse response) {
             searchResponse.get().updateFinalResponse(response, ccsMinimizeRoundtrips);

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/MutableSearchResponse.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/MutableSearchResponse.java
@@ -108,6 +108,19 @@ class MutableSearchResponse {
     }
 
     /**
+     * Updates the response with the result of a partial reduction.
+     * Called only when minimize_roundtrips=true
+     * @param response
+     */
+    synchronized void updatePartialResponse(SearchResponse response) {
+        failIfFrozen();
+
+        this.responseHeaders = threadContext.getResponseHeaders();
+        this.finalResponse = response;
+        this.isPartial = true;
+    }
+
+    /**
      * Updates the response with the final {@link SearchResponse} once the
      * search is complete.
      */


### PR DESCRIPTION
To help address the issue of slow-to-respond clusters in a cross-cluster search,
async-search based CCS with minimize_roundtrips=true performs incremental
merges of each SearchResponse as they come in from each cluster (including
the local cluster).

This means, any time the user calls `GET _async_search/:id`, they will now get
search hits and/or aggregation results from any clusters that have finished so far.

The `is_running` field in the async-search response should be used to determine
whether at least one cluster has still not reported back.