### PR TITLE
Add more logging to the real memory circuit breaker and lower minimum interval

### DIFF
--- a/docs/changelog/102396.yaml
+++ b/docs/changelog/102396.yaml
@@ -1,0 +1,5 @@
+pr: 102396
+summary: Add more logging to the real memory circuit breaker and lower minimum interval
+area: "Distributed, Infra/Circuit Breakers"
+type: bug
+issues: []

--- a/docs/changelog/102396.yaml
+++ b/docs/changelog/102396.yaml
@@ -1,5 +1,5 @@
 pr: 102396
 summary: Add more logging to the real memory circuit breaker and lower minimum interval
-area: "Distributed, Infra/Circuit Breakers"
+area: "Infra/Circuit Breakers"
 type: bug
 issues: []

--- a/server/src/main/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerService.java
+++ b/server/src/main/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerService.java
@@ -622,6 +622,12 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
                         long now = timeSupplier.getAsLong();
                         this.lastCheckTime = now;
                         allocationDuration = now - begin;
+                    } else {
+                        logger.info(
+                            "not attempting to trigger G1GC due to time interval [{}] being lower than [{}]",
+                            begin - lastCheckTime,
+                            minimumInterval
+                        );
                     }
                 }
             } catch (InterruptedException e) {
@@ -639,6 +645,8 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
                         allocationIndex,
                         allocationDuration
                     );
+                } else {
+                    logger.info("memory usage down, before [{}], after [{}]", memoryUsed.baseUsage, current);
                 }
                 return new MemoryUsage(
                     current,
@@ -655,6 +663,8 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
                         allocationIndex,
                         allocationDuration
                     );
+                } else {
+                    logger.info("memory usage not down, before [{}], after [{}]", memoryUsed.baseUsage, current);
                 }
                 // prefer original measurement when reporting if heap usage was not brought down.
                 return memoryUsed;

--- a/server/src/main/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerService.java
+++ b/server/src/main/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerService.java
@@ -591,9 +591,10 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
             int allocationIndex = 0;
             long allocationDuration = 0;
             long begin = 0;
+            int attemptNoCopy = 0;
             try (ReleasableLock locked = lock.tryAcquire(lockTimeout)) {
                 if (locked != null) {
-                    this.attemptNo++;
+                    attemptNoCopy = ++this.attemptNo;
                     begin = timeSupplier.getAsLong();
                     leader = begin >= lastCheckTime + minimumInterval;
                     overLimitTriggered(leader);
@@ -645,7 +646,7 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
                         allocationIndex,
                         allocationDuration
                     );
-                } else if (attemptNo < 10 || Long.bitCount(attemptNo) == 1) {
+                } else if (attemptNoCopy < 10 || Long.bitCount(attemptNoCopy) == 1) {
                     logger.info(
                         "memory usage down after [{}], before [{}], after [{}]",
                         begin - lastCheckTime,
@@ -668,7 +669,7 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
                         allocationIndex,
                         allocationDuration
                     );
-                } else if (attemptNo < 10 || Long.bitCount(attemptNo) == 1) {
+                } else if (attemptNoCopy < 10 || Long.bitCount(attemptNoCopy) == 1) {
                     logger.info(
                         "memory usage not down after [{}], before [{}], after [{}]",
                         begin - lastCheckTime,


### PR DESCRIPTION
This PR adds more logging to the real memory circuit breaker. In particular it covers that code path when the code is executed inside the `minimumInterval` and therefore we don't attempt to trigger G1GC. 

It lowers the `minimumInterval` from 5000ms to 500ms as we observed high number of CBEs when there are bursting allocations.