### PR TITLE
[8.11] Update build cache setup to use Gradle Enterprise connector (#102180)

### DIFF
--- a/.ci/init.gradle
+++ b/.ci/init.gradle
@@ -10,8 +10,6 @@ initscript {
   }
 }
 
-boolean USE_ARTIFACTORY = false
-
 if (System.getenv('VAULT_ADDR') == null) {
   // When trying to reproduce errors outside of CI, it can be useful to allow this to just return rather than blowing up
   if (System.getenv('CI') == null) {
@@ -50,75 +48,38 @@ final Vault vault = new Vault(
     .engineVersion(1)
     .token(vaultToken)
     .build()
-)
-  .withRetries(5, 1000)
+).withRetries(5, 1000)
 
-
-if (USE_ARTIFACTORY) {
-  final Map<String, String> artifactoryCredentials = vault.logical()
-    .read("${vaultPathPrefix}/artifactory.elstc.co")
-    .getData()
-  logger.info("Using elastic artifactory repos")
-  Closure configCache = {
-    return {
-      name "artifactory-gradle-release"
-      url "https://artifactory.elstc.co/artifactory/gradle-release"
-      credentials {
-        username artifactoryCredentials.get("username")
-        password artifactoryCredentials.get("token")
-      }
-    }
-  }
-  settingsEvaluated { settings ->
-    settings.pluginManagement {
-      repositories {
-        maven configCache()
-      }
-    }
-  }
-  projectsLoaded {
-    allprojects {
-      buildscript {
-        repositories {
-          maven configCache()
-        }
-      }
-      repositories {
-        maven configCache()
-      }
-    }
-  }
-}
 
 gradle.settingsEvaluated { settings ->
   settings.pluginManager.withPlugin("com.gradle.enterprise") {
-    settings.gradleEnterprise {
-      server = 'https://gradle-enterprise.elastic.co'
-    }
+    configureGradleEnterprise(settings)
   }
 }
 
+void configureGradleEnterprise(def settings) {
+  settings.gradleEnterprise {
+    server = 'https://gradle-enterprise.elastic.co'
+    buildScan.publishAlways()
+  }
 
-final String buildCacheUrl = System.getProperty('org.elasticsearch.build.cache.url')
-final boolean buildCachePush = Boolean.valueOf(System.getProperty('org.elasticsearch.build.cache.push', 'false'))
+  def isCI = System.getenv("CI") == "true"
+  settings.buildCache {
+    local {
+      // Disable the local build cache in CI since we use ephemeral workers and it incurs an IO penalty
+      enabled = isCI == false
+    }
+    remote(settings.gradleEnterprise.buildCache) {
+      if (isCI) {
+        final boolean buildCachePush = Boolean.valueOf(System.getProperty('org.elasticsearch.build.cache.push', 'false'))
+        final Map<String, String> buildCacheCredentials = System.getenv("GRADLE_BUILD_CACHE_USERNAME") ? [:] : vault.logical()
+          .read("${vaultPathPrefix}/gradle-build-cache")
+          .getData()
+        def username = System.getenv("GRADLE_BUILD_CACHE_USERNAME") ?: buildCacheCredentials.get("username")
+        def password = System.getenv("GRADLE_BUILD_CACHE_PASSWORD") ?: buildCacheCredentials.get("password")
 
-if (buildCacheUrl) {
-  final Map<String, String> buildCacheCredentials = System.getenv("GRADLE_BUILD_CACHE_USERNAME") ? [:] : vault.logical()
-    .read("${vaultPathPrefix}/gradle-build-cache")
-    .getData()
-  gradle.settingsEvaluated { settings ->
-    settings.buildCache {
-      local {
-        // Disable the local build cache in CI since we use ephemeral workers and it incurs an IO penalty
-        enabled = false
-      }
-      remote(HttpBuildCache) {
-        url = buildCacheUrl
         push = buildCachePush
-        credentials {
-          username = System.getenv("GRADLE_BUILD_CACHE_USERNAME") ?: buildCacheCredentials.get("username")
-          password = System.getenv("GRADLE_BUILD_CACHE_PASSWORD") ?: buildCacheCredentials.get("password")
-        }
+        usernameAndPassword(username, password)
       }
     }
   }

--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -15,12 +15,6 @@ buildScan {
   URL jenkinsUrl = System.getenv('JENKINS_URL') ? new URL(System.getenv('JENKINS_URL')) : null
   String buildKiteUrl = System.getenv('BUILDKITE_BUILD_URL') ? System.getenv('BUILDKITE_BUILD_URL') : null
 
-  // Automatically publish scans from Elasticsearch CI
-  if (jenkinsUrl?.host?.endsWith('elastic.co') || jenkinsUrl?.host?.endsWith('elastic.dev') || System.getenv('BUILDKITE') == 'true') {
-    publishAlways()
-    buildScan.server = 'https://gradle-enterprise.elastic.co'
-  }
-
   background {
     tag OS.current().name()
     tag Architecture.current().name()

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcSetupExtension.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcSetupExtension.java
@@ -74,6 +74,11 @@ public class BwcSetupExtension {
                 return getJavaHome(Integer.parseInt(minimumCompilerVersion));
             }));
 
+            // temporally workaround for reworked gradle enterprise setup
+            // removed when PR https://github.com/elastic/elasticsearch/pull/102180 backported
+            // to all BWC branches
+            loggedExec.getEnvironment().put("BUILDKITE", "false");
+
             if (BuildParams.isCi() && OS.current() != OS.WINDOWS) {
                 // TODO: Disabled for now until we can figure out why files are getting corrupted
                 // loggedExec.getEnvironment().put("GRADLE_RO_DEP_CACHE", System.getProperty("user.home") + "/gradle_ro_cache");


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Update build cache setup to use Gradle Enterprise connector (#102180)