### PR TITLE
[DOCS] Adds Search Labs links to the ES landing page

### DIFF
--- a/docs/reference/landing-page.asciidoc
+++ b/docs/reference/landing-page.asciidoc
@@ -172,9 +172,6 @@
     <li>
       <a href="xpack-alerting.html">Alerting</a>
     </li>
-    <li>
-      <a href="https://www.elastic.co/search-labs/tutorials/examples">Notebook examples</a>
-    </li>
   </ul>
 </div>
 
@@ -220,6 +217,9 @@
     </li>
      <li>
       <a href="https://www.elastic.co/search-labs">Search Labs</a>
+    </li>
+    <li>
+      <a href="https://www.elastic.co/search-labs/tutorials/examples">Notebook examples</a>
     </li>
   </ul>
 </div>

--- a/docs/reference/landing-page.asciidoc
+++ b/docs/reference/landing-page.asciidoc
@@ -172,6 +172,9 @@
     <li>
       <a href="xpack-alerting.html">Alerting</a>
     </li>
+    <li>
+      <a href="https://www.elastic.co/search-labs/tutorials/examples">Notebook examples</a>
+    </li>
   </ul>
 </div>
 
@@ -214,6 +217,9 @@
     </li>
     <li>
       <a href="https://www.elastic.co/guide/en/elasticsearch/plugins/current/index.html">Plugins and integrations</a>
+    </li>
+     <li>
+      <a href="https://www.elastic.co/search-labs">Search Labs</a>
     </li>
   </ul>
 </div>


### PR DESCRIPTION
## Overview

This PR adds two links to the ES landing page under the `APIs and developer docs` section:
* link to the Search Labs home page,
* link to the examples section of the Search Labs.