### PR TITLE
Mute two flaky tests for #102339

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/simulate.ingest/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/simulate.ingest/10_basic.yml
@@ -118,6 +118,8 @@ setup:
 
   - skip:
       features: headers
+      version: "all"
+      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/102339"
 
   - do:
       headers:
@@ -195,6 +197,8 @@ setup:
 
   - skip:
       features: headers
+      version: "all"
+      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/102339"
 
   - do:
       headers:


### PR DESCRIPTION
These two fail about 2% of the time, which is actually quite a high failure rate. The issue to fix is https://github.com/elastic/elasticsearch/issues/102339
