### PR TITLE
Fix flaky test for #102406

### DIFF
--- a/x-pack/plugin/fleet/src/test/java/org/elasticsearch/xpack/fleet/action/PostSecretResponseTests.java
+++ b/x-pack/plugin/fleet/src/test/java/org/elasticsearch/xpack/fleet/action/PostSecretResponseTests.java
@@ -24,6 +24,7 @@ public class PostSecretResponseTests extends AbstractWireSerializingTestCase<Pos
 
     @Override
     protected PostSecretResponse mutateInstance(PostSecretResponse instance) {
-        return new PostSecretResponse(randomAlphaOfLengthBetween(2, 10));
+        String id = randomValueOtherThan(instance.id(), () -> randomAlphaOfLengthBetween(2, 10));
+        return new PostSecretResponse(id);
     }
 }


### PR DESCRIPTION
The mutateInstance just happens to generate the exact same id with this particular random seed, so the test fails. Just checking that the id is the same and generating another one is sufficient to fix this.

Fixes #102406
