### PR TITLE
[8.11] [DOCS] Adds Search Labs links to the ES landing page (#102401)

### DIFF
--- a/docs/reference/landing-page.asciidoc
+++ b/docs/reference/landing-page.asciidoc
@@ -215,6 +215,12 @@
     <li>
       <a href="https://www.elastic.co/guide/en/elasticsearch/plugins/current/index.html">Plugins and integrations</a>
     </li>
+     <li>
+      <a href="https://www.elastic.co/search-labs">Search Labs</a>
+    </li>
+    <li>
+      <a href="https://www.elastic.co/search-labs/tutorials/examples">Notebook examples</a>
+    </li>
   </ul>
 </div>
 


### PR DESCRIPTION
Backports the following commits to 8.11:
 - [DOCS] Adds Search Labs links to the ES landing page (#102401)