### PR TITLE
[ML] Add cluster settings to override ML autoscaling

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -656,6 +656,20 @@ public class MachineLearning extends Plugin
         Property.NodeScope
     );
 
+    // Serverless only - trigger scale up if necessary
+    public static final Setting<ByteSizeValue> DUMMY_ENTITY_MEMORY = Setting.memorySizeSetting(
+        "xpack.ml.dummy_entity_memory",
+        ByteSizeValue.ofBytes(0),
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+    public static final Setting<Integer> DUMMY_ENTITY_PROCESSORS = Setting.intSetting(
+        "xpack.ml.dummy_entity_processors",
+        0,
+        Setting.Property.Dynamic,
+        Setting.Property.NodeScope
+    );
+
     public static final Setting<TimeValue> PROCESS_CONNECT_TIMEOUT = Setting.timeSetting(
         "xpack.ml.process_connect_timeout",
         TimeValue.timeValueSeconds(10),
@@ -785,7 +799,9 @@ public class MachineLearning extends Plugin
             NIGHTLY_MAINTENANCE_REQUESTS_PER_SECOND,
             MachineLearningField.USE_AUTO_MACHINE_MEMORY_PERCENT,
             MAX_ML_NODE_SIZE,
-            DELAYED_DATA_CHECK_FREQ
+            DELAYED_DATA_CHECK_FREQ,
+            DUMMY_ENTITY_MEMORY,
+            DUMMY_ENTITY_PROCESSORS
         );
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -656,15 +656,18 @@ public class MachineLearning extends Plugin
         Property.NodeScope
     );
 
-    // Serverless only - trigger scale up if necessary
+    // The next two settings currently only have an effect in serverless. They can be set as overrides to
+    // trigger a scale up of the ML tier so that it could accommodate the dummy entity in addition to
+    // whatever the standard autoscaling formula thinks is necessary.
     public static final Setting<ByteSizeValue> DUMMY_ENTITY_MEMORY = Setting.memorySizeSetting(
         "xpack.ml.dummy_entity_memory",
-        ByteSizeValue.ofBytes(0),
+        ByteSizeValue.ZERO,
         Setting.Property.Dynamic,
         Setting.Property.NodeScope
     );
     public static final Setting<Integer> DUMMY_ENTITY_PROCESSORS = Setting.intSetting(
         "xpack.ml.dummy_entity_processors",
+        0,
         0,
         Setting.Property.Dynamic,
         Setting.Property.NodeScope

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingResourceTracker.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingResourceTracker.java
@@ -373,25 +373,30 @@ public final class MlAutoscalingResourceTracker {
             return false;
         }
 
-        Optional<MlJobRequirements> leastLodedNodeRequirements = Optional.ofNullable(perNodeJobRequirements.entrySet()
-            .stream()
-            .map(
-                entry -> tuple(
-                    entry.getKey(),
-                    entry.getValue()
-                        .stream()
-                        .reduce(
-                            MlJobRequirements.of(0L, 0, 0),
-                            (subtotal, element) -> MlJobRequirements.of(
-                                subtotal.memory + element.memory,
-                                subtotal.processors + element.processors,
-                                subtotal.jobs + element.jobs
+        Optional<MlJobRequirements> leastLodedNodeRequirements = Optional.ofNullable(
+            perNodeJobRequirements.entrySet()
+                .stream()
+                .map(
+                    entry -> tuple(
+                        entry.getKey(),
+                        entry.getValue()
+                            .stream()
+                            .reduce(
+                                MlJobRequirements.of(0L, 0, 0),
+                                (subtotal, element) -> MlJobRequirements.of(
+                                    subtotal.memory + element.memory,
+                                    subtotal.processors + element.processors,
+                                    subtotal.jobs + element.jobs
+                                )
                             )
-                        )
+                    )
                 )
-            ).min(Comparator.comparingLong(tuple -> tuple.v2().memory)).get().v2());
+                .min(Comparator.comparingLong(tuple -> tuple.v2().memory))
+                .get()
+                .v2()
+        );
 
-        assert(leastLodedNodeRequirements.isPresent());
+        assert (leastLodedNodeRequirements.isPresent());
         assert leastLodedNodeRequirements.get().memory >= 0L;
         assert leastLodedNodeRequirements.get().processors >= 0;
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingResourceTracker.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingResourceTracker.java
@@ -41,6 +41,8 @@ import java.util.stream.Collectors;
 
 import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.core.Tuple.tuple;
+import static org.elasticsearch.xpack.ml.MachineLearning.DUMMY_ENTITY_MEMORY;
+import static org.elasticsearch.xpack.ml.MachineLearning.DUMMY_ENTITY_PROCESSORS;
 import static org.elasticsearch.xpack.ml.MachineLearning.MAX_OPEN_JOBS_PER_NODE;
 import static org.elasticsearch.xpack.ml.job.JobNodeSelector.AWAITING_LAZY_ASSIGNMENT;
 
@@ -59,6 +61,12 @@ public final class MlAutoscalingResourceTracker {
             return new MlJobRequirements(memory, processors, 1);
         }
     };
+
+    record MlDummyAutoscalingEntity(long memory, int processors) {
+        static MlDummyAutoscalingEntity of(long memory, int processors) {
+            return new MlDummyAutoscalingEntity(memory, processors);
+        }
+    }
 
     private MlAutoscalingResourceTracker() {}
 
@@ -85,6 +93,11 @@ public final class MlAutoscalingResourceTracker {
                 .roundDown()
             : 0;
 
+        MlDummyAutoscalingEntity mlDummyAutoscalingEntity = new MlDummyAutoscalingEntity(
+            DUMMY_ENTITY_MEMORY.get(settings).getBytes(),
+            DUMMY_ENTITY_PROCESSORS.get(settings)
+        );
+
         // Todo: MAX_LOW_PRIORITY_MODELS_PER_NODE not checked yet
         int maxOpenJobsPerNode = MAX_OPEN_JOBS_PER_NODE.get(settings);
 
@@ -95,6 +108,7 @@ public final class MlAutoscalingResourceTracker {
             modelMemoryAvailableFirstNode,
             processorsAvailableFirstNode,
             maxOpenJobsPerNode,
+            mlDummyAutoscalingEntity,
             listener
         );
     }
@@ -106,6 +120,7 @@ public final class MlAutoscalingResourceTracker {
         long perNodeAvailableModelMemoryInBytes,
         int perNodeAvailableProcessors,
         int maxOpenJobsPerNode,
+        MlDummyAutoscalingEntity dummyAutoscalingEntity,
         ActionListener<MlAutoscalingStats> listener
     ) {
         Map<String, List<MlJobRequirements>> perNodeModelMemoryInBytes = new HashMap<>();
@@ -262,6 +277,35 @@ public final class MlAutoscalingResourceTracker {
             minNodes = Math.min(3, Math.max(minNodes, numberOfAllocations));
         }
 
+        // dummy autoscaling entity
+        //
+        // Is there enough capacity to accommodate the dummy entity?
+        // If there exists a node that can accommodate the dummy entity then return true (nothing to do),
+        // else return false and increment the memory and processor counts accordingly.
+        //
+        // We perform the calculation by identifying the least loaded node in terms of memory
+        // and determining if the addition of the dummy entity's memory & processor requirements could
+        // be accommodated on it.
+        //
+        // If the calculation returns false then treat the case as for a single trained model job
+        // that is already assigned, i.e. increment modelMemoryBytesSum and processorsSum appropriately.
+        //
+        if (checkIfDummyEntityCanBeAccommodatedOnLeastLoadedNode(
+            perNodeModelMemoryInBytes,
+            perNodeAvailableModelMemoryInBytes,
+            perNodeAvailableProcessors,
+            dummyAutoscalingEntity
+        ) == false) {
+            logger.info(
+                "Scaling up due to dummy entity: dummyEntityMemory: [{}], dummyEntityProcessors: [{}]",
+                dummyAutoscalingEntity.memory,
+                dummyAutoscalingEntity.processors
+            );
+
+            modelMemoryBytesSum += dummyAutoscalingEntity.memory;
+            processorsSum += dummyAutoscalingEntity.processors;
+        }
+
         // check for downscaling
         long removeNodeMemoryInBytes = 0;
 
@@ -282,7 +326,8 @@ public final class MlAutoscalingResourceTracker {
                     perNodeModelMemoryInBytes,
                     perNodeAvailableModelMemoryInBytes,
                     perNodeAvailableProcessors,
-                    maxOpenJobsPerNode
+                    maxOpenJobsPerNode,
+                    dummyAutoscalingEntity
                 ))) {
             removeNodeMemoryInBytes = perNodeMemoryInBytes;
         }
@@ -302,6 +347,72 @@ public final class MlAutoscalingResourceTracker {
                 MachineLearning.NATIVE_EXECUTABLE_CODE_OVERHEAD.getBytes()
             )
         );
+    }
+
+    /**
+     * Check if the dummy autoscaling entity task can be added by placing
+     * the task on the least loaded node.
+     *
+     * @param perNodeJobRequirements per Node lists of requirements
+     * @param perNodeMemoryInBytes total model memory available on every node
+     * @param perNodeProcessors total processors on every node
+     * @param dummyAutoscalingEntity "dummy" entity requirements used to potentially trigger a scaling event
+     * @return true if the dummy entity can be accommodated, false if not
+     */
+    static boolean checkIfDummyEntityCanBeAccommodatedOnLeastLoadedNode(
+        Map<String, List<MlJobRequirements>> perNodeJobRequirements, // total up requirements...
+        long perNodeMemoryInBytes,
+        int perNodeProcessors,
+        MlDummyAutoscalingEntity dummyAutoscalingEntity
+    ) {
+
+        if (dummyAutoscalingEntity.processors == 0 && dummyAutoscalingEntity.memory == 0L) {
+            return true;
+        }
+
+        if (perNodeJobRequirements.size() <= 1) {
+            return true;
+        }
+
+        Map<String, MlJobRequirements> perNodeMlJobRequirementSum = perNodeJobRequirements.entrySet()
+            .stream()
+            .map(
+                entry -> tuple(
+                    entry.getKey(),
+                    entry.getValue()
+                        .stream()
+                        .reduce(
+                            MlJobRequirements.of(0L, 0, 0),
+                            (subtotal, element) -> MlJobRequirements.of(
+                                subtotal.memory + element.memory,
+                                subtotal.processors + element.processors,
+                                subtotal.jobs + element.jobs
+                            )
+                        )
+                )
+            )
+            .collect(Collectors.toMap(Tuple::v1, Tuple::v2));
+
+        // check least loaded based on memory...
+        Optional<Map.Entry<String, MlJobRequirements>> leastLoadedNodeAndMemoryUsage = perNodeMlJobRequirementSum.entrySet()
+            .stream()
+            .min(Comparator.comparingLong(entry -> entry.getValue().memory));
+
+        if (leastLoadedNodeAndMemoryUsage.isPresent()) {
+            // Check if the dummy entity could be accommodated
+            assert leastLoadedNodeAndMemoryUsage.get().getValue().memory >= 0L;
+            assert leastLoadedNodeAndMemoryUsage.get().getValue().processors >= 0;
+
+            if (leastLoadedNodeAndMemoryUsage.get().getValue().memory + dummyAutoscalingEntity.memory > perNodeMemoryInBytes) {
+                return false;
+            }
+
+            if (leastLoadedNodeAndMemoryUsage.get().getValue().processors + dummyAutoscalingEntity.processors > perNodeProcessors) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**
@@ -340,7 +451,8 @@ public final class MlAutoscalingResourceTracker {
         Map<String, List<MlJobRequirements>> perNodeJobRequirements,
         long perNodeMemoryInBytes,
         int perNodeProcessors,
-        int maxOpenJobsPerNode
+        int maxOpenJobsPerNode,
+        MlDummyAutoscalingEntity dummyAutoscalingEntity
     ) {
         if (perNodeJobRequirements.size() <= 1) {
             return false;
@@ -377,7 +489,11 @@ public final class MlAutoscalingResourceTracker {
         assert leastLoadedNodeAndMemoryUsage.get().getValue().memory >= 0L;
 
         String candidateNode = leastLoadedNodeAndMemoryUsage.get().getKey();
-        List<MlJobRequirements> candidateJobRequirements = perNodeJobRequirements.get(candidateNode);
+        List<MlJobRequirements> candidateJobRequirements = perNodeJobRequirements.get(candidateNode); // add dummy
+        if (dummyAutoscalingEntity.memory > 0L || dummyAutoscalingEntity.processors > 0) {
+            candidateJobRequirements = new ArrayList<>(candidateJobRequirements);
+            candidateJobRequirements.add(MlJobRequirements.of(dummyAutoscalingEntity.memory, dummyAutoscalingEntity.processors));
+        }
         perNodeMlJobRequirementSum.remove(candidateNode);
 
         // if all jobs fit on other nodes, we can scale down one node

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingResourceTracker.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingResourceTracker.java
@@ -373,6 +373,7 @@ public final class MlAutoscalingResourceTracker {
             return false;
         }
 
+        // Note: we check least loaded based _only_ on memory...
         Optional<MlJobRequirements> leastLoadedNodeRequirements = perNodeJobRequirements.values()
             .stream()
             .map(

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingResourceTrackerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingResourceTrackerTests.java
@@ -41,6 +41,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
+import static org.elasticsearch.xpack.ml.autoscaling.MlAutoscalingResourceTracker.MlDummyAutoscalingEntity;
 import static org.elasticsearch.xpack.ml.autoscaling.MlAutoscalingResourceTracker.MlJobRequirements;
 import static org.elasticsearch.xpack.ml.job.JobNodeSelector.AWAITING_LAZY_ASSIGNMENT;
 import static org.mockito.Mockito.mock;
@@ -61,6 +62,7 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
                 memory / 2,
                 10,
                 MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE,
+                MlDummyAutoscalingEntity.of(0L, 0),
                 listener
             ),
             stats -> {
@@ -81,6 +83,7 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
                 memory / 2,
                 10,
                 MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE,
+                MlDummyAutoscalingEntity.of(0L, 0),
                 listener
             ),
             stats -> {
@@ -88,6 +91,30 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
                 assertEquals(2, stats.nodes());
                 assertEquals(0, stats.minNodes());
                 assertEquals(0, stats.extraSingleNodeProcessors());
+                assertEquals(MachineLearning.NATIVE_EXECUTABLE_CODE_OVERHEAD.getBytes(), stats.perNodeMemoryOverheadInBytes());
+            }
+        );
+
+        // Simulate 1 node & 1 "dummy" task requiring 1 processor and the same memory as the other node
+        // We don't expect any extra memory or processor usage in this situation.
+        this.<MlAutoscalingStats>assertAsync(
+            listener -> MlAutoscalingResourceTracker.getMemoryAndProcessors(
+                mlAutoscalingContext,
+                mockTracker,
+                Map.of("ml-1", randomLongBetween(0, memory), "ml-2", randomLongBetween(0, memory)),
+                memory / 2,
+                10,
+                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE,
+                MlDummyAutoscalingEntity.of(memory / 2, 1),
+                listener
+            ),
+            stats -> {
+                assertEquals(0, stats.perNodeMemoryInBytes());
+                assertEquals(2, stats.nodes());
+                assertEquals(0, stats.minNodes());
+                assertEquals(0, stats.extraSingleNodeProcessors());
+                assertEquals(0, stats.extraModelMemoryInBytes());
+                assertEquals(0, stats.extraSingleNodeModelMemoryInBytes());
                 assertEquals(MachineLearning.NATIVE_EXECUTABLE_CODE_OVERHEAD.getBytes(), stats.perNodeMemoryOverheadInBytes());
             }
         );
@@ -143,12 +170,68 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
                 memory / 2,
                 10,
                 MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE,
+                MlDummyAutoscalingEntity.of(0L, 0),
                 listener
             ),
             stats -> {
                 assertEquals(memory, stats.perNodeMemoryInBytes());
                 assertEquals(2, stats.nodes());
                 assertEquals(1, stats.minNodes());
+                assertEquals(0, stats.extraProcessors());
+                assertEquals(0, stats.modelMemoryInBytesSum());
+                assertEquals(0, stats.processorsSum());
+                assertEquals(0, stats.extraSingleNodeProcessors());
+                assertEquals(memory / 4, stats.extraSingleNodeModelMemoryInBytes());
+                assertEquals(memory / 4, stats.extraModelMemoryInBytes());
+                assertEquals(MachineLearning.NATIVE_EXECUTABLE_CODE_OVERHEAD.getBytes(), stats.perNodeMemoryOverheadInBytes());
+            }
+        );
+
+        // As above but allocate an equal amount of memory to a dummy task
+        this.<MlAutoscalingStats>assertAsync(
+            listener -> MlAutoscalingResourceTracker.getMemoryAndProcessors(
+                mlAutoscalingContext,
+                mockTracker,
+                Map.of("ml-1", memory, "ml-2", memory),
+                memory / 2,
+                10,
+                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE,
+                MlDummyAutoscalingEntity.of(memory / 4, 0),
+                listener
+            ),
+            stats -> {
+                assertEquals(memory, stats.perNodeMemoryInBytes());
+                assertEquals(2, stats.nodes());
+                assertEquals(1, stats.minNodes());
+                assertEquals(0, stats.extraProcessors());
+                assertEquals(0, stats.modelMemoryInBytesSum());
+                assertEquals(0, stats.processorsSum());
+                assertEquals(0, stats.extraSingleNodeProcessors());
+                assertEquals(memory / 4, stats.extraSingleNodeModelMemoryInBytes());
+                assertEquals(memory / 4, stats.extraModelMemoryInBytes());
+                assertEquals(MachineLearning.NATIVE_EXECUTABLE_CODE_OVERHEAD.getBytes(), stats.perNodeMemoryOverheadInBytes());
+            }
+        );
+
+        // As above but also allocate a processor to the dummy task
+        this.<MlAutoscalingStats>assertAsync(
+            listener -> MlAutoscalingResourceTracker.getMemoryAndProcessors(
+                mlAutoscalingContext,
+                mockTracker,
+                Map.of("ml-1", memory, "ml-2", memory),
+                memory / 2,
+                10,
+                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE,
+                MlDummyAutoscalingEntity.of(memory / 4, 1),
+                listener
+            ),
+            stats -> {
+                assertEquals(memory, stats.perNodeMemoryInBytes());
+                assertEquals(2, stats.nodes());
+                assertEquals(1, stats.minNodes());
+                assertEquals(0, stats.extraProcessors());
+                assertEquals(0, stats.modelMemoryInBytesSum());
+                assertEquals(0, stats.processorsSum());
                 assertEquals(0, stats.extraSingleNodeProcessors());
                 assertEquals(memory / 4, stats.extraSingleNodeModelMemoryInBytes());
                 assertEquals(memory / 4, stats.extraModelMemoryInBytes());
@@ -210,10 +293,12 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
                 memory / 2,
                 10,
                 MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE,
+                MlDummyAutoscalingEntity.of(0L, 0),
                 listener
             ),
             stats -> {
                 assertEquals(memory, stats.perNodeMemoryInBytes());
+                assertEquals(memory, stats.removeNodeMemoryInBytes());
                 assertEquals(2, stats.nodes());
                 assertEquals(0, stats.minNodes());
                 assertEquals(0, stats.extraSingleNodeProcessors());
@@ -680,7 +765,8 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
                 ),
                 600L,
                 10,
-                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE
+                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE,
+                MlDummyAutoscalingEntity.of(0L, 0)
             )
         );
 
@@ -703,7 +789,8 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
                 ),
                 600L,
                 10,
-                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE
+                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE,
+                MlDummyAutoscalingEntity.of(0L, 0)
             )
         );
 
@@ -722,7 +809,8 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
                 ),
                 600L,
                 10,
-                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE
+                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE,
+                MlDummyAutoscalingEntity.of(0L, 0)
             )
         );
 
@@ -732,7 +820,8 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
                 Collections.emptyMap(),
                 999L,
                 10,
-                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE
+                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE,
+                MlDummyAutoscalingEntity.of(0L, 0)
             )
         );
 
@@ -757,7 +846,8 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
                 ),
                 1000L,
                 10,
-                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE
+                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE,
+                MlDummyAutoscalingEntity.of(0L, 0)
             )
         );
 
@@ -786,7 +876,8 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
                 ),
                 1000L,
                 10,
-                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE
+                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE,
+                MlDummyAutoscalingEntity.of(0L, 0)
             )
         );
 
@@ -814,7 +905,8 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
                 ),
                 1000L,
                 10,
-                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE
+                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE,
+                MlDummyAutoscalingEntity.of(0L, 0)
             )
         );
 
@@ -842,7 +934,8 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
                 ),
                 1000L,
                 10,
-                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE
+                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE,
+                MlDummyAutoscalingEntity.of(0L, 0)
             )
         );
     }
@@ -868,7 +961,8 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
                 ),
                 600L,
                 10,
-                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE
+                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE,
+                MlDummyAutoscalingEntity.of(0L, 0)
             )
         );
 
@@ -892,7 +986,8 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
                 ),
                 600L,
                 2,
-                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE
+                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE,
+                MlDummyAutoscalingEntity.of(0L, 0)
             )
         );
 
@@ -916,7 +1011,8 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
                 ),
                 600L,
                 10,
-                5
+                5,
+                MlDummyAutoscalingEntity.of(0L, 0)
             )
         );
 
@@ -936,7 +1032,8 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
                 ),
                 600L,
                 10,
-                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE
+                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE,
+                MlDummyAutoscalingEntity.of(0L, 0)
             )
         );
     }
@@ -957,6 +1054,7 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
                 perNodeAvailableModelMemoryInBytes,
                 10,
                 MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE,
+                MlDummyAutoscalingEntity.of(0L, 0),
                 listener
             ),
             stats -> {
@@ -964,6 +1062,29 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
                 assertEquals(1, stats.nodes());
                 assertEquals(0, stats.minNodes());
                 assertEquals(0, stats.extraSingleNodeProcessors());
+                assertEquals(memory, stats.removeNodeMemoryInBytes());
+                assertEquals(MachineLearning.NATIVE_EXECUTABLE_CODE_OVERHEAD.getBytes(), stats.perNodeMemoryOverheadInBytes());
+            }
+        );
+
+        // Dummy task should not affect results
+        this.<MlAutoscalingStats>assertAsync(
+            listener -> MlAutoscalingResourceTracker.getMemoryAndProcessors(
+                mlAutoscalingContext,
+                mockTracker,
+                Map.of("ml-1", memory),
+                perNodeAvailableModelMemoryInBytes,
+                10,
+                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE,
+                MlDummyAutoscalingEntity.of(0L, 1),
+                listener
+            ),
+            stats -> {
+                assertEquals(memory, stats.perNodeMemoryInBytes());
+                assertEquals(1, stats.nodes());
+                assertEquals(0, stats.minNodes());
+                assertEquals(0, stats.extraSingleNodeProcessors());
+                assertEquals(0, stats.extraProcessors());
                 assertEquals(memory, stats.removeNodeMemoryInBytes());
                 assertEquals(MachineLearning.NATIVE_EXECUTABLE_CODE_OVERHEAD.getBytes(), stats.perNodeMemoryOverheadInBytes());
             }
@@ -978,6 +1099,7 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
                 perNodeAvailableModelMemoryInBytes,
                 10,
                 MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE,
+                MlDummyAutoscalingEntity.of(0L, 0),
                 listener
             ),
             stats -> {
@@ -1067,6 +1189,7 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
                 perNodeAvailableModelMemoryInBytes,
                 10,
                 MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE,
+                MlDummyAutoscalingEntity.of(0L, 0),
                 listener
             ),
             stats -> {
@@ -1166,6 +1289,7 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
                 NativeMemoryCalculator.allowedBytesForMl(firstNode, settings).getAsLong(),
                 4,
                 MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE,
+                MlDummyAutoscalingEntity.of(0L, 0),
                 listener
             ),
             stats -> {
@@ -1174,6 +1298,292 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
                 assertEquals(3, stats.minNodes());
                 assertEquals(0, stats.extraSingleNodeProcessors());
                 assertEquals(0, stats.removeNodeMemoryInBytes());
+                assertEquals(MachineLearning.NATIVE_EXECUTABLE_CODE_OVERHEAD.getBytes(), stats.perNodeMemoryOverheadInBytes());
+            }
+        );
+    }
+
+    // scenario: 3 ml nodes, but only 2 have assigned models. This situation would normally result in a scale down but that is prevented
+    // by a "dummy" entity having sufficient memory to do so.
+    public void testGetMemoryAndProcessorsScaleDownPreventedByDummyEntityMemory() throws InterruptedException {
+        Map<String, String> nodeAttr = Map.of(
+            MachineLearning.MACHINE_MEMORY_NODE_ATTR,
+            "1000000000",
+            MachineLearning.MAX_JVM_SIZE_NODE_ATTR,
+            "400000000",
+            MachineLearning.ML_CONFIG_VERSION_NODE_ATTR,
+            "7.2.0"
+        );
+
+        MlAutoscalingContext mlAutoscalingContext = new MlAutoscalingContext(
+            List.of(),
+            List.of(),
+            List.of(),
+            Map.of(
+                "model-1",
+                TrainedModelAssignment.Builder.empty(
+                    new StartTrainedModelDeploymentAction.TaskParams(
+                        "model-1",
+                        "model-1-deployment",
+                        400,
+                        1,
+                        2,
+                        100,
+                        null,
+                        Priority.NORMAL,
+                        0L,
+                        0L
+                    )
+                ).addRoutingEntry("ml-node-1", new RoutingInfo(1, 1, RoutingState.STARTED, "")).build(),
+                "model-2",
+                TrainedModelAssignment.Builder.empty(
+                    new StartTrainedModelDeploymentAction.TaskParams(
+                        "model-2",
+                        "model-2-deployment",
+                        400,
+                        1,
+                        2,
+                        100,
+                        null,
+                        Priority.NORMAL,
+                        0L,
+                        0L
+                    )
+                ).addRoutingEntry("ml-node-3", new RoutingInfo(1, 1, RoutingState.STARTED, "")).build()
+            ),
+            List.of(
+                DiscoveryNodeUtils.builder("ml-node-1")
+                    .name("ml-node-name-1")
+                    .address(new TransportAddress(InetAddress.getLoopbackAddress(), 9300))
+                    .attributes(nodeAttr)
+                    .roles(Set.of(DiscoveryNodeRole.ML_ROLE))
+                    .build(),
+                DiscoveryNodeUtils.builder("ml-node-3")
+                    .name("ml-node-name-3")
+                    .address(new TransportAddress(InetAddress.getLoopbackAddress(), 9300))
+                    .attributes(nodeAttr)
+                    .roles(Set.of(DiscoveryNodeRole.ML_ROLE))
+                    .build()
+            ),
+            PersistentTasksCustomMetadata.builder().build()
+        );
+        MlMemoryTracker mockTracker = mock(MlMemoryTracker.class);
+
+        long memory = 1000000000;
+        long perNodeAvailableModelMemoryInBytes = 600000000;
+
+        this.<MlAutoscalingStats>assertAsync(
+            listener -> MlAutoscalingResourceTracker.getMemoryAndProcessors(
+                mlAutoscalingContext,
+                mockTracker,
+                Map.of("ml-node-1", memory, "ml-node-2", memory, "ml-node-3", memory),
+                perNodeAvailableModelMemoryInBytes,
+                10,
+                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE,
+                MlDummyAutoscalingEntity.of(perNodeAvailableModelMemoryInBytes, 1),
+                listener
+            ),
+            stats -> {
+                assertEquals(memory, stats.perNodeMemoryInBytes());
+                assertEquals(perNodeAvailableModelMemoryInBytes + 503318080, stats.modelMemoryInBytesSum()); // total model memory is that
+                                                                                                             // configured in the dummy
+                                                                                                             // entity plus that used by the
+                                                                                                             // trained models.
+                assertEquals(5, stats.processorsSum()); // account for the extra processor from the dummy entity
+                assertEquals(3, stats.nodes());
+                assertEquals(1, stats.minNodes());
+                assertEquals(0, stats.extraSingleNodeProcessors());
+                assertEquals(0, stats.extraProcessors());
+                assertEquals(0, stats.extraModelMemoryInBytes());
+                assertEquals(0, stats.extraSingleNodeModelMemoryInBytes());
+                assertEquals(MachineLearning.NATIVE_EXECUTABLE_CODE_OVERHEAD.getBytes(), stats.perNodeMemoryOverheadInBytes());
+            }
+        );
+    }
+
+    // scenario: 3 ml nodes, but only 2 have assigned models. This situation does result in a scale down since dummy
+    // processors alone are not sufficient to prevent it.
+    public void testGetMemoryAndProcessorsScaleDownNotPreventedByDummyEntityProcessors() throws InterruptedException {
+        Map<String, String> nodeAttr = Map.of(
+            MachineLearning.MACHINE_MEMORY_NODE_ATTR,
+            "1000000000",
+            MachineLearning.MAX_JVM_SIZE_NODE_ATTR,
+            "400000000",
+            MachineLearning.ML_CONFIG_VERSION_NODE_ATTR,
+            "7.2.0"
+        );
+
+        MlAutoscalingContext mlAutoscalingContext = new MlAutoscalingContext(
+            List.of(),
+            List.of(),
+            List.of(),
+            Map.of(
+                "model-1",
+                TrainedModelAssignment.Builder.empty(
+                    new StartTrainedModelDeploymentAction.TaskParams(
+                        "model-1",
+                        "model-1-deployment",
+                        400,
+                        1,
+                        2,
+                        100,
+                        null,
+                        Priority.NORMAL,
+                        0L,
+                        0L
+                    )
+                ).addRoutingEntry("ml-node-1", new RoutingInfo(1, 1, RoutingState.STARTED, "")).build(),
+                "model-2",
+                TrainedModelAssignment.Builder.empty(
+                    new StartTrainedModelDeploymentAction.TaskParams(
+                        "model-2",
+                        "model-2-deployment",
+                        400,
+                        1,
+                        2,
+                        100,
+                        null,
+                        Priority.NORMAL,
+                        0L,
+                        0L
+                    )
+                ).addRoutingEntry("ml-node-3", new RoutingInfo(1, 1, RoutingState.STARTED, "")).build()
+            ),
+            List.of(
+                DiscoveryNodeUtils.builder("ml-node-1")
+                    .name("ml-node-name-1")
+                    .address(new TransportAddress(InetAddress.getLoopbackAddress(), 9300))
+                    .attributes(nodeAttr)
+                    .roles(Set.of(DiscoveryNodeRole.ML_ROLE))
+                    .build(),
+                DiscoveryNodeUtils.builder("ml-node-3")
+                    .name("ml-node-name-3")
+                    .address(new TransportAddress(InetAddress.getLoopbackAddress(), 9300))
+                    .attributes(nodeAttr)
+                    .roles(Set.of(DiscoveryNodeRole.ML_ROLE))
+                    .build()
+            ),
+            PersistentTasksCustomMetadata.builder().build()
+        );
+        MlMemoryTracker mockTracker = mock(MlMemoryTracker.class);
+
+        long memory = 1000000000;
+        long perNodeAvailableModelMemoryInBytes = 600000000;
+
+        this.<MlAutoscalingStats>assertAsync(
+            listener -> MlAutoscalingResourceTracker.getMemoryAndProcessors(
+                mlAutoscalingContext,
+                mockTracker,
+                Map.of("ml-node-1", memory, "ml-node-2", memory, "ml-node-3", memory),
+                perNodeAvailableModelMemoryInBytes,
+                10,
+                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE,
+                MlDummyAutoscalingEntity.of(0L, 9),
+                listener
+            ),
+            stats -> {
+                assertEquals(memory, stats.perNodeMemoryInBytes());
+                assertEquals(503318080, stats.modelMemoryInBytesSum());
+                assertEquals(13, stats.processorsSum()); // account for the extra processors from the dummy entity
+                assertEquals(3, stats.nodes());
+                assertEquals(1, stats.minNodes());
+                assertEquals(0, stats.extraSingleNodeProcessors());
+                assertEquals(0, stats.extraProcessors());
+                assertEquals(0, stats.extraModelMemoryInBytes());
+                assertEquals(0, stats.extraSingleNodeModelMemoryInBytes());
+                assertEquals(MachineLearning.NATIVE_EXECUTABLE_CODE_OVERHEAD.getBytes(), stats.perNodeMemoryOverheadInBytes());
+            }
+        );
+    }
+
+    public void testGetMemoryAndProcessorsScaleDownNotPreventedByDummyEntityAsMemoryTooLow() throws InterruptedException {
+        Map<String, String> nodeAttr = Map.of(
+            MachineLearning.MACHINE_MEMORY_NODE_ATTR,
+            "1000000000",
+            MachineLearning.MAX_JVM_SIZE_NODE_ATTR,
+            "400000000",
+            MachineLearning.ML_CONFIG_VERSION_NODE_ATTR,
+            "7.2.0"
+        );
+
+        MlAutoscalingContext mlAutoscalingContext = new MlAutoscalingContext(
+            List.of(),
+            List.of(),
+            List.of(),
+            Map.of(
+                "model-1",
+                TrainedModelAssignment.Builder.empty(
+                    new StartTrainedModelDeploymentAction.TaskParams(
+                        "model-1",
+                        "model-1-deployment",
+                        400,
+                        1,
+                        2,
+                        100,
+                        null,
+                        Priority.NORMAL,
+                        0L,
+                        0L
+                    )
+                ).addRoutingEntry("ml-node-1", new RoutingInfo(1, 1, RoutingState.STARTED, "")).build(),
+                "model-2",
+                TrainedModelAssignment.Builder.empty(
+                    new StartTrainedModelDeploymentAction.TaskParams(
+                        "model-2",
+                        "model-2-deployment",
+                        400,
+                        1,
+                        2,
+                        100,
+                        null,
+                        Priority.NORMAL,
+                        0L,
+                        0L
+                    )
+                ).addRoutingEntry("ml-node-3", new RoutingInfo(1, 1, RoutingState.STARTED, "")).build()
+            ),
+            List.of(
+                DiscoveryNodeUtils.builder("ml-node-1")
+                    .name("ml-node-name-1")
+                    .address(new TransportAddress(InetAddress.getLoopbackAddress(), 9300))
+                    .attributes(nodeAttr)
+                    .roles(Set.of(DiscoveryNodeRole.ML_ROLE))
+                    .build(),
+                DiscoveryNodeUtils.builder("ml-node-3")
+                    .name("ml-node-name-3")
+                    .address(new TransportAddress(InetAddress.getLoopbackAddress(), 9300))
+                    .attributes(nodeAttr)
+                    .roles(Set.of(DiscoveryNodeRole.ML_ROLE))
+                    .build()
+            ),
+            PersistentTasksCustomMetadata.builder().build()
+        );
+        MlMemoryTracker mockTracker = mock(MlMemoryTracker.class);
+
+        long memory = 1000000000;
+        long perNodeAvailableModelMemoryInBytes = 600000000;
+
+        this.<MlAutoscalingStats>assertAsync(
+            listener -> MlAutoscalingResourceTracker.getMemoryAndProcessors(
+                mlAutoscalingContext,
+                mockTracker,
+                Map.of("ml-node-1", memory, "ml-node-2", memory, "ml-node-3", memory),
+                perNodeAvailableModelMemoryInBytes,
+                10,
+                MachineLearning.DEFAULT_MAX_OPEN_JOBS_PER_NODE,
+                MlDummyAutoscalingEntity.of(1024, 0),
+                listener
+            ),
+            stats -> {
+                assertEquals(memory, stats.perNodeMemoryInBytes());
+                assertEquals(503318080, stats.modelMemoryInBytesSum());
+                assertEquals(4, stats.processorsSum());
+                assertEquals(3, stats.nodes());
+                assertEquals(1, stats.minNodes());
+                assertEquals(0, stats.extraSingleNodeProcessors());
+                assertEquals(0, stats.extraProcessors());
+                assertEquals(0, stats.extraModelMemoryInBytes());
+                assertEquals(0, stats.extraSingleNodeModelMemoryInBytes());
                 assertEquals(MachineLearning.NATIVE_EXECUTABLE_CODE_OVERHEAD.getBytes(), stats.perNodeMemoryOverheadInBytes());
             }
         );

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingResourceTrackerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingResourceTrackerTests.java
@@ -204,7 +204,7 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
                 assertEquals(2, stats.nodes());
                 assertEquals(1, stats.minNodes());
                 assertEquals(0, stats.extraProcessors());
-                assertEquals(0, stats.modelMemoryInBytesSum());
+                assertEquals(memory / 4, stats.modelMemoryInBytesSum());
                 assertEquals(0, stats.processorsSum());
                 assertEquals(0, stats.extraSingleNodeProcessors());
                 assertEquals(memory / 4, stats.extraSingleNodeModelMemoryInBytes());
@@ -230,8 +230,8 @@ public class MlAutoscalingResourceTrackerTests extends ESTestCase {
                 assertEquals(2, stats.nodes());
                 assertEquals(1, stats.minNodes());
                 assertEquals(0, stats.extraProcessors());
-                assertEquals(0, stats.modelMemoryInBytesSum());
-                assertEquals(0, stats.processorsSum());
+                assertEquals(memory / 4, stats.modelMemoryInBytesSum());
+                assertEquals(1, stats.processorsSum());
                 assertEquals(0, stats.extraSingleNodeProcessors());
                 assertEquals(memory / 4, stats.extraSingleNodeModelMemoryInBytes());
                 assertEquals(memory / 4, stats.extraModelMemoryInBytes());


### PR DESCRIPTION
Add the concept of an autoscaling dummy entity, comprised of the `xpack.ml.dummy_entity_memory` and `xpack.ml.dummy_entity_processors` cluster settings. These are intended to be used in extreme cases to trigger autoscaling events.

Labelling as `>non-issue` as these are not intended to be used externally.
