### PR TITLE
ilm error-handling - index name does not match pattern

### DIFF
--- a/docs/reference/ilm/error-handling.asciidoc
+++ b/docs/reference/ilm/error-handling.asciidoc
@@ -215,7 +215,7 @@ The preferred solution is using data streams so bootstraping the initial time se
 
 Without using data streams, the solution is to append a numeric value to the index name. For example, `my-index-000001` is the expected index name created by <<ilm-gs-alias-bootstrap,bootstrapping the initial time series index with a write index alias>>.
 
-Note that it is not possible to rename an index so you will need to reindex (https://www.elastic.co/guide/en/elasticsearch/reference/8.11/docs-reindex.html) the data in `my-index` using the desired rollover alias name (after bootstraping the initial time series index) or data stream name
+Note that it is not possible to rename an index so you will need to <<docs-reindex,reindex>> the data in `my-index`, using the desired rollover alias name (after bootstrapping the initial time series index) or data stream name.
 
 [discrete]
 ==== CircuitBreakingException: [x] data too large, data for [y]

--- a/docs/reference/ilm/error-handling.asciidoc
+++ b/docs/reference/ilm/error-handling.asciidoc
@@ -211,7 +211,11 @@ The index name must match the regex pattern `^.*-\d+` for the rollover action to
 The most common problem is that the index name does not contain trailing digits.
 For example, `my-index` does not match the pattern requirement.
 
-Append a numeric value to the index name, for example `my-index-000001`.
+The preferred solution is using data streams so bootstraping the initial time series index is not needed
+
+Without using data streams, the solution is to append a numeric value to the index name, for example `my-index-000001` is the expected index name created by bootstraping the initial time series index with a write index alias (https://www.elastic.co/guide/en/elasticsearch/reference/8.11/getting-started-index-lifecycle-management.html#ilm-gs-alias-bootstrap).
+
+Note that it is not possible to rename an index so you will need to reindex (https://www.elastic.co/guide/en/elasticsearch/reference/8.11/docs-reindex.html) the data in `my-index` using the desired rollover alias name (after bootstraping the initial time series index) or data stream name
 
 [discrete]
 ==== CircuitBreakingException: [x] data too large, data for [y]

--- a/docs/reference/ilm/error-handling.asciidoc
+++ b/docs/reference/ilm/error-handling.asciidoc
@@ -213,7 +213,7 @@ For example, `my-index` does not match the pattern requirement.
 
 The preferred solution is using data streams so bootstraping the initial time series index is not needed
 
-Without using data streams, the solution is to append a numeric value to the index name, for example `my-index-000001` is the expected index name created by bootstraping the initial time series index with a write index alias (https://www.elastic.co/guide/en/elasticsearch/reference/8.11/getting-started-index-lifecycle-management.html#ilm-gs-alias-bootstrap).
+Without using data streams, the solution is to append a numeric value to the index name. For example, `my-index-000001` is the expected index name created by <<ilm-gs-alias-bootstrap,bootstrapping the initial time series index with a write index alias>>.
 
 Note that it is not possible to rename an index so you will need to reindex (https://www.elastic.co/guide/en/elasticsearch/reference/8.11/docs-reindex.html) the data in `my-index` using the desired rollover alias name (after bootstraping the initial time series index) or data stream name
 

--- a/docs/reference/ilm/error-handling.asciidoc
+++ b/docs/reference/ilm/error-handling.asciidoc
@@ -211,7 +211,7 @@ The index name must match the regex pattern `^.*-\d+` for the rollover action to
 The most common problem is that the index name does not contain trailing digits.
 For example, `my-index` does not match the pattern requirement.
 
-The preferred solution is using data streams so bootstraping the initial time series index is not needed
+The preferred solution is to use <<data-streams,data streams>> so bootstrapping the initial time series index is not needed.
 
 Without using data streams, the solution is to append a numeric value to the index name. For example, `my-index-000001` is the expected index name created by <<ilm-gs-alias-bootstrap,bootstrapping the initial time series index with a write index alias>>.
 


### PR DESCRIPTION
Currently the troubleshooting guide for ILM mentions `my-index` needs to be named `my-index-000001` for rollover API to be able to roll over the index which is correct but lacking some context about what causes or solves this

Can reviewer fix hyperlinks to use appropriate asciidoc format ? I wanted to link to : 
- https://www.elastic.co/guide/en/elasticsearch/reference/8.11/getting-started-index-lifecycle-management.html#ilm-gs-alias-bootstrap (usually the cause of the error is when user skipped this step)
- https://www.elastic.co/guide/en/elasticsearch/reference/8.11/docs-reindex.html (as an index cannot be renamed reindex will likely be needed after fixing the issue)