### PR TITLE
[8.11] AwaitsFix for #100653

### DIFF
--- a/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/DownsampleClusterDisruptionIT.java
+++ b/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/DownsampleClusterDisruptionIT.java
@@ -209,6 +209,7 @@ public class DownsampleClusterDisruptionIT extends ESIntegTestCase {
         }
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/100653")
     public void testDownsampleIndexWithRollingRestart() throws Exception {
         try (InternalTestCluster cluster = internalCluster()) {
             final List<String> masterNodes = cluster.startMasterOnlyNodes(1);


### PR DESCRIPTION
This mutes https://github.com/elastic/elasticsearch/issues/100653 for 8.11, since it is still flaky on that branch.

It is just a cherry-pick of https://github.com/elastic/elasticsearch/commit/f35c3b49b535d7510c9ad2adae35d6cd4dd1f785 onto the 8.11 branch.