### PR TITLE
ESQL: Short circuit loading empty doc values

### DIFF
--- a/docs/changelog/102434.yaml
+++ b/docs/changelog/102434.yaml
@@ -1,0 +1,5 @@
+pr: 102434
+summary: "ESQL: Short circuit loading empty doc values"
+area: ES|QL
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/mapper/BlockDocValuesReader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BlockDocValuesReader.java
@@ -95,12 +95,19 @@ public abstract class BlockDocValuesReader implements BlockLoader.AllReader {
 
         @Override
         public AllReader reader(LeafReaderContext context) throws IOException {
-            SortedNumericDocValues docValues = DocValues.getSortedNumeric(context.reader(), fieldName);
-            NumericDocValues singleton = DocValues.unwrapSingleton(docValues);
+            SortedNumericDocValues docValues = context.reader().getSortedNumericDocValues(fieldName);
+            if (docValues != null) {
+                NumericDocValues singleton = DocValues.unwrapSingleton(docValues);
+                if (singleton != null) {
+                    return new SingletonLongs(singleton);
+                }
+                return new Longs(docValues);
+            }
+            NumericDocValues singleton = context.reader().getNumericDocValues(fieldName);
             if (singleton != null) {
                 return new SingletonLongs(singleton);
             }
-            return new Longs(docValues);
+            return new ConstantNullsReader();
         }
     }
 
@@ -223,12 +230,19 @@ public abstract class BlockDocValuesReader implements BlockLoader.AllReader {
 
         @Override
         public AllReader reader(LeafReaderContext context) throws IOException {
-            SortedNumericDocValues docValues = DocValues.getSortedNumeric(context.reader(), fieldName);
-            NumericDocValues singleton = DocValues.unwrapSingleton(docValues);
+            SortedNumericDocValues docValues = context.reader().getSortedNumericDocValues(fieldName);
+            if (docValues != null) {
+                NumericDocValues singleton = DocValues.unwrapSingleton(docValues);
+                if (singleton != null) {
+                    return new SingletonInts(singleton);
+                }
+                return new Ints(docValues);
+            }
+            NumericDocValues singleton = context.reader().getNumericDocValues(fieldName);
             if (singleton != null) {
                 return new SingletonInts(singleton);
             }
-            return new Ints(docValues);
+            return new ConstantNullsReader();
         }
     }
 
@@ -362,12 +376,19 @@ public abstract class BlockDocValuesReader implements BlockLoader.AllReader {
 
         @Override
         public AllReader reader(LeafReaderContext context) throws IOException {
-            SortedNumericDocValues docValues = DocValues.getSortedNumeric(context.reader(), fieldName);
-            NumericDocValues singleton = DocValues.unwrapSingleton(docValues);
+            SortedNumericDocValues docValues = context.reader().getSortedNumericDocValues(fieldName);
+            if (docValues != null) {
+                NumericDocValues singleton = DocValues.unwrapSingleton(docValues);
+                if (singleton != null) {
+                    return new SingletonDoubles(singleton, toDouble);
+                }
+                return new Doubles(docValues, toDouble);
+            }
+            NumericDocValues singleton = context.reader().getNumericDocValues(fieldName);
             if (singleton != null) {
                 return new SingletonDoubles(singleton, toDouble);
             }
-            return new Doubles(docValues, toDouble);
+            return new ConstantNullsReader();
         }
     }
 
@@ -496,12 +517,19 @@ public abstract class BlockDocValuesReader implements BlockLoader.AllReader {
 
         @Override
         public AllReader reader(LeafReaderContext context) throws IOException {
-            SortedSetDocValues docValues = ordinals(context);
-            SortedDocValues singleton = DocValues.unwrapSingleton(docValues);
+            SortedSetDocValues docValues = context.reader().getSortedSetDocValues(fieldName);
+            if (docValues != null) {
+                SortedDocValues singleton = DocValues.unwrapSingleton(docValues);
+                if (singleton != null) {
+                    return new SingletonOrdinals(singleton);
+                }
+                return new Ordinals(docValues);
+            }
+            SortedDocValues singleton = context.reader().getSortedDocValues(fieldName);
             if (singleton != null) {
                 return new SingletonOrdinals(singleton);
             }
-            return new Ordinals(docValues);
+            return new ConstantNullsReader();
         }
 
         @Override
@@ -719,12 +747,19 @@ public abstract class BlockDocValuesReader implements BlockLoader.AllReader {
 
         @Override
         public AllReader reader(LeafReaderContext context) throws IOException {
-            SortedNumericDocValues docValues = DocValues.getSortedNumeric(context.reader(), fieldName);
-            NumericDocValues singleton = DocValues.unwrapSingleton(docValues);
+            SortedNumericDocValues docValues = context.reader().getSortedNumericDocValues(fieldName);
+            if (docValues != null) {
+                NumericDocValues singleton = DocValues.unwrapSingleton(docValues);
+                if (singleton != null) {
+                    return new SingletonBooleans(singleton);
+                }
+                return new Booleans(docValues);
+            }
+            NumericDocValues singleton = context.reader().getNumericDocValues(fieldName);
             if (singleton != null) {
                 return new SingletonBooleans(singleton);
             }
-            return new Booleans(docValues);
+            return new ConstantNullsReader();
         }
     }
 


### PR DESCRIPTION
This optimizes loading from empty doc values by returning a builder that always returns a `ConstantNullBlock` without without needing to perform and per-tuple work. This *really* improves workloads where most fields are missing:
```
|                Min Throughput |   3.6941  |  6.49017 |   2.79608 |  ops/s | +75.69% |
|               Mean Throughput |   3.99176 |  7.26555 |   3.27379 |  ops/s | +82.01% |
|             Median Throughput |   4.02304 |  7.34932 |   3.32628 |  ops/s | +82.68% |
|                Max Throughput |   4.16047 |  7.71378 |   3.55331 |  ops/s | +85.41% |
|       50th percentile latency | 153.725   | 69.5784  | -84.1469  |     ms | -54.74% |
|       90th percentile latency | 163.613   | 74.8399  | -88.7731  |     ms | -54.26% |
|       99th percentile latency | 172.899   | 86.3224  | -86.5764  |     ms | -50.07% |
|      100th percentile latency | 184.158   | 88.4151  | -95.7431  |     ms | -51.99% |
|  50th percentile service time | 153.725   | 69.5784  | -84.1469  |     ms | -54.74% |
|  90th percentile service time | 163.613   | 74.8399  | -88.7731  |     ms | -54.26% |
|  99th percentile service time | 172.899   | 86.3224  | -86.5764  |     ms | -50.07% |
| 100th percentile service time | 184.158   | 88.4151  | -95.7431  |     ms | -51.99% |
```

That example above has about 90% of fields declared but missing.
