### PR TITLE
Add @UpdateForV9 markers on versions

### DIFF
--- a/libs/core/src/main/java/org/elasticsearch/core/RestApiVersion.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/RestApiVersion.java
@@ -18,6 +18,8 @@ import java.util.function.Predicate;
 public enum RestApiVersion {
 
     V_8(8),
+
+    @UpdateForV9 // v9 will not need to support the v7 REST API
     V_7(7);
 
     public final byte major;

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -9,6 +9,7 @@
 package org.elasticsearch;
 
 import org.elasticsearch.core.Assertions;
+import org.elasticsearch.core.UpdateForV9;
 
 import java.lang.reflect.Field;
 import java.util.Collection;
@@ -47,6 +48,7 @@ public class TransportVersions {
         return new TransportVersion(id);
     }
 
+    @UpdateForV9 // remove the transport versions with which v9 will not need to interact
     public static final TransportVersion ZERO = def(0);
     public static final TransportVersion V_7_0_0 = def(7_00_00_99);
     public static final TransportVersion V_7_0_1 = def(7_00_01_99);

--- a/server/src/main/java/org/elasticsearch/index/IndexVersions.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersions.java
@@ -10,6 +10,7 @@ package org.elasticsearch.index;
 
 import org.apache.lucene.util.Version;
 import org.elasticsearch.core.Assertions;
+import org.elasticsearch.core.UpdateForV9;
 
 import java.lang.reflect.Field;
 import java.util.Collection;
@@ -44,6 +45,7 @@ public class IndexVersions {
         return new IndexVersion(id, luceneVersion);
     }
 
+    @UpdateForV9 // remove the index versions with which v9 will not need to interact
     public static final IndexVersion ZERO = def(0, Version.LATEST);
     public static final IndexVersion V_7_0_0 = def(7_00_00_99, Version.LUCENE_8_0_0);
 


### PR DESCRIPTION
We probably wouldn't forget these, but for the sake of completeness this
commit marks several lists of versions with the `@UpdateForV9`
annotation.