### PR TITLE
Reset reconciler apm gauges on no longer master

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocator.java
@@ -293,6 +293,10 @@ public class DesiredBalanceShardsAllocator implements ShardsAllocator {
             queue.completeAllAsNotMaster();
             pendingDesiredBalanceMoves.clear();
             desiredBalanceReconciler.clear();
+
+            desiredBalanceReconciler.unassignedShards.set(0);
+            desiredBalanceReconciler.totalAllocations.set(0);
+            desiredBalanceReconciler.undesiredAllocations.set(0);
         }
     }
 


### PR DESCRIPTION
Stats rest endpoint is always served by elected master so numbers on other nodes
 do not matter. In contrast, APM collects metrics from all independently. In
 order to show correct stats we need to reset gauges to 0 when the node is no
 longer master, otherwise it keeps reporting outdated numbers.

