### PR TITLE
Mark Forbidden API errors as Verification failures

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/CheckForbiddenApisTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/CheckForbiddenApisTask.java
@@ -10,6 +10,7 @@ package org.elasticsearch.gradle.internal.precommit;
 
 import de.thetaphi.forbiddenapis.Checker;
 import de.thetaphi.forbiddenapis.Constants;
+import de.thetaphi.forbiddenapis.ForbiddenApiException;
 import de.thetaphi.forbiddenapis.Logger;
 import de.thetaphi.forbiddenapis.ParseException;
 import groovy.lang.Closure;
@@ -43,6 +44,7 @@ import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.VerificationException;
 import org.gradle.api.tasks.VerificationTask;
 import org.gradle.api.tasks.util.PatternFilterable;
 import org.gradle.api.tasks.util.PatternSet;
@@ -469,6 +471,8 @@ public abstract class CheckForbiddenApisTask extends DefaultTask implements Patt
                 }
                 checker.run();
                 writeMarker(getParameters().getSuccessMarker().getAsFile().get());
+            } catch (ForbiddenApiException e) {
+                throw new VerificationException("Forbidden API verification failed", e);
             } catch (Exception e) {
                 throw new RuntimeException(e);
             } finally {


### PR DESCRIPTION
Forbidden APIs failures should appear as verification checks in Gradle enterprise.

See: https://gradle-enterprise.elastic.co/scans/failures?failures.failureClassification=verification&failures.failureMessage=Execution%20failed%20for%20task%20%27:server:forbiddenApisMain%27.%0A%3E%20A%20failure%20occurred%20while%20executing%20org.elasticsearch.gradle.internal.precommit.CheckForbiddenApisTask$ForbiddenApisCheckWorkAction%0A%20%20%20%3E%20Forbidden%20API%20verification%20failed&search.timeZoneId=Europe%2FBerlin&search.usernames=rene