### PR TITLE
Enable concurrency for scripted metric agg

### DIFF
--- a/docs/changelog/102461.yaml
+++ b/docs/changelog/102461.yaml
@@ -1,0 +1,5 @@
+pr: 102461
+summary: Enable concurrency for scripted metric agg
+area: Aggregations
+type: enhancement
+issues: []

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricIT.java
@@ -742,7 +742,6 @@ public class ScriptedMetricIT extends ESIntegTestCase {
                 assertThat(((InternalAggregation) global).getProperty("scripted"), sameInstance(scriptedMetricAggregation));
                 assertThat((List) ((InternalAggregation) global).getProperty("scripted.value"), sameInstance(aggregationList));
                 assertThat((List) ((InternalAggregation) scriptedMetricAggregation).getProperty("value"), sameInstance(aggregationList));
-                
             }
         );
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricIT.java
@@ -742,6 +742,7 @@ public class ScriptedMetricIT extends ESIntegTestCase {
                 assertThat(((InternalAggregation) global).getProperty("scripted"), sameInstance(scriptedMetricAggregation));
                 assertThat((List) ((InternalAggregation) global).getProperty("scripted.value"), sameInstance(aggregationList));
                 assertThat((List) ((InternalAggregation) scriptedMetricAggregation).getProperty("value"), sameInstance(aggregationList));
+                
             }
         );
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricIT.java
@@ -373,7 +373,7 @@ public class ScriptedMetricIT extends ESIntegTestCase {
                 assertThat(scriptedMetricAggregation.aggregation(), notNullValue());
                 assertThat(scriptedMetricAggregation.aggregation(), instanceOf(ArrayList.class));
                 List<?> aggregationList = (List<?>) scriptedMetricAggregation.aggregation();
-                assertThat(aggregationList.size(), equalTo(getNumShards("idx").numPrimaries));
+                assertThat(aggregationList.size(), greaterThanOrEqualTo(getNumShards("idx").numPrimaries));
                 int numShardsRun = 0;
                 for (Object object : aggregationList) {
                     assertThat(object, notNullValue());
@@ -422,7 +422,7 @@ public class ScriptedMetricIT extends ESIntegTestCase {
                 assertThat(scriptedMetricAggregation.aggregation(), notNullValue());
                 assertThat(scriptedMetricAggregation.aggregation(), instanceOf(ArrayList.class));
                 List<?> aggregationList = (List<?>) scriptedMetricAggregation.aggregation();
-                assertThat(aggregationList.size(), equalTo(getNumShards("idx").numPrimaries));
+                assertThat(aggregationList.size(), greaterThanOrEqualTo(getNumShards("idx").numPrimaries));
                 int numShardsRun = 0;
                 for (Object object : aggregationList) {
                     assertThat(object, notNullValue());
@@ -482,7 +482,7 @@ public class ScriptedMetricIT extends ESIntegTestCase {
                 assertThat(scriptedMetricAggregation.aggregation(), notNullValue());
                 assertThat(scriptedMetricAggregation.aggregation(), instanceOf(ArrayList.class));
                 List<?> aggregationList = (List<?>) scriptedMetricAggregation.aggregation();
-                assertThat(aggregationList.size(), equalTo(getNumShards("idx").numPrimaries));
+                assertThat(aggregationList.size(), greaterThanOrEqualTo(getNumShards("idx").numPrimaries));
                 long totalCount = 0;
                 for (Object object : aggregationList) {
                     assertThat(object, notNullValue());
@@ -537,7 +537,7 @@ public class ScriptedMetricIT extends ESIntegTestCase {
                 assertThat(scriptedMetricAggregation.aggregation(), notNullValue());
                 assertThat(scriptedMetricAggregation.aggregation(), instanceOf(ArrayList.class));
                 List<?> aggregationList = (List<?>) scriptedMetricAggregation.aggregation();
-                assertThat(aggregationList.size(), equalTo(getNumShards("idx").numPrimaries));
+                assertThat(aggregationList.size(), greaterThanOrEqualTo(getNumShards("idx").numPrimaries));
                 long totalCount = 0;
                 for (Object object : aggregationList) {
                     assertThat(object, notNullValue());
@@ -601,7 +601,7 @@ public class ScriptedMetricIT extends ESIntegTestCase {
                 assertThat(scriptedMetricAggregation.aggregation(), notNullValue());
                 assertThat(scriptedMetricAggregation.aggregation(), instanceOf(ArrayList.class));
                 List<?> aggregationList = (List<?>) scriptedMetricAggregation.aggregation();
-                assertThat(aggregationList.size(), equalTo(getNumShards("idx").numPrimaries));
+                assertThat(aggregationList.size(), greaterThanOrEqualTo(getNumShards("idx").numPrimaries));
                 long totalCount = 0;
                 for (Object object : aggregationList) {
                     assertThat(object, notNullValue());

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricAggregationBuilder.java
@@ -284,9 +284,4 @@ public class ScriptedMetricAggregationBuilder extends AbstractAggregationBuilder
             && Objects.equals(reduceScript, other.reduceScript)
             && Objects.equals(params, other.params);
     }
-
-    @Override
-    public boolean supportsParallelCollection() {
-        return false;
-    }
 }


### PR DESCRIPTION
Scripted metric has concurrency enabled due to test failures on ScriptedMetricIT.

Those are merely test issues that can be addressed though, hence concurrency can be enabled for scripted metric.
