### PR TITLE
[Health API] Abstract data tier diagnoses as node roles

### DIFF
--- a/server/src/main/java/module-info.java
+++ b/server/src/main/java/module-info.java
@@ -422,5 +422,9 @@ module org.elasticsearch.server {
             org.elasticsearch.index.codec.bloomfilter.ES87BloomFilterPostingsFormat;
     provides org.apache.lucene.codecs.DocValuesFormat with ES87TSDBDocValuesFormat;
 
-    exports org.elasticsearch.cluster.routing.allocation.shards to org.elasticsearch.shardhealth, org.elasticsearch.serverless.shardhealth, org.elasticsearch.serverless.apifiltering;
+    exports org.elasticsearch.cluster.routing.allocation.shards
+        to
+            org.elasticsearch.shardhealth,
+            org.elasticsearch.serverless.shardhealth,
+            org.elasticsearch.serverless.apifiltering;
 }

--- a/server/src/main/java/module-info.java
+++ b/server/src/main/java/module-info.java
@@ -422,5 +422,5 @@ module org.elasticsearch.server {
             org.elasticsearch.index.codec.bloomfilter.ES87BloomFilterPostingsFormat;
     provides org.apache.lucene.codecs.DocValuesFormat with ES87TSDBDocValuesFormat;
 
-    exports org.elasticsearch.cluster.routing.allocation.shards to org.elasticsearch.shardhealth, org.elasticsearch.serverless.shardhealth;
+    exports org.elasticsearch.cluster.routing.allocation.shards to org.elasticsearch.shardhealth, org.elasticsearch.serverless.shardhealth, org.elasticsearch.serverless.apifiltering;
 }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/shards/ShardsAvailabilityHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/shards/ShardsAvailabilityHealthIndicatorService.java
@@ -641,7 +641,7 @@ public class ShardsAvailabilityHealthIndicatorService implements HealthIndicator
      * @param outcome The outcome expected
      * @return A predicate that returns true if the decision exists and matches the expected outcome, false otherwise.
      */
-    private static Predicate<NodeAllocationResult> hasDeciderResult(String deciderName, Decision.Type outcome) {
+    protected static Predicate<NodeAllocationResult> hasDeciderResult(String deciderName, Decision.Type outcome) {
         return (nodeResult) -> {
             Decision decision = nodeResult.getCanAllocateDecision();
             return decision != null && decision.getDecisions().stream().anyMatch(d -> deciderName.equals(d.label()) && outcome == d.type());

--- a/server/src/main/java/org/elasticsearch/health/GetHealthAction.java
+++ b/server/src/main/java/org/elasticsearch/health/GetHealthAction.java
@@ -67,6 +67,12 @@ public class GetHealthAction extends ActionType<GetHealthAction.Response> {
             }
         }
 
+        public Response(final ClusterName clusterName, final List<HealthIndicatorResult> indicators, HealthStatus topLevelStatus) {
+            this.indicators = indicators;
+            this.clusterName = clusterName;
+            this.status = topLevelStatus;
+        }
+
         public ClusterName getClusterName() {
             return clusterName;
         }

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityActionGuideTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityActionGuideTests.java
@@ -8,17 +8,17 @@
 
 package org.elasticsearch.cluster.routing.allocation;
 
+import org.elasticsearch.cluster.routing.allocation.shards.ShardsAvailabilityHealthIndicatorService;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.indices.SystemIndices;
 import org.elasticsearch.test.ESTestCase;
 
 import static org.elasticsearch.cluster.routing.allocation.shards.ShardsAvailabilityHealthIndicatorService.ACTION_CHECK_ALLOCATION_EXPLAIN_API;
 import static org.elasticsearch.cluster.routing.allocation.shards.ShardsAvailabilityHealthIndicatorService.ACTION_ENABLE_CLUSTER_ROUTING_ALLOCATION;
 import static org.elasticsearch.cluster.routing.allocation.shards.ShardsAvailabilityHealthIndicatorService.ACTION_ENABLE_INDEX_ROUTING_ALLOCATION;
-import static org.elasticsearch.cluster.routing.allocation.shards.ShardsAvailabilityHealthIndicatorService.ACTION_ENABLE_TIERS_LOOKUP;
 import static org.elasticsearch.cluster.routing.allocation.shards.ShardsAvailabilityHealthIndicatorService.ACTION_INCREASE_NODE_CAPACITY;
 import static org.elasticsearch.cluster.routing.allocation.shards.ShardsAvailabilityHealthIndicatorService.ACTION_INCREASE_SHARD_LIMIT_CLUSTER_SETTING;
-import static org.elasticsearch.cluster.routing.allocation.shards.ShardsAvailabilityHealthIndicatorService.ACTION_INCREASE_SHARD_LIMIT_CLUSTER_SETTING_LOOKUP;
 import static org.elasticsearch.cluster.routing.allocation.shards.ShardsAvailabilityHealthIndicatorService.ACTION_INCREASE_SHARD_LIMIT_INDEX_SETTING;
-import static org.elasticsearch.cluster.routing.allocation.shards.ShardsAvailabilityHealthIndicatorService.ACTION_INCREASE_SHARD_LIMIT_INDEX_SETTING_LOOKUP;
 import static org.elasticsearch.cluster.routing.allocation.shards.ShardsAvailabilityHealthIndicatorService.ACTION_MIGRATE_TIERS_AWAY_FROM_INCLUDE_DATA;
 import static org.elasticsearch.cluster.routing.allocation.shards.ShardsAvailabilityHealthIndicatorService.ACTION_MIGRATE_TIERS_AWAY_FROM_REQUIRE_DATA;
 import static org.elasticsearch.cluster.routing.allocation.shards.ShardsAvailabilityHealthIndicatorService.ACTION_RESTORE_FROM_SNAPSHOT;
@@ -32,8 +32,15 @@ import static org.elasticsearch.cluster.routing.allocation.shards.ShardsAvailabi
 import static org.elasticsearch.cluster.routing.allocation.shards.ShardsAvailabilityHealthIndicatorService.RESTORE_FROM_SNAPSHOT_ACTION_GUIDE;
 import static org.elasticsearch.cluster.routing.allocation.shards.ShardsAvailabilityHealthIndicatorService.TIER_CAPACITY_ACTION_GUIDE;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
 
 public class ShardsAvailabilityActionGuideTests extends ESTestCase {
+
+    private final ShardsAvailabilityHealthIndicatorService service = new ShardsAvailabilityHealthIndicatorService(
+        mock(ClusterService.class),
+        mock(AllocationService.class),
+        mock(SystemIndices.class)
+    );
 
     public void testRestoreFromSnapshotAction() {
         assertThat(ACTION_RESTORE_FROM_SNAPSHOT.helpURL(), is(RESTORE_FROM_SNAPSHOT_ACTION_GUIDE));
@@ -60,20 +67,17 @@ public class ShardsAvailabilityActionGuideTests extends ESTestCase {
     }
 
     public void testEnableDataTiers() {
-        assertThat(ACTION_ENABLE_TIERS_LOOKUP.get(DataTier.DATA_HOT).helpURL(), is(ENABLE_TIER_ACTION_GUIDE));
+        assertThat(service.getAddNodesWithRoleAction(DataTier.DATA_HOT).helpURL(), is(ENABLE_TIER_ACTION_GUIDE));
     }
 
     public void testIncreaseShardLimitIndexSettingInTier() {
-        assertThat(
-            ACTION_INCREASE_SHARD_LIMIT_INDEX_SETTING_LOOKUP.get(DataTier.DATA_HOT).helpURL(),
-            is(INCREASE_SHARD_LIMIT_ACTION_GUIDE)
-        );
+        assertThat(service.getIncreaseShardLimitIndexSettingAction(DataTier.DATA_HOT).helpURL(), is(INCREASE_SHARD_LIMIT_ACTION_GUIDE));
         assertThat(ACTION_INCREASE_SHARD_LIMIT_INDEX_SETTING.helpURL(), is(INCREASE_SHARD_LIMIT_ACTION_GUIDE));
     }
 
     public void testIncreaseShardLimitClusterSettingInTier() {
         assertThat(
-            ACTION_INCREASE_SHARD_LIMIT_CLUSTER_SETTING_LOOKUP.get(DataTier.DATA_HOT).helpURL(),
+            service.getIncreaseShardLimitClusterSettingAction(DataTier.DATA_HOT).helpURL(),
             is(INCREASE_CLUSTER_SHARD_LIMIT_ACTION_GUIDE)
         );
         assertThat(ACTION_INCREASE_SHARD_LIMIT_CLUSTER_SETTING.helpURL(), is(INCREASE_CLUSTER_SHARD_LIMIT_ACTION_GUIDE));

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/shards/ShardsAvailabilityHealthIndicatorServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/shards/ShardsAvailabilityHealthIndicatorServiceTests.java
@@ -1111,7 +1111,7 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
         var service = createShardsAvailabilityIndicatorService();
 
         // Get the list of user actions that are generated for this unassigned index shard
-        List<Diagnosis.Definition> actions = service.checkDataTierRelatedIssues(
+        List<Diagnosis.Definition> actions = service.checkNodeRoleRelatedIssues(
             indexMetadata,
             List.of(
                 // Shard is not allowed due to data tier filter
@@ -1121,7 +1121,8 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
                     1
                 )
             ),
-            ClusterState.EMPTY_STATE
+            ClusterState.EMPTY_STATE,
+            null
         );
 
         assertThat(actions, hasSize(1));
@@ -1169,7 +1170,7 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
         var service = createShardsAvailabilityIndicatorService();
 
         // Get the list of user actions that are generated for this unassigned index shard
-        List<Diagnosis.Definition> actions = service.checkDataTierRelatedIssues(
+        List<Diagnosis.Definition> actions = service.checkNodeRoleRelatedIssues(
             indexMetadata,
             List.of(
                 new NodeAllocationResult(
@@ -1180,7 +1181,8 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
                     1
                 )
             ),
-            clusterState
+            clusterState,
+            null
         );
 
         assertThat(actions, hasSize(1));
@@ -1233,7 +1235,7 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
         );
 
         // Get the list of user actions that are generated for this unassigned index shard
-        List<Diagnosis.Definition> actions = service.checkDataTierRelatedIssues(
+        List<Diagnosis.Definition> actions = service.checkNodeRoleRelatedIssues(
             indexMetadata,
             List.of(
                 new NodeAllocationResult(
@@ -1244,7 +1246,8 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
                     1
                 )
             ),
-            clusterState
+            clusterState,
+            null
         );
 
         assertThat(actions, hasSize(1));
@@ -1292,7 +1295,7 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
         var service = createShardsAvailabilityIndicatorService();
 
         // Get the list of user actions that are generated for this unassigned index shard
-        List<Diagnosis.Definition> actions = service.checkDataTierRelatedIssues(
+        List<Diagnosis.Definition> actions = service.checkNodeRoleRelatedIssues(
             indexMetadata,
             List.of(
                 new NodeAllocationResult(
@@ -1303,7 +1306,8 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
                     1
                 )
             ),
-            clusterState
+            clusterState,
+            null
         );
 
         assertThat(actions, hasSize(1));
@@ -1356,7 +1360,7 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
         );
 
         // Get the list of user actions that are generated for this unassigned index shard
-        List<Diagnosis.Definition> actions = service.checkDataTierRelatedIssues(
+        List<Diagnosis.Definition> actions = service.checkNodeRoleRelatedIssues(
             indexMetadata,
             List.of(
                 new NodeAllocationResult(
@@ -1367,7 +1371,8 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
                     1
                 )
             ),
-            clusterState
+            clusterState,
+            null
         );
 
         assertThat(actions, hasSize(1));
@@ -1391,7 +1396,7 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
         var service = createShardsAvailabilityIndicatorService();
 
         // Get the list of user actions that are generated for this unassigned index shard
-        List<Diagnosis.Definition> actions = service.checkDataTierRelatedIssues(
+        List<Diagnosis.Definition> actions = service.checkNodeRoleRelatedIssues(
             indexMetadata,
             List.of(
                 // Shard is allowed on data tier, but disallowed because of allocation filters
@@ -1403,7 +1408,8 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
                     1
                 )
             ),
-            ClusterState.EMPTY_STATE
+            ClusterState.EMPTY_STATE,
+            null
         );
 
         assertThat(actions, hasSize(1));
@@ -1427,7 +1433,7 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
         var service = createShardsAvailabilityIndicatorService();
 
         // Get the list of user actions that are generated for this unassigned index shard
-        List<Diagnosis.Definition> actions = service.checkDataTierRelatedIssues(
+        List<Diagnosis.Definition> actions = service.checkNodeRoleRelatedIssues(
             indexMetadata,
             List.of(
                 // Shard is allowed on data tier, but disallowed because of allocation filters
@@ -1439,7 +1445,8 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
                     1
                 )
             ),
-            ClusterState.EMPTY_STATE
+            ClusterState.EMPTY_STATE,
+            null
         );
 
         assertThat(actions, hasSize(1));
@@ -1462,7 +1469,7 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
         var service = createShardsAvailabilityIndicatorService();
 
         // Get the list of user actions that are generated for this unassigned index shard
-        List<Diagnosis.Definition> actions = service.checkDataTierRelatedIssues(
+        List<Diagnosis.Definition> actions = service.checkNodeRoleRelatedIssues(
             indexMetadata,
             List.of(
                 // Shard is allowed on data tier, but disallowed because of allocation filters
@@ -1474,7 +1481,8 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
                     1
                 )
             ),
-            ClusterState.EMPTY_STATE
+            ClusterState.EMPTY_STATE,
+            null
         );
 
         // checkDataTierRelatedIssues will leave list empty. Diagnosis methods upstream will add "Check allocation explain" action.
@@ -1497,7 +1505,7 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
         var service = createShardsAvailabilityIndicatorService();
 
         // Get the list of user actions that are generated for this unassigned index shard
-        List<Diagnosis.Definition> actions = service.checkDataTierRelatedIssues(
+        List<Diagnosis.Definition> actions = service.checkNodeRoleRelatedIssues(
             indexMetadata,
             List.of(
                 // Shard is allowed on data tier, but disallowed because node is already hosting a copy of it.
@@ -1513,7 +1521,8 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
                     1
                 )
             ),
-            ClusterState.EMPTY_STATE
+            ClusterState.EMPTY_STATE,
+            null
         );
 
         assertThat(actions, hasSize(1));
@@ -1536,7 +1545,7 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
         var service = createShardsAvailabilityIndicatorService();
 
         // Get the list of user actions that are generated for this unassigned index shard
-        List<Diagnosis.Definition> actions = service.checkDataTierRelatedIssues(
+        List<Diagnosis.Definition> actions = service.checkNodeRoleRelatedIssues(
             indexMetadata,
             List.of(
                 // Shard is allowed on data tier, but disallowed because node is already hosting a copy of it.
@@ -1552,7 +1561,8 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
                     1
                 )
             ),
-            ClusterState.EMPTY_STATE
+            ClusterState.EMPTY_STATE,
+            null
         );
 
         assertThat(actions, hasSize(1));

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/shards/ShardsAvailabilityHealthIndicatorServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/shards/ShardsAvailabilityHealthIndicatorServiceTests.java
@@ -60,7 +60,6 @@ import org.elasticsearch.indices.SystemIndices;
 import org.elasticsearch.snapshots.SearchableSnapshotsSettings;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.hamcrest.Matchers;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 
@@ -115,6 +114,7 @@ import static org.hamcrest.Matchers.emptyCollectionOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -832,16 +832,16 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
         );
         HealthIndicatorResult result = service.calculate(true, HealthInfo.EMPTY_HEALTH_INFO);
 
-        assertThat(result.status(), Matchers.is(HealthStatus.RED));
-        assertThat(result.diagnosisList().size(), Matchers.is(1));
+        assertThat(result.status(), is(HealthStatus.RED));
+        assertThat(result.diagnosisList().size(), is(1));
         Diagnosis diagnosis = result.diagnosisList().get(0);
         List<Diagnosis.Resource> affectedResources = diagnosis.affectedResources();
-        assertThat("expecting we report a resource of type INDEX and one of type FEATURE_STATE", affectedResources.size(), Matchers.is(2));
+        assertThat("expecting we report a resource of type INDEX and one of type FEATURE_STATE", affectedResources.size(), is(2));
         for (Diagnosis.Resource resource : affectedResources) {
             if (resource.getType() == INDEX) {
                 assertThat(resource.getValues(), hasItems("regular-index"));
             } else {
-                assertThat(resource.getType(), Matchers.is(FEATURE_STATE));
+                assertThat(resource.getType(), is(FEATURE_STATE));
                 assertThat(resource.getValues(), hasItems("feature-with-system-data-stream", "feature-with-system-index"));
             }
         }
@@ -881,12 +881,12 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
                 10
             );
 
-            assertThat(affectedResources.size(), Matchers.is(2));
+            assertThat(affectedResources.size(), is(2));
             for (Diagnosis.Resource resource : affectedResources) {
                 if (resource.getType() == INDEX) {
                     assertThat(resource.getValues(), hasItems("regular-index"));
                 } else {
-                    assertThat(resource.getType(), Matchers.is(FEATURE_STATE));
+                    assertThat(resource.getType(), is(FEATURE_STATE));
                     assertThat(resource.getValues(), hasItems("feature-with-system-data-stream", "feature-with-system-index"));
                 }
             }
@@ -900,12 +900,12 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
                 0
             );
 
-            assertThat(affectedResources.size(), Matchers.is(2));
+            assertThat(affectedResources.size(), is(2));
             for (Diagnosis.Resource resource : affectedResources) {
                 if (resource.getType() == INDEX) {
                     assertThat(resource.getValues(), emptyCollectionOf(String.class));
                 } else {
-                    assertThat(resource.getType(), Matchers.is(FEATURE_STATE));
+                    assertThat(resource.getType(), is(FEATURE_STATE));
                     assertThat(resource.getValues(), emptyCollectionOf(String.class));
                 }
             }

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/shards/ShardsAvailabilityHealthIndicatorServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/shards/ShardsAvailabilityHealthIndicatorServiceTests.java
@@ -60,6 +60,7 @@ import org.elasticsearch.indices.SystemIndices;
 import org.elasticsearch.snapshots.SearchableSnapshotsSettings;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.hamcrest.Matchers;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 
@@ -85,13 +86,9 @@ import static org.elasticsearch.cluster.routing.allocation.decider.ShardsLimitAl
 import static org.elasticsearch.cluster.routing.allocation.shards.ShardsAvailabilityHealthIndicatorService.ACTION_CHECK_ALLOCATION_EXPLAIN_API;
 import static org.elasticsearch.cluster.routing.allocation.shards.ShardsAvailabilityHealthIndicatorService.ACTION_ENABLE_CLUSTER_ROUTING_ALLOCATION;
 import static org.elasticsearch.cluster.routing.allocation.shards.ShardsAvailabilityHealthIndicatorService.ACTION_ENABLE_INDEX_ROUTING_ALLOCATION;
-import static org.elasticsearch.cluster.routing.allocation.shards.ShardsAvailabilityHealthIndicatorService.ACTION_ENABLE_TIERS_LOOKUP;
 import static org.elasticsearch.cluster.routing.allocation.shards.ShardsAvailabilityHealthIndicatorService.ACTION_INCREASE_NODE_CAPACITY;
 import static org.elasticsearch.cluster.routing.allocation.shards.ShardsAvailabilityHealthIndicatorService.ACTION_INCREASE_SHARD_LIMIT_CLUSTER_SETTING;
-import static org.elasticsearch.cluster.routing.allocation.shards.ShardsAvailabilityHealthIndicatorService.ACTION_INCREASE_SHARD_LIMIT_CLUSTER_SETTING_LOOKUP;
 import static org.elasticsearch.cluster.routing.allocation.shards.ShardsAvailabilityHealthIndicatorService.ACTION_INCREASE_SHARD_LIMIT_INDEX_SETTING;
-import static org.elasticsearch.cluster.routing.allocation.shards.ShardsAvailabilityHealthIndicatorService.ACTION_INCREASE_SHARD_LIMIT_INDEX_SETTING_LOOKUP;
-import static org.elasticsearch.cluster.routing.allocation.shards.ShardsAvailabilityHealthIndicatorService.ACTION_INCREASE_TIER_CAPACITY_LOOKUP;
 import static org.elasticsearch.cluster.routing.allocation.shards.ShardsAvailabilityHealthIndicatorService.ACTION_MIGRATE_TIERS_AWAY_FROM_INCLUDE_DATA;
 import static org.elasticsearch.cluster.routing.allocation.shards.ShardsAvailabilityHealthIndicatorService.ACTION_MIGRATE_TIERS_AWAY_FROM_INCLUDE_DATA_LOOKUP;
 import static org.elasticsearch.cluster.routing.allocation.shards.ShardsAvailabilityHealthIndicatorService.ACTION_MIGRATE_TIERS_AWAY_FROM_REQUIRE_DATA;
@@ -118,7 +115,6 @@ import static org.hamcrest.Matchers.emptyCollectionOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -836,16 +832,16 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
         );
         HealthIndicatorResult result = service.calculate(true, HealthInfo.EMPTY_HEALTH_INFO);
 
-        assertThat(result.status(), is(HealthStatus.RED));
-        assertThat(result.diagnosisList().size(), is(1));
+        assertThat(result.status(), Matchers.is(HealthStatus.RED));
+        assertThat(result.diagnosisList().size(), Matchers.is(1));
         Diagnosis diagnosis = result.diagnosisList().get(0);
         List<Diagnosis.Resource> affectedResources = diagnosis.affectedResources();
-        assertThat("expecting we report a resource of type INDEX and one of type FEATURE_STATE", affectedResources.size(), is(2));
+        assertThat("expecting we report a resource of type INDEX and one of type FEATURE_STATE", affectedResources.size(), Matchers.is(2));
         for (Diagnosis.Resource resource : affectedResources) {
             if (resource.getType() == INDEX) {
                 assertThat(resource.getValues(), hasItems("regular-index"));
             } else {
-                assertThat(resource.getType(), is(FEATURE_STATE));
+                assertThat(resource.getType(), Matchers.is(FEATURE_STATE));
                 assertThat(resource.getValues(), hasItems("feature-with-system-data-stream", "feature-with-system-index"));
             }
         }
@@ -885,12 +881,12 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
                 10
             );
 
-            assertThat(affectedResources.size(), is(2));
+            assertThat(affectedResources.size(), Matchers.is(2));
             for (Diagnosis.Resource resource : affectedResources) {
                 if (resource.getType() == INDEX) {
                     assertThat(resource.getValues(), hasItems("regular-index"));
                 } else {
-                    assertThat(resource.getType(), is(FEATURE_STATE));
+                    assertThat(resource.getType(), Matchers.is(FEATURE_STATE));
                     assertThat(resource.getValues(), hasItems("feature-with-system-data-stream", "feature-with-system-index"));
                 }
             }
@@ -904,12 +900,12 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
                 0
             );
 
-            assertThat(affectedResources.size(), is(2));
+            assertThat(affectedResources.size(), Matchers.is(2));
             for (Diagnosis.Resource resource : affectedResources) {
                 if (resource.getType() == INDEX) {
                     assertThat(resource.getValues(), emptyCollectionOf(String.class));
                 } else {
-                    assertThat(resource.getType(), is(FEATURE_STATE));
+                    assertThat(resource.getType(), Matchers.is(FEATURE_STATE));
                     assertThat(resource.getValues(), emptyCollectionOf(String.class));
                 }
             }
@@ -1129,7 +1125,7 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
         );
 
         assertThat(actions, hasSize(1));
-        assertThat(actions, contains(ACTION_ENABLE_TIERS_LOOKUP.get(DataTier.DATA_HOT)));
+        assertThat(actions, contains(service.getAddNodesWithRoleAction(DataTier.DATA_HOT)));
     }
 
     public void testDiagnoseIncreaseShardLimitIndexSettingInTier() {
@@ -1188,7 +1184,7 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
         );
 
         assertThat(actions, hasSize(1));
-        assertThat(actions, contains(ACTION_INCREASE_SHARD_LIMIT_INDEX_SETTING_LOOKUP.get(DataTier.DATA_HOT)));
+        assertThat(actions, contains(service.getIncreaseShardLimitIndexSettingAction(DataTier.DATA_HOT)));
     }
 
     public void testDiagnoseIncreaseShardLimitClusterSettingInTier() {
@@ -1252,7 +1248,7 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
         );
 
         assertThat(actions, hasSize(1));
-        assertThat(actions, contains(ACTION_INCREASE_SHARD_LIMIT_CLUSTER_SETTING_LOOKUP.get(DataTier.DATA_HOT)));
+        assertThat(actions, contains(service.getIncreaseShardLimitClusterSettingAction(DataTier.DATA_HOT)));
     }
 
     public void testDiagnoseIncreaseShardLimitIndexSettingInGeneral() {
@@ -1521,7 +1517,7 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
         );
 
         assertThat(actions, hasSize(1));
-        assertThat(actions, contains(ACTION_INCREASE_TIER_CAPACITY_LOOKUP.get(DataTier.DATA_HOT)));
+        assertThat(actions, contains(service.getIncreaseNodeWithRoleCapacityAction(DataTier.DATA_HOT)));
     }
 
     public void testDiagnoseIncreaseNodeCapacity() {
@@ -1874,17 +1870,22 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
             DIAGNOSIS_WAIT_FOR_INITIALIZATION.getUniqueId(),
             equalTo("elasticsearch:health:shards_availability:diagnosis:initializing_shards")
         );
+        var service = new ShardsAvailabilityHealthIndicatorService(
+            mock(ClusterService.class),
+            mock(AllocationService.class),
+            mock(SystemIndices.class)
+        );
         for (String tier : List.of("data_content", "data_hot", "data_warm", "data_cold", "data_frozen")) {
             assertThat(
-                ACTION_ENABLE_TIERS_LOOKUP.get(tier).getUniqueId(),
+                service.getAddNodesWithRoleAction(tier).getUniqueId(),
                 equalTo("elasticsearch:health:shards_availability:diagnosis:enable_data_tiers:tier:" + tier)
             );
             assertThat(
-                ACTION_INCREASE_SHARD_LIMIT_INDEX_SETTING_LOOKUP.get(tier).getUniqueId(),
+                service.getIncreaseShardLimitIndexSettingAction(tier).getUniqueId(),
                 equalTo("elasticsearch:health:shards_availability:diagnosis:increase_shard_limit_index_setting:tier:" + tier)
             );
             assertThat(
-                ACTION_INCREASE_SHARD_LIMIT_CLUSTER_SETTING_LOOKUP.get(tier).getUniqueId(),
+                service.getIncreaseShardLimitClusterSettingAction(tier).getUniqueId(),
                 equalTo("elasticsearch:health:shards_availability:diagnosis:increase_shard_limit_cluster_setting:tier:" + tier)
             );
             assertThat(
@@ -1896,7 +1897,7 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
                 equalTo("elasticsearch:health:shards_availability:diagnosis:migrate_data_tiers_include_data:tier:" + tier)
             );
             assertThat(
-                ACTION_INCREASE_TIER_CAPACITY_LOOKUP.get(tier).getUniqueId(),
+                service.getIncreaseNodeWithRoleCapacityAction(tier).getUniqueId(),
                 equalTo("elasticsearch:health:shards_availability:diagnosis:increase_tier_capacity_for_allocations:tier:" + tier)
             );
         }


### PR DESCRIPTION
In this PR we would like to generalise the code that is diagnosing the shard availability when it comes to data tier issues. We would like to make it a bit more extensible so in serverless we can introduce new roles.

For this reason, we consider a tier as a more specific kind of a role. Then we expose some methods and some diagnosis definitions in the `ShardsAvailabilityHealthIndicatorService` so they can be extended. This includes the following lookup tables:
- `ACTION_ENABLE_TIERS_LOOKUP` is accessed via `getAddNodesWithRoleAction`
- `ACTION_INCREASE_SHARD_LIMIT_INDEX_SETTING_LOOKUP` is accessed via `getIncreaseShardLimitIndexSettingAction`
- `ACTION_INCREASE_SHARD_LIMIT_CLUSTER_SETTING_LOOKUP` is accessed via `getIncreaseShardLimitClusterSettingAction`
- `ACTION_INCREASE_TIER_CAPACITY_LOOKUP` is accessed via `getIncreaseNodeWithRoleCapacityAction`

And the methods:
- `checkDataTierRelatedIssues`
- `checkDataTierAtShardLimit`
- `checkNotEnoughNodesInDataTier`

We only leave the migrate diagnoses because they refer to data tier migration.