### PR TITLE
Don't wrap ElasticsearchExceptions when loading in the Cache

### DIFF
--- a/docs/changelog/102471.yaml
+++ b/docs/changelog/102471.yaml
@@ -1,0 +1,5 @@
+pr: 102471
+summary: Don't wrap `ElasticsearchExceptions` when loading in the Cache
+area: Aggregations
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/common/cache/Cache.java
+++ b/server/src/main/java/org/elasticsearch/common/cache/Cache.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.common.cache;
 
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.util.concurrent.ReleasableLock;
 import org.elasticsearch.core.Tuple;
 
@@ -418,6 +419,9 @@ public class Cache<K, V> {
                     loaded = loader.load(key);
                 } catch (Exception e) {
                     future.completeExceptionally(e);
+                    if (e instanceof ElasticsearchException ex) {
+                        throw ex;
+                    }
                     throw new ExecutionException(e);
                 }
                 if (loaded == null) {

--- a/server/src/test/java/org/elasticsearch/common/cache/CacheTests.java
+++ b/server/src/test/java/org/elasticsearch/common/cache/CacheTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.common.cache;
 
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Before;
@@ -36,6 +37,7 @@ import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 public class CacheTests extends ESTestCase {
@@ -792,6 +794,14 @@ public class CacheTests extends ESTestCase {
         safeAwait(barrier);
         // wait for all threads to finish
         safeAwait(barrier);
+    }
+
+    public void testElasticSearchExceptionNotWrappedWhileAddingEntry() {
+        final Cache<Integer, String> cache = CacheBuilder.<Integer, String>builder().build();
+        ElasticsearchException ex = expectThrows(ElasticsearchException.class, () -> cache.computeIfAbsent(0, i -> {
+            throw new ElasticsearchException("fail");
+        }));
+        assertThat(ex.getMessage(), equalTo("fail"));
     }
 
     public void testExceptionThrownDuringConcurrentComputeIfAbsent() {


### PR DESCRIPTION
This is an issue, for example when throwing a Circuit breaker exception as the cause gets hidden and ends up logged.