### PR TITLE
Adding extension point in ServerCli to add processing after server process exited

### DIFF
--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/ServerCli.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/ServerCli.java
@@ -108,16 +108,17 @@ class ServerCli extends EnvironmentAwareCommand {
         // we are running in the foreground, so wait for the server to exit
         int exitCode = server.waitFor();
         onExit(exitCode);
+    }
+
+    /**
+     * A post-exit hook to perform additional processing before the command terminates
+     * @param exitCode the server process exit code
+     */
+    protected void onExit(int exitCode) throws UserException {
         if (exitCode != ExitCodes.OK) {
             throw new UserException(exitCode, "Elasticsearch exited unexpectedly");
         }
     }
-
-    /**
-     * A post-exit hook to optionally perform additional processing before the command terminates
-     * @param exitCode the server process exit code
-     */
-    protected void onExit(int exitCode) {}
 
     private static void printVersion(Terminal terminal) {
         final String versionOutput = String.format(

--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/ServerCli.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/ServerCli.java
@@ -107,10 +107,17 @@ class ServerCli extends EnvironmentAwareCommand {
 
         // we are running in the foreground, so wait for the server to exit
         int exitCode = server.waitFor();
+        checkExit(exitCode);
         if (exitCode != ExitCodes.OK) {
             throw new UserException(exitCode, "Elasticsearch exited unexpectedly");
         }
     }
+
+    /**
+     * A post-exit hook to optionally perform additional processing before the command terminates
+     * @param exitCode the server process exit code
+     */
+    protected void checkExit(int exitCode) {}
 
     private static void printVersion(Terminal terminal) {
         final String versionOutput = String.format(

--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/ServerCli.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/ServerCli.java
@@ -107,7 +107,7 @@ class ServerCli extends EnvironmentAwareCommand {
 
         // we are running in the foreground, so wait for the server to exit
         int exitCode = server.waitFor();
-        checkExit(exitCode);
+        onExit(exitCode);
         if (exitCode != ExitCodes.OK) {
             throw new UserException(exitCode, "Elasticsearch exited unexpectedly");
         }
@@ -117,7 +117,7 @@ class ServerCli extends EnvironmentAwareCommand {
      * A post-exit hook to optionally perform additional processing before the command terminates
      * @param exitCode the server process exit code
      */
-    protected void checkExit(int exitCode) {}
+    protected void onExit(int exitCode) {}
 
     private static void printVersion(Terminal terminal) {
         final String versionOutput = String.format(


### PR DESCRIPTION
`ServerCli` can be extended to customize the launch of the elasticsearch server process - we use this feature in serverless, were we have `ServerlessServerCli`.

This PR adds an extension point just after the server process exited, allowing to add custom processing to happen after the server process returned but before the cli launcher exits (when the server process is not daemonized).
The extension point will be used in `elasticsearch-serverless` to enable post-processing when the process died for OOME and a heap dump was created and needs to be handled.
