### PR TITLE
Unwrap ExecutionException when loading from cache in AbstractIndexOrdinalsFieldData

### DIFF
--- a/docs/changelog/102476.yaml
+++ b/docs/changelog/102476.yaml
@@ -1,0 +1,5 @@
+pr: 102476
+summary: Unwrap `ExecutionException` when loading from cache in `AbstractIndexOrdinalsFieldData`
+area: Aggregations
+type: bug
+issues: []

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/memory/breaker/CircuitBreakerServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/memory/breaker/CircuitBreakerServiceIT.java
@@ -144,9 +144,9 @@ public class CircuitBreakerServiceIT extends ESIntegTestCase {
         SearchRequestBuilder searchRequest = client.prepareSearch("cb-test").setQuery(matchAllQuery()).addSort("test", SortOrder.DESC);
 
         String errMsg = "Data too large, data for [test] would be";
-        assertFailures(searchRequest, RestStatus.INTERNAL_SERVER_ERROR, containsString(errMsg));
+        assertFailures(searchRequest, RestStatus.TOO_MANY_REQUESTS, containsString(errMsg));
         errMsg = "which is larger than the limit of [100/100b]";
-        assertFailures(searchRequest, RestStatus.INTERNAL_SERVER_ERROR, containsString(errMsg));
+        assertFailures(searchRequest, RestStatus.TOO_MANY_REQUESTS, containsString(errMsg));
 
         NodesStatsResponse stats = client.admin().cluster().prepareNodesStats().setBreaker(true).get();
         long breaks = 0;
@@ -210,9 +210,9 @@ public class CircuitBreakerServiceIT extends ESIntegTestCase {
         SearchRequestBuilder searchRequest = client.prepareSearch("ramtest").setQuery(matchAllQuery()).addSort("test", SortOrder.DESC);
 
         String errMsg = "Data too large, data for [test] would be";
-        assertFailures(searchRequest, RestStatus.INTERNAL_SERVER_ERROR, containsString(errMsg));
+        assertFailures(searchRequest, RestStatus.TOO_MANY_REQUESTS, containsString(errMsg));
         errMsg = "which is larger than the limit of [100/100b]";
-        assertFailures(searchRequest, RestStatus.INTERNAL_SERVER_ERROR, containsString(errMsg));
+        assertFailures(searchRequest, RestStatus.TOO_MANY_REQUESTS, containsString(errMsg));
 
         NodesStatsResponse stats = client.admin().cluster().prepareNodesStats().setBreaker(true).get();
         long breaks = 0;

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractIndexOrdinalsFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/AbstractIndexOrdinalsFieldData.java
@@ -29,6 +29,7 @@ import org.elasticsearch.script.field.ToScriptFieldFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
 
 import java.io.IOException;
+import java.util.concurrent.ExecutionException;
 
 public abstract class AbstractIndexOrdinalsFieldData implements IndexOrdinalsFieldData {
     private static final Logger logger = LogManager.getLogger(AbstractIndexOrdinalsFieldData.class);
@@ -83,6 +84,8 @@ public abstract class AbstractIndexOrdinalsFieldData implements IndexOrdinalsFie
         } catch (Exception e) {
             if (e instanceof ElasticsearchException) {
                 throw (ElasticsearchException) e;
+            } else if (e instanceof ExecutionException && e.getCause() instanceof ElasticsearchException) {
+                throw (ElasticsearchException) e.getCause();
             } else {
                 throw new ElasticsearchException(e);
             }
@@ -129,6 +132,8 @@ public abstract class AbstractIndexOrdinalsFieldData implements IndexOrdinalsFie
         } catch (Exception e) {
             if (e instanceof ElasticsearchException) {
                 throw (ElasticsearchException) e;
+            } else if (e instanceof ExecutionException && e.getCause() instanceof ElasticsearchException) {
+                throw (ElasticsearchException) e.getCause();
             } else {
                 throw new ElasticsearchException(e);
             }


### PR DESCRIPTION
This is necessary to uncover for example circuit breaker exceptions happening when building global ordinals. The cache logic will wrap them into an ExecutionException and they will not be identified as root cause.

