### PR TITLE
[CI] Temporarily muting failed MLT test

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mlt/25_docs_one_shard.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mlt/25_docs_one_shard.yml
@@ -1,5 +1,9 @@
 ---
 "Basic mlt query with docs - explicitly on same shard":
+  - skip:
+      version: "all"
+      reason: temporarily disabling for serverless
+
   - do:
       indices.create:
         index: mlt_one_shard_test_index

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mlt/25_docs_one_shard.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mlt/25_docs_one_shard.yml
@@ -2,7 +2,7 @@
 "Basic mlt query with docs - explicitly on same shard":
   - skip:
       version: "all"
-      reason: temporarily disabling for serverless
+      reason: temporarily disabling for investigation
 
   - do:
       indices.create:


### PR DESCRIPTION
Temporarily disabling MLT test that failed with the following: 
```
Caused by: java.lang.AssertionError: expected [2xx] status code but api [get] returned [503 Service Unavailable] [{"error":{"root_cause":[{"type":"no_shard_available_action_exception","reason":"No shard available for [get [mlt_one_shard_test_index][1]: routing [null]]","stack_trace":"org.elasticsearch.action.NoShardAvailableActionException: No shard available for [get [mlt_one_shard_test_index][1]: routing [null]]
	 org.elasticsearch.server@8.12.0-SNAPSHOT/org.elasticsearch.action.support.single.shard.TransportSingleShardAction$AsyncSingleAction.perform(TransportSingleShardAction.java:210)
	 org.elasticsearch.server@8.12.0-SNAPSHOT/org.elasticsearch.action.support.single.shard.TransportSingleShardAction$AsyncSingleAction.start(TransportSingleShardAction.java:187)
....
``` 