### PR TITLE
Avoid closing InternalTestCluster

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/health/HealthMetadataServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/health/HealthMetadataServiceIT.java
@@ -45,210 +45,207 @@ public class HealthMetadataServiceIT extends ESIntegTestCase {
     }
 
     public void testEachMasterPublishesTheirThresholds() throws Exception {
-        try (InternalTestCluster internalCluster = internalCluster()) {
-            int numberOfNodes = 3;
-            Map<String, String> watermarkByNode = new HashMap<>();
-            Map<String, ByteSizeValue> maxHeadroomByNode = new HashMap<>();
-            Map<String, HealthMetadata.ShardLimits> shardLimitsPerNode = new HashMap<>();
-            for (int i = 0; i < numberOfNodes; i++) {
-                ByteSizeValue randomBytes = ByteSizeValue.ofBytes(randomLongBetween(6, 19));
-                String customWatermark = percentageMode ? randomIntBetween(86, 94) + "%" : randomBytes.toString();
-                ByteSizeValue customMaxHeadroom = percentageMode ? randomBytes : ByteSizeValue.MINUS_ONE;
-                var customShardLimits = new HealthMetadata.ShardLimits(randomIntBetween(1, 1000), randomIntBetween(1001, 2000));
-                String nodeName = startNode(internalCluster, customWatermark, customMaxHeadroom.toString(), customShardLimits);
-                watermarkByNode.put(nodeName, customWatermark);
-                maxHeadroomByNode.put(nodeName, customMaxHeadroom);
-                shardLimitsPerNode.put(nodeName, customShardLimits);
-            }
-            ensureStableCluster(numberOfNodes);
+        final InternalTestCluster internalCluster = internalCluster();
+        int numberOfNodes = 3;
+        Map<String, String> watermarkByNode = new HashMap<>();
+        Map<String, ByteSizeValue> maxHeadroomByNode = new HashMap<>();
+        Map<String, HealthMetadata.ShardLimits> shardLimitsPerNode = new HashMap<>();
+        for (int i = 0; i < numberOfNodes; i++) {
+            ByteSizeValue randomBytes = ByteSizeValue.ofBytes(randomLongBetween(6, 19));
+            String customWatermark = percentageMode ? randomIntBetween(86, 94) + "%" : randomBytes.toString();
+            ByteSizeValue customMaxHeadroom = percentageMode ? randomBytes : ByteSizeValue.MINUS_ONE;
+            var customShardLimits = new HealthMetadata.ShardLimits(randomIntBetween(1, 1000), randomIntBetween(1001, 2000));
+            String nodeName = startNode(internalCluster, customWatermark, customMaxHeadroom.toString(), customShardLimits);
+            watermarkByNode.put(nodeName, customWatermark);
+            maxHeadroomByNode.put(nodeName, customMaxHeadroom);
+            shardLimitsPerNode.put(nodeName, customShardLimits);
+        }
+        ensureStableCluster(numberOfNodes);
 
-            String electedMaster = internalCluster.getMasterName();
-            {
-                var healthMetadata = HealthMetadata.getFromClusterState(internalCluster.clusterService().state());
-                var diskMetadata = healthMetadata.getDiskMetadata();
-                assertThat(diskMetadata.describeHighWatermark(), equalTo(watermarkByNode.get(electedMaster)));
-                assertThat(diskMetadata.highMaxHeadroom(), equalTo(maxHeadroomByNode.get(electedMaster)));
+        String electedMaster = internalCluster.getMasterName();
+        {
+            var healthMetadata = HealthMetadata.getFromClusterState(internalCluster.clusterService().state());
+            var diskMetadata = healthMetadata.getDiskMetadata();
+            assertThat(diskMetadata.describeHighWatermark(), equalTo(watermarkByNode.get(electedMaster)));
+            assertThat(diskMetadata.highMaxHeadroom(), equalTo(maxHeadroomByNode.get(electedMaster)));
 
-                var shardLimitsMetadata = healthMetadata.getShardLimitsMetadata();
-                assertEquals(shardLimitsMetadata, shardLimitsPerNode.get(electedMaster));
-            }
+            var shardLimitsMetadata = healthMetadata.getShardLimitsMetadata();
+            assertEquals(shardLimitsMetadata, shardLimitsPerNode.get(electedMaster));
+        }
 
-            // Stop the master to ensure another node will become master with a different watermark
-            internalCluster.stopNode(electedMaster);
-            ensureStableCluster(numberOfNodes - 1);
-            electedMaster = internalCluster.getMasterName();
-            {
-                var healthMetadata = HealthMetadata.getFromClusterState(internalCluster.clusterService().state());
-                var diskMetadata = healthMetadata.getDiskMetadata();
-                assertThat(diskMetadata.describeHighWatermark(), equalTo(watermarkByNode.get(electedMaster)));
-                assertThat(diskMetadata.highMaxHeadroom(), equalTo(maxHeadroomByNode.get(electedMaster)));
+        // Stop the master to ensure another node will become master with a different watermark
+        internalCluster.stopNode(electedMaster);
+        ensureStableCluster(numberOfNodes - 1);
+        electedMaster = internalCluster.getMasterName();
+        {
+            var healthMetadata = HealthMetadata.getFromClusterState(internalCluster.clusterService().state());
+            var diskMetadata = healthMetadata.getDiskMetadata();
+            assertThat(diskMetadata.describeHighWatermark(), equalTo(watermarkByNode.get(electedMaster)));
+            assertThat(diskMetadata.highMaxHeadroom(), equalTo(maxHeadroomByNode.get(electedMaster)));
 
-                var shardLimitsMetadata = healthMetadata.getShardLimitsMetadata();
-                assertEquals(shardLimitsMetadata, shardLimitsPerNode.get(electedMaster));
-            }
+            var shardLimitsMetadata = healthMetadata.getShardLimitsMetadata();
+            assertEquals(shardLimitsMetadata, shardLimitsPerNode.get(electedMaster));
+        }
 
-            // restart the whole cluster
-            internalCluster.fullRestart();
-            ensureStableCluster(internalCluster.numDataAndMasterNodes());
-            String electedMasterAfterRestart = internalCluster.getMasterName();
-            {
-                var healthMetadata = HealthMetadata.getFromClusterState(internalCluster.clusterService().state());
-                var diskMetadata = healthMetadata.getDiskMetadata();
-                assertThat(diskMetadata.describeHighWatermark(), equalTo(watermarkByNode.get(electedMasterAfterRestart)));
-                assertThat(diskMetadata.highMaxHeadroom(), equalTo(maxHeadroomByNode.get(electedMasterAfterRestart)));
+        // restart the whole cluster
+        internalCluster.fullRestart();
+        ensureStableCluster(internalCluster.numDataAndMasterNodes());
+        String electedMasterAfterRestart = internalCluster.getMasterName();
+        {
+            var healthMetadata = HealthMetadata.getFromClusterState(internalCluster.clusterService().state());
+            var diskMetadata = healthMetadata.getDiskMetadata();
+            assertThat(diskMetadata.describeHighWatermark(), equalTo(watermarkByNode.get(electedMasterAfterRestart)));
+            assertThat(diskMetadata.highMaxHeadroom(), equalTo(maxHeadroomByNode.get(electedMasterAfterRestart)));
 
-                var shardLimitsMetadata = healthMetadata.getShardLimitsMetadata();
-                assertEquals(shardLimitsMetadata, shardLimitsPerNode.get(electedMasterAfterRestart));
-            }
+            var shardLimitsMetadata = healthMetadata.getShardLimitsMetadata();
+            assertEquals(shardLimitsMetadata, shardLimitsPerNode.get(electedMasterAfterRestart));
         }
     }
 
     public void testWatermarkSettingUpdate() throws Exception {
-        try (InternalTestCluster internalCluster = internalCluster()) {
-            int numberOfNodes = 3;
-            ByteSizeValue randomBytes = ByteSizeValue.ofBytes(randomLongBetween(6, 19));
-            String initialWatermark = percentageMode ? randomIntBetween(86, 94) + "%" : randomBytes.toString();
-            ByteSizeValue initialMaxHeadroom = percentageMode ? randomBytes : ByteSizeValue.MINUS_ONE;
-            HealthMetadata.ShardLimits initialShardLimits = new HealthMetadata.ShardLimits(
-                randomIntBetween(1, 1000),
-                randomIntBetween(1001, 2000)
-            );
-            for (int i = 0; i < numberOfNodes; i++) {
-                startNode(internalCluster, initialWatermark, initialMaxHeadroom.toString(), initialShardLimits);
-            }
-
-            randomBytes = ByteSizeValue.ofBytes(randomLongBetween(101, 200));
-            String updatedLowWatermark = percentageMode ? randomIntBetween(40, 59) + "%" : randomBytes.toString();
-            ByteSizeValue updatedLowMaxHeadroom = percentageMode ? randomBytes : ByteSizeValue.MINUS_ONE;
-            randomBytes = ByteSizeValue.ofBytes(randomLongBetween(50, 100));
-            String updatedHighWatermark = percentageMode ? randomIntBetween(60, 90) + "%" : randomBytes.toString();
-            ByteSizeValue updatedHighMaxHeadroom = percentageMode ? randomBytes : ByteSizeValue.MINUS_ONE;
-            randomBytes = ByteSizeValue.ofBytes(randomLongBetween(5, 10));
-            String updatedFloodStageWatermark = percentageMode ? randomIntBetween(91, 95) + "%" : randomBytes.toString();
-            ByteSizeValue updatedFloodStageMaxHeadroom = percentageMode ? randomBytes : ByteSizeValue.MINUS_ONE;
-            HealthMetadata.ShardLimits updatedShardLimits = new HealthMetadata.ShardLimits(
-                randomIntBetween(3000, 4000),
-                randomIntBetween(4001, 5000)
-            );
-
-            ensureStableCluster(numberOfNodes);
-            {
-                var healthMetadata = HealthMetadata.getFromClusterState(internalCluster.clusterService().state());
-                var diskMetadata = healthMetadata.getDiskMetadata();
-                assertThat(diskMetadata.describeHighWatermark(), equalTo(initialWatermark));
-                assertThat(diskMetadata.highMaxHeadroom(), equalTo(initialMaxHeadroom));
-
-                var shardLimitsMetadata = healthMetadata.getShardLimitsMetadata();
-                assertEquals(shardLimitsMetadata, initialShardLimits);
-            }
-            var settingsBuilder = Settings.builder()
-                .put(CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK_SETTING.getKey(), updatedLowWatermark)
-                .put(CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING.getKey(), updatedHighWatermark)
-                .put(CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_WATERMARK_SETTING.getKey(), updatedFloodStageWatermark)
-                .put(SETTING_CLUSTER_MAX_SHARDS_PER_NODE.getKey(), updatedShardLimits.maxShardsPerNode())
-                .put(SETTING_CLUSTER_MAX_SHARDS_PER_NODE_FROZEN.getKey(), updatedShardLimits.maxShardsPerNodeFrozen());
-
-            if (percentageMode) {
-                settingsBuilder.put(CLUSTER_ROUTING_ALLOCATION_LOW_DISK_MAX_HEADROOM_SETTING.getKey(), updatedLowMaxHeadroom)
-                    .put(CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_MAX_HEADROOM_SETTING.getKey(), updatedHighMaxHeadroom)
-                    .put(CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_MAX_HEADROOM_SETTING.getKey(), updatedFloodStageMaxHeadroom);
-            }
-            updateSettings(internalCluster, settingsBuilder);
-
-            assertBusy(() -> {
-                var healthMetadata = HealthMetadata.getFromClusterState(internalCluster.clusterService().state());
-                var diskMetadata = healthMetadata.getDiskMetadata();
-                assertThat(diskMetadata.describeHighWatermark(), equalTo(updatedHighWatermark));
-                assertThat(diskMetadata.highMaxHeadroom(), equalTo(updatedHighMaxHeadroom));
-                assertThat(diskMetadata.describeFloodStageWatermark(), equalTo(updatedFloodStageWatermark));
-                assertThat(diskMetadata.floodStageMaxHeadroom(), equalTo(updatedFloodStageMaxHeadroom));
-
-                var shardLimitsMetadata = healthMetadata.getShardLimitsMetadata();
-                assertEquals(shardLimitsMetadata, updatedShardLimits);
-            });
-
-            var electedMaster = internalCluster.getMasterName();
-
-            // Force a master fail-over but, since the settings were manually changed, we should return the manually set values
-            internalCluster.stopNode(electedMaster);
-            ensureStableCluster(numberOfNodes - 1);
-
-            assertBusy(() -> {
-                var healthMetadata = HealthMetadata.getFromClusterState(
-                    internalCluster.clusterService(internalCluster.getMasterName()).state()
-                );
-                var diskMetadata = healthMetadata.getDiskMetadata();
-                assertThat(diskMetadata.describeHighWatermark(), equalTo(updatedHighWatermark));
-                assertThat(diskMetadata.highMaxHeadroom(), equalTo(updatedHighMaxHeadroom));
-                assertThat(diskMetadata.describeFloodStageWatermark(), equalTo(updatedFloodStageWatermark));
-                assertThat(diskMetadata.floodStageMaxHeadroom(), equalTo(updatedFloodStageMaxHeadroom));
-
-                var shardLimitsMetadata = healthMetadata.getShardLimitsMetadata();
-                assertEquals(shardLimitsMetadata, updatedShardLimits);
-            });
-
-            // restart the whole cluster
-            internalCluster.fullRestart();
-            ensureStableCluster(internalCluster.numDataAndMasterNodes());
-            String electedMasterAfterRestart = internalCluster.getMasterName();
-            assertBusy(() -> {
-                var healthMetadata = HealthMetadata.getFromClusterState(internalCluster.clusterService(electedMasterAfterRestart).state());
-                var diskMetadata = healthMetadata.getDiskMetadata();
-                assertThat(diskMetadata.describeHighWatermark(), equalTo(updatedHighWatermark));
-                assertThat(diskMetadata.highMaxHeadroom(), equalTo(updatedHighMaxHeadroom));
-                assertThat(diskMetadata.describeFloodStageWatermark(), equalTo(updatedFloodStageWatermark));
-                assertThat(diskMetadata.floodStageMaxHeadroom(), equalTo(updatedFloodStageMaxHeadroom));
-
-                var shardLimitsMetadata = healthMetadata.getShardLimitsMetadata();
-                assertEquals(shardLimitsMetadata, updatedShardLimits);
-            });
+        final InternalTestCluster internalCluster = internalCluster();
+        int numberOfNodes = 3;
+        ByteSizeValue randomBytes = ByteSizeValue.ofBytes(randomLongBetween(6, 19));
+        String initialWatermark = percentageMode ? randomIntBetween(86, 94) + "%" : randomBytes.toString();
+        ByteSizeValue initialMaxHeadroom = percentageMode ? randomBytes : ByteSizeValue.MINUS_ONE;
+        HealthMetadata.ShardLimits initialShardLimits = new HealthMetadata.ShardLimits(
+            randomIntBetween(1, 1000),
+            randomIntBetween(1001, 2000)
+        );
+        for (int i = 0; i < numberOfNodes; i++) {
+            startNode(internalCluster, initialWatermark, initialMaxHeadroom.toString(), initialShardLimits);
         }
+
+        randomBytes = ByteSizeValue.ofBytes(randomLongBetween(101, 200));
+        String updatedLowWatermark = percentageMode ? randomIntBetween(40, 59) + "%" : randomBytes.toString();
+        ByteSizeValue updatedLowMaxHeadroom = percentageMode ? randomBytes : ByteSizeValue.MINUS_ONE;
+        randomBytes = ByteSizeValue.ofBytes(randomLongBetween(50, 100));
+        String updatedHighWatermark = percentageMode ? randomIntBetween(60, 90) + "%" : randomBytes.toString();
+        ByteSizeValue updatedHighMaxHeadroom = percentageMode ? randomBytes : ByteSizeValue.MINUS_ONE;
+        randomBytes = ByteSizeValue.ofBytes(randomLongBetween(5, 10));
+        String updatedFloodStageWatermark = percentageMode ? randomIntBetween(91, 95) + "%" : randomBytes.toString();
+        ByteSizeValue updatedFloodStageMaxHeadroom = percentageMode ? randomBytes : ByteSizeValue.MINUS_ONE;
+        HealthMetadata.ShardLimits updatedShardLimits = new HealthMetadata.ShardLimits(
+            randomIntBetween(3000, 4000),
+            randomIntBetween(4001, 5000)
+        );
+
+        ensureStableCluster(numberOfNodes);
+        {
+            var healthMetadata = HealthMetadata.getFromClusterState(internalCluster.clusterService().state());
+            var diskMetadata = healthMetadata.getDiskMetadata();
+            assertThat(diskMetadata.describeHighWatermark(), equalTo(initialWatermark));
+            assertThat(diskMetadata.highMaxHeadroom(), equalTo(initialMaxHeadroom));
+
+            var shardLimitsMetadata = healthMetadata.getShardLimitsMetadata();
+            assertEquals(shardLimitsMetadata, initialShardLimits);
+        }
+        var settingsBuilder = Settings.builder()
+            .put(CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK_SETTING.getKey(), updatedLowWatermark)
+            .put(CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING.getKey(), updatedHighWatermark)
+            .put(CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_WATERMARK_SETTING.getKey(), updatedFloodStageWatermark)
+            .put(SETTING_CLUSTER_MAX_SHARDS_PER_NODE.getKey(), updatedShardLimits.maxShardsPerNode())
+            .put(SETTING_CLUSTER_MAX_SHARDS_PER_NODE_FROZEN.getKey(), updatedShardLimits.maxShardsPerNodeFrozen());
+
+        if (percentageMode) {
+            settingsBuilder.put(CLUSTER_ROUTING_ALLOCATION_LOW_DISK_MAX_HEADROOM_SETTING.getKey(), updatedLowMaxHeadroom)
+                .put(CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_MAX_HEADROOM_SETTING.getKey(), updatedHighMaxHeadroom)
+                .put(CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_MAX_HEADROOM_SETTING.getKey(), updatedFloodStageMaxHeadroom);
+        }
+        updateSettings(internalCluster, settingsBuilder);
+
+        assertBusy(() -> {
+            var healthMetadata = HealthMetadata.getFromClusterState(internalCluster.clusterService().state());
+            var diskMetadata = healthMetadata.getDiskMetadata();
+            assertThat(diskMetadata.describeHighWatermark(), equalTo(updatedHighWatermark));
+            assertThat(diskMetadata.highMaxHeadroom(), equalTo(updatedHighMaxHeadroom));
+            assertThat(diskMetadata.describeFloodStageWatermark(), equalTo(updatedFloodStageWatermark));
+            assertThat(diskMetadata.floodStageMaxHeadroom(), equalTo(updatedFloodStageMaxHeadroom));
+
+            var shardLimitsMetadata = healthMetadata.getShardLimitsMetadata();
+            assertEquals(shardLimitsMetadata, updatedShardLimits);
+        });
+
+        var electedMaster = internalCluster.getMasterName();
+
+        // Force a master fail-over but, since the settings were manually changed, we should return the manually set values
+        internalCluster.stopNode(electedMaster);
+        ensureStableCluster(numberOfNodes - 1);
+
+        assertBusy(() -> {
+            var healthMetadata = HealthMetadata.getFromClusterState(
+                internalCluster.clusterService(internalCluster.getMasterName()).state()
+            );
+            var diskMetadata = healthMetadata.getDiskMetadata();
+            assertThat(diskMetadata.describeHighWatermark(), equalTo(updatedHighWatermark));
+            assertThat(diskMetadata.highMaxHeadroom(), equalTo(updatedHighMaxHeadroom));
+            assertThat(diskMetadata.describeFloodStageWatermark(), equalTo(updatedFloodStageWatermark));
+            assertThat(diskMetadata.floodStageMaxHeadroom(), equalTo(updatedFloodStageMaxHeadroom));
+
+            var shardLimitsMetadata = healthMetadata.getShardLimitsMetadata();
+            assertEquals(shardLimitsMetadata, updatedShardLimits);
+        });
+
+        // restart the whole cluster
+        internalCluster.fullRestart();
+        ensureStableCluster(internalCluster.numDataAndMasterNodes());
+        String electedMasterAfterRestart = internalCluster.getMasterName();
+        assertBusy(() -> {
+            var healthMetadata = HealthMetadata.getFromClusterState(internalCluster.clusterService(electedMasterAfterRestart).state());
+            var diskMetadata = healthMetadata.getDiskMetadata();
+            assertThat(diskMetadata.describeHighWatermark(), equalTo(updatedHighWatermark));
+            assertThat(diskMetadata.highMaxHeadroom(), equalTo(updatedHighMaxHeadroom));
+            assertThat(diskMetadata.describeFloodStageWatermark(), equalTo(updatedFloodStageWatermark));
+            assertThat(diskMetadata.floodStageMaxHeadroom(), equalTo(updatedFloodStageMaxHeadroom));
+
+            var shardLimitsMetadata = healthMetadata.getShardLimitsMetadata();
+            assertEquals(shardLimitsMetadata, updatedShardLimits);
+        });
     }
 
     public void testHealthNodeToggleEnabled() throws Exception {
-        try (InternalTestCluster internalCluster = internalCluster()) {
-            int numberOfNodes = 3;
-            Map<String, String> watermarkByNode = new HashMap<>();
-            Map<String, ByteSizeValue> maxHeadroomByNode = new HashMap<>();
-            Map<String, HealthMetadata.ShardLimits> shardLimitsPerNode = new HashMap<>();
-            for (int i = 0; i < numberOfNodes; i++) {
-                ByteSizeValue randomBytes = ByteSizeValue.ofBytes(randomLongBetween(6, 19));
-                String customWatermark = percentageMode ? randomIntBetween(86, 94) + "%" : randomBytes.toString();
-                ByteSizeValue customMaxHeadroom = percentageMode ? randomBytes : ByteSizeValue.MINUS_ONE;
-                var customShardLimits = new HealthMetadata.ShardLimits(randomIntBetween(1, 1000), randomIntBetween(1001, 2000));
-                String nodeName = startNode(internalCluster, customWatermark, customMaxHeadroom.toString(), customShardLimits);
-                watermarkByNode.put(nodeName, customWatermark);
-                maxHeadroomByNode.put(nodeName, customMaxHeadroom);
-                shardLimitsPerNode.put(nodeName, customShardLimits);
-            }
+        final InternalTestCluster internalCluster = internalCluster();
+        int numberOfNodes = 3;
+        Map<String, String> watermarkByNode = new HashMap<>();
+        Map<String, ByteSizeValue> maxHeadroomByNode = new HashMap<>();
+        Map<String, HealthMetadata.ShardLimits> shardLimitsPerNode = new HashMap<>();
+        for (int i = 0; i < numberOfNodes; i++) {
+            ByteSizeValue randomBytes = ByteSizeValue.ofBytes(randomLongBetween(6, 19));
+            String customWatermark = percentageMode ? randomIntBetween(86, 94) + "%" : randomBytes.toString();
+            ByteSizeValue customMaxHeadroom = percentageMode ? randomBytes : ByteSizeValue.MINUS_ONE;
+            var customShardLimits = new HealthMetadata.ShardLimits(randomIntBetween(1, 1000), randomIntBetween(1001, 2000));
+            String nodeName = startNode(internalCluster, customWatermark, customMaxHeadroom.toString(), customShardLimits);
+            watermarkByNode.put(nodeName, customWatermark);
+            maxHeadroomByNode.put(nodeName, customMaxHeadroom);
+            shardLimitsPerNode.put(nodeName, customShardLimits);
+        }
 
-            String electedMaster = internalCluster.getMasterName();
-            {
-                var healthMetadata = HealthMetadata.getFromClusterState(internalCluster.clusterService().state());
-                var diskMetadata = healthMetadata.getDiskMetadata();
-                assertThat(diskMetadata.describeHighWatermark(), equalTo(watermarkByNode.get(electedMaster)));
-                assertThat(diskMetadata.highMaxHeadroom(), equalTo(maxHeadroomByNode.get(electedMaster)));
+        String electedMaster = internalCluster.getMasterName();
+        {
+            var healthMetadata = HealthMetadata.getFromClusterState(internalCluster.clusterService().state());
+            var diskMetadata = healthMetadata.getDiskMetadata();
+            assertThat(diskMetadata.describeHighWatermark(), equalTo(watermarkByNode.get(electedMaster)));
+            assertThat(diskMetadata.highMaxHeadroom(), equalTo(maxHeadroomByNode.get(electedMaster)));
 
-                var shardLimitsMetadata = healthMetadata.getShardLimitsMetadata();
-                assertEquals(shardLimitsMetadata, shardLimitsPerNode.get(electedMaster));
-            }
+            var shardLimitsMetadata = healthMetadata.getShardLimitsMetadata();
+            assertEquals(shardLimitsMetadata, shardLimitsPerNode.get(electedMaster));
+        }
 
-            // toggle the health metadata service so we can check that the posted settings are still from the master node
-            updateSettings(internalCluster, Settings.builder().put(HealthNodeTaskExecutor.ENABLED_SETTING.getKey(), false));
+        // toggle the health metadata service so we can check that the posted settings are still from the master node
+        updateSettings(internalCluster, Settings.builder().put(HealthNodeTaskExecutor.ENABLED_SETTING.getKey(), false));
 
-            updateSettings(internalCluster, Settings.builder().put(HealthNodeTaskExecutor.ENABLED_SETTING.getKey(), true));
+        updateSettings(internalCluster, Settings.builder().put(HealthNodeTaskExecutor.ENABLED_SETTING.getKey(), true));
 
-            electedMaster = internalCluster.getMasterName();
-            ensureStableCluster(numberOfNodes);
-            {
-                var healthMetadata = HealthMetadata.getFromClusterState(internalCluster.clusterService().state());
-                var diskMetadata = healthMetadata.getDiskMetadata();
-                assertThat(diskMetadata.describeHighWatermark(), equalTo(watermarkByNode.get(electedMaster)));
-                assertThat(diskMetadata.highMaxHeadroom(), equalTo(maxHeadroomByNode.get(electedMaster)));
+        electedMaster = internalCluster.getMasterName();
+        ensureStableCluster(numberOfNodes);
+        {
+            var healthMetadata = HealthMetadata.getFromClusterState(internalCluster.clusterService().state());
+            var diskMetadata = healthMetadata.getDiskMetadata();
+            assertThat(diskMetadata.describeHighWatermark(), equalTo(watermarkByNode.get(electedMaster)));
+            assertThat(diskMetadata.highMaxHeadroom(), equalTo(maxHeadroomByNode.get(electedMaster)));
 
-                var shardLimitsMetadata = healthMetadata.getShardLimitsMetadata();
-                assertEquals(shardLimitsMetadata, shardLimitsPerNode.get(electedMaster));
-            }
+            var shardLimitsMetadata = healthMetadata.getShardLimitsMetadata();
+            assertEquals(shardLimitsMetadata, shardLimitsPerNode.get(electedMaster));
         }
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/health/UpdateHealthInfoCacheIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/health/UpdateHealthInfoCacheIT.java
@@ -21,7 +21,6 @@ import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 
-import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -35,78 +34,66 @@ public class UpdateHealthInfoCacheIT extends ESIntegTestCase {
     private static final DiskHealthInfo GREEN = new DiskHealthInfo(HealthStatus.GREEN, null);
 
     public void testNodesReportingHealth() throws Exception {
-        try (InternalTestCluster internalCluster = internalCluster()) {
-            decreasePollingInterval(internalCluster);
-            String[] nodeIds = getNodes(internalCluster).keySet().toArray(new String[0]);
-            DiscoveryNode healthNode = waitAndGetHealthNode(internalCluster);
-            assertThat(healthNode, notNullValue());
-            assertBusy(() -> assertResultsCanBeFetched(internalCluster, healthNode, List.of(nodeIds), null));
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to close internal cluster: " + e.getMessage(), e);
-        }
+        final InternalTestCluster internalCluster = internalCluster();
+        decreasePollingInterval(internalCluster);
+        String[] nodeIds = getNodes(internalCluster).keySet().toArray(new String[0]);
+        DiscoveryNode healthNode = waitAndGetHealthNode(internalCluster);
+        assertThat(healthNode, notNullValue());
+        assertBusy(() -> assertResultsCanBeFetched(internalCluster, healthNode, List.of(nodeIds), null));
     }
 
     public void testNodeLeavingCluster() throws Exception {
-        try (InternalTestCluster internalCluster = internalCluster()) {
-            decreasePollingInterval(internalCluster);
-            Collection<DiscoveryNode> nodes = getNodes(internalCluster).values();
-            DiscoveryNode healthNode = waitAndGetHealthNode(internalCluster);
-            assertThat(healthNode, notNullValue());
-            DiscoveryNode nodeToLeave = nodes.stream().filter(node -> {
-                boolean isMaster = node.getName().equals(internalCluster.getMasterName());
-                boolean isHealthNode = node.getId().equals(healthNode.getId());
-                // We have dedicated tests for master and health node
-                return isMaster == false && isHealthNode == false;
-            }).findAny().orElseThrow();
-            internalCluster.stopNode(nodeToLeave.getName());
-            assertBusy(
-                () -> assertResultsCanBeFetched(
-                    internalCluster,
-                    healthNode,
-                    nodes.stream().filter(node -> node.equals(nodeToLeave) == false).map(DiscoveryNode::getId).toList(),
-                    nodeToLeave.getId()
-                )
-            );
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to close internal cluster: " + e.getMessage(), e);
-        }
+        final InternalTestCluster internalCluster = internalCluster();
+        decreasePollingInterval(internalCluster);
+        Collection<DiscoveryNode> nodes = getNodes(internalCluster).values();
+        DiscoveryNode healthNode = waitAndGetHealthNode(internalCluster);
+        assertThat(healthNode, notNullValue());
+        DiscoveryNode nodeToLeave = nodes.stream().filter(node -> {
+            boolean isMaster = node.getName().equals(internalCluster.getMasterName());
+            boolean isHealthNode = node.getId().equals(healthNode.getId());
+            // We have dedicated tests for master and health node
+            return isMaster == false && isHealthNode == false;
+        }).findAny().orElseThrow();
+        internalCluster.stopNode(nodeToLeave.getName());
+        assertBusy(
+            () -> assertResultsCanBeFetched(
+                internalCluster,
+                healthNode,
+                nodes.stream().filter(node -> node.equals(nodeToLeave) == false).map(DiscoveryNode::getId).toList(),
+                nodeToLeave.getId()
+            )
+        );
     }
 
     @TestLogging(value = "org.elasticsearch.health.node:DEBUG", reason = "https://github.com/elastic/elasticsearch/issues/97213")
     public void testHealthNodeFailOver() throws Exception {
-        try (InternalTestCluster internalCluster = internalCluster()) {
-            decreasePollingInterval(internalCluster);
-            String[] nodeIds = getNodes(internalCluster).keySet().toArray(new String[0]);
-            DiscoveryNode healthNodeToBeShutDown = waitAndGetHealthNode(internalCluster);
-            assertThat(healthNodeToBeShutDown, notNullValue());
-            internalCluster.restartNode(healthNodeToBeShutDown.getName());
-            ensureStableCluster(nodeIds.length);
-            DiscoveryNode newHealthNode = waitAndGetHealthNode(internalCluster);
-            assertThat(newHealthNode, notNullValue());
-            logger.info("Previous health node {}, new health node {}.", healthNodeToBeShutDown, newHealthNode);
-            assertBusy(() -> assertResultsCanBeFetched(internalCluster, newHealthNode, List.of(nodeIds), null));
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to close internal cluster: " + e.getMessage(), e);
-        }
+        final InternalTestCluster internalCluster = internalCluster();
+        decreasePollingInterval(internalCluster);
+        String[] nodeIds = getNodes(internalCluster).keySet().toArray(new String[0]);
+        DiscoveryNode healthNodeToBeShutDown = waitAndGetHealthNode(internalCluster);
+        assertThat(healthNodeToBeShutDown, notNullValue());
+        internalCluster.restartNode(healthNodeToBeShutDown.getName());
+        ensureStableCluster(nodeIds.length);
+        DiscoveryNode newHealthNode = waitAndGetHealthNode(internalCluster);
+        assertThat(newHealthNode, notNullValue());
+        logger.info("Previous health node {}, new health node {}.", healthNodeToBeShutDown, newHealthNode);
+        assertBusy(() -> assertResultsCanBeFetched(internalCluster, newHealthNode, List.of(nodeIds), null));
     }
 
     @TestLogging(value = "org.elasticsearch.health.node:DEBUG", reason = "https://github.com/elastic/elasticsearch/issues/97213")
     public void testMasterFailure() throws Exception {
-        try (InternalTestCluster internalCluster = internalCluster()) {
-            decreasePollingInterval(internalCluster);
-            String[] nodeIds = getNodes(internalCluster).keySet().toArray(new String[0]);
-            DiscoveryNode healthNodeBeforeIncident = waitAndGetHealthNode(internalCluster);
-            assertThat(healthNodeBeforeIncident, notNullValue());
-            String masterName = internalCluster.getMasterName();
-            logger.info("Restarting elected master node {}.", masterName);
-            internalCluster.restartNode(masterName);
-            ensureStableCluster(nodeIds.length);
-            DiscoveryNode newHealthNode = waitAndGetHealthNode(internalCluster);
-            assertThat(newHealthNode, notNullValue());
-            assertBusy(() -> assertResultsCanBeFetched(internalCluster, newHealthNode, List.of(nodeIds), null));
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to close internal cluster: " + e.getMessage(), e);
-        }
+        final InternalTestCluster internalCluster = internalCluster();
+        decreasePollingInterval(internalCluster);
+        String[] nodeIds = getNodes(internalCluster).keySet().toArray(new String[0]);
+        DiscoveryNode healthNodeBeforeIncident = waitAndGetHealthNode(internalCluster);
+        assertThat(healthNodeBeforeIncident, notNullValue());
+        String masterName = internalCluster.getMasterName();
+        logger.info("Restarting elected master node {}.", masterName);
+        internalCluster.restartNode(masterName);
+        ensureStableCluster(nodeIds.length);
+        DiscoveryNode newHealthNode = waitAndGetHealthNode(internalCluster);
+        assertThat(newHealthNode, notNullValue());
+        assertBusy(() -> assertResultsCanBeFetched(internalCluster, newHealthNode, List.of(nodeIds), null));
     }
 
     /**

--- a/server/src/internalClusterTest/java/org/elasticsearch/health/node/DiskHealthIndicatorServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/health/node/DiskHealthIndicatorServiceIT.java
@@ -18,7 +18,6 @@ import org.elasticsearch.health.HealthService;
 import org.elasticsearch.health.HealthStatus;
 import org.elasticsearch.health.node.selection.HealthNode;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.InternalTestCluster;
 
 import java.util.List;
 import java.util.Map;
@@ -30,41 +29,39 @@ import static org.hamcrest.Matchers.equalTo;
 public class DiskHealthIndicatorServiceIT extends ESIntegTestCase {
 
     public void testGreen() throws Exception {
-        try (InternalTestCluster internalCluster = internalCluster()) {
-            internalCluster.startMasterOnlyNode();
-            internalCluster.startDataOnlyNode();
-            ensureStableCluster(internalCluster.getNodeNames().length);
-            waitForAllNodesToReportHealth();
-            for (String node : internalCluster.getNodeNames()) {
-                HealthService healthService = internalCluster.getInstance(HealthService.class, node);
-                List<HealthIndicatorResult> resultList = getHealthServiceResults(healthService, node);
-                assertNotNull(resultList);
-                assertThat(resultList.size(), equalTo(1));
-                HealthIndicatorResult testIndicatorResult = resultList.get(0);
-                assertThat(testIndicatorResult.status(), equalTo(HealthStatus.GREEN));
-                assertThat(testIndicatorResult.symptom(), equalTo("The cluster has enough available disk space."));
-            }
+        final var internalCluster = internalCluster();
+        internalCluster.startMasterOnlyNode();
+        internalCluster.startDataOnlyNode();
+        ensureStableCluster(internalCluster.getNodeNames().length);
+        waitForAllNodesToReportHealth();
+        for (String node : internalCluster.getNodeNames()) {
+            HealthService healthService = internalCluster.getInstance(HealthService.class, node);
+            List<HealthIndicatorResult> resultList = getHealthServiceResults(healthService, node);
+            assertNotNull(resultList);
+            assertThat(resultList.size(), equalTo(1));
+            HealthIndicatorResult testIndicatorResult = resultList.get(0);
+            assertThat(testIndicatorResult.status(), equalTo(HealthStatus.GREEN));
+            assertThat(testIndicatorResult.symptom(), equalTo("The cluster has enough available disk space."));
         }
     }
 
     public void testRed() throws Exception {
-        try (InternalTestCluster internalCluster = internalCluster()) {
-            internalCluster.startMasterOnlyNode(getVeryLowWatermarksSettings());
-            internalCluster.startDataOnlyNode(getVeryLowWatermarksSettings());
-            ensureStableCluster(internalCluster.getNodeNames().length);
-            waitForAllNodesToReportHealth();
-            for (String node : internalCluster.getNodeNames()) {
-                HealthService healthService = internalCluster.getInstance(HealthService.class, node);
-                List<HealthIndicatorResult> resultList = getHealthServiceResults(healthService, node);
-                assertNotNull(resultList);
-                assertThat(resultList.size(), equalTo(1));
-                HealthIndicatorResult testIndicatorResult = resultList.get(0);
-                assertThat(testIndicatorResult.status(), equalTo(HealthStatus.RED));
-                assertThat(
-                    testIndicatorResult.symptom(),
-                    equalTo("2 nodes with roles: [data, master] are out of disk or running low on disk space.")
-                );
-            }
+        final var internalCluster = internalCluster();
+        internalCluster.startMasterOnlyNode(getVeryLowWatermarksSettings());
+        internalCluster.startDataOnlyNode(getVeryLowWatermarksSettings());
+        ensureStableCluster(internalCluster.getNodeNames().length);
+        waitForAllNodesToReportHealth();
+        for (String node : internalCluster.getNodeNames()) {
+            HealthService healthService = internalCluster.getInstance(HealthService.class, node);
+            List<HealthIndicatorResult> resultList = getHealthServiceResults(healthService, node);
+            assertNotNull(resultList);
+            assertThat(resultList.size(), equalTo(1));
+            HealthIndicatorResult testIndicatorResult = resultList.get(0);
+            assertThat(testIndicatorResult.status(), equalTo(HealthStatus.RED));
+            assertThat(
+                testIndicatorResult.symptom(),
+                equalTo("2 nodes with roles: [data, master] are out of disk or running low on disk space.")
+            );
         }
     }
 

--- a/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/DataStreamLifecycleDownsampleDisruptionIT.java
+++ b/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/DataStreamLifecycleDownsampleDisruptionIT.java
@@ -59,95 +59,94 @@ public class DataStreamLifecycleDownsampleDisruptionIT extends ESIntegTestCase {
     @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/99520")
     @TestLogging(value = "org.elasticsearch.datastreams.lifecycle:TRACE", reason = "debugging")
     public void testDataStreamLifecycleDownsampleRollingRestart() throws Exception {
-        try (InternalTestCluster cluster = internalCluster()) {
-            final List<String> masterNodes = cluster.startMasterOnlyNodes(1);
-            cluster.startDataOnlyNodes(3);
-            ensureStableCluster(cluster.size());
-            ensureGreen();
+        final InternalTestCluster cluster = internalCluster();
+        final List<String> masterNodes = cluster.startMasterOnlyNodes(1);
+        cluster.startDataOnlyNodes(3);
+        ensureStableCluster(cluster.size());
+        ensureGreen();
 
-            final String dataStreamName = "metrics-foo";
-            DataStreamLifecycle lifecycle = DataStreamLifecycle.newBuilder()
-                .downsampling(
-                    new DataStreamLifecycle.Downsampling(
-                        List.of(
-                            new DataStreamLifecycle.Downsampling.Round(
-                                TimeValue.timeValueMillis(0),
-                                new DownsampleConfig(new DateHistogramInterval("5m"))
-                            )
+        final String dataStreamName = "metrics-foo";
+        DataStreamLifecycle lifecycle = DataStreamLifecycle.newBuilder()
+            .downsampling(
+                new DataStreamLifecycle.Downsampling(
+                    List.of(
+                        new DataStreamLifecycle.Downsampling.Round(
+                            TimeValue.timeValueMillis(0),
+                            new DownsampleConfig(new DateHistogramInterval("5m"))
                         )
                     )
                 )
-                .build();
-            DataStreamLifecycleDriver.setupTSDBDataStreamAndIngestDocs(
-                client(),
-                dataStreamName,
-                "1986-01-08T23:40:53.384Z",
-                "2022-01-08T23:40:53.384Z",
-                lifecycle,
-                DOC_COUNT,
-                "1990-09-09T18:00:00"
-            );
+            )
+            .build();
+        DataStreamLifecycleDriver.setupTSDBDataStreamAndIngestDocs(
+            client(),
+            dataStreamName,
+            "1986-01-08T23:40:53.384Z",
+            "2022-01-08T23:40:53.384Z",
+            lifecycle,
+            DOC_COUNT,
+            "1990-09-09T18:00:00"
+        );
 
-            // before we rollover we update the index template to remove the start/end time boundaries (they're there just to ease with
-            // testing so DSL doesn't have to wait for the end_time to lapse)
-            putTSDBIndexTemplate(client(), dataStreamName, null, null, lifecycle);
-            client().execute(RolloverAction.INSTANCE, new RolloverRequest(dataStreamName, null)).actionGet();
+        // before we rollover we update the index template to remove the start/end time boundaries (they're there just to ease with
+        // testing so DSL doesn't have to wait for the end_time to lapse)
+        putTSDBIndexTemplate(client(), dataStreamName, null, null, lifecycle);
+        client().execute(RolloverAction.INSTANCE, new RolloverRequest(dataStreamName, null)).actionGet();
 
-            // DSL runs every second and it has to tail forcemerge the index (2 seconds) and mark it as read-only (2s) before it starts
-            // downsampling. This sleep here tries to get as close as possible to having disruption during the downsample execution.
-            long sleepTime = randomLongBetween(3000, 4500);
-            logger.info("-> giving data stream lifecycle [{}] millis to make some progress before starting the disruption", sleepTime);
-            Thread.sleep(sleepTime);
-            final CountDownLatch disruptionStart = new CountDownLatch(1);
-            final CountDownLatch disruptionEnd = new CountDownLatch(1);
-            List<String> backingIndices = getBackingIndices(client(), dataStreamName);
-            // first generation index
-            String sourceIndex = backingIndices.get(0);
-            new Thread(new Disruptor(cluster, sourceIndex, new DisruptionListener() {
-                @Override
-                public void disruptionStart() {
-                    disruptionStart.countDown();
-                }
+        // DSL runs every second and it has to tail forcemerge the index (2 seconds) and mark it as read-only (2s) before it starts
+        // downsampling. This sleep here tries to get as close as possible to having disruption during the downsample execution.
+        long sleepTime = randomLongBetween(3000, 4500);
+        logger.info("-> giving data stream lifecycle [{}] millis to make some progress before starting the disruption", sleepTime);
+        Thread.sleep(sleepTime);
+        final CountDownLatch disruptionStart = new CountDownLatch(1);
+        final CountDownLatch disruptionEnd = new CountDownLatch(1);
+        List<String> backingIndices = getBackingIndices(client(), dataStreamName);
+        // first generation index
+        String sourceIndex = backingIndices.get(0);
+        new Thread(new Disruptor(cluster, sourceIndex, new DisruptionListener() {
+            @Override
+            public void disruptionStart() {
+                disruptionStart.countDown();
+            }
 
-                @Override
-                public void disruptionEnd() {
-                    disruptionEnd.countDown();
-                }
-            }, masterNodes.get(0), (ignored) -> {
-                try {
-                    cluster.rollingRestart(new InternalTestCluster.RestartCallback() {
-                        @Override
-                        public boolean validateClusterForming() {
-                            return true;
-                        }
-                    });
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
-            })).start();
+            @Override
+            public void disruptionEnd() {
+                disruptionEnd.countDown();
+            }
+        }, masterNodes.get(0), (ignored) -> {
+            try {
+                cluster.rollingRestart(new InternalTestCluster.RestartCallback() {
+                    @Override
+                    public boolean validateClusterForming() {
+                        return true;
+                    }
+                });
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        })).start();
 
-            waitUntil(
-                () -> cluster.client().admin().cluster().preparePendingClusterTasks().get().pendingTasks().isEmpty(),
-                60,
-                TimeUnit.SECONDS
-            );
-            ensureStableCluster(cluster.numDataAndMasterNodes());
+        waitUntil(
+            () -> cluster.client().admin().cluster().preparePendingClusterTasks().get().pendingTasks().isEmpty(),
+            60,
+            TimeUnit.SECONDS
+        );
+        ensureStableCluster(cluster.numDataAndMasterNodes());
 
-            final String targetIndex = "downsample-5m-" + sourceIndex;
-            assertBusy(() -> {
-                try {
-                    GetSettingsResponse getSettingsResponse = client().admin()
-                        .indices()
-                        .getSettings(new GetSettingsRequest().indices(targetIndex))
-                        .actionGet();
-                    Settings indexSettings = getSettingsResponse.getIndexToSettings().get(targetIndex);
-                    assertThat(indexSettings, is(notNullValue()));
-                    assertThat(IndexMetadata.INDEX_DOWNSAMPLE_STATUS.get(indexSettings), is(IndexMetadata.DownsampleTaskStatus.SUCCESS));
-                } catch (Exception e) {
-                    throw new AssertionError(e);
-                }
-            }, 60, TimeUnit.SECONDS);
-        }
+        final String targetIndex = "downsample-5m-" + sourceIndex;
+        assertBusy(() -> {
+            try {
+                GetSettingsResponse getSettingsResponse = client().admin()
+                    .indices()
+                    .getSettings(new GetSettingsRequest().indices(targetIndex))
+                    .actionGet();
+                Settings indexSettings = getSettingsResponse.getIndexToSettings().get(targetIndex);
+                assertThat(indexSettings, is(notNullValue()));
+                assertThat(IndexMetadata.INDEX_DOWNSAMPLE_STATUS.get(indexSettings), is(IndexMetadata.DownsampleTaskStatus.SUCCESS));
+            } catch (Exception e) {
+                throw new AssertionError(e);
+            }
+        }, 60, TimeUnit.SECONDS);
     }
 
     interface DisruptionListener {

--- a/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/ILMDownsampleDisruptionIT.java
+++ b/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/ILMDownsampleDisruptionIT.java
@@ -140,64 +140,63 @@ public class ILMDownsampleDisruptionIT extends ESIntegTestCase {
     }
 
     public void testILMDownsampleRollingRestart() throws Exception {
-        try (InternalTestCluster cluster = internalCluster()) {
-            final List<String> masterNodes = cluster.startMasterOnlyNodes(1);
-            cluster.startDataOnlyNodes(3);
-            ensureStableCluster(cluster.size());
-            ensureGreen();
+        final InternalTestCluster cluster = internalCluster();
+        final List<String> masterNodes = cluster.startMasterOnlyNodes(1);
+        cluster.startDataOnlyNodes(3);
+        ensureStableCluster(cluster.size());
+        ensureGreen();
 
-            final String sourceIndex = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
-            long startTime = LocalDateTime.parse("1993-09-09T18:00:00").atZone(ZoneId.of("UTC")).toInstant().toEpochMilli();
-            setup(sourceIndex, 1, 0, startTime);
-            final DownsampleConfig config = new DownsampleConfig(randomInterval());
-            final SourceSupplier sourceSupplier = () -> {
-                final String ts = randomDateForInterval(config.getInterval(), startTime);
-                double counterValue = DATE_FORMATTER.parseMillis(ts);
-                final List<String> dimensionValues = new ArrayList<>(5);
-                for (int j = 0; j < randomIntBetween(1, 5); j++) {
-                    dimensionValues.add(randomAlphaOfLength(6));
-                }
-                return XContentFactory.jsonBuilder()
-                    .startObject()
-                    .field(FIELD_TIMESTAMP, ts)
-                    .field(FIELD_DIMENSION_1, randomFrom(dimensionValues))
-                    .field(FIELD_DIMENSION_2, randomIntBetween(1, 10))
-                    .field(FIELD_METRIC_COUNTER, counterValue)
-                    .endObject();
-            };
-            int indexedDocs = bulkIndex(sourceIndex, sourceSupplier, DOC_COUNT);
-            final CountDownLatch disruptionStart = new CountDownLatch(1);
-            final CountDownLatch disruptionEnd = new CountDownLatch(1);
+        final String sourceIndex = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
+        long startTime = LocalDateTime.parse("1993-09-09T18:00:00").atZone(ZoneId.of("UTC")).toInstant().toEpochMilli();
+        setup(sourceIndex, 1, 0, startTime);
+        final DownsampleConfig config = new DownsampleConfig(randomInterval());
+        final SourceSupplier sourceSupplier = () -> {
+            final String ts = randomDateForInterval(config.getInterval(), startTime);
+            double counterValue = DATE_FORMATTER.parseMillis(ts);
+            final List<String> dimensionValues = new ArrayList<>(5);
+            for (int j = 0; j < randomIntBetween(1, 5); j++) {
+                dimensionValues.add(randomAlphaOfLength(6));
+            }
+            return XContentFactory.jsonBuilder()
+                .startObject()
+                .field(FIELD_TIMESTAMP, ts)
+                .field(FIELD_DIMENSION_1, randomFrom(dimensionValues))
+                .field(FIELD_DIMENSION_2, randomIntBetween(1, 10))
+                .field(FIELD_METRIC_COUNTER, counterValue)
+                .endObject();
+        };
+        int indexedDocs = bulkIndex(sourceIndex, sourceSupplier, DOC_COUNT);
+        final CountDownLatch disruptionStart = new CountDownLatch(1);
+        final CountDownLatch disruptionEnd = new CountDownLatch(1);
 
-            new Thread(new Disruptor(cluster, sourceIndex, new DisruptionListener() {
-                @Override
-                public void disruptionStart() {
-                    disruptionStart.countDown();
-                }
+        new Thread(new Disruptor(cluster, sourceIndex, new DisruptionListener() {
+            @Override
+            public void disruptionStart() {
+                disruptionStart.countDown();
+            }
 
-                @Override
-                public void disruptionEnd() {
-                    disruptionEnd.countDown();
-                }
-            }, masterNodes.get(0), (ignored) -> {
-                try {
-                    cluster.rollingRestart(new InternalTestCluster.RestartCallback() {
-                        @Override
-                        public boolean validateClusterForming() {
-                            return true;
-                        }
-                    });
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
-            })).start();
+            @Override
+            public void disruptionEnd() {
+                disruptionEnd.countDown();
+            }
+        }, masterNodes.get(0), (ignored) -> {
+            try {
+                cluster.rollingRestart(new InternalTestCluster.RestartCallback() {
+                    @Override
+                    public boolean validateClusterForming() {
+                        return true;
+                    }
+                });
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        })).start();
 
-            final String targetIndex = "downsample-1h-" + sourceIndex;
-            startDownsampleTaskViaIlm(sourceIndex, targetIndex, disruptionStart, disruptionEnd);
-            waitUntil(() -> cluster.client().admin().cluster().preparePendingClusterTasks().get().pendingTasks().isEmpty());
-            ensureStableCluster(cluster.numDataAndMasterNodes());
-            assertTargetIndex(cluster, targetIndex, indexedDocs);
-        }
+        final String targetIndex = "downsample-1h-" + sourceIndex;
+        startDownsampleTaskViaIlm(sourceIndex, targetIndex, disruptionStart, disruptionEnd);
+        waitUntil(() -> cluster.client().admin().cluster().preparePendingClusterTasks().get().pendingTasks().isEmpty());
+        ensureStableCluster(cluster.numDataAndMasterNodes());
+        assertTargetIndex(cluster, targetIndex, indexedDocs);
     }
 
     private void startDownsampleTaskViaIlm(


### PR DESCRIPTION
We have a few `ESIntegTestCase` tests which explicitly close the test
cluster at the end. Test code itself shouldn't close this cluster: these
cases all run with cluster scope `TEST` so the test framework closes the
cluster for us anyway. This commit removes the unwanted closing.