### PR TITLE
Adjust test skip to include 8.11.2

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/60_dense_vector_dynamic_mapping.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/60_dense_vector_dynamic_mapping.yml
@@ -572,11 +572,10 @@ setup:
 
 ---
 "Fields mapped as dense_vector without dims or docs have correct cluster stats values":
-  # replace with 8.11.1 when the bug fix is backported to 8.11.2
   - skip:
-      version: ' - 8.11.2'
+      version: ' - 8.11.1'
       reason: 'Bug fix was added in 8.11.2'
-      
+
   - do:
       indices.create:
         index: test-mapped-index
@@ -604,9 +603,8 @@ setup:
 
 ---
 "Fields mapped as dense_vector have correct cluster stats min max values":
-  # replace with 8.11.1 when the bug fix is backported to 8.11.2
   - skip:
-      version: ' - 8.11.2'
+      version: ' - 8.11.1'
       reason: 'Bug fix was added in 8.11.2'
 
   - do:


### PR DESCRIPTION
Now that #102480 has been merged to 8.11.2, enable the test in this version.