### PR TITLE
Add support for configuring proxy scheme in S3 client settings and EC2 discovery plugin

### DIFF
--- a/docs/changelog/102495.yaml
+++ b/docs/changelog/102495.yaml
@@ -1,5 +1,5 @@
 pr: 102495
-summary: "Add support for configuring proxy scheme in S3 client settings"
+summary: "Add support for configuring proxy scheme in S3 client settings and EC2 discovery plugin"
 area: Distributed
 type: enhancement
 issues:

--- a/docs/changelog/102495.yaml
+++ b/docs/changelog/102495.yaml
@@ -1,0 +1,6 @@
+pr: 102495
+summary: "Add support for configuring proxy scheme in S3 client settings"
+area: Distributed
+type: enhancement
+issues:
+  - 101873

--- a/docs/plugins/discovery-ec2.asciidoc
+++ b/docs/plugins/discovery-ec2.asciidoc
@@ -97,6 +97,11 @@ The available settings for the EC2 discovery plugin are as follows.
     this setting determines the port to use to connect to the proxy. Defaults to
     `80`.
 
+`discovery.ec2.proxy.scheme`::
+
+    The scheme to use when connecting to the EC2 service endpoint through proxy specified
+    in `discovery.ec2.proxy.host`. Valid values are `http` or `https`. Defaults to `http`.
+
 `discovery.ec2.proxy.username` ({ref}/secure-settings.html[Secure], {ref}/secure-settings.html#reloadable-secure-settings[reloadable])::
 
     When the address of an HTTP proxy is given in `discovery.ec2.proxy.host`,

--- a/docs/reference/snapshot-restore/repository-s3.asciidoc
+++ b/docs/reference/snapshot-restore/repository-s3.asciidoc
@@ -136,7 +136,7 @@ settings belong in the `elasticsearch.yml` file.
 `proxy.scheme`::
 
     The scheme to use for the proxy connection to S3. Valid values are either `http` or `https`.
-    Defaults to `https`. This setting allows to specify the protocol used for communication with the
+    Defaults to `http`. This setting allows to specify the protocol used for communication with the
     proxy server
 
 `proxy.username` ({ref}/secure-settings.html[Secure], {ref}/secure-settings.html#reloadable-secure-settings[reloadable])::

--- a/docs/reference/snapshot-restore/repository-s3.asciidoc
+++ b/docs/reference/snapshot-restore/repository-s3.asciidoc
@@ -133,6 +133,12 @@ settings belong in the `elasticsearch.yml` file.
 
     The port of a proxy to connect to S3 through.
 
+`proxy.scheme`::
+
+    The scheme to use for the proxy connection to S3. Valid values are either `http` or `https`.
+    Defaults to `https`. This setting allows to specify the protocol used for communication with the
+    proxy server
+
 `proxy.username` ({ref}/secure-settings.html[Secure], {ref}/secure-settings.html#reloadable-secure-settings[reloadable])::
 
     The username to connect to the `proxy.host` with.

--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3ClientSettings.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3ClientSettings.java
@@ -96,6 +96,13 @@ final class S3ClientSettings {
         key -> Setting.intSetting(key, 80, 0, 1 << 16, Property.NodeScope)
     );
 
+    /** The proxy scheme for connecting to S3 through a proxy. */
+    static final Setting.AffixSetting<Protocol> PROXY_SCHEME_SETTING = Setting.affixKeySetting(
+        PREFIX,
+        "proxy.scheme",
+        key -> new Setting<>(key, "https", s -> Protocol.valueOf(s.toUpperCase(Locale.ROOT)), Property.NodeScope)
+    );
+
     /** The username of a proxy to connect to s3 through. */
     static final Setting.AffixSetting<SecureString> PROXY_USERNAME_SETTING = Setting.affixKeySetting(
         PREFIX,
@@ -174,6 +181,9 @@ final class S3ClientSettings {
     /** The port number the proxy host should be connected on. */
     final int proxyPort;
 
+    /** The proxy scheme to use for connecting to s3 through a proxy. */
+    final Protocol proxyScheme;
+
     // these should be "secure" yet the api for the s3 client only takes String, so storing them
     // as SecureString here won't really help with anything
     /** An optional username for the proxy host, for basic authentication. */
@@ -209,6 +219,7 @@ final class S3ClientSettings {
         Protocol protocol,
         String proxyHost,
         int proxyPort,
+        Protocol proxyScheme,
         String proxyUsername,
         String proxyPassword,
         int readTimeoutMillis,
@@ -224,6 +235,7 @@ final class S3ClientSettings {
         this.protocol = protocol;
         this.proxyHost = proxyHost;
         this.proxyPort = proxyPort;
+        this.proxyScheme = proxyScheme;
         this.proxyUsername = proxyUsername;
         this.proxyPassword = proxyPassword;
         this.readTimeoutMillis = readTimeoutMillis;
@@ -252,6 +264,7 @@ final class S3ClientSettings {
         final Protocol newProtocol = getRepoSettingOrDefault(PROTOCOL_SETTING, normalizedSettings, protocol);
         final String newProxyHost = getRepoSettingOrDefault(PROXY_HOST_SETTING, normalizedSettings, proxyHost);
         final int newProxyPort = getRepoSettingOrDefault(PROXY_PORT_SETTING, normalizedSettings, proxyPort);
+        final Protocol newProxyScheme = getRepoSettingOrDefault(PROXY_SCHEME_SETTING, normalizedSettings, proxyScheme);
         final int newReadTimeoutMillis = Math.toIntExact(
             getRepoSettingOrDefault(READ_TIMEOUT_SETTING, normalizedSettings, TimeValue.timeValueMillis(readTimeoutMillis)).millis()
         );
@@ -275,6 +288,7 @@ final class S3ClientSettings {
             && protocol == newProtocol
             && Objects.equals(proxyHost, newProxyHost)
             && proxyPort == newProxyPort
+            && proxyScheme == newProxyScheme
             && newReadTimeoutMillis == readTimeoutMillis
             && maxRetries == newMaxRetries
             && newThrottleRetries == throttleRetries
@@ -291,6 +305,7 @@ final class S3ClientSettings {
             newProtocol,
             newProxyHost,
             newProxyPort,
+            newProxyScheme,
             proxyUsername,
             proxyPassword,
             newReadTimeoutMillis,
@@ -398,6 +413,7 @@ final class S3ClientSettings {
                 getConfigValue(settings, clientName, PROTOCOL_SETTING),
                 getConfigValue(settings, clientName, PROXY_HOST_SETTING),
                 getConfigValue(settings, clientName, PROXY_PORT_SETTING),
+                getConfigValue(settings, clientName, PROXY_SCHEME_SETTING),
                 proxyUsername.toString(),
                 proxyPassword.toString(),
                 Math.toIntExact(getConfigValue(settings, clientName, READ_TIMEOUT_SETTING).millis()),
@@ -428,6 +444,7 @@ final class S3ClientSettings {
             && Objects.equals(endpoint, that.endpoint)
             && protocol == that.protocol
             && Objects.equals(proxyHost, that.proxyHost)
+            && proxyScheme == that.proxyScheme
             && Objects.equals(proxyUsername, that.proxyUsername)
             && Objects.equals(proxyPassword, that.proxyPassword)
             && Objects.equals(disableChunkedEncoding, that.disableChunkedEncoding)
@@ -443,6 +460,7 @@ final class S3ClientSettings {
             protocol,
             proxyHost,
             proxyPort,
+            proxyScheme,
             proxyUsername,
             proxyPassword,
             readTimeoutMillis,

--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3ClientSettings.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3ClientSettings.java
@@ -100,7 +100,7 @@ final class S3ClientSettings {
     static final Setting.AffixSetting<Protocol> PROXY_SCHEME_SETTING = Setting.affixKeySetting(
         PREFIX,
         "proxy.scheme",
-        key -> new Setting<>(key, "https", s -> Protocol.valueOf(s.toUpperCase(Locale.ROOT)), Property.NodeScope)
+        key -> new Setting<>(key, "http", s -> Protocol.valueOf(s.toUpperCase(Locale.ROOT)), Property.NodeScope)
     );
 
     /** The username of a proxy to connect to s3 through. */

--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RepositoryPlugin.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RepositoryPlugin.java
@@ -119,6 +119,7 @@ public class S3RepositoryPlugin extends Plugin implements RepositoryPlugin, Relo
             S3ClientSettings.PROTOCOL_SETTING,
             S3ClientSettings.PROXY_HOST_SETTING,
             S3ClientSettings.PROXY_PORT_SETTING,
+            S3ClientSettings.PROXY_SCHEME_SETTING,
             S3ClientSettings.PROXY_USERNAME_SETTING,
             S3ClientSettings.PROXY_PASSWORD_SETTING,
             S3ClientSettings.READ_TIMEOUT_SETTING,

--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Service.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3Service.java
@@ -221,6 +221,7 @@ class S3Service implements Closeable {
             // TODO: remove this leniency, these settings should exist together and be validated
             clientConfiguration.setProxyHost(clientSettings.proxyHost);
             clientConfiguration.setProxyPort(clientSettings.proxyPort);
+            clientConfiguration.setProxyProtocol(clientSettings.proxyScheme);
             clientConfiguration.setProxyUsername(clientSettings.proxyUsername);
             clientConfiguration.setProxyPassword(clientSettings.proxyPassword);
         }

--- a/modules/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3ClientSettingsTests.java
+++ b/modules/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3ClientSettingsTests.java
@@ -37,6 +37,7 @@ public class S3ClientSettingsTests extends ESTestCase {
         assertThat(defaultSettings.protocol, is(Protocol.HTTPS));
         assertThat(defaultSettings.proxyHost, is(emptyString()));
         assertThat(defaultSettings.proxyPort, is(80));
+        assertThat(defaultSettings.proxyScheme, is(Protocol.HTTPS));
         assertThat(defaultSettings.proxyUsername, is(emptyString()));
         assertThat(defaultSettings.proxyPassword, is(emptyString()));
         assertThat(defaultSettings.readTimeoutMillis, is(ClientConfiguration.DEFAULT_SOCKET_TIMEOUT));

--- a/modules/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3ClientSettingsTests.java
+++ b/modules/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3ClientSettingsTests.java
@@ -37,7 +37,7 @@ public class S3ClientSettingsTests extends ESTestCase {
         assertThat(defaultSettings.protocol, is(Protocol.HTTPS));
         assertThat(defaultSettings.proxyHost, is(emptyString()));
         assertThat(defaultSettings.proxyPort, is(80));
-        assertThat(defaultSettings.proxyScheme, is(Protocol.HTTPS));
+        assertThat(defaultSettings.proxyScheme, is(Protocol.HTTP));
         assertThat(defaultSettings.proxyUsername, is(emptyString()));
         assertThat(defaultSettings.proxyPassword, is(emptyString()));
         assertThat(defaultSettings.readTimeoutMillis, is(ClientConfiguration.DEFAULT_SOCKET_TIMEOUT));

--- a/plugins/discovery-ec2/src/main/java/org/elasticsearch/discovery/ec2/AwsEc2ServiceImpl.java
+++ b/plugins/discovery-ec2/src/main/java/org/elasticsearch/discovery/ec2/AwsEc2ServiceImpl.java
@@ -62,6 +62,7 @@ class AwsEc2ServiceImpl implements AwsEc2Service {
             // TODO: remove this leniency, these settings should exist together and be validated
             clientConfiguration.setProxyHost(clientSettings.proxyHost);
             clientConfiguration.setProxyPort(clientSettings.proxyPort);
+            clientConfiguration.setProxyProtocol(clientSettings.proxyScheme);
             clientConfiguration.setProxyUsername(clientSettings.proxyUsername);
             clientConfiguration.setProxyPassword(clientSettings.proxyPassword);
         }

--- a/plugins/discovery-ec2/src/main/java/org/elasticsearch/discovery/ec2/Ec2ClientSettings.java
+++ b/plugins/discovery-ec2/src/main/java/org/elasticsearch/discovery/ec2/Ec2ClientSettings.java
@@ -48,6 +48,14 @@ final class Ec2ClientSettings {
     /** The port of a proxy to connect to ec2 through. */
     static final Setting<Integer> PROXY_PORT_SETTING = Setting.intSetting("discovery.ec2.proxy.port", 80, 0, 1 << 16, Property.NodeScope);
 
+    /** The scheme to use for the proxy connection to ec2. Defaults to "http". */
+    static final Setting<Protocol> PROXY_SCHEME_SETTING = new Setting<>(
+        "discovery.ec2.proxy.scheme",
+        "http",
+        s -> Protocol.valueOf(s.toUpperCase(Locale.ROOT)),
+        Property.NodeScope
+    );
+
     /** An override for the ec2 endpoint to connect to. */
     static final Setting<String> ENDPOINT_SETTING = new Setting<>(
         "discovery.ec2.endpoint",
@@ -56,7 +64,7 @@ final class Ec2ClientSettings {
         Property.NodeScope
     );
 
-    /** The protocol to use to connect to to ec2. */
+    /** The protocol to use to connect  to ec2. */
     static final Setting<Protocol> PROTOCOL_SETTING = new Setting<>(
         "discovery.ec2.protocol",
         "https",
@@ -99,6 +107,9 @@ final class Ec2ClientSettings {
     /** The port number the proxy host should be connected on. */
     final int proxyPort;
 
+    /** The scheme to use for the proxy connection to ec2 */
+    final Protocol proxyScheme;
+
     // these should be "secure" yet the api for the ec2 client only takes String, so
     // storing them
     // as SecureString here won't really help with anything
@@ -117,6 +128,7 @@ final class Ec2ClientSettings {
         Protocol protocol,
         String proxyHost,
         int proxyPort,
+        Protocol proxyScheme,
         String proxyUsername,
         String proxyPassword,
         int readTimeoutMillis
@@ -126,6 +138,7 @@ final class Ec2ClientSettings {
         this.protocol = protocol;
         this.proxyHost = proxyHost;
         this.proxyPort = proxyPort;
+        this.proxyScheme = proxyScheme;
         this.proxyUsername = proxyUsername;
         this.proxyPassword = proxyPassword;
         this.readTimeoutMillis = readTimeoutMillis;
@@ -196,6 +209,7 @@ final class Ec2ClientSettings {
                 PROTOCOL_SETTING.get(settings),
                 PROXY_HOST_SETTING.get(settings),
                 PROXY_PORT_SETTING.get(settings),
+                PROXY_SCHEME_SETTING.get(settings),
                 proxyUsername.toString(),
                 proxyPassword.toString(),
                 (int) READ_TIMEOUT_SETTING.get(settings).millis()

--- a/plugins/discovery-ec2/src/main/java/org/elasticsearch/discovery/ec2/Ec2DiscoveryPlugin.java
+++ b/plugins/discovery-ec2/src/main/java/org/elasticsearch/discovery/ec2/Ec2DiscoveryPlugin.java
@@ -104,6 +104,7 @@ public class Ec2DiscoveryPlugin extends Plugin implements DiscoveryPlugin, Reloa
             Ec2ClientSettings.PROTOCOL_SETTING,
             Ec2ClientSettings.PROXY_HOST_SETTING,
             Ec2ClientSettings.PROXY_PORT_SETTING,
+            Ec2ClientSettings.PROXY_SCHEME_SETTING,
             Ec2ClientSettings.PROXY_USERNAME_SETTING,
             Ec2ClientSettings.PROXY_PASSWORD_SETTING,
             Ec2ClientSettings.READ_TIMEOUT_SETTING,

--- a/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/AwsEc2ServiceImplTests.java
+++ b/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/AwsEc2ServiceImplTests.java
@@ -119,7 +119,16 @@ public class AwsEc2ServiceImplTests extends ESTestCase {
     }
 
     public void testAWSDefaultConfiguration() {
-        launchAWSConfigurationTest(Settings.EMPTY, Protocol.HTTPS, null, -1, null, null, ClientConfiguration.DEFAULT_SOCKET_TIMEOUT);
+        launchAWSConfigurationTest(
+            Settings.EMPTY,
+            Protocol.HTTPS,
+            null,
+            -1,
+            Protocol.HTTP,
+            null,
+            null,
+            ClientConfiguration.DEFAULT_SOCKET_TIMEOUT
+        );
     }
 
     public void testAWSConfigurationWithAwsSettings() {
@@ -134,7 +143,16 @@ public class AwsEc2ServiceImplTests extends ESTestCase {
             .put("discovery.ec2.read_timeout", "10s")
             .setSecureSettings(secureSettings)
             .build();
-        launchAWSConfigurationTest(settings, Protocol.HTTP, "aws_proxy_host", 8080, "http",  "aws_proxy_username", "aws_proxy_password", 10000);
+        launchAWSConfigurationTest(
+            settings,
+            Protocol.HTTP,
+            "aws_proxy_host",
+            8080,
+            Protocol.HTTP,
+            "aws_proxy_username",
+            "aws_proxy_password",
+            10000
+        );
     }
 
     protected void launchAWSConfigurationTest(

--- a/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/AwsEc2ServiceImplTests.java
+++ b/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/AwsEc2ServiceImplTests.java
@@ -130,10 +130,11 @@ public class AwsEc2ServiceImplTests extends ESTestCase {
             .put("discovery.ec2.protocol", "http")
             .put("discovery.ec2.proxy.host", "aws_proxy_host")
             .put("discovery.ec2.proxy.port", 8080)
+            .put("discovery.ec2.proxy.scheme", "http")
             .put("discovery.ec2.read_timeout", "10s")
             .setSecureSettings(secureSettings)
             .build();
-        launchAWSConfigurationTest(settings, Protocol.HTTP, "aws_proxy_host", 8080, "aws_proxy_username", "aws_proxy_password", 10000);
+        launchAWSConfigurationTest(settings, Protocol.HTTP, "aws_proxy_host", 8080, "http",  "aws_proxy_username", "aws_proxy_password", 10000);
     }
 
     protected void launchAWSConfigurationTest(
@@ -141,6 +142,7 @@ public class AwsEc2ServiceImplTests extends ESTestCase {
         Protocol expectedProtocol,
         String expectedProxyHost,
         int expectedProxyPort,
+        Protocol expectedProxyScheme,
         String expectedProxyUsername,
         String expectedProxyPassword,
         int expectedReadTimeout
@@ -151,6 +153,7 @@ public class AwsEc2ServiceImplTests extends ESTestCase {
         assertThat(configuration.getProtocol(), is(expectedProtocol));
         assertThat(configuration.getProxyHost(), is(expectedProxyHost));
         assertThat(configuration.getProxyPort(), is(expectedProxyPort));
+        assertThat(configuration.getProxyProtocol(), is(expectedProxyScheme));
         assertThat(configuration.getProxyUsername(), is(expectedProxyUsername));
         assertThat(configuration.getProxyPassword(), is(expectedProxyPassword));
         assertThat(configuration.getSocketTimeout(), is(expectedReadTimeout));

--- a/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/Ec2DiscoveryPluginTests.java
+++ b/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/Ec2DiscoveryPluginTests.java
@@ -160,6 +160,7 @@ public class Ec2DiscoveryPluginTests extends ESTestCase {
         final Settings settings1 = Settings.builder()
             .put(Ec2ClientSettings.PROXY_HOST_SETTING.getKey(), "proxy_host_1")
             .put(Ec2ClientSettings.PROXY_PORT_SETTING.getKey(), 881)
+            .put(Ec2ClientSettings.PROXY_SCHEME_SETTING.getKey(), "http")
             .put(Ec2ClientSettings.ENDPOINT_SETTING.getKey(), "ec2_endpoint_1")
             .setSecureSettings(mockSecure1)
             .build();
@@ -175,6 +176,7 @@ public class Ec2DiscoveryPluginTests extends ESTestCase {
         final Settings settings2 = Settings.builder()
             .put(Ec2ClientSettings.PROXY_HOST_SETTING.getKey(), "proxy_host_2")
             .put(Ec2ClientSettings.PROXY_PORT_SETTING.getKey(), 882)
+            .put(Ec2ClientSettings.PROXY_SCHEME_SETTING.getKey(), "http")
             .put(Ec2ClientSettings.ENDPOINT_SETTING.getKey(), "ec2_endpoint_2")
             .setSecureSettings(mockSecure2)
             .build();
@@ -194,6 +196,7 @@ public class Ec2DiscoveryPluginTests extends ESTestCase {
                     assertThat(((AmazonEC2Mock) clientReference.client()).configuration.getProxyPassword(), is("proxy_password_1"));
                     assertThat(((AmazonEC2Mock) clientReference.client()).configuration.getProxyHost(), is("proxy_host_1"));
                     assertThat(((AmazonEC2Mock) clientReference.client()).configuration.getProxyPort(), is(881));
+                    assertThat(((AmazonEC2Mock) clientReference.client()).configuration.getProxyProtocol(), is("http"));
                     assertThat(((AmazonEC2Mock) clientReference.client()).endpoint, is("ec2_endpoint_1"));
                 }
                 // reload secure settings2
@@ -211,6 +214,7 @@ public class Ec2DiscoveryPluginTests extends ESTestCase {
                     assertThat(((AmazonEC2Mock) clientReference.client()).configuration.getProxyPassword(), is("proxy_password_1"));
                     assertThat(((AmazonEC2Mock) clientReference.client()).configuration.getProxyHost(), is("proxy_host_1"));
                     assertThat(((AmazonEC2Mock) clientReference.client()).configuration.getProxyPort(), is(881));
+                    assertThat(((AmazonEC2Mock) clientReference.client()).configuration.getProxyProtocol(), is("http"));
                     assertThat(((AmazonEC2Mock) clientReference.client()).endpoint, is("ec2_endpoint_1"));
                 }
             }
@@ -228,6 +232,7 @@ public class Ec2DiscoveryPluginTests extends ESTestCase {
                 assertThat(((AmazonEC2Mock) clientReference.client()).configuration.getProxyPassword(), is("proxy_password_2"));
                 assertThat(((AmazonEC2Mock) clientReference.client()).configuration.getProxyHost(), is("proxy_host_2"));
                 assertThat(((AmazonEC2Mock) clientReference.client()).configuration.getProxyPort(), is(882));
+                assertThat(((AmazonEC2Mock) clientReference.client()).configuration.getProxyProtocol(), is("http"));
                 assertThat(((AmazonEC2Mock) clientReference.client()).endpoint, is("ec2_endpoint_2"));
             }
         }

--- a/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/Ec2DiscoveryPluginTests.java
+++ b/plugins/discovery-ec2/src/test/java/org/elasticsearch/discovery/ec2/Ec2DiscoveryPluginTests.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.discovery.ec2;
 
 import com.amazonaws.ClientConfiguration;
+import com.amazonaws.Protocol;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
@@ -196,7 +197,7 @@ public class Ec2DiscoveryPluginTests extends ESTestCase {
                     assertThat(((AmazonEC2Mock) clientReference.client()).configuration.getProxyPassword(), is("proxy_password_1"));
                     assertThat(((AmazonEC2Mock) clientReference.client()).configuration.getProxyHost(), is("proxy_host_1"));
                     assertThat(((AmazonEC2Mock) clientReference.client()).configuration.getProxyPort(), is(881));
-                    assertThat(((AmazonEC2Mock) clientReference.client()).configuration.getProxyProtocol(), is("http"));
+                    assertThat(((AmazonEC2Mock) clientReference.client()).configuration.getProxyProtocol(), is(Protocol.HTTP));
                     assertThat(((AmazonEC2Mock) clientReference.client()).endpoint, is("ec2_endpoint_1"));
                 }
                 // reload secure settings2
@@ -214,7 +215,7 @@ public class Ec2DiscoveryPluginTests extends ESTestCase {
                     assertThat(((AmazonEC2Mock) clientReference.client()).configuration.getProxyPassword(), is("proxy_password_1"));
                     assertThat(((AmazonEC2Mock) clientReference.client()).configuration.getProxyHost(), is("proxy_host_1"));
                     assertThat(((AmazonEC2Mock) clientReference.client()).configuration.getProxyPort(), is(881));
-                    assertThat(((AmazonEC2Mock) clientReference.client()).configuration.getProxyProtocol(), is("http"));
+                    assertThat(((AmazonEC2Mock) clientReference.client()).configuration.getProxyProtocol(), is(Protocol.HTTP));
                     assertThat(((AmazonEC2Mock) clientReference.client()).endpoint, is("ec2_endpoint_1"));
                 }
             }
@@ -232,7 +233,7 @@ public class Ec2DiscoveryPluginTests extends ESTestCase {
                 assertThat(((AmazonEC2Mock) clientReference.client()).configuration.getProxyPassword(), is("proxy_password_2"));
                 assertThat(((AmazonEC2Mock) clientReference.client()).configuration.getProxyHost(), is("proxy_host_2"));
                 assertThat(((AmazonEC2Mock) clientReference.client()).configuration.getProxyPort(), is(882));
-                assertThat(((AmazonEC2Mock) clientReference.client()).configuration.getProxyProtocol(), is("http"));
+                assertThat(((AmazonEC2Mock) clientReference.client()).configuration.getProxyProtocol(), is(Protocol.HTTP));
                 assertThat(((AmazonEC2Mock) clientReference.client()).endpoint, is("ec2_endpoint_2"));
             }
         }


### PR DESCRIPTION

This PR introduces improvements to the S3 client configuration enables the specification of proxy schemes, providing more flexibility for users operating Elasticsearch in environments with specific proxy requirements.


Closes #101873