### PR TITLE
Fix ref counting when using futures in AbstractClient

### DIFF
--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderTests.java
@@ -180,11 +180,15 @@ public class GeoIpDownloaderTests extends ESTestCase {
     public void testIndexChunksNoData() throws IOException {
         client.addHandler(FlushAction.INSTANCE, (FlushRequest request, ActionListener<FlushResponse> flushResponseActionListener) -> {
             assertArrayEquals(new String[] { GeoIpDownloader.DATABASES_INDEX }, request.indices());
-            flushResponseActionListener.onResponse(mock(FlushResponse.class));
+            var flushResponse = mock(FlushResponse.class);
+            when(flushResponse.hasReferences()).thenReturn(true);
+            flushResponseActionListener.onResponse(flushResponse);
         });
         client.addHandler(RefreshAction.INSTANCE, (RefreshRequest request, ActionListener<RefreshResponse> flushResponseActionListener) -> {
             assertArrayEquals(new String[] { GeoIpDownloader.DATABASES_INDEX }, request.indices());
-            flushResponseActionListener.onResponse(mock(RefreshResponse.class));
+            var refreshResponse = mock(RefreshResponse.class);
+            when(refreshResponse.hasReferences()).thenReturn(true);
+            flushResponseActionListener.onResponse(refreshResponse);
         });
 
         InputStream empty = new ByteArrayInputStream(new byte[0]);
@@ -194,11 +198,15 @@ public class GeoIpDownloaderTests extends ESTestCase {
     public void testIndexChunksMd5Mismatch() {
         client.addHandler(FlushAction.INSTANCE, (FlushRequest request, ActionListener<FlushResponse> flushResponseActionListener) -> {
             assertArrayEquals(new String[] { GeoIpDownloader.DATABASES_INDEX }, request.indices());
-            flushResponseActionListener.onResponse(mock(FlushResponse.class));
+            var flushResponse = mock(FlushResponse.class);
+            when(flushResponse.hasReferences()).thenReturn(true);
+            flushResponseActionListener.onResponse(flushResponse);
         });
         client.addHandler(RefreshAction.INSTANCE, (RefreshRequest request, ActionListener<RefreshResponse> flushResponseActionListener) -> {
             assertArrayEquals(new String[] { GeoIpDownloader.DATABASES_INDEX }, request.indices());
-            flushResponseActionListener.onResponse(mock(RefreshResponse.class));
+            var refreshResponse = mock(RefreshResponse.class);
+            when(refreshResponse.hasReferences()).thenReturn(true);
+            flushResponseActionListener.onResponse(refreshResponse);
         });
 
         IOException exception = expectThrows(
@@ -230,15 +238,21 @@ public class GeoIpDownloaderTests extends ESTestCase {
             assertEquals("test", source.get("name"));
             assertArrayEquals(chunksData[chunk], (byte[]) source.get("data"));
             assertEquals(chunk + 15, source.get("chunk"));
-            listener.onResponse(mock(IndexResponse.class));
+            var indexResponse = mock(IndexResponse.class);
+            when(indexResponse.hasReferences()).thenReturn(true);
+            listener.onResponse(indexResponse);
         });
         client.addHandler(FlushAction.INSTANCE, (FlushRequest request, ActionListener<FlushResponse> flushResponseActionListener) -> {
             assertArrayEquals(new String[] { GeoIpDownloader.DATABASES_INDEX }, request.indices());
-            flushResponseActionListener.onResponse(mock(FlushResponse.class));
+            var flushResponse = mock(FlushResponse.class);
+            when(flushResponse.hasReferences()).thenReturn(true);
+            flushResponseActionListener.onResponse(flushResponse);
         });
         client.addHandler(RefreshAction.INSTANCE, (RefreshRequest request, ActionListener<RefreshResponse> flushResponseActionListener) -> {
             assertArrayEquals(new String[] { GeoIpDownloader.DATABASES_INDEX }, request.indices());
-            flushResponseActionListener.onResponse(mock(RefreshResponse.class));
+            var refreshResponse = mock(RefreshResponse.class);
+            when(refreshResponse.hasReferences()).thenReturn(true);
+            flushResponseActionListener.onResponse(refreshResponse);
         });
 
         InputStream big = new ByteArrayInputStream(bigArray);

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/RetryTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/RetryTests.java
@@ -199,18 +199,21 @@ public class RetryTests extends ESIntegTestCase {
         logger.info("Starting request");
         ActionFuture<BulkByScrollResponse> responseListener = builder.execute();
 
+        BulkByScrollResponse response = null;
         try {
             logger.info("Waiting for bulk rejections");
             assertBusy(() -> assertThat(taskStatus(action).getBulkRetries(), greaterThan(0L)));
             bulkBlock.await();
 
             logger.info("Waiting for the request to finish");
-            BulkByScrollResponse response = responseListener.get();
+            response = responseListener.get();
             assertThat(response, matcher);
             assertThat(response.getBulkRetries(), greaterThan(0L));
         } finally {
             // Fetch the response just in case we blew up half way through. This will make sure the failure is thrown up to the top level.
-            BulkByScrollResponse response = responseListener.get();
+            if (response == null) {
+                response = responseListener.get();
+            }
             assertThat(response.getSearchFailures(), empty());
             assertThat(response.getBulkFailures(), empty());
         }

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/node/tasks/CancellableTasksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/node/tasks/CancellableTasksIT.java
@@ -225,7 +225,6 @@ public class CancellableTasksIT extends ESIntegTestCase {
         assertFalse(cancelFuture.isDone());
         allowEntireRequest(rootRequest);
         assertThat(cancelFuture.actionGet().getTaskFailures(), empty());
-        assertThat(cancelFuture.actionGet().getTaskFailures(), empty());
         waitForRootTask(mainTaskFuture, false);
         CancelTasksResponse cancelError = clusterAdmin().prepareCancelTasks()
             .setTargetTaskId(taskId)

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/WaitUntilRefreshIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/WaitUntilRefreshIT.java
@@ -151,8 +151,9 @@ public class WaitUntilRefreshIT extends ESIntegTestCase {
         while (false == index.isDone()) {
             indicesAdmin().prepareRefresh("test").get();
         }
-        assertEquals(RestStatus.CREATED, index.get().status());
-        assertFalse("request shouldn't have forced a refresh", index.get().forcedRefresh());
+        var response = index.get();
+        assertEquals(RestStatus.CREATED, response.status());
+        assertFalse("request shouldn't have forced a refresh", response.forcedRefresh());
         assertSearchHits(prepareSearch("test").setQuery(matchQuery("foo", "bar")), "1");
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotStatusApisIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotStatusApisIT.java
@@ -677,8 +677,9 @@ public class SnapshotStatusApisIT extends AbstractSnapshotIntegTestCase {
         }, 60, TimeUnit.SECONDS);
 
         for (ActionFuture<SnapshotsStatusResponse> status : statuses) {
-            assertThat(status.get().getSnapshots(), hasSize(snapshots));
-            for (SnapshotStatus snapshot : status.get().getSnapshots()) {
+            var statusResponse = status.get();
+            assertThat(statusResponse.getSnapshots(), hasSize(snapshots));
+            for (SnapshotStatus snapshot : statusResponse.getSnapshots()) {
                 assertThat(snapshot.getState(), allOf(not(SnapshotsInProgress.State.FAILED), not(SnapshotsInProgress.State.ABORTED)));
                 for (final var shard : snapshot.getShards()) {
                     if (shard.getStage() == SnapshotIndexShardStage.DONE) {

--- a/server/src/main/java/org/elasticsearch/action/support/PlainActionFuture.java
+++ b/server/src/main/java/org/elasticsearch/action/support/PlainActionFuture.java
@@ -17,6 +17,7 @@ import org.elasticsearch.common.util.concurrent.FutureUtils;
 import org.elasticsearch.common.util.concurrent.UncategorizedExecutionException;
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.RefCounted;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.Transports;
@@ -447,5 +448,19 @@ public class PlainActionFuture<T> implements ActionFuture<T>, ActionListener<T> 
         PlainActionFuture<T> fut = new PlainActionFuture<>();
         e.accept(fut);
         return fut.actionGet(timeout, unit);
+    }
+
+    /**
+     * Same as {@code PlainActionFuture} but for use with {@link RefCounted} result types. Unlike {@code PlainActionFuture} this future
+     * acquires a reference to its result. This means that the result reference must be released by a call to {@link RefCounted#decRef()}
+     * on the result before it goes out of scope.
+     * @param <R> reference counted result type
+     */
+    public static class ForRefCounted<R extends RefCounted> extends PlainActionFuture<R> {
+        @Override
+        public final void onResponse(R result) {
+            result.incRef();
+            super.onResponse(result);
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/support/PlainActionFuture.java
+++ b/server/src/main/java/org/elasticsearch/action/support/PlainActionFuture.java
@@ -17,7 +17,6 @@ import org.elasticsearch.common.util.concurrent.FutureUtils;
 import org.elasticsearch.common.util.concurrent.UncategorizedExecutionException;
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.core.Nullable;
-import org.elasticsearch.core.RefCounted;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.Transports;
@@ -448,19 +447,5 @@ public class PlainActionFuture<T> implements ActionFuture<T>, ActionListener<T> 
         PlainActionFuture<T> fut = new PlainActionFuture<>();
         e.accept(fut);
         return fut.actionGet(timeout, unit);
-    }
-
-    /**
-     * Same as {@code PlainActionFuture} but for use with {@link RefCounted} result types. Unlike {@code PlainActionFuture} this future
-     * acquires a reference to its result. This means that the result reference must be released by a call to {@link RefCounted#decRef()}
-     * on the result before it goes out of scope.
-     * @param <R> reference counted result type
-     */
-    public static class ForRefCounted<R extends RefCounted> extends PlainActionFuture<R> {
-        @Override
-        public final void onResponse(R result) {
-            result.incRef();
-            super.onResponse(result);
-        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/client/internal/support/AbstractClient.java
+++ b/server/src/main/java/org/elasticsearch/client/internal/support/AbstractClient.java
@@ -1612,8 +1612,6 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public final void onResponse(R result) {
-            result.incRef();
-            super.onResponse(result);
             assert result.hasReferences();
             if (set(result)) {
                 result.incRef();

--- a/server/src/main/java/org/elasticsearch/client/internal/support/AbstractClient.java
+++ b/server/src/main/java/org/elasticsearch/client/internal/support/AbstractClient.java
@@ -361,7 +361,7 @@ public abstract class AbstractClient implements Client {
         ActionType<Response> action,
         Request request
     ) {
-        PlainActionFuture<Response> actionFuture = new PlainActionFuture<>();
+        PlainActionFuture<Response> actionFuture = new PlainActionFuture.ForRefCounted<>();
         execute(action, request, actionFuture);
         return actionFuture;
     }

--- a/server/src/test/java/org/elasticsearch/client/internal/OriginSettingClientTests.java
+++ b/server/src/test/java/org/elasticsearch/client/internal/OriginSettingClientTests.java
@@ -37,7 +37,6 @@ public class OriginSettingClientTests extends ESTestCase {
                     ActionListener<Response> listener
                 ) {
                     assertEquals(origin, threadPool().getThreadContext().getTransient(ThreadContext.ACTION_ORIGIN_TRANSIENT_NAME));
-                    super.doExecute(action, request, listener);
                 }
             };
 

--- a/server/src/test/java/org/elasticsearch/client/internal/ParentTaskAssigningClientTests.java
+++ b/server/src/test/java/org/elasticsearch/client/internal/ParentTaskAssigningClientTests.java
@@ -33,7 +33,6 @@ public class ParentTaskAssigningClientTests extends ESTestCase {
                     ActionListener<Response> listener
                 ) {
                     assertEquals(parentTaskId[0], request.getParentTask());
-                    super.doExecute(action, request, listener);
                 }
             };
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/utils/persistence/BatchedDocumentsIteratorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/utils/persistence/BatchedDocumentsIteratorTests.java
@@ -140,7 +140,9 @@ public class BatchedDocumentsIteratorTests extends ESTestCase {
         doAnswer(invocationOnMock -> {
             ActionListener<ClearScrollResponse> listener = (ActionListener<ClearScrollResponse>) invocationOnMock.getArguments()[2];
             wasScrollCleared = true;
-            listener.onResponse(mock(ClearScrollResponse.class));
+            var clearScrollResponse = mock(ClearScrollResponse.class);
+            when(clearScrollResponse.hasReferences()).thenReturn(true);
+            listener.onResponse(clearScrollResponse);
             return null;
         }).when(client).execute(eq(ClearScrollAction.INSTANCE), any(), any());
     }
@@ -171,6 +173,7 @@ public class BatchedDocumentsIteratorTests extends ESTestCase {
         protected SearchResponse createSearchResponseWithHits(String... hits) {
             SearchHits searchHits = createHits(hits);
             SearchResponse searchResponse = mock(SearchResponse.class);
+            when(searchResponse.hasReferences()).thenReturn(true);
             when(searchResponse.getScrollId()).thenReturn(SCROLL_ID);
             when(searchResponse.getHits()).thenReturn(searchHits);
             return searchResponse;

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherServiceTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherServiceTests.java
@@ -163,6 +163,7 @@ public class WatcherServiceTests extends ESTestCase {
 
         // response setup, successful refresh response
         RefreshResponse refreshResponse = mock(RefreshResponse.class);
+        when(refreshResponse.hasReferences()).thenReturn(true);
         when(refreshResponse.getSuccessfulShards()).thenReturn(
             clusterState.getMetadata().getIndices().get(Watch.INDEX).getNumberOfShards()
         );

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/execution/TriggeredWatchStoreTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/execution/TriggeredWatchStoreTests.java
@@ -210,6 +210,7 @@ public class TriggeredWatchStoreTests extends ESTestCase {
         SearchResponse searchResponse1 = mock(SearchResponse.class);
         when(searchResponse1.getSuccessfulShards()).thenReturn(1);
         when(searchResponse1.getTotalShards()).thenReturn(1);
+        when(searchResponse1.hasReferences()).thenReturn(true);
         BytesArray source = new BytesArray("{}");
         SearchHit hit = new SearchHit(0, "first_foo");
         hit.version(1L);
@@ -512,6 +513,7 @@ public class TriggeredWatchStoreTests extends ESTestCase {
         RefreshResponse refreshResponse = mock(RefreshResponse.class);
         when(refreshResponse.getTotalShards()).thenReturn(total);
         when(refreshResponse.getSuccessfulShards()).thenReturn(successful);
+        when(refreshResponse.hasReferences()).thenReturn(true);
         return refreshResponse;
     }
 }


### PR DESCRIPTION
Found this now that #102030 is getting closer to completion. It's fundamentally broken how the client deals with ref counted messages. We were only saved by the fact that currently we do do not handle any messages with non-noop ref counting through this client interface. 

We fundamentally need to increment the ref count by one before assigning a ref counted value to a future result.
Otherwise, transport actions will have to understand the specific kind of listener they resolve and cannot decrement sent/consumed transport messages themselves.

marking non-issue since this hasn't caused any production trouble yet.