### PR TITLE
Collapse verbose .execute().actionGet() calls in tests

### DIFF
--- a/modules/analysis-common/src/internalClusterTest/java/org/elasticsearch/analysis/common/ReloadAnalyzerTests.java
+++ b/modules/analysis-common/src/internalClusterTest/java/org/elasticsearch/analysis/common/ReloadAnalyzerTests.java
@@ -92,7 +92,7 @@ public class ReloadAnalyzerTests extends ESSingleNodeTestCase {
         );
 
         client().prepareIndex(INDEX_NAME).setId("1").setSource("field", "Foo").get();
-        assertNoFailures(indicesAdmin().prepareRefresh(INDEX_NAME).execute().actionGet());
+        assertNoFailures(indicesAdmin().prepareRefresh(INDEX_NAME).get());
 
         assertHitCount(client().prepareSearch(INDEX_NAME).setQuery(QueryBuilders.matchQuery("field", "baz")), 1L);
         assertHitCount(client().prepareSearch(INDEX_NAME).setQuery(QueryBuilders.matchQuery("field", "buzz")), 0L);
@@ -162,7 +162,7 @@ public class ReloadAnalyzerTests extends ESSingleNodeTestCase {
         );
 
         client().prepareIndex(INDEX_NAME).setId("1").setSource("field", "foo").get();
-        assertNoFailures(indicesAdmin().prepareRefresh(INDEX_NAME).execute().actionGet());
+        assertNoFailures(indicesAdmin().prepareRefresh(INDEX_NAME).get());
 
         assertHitCount(client().prepareSearch(INDEX_NAME).setQuery(QueryBuilders.matchQuery("field", "baz")), 1L);
         assertHitCount(client().prepareSearch(INDEX_NAME).setQuery(QueryBuilders.matchQuery("field", "buzz")), 0L);

--- a/modules/analysis-common/src/internalClusterTest/java/org/elasticsearch/analysis/common/ReloadSynonymAnalyzerIT.java
+++ b/modules/analysis-common/src/internalClusterTest/java/org/elasticsearch/analysis/common/ReloadSynonymAnalyzerIT.java
@@ -71,7 +71,7 @@ public class ReloadSynonymAnalyzerIT extends ESIntegTestCase {
         );
 
         client().prepareIndex("test").setId("1").setSource("field", "foo").get();
-        assertNoFailures(indicesAdmin().prepareRefresh("test").execute().actionGet());
+        assertNoFailures(indicesAdmin().prepareRefresh("test").get());
 
         assertHitCount(prepareSearch("test").setQuery(QueryBuilders.matchQuery("field", "baz")), 1L);
         assertHitCount(prepareSearch("test").setQuery(QueryBuilders.matchQuery("field", "buzz")), 0L);

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamsSnapshotsIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamsSnapshotsIT.java
@@ -842,8 +842,7 @@ public class DataStreamsSnapshotsIT extends AbstractSnapshotIntegTestCase {
                 .setOpType(DocWriteRequest.OpType.CREATE)
                 .setId(Integer.toString(i))
                 .setSource(Collections.singletonMap("@timestamp", "2020-12-12"))
-                .execute()
-                .actionGet();
+                .get();
         }
         refresh();
         assertDocCount(dataStream, 100L);

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/SystemDataStreamSnapshotIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/SystemDataStreamSnapshotIT.java
@@ -166,8 +166,7 @@ public class SystemDataStreamSnapshotIT extends AbstractSnapshotIntegTestCase {
             .setId("42")
             .setSource("{ \"@timestamp\": \"2099-03-08T11:06:07.000Z\", \"name\": \"my-name\" }", XContentType.JSON)
             .setOpType(DocWriteRequest.OpType.CREATE)
-            .execute()
-            .actionGet();
+            .get();
         assertThat(indexToDataStreamResponse.status().getStatus(), oneOf(200, 201));
 
         // Index a doc so that a concrete backing index will be created
@@ -175,7 +174,6 @@ public class SystemDataStreamSnapshotIT extends AbstractSnapshotIntegTestCase {
             .setId("42")
             .setSource("{ \"name\": \"my-name\" }", XContentType.JSON)
             .setOpType(DocWriteRequest.OpType.CREATE)
-            .execute()
             .get();
         assertThat(indexResponse.status().getStatus(), oneOf(200, 201));
 

--- a/modules/lang-expression/src/internalClusterTest/java/org/elasticsearch/script/expression/MoreExpressionIT.java
+++ b/modules/lang-expression/src/internalClusterTest/java/org/elasticsearch/script/expression/MoreExpressionIT.java
@@ -650,8 +650,7 @@ public class MoreExpressionIT extends ESIntegTestCase {
                     .endObject()
                     .endObject()
             )
-            .execute()
-            .actionGet();
+            .get();
         refresh();
         // access .lat
         assertNoFailuresAndResponse(buildRequest("doc['location'].lat"), rsp -> {

--- a/modules/parent-join/src/internalClusterTest/java/org/elasticsearch/join/query/ChildQuerySearchIT.java
+++ b/modules/parent-join/src/internalClusterTest/java/org/elasticsearch/join/query/ChildQuerySearchIT.java
@@ -1409,8 +1409,7 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
                 .setSize(1)
                 .addStoredField("_id")
                 .setQuery(query)
-                .execute()
-                .actionGet();
+                .get();
 
             assertNoFailures(scrollResponse);
             assertThat(scrollResponse.getHits().getTotalHits().value, equalTo(10L));

--- a/modules/percolator/src/internalClusterTest/java/org/elasticsearch/percolator/PercolatorQuerySearchIT.java
+++ b/modules/percolator/src/internalClusterTest/java/org/elasticsearch/percolator/PercolatorQuerySearchIT.java
@@ -536,28 +536,23 @@ public class PercolatorQuerySearchIT extends ESIntegTestCase {
         client().prepareIndex("test")
             .setId("1")
             .setSource(jsonBuilder().startObject().field("id", "1").field("query", matchQuery("field1", "brown fox")).endObject())
-            .execute()
-            .actionGet();
+            .get();
         client().prepareIndex("test")
             .setId("2")
             .setSource(jsonBuilder().startObject().field("id", "2").field("query", matchQuery("field1", "lazy dog")).endObject())
-            .execute()
-            .actionGet();
+            .get();
         client().prepareIndex("test")
             .setId("3")
             .setSource(jsonBuilder().startObject().field("id", "3").field("query", termQuery("field1", "jumps")).endObject())
-            .execute()
-            .actionGet();
+            .get();
         client().prepareIndex("test")
             .setId("4")
             .setSource(jsonBuilder().startObject().field("id", "4").field("query", termQuery("field1", "dog")).endObject())
-            .execute()
-            .actionGet();
+            .get();
         client().prepareIndex("test")
             .setId("5")
             .setSource(jsonBuilder().startObject().field("id", "5").field("query", termQuery("field1", "fox")).endObject())
-            .execute()
-            .actionGet();
+            .get();
         indicesAdmin().prepareRefresh().get();
 
         BytesReference document = BytesReference.bytes(
@@ -1123,13 +1118,11 @@ public class PercolatorQuerySearchIT extends ESIntegTestCase {
         client().prepareIndex("test")
             .setId("1")
             .setSource(jsonBuilder().startObject().field("query", matchQuery("field1", "b")).field("a", "b").endObject())
-            .execute()
-            .actionGet();
+            .get();
         client().prepareIndex("test")
             .setId("2")
             .setSource(jsonBuilder().startObject().field("query", matchQuery("field1", "c")).endObject())
-            .execute()
-            .actionGet();
+            .get();
         client().prepareIndex("test")
             .setId("3")
             .setSource(
@@ -1137,18 +1130,9 @@ public class PercolatorQuerySearchIT extends ESIntegTestCase {
                     .field("query", boolQuery().must(matchQuery("field1", "b")).must(matchQuery("field1", "c")))
                     .endObject()
             )
-            .execute()
-            .actionGet();
-        client().prepareIndex("test")
-            .setId("4")
-            .setSource(jsonBuilder().startObject().field("query", matchAllQuery()).endObject())
-            .execute()
-            .actionGet();
-        client().prepareIndex("test")
-            .setId("5")
-            .setSource(jsonBuilder().startObject().field("field1", "c").endObject())
-            .execute()
-            .actionGet();
+            .get();
+        client().prepareIndex("test").setId("4").setSource(jsonBuilder().startObject().field("query", matchAllQuery()).endObject()).get();
+        client().prepareIndex("test").setId("5").setSource(jsonBuilder().startObject().field("field1", "c").endObject()).get();
         indicesAdmin().prepareRefresh().get();
 
         MultiSearchResponse response = client().prepareMultiSearch()
@@ -1278,14 +1262,12 @@ public class PercolatorQuerySearchIT extends ESIntegTestCase {
         client().prepareIndex("test")
             .setId("1")
             .setSource(jsonBuilder().startObject().field("q", boolQuery().must(rangeQuery("d").gt("now"))).endObject())
-            .execute()
-            .actionGet();
+            .get();
 
         client().prepareIndex("test")
             .setId("2")
             .setSource(jsonBuilder().startObject().field("q", boolQuery().must(rangeQuery("d").lt("now"))).endObject())
-            .execute()
-            .actionGet();
+            .get();
 
         indicesAdmin().prepareRefresh().get();
 
@@ -1353,8 +1335,7 @@ public class PercolatorQuerySearchIT extends ESIntegTestCase {
                     .endObject()
             )
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
-            .execute()
-            .actionGet();
+            .get();
 
         assertHitCount(
             prepareSearch("test").setQuery(

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorQuerySearchTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorQuerySearchTests.java
@@ -84,8 +84,7 @@ public class PercolatorQuerySearchTests extends ESSingleNodeTestCase {
                     .endObject()
             )
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
-            .execute()
-            .actionGet();
+            .get();
         assertSearchHitsWithoutFailures(
             client().prepareSearch("index")
                 .setQuery(

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/RetryTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/RetryTests.java
@@ -175,9 +175,9 @@ public class RetryTests extends ESIntegTestCase {
         final Settings indexSettings = indexSettings(1, 0).put("index.routing.allocation.include.color", "blue").build();
 
         // Create the source index on the node with small thread pools so we can block them.
-        indicesAdmin().prepareCreate("source").setSettings(indexSettings).execute().actionGet();
+        indicesAdmin().prepareCreate("source").setSettings(indexSettings).get();
         // Not all test cases use the dest index but those that do require that it be on the node will small thread pools
-        indicesAdmin().prepareCreate("dest").setSettings(indexSettings).execute().actionGet();
+        indicesAdmin().prepareCreate("dest").setSettings(indexSettings).get();
         // Build the test data. Don't use indexRandom because that won't work consistently with such small thread pools.
         BulkRequestBuilder bulk = client().prepareBulk();
         for (int i = 0; i < DOC_COUNT; i++) {

--- a/modules/repository-url/src/internalClusterTest/java/org/elasticsearch/repositories/url/URLSnapshotRestoreIT.java
+++ b/modules/repository-url/src/internalClusterTest/java/org/elasticsearch/repositories/url/URLSnapshotRestoreIT.java
@@ -107,8 +107,7 @@ public class URLSnapshotRestoreIT extends ESIntegTestCase {
             .prepareRestoreSnapshot("url-repo", "test-snap")
             .setWaitForCompletion(true)
             .setIndices("test-idx")
-            .execute()
-            .actionGet();
+            .get();
         assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), greaterThan(0));
 
         assertThat(client.prepareSearch("test-idx").setSize(0).get().getHits().getTotalHits().value, equalTo(100L));

--- a/plugins/discovery-azure-classic/src/internalClusterTest/java/org/elasticsearch/cloud/azure/classic/AbstractAzureComputeServiceTestCase.java
+++ b/plugins/discovery-azure-classic/src/internalClusterTest/java/org/elasticsearch/cloud/azure/classic/AbstractAzureComputeServiceTestCase.java
@@ -86,7 +86,7 @@ public abstract class AbstractAzureComputeServiceTestCase extends ESIntegTestCas
     }
 
     protected void assertNumberOfNodes(int expected) {
-        NodesInfoResponse nodeInfos = clusterAdmin().prepareNodesInfo().clear().execute().actionGet();
+        NodesInfoResponse nodeInfos = clusterAdmin().prepareNodesInfo().clear().get();
         assertNotNull(nodeInfos);
         assertNotNull(nodeInfos.getNodes());
         assertEquals(expected, nodeInfos.getNodes().size());

--- a/plugins/repository-hdfs/src/test/java/org/elasticsearch/repositories/hdfs/HdfsTests.java
+++ b/plugins/repository-hdfs/src/test/java/org/elasticsearch/repositories/hdfs/HdfsTests.java
@@ -111,8 +111,7 @@ public class HdfsTests extends ESSingleNodeTestCase {
             .cluster()
             .prepareRestoreSnapshot("test-repo", "test-snap")
             .setWaitForCompletion(true)
-            .execute()
-            .actionGet();
+            .get();
         assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), greaterThan(0));
 
         ensureGreen();
@@ -129,8 +128,7 @@ public class HdfsTests extends ESSingleNodeTestCase {
             .prepareRestoreSnapshot("test-repo", "test-snap")
             .setWaitForCompletion(true)
             .setIndices("test-idx-*", "-test-idx-2")
-            .execute()
-            .actionGet();
+            .get();
         assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), greaterThan(0));
         ensureGreen();
         assertThat(count(client, "test-idx-1"), equalTo(100L));

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/repositories/RepositoryBlocksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/repositories/RepositoryBlocksIT.java
@@ -62,7 +62,7 @@ public class RepositoryBlocksIT extends ESIntegTestCase {
         // This test checks that the Get Repository operation is never blocked, even if the cluster is read only.
         try {
             setClusterReadOnly(true);
-            VerifyRepositoryResponse response = clusterAdmin().prepareVerifyRepository("test-repo-blocks").execute().actionGet();
+            VerifyRepositoryResponse response = clusterAdmin().prepareVerifyRepository("test-repo-blocks").get();
             assertThat(response.getNodes().size(), equalTo(cluster().numDataAndMasterNodes()));
         } finally {
             setClusterReadOnly(false);
@@ -100,7 +100,7 @@ public class RepositoryBlocksIT extends ESIntegTestCase {
         // This test checks that the Get Repository operation is never blocked, even if the cluster is read only.
         try {
             setClusterReadOnly(true);
-            GetRepositoriesResponse response = clusterAdmin().prepareGetRepositories("test-repo-blocks").execute().actionGet();
+            GetRepositoriesResponse response = clusterAdmin().prepareGetRepositories("test-repo-blocks").get();
             assertThat(response.repositories(), hasSize(1));
         } finally {
             setClusterReadOnly(false);

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/snapshots/SnapshotBlocksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/snapshots/SnapshotBlocksIT.java
@@ -46,11 +46,11 @@ public class SnapshotBlocksIT extends ESIntegTestCase {
 
         int docs = between(10, 100);
         for (int i = 0; i < docs; i++) {
-            client().prepareIndex(INDEX_NAME).setSource("test", "init").execute().actionGet();
+            client().prepareIndex(INDEX_NAME).setSource("test", "init").get();
         }
         docs = between(10, 100);
         for (int i = 0; i < docs; i++) {
-            client().prepareIndex(OTHER_INDEX_NAME).setSource("test", "init").execute().actionGet();
+            client().prepareIndex(OTHER_INDEX_NAME).setSource("test", "init").get();
         }
 
         logger.info("--> register a repository");
@@ -69,8 +69,7 @@ public class SnapshotBlocksIT extends ESIntegTestCase {
         CreateSnapshotResponse snapshotResponse = clusterAdmin().prepareCreateSnapshot(REPOSITORY_NAME, SNAPSHOT_NAME)
             .setIncludeGlobalState(true)
             .setWaitForCompletion(true)
-            .execute()
-            .actionGet();
+            .get();
         assertThat(snapshotResponse.status(), equalTo(RestStatus.OK));
         ensureSearchable();
     }
@@ -90,8 +89,7 @@ public class SnapshotBlocksIT extends ESIntegTestCase {
         logger.info("-->  creating a snapshot is allowed when the cluster is not read only");
         CreateSnapshotResponse response = clusterAdmin().prepareCreateSnapshot(REPOSITORY_NAME, "snapshot-2")
             .setWaitForCompletion(true)
-            .execute()
-            .actionGet();
+            .get();
         assertThat(response.status(), equalTo(RestStatus.OK));
     }
 
@@ -153,8 +151,7 @@ public class SnapshotBlocksIT extends ESIntegTestCase {
         logger.info("-->  creating a snapshot is allowed when the cluster is not read only");
         RestoreSnapshotResponse response = clusterAdmin().prepareRestoreSnapshot(REPOSITORY_NAME, SNAPSHOT_NAME)
             .setWaitForCompletion(true)
-            .execute()
-            .actionGet();
+            .get();
         assertThat(response.status(), equalTo(RestStatus.OK));
         assertTrue(indexExists(INDEX_NAME));
         assertTrue(indexExists(OTHER_INDEX_NAME));
@@ -164,7 +161,7 @@ public class SnapshotBlocksIT extends ESIntegTestCase {
         // This test checks that the Get Snapshot operation is never blocked, even if the cluster is read only.
         try {
             setClusterReadOnly(true);
-            GetSnapshotsResponse response = clusterAdmin().prepareGetSnapshots(REPOSITORY_NAME).execute().actionGet();
+            GetSnapshotsResponse response = clusterAdmin().prepareGetSnapshots(REPOSITORY_NAME).get();
             assertThat(response.getSnapshots(), hasSize(1));
             assertThat(response.getSnapshots().get(0).snapshotId().getName(), equalTo(SNAPSHOT_NAME));
         } finally {
@@ -176,10 +173,7 @@ public class SnapshotBlocksIT extends ESIntegTestCase {
         // This test checks that the Snapshot Status operation is never blocked, even if the cluster is read only.
         try {
             setClusterReadOnly(true);
-            SnapshotsStatusResponse response = clusterAdmin().prepareSnapshotStatus(REPOSITORY_NAME)
-                .setSnapshots(SNAPSHOT_NAME)
-                .execute()
-                .actionGet();
+            SnapshotsStatusResponse response = clusterAdmin().prepareSnapshotStatus(REPOSITORY_NAME).setSnapshots(SNAPSHOT_NAME).get();
             assertThat(response.getSnapshots(), hasSize(1));
             assertThat(response.getSnapshots().get(0).getState().completed(), equalTo(true));
         } finally {

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/cache/clear/ClearIndicesCacheBlocksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/cache/clear/ClearIndicesCacheBlocksIT.java
@@ -37,8 +37,7 @@ public class ClearIndicesCacheBlocksIT extends ESIntegTestCase {
                     .setFieldDataCache(true)
                     .setQueryCache(true)
                     .setFieldDataCache(true)
-                    .execute()
-                    .actionGet();
+                    .get();
                 assertNoFailures(clearIndicesCacheResponse);
                 assertThat(clearIndicesCacheResponse.getSuccessfulShards(), equalTo(numShards.totalNumShards));
             } finally {

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/create/CreateIndexIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/create/CreateIndexIT.java
@@ -338,7 +338,7 @@ public class CreateIndexIT extends ESIntegTestCase {
                         .put("index.number_of_shards", shards)
                         .put("index.number_of_routing_shards", shards)
                         .put("index.routing_partition_size", partitionSize)
-                ).execute().actionGet();
+                ).get();
             } catch (IllegalStateException | IllegalArgumentException e) {
                 return false;
             }

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/create/ShrinkIndexIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/create/ShrinkIndexIT.java
@@ -465,7 +465,7 @@ public class ShrinkIndexIT extends ESIntegTestCase {
         assertNoResizeSourceIndexSettings("target");
 
         flushAndRefresh();
-        GetSettingsResponse settingsResponse = indicesAdmin().prepareGetSettings("target").execute().actionGet();
+        GetSettingsResponse settingsResponse = indicesAdmin().prepareGetSettings("target").get();
         assertEquals(settingsResponse.getSetting("target", "index.sort.field"), "id");
         assertEquals(settingsResponse.getSetting("target", "index.sort.order"), "desc");
         assertSortedSegments("target", expectedIndexSort);
@@ -610,8 +610,7 @@ public class ShrinkIndexIT extends ESIntegTestCase {
             .clear()
             .setMetadata(true)
             .setRoutingTable(true)
-            .execute()
-            .actionGet();
+            .get();
         IndexRoutingTable indexRoutingTable = clusterStateResponse.getState().routingTable().index(index);
         assertThat("Index " + index + " should have all primaries started", indexRoutingTable.allPrimaryShardsActive(), equalTo(true));
         IndexMetadata indexMetadata = clusterStateResponse.getState().metadata().index(index);

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/create/SplitIndexIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/create/SplitIndexIT.java
@@ -480,7 +480,7 @@ public class SplitIndexIT extends ESIntegTestCase {
         );
         ensureGreen();
         flushAndRefresh();
-        GetSettingsResponse settingsResponse = indicesAdmin().prepareGetSettings("target").execute().actionGet();
+        GetSettingsResponse settingsResponse = indicesAdmin().prepareGetSettings("target").get();
         assertEquals(settingsResponse.getSetting("target", "index.sort.field"), "id");
         assertEquals(settingsResponse.getSetting("target", "index.sort.order"), "desc");
         assertSortedSegments("target", expectedIndexSort);

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/flush/FlushBlocksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/flush/FlushBlocksIT.java
@@ -31,7 +31,7 @@ public class FlushBlocksIT extends ESIntegTestCase {
 
         int docs = between(10, 100);
         for (int i = 0; i < docs; i++) {
-            client().prepareIndex("test").setId("" + i).setSource("test", "init").execute().actionGet();
+            client().prepareIndex("test").setId("" + i).setSource("test", "init").get();
         }
 
         // Request is not blocked
@@ -44,7 +44,7 @@ public class FlushBlocksIT extends ESIntegTestCase {
         )) {
             try {
                 enableIndexBlock("test", blockSetting);
-                FlushResponse response = indicesAdmin().prepareFlush("test").execute().actionGet();
+                FlushResponse response = indicesAdmin().prepareFlush("test").get();
                 assertNoFailures(response);
                 assertThat(response.getSuccessfulShards(), equalTo(numShards.totalNumShards));
             } finally {

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/forcemerge/ForceMergeBlocksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/forcemerge/ForceMergeBlocksIT.java
@@ -43,14 +43,14 @@ public class ForceMergeBlocksIT extends ESIntegTestCase {
 
         int docs = between(10, 100);
         for (int i = 0; i < docs; i++) {
-            client().prepareIndex("test").setId("" + i).setSource("test", "init").execute().actionGet();
+            client().prepareIndex("test").setId("" + i).setSource("test", "init").get();
         }
 
         // Request is not blocked
         for (String blockSetting : Arrays.asList(SETTING_BLOCKS_READ, SETTING_BLOCKS_WRITE, SETTING_READ_ONLY_ALLOW_DELETE)) {
             try {
                 enableIndexBlock("test", blockSetting);
-                ForceMergeResponse response = indicesAdmin().prepareForceMerge("test").execute().actionGet();
+                ForceMergeResponse response = indicesAdmin().prepareForceMerge("test").get();
                 assertNoFailures(response);
                 assertThat(response.getSuccessfulShards(), equalTo(numShards.totalNumShards));
             } finally {
@@ -70,7 +70,7 @@ public class ForceMergeBlocksIT extends ESIntegTestCase {
 
         // Merging all indices is blocked when the cluster is read-only
         try {
-            ForceMergeResponse response = indicesAdmin().prepareForceMerge().execute().actionGet();
+            ForceMergeResponse response = indicesAdmin().prepareForceMerge().get();
             assertNoFailures(response);
             assertThat(response.getSuccessfulShards(), equalTo(numShards.totalNumShards));
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/refresh/RefreshBlocksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/refresh/RefreshBlocksIT.java
@@ -39,7 +39,7 @@ public class RefreshBlocksIT extends ESIntegTestCase {
         )) {
             try {
                 enableIndexBlock("test", blockSetting);
-                RefreshResponse response = indicesAdmin().prepareRefresh("test").execute().actionGet();
+                RefreshResponse response = indicesAdmin().prepareRefresh("test").get();
                 assertNoFailures(response);
                 assertThat(response.getSuccessfulShards(), equalTo(numShards.totalNumShards));
             } finally {

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentsBlocksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentsBlocksIT.java
@@ -29,7 +29,7 @@ public class IndicesSegmentsBlocksIT extends ESIntegTestCase {
 
         int docs = between(10, 100);
         for (int i = 0; i < docs; i++) {
-            client().prepareIndex("test-blocks").setId("" + i).setSource("test", "init").execute().actionGet();
+            client().prepareIndex("test-blocks").setId("" + i).setSource("test", "init").get();
         }
         indicesAdmin().prepareFlush("test-blocks").get();
 
@@ -42,7 +42,7 @@ public class IndicesSegmentsBlocksIT extends ESIntegTestCase {
         )) {
             try {
                 enableIndexBlock("test-blocks", blockSetting);
-                IndicesSegmentResponse response = indicesAdmin().prepareSegments("test-blocks").execute().actionGet();
+                IndicesSegmentResponse response = indicesAdmin().prepareSegments("test-blocks").get();
                 assertNoFailures(response);
             } finally {
                 disableIndexBlock("test-blocks", blockSetting);

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoreRequestIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoreRequestIT.java
@@ -31,7 +31,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
 import java.util.function.Predicate;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
@@ -197,14 +196,14 @@ public class IndicesShardStoreRequestIT extends ESIntegTestCase {
         enableAllocation(index);
     }
 
-    private void indexRandomData(String index) throws ExecutionException, InterruptedException {
+    private void indexRandomData(String index) throws InterruptedException {
         int numDocs = scaledRandomIntBetween(10, 20);
         IndexRequestBuilder[] builders = new IndexRequestBuilder[numDocs];
         for (int i = 0; i < builders.length; i++) {
             builders[i] = client().prepareIndex(index).setSource("field", "value");
         }
         indexRandom(true, builders);
-        indicesAdmin().prepareFlush().setForce(true).execute().actionGet();
+        indicesAdmin().prepareFlush().setForce(true).get();
     }
 
     private static final class IndexNodePredicate implements Predicate<Settings> {

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsBlocksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsBlocksIT.java
@@ -36,7 +36,7 @@ public class IndicesStatsBlocksIT extends ESIntegTestCase {
         )) {
             try {
                 enableIndexBlock("ro", blockSetting);
-                IndicesStatsResponse indicesStatsResponse = indicesAdmin().prepareStats("ro").execute().actionGet();
+                IndicesStatsResponse indicesStatsResponse = indicesAdmin().prepareStats("ro").get();
                 assertNotNull(indicesStatsResponse.getIndex("ro"));
             } finally {
                 disableIndexBlock("ro", blockSetting);
@@ -46,7 +46,7 @@ public class IndicesStatsBlocksIT extends ESIntegTestCase {
         // Request is blocked
         try {
             enableIndexBlock("ro", IndexMetadata.SETTING_BLOCKS_METADATA);
-            indicesAdmin().prepareStats("ro").execute().actionGet();
+            indicesAdmin().prepareStats("ro").get();
             fail("Exists should fail when " + IndexMetadata.SETTING_BLOCKS_METADATA + " is true");
         } catch (ClusterBlockException e) {
             // Ok, a ClusterBlockException is expected

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkProcessorClusterSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkProcessorClusterSettingsIT.java
@@ -28,7 +28,7 @@ public class BulkProcessorClusterSettingsIT extends ESIntegTestCase {
         internalCluster().startNode(settings);
 
         createIndex("willwork");
-        clusterAdmin().prepareHealth("willwork").setWaitForGreenStatus().execute().actionGet();
+        clusterAdmin().prepareHealth("willwork").setWaitForGreenStatus().get();
 
         BulkRequestBuilder bulkRequestBuilder = client().prepareBulk();
         bulkRequestBuilder.add(client().prepareIndex("willwork").setId("1").setSource("{\"foo\":1}", XContentType.JSON));

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkWithUpdatesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkWithUpdatesIT.java
@@ -107,8 +107,7 @@ public class BulkWithUpdatesIT extends ESIntegTestCase {
             .add(client().prepareIndex().setIndex(indexOrAlias()).setId("3").setSource("field", 3))
             .add(client().prepareIndex().setIndex(indexOrAlias()).setId("4").setSource("field", 4))
             .add(client().prepareIndex().setIndex(indexOrAlias()).setId("5").setSource("field", 5))
-            .execute()
-            .actionGet();
+            .get();
 
         assertThat(bulkResponse.hasFailures(), equalTo(false));
         assertThat(bulkResponse.getItems().length, equalTo(5));
@@ -141,17 +140,17 @@ public class BulkWithUpdatesIT extends ESIntegTestCase {
         assertThat(bulkResponse.getItems()[2].getResponse().getId(), equalTo("3"));
         assertThat(bulkResponse.getItems()[2].getResponse().getVersion(), equalTo(2L));
 
-        GetResponse getResponse = client().prepareGet().setIndex("test").setId("1").execute().actionGet();
+        GetResponse getResponse = client().prepareGet().setIndex("test").setId("1").get();
         assertThat(getResponse.isExists(), equalTo(true));
         assertThat(getResponse.getVersion(), equalTo(2L));
         assertThat(((Number) getResponse.getSource().get("field")).longValue(), equalTo(2L));
 
-        getResponse = client().prepareGet().setIndex("test").setId("2").execute().actionGet();
+        getResponse = client().prepareGet().setIndex("test").setId("2").get();
         assertThat(getResponse.isExists(), equalTo(true));
         assertThat(getResponse.getVersion(), equalTo(2L));
         assertThat(((Number) getResponse.getSource().get("field")).longValue(), equalTo(3L));
 
-        getResponse = client().prepareGet().setIndex("test").setId("3").execute().actionGet();
+        getResponse = client().prepareGet().setIndex("test").setId("3").get();
         assertThat(getResponse.isExists(), equalTo(true));
         assertThat(getResponse.getVersion(), equalTo(2L));
         assertThat(getResponse.getSource().get("field1").toString(), equalTo("test"));
@@ -180,15 +179,15 @@ public class BulkWithUpdatesIT extends ESIntegTestCase {
         assertThat(bulkResponse.getItems()[2].getResponse().getIndex(), equalTo("test"));
         assertThat(bulkResponse.getItems()[2].getResponse().getVersion(), equalTo(3L));
 
-        getResponse = client().prepareGet().setIndex("test").setId("6").execute().actionGet();
+        getResponse = client().prepareGet().setIndex("test").setId("6").get();
         assertThat(getResponse.isExists(), equalTo(true));
         assertThat(getResponse.getVersion(), equalTo(1L));
         assertThat(((Number) getResponse.getSource().get("field")).longValue(), equalTo(0L));
 
-        getResponse = client().prepareGet().setIndex("test").setId("7").execute().actionGet();
+        getResponse = client().prepareGet().setIndex("test").setId("7").get();
         assertThat(getResponse.isExists(), equalTo(false));
 
-        getResponse = client().prepareGet().setIndex("test").setId("2").execute().actionGet();
+        getResponse = client().prepareGet().setIndex("test").setId("2").get();
         assertThat(getResponse.isExists(), equalTo(true));
         assertThat(getResponse.getVersion(), equalTo(3L));
         assertThat(((Number) getResponse.getSource().get("field")).longValue(), equalTo(4L));
@@ -221,12 +220,12 @@ public class BulkWithUpdatesIT extends ESIntegTestCase {
         assertThat(bulkResponse.getItems()[1].getResponse().getId(), equalTo("2"));
         assertThat(bulkResponse.getItems()[1].getResponse().getVersion(), equalTo(1L));
 
-        GetResponse getResponse = client().prepareGet().setIndex("test").setId("1").execute().actionGet();
+        GetResponse getResponse = client().prepareGet().setIndex("test").setId("1").get();
         assertThat(getResponse.isExists(), equalTo(true));
         assertThat(getResponse.getVersion(), equalTo(1L));
         assertThat(((Number) getResponse.getSource().get("field")).longValue(), equalTo(2L));
 
-        getResponse = client().prepareGet().setIndex("test").setId("2").execute().actionGet();
+        getResponse = client().prepareGet().setIndex("test").setId("2").get();
         assertThat(getResponse.isExists(), equalTo(true));
         assertThat(getResponse.getVersion(), equalTo(1L));
         assertThat(((Number) getResponse.getSource().get("field")).longValue(), equalTo(2L));
@@ -288,8 +287,7 @@ public class BulkWithUpdatesIT extends ESIntegTestCase {
             .add(client().prepareIndex().setIndex("test").setId("1").setSource("field", 1))
             .add(client().prepareIndex().setIndex("test").setId("2").setSource("field", 1))
             .add(client().prepareIndex().setIndex("test").setId("3").setSource("field", 1))
-            .execute()
-            .actionGet();
+            .get();
 
         assertThat(bulkResponse.hasFailures(), equalTo(false));
         assertThat(bulkResponse.getItems().length, equalTo(3));
@@ -330,8 +328,7 @@ public class BulkWithUpdatesIT extends ESIntegTestCase {
                         )
                     )
             )
-            .execute()
-            .actionGet();
+            .get();
 
         assertThat(bulkResponse.hasFailures(), equalTo(true));
         assertThat(bulkResponse.getItems().length, equalTo(3));
@@ -385,7 +382,7 @@ public class BulkWithUpdatesIT extends ESIntegTestCase {
             assertThat(((UpdateResponse) response.getItems()[i].getResponse()).getGetResult().sourceAsMap().get("counter"), equalTo(1));
 
             for (int j = 0; j < 5; j++) {
-                GetResponse getResponse = client().prepareGet("test", Integer.toString(i)).execute().actionGet();
+                GetResponse getResponse = client().prepareGet("test", Integer.toString(i)).get();
                 assertThat(getResponse.isExists(), equalTo(true));
                 assertThat(getResponse.getVersion(), equalTo(1L));
                 assertThat(((Number) getResponse.getSource().get("counter")).longValue(), equalTo(1L));
@@ -410,7 +407,7 @@ public class BulkWithUpdatesIT extends ESIntegTestCase {
             builder.add(updateBuilder);
         }
 
-        response = builder.execute().actionGet();
+        response = builder.get();
         assertThat(response.hasFailures(), equalTo(false));
         assertThat(response.getItems().length, equalTo(numDocs));
         for (int i = 0; i < numDocs; i++) {
@@ -428,7 +425,7 @@ public class BulkWithUpdatesIT extends ESIntegTestCase {
         for (int i = (numDocs / 2); i < maxDocs; i++) {
             builder.add(client().prepareUpdate().setIndex("test").setId(Integer.toString(i)).setScript(script));
         }
-        response = builder.execute().actionGet();
+        response = builder.get();
         assertThat(response.hasFailures(), equalTo(true));
         assertThat(response.getItems().length, equalTo(numDocs));
         for (int i = 0; i < numDocs; i++) {
@@ -453,7 +450,7 @@ public class BulkWithUpdatesIT extends ESIntegTestCase {
                     .setScript(new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "ctx.op = \"none\"", Collections.emptyMap()))
             );
         }
-        response = builder.execute().actionGet();
+        response = builder.get();
         assertThat(response.buildFailureMessage(), response.hasFailures(), equalTo(false));
         assertThat(response.getItems().length, equalTo(numDocs));
         for (int i = 0; i < numDocs; i++) {
@@ -472,7 +469,7 @@ public class BulkWithUpdatesIT extends ESIntegTestCase {
                     .setScript(new Script(ScriptType.INLINE, CustomScriptPlugin.NAME, "ctx.op = \"delete\"", Collections.emptyMap()))
             );
         }
-        response = builder.execute().actionGet();
+        response = builder.get();
         assertThat("expected no failures but got: " + response.buildFailureMessage(), response.hasFailures(), equalTo(false));
         assertThat(response.getItems().length, equalTo(numDocs));
         for (int i = 0; i < numDocs; i++) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/support/WaitActiveShardCountIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/support/WaitActiveShardCountIT.java
@@ -34,15 +34,14 @@ public class WaitActiveShardCountIT extends ESIntegTestCase {
         assertAcked(createIndexResponse);
 
         // indexing, by default, will work (waiting for one shard copy only)
-        client().prepareIndex("test").setId("1").setSource(source("1", "test"), XContentType.JSON).execute().actionGet();
+        client().prepareIndex("test").setId("1").setSource(source("1", "test"), XContentType.JSON).get();
         try {
             client().prepareIndex("test")
                 .setId("1")
                 .setSource(source("1", "test"), XContentType.JSON)
                 .setWaitForActiveShards(2) // wait for 2 active shard copies
                 .setTimeout(timeValueMillis(100))
-                .execute()
-                .actionGet();
+                .get();
             fail("can't index, does not enough active shard copies");
         } catch (UnavailableShardsException e) {
             assertThat(e.status(), equalTo(RestStatus.SERVICE_UNAVAILABLE));
@@ -59,8 +58,7 @@ public class WaitActiveShardCountIT extends ESIntegTestCase {
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForActiveShards(2)
             .setWaitForYellowStatus()
-            .execute()
-            .actionGet();
+            .get();
         logger.info("Done Cluster Health, status {}", clusterHealth.getStatus());
         assertThat(clusterHealth.isTimedOut(), equalTo(false));
         assertThat(clusterHealth.getStatus(), equalTo(ClusterHealthStatus.YELLOW));
@@ -71,8 +69,7 @@ public class WaitActiveShardCountIT extends ESIntegTestCase {
             .setSource(source("1", "test"), XContentType.JSON)
             .setWaitForActiveShards(2)
             .setTimeout(timeValueSeconds(1))
-            .execute()
-            .actionGet();
+            .get();
 
         try {
             client().prepareIndex("test")
@@ -80,8 +77,7 @@ public class WaitActiveShardCountIT extends ESIntegTestCase {
                 .setSource(source("1", "test"), XContentType.JSON)
                 .setWaitForActiveShards(ActiveShardCount.ALL)
                 .setTimeout(timeValueMillis(100))
-                .execute()
-                .actionGet();
+                .get();
             fail("can't index, not enough active shard copies");
         } catch (UnavailableShardsException e) {
             assertThat(e.status(), equalTo(RestStatus.SERVICE_UNAVAILABLE));
@@ -101,8 +97,7 @@ public class WaitActiveShardCountIT extends ESIntegTestCase {
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForActiveShards(3)
             .setWaitForGreenStatus()
-            .execute()
-            .actionGet();
+            .get();
         logger.info("Done Cluster Health, status {}", clusterHealth.getStatus());
         assertThat(clusterHealth.isTimedOut(), equalTo(false));
         assertThat(clusterHealth.getStatus(), equalTo(ClusterHealthStatus.GREEN));
@@ -113,8 +108,7 @@ public class WaitActiveShardCountIT extends ESIntegTestCase {
             .setSource(source("1", "test"), XContentType.JSON)
             .setWaitForActiveShards(ActiveShardCount.ALL)
             .setTimeout(timeValueSeconds(1))
-            .execute()
-            .actionGet();
+            .get();
     }
 
     private String source(String id, String nameValue) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/termvectors/GetTermVectorsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/termvectors/GetTermVectorsIT.java
@@ -70,7 +70,7 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
             .endObject();
         assertAcked(prepareCreate("test").addAlias(new Alias("alias")).setMapping(mapping));
 
-        client().prepareIndex("test").setId("666").setSource("field", "foo bar").execute().actionGet();
+        client().prepareIndex("test").setId("666").setSource("field", "foo bar").get();
         refresh();
         for (int i = 0; i < 20; i++) {
             ActionFuture<TermVectorsResponse> termVector = client().termVectors(new TermVectorsRequest(indexOrAlias(), "" + i));
@@ -97,7 +97,7 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
         assertAcked(prepareCreate("test").addAlias(new Alias("alias")).setMapping(mapping));
 
         // when indexing a field that simply has a question mark, the term vectors will be null
-        client().prepareIndex("test").setId("0").setSource("existingfield", "?").execute().actionGet();
+        client().prepareIndex("test").setId("0").setSource("existingfield", "?").get();
         refresh();
         ActionFuture<TermVectorsResponse> termVector = client().termVectors(
             new TermVectorsRequest(indexOrAlias(), "0").selectedFields(new String[] { "existingfield" })
@@ -125,7 +125,7 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
         assertAcked(prepareCreate("test").addAlias(new Alias("alias")).setMapping(mapping));
 
         // when indexing a field that simply has a question mark, the term vectors will be null
-        client().prepareIndex("test").setId("0").setSource("anotherexistingfield", 1).execute().actionGet();
+        client().prepareIndex("test").setId("0").setSource("anotherexistingfield", 1).get();
         refresh();
         ActionFuture<TermVectorsResponse> termVectors = client().termVectors(
             new TermVectorsRequest(indexOrAlias(), "0").selectedFields(randomBoolean() ? new String[] { "existingfield" } : null)
@@ -214,8 +214,7 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
                         // 31the34 35lazy39 40dog43
                         .endObject()
                 )
-                .execute()
-                .actionGet();
+                .get();
             refresh();
         }
         for (int i = 0; i < 10; i++) {
@@ -224,7 +223,7 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
                 .setOffsets(true)
                 .setPositions(true)
                 .setSelectedFields();
-            TermVectorsResponse response = resp.execute().actionGet();
+            TermVectorsResponse response = resp.get();
             assertThat(response.getIndex(), equalTo("test"));
             assertThat("doc id: " + i + " doesn't exists but should", response.isExists(), equalTo(true));
             Fields fields = response.getFields();
@@ -317,8 +316,7 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
                         // 31the34 35lazy39 40dog43
                         .endObject()
                 )
-                .execute()
-                .actionGet();
+                .get();
             refresh();
         }
         String[] values = { "brown", "dog", "fox", "jumps", "lazy", "over", "quick", "the" };
@@ -335,7 +333,7 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
                 .setOffsets(isOffsetRequested)
                 .setPositions(isPositionsRequested)
                 .setSelectedFields();
-            TermVectorsResponse response = resp.execute().actionGet();
+            TermVectorsResponse response = resp.get();
             assertThat(infoString + "doc id: " + i + " doesn't exists but should", response.isExists(), equalTo(true));
             Fields fields = response.getFields();
             assertThat(fields.size(), equalTo(ft.storeTermVectors() ? 1 : 0));
@@ -470,7 +468,7 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
         ensureGreen();
 
         for (int i = 0; i < 10; i++) {
-            client().prepareIndex("test").setId(Integer.toString(i)).setSource(source).execute().actionGet();
+            client().prepareIndex("test").setId(Integer.toString(i)).setSource(source).get();
             refresh();
         }
 
@@ -480,8 +478,7 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
                 .setOffsets(true)
                 .setPositions(true)
                 .setSelectedFields(fieldNames)
-                .execute()
-                .actionGet();
+                .get();
             assertThat("doc id: " + i + " doesn't exists but should", response.isExists(), equalTo(true));
             Fields fields = response.getFields();
             assertThat(fields.size(), equalTo(fieldNames.length));

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/termvectors/MultiTermVectorsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/termvectors/MultiTermVectorsIT.java
@@ -69,7 +69,7 @@ public class MultiTermVectorsIT extends AbstractTermVectorsTestCase {
         TermVectorsRequestBuilder requestBuilder = client().prepareTermVectors("testX", Integer.toString(1));
         MultiTermVectorsRequestBuilder mtvBuilder = client().prepareMultiTermVectors();
         mtvBuilder.add(requestBuilder.request());
-        MultiTermVectorsResponse response = mtvBuilder.execute().actionGet();
+        MultiTermVectorsResponse response = mtvBuilder.get();
         assertThat(response.getResponses().length, equalTo(1));
         assertThat(response.getResponses()[0].getFailure().getCause(), instanceOf(IndexNotFoundException.class));
         assertThat(response.getResponses()[0].getFailure().getCause().getMessage(), equalTo("no such index [testX]"));

--- a/server/src/internalClusterTest/java/org/elasticsearch/aliases/IndexAliasesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/aliases/IndexAliasesIT.java
@@ -677,7 +677,7 @@ public class IndexAliasesIT extends ESIntegTestCase {
         assertFalse(indicesAdmin().prepareGetAliases("foo").setIndices("bar_bar").get().getAliases().isEmpty());
         IllegalArgumentException iae = expectThrows(
             IllegalArgumentException.class,
-            () -> indicesAdmin().prepareAliases().addAliasAction(AliasActions.remove().index("foo").alias("foo")).execute().actionGet()
+            () -> indicesAdmin().prepareAliases().addAliasAction(AliasActions.remove().index("foo").alias("foo")).get()
         );
         assertEquals(
             "The provided expression [foo] matches an alias, specify the corresponding concrete indices instead.",
@@ -1090,13 +1090,13 @@ public class IndexAliasesIT extends ESIntegTestCase {
 
         IllegalArgumentException iae = expectThrows(
             IllegalArgumentException.class,
-            () -> indicesAdmin().prepareAliases().addAliasAction(AliasActions.add().index("week_20").alias("tmp")).execute().actionGet()
+            () -> indicesAdmin().prepareAliases().addAliasAction(AliasActions.add().index("week_20").alias("tmp")).get()
         );
         assertEquals(
             "The provided expression [week_20] matches an alias, specify the corresponding concrete indices instead.",
             iae.getMessage()
         );
-        assertAcked(indicesAdmin().prepareAliases().addAliasAction(AliasActions.add().index("2017-05-20").alias("tmp")).execute().get());
+        assertAcked(indicesAdmin().prepareAliases().addAliasAction(AliasActions.add().index("2017-05-20").alias("tmp")));
     }
 
     // Before 2.0 alias filters were parsed at alias creation time, in order
@@ -1159,7 +1159,7 @@ public class IndexAliasesIT extends ESIntegTestCase {
                     () -> assertAcked(indicesAdmin().prepareAliases().addAlias("test", "alias1").addAlias("test", "alias2"))
                 );
                 assertAliasesVersionIncreases("test", () -> assertAcked(indicesAdmin().prepareAliases().removeAlias("test", "alias1")));
-                assertThat(indicesAdmin().prepareGetAliases("alias2").execute().actionGet().getAliases().get("test").size(), equalTo(1));
+                assertThat(indicesAdmin().prepareGetAliases("alias2").get().getAliases().get("test").size(), equalTo(1));
                 assertFalse(indicesAdmin().prepareGetAliases("alias2").get().getAliases().isEmpty());
             } finally {
                 disableIndexBlock("test", block);
@@ -1177,7 +1177,7 @@ public class IndexAliasesIT extends ESIntegTestCase {
                 "test",
                 () -> assertBlocked(indicesAdmin().prepareAliases().removeAlias("test", "alias2"), INDEX_READ_ONLY_BLOCK)
             );
-            assertThat(indicesAdmin().prepareGetAliases("alias2").execute().actionGet().getAliases().get("test").size(), equalTo(1));
+            assertThat(indicesAdmin().prepareGetAliases("alias2").get().getAliases().get("test").size(), equalTo(1));
             assertFalse(indicesAdmin().prepareGetAliases("alias2").get().getAliases().isEmpty());
 
         } finally {
@@ -1213,7 +1213,7 @@ public class IndexAliasesIT extends ESIntegTestCase {
 
         IllegalArgumentException iae = expectThrows(
             IllegalArgumentException.class,
-            () -> indicesAdmin().prepareAliases().removeIndex("foo").execute().actionGet()
+            () -> indicesAdmin().prepareAliases().removeIndex("foo").get()
         );
         assertEquals(
             "The provided expression [foo] matches an alias, specify the corresponding concrete indices instead.",
@@ -1359,7 +1359,7 @@ public class IndexAliasesIT extends ESIntegTestCase {
         final String indexName = "index-name";
         final IllegalArgumentException iae = expectThrows(
             IllegalArgumentException.class,
-            () -> indicesAdmin().prepareCreate(indexName).addAlias(new Alias(indexName)).execute().actionGet()
+            () -> indicesAdmin().prepareCreate(indexName).addAlias(new Alias(indexName)).get()
         );
         assertEquals("alias name [" + indexName + "] self-conflicts with index name", iae.getMessage());
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/blocks/SimpleBlocksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/blocks/SimpleBlocksIT.java
@@ -107,7 +107,7 @@ public class SimpleBlocksIT extends ESIntegTestCase {
 
     private void canCreateIndex(String index) {
         try {
-            CreateIndexResponse r = indicesAdmin().prepareCreate(index).execute().actionGet();
+            CreateIndexResponse r = indicesAdmin().prepareCreate(index).get();
             assertThat(r, notNullValue());
         } catch (ClusterBlockException e) {
             fail();
@@ -116,7 +116,7 @@ public class SimpleBlocksIT extends ESIntegTestCase {
 
     private void canNotCreateIndex(String index) {
         try {
-            indicesAdmin().prepareCreate(index).execute().actionGet();
+            indicesAdmin().prepareCreate(index).get();
             fail();
         } catch (ClusterBlockException e) {
             // all is well
@@ -127,7 +127,7 @@ public class SimpleBlocksIT extends ESIntegTestCase {
         try {
             IndexRequestBuilder builder = client().prepareIndex(index);
             builder.setSource("foo", "bar");
-            DocWriteResponse r = builder.execute().actionGet();
+            DocWriteResponse r = builder.get();
             assertThat(r, notNullValue());
         } catch (ClusterBlockException e) {
             fail();
@@ -138,7 +138,7 @@ public class SimpleBlocksIT extends ESIntegTestCase {
         try {
             IndexRequestBuilder builder = client().prepareIndex(index);
             builder.setSource("foo", "bar");
-            builder.execute().actionGet();
+            builder.get();
             fail();
         } catch (ClusterBlockException e) {
             // all is well

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterHealthIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterHealthIT.java
@@ -56,17 +56,13 @@ public class ClusterHealthIT extends ESIntegTestCase {
 
     public void testHealth() {
         logger.info("--> running cluster health on an index that does not exists");
-        ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth("test1")
-            .setWaitForYellowStatus()
-            .setTimeout("1s")
-            .execute()
-            .actionGet();
+        ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth("test1").setWaitForYellowStatus().setTimeout("1s").get();
         assertThat(healthResponse.isTimedOut(), equalTo(true));
         assertThat(healthResponse.getStatus(), equalTo(ClusterHealthStatus.RED));
         assertThat(healthResponse.getIndices().isEmpty(), equalTo(true));
 
         logger.info("--> running cluster wide health");
-        healthResponse = clusterAdmin().prepareHealth().setWaitForGreenStatus().setTimeout("10s").execute().actionGet();
+        healthResponse = clusterAdmin().prepareHealth().setWaitForGreenStatus().setTimeout("10s").get();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
         assertThat(healthResponse.getStatus(), equalTo(ClusterHealthStatus.GREEN));
         assertThat(healthResponse.getIndices().isEmpty(), equalTo(true));
@@ -75,13 +71,13 @@ public class ClusterHealthIT extends ESIntegTestCase {
         createIndex("test1");
 
         logger.info("--> running cluster health on an index that does exists");
-        healthResponse = clusterAdmin().prepareHealth("test1").setWaitForGreenStatus().setTimeout("10s").execute().actionGet();
+        healthResponse = clusterAdmin().prepareHealth("test1").setWaitForGreenStatus().setTimeout("10s").get();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
         assertThat(healthResponse.getStatus(), equalTo(ClusterHealthStatus.GREEN));
         assertThat(healthResponse.getIndices().get("test1").getStatus(), equalTo(ClusterHealthStatus.GREEN));
 
         logger.info("--> running cluster health on an index that does exists and an index that doesn't exists");
-        healthResponse = clusterAdmin().prepareHealth("test1", "test2").setWaitForYellowStatus().setTimeout("1s").execute().actionGet();
+        healthResponse = clusterAdmin().prepareHealth("test1", "test2").setWaitForYellowStatus().setTimeout("1s").get();
         assertThat(healthResponse.isTimedOut(), equalTo(true));
         assertThat(healthResponse.getStatus(), equalTo(ClusterHealthStatus.RED));
         assertThat(healthResponse.getIndices().get("test1").getStatus(), equalTo(ClusterHealthStatus.GREEN));

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/MinimumMasterNodesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/MinimumMasterNodesIT.java
@@ -67,7 +67,7 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
         String node1Name = internalCluster().startNode(settings);
 
         logger.info("--> should be blocked, no master...");
-        ClusterState state = clusterAdmin().prepareState().setLocal(true).execute().actionGet().getState();
+        ClusterState state = clusterAdmin().prepareState().setLocal(true).get().getState();
         assertThat(state.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID), equalTo(true));
         assertThat(state.nodes().getSize(), equalTo(1)); // verify that we still see the local node in the cluster state
 
@@ -77,16 +77,15 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
         ClusterHealthResponse clusterHealthResponse = clusterAdmin().prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForNodes("2")
-            .execute()
-            .actionGet();
+            .get();
         assertThat(clusterHealthResponse.isTimedOut(), equalTo(false));
 
-        state = clusterAdmin().prepareState().setLocal(true).execute().actionGet().getState();
+        state = clusterAdmin().prepareState().setLocal(true).get().getState();
         assertThat(state.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID), equalTo(false));
-        state = clusterAdmin().prepareState().setLocal(true).execute().actionGet().getState();
+        state = clusterAdmin().prepareState().setLocal(true).get().getState();
         assertThat(state.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID), equalTo(false));
 
-        state = clusterAdmin().prepareState().execute().actionGet().getState();
+        state = clusterAdmin().prepareState().get().getState();
         assertThat(state.nodes().getSize(), equalTo(2));
         assertThat(state.metadata().indices().containsKey("test"), equalTo(false));
 
@@ -94,11 +93,11 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
         NumShards numShards = getNumShards("test");
         logger.info("--> indexing some data");
         for (int i = 0; i < 100; i++) {
-            client().prepareIndex("test").setId(Integer.toString(i)).setSource("field", "value").execute().actionGet();
+            client().prepareIndex("test").setId(Integer.toString(i)).setSource("field", "value").get();
         }
         // make sure that all shards recovered before trying to flush
         assertThat(
-            clusterAdmin().prepareHealth("test").setWaitForActiveShards(numShards.totalNumShards).execute().actionGet().getActiveShards(),
+            clusterAdmin().prepareHealth("test").setWaitForActiveShards(numShards.totalNumShards).get().getActiveShards(),
             equalTo(numShards.totalNumShards)
         );
         // flush for simpler debugging
@@ -107,7 +106,7 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
         logger.info("--> verify we get the data back");
         for (int i = 0; i < 10; i++) {
             assertThat(
-                prepareSearch().setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().getTotalHits().value,
+                prepareSearch().setSize(0).setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value,
                 equalTo(100L)
             );
         }
@@ -121,11 +120,11 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
         internalCluster().stopNode(masterNode);
 
         assertBusy(() -> {
-            ClusterState clusterState = clusterAdmin().prepareState().setLocal(true).execute().actionGet().getState();
+            ClusterState clusterState = clusterAdmin().prepareState().setLocal(true).get().getState();
             assertTrue(clusterState.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID));
         });
 
-        state = clusterAdmin().prepareState().setLocal(true).execute().actionGet().getState();
+        state = clusterAdmin().prepareState().setLocal(true).get().getState();
         assertThat(state.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID), equalTo(true));
         // verify that both nodes are still in the cluster state but there is no master
         assertThat(state.nodes().getSize(), equalTo(2));
@@ -138,16 +137,15 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForYellowStatus()
             .setWaitForNodes("2")
-            .execute()
-            .actionGet();
+            .get();
         assertThat(clusterHealthResponse.isTimedOut(), equalTo(false));
 
-        state = clusterAdmin().prepareState().setLocal(true).execute().actionGet().getState();
+        state = clusterAdmin().prepareState().setLocal(true).get().getState();
         assertThat(state.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID), equalTo(false));
-        state = clusterAdmin().prepareState().setLocal(true).execute().actionGet().getState();
+        state = clusterAdmin().prepareState().setLocal(true).get().getState();
         assertThat(state.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID), equalTo(false));
 
-        state = clusterAdmin().prepareState().execute().actionGet().getState();
+        state = clusterAdmin().prepareState().get().getState();
         assertThat(state.nodes().getSize(), equalTo(2));
         assertThat(state.metadata().indices().containsKey("test"), equalTo(true));
 
@@ -172,7 +170,7 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
         internalCluster().stopNode(otherNode);
 
         assertBusy(() -> {
-            ClusterState state1 = clusterAdmin().prepareState().setLocal(true).execute().actionGet().getState();
+            ClusterState state1 = clusterAdmin().prepareState().setLocal(true).get().getState();
             assertThat(state1.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID), equalTo(true));
         });
 
@@ -184,16 +182,15 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForNodes("2")
             .setWaitForGreenStatus()
-            .execute()
-            .actionGet();
+            .get();
         assertThat(clusterHealthResponse.isTimedOut(), equalTo(false));
 
-        state = clusterAdmin().prepareState().setLocal(true).execute().actionGet().getState();
+        state = clusterAdmin().prepareState().setLocal(true).get().getState();
         assertThat(state.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID), equalTo(false));
-        state = clusterAdmin().prepareState().setLocal(true).execute().actionGet().getState();
+        state = clusterAdmin().prepareState().setLocal(true).get().getState();
         assertThat(state.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID), equalTo(false));
 
-        state = clusterAdmin().prepareState().execute().actionGet().getState();
+        state = clusterAdmin().prepareState().get().getState();
         assertThat(state.nodes().getSize(), equalTo(2));
         assertThat(state.metadata().indices().containsKey("test"), equalTo(true));
 
@@ -218,7 +215,7 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
 
         assertBusy(() -> {
             for (Client client : clients()) {
-                ClusterState state1 = client.admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
+                ClusterState state1 = client.admin().cluster().prepareState().setLocal(true).get().getState();
                 assertThat(state1.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID), equalTo(true));
             }
         });
@@ -230,27 +227,26 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
         ClusterHealthResponse clusterHealthResponse = clusterAdmin().prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForNodes("3")
-            .execute()
-            .actionGet();
+            .get();
         assertThat(clusterHealthResponse.isTimedOut(), equalTo(false));
 
-        state = clusterAdmin().prepareState().execute().actionGet().getState();
+        state = clusterAdmin().prepareState().get().getState();
         assertThat(state.nodes().getSize(), equalTo(3));
 
         createIndex("test");
         NumShards numShards = getNumShards("test");
         logger.info("--> indexing some data");
         for (int i = 0; i < 100; i++) {
-            client().prepareIndex("test").setId(Integer.toString(i)).setSource("field", "value").execute().actionGet();
+            client().prepareIndex("test").setId(Integer.toString(i)).setSource("field", "value").get();
         }
         ensureGreen();
         // make sure that all shards recovered before trying to flush
         assertThat(
-            clusterAdmin().prepareHealth("test").setWaitForActiveShards(numShards.totalNumShards).execute().actionGet().isTimedOut(),
+            clusterAdmin().prepareHealth("test").setWaitForActiveShards(numShards.totalNumShards).get().isTimedOut(),
             equalTo(false)
         );
         // flush for simpler debugging
-        indicesAdmin().prepareFlush().execute().actionGet();
+        indicesAdmin().prepareFlush().get();
 
         refresh();
         logger.info("--> verify we get the data back");
@@ -269,7 +265,7 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
         logger.info("--> verify that there is no master anymore on remaining node");
         // spin here to wait till the state is set
         assertBusy(() -> {
-            ClusterState st = clusterAdmin().prepareState().setLocal(true).execute().actionGet().getState();
+            ClusterState st = clusterAdmin().prepareState().setLocal(true).get().getState();
             assertThat(st.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID), equalTo(true));
         });
 
@@ -279,7 +275,7 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
         internalCluster().validateClusterFormed();
         ensureGreen();
 
-        state = clusterAdmin().prepareState().execute().actionGet().getState();
+        state = clusterAdmin().prepareState().get().getState();
         assertThat(state.nodes().getSize(), equalTo(3));
 
         logger.info("--> verify we the data back");
@@ -346,8 +342,7 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
                 .admin()
                 .cluster()
                 .prepareState()
-                .execute()
-                .actionGet()
+                .get()
                 .getState()
                 .nodes()
                 .getMasterNode();

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/NoMasterNodeIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/NoMasterNodeIT.java
@@ -72,7 +72,7 @@ public class NoMasterNodeIT extends ESIntegTestCase {
         final List<String> nodes = internalCluster().startNodes(3, settings);
 
         createIndex("test");
-        clusterAdmin().prepareHealth("test").setWaitForGreenStatus().execute().actionGet();
+        clusterAdmin().prepareHealth("test").setWaitForGreenStatus().get();
 
         final NetworkDisruption disruptionScheme = new NetworkDisruption(
             new IsolateAllNodes(new HashSet<>(nodes)),
@@ -84,7 +84,7 @@ public class NoMasterNodeIT extends ESIntegTestCase {
         final Client clientToMasterlessNode = client();
 
         assertBusy(() -> {
-            ClusterState state = clientToMasterlessNode.admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
+            ClusterState state = clientToMasterlessNode.admin().cluster().prepareState().setLocal(true).get().getState();
             assertTrue(state.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID));
         });
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/PrevalidateNodeRemovalIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/PrevalidateNodeRemovalIT.java
@@ -205,8 +205,7 @@ public class PrevalidateNodeRemovalIT extends ESIntegTestCase {
             ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth(indexName)
                 .setWaitForStatus(ClusterHealthStatus.RED)
                 .setWaitForEvents(Priority.LANGUID)
-                .execute()
-                .actionGet();
+                .get();
             assertThat(healthResponse.getStatus(), equalTo(ClusterHealthStatus.RED));
         });
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/SimpleDataNodesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/SimpleDataNodesIT.java
@@ -46,13 +46,7 @@ public class SimpleDataNodesIT extends ESIntegTestCase {
 
         internalCluster().startNode(nonDataNode());
         assertThat(
-            clusterAdmin().prepareHealth()
-                .setWaitForEvents(Priority.LANGUID)
-                .setWaitForNodes("2")
-                .setLocal(true)
-                .execute()
-                .actionGet()
-                .isTimedOut(),
+            clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForNodes("2").setLocal(true).get().isTimedOut(),
             equalTo(false)
         );
 
@@ -67,13 +61,7 @@ public class SimpleDataNodesIT extends ESIntegTestCase {
         // now, start a node data, and see that it gets with shards
         internalCluster().startNode(dataNode());
         assertThat(
-            clusterAdmin().prepareHealth()
-                .setWaitForEvents(Priority.LANGUID)
-                .setWaitForNodes("3")
-                .setLocal(true)
-                .execute()
-                .actionGet()
-                .isTimedOut(),
+            clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForNodes("3").setLocal(true).get().isTimedOut(),
             equalTo(false)
         );
 
@@ -87,10 +75,7 @@ public class SimpleDataNodesIT extends ESIntegTestCase {
             new CreateIndexRequest("test").settings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0))
                 .waitForActiveShards(ActiveShardCount.NONE)
         ).actionGet();
-        final ClusterHealthResponse healthResponse1 = clusterAdmin().prepareHealth()
-            .setWaitForEvents(Priority.LANGUID)
-            .execute()
-            .actionGet();
+        final ClusterHealthResponse healthResponse1 = clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).get();
         assertThat(healthResponse1.isTimedOut(), equalTo(false));
         assertThat(healthResponse1.getStatus(), equalTo(ClusterHealthStatus.RED));
         assertThat(healthResponse1.getActiveShards(), equalTo(0));
@@ -102,8 +87,7 @@ public class SimpleDataNodesIT extends ESIntegTestCase {
                 .setWaitForEvents(Priority.LANGUID)
                 .setWaitForNodes("2")
                 .setWaitForGreenStatus()
-                .execute()
-                .actionGet()
+                .get()
                 .isTimedOut(),
             equalTo(false)
         );
@@ -115,10 +99,7 @@ public class SimpleDataNodesIT extends ESIntegTestCase {
             new CreateIndexRequest("test").settings(Settings.builder().put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-all"))
                 .waitForActiveShards(ActiveShardCount.NONE)
         ).actionGet();
-        final ClusterHealthResponse healthResponse1 = clusterAdmin().prepareHealth()
-            .setWaitForEvents(Priority.LANGUID)
-            .execute()
-            .actionGet();
+        final ClusterHealthResponse healthResponse1 = clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).get();
         assertThat(healthResponse1.isTimedOut(), equalTo(false));
         assertThat(healthResponse1.getStatus(), equalTo(ClusterHealthStatus.RED));
         assertThat(healthResponse1.getActiveShards(), equalTo(0));

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/SpecificMasterNodesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/SpecificMasterNodesIT.java
@@ -35,10 +35,7 @@ public class SpecificMasterNodesIT extends ESIntegTestCase {
         logger.info("--> start data node / non master node");
         internalCluster().startNode(Settings.builder().put(dataOnlyNode()).put("discovery.initial_state_timeout", "1s"));
         try {
-            assertThat(
-                clusterAdmin().prepareState().setMasterNodeTimeout("100ms").execute().actionGet().getState().nodes().getMasterNodeId(),
-                nullValue()
-            );
+            assertThat(clusterAdmin().prepareState().setMasterNodeTimeout("100ms").get().getState().nodes().getMasterNodeId(), nullValue());
             fail("should not be able to find master");
         } catch (MasterNotDiscoveredException e) {
             // all is well, no master elected
@@ -46,29 +43,11 @@ public class SpecificMasterNodesIT extends ESIntegTestCase {
         logger.info("--> start master node");
         final String masterNodeName = internalCluster().startMasterOnlyNode();
         assertThat(
-            internalCluster().nonMasterClient()
-                .admin()
-                .cluster()
-                .prepareState()
-                .execute()
-                .actionGet()
-                .getState()
-                .nodes()
-                .getMasterNode()
-                .getName(),
+            internalCluster().nonMasterClient().admin().cluster().prepareState().get().getState().nodes().getMasterNode().getName(),
             equalTo(masterNodeName)
         );
         assertThat(
-            internalCluster().masterClient()
-                .admin()
-                .cluster()
-                .prepareState()
-                .execute()
-                .actionGet()
-                .getState()
-                .nodes()
-                .getMasterNode()
-                .getName(),
+            internalCluster().masterClient().admin().cluster().prepareState().get().getState().nodes().getMasterNode().getName(),
             equalTo(masterNodeName)
         );
 
@@ -77,10 +56,7 @@ public class SpecificMasterNodesIT extends ESIntegTestCase {
         internalCluster().stopCurrentMasterNode();
 
         try {
-            assertThat(
-                clusterAdmin().prepareState().setMasterNodeTimeout("100ms").execute().actionGet().getState().nodes().getMasterNodeId(),
-                nullValue()
-            );
+            assertThat(clusterAdmin().prepareState().setMasterNodeTimeout("100ms").get().getState().nodes().getMasterNodeId(), nullValue());
             fail("should not be able to find master");
         } catch (MasterNotDiscoveredException e) {
             // all is well, no master elected
@@ -91,29 +67,11 @@ public class SpecificMasterNodesIT extends ESIntegTestCase {
             Settings.builder().put(nonDataNode(masterNode())).put(masterDataPathSettings)
         );
         assertThat(
-            internalCluster().nonMasterClient()
-                .admin()
-                .cluster()
-                .prepareState()
-                .execute()
-                .actionGet()
-                .getState()
-                .nodes()
-                .getMasterNode()
-                .getName(),
+            internalCluster().nonMasterClient().admin().cluster().prepareState().get().getState().nodes().getMasterNode().getName(),
             equalTo(nextMasterEligibleNodeName)
         );
         assertThat(
-            internalCluster().masterClient()
-                .admin()
-                .cluster()
-                .prepareState()
-                .execute()
-                .actionGet()
-                .getState()
-                .nodes()
-                .getMasterNode()
-                .getName(),
+            internalCluster().masterClient().admin().cluster().prepareState().get().getState().nodes().getMasterNode().getName(),
             equalTo(nextMasterEligibleNodeName)
         );
     }
@@ -123,10 +81,7 @@ public class SpecificMasterNodesIT extends ESIntegTestCase {
         logger.info("--> start data node / non master node");
         internalCluster().startNode(Settings.builder().put(dataOnlyNode()).put("discovery.initial_state_timeout", "1s"));
         try {
-            assertThat(
-                clusterAdmin().prepareState().setMasterNodeTimeout("100ms").execute().actionGet().getState().nodes().getMasterNodeId(),
-                nullValue()
-            );
+            assertThat(clusterAdmin().prepareState().setMasterNodeTimeout("100ms").get().getState().nodes().getMasterNodeId(), nullValue());
             fail("should not be able to find master");
         } catch (MasterNotDiscoveredException e) {
             // all is well, no master elected
@@ -134,71 +89,26 @@ public class SpecificMasterNodesIT extends ESIntegTestCase {
         logger.info("--> start master node (1)");
         final String masterNodeName = internalCluster().startMasterOnlyNode();
         assertThat(
-            internalCluster().nonMasterClient()
-                .admin()
-                .cluster()
-                .prepareState()
-                .execute()
-                .actionGet()
-                .getState()
-                .nodes()
-                .getMasterNode()
-                .getName(),
+            internalCluster().nonMasterClient().admin().cluster().prepareState().get().getState().nodes().getMasterNode().getName(),
             equalTo(masterNodeName)
         );
         assertThat(
-            internalCluster().masterClient()
-                .admin()
-                .cluster()
-                .prepareState()
-                .execute()
-                .actionGet()
-                .getState()
-                .nodes()
-                .getMasterNode()
-                .getName(),
+            internalCluster().masterClient().admin().cluster().prepareState().get().getState().nodes().getMasterNode().getName(),
             equalTo(masterNodeName)
         );
 
         logger.info("--> start master node (2)");
         final String nextMasterEligableNodeName = internalCluster().startMasterOnlyNode();
         assertThat(
-            internalCluster().nonMasterClient()
-                .admin()
-                .cluster()
-                .prepareState()
-                .execute()
-                .actionGet()
-                .getState()
-                .nodes()
-                .getMasterNode()
-                .getName(),
+            internalCluster().nonMasterClient().admin().cluster().prepareState().get().getState().nodes().getMasterNode().getName(),
             equalTo(masterNodeName)
         );
         assertThat(
-            internalCluster().nonMasterClient()
-                .admin()
-                .cluster()
-                .prepareState()
-                .execute()
-                .actionGet()
-                .getState()
-                .nodes()
-                .getMasterNode()
-                .getName(),
+            internalCluster().nonMasterClient().admin().cluster().prepareState().get().getState().nodes().getMasterNode().getName(),
             equalTo(masterNodeName)
         );
         assertThat(
-            internalCluster().masterClient()
-                .admin()
-                .cluster()
-                .prepareState()
-                .execute()
-                .actionGet()
-                .getState()
-                .nodes()
-                .getMasterNode()
-                .getName(),
+            internalCluster().masterClient().admin().cluster().prepareState().get().getState().nodes().getMasterNode().getName(),
             equalTo(masterNodeName)
         );
 
@@ -207,57 +117,21 @@ public class SpecificMasterNodesIT extends ESIntegTestCase {
         // removing the master from the voting configuration immediately triggers the master to step down
         assertBusy(() -> {
             assertThat(
-                internalCluster().nonMasterClient()
-                    .admin()
-                    .cluster()
-                    .prepareState()
-                    .execute()
-                    .actionGet()
-                    .getState()
-                    .nodes()
-                    .getMasterNode()
-                    .getName(),
+                internalCluster().nonMasterClient().admin().cluster().prepareState().get().getState().nodes().getMasterNode().getName(),
                 equalTo(nextMasterEligableNodeName)
             );
             assertThat(
-                internalCluster().masterClient()
-                    .admin()
-                    .cluster()
-                    .prepareState()
-                    .execute()
-                    .actionGet()
-                    .getState()
-                    .nodes()
-                    .getMasterNode()
-                    .getName(),
+                internalCluster().masterClient().admin().cluster().prepareState().get().getState().nodes().getMasterNode().getName(),
                 equalTo(nextMasterEligableNodeName)
             );
         });
         internalCluster().stopNode(masterNodeName);
         assertThat(
-            internalCluster().nonMasterClient()
-                .admin()
-                .cluster()
-                .prepareState()
-                .execute()
-                .actionGet()
-                .getState()
-                .nodes()
-                .getMasterNode()
-                .getName(),
+            internalCluster().nonMasterClient().admin().cluster().prepareState().get().getState().nodes().getMasterNode().getName(),
             equalTo(nextMasterEligableNodeName)
         );
         assertThat(
-            internalCluster().masterClient()
-                .admin()
-                .cluster()
-                .prepareState()
-                .execute()
-                .actionGet()
-                .getState()
-                .nodes()
-                .getMasterNode()
-                .getName(),
+            internalCluster().masterClient().admin().cluster().prepareState().get().getState().nodes().getMasterNode().getName(),
             equalTo(nextMasterEligableNodeName)
         );
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/UpdateSettingsValidationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/UpdateSettingsValidationIT.java
@@ -31,25 +31,17 @@ public class UpdateSettingsValidationIT extends ESIntegTestCase {
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForNodes("3")
             .setWaitForGreenStatus()
-            .execute()
-            .actionGet();
+            .get();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
         assertThat(healthResponse.getIndices().get("test").getActiveShards(), equalTo(test.totalNumShards));
 
         setReplicaCount(0, "test");
-        healthResponse = clusterAdmin().prepareHealth("test")
-            .setWaitForEvents(Priority.LANGUID)
-            .setWaitForGreenStatus()
-            .execute()
-            .actionGet();
+        healthResponse = clusterAdmin().prepareHealth("test").setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
         assertThat(healthResponse.getIndices().get("test").getActiveShards(), equalTo(test.numPrimaries));
 
         try {
-            indicesAdmin().prepareUpdateSettings("test")
-                .setSettings(Settings.builder().put("index.refresh_interval", ""))
-                .execute()
-                .actionGet();
+            indicesAdmin().prepareUpdateSettings("test").setSettings(Settings.builder().put("index.refresh_interval", "")).get();
             fail();
         } catch (IllegalArgumentException ex) {
             logger.info("Error message: [{}]", ex.getMessage());

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/allocation/AwarenessAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/allocation/AwarenessAllocationIT.java
@@ -81,7 +81,7 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
             assertThat("Cluster health request timed out", clusterHealth.isTimedOut(), equalTo(false));
 
             logger.info("--> checking current state");
-            ClusterState clusterState = clusterAdmin().prepareState().execute().actionGet().getState();
+            ClusterState clusterState = clusterAdmin().prepareState().get().getState();
 
             // check that closed indices are effectively closed
             final List<String> notClosedIndices = indicesToClose.stream()
@@ -114,7 +114,7 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
         String A_1 = nodes.get(3);
 
         logger.info("--> waiting for nodes to form a cluster");
-        ClusterHealthResponse health = clusterAdmin().prepareHealth().setWaitForNodes("4").execute().actionGet();
+        ClusterHealthResponse health = clusterAdmin().prepareHealth().setWaitForNodes("4").get();
         assertThat(health.isTimedOut(), equalTo(false));
 
         createIndex("test", 5, 1);
@@ -129,11 +129,10 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
             .setWaitForNoRelocatingShards(true)
-            .execute()
-            .actionGet();
+            .get();
         assertThat(health.isTimedOut(), equalTo(false));
 
-        ClusterState clusterState = clusterAdmin().prepareState().execute().actionGet().getState();
+        ClusterState clusterState = clusterAdmin().prepareState().get().getState();
         Map<String, Integer> counts = computeShardCounts(clusterState);
 
         assertThat(counts.get(A_1), anyOf(equalTo(2), equalTo(3)));
@@ -168,10 +167,9 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
             .setWaitForGreenStatus()
             .setWaitForNodes("2")
             .setWaitForNoRelocatingShards(true)
-            .execute()
-            .actionGet();
+            .get();
         assertThat(health.isTimedOut(), equalTo(false));
-        ClusterState clusterState = clusterAdmin().prepareState().execute().actionGet().getState();
+        ClusterState clusterState = clusterAdmin().prepareState().get().getState();
         Map<String, Integer> counts = computeShardCounts(clusterState);
 
         assertThat(counts.get(A_0), equalTo(5));
@@ -184,8 +182,7 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
             .setWaitForNodes("3")
-            .execute()
-            .actionGet();
+            .get();
         assertThat(health.isTimedOut(), equalTo(false));
         clusterAdmin().prepareReroute().get();
         health = clusterAdmin().prepareHealth()
@@ -195,11 +192,10 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
             .setWaitForNodes("3")
             .setWaitForActiveShards(10)
             .setWaitForNoRelocatingShards(true)
-            .execute()
-            .actionGet();
+            .get();
 
         assertThat(health.isTimedOut(), equalTo(false));
-        clusterState = clusterAdmin().prepareState().execute().actionGet().getState();
+        clusterState = clusterAdmin().prepareState().get().getState();
         counts = computeShardCounts(clusterState);
 
         assertThat(counts.get(A_0), equalTo(5));
@@ -212,8 +208,7 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
             .setWaitForNodes("4")
-            .execute()
-            .actionGet();
+            .get();
         assertThat(health.isTimedOut(), equalTo(false));
         clusterAdmin().prepareReroute().get();
         health = clusterAdmin().prepareHealth()
@@ -223,11 +218,10 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
             .setWaitForNodes("4")
             .setWaitForActiveShards(10)
             .setWaitForNoRelocatingShards(true)
-            .execute()
-            .actionGet();
+            .get();
 
         assertThat(health.isTimedOut(), equalTo(false));
-        clusterState = clusterAdmin().prepareState().execute().actionGet().getState();
+        clusterState = clusterAdmin().prepareState().get().getState();
         counts = computeShardCounts(clusterState);
 
         assertThat(counts.get(A_0), equalTo(5));
@@ -242,11 +236,10 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
             .setWaitForNodes("4")
             .setWaitForActiveShards(10)
             .setWaitForNoRelocatingShards(true)
-            .execute()
-            .actionGet();
+            .get();
 
         assertThat(health.isTimedOut(), equalTo(false));
-        clusterState = clusterAdmin().prepareState().execute().actionGet().getState();
+        clusterState = clusterAdmin().prepareState().get().getState();
         counts = computeShardCounts(clusterState);
 
         assertThat(counts.get(A_0), equalTo(3));

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/allocation/ClusterRerouteIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/allocation/ClusterRerouteIT.java
@@ -89,14 +89,13 @@ public class ClusterRerouteIT extends ESIntegTestCase {
         indicesAdmin().prepareCreate("test")
             .setWaitForActiveShards(ActiveShardCount.NONE)
             .setSettings(Settings.builder().put("index.number_of_shards", 1))
-            .execute()
-            .actionGet();
+            .get();
 
         if (randomBoolean()) {
             indicesAdmin().prepareClose("test").setWaitForActiveShards(ActiveShardCount.NONE).get();
         }
 
-        ClusterState state = clusterAdmin().prepareState().execute().actionGet().getState();
+        ClusterState state = clusterAdmin().prepareState().get().getState();
         assertThat(state.getRoutingNodes().unassigned().size(), equalTo(2));
 
         logger.info("--> explicitly allocate shard 1, *under dry_run*");
@@ -104,8 +103,7 @@ public class ClusterRerouteIT extends ESIntegTestCase {
             .setExplain(randomBoolean())
             .add(new AllocateEmptyPrimaryAllocationCommand("test", 0, node_1, true))
             .setDryRun(true)
-            .execute()
-            .actionGet()
+            .get()
             .getState();
         assertThat(state.getRoutingNodes().unassigned().size(), equalTo(1));
         assertThat(
@@ -114,15 +112,14 @@ public class ClusterRerouteIT extends ESIntegTestCase {
         );
 
         logger.info("--> get the state, verify nothing changed because of the dry run");
-        state = clusterAdmin().prepareState().execute().actionGet().getState();
+        state = clusterAdmin().prepareState().get().getState();
         assertThat(state.getRoutingNodes().unassigned().size(), equalTo(2));
 
         logger.info("--> explicitly allocate shard 1, actually allocating, no dry run");
         state = clusterAdmin().prepareReroute()
             .setExplain(randomBoolean())
             .add(new AllocateEmptyPrimaryAllocationCommand("test", 0, node_1, true))
-            .execute()
-            .actionGet()
+            .get()
             .getState();
         assertThat(state.getRoutingNodes().unassigned().size(), equalTo(1));
         assertThat(
@@ -134,12 +131,11 @@ public class ClusterRerouteIT extends ESIntegTestCase {
             .setIndices("test")
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForYellowStatus()
-            .execute()
-            .actionGet();
+            .get();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
 
         logger.info("--> get the state, verify shard 1 primary allocated");
-        state = clusterAdmin().prepareState().execute().actionGet().getState();
+        state = clusterAdmin().prepareState().get().getState();
         assertThat(state.getRoutingNodes().unassigned().size(), equalTo(1));
         assertThat(
             state.getRoutingNodes().node(state.nodes().resolveNode(node_1).getId()).iterator().next().state(),
@@ -150,8 +146,7 @@ public class ClusterRerouteIT extends ESIntegTestCase {
         state = clusterAdmin().prepareReroute()
             .setExplain(randomBoolean())
             .add(new MoveAllocationCommand("test", 0, node_1, node_2))
-            .execute()
-            .actionGet()
+            .get()
             .getState();
 
         assertThat(
@@ -168,12 +163,11 @@ public class ClusterRerouteIT extends ESIntegTestCase {
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForYellowStatus()
             .setWaitForNoRelocatingShards(true)
-            .execute()
-            .actionGet();
+            .get();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
 
         logger.info("--> get the state, verify shard 1 primary moved from node1 to node2");
-        state = clusterAdmin().prepareState().execute().actionGet().getState();
+        state = clusterAdmin().prepareState().get().getState();
         assertThat(state.getRoutingNodes().unassigned().size(), equalTo(1));
         assertThat(
             state.getRoutingNodes().node(state.nodes().resolveNode(node_2).getId()).iterator().next().state(),
@@ -208,7 +202,7 @@ public class ClusterRerouteIT extends ESIntegTestCase {
         internalCluster().startNode(commonSettings);
 
         assertThat(cluster().size(), equalTo(4));
-        ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth().setWaitForNodes("4").execute().actionGet();
+        ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth().setWaitForNodes("4").get();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
 
         logger.info("--> create indices");
@@ -238,30 +232,28 @@ public class ClusterRerouteIT extends ESIntegTestCase {
         String node_1 = internalCluster().startNode(commonSettings);
         internalCluster().startNode(commonSettings);
         assertThat(cluster().size(), equalTo(2));
-        ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth().setWaitForNodes("2").execute().actionGet();
+        ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth().setWaitForNodes("2").get();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
 
         logger.info("--> create an index with 1 shard, 1 replica, nothing should allocate");
         indicesAdmin().prepareCreate("test")
             .setWaitForActiveShards(ActiveShardCount.NONE)
             .setSettings(Settings.builder().put("index.number_of_shards", 1))
-            .execute()
-            .actionGet();
+            .get();
 
         final boolean closed = randomBoolean();
         if (closed) {
             indicesAdmin().prepareClose("test").setWaitForActiveShards(ActiveShardCount.NONE).get();
         }
 
-        ClusterState state = clusterAdmin().prepareState().execute().actionGet().getState();
+        ClusterState state = clusterAdmin().prepareState().get().getState();
         assertThat(state.getRoutingNodes().unassigned().size(), equalTo(2));
 
         logger.info("--> explicitly allocate shard 1, actually allocating, no dry run");
         state = clusterAdmin().prepareReroute()
             .setExplain(randomBoolean())
             .add(new AllocateEmptyPrimaryAllocationCommand("test", 0, node_1, true))
-            .execute()
-            .actionGet()
+            .get()
             .getState();
         assertThat(state.getRoutingNodes().unassigned().size(), equalTo(1));
         assertThat(
@@ -273,12 +265,11 @@ public class ClusterRerouteIT extends ESIntegTestCase {
             .setIndices("test")
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForYellowStatus()
-            .execute()
-            .actionGet();
+            .get();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
 
         logger.info("--> get the state, verify shard 1 primary allocated");
-        state = clusterAdmin().prepareState().execute().actionGet().getState();
+        state = clusterAdmin().prepareState().get().getState();
         assertThat(state.getRoutingNodes().unassigned().size(), equalTo(1));
         assertThat(
             state.getRoutingNodes().node(state.nodes().resolveNode(node_1).getId()).iterator().next().state(),
@@ -306,15 +297,14 @@ public class ClusterRerouteIT extends ESIntegTestCase {
         // TODO can we get around this? the cluster is RED, so what do we wait for?
         clusterAdmin().prepareReroute().get();
         assertThat(
-            clusterAdmin().prepareHealth().setIndices("test").setWaitForNodes("2").execute().actionGet().getStatus(),
+            clusterAdmin().prepareHealth().setIndices("test").setWaitForNodes("2").get().getStatus(),
             equalTo(ClusterHealthStatus.RED)
         );
         logger.info("--> explicitly allocate primary");
         state = clusterAdmin().prepareReroute()
             .setExplain(randomBoolean())
             .add(new AllocateEmptyPrimaryAllocationCommand("test", 0, node_1, true))
-            .execute()
-            .actionGet()
+            .get()
             .getState();
         assertThat(state.getRoutingNodes().unassigned().size(), equalTo(1));
         assertThat(
@@ -325,7 +315,7 @@ public class ClusterRerouteIT extends ESIntegTestCase {
         logger.info("--> get the state, verify shard 1 primary allocated");
         final String nodeToCheck = node_1;
         assertBusy(() -> {
-            ClusterState clusterState = clusterAdmin().prepareState().execute().actionGet().getState();
+            ClusterState clusterState = clusterAdmin().prepareState().get().getState();
             String nodeId = clusterState.nodes().resolveNode(nodeToCheck).getId();
             assertThat(clusterState.getRoutingNodes().node(nodeId).iterator().next().state(), equalTo(ShardRoutingState.STARTED));
         });
@@ -338,7 +328,7 @@ public class ClusterRerouteIT extends ESIntegTestCase {
         String node_1 = internalCluster().startNode(commonSettings);
 
         assertThat(cluster().size(), equalTo(1));
-        ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth().setWaitForNodes("1").execute().actionGet();
+        ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth().setWaitForNodes("1").get();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
 
         logger.info("--> create an index with 1 shard");
@@ -355,12 +345,12 @@ public class ClusterRerouteIT extends ESIntegTestCase {
         logger.info("--> starting a second node");
         String node_2 = internalCluster().startNode(commonSettings);
         assertThat(cluster().size(), equalTo(2));
-        healthResponse = clusterAdmin().prepareHealth().setWaitForNodes("2").execute().actionGet();
+        healthResponse = clusterAdmin().prepareHealth().setWaitForNodes("2").get();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
 
         logger.info("--> try to move the shard from node1 to node2");
         MoveAllocationCommand cmd = new MoveAllocationCommand("test", 0, node_1, node_2);
-        ClusterRerouteResponse resp = clusterAdmin().prepareReroute().add(cmd).setExplain(true).execute().actionGet();
+        ClusterRerouteResponse resp = clusterAdmin().prepareReroute().add(cmd).setExplain(true).get();
         RoutingExplanations e = resp.getExplanations();
         assertThat(e.explanations().size(), equalTo(1));
         RerouteExplanation explanation = e.explanations().get(0);
@@ -379,12 +369,12 @@ public class ClusterRerouteIT extends ESIntegTestCase {
 
         final String nodeName1 = internalCluster().startNode(settings);
         assertThat(cluster().size(), equalTo(1));
-        ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth().setWaitForNodes("1").execute().actionGet();
+        ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth().setWaitForNodes("1").get();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
 
         final String nodeName2 = internalCluster().startNode(settings);
         assertThat(cluster().size(), equalTo(2));
-        healthResponse = clusterAdmin().prepareHealth().setWaitForNodes("2").execute().actionGet();
+        healthResponse = clusterAdmin().prepareHealth().setWaitForNodes("2").get();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
 
         final String indexName = "test_index";
@@ -395,8 +385,7 @@ public class ClusterRerouteIT extends ESIntegTestCase {
                     .put(IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 2)
                     .put(IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 1)
             )
-            .execute()
-            .actionGet();
+            .get();
 
         MockLogAppender dryRunMockLog = new MockLogAppender();
         dryRunMockLog.addExpectation(
@@ -414,8 +403,7 @@ public class ClusterRerouteIT extends ESIntegTestCase {
                 .setExplain(randomBoolean())
                 .setDryRun(true)
                 .add(dryRunAllocation)
-                .execute()
-                .actionGet();
+                .get();
 
             // during a dry run, messages exist but are not logged or exposed
             assertThat(dryRunResponse.getExplanations().getYesDecisionMessages(), hasSize(1));
@@ -449,8 +437,7 @@ public class ClusterRerouteIT extends ESIntegTestCase {
                 .setExplain(true) // so we get a NO decision back rather than an exception
                 .add(yesDecisionAllocation)
                 .add(noDecisionAllocation)
-                .execute()
-                .actionGet();
+                .get();
 
             assertThat(response.getExplanations().getYesDecisionMessages(), hasSize(1));
             assertThat(response.getExplanations().getYesDecisionMessages().get(0), containsString("allocated an empty primary"));
@@ -472,7 +459,7 @@ public class ClusterRerouteIT extends ESIntegTestCase {
         ensureGreen("test-blocks");
 
         logger.info("--> check that the index has 1 shard");
-        ClusterState state = clusterAdmin().prepareState().execute().actionGet().getState();
+        ClusterState state = clusterAdmin().prepareState().get().getState();
         List<ShardRouting> shards = state.routingTable().allShards("test-blocks");
         assertThat(shards, hasSize(1));
 
@@ -506,8 +493,7 @@ public class ClusterRerouteIT extends ESIntegTestCase {
                     .setIndices("test-blocks")
                     .setWaitForYellowStatus()
                     .setWaitForNoRelocatingShards(true)
-                    .execute()
-                    .actionGet();
+                    .get();
                 assertThat(healthResponse.isTimedOut(), equalTo(false));
             } finally {
                 disableIndexBlock("test-blocks", blockSetting);

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/allocation/FilteringAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/allocation/FilteringAllocationIT.java
@@ -48,13 +48,10 @@ public class FilteringAllocationIT extends ESIntegTestCase {
         ensureGreen("test");
         logger.info("--> index some data");
         for (int i = 0; i < 100; i++) {
-            client().prepareIndex("test").setId(Integer.toString(i)).setSource("field", "value" + i).execute().actionGet();
+            client().prepareIndex("test").setId(Integer.toString(i)).setSource("field", "value" + i).get();
         }
-        indicesAdmin().prepareRefresh().execute().actionGet();
-        assertThat(
-            prepareSearch().setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().getTotalHits().value,
-            equalTo(100L)
-        );
+        indicesAdmin().prepareRefresh().get();
+        assertThat(prepareSearch().setSize(0).setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value, equalTo(100L));
 
         final boolean closed = randomBoolean();
         if (closed) {
@@ -67,7 +64,7 @@ public class FilteringAllocationIT extends ESIntegTestCase {
         ensureGreen("test");
 
         logger.info("--> verify all are allocated on node1 now");
-        ClusterState clusterState = clusterAdmin().prepareState().execute().actionGet().getState();
+        ClusterState clusterState = clusterAdmin().prepareState().get().getState();
         for (IndexRoutingTable indexRoutingTable : clusterState.routingTable()) {
             for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
                 final IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(shardId);
@@ -81,11 +78,8 @@ public class FilteringAllocationIT extends ESIntegTestCase {
             assertAcked(indicesAdmin().prepareOpen("test"));
         }
 
-        indicesAdmin().prepareRefresh().execute().actionGet();
-        assertThat(
-            prepareSearch().setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().getTotalHits().value,
-            equalTo(100L)
-        );
+        indicesAdmin().prepareRefresh().get();
+        assertThat(prepareSearch().setSize(0).setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value, equalTo(100L));
     }
 
     public void testAutoExpandReplicasToFilteredNodes() {
@@ -97,7 +91,7 @@ public class FilteringAllocationIT extends ESIntegTestCase {
 
         logger.info("--> creating an index with auto-expand replicas");
         createIndex("test", Settings.builder().put(AutoExpandReplicas.SETTING.getKey(), "0-all").build());
-        ClusterState clusterState = clusterAdmin().prepareState().execute().actionGet().getState();
+        ClusterState clusterState = clusterAdmin().prepareState().get().getState();
         assertThat(clusterState.metadata().index("test").getNumberOfReplicas(), equalTo(1));
         ensureGreen("test");
 
@@ -110,7 +104,7 @@ public class FilteringAllocationIT extends ESIntegTestCase {
         ensureGreen("test");
 
         logger.info("--> verify all are allocated on node1 now");
-        clusterState = clusterAdmin().prepareState().execute().actionGet().getState();
+        clusterState = clusterAdmin().prepareState().get().getState();
         assertThat(clusterState.metadata().index("test").getNumberOfReplicas(), equalTo(0));
         for (IndexRoutingTable indexRoutingTable : clusterState.routingTable()) {
             for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
@@ -135,13 +129,10 @@ public class FilteringAllocationIT extends ESIntegTestCase {
 
         logger.info("--> index some data");
         for (int i = 0; i < 100; i++) {
-            client().prepareIndex("test").setId(Integer.toString(i)).setSource("field", "value" + i).execute().actionGet();
+            client().prepareIndex("test").setId(Integer.toString(i)).setSource("field", "value" + i).get();
         }
-        indicesAdmin().prepareRefresh().execute().actionGet();
-        assertThat(
-            prepareSearch().setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().getTotalHits().value,
-            equalTo(100L)
-        );
+        indicesAdmin().prepareRefresh().get();
+        assertThat(prepareSearch().setSize(0).setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value, equalTo(100L));
 
         final boolean closed = randomBoolean();
         if (closed) {
@@ -149,7 +140,7 @@ public class FilteringAllocationIT extends ESIntegTestCase {
             ensureGreen("test");
         }
 
-        ClusterState clusterState = clusterAdmin().prepareState().execute().actionGet().getState();
+        ClusterState clusterState = clusterAdmin().prepareState().get().getState();
         IndexRoutingTable indexRoutingTable = clusterState.routingTable().index("test");
         int numShardsOnNode1 = 0;
         for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
@@ -172,7 +163,7 @@ public class FilteringAllocationIT extends ESIntegTestCase {
         ensureGreen("test");
 
         logger.info("--> verify all shards are allocated on node_1 now");
-        clusterState = clusterAdmin().prepareState().execute().actionGet().getState();
+        clusterState = clusterAdmin().prepareState().get().getState();
         indexRoutingTable = clusterState.routingTable().index("test");
         for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
             final IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(shardId);
@@ -187,7 +178,7 @@ public class FilteringAllocationIT extends ESIntegTestCase {
         ensureGreen("test");
 
         logger.info("--> verify that there are shards allocated on both nodes now");
-        clusterState = clusterAdmin().prepareState().execute().actionGet().getState();
+        clusterState = clusterAdmin().prepareState().get().getState();
         assertThat(clusterState.routingTable().index("test").numberOfNodesShardsAreAllocatedOn(), equalTo(2));
     }
 
@@ -202,8 +193,7 @@ public class FilteringAllocationIT extends ESIntegTestCase {
             IllegalArgumentException.class,
             () -> clusterAdmin().prepareUpdateSettings()
                 .setPersistentSettings(Settings.builder().put(filterSetting.getKey() + ipKey, "192.168.1.1."))
-                .execute()
-                .actionGet()
+                .get()
         );
         assertEquals("invalid IP address [192.168.1.1.] for [" + filterSetting.getKey() + ipKey + "]", e.getMessage());
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/allocation/SimpleAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/allocation/SimpleAllocationIT.java
@@ -33,7 +33,7 @@ public class SimpleAllocationIT extends ESIntegTestCase {
         }
         ensureGreen("test");
 
-        ClusterState state = clusterAdmin().prepareState().execute().actionGet().getState();
+        ClusterState state = clusterAdmin().prepareState().get().getState();
         assertThat(state.getRoutingNodes().unassigned().size(), equalTo(0));
         for (RoutingNode node : state.getRoutingNodes()) {
             if (node.isEmpty() == false) {
@@ -42,7 +42,7 @@ public class SimpleAllocationIT extends ESIntegTestCase {
         }
         setReplicaCount(0, "test");
         ensureGreen("test");
-        state = clusterAdmin().prepareState().execute().actionGet().getState();
+        state = clusterAdmin().prepareState().get().getState();
 
         assertThat(state.getRoutingNodes().unassigned().size(), equalTo(0));
         for (RoutingNode node : state.getRoutingNodes()) {
@@ -60,7 +60,7 @@ public class SimpleAllocationIT extends ESIntegTestCase {
 
         setReplicaCount(1, "test");
         ensureGreen("test");
-        state = clusterAdmin().prepareState().execute().actionGet().getState();
+        state = clusterAdmin().prepareState().get().getState();
 
         assertThat(state.getRoutingNodes().unassigned().size(), equalTo(0));
         for (RoutingNode node : state.getRoutingNodes()) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/UnsafeBootstrapAndDetachCommandIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/UnsafeBootstrapAndDetachCommandIT.java
@@ -137,7 +137,7 @@ public class UnsafeBootstrapAndDetachCommandIT extends ESIntegTestCase {
                 .build()
         );
         assertBusy(() -> {
-            ClusterState state = clusterAdmin().prepareState().setLocal(true).execute().actionGet().getState();
+            ClusterState state = clusterAdmin().prepareState().setLocal(true).get().getState();
             assertTrue(state.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID));
         });
 
@@ -242,14 +242,7 @@ public class UnsafeBootstrapAndDetachCommandIT extends ESIntegTestCase {
 
         logger.info("--> ensure NO_MASTER_BLOCK on data-only node");
         assertBusy(() -> {
-            ClusterState state = internalCluster().client(dataNode)
-                .admin()
-                .cluster()
-                .prepareState()
-                .setLocal(true)
-                .execute()
-                .actionGet()
-                .getState();
+            ClusterState state = internalCluster().client(dataNode).admin().cluster().prepareState().setLocal(true).get().getState();
             assertTrue(state.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID));
         });
 
@@ -295,14 +288,7 @@ public class UnsafeBootstrapAndDetachCommandIT extends ESIntegTestCase {
 
         logger.info("--> ensure there is no NO_MASTER_BLOCK and unsafe-bootstrap is reflected in cluster state");
         assertBusy(() -> {
-            ClusterState state = internalCluster().client(dataNode2)
-                .admin()
-                .cluster()
-                .prepareState()
-                .setLocal(true)
-                .execute()
-                .actionGet()
-                .getState();
+            ClusterState state = internalCluster().client(dataNode2).admin().cluster().prepareState().setLocal(true).get().getState();
             assertFalse(state.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID));
             assertTrue(state.metadata().persistentSettings().getAsBoolean(UnsafeBootstrapMasterCommand.UNSAFE_BOOTSTRAP.getKey(), false));
         });
@@ -347,7 +333,7 @@ public class UnsafeBootstrapAndDetachCommandIT extends ESIntegTestCase {
                 .build()
         );
 
-        ClusterState state = internalCluster().client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
+        ClusterState state = internalCluster().client().admin().cluster().prepareState().setLocal(true).get().getState();
         assertTrue(state.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID));
 
         internalCluster().stopNode(node);
@@ -359,7 +345,7 @@ public class UnsafeBootstrapAndDetachCommandIT extends ESIntegTestCase {
         Settings masterNodeDataPathSettings = internalCluster().dataPathSettings(masterNode);
         updateClusterSettings(Settings.builder().put(INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING.getKey(), "1234kb"));
 
-        ClusterState state = internalCluster().client().admin().cluster().prepareState().execute().actionGet().getState();
+        ClusterState state = internalCluster().client().admin().cluster().prepareState().get().getState();
         assertThat(state.metadata().persistentSettings().get(INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING.getKey()), equalTo("1234kb"));
 
         internalCluster().stopCurrentMasterNode();
@@ -373,7 +359,7 @@ public class UnsafeBootstrapAndDetachCommandIT extends ESIntegTestCase {
         internalCluster().startMasterOnlyNode(masterNodeDataPathSettings);
         ensureGreen();
 
-        state = internalCluster().client().admin().cluster().prepareState().execute().actionGet().getState();
+        state = internalCluster().client().admin().cluster().prepareState().get().getState();
         assertThat(state.metadata().settings().get(INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING.getKey()), equalTo("1234kb"));
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/PrimaryAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/PrimaryAllocationIT.java
@@ -93,8 +93,7 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
         BulkResponse bulkResponse = client().prepareBulk()
             .add(client().prepareIndex().setIndex("test").setId("1").setSource("field1", "value1"))
             .add(client().prepareUpdate().setIndex("test").setId("1").setDoc("field2", "value2"))
-            .execute()
-            .actionGet();
+            .get();
 
         assertThat(bulkResponse.hasFailures(), equalTo(false));
         assertThat(bulkResponse.getItems().length, equalTo(2));

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/ShardRoutingRoleIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/ShardRoutingRoleIT.java
@@ -697,7 +697,7 @@ public class ShardRoutingRoleIT extends ESIntegTestCase {
                 });
             }
 
-            RefreshResponse response = indicesAdmin().prepareRefresh(INDEX_NAME).execute().actionGet();
+            RefreshResponse response = indicesAdmin().prepareRefresh(INDEX_NAME).get();
             assertThat(
                 "each unpromotable replica shard should be added to the shard failures",
                 response.getFailedShards(),

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/settings/ClusterSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/settings/ClusterSettingsIT.java
@@ -212,8 +212,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         ClusterUpdateSettingsResponse response1 = clusterAdmin().prepareUpdateSettings()
             .setTransientSettings(transientSettings1)
             .setPersistentSettings(persistentSettings1)
-            .execute()
-            .actionGet();
+            .get();
 
         assertAcked(response1);
         assertThat(response1.getTransientSettings().get(key1), notNullValue());
@@ -227,8 +226,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         ClusterUpdateSettingsResponse response2 = clusterAdmin().prepareUpdateSettings()
             .setTransientSettings(transientSettings2)
             .setPersistentSettings(persistentSettings2)
-            .execute()
-            .actionGet();
+            .get();
 
         assertAcked(response2);
         assertThat(response2.getTransientSettings().get(key1), notNullValue());
@@ -242,8 +240,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         ClusterUpdateSettingsResponse response3 = clusterAdmin().prepareUpdateSettings()
             .setTransientSettings(transientSettings3)
             .setPersistentSettings(persistentSettings3)
-            .execute()
-            .actionGet();
+            .get();
 
         assertAcked(response3);
         assertThat(response3.getTransientSettings().get(key1), nullValue());
@@ -502,7 +499,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         }
 
         // It should work now
-        ClusterUpdateSettingsResponse response = request.execute().actionGet();
+        ClusterUpdateSettingsResponse response = request.get();
 
         assertAcked(response);
         assertThat(response.getTransientSettings().get(key1), notNullValue());
@@ -515,10 +512,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         assertAcked(prepareCreate("test"));
 
         try {
-            indicesAdmin().prepareUpdateSettings("test")
-                .setSettings(Settings.builder().put("index.refresh_interval", "10"))
-                .execute()
-                .actionGet();
+            indicesAdmin().prepareUpdateSettings("test").setSettings(Settings.builder().put("index.refresh_interval", "10")).get();
             fail("Expected IllegalArgumentException");
         } catch (IllegalArgumentException e) {
             assertThat(e.getMessage(), containsString("[index.refresh_interval] with value [10]"));
@@ -542,7 +536,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         ClusterUpdateSettingsRequestBuilder throwBuilder = clusterAdmin().prepareUpdateSettings();
         consumer.accept(Settings.builder().put("logger._root", "BOOM"), throwBuilder);
 
-        final IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> throwBuilder.execute().actionGet());
+        final IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> throwBuilder.get());
         assertEquals("Unknown level constant [BOOM].", e.getMessage());
 
         try {
@@ -550,7 +544,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
             ClusterUpdateSettingsRequestBuilder updateBuilder = clusterAdmin().prepareUpdateSettings();
             consumer.accept(testSettings, updateBuilder);
 
-            updateBuilder.execute().actionGet();
+            updateBuilder.get();
             assertEquals(Level.TRACE, LogManager.getLogger("test").getLevel());
             assertEquals(Level.TRACE, LogManager.getRootLogger().getLevel());
         } finally {
@@ -560,12 +554,12 @@ public class ClusterSettingsIT extends ESIntegTestCase {
                 final Settings.Builder defaultSettings = Settings.builder().putNull("logger.test").putNull("logger._root");
                 consumer.accept(defaultSettings, undoBuilder);
 
-                undoBuilder.execute().actionGet();
+                undoBuilder.get();
             } else {
                 final Settings.Builder defaultSettings = Settings.builder().putNull("logger.*");
                 consumer.accept(defaultSettings, undoBuilder);
 
-                undoBuilder.execute().actionGet();
+                undoBuilder.get();
             }
             assertEquals(level, LogManager.getLogger("test").getLevel());
             assertEquals(level, LogManager.getRootLogger().getLevel());
@@ -593,15 +587,15 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         ClusterUpdateSettingsRequestBuilder builder = clusterAdmin().prepareUpdateSettings();
         consumer.accept(settings, builder);
 
-        builder.execute().actionGet();
-        ClusterStateResponse state = clusterAdmin().prepareState().execute().actionGet();
+        builder.get();
+        ClusterStateResponse state = clusterAdmin().prepareState().get();
         assertEquals(value, getter.apply(state.getState().getMetadata()).get(key));
 
         ClusterUpdateSettingsRequestBuilder updateBuilder = clusterAdmin().prepareUpdateSettings();
         consumer.accept(updatedSettings, updateBuilder);
-        updateBuilder.execute().actionGet();
+        updateBuilder.get();
 
-        ClusterStateResponse updatedState = clusterAdmin().prepareState().execute().actionGet();
+        ClusterStateResponse updatedState = clusterAdmin().prepareState().get();
         assertEquals(updatedValue, getter.apply(updatedState.getState().getMetadata()).get(key));
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/shards/ClusterSearchShardsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/shards/ClusterSearchShardsIT.java
@@ -39,12 +39,9 @@ public class ClusterSearchShardsIT extends ESIntegTestCase {
     }
 
     public void testSingleShardAllocation() throws Exception {
-        indicesAdmin().prepareCreate("test")
-            .setSettings(indexSettings(1, 0).put("index.routing.allocation.include.tag", "A"))
-            .execute()
-            .actionGet();
+        indicesAdmin().prepareCreate("test").setSettings(indexSettings(1, 0).put("index.routing.allocation.include.tag", "A")).get();
         ensureGreen();
-        ClusterSearchShardsResponse response = clusterAdmin().prepareSearchShards("test").execute().actionGet();
+        ClusterSearchShardsResponse response = clusterAdmin().prepareSearchShards("test").get();
         assertThat(response.getGroups().length, equalTo(1));
         assertThat(response.getGroups()[0].getShardId().getIndexName(), equalTo("test"));
         assertThat(response.getGroups()[0].getShardId().getId(), equalTo(0));
@@ -52,7 +49,7 @@ public class ClusterSearchShardsIT extends ESIntegTestCase {
         assertThat(response.getNodes().length, equalTo(1));
         assertThat(response.getGroups()[0].getShards()[0].currentNodeId(), equalTo(response.getNodes()[0].getId()));
 
-        response = clusterAdmin().prepareSearchShards("test").setRouting("A").execute().actionGet();
+        response = clusterAdmin().prepareSearchShards("test").setRouting("A").get();
         assertThat(response.getGroups().length, equalTo(1));
         assertThat(response.getGroups()[0].getShardId().getIndexName(), equalTo("test"));
         assertThat(response.getGroups()[0].getShardId().getId(), equalTo(0));
@@ -63,22 +60,19 @@ public class ClusterSearchShardsIT extends ESIntegTestCase {
     }
 
     public void testMultipleShardsSingleNodeAllocation() throws Exception {
-        indicesAdmin().prepareCreate("test")
-            .setSettings(indexSettings(4, 0).put("index.routing.allocation.include.tag", "A"))
-            .execute()
-            .actionGet();
+        indicesAdmin().prepareCreate("test").setSettings(indexSettings(4, 0).put("index.routing.allocation.include.tag", "A")).get();
         ensureGreen();
 
-        ClusterSearchShardsResponse response = clusterAdmin().prepareSearchShards("test").execute().actionGet();
+        ClusterSearchShardsResponse response = clusterAdmin().prepareSearchShards("test").get();
         assertThat(response.getGroups().length, equalTo(4));
         assertThat(response.getGroups()[0].getShardId().getIndexName(), equalTo("test"));
         assertThat(response.getNodes().length, equalTo(1));
         assertThat(response.getGroups()[0].getShards()[0].currentNodeId(), equalTo(response.getNodes()[0].getId()));
 
-        response = clusterAdmin().prepareSearchShards("test").setRouting("ABC").execute().actionGet();
+        response = clusterAdmin().prepareSearchShards("test").setRouting("ABC").get();
         assertThat(response.getGroups().length, equalTo(1));
 
-        response = clusterAdmin().prepareSearchShards("test").setPreference("_shards:2").execute().actionGet();
+        response = clusterAdmin().prepareSearchShards("test").setPreference("_shards:2").get();
         assertThat(response.getGroups().length, equalTo(1));
         assertThat(response.getGroups()[0].getShardId().getId(), equalTo(2));
     }
@@ -90,9 +84,9 @@ public class ClusterSearchShardsIT extends ESIntegTestCase {
             .addAliasAction(AliasActions.add().index("test1").alias("routing_alias").routing("ABC"))
             .addAliasAction(AliasActions.add().index("test2").alias("routing_alias").routing("EFG"))
             .get();
-        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
 
-        ClusterSearchShardsResponse response = clusterAdmin().prepareSearchShards("routing_alias").execute().actionGet();
+        ClusterSearchShardsResponse response = clusterAdmin().prepareSearchShards("routing_alias").get();
         assertThat(response.getGroups().length, equalTo(2));
         assertThat(response.getGroups()[0].getShards().length, equalTo(2));
         assertThat(response.getGroups()[1].getShards().length, equalTo(2));
@@ -121,7 +115,7 @@ public class ClusterSearchShardsIT extends ESIntegTestCase {
 
         int docs = between(10, 100);
         for (int i = 0; i < docs; i++) {
-            client().prepareIndex("test-blocks").setId("" + i).setSource("test", "init").execute().actionGet();
+            client().prepareIndex("test-blocks").setId("" + i).setSource("test", "init").get();
         }
         ensureGreen("test-blocks");
 
@@ -134,7 +128,7 @@ public class ClusterSearchShardsIT extends ESIntegTestCase {
         )) {
             try {
                 enableIndexBlock("test-blocks", blockSetting);
-                ClusterSearchShardsResponse response = clusterAdmin().prepareSearchShards("test-blocks").execute().actionGet();
+                ClusterSearchShardsResponse response = clusterAdmin().prepareSearchShards("test-blocks").get();
                 assertThat(response.getGroups().length, equalTo(numShards.numPrimaries));
             } finally {
                 disableIndexBlock("test-blocks", blockSetting);

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/shards/ClusterShardLimitIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/shards/ClusterShardLimitIT.java
@@ -316,8 +316,7 @@ public class ClusterShardLimitIT extends ESIntegTestCase {
                 .prepareRestoreSnapshot("test-repo", "test-snap")
                 .setWaitForCompletion(true)
                 .setIndices("snapshot-index")
-                .execute()
-                .actionGet();
+                .get();
             fail("Should not have been able to restore snapshot in full cluster");
         } catch (IllegalArgumentException e) {
             verifyException(dataNodes, counts, e);
@@ -341,10 +340,10 @@ public class ClusterShardLimitIT extends ESIntegTestCase {
                 .build()
         );
 
-        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
+        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().get();
         assertFalse(healthResponse.isTimedOut());
 
-        AcknowledgedResponse closeIndexResponse = client.admin().indices().prepareClose("test-index-1").execute().actionGet();
+        AcknowledgedResponse closeIndexResponse = client.admin().indices().prepareClose("test-index-1").get();
         assertTrue(closeIndexResponse.isAcknowledged());
 
         // Fill up the cluster
@@ -359,7 +358,7 @@ public class ClusterShardLimitIT extends ESIntegTestCase {
         );
 
         try {
-            client.admin().indices().prepareOpen("test-index-1").execute().actionGet();
+            client.admin().indices().prepareOpen("test-index-1").get();
             fail("should not have been able to open index");
         } catch (IllegalArgumentException e) {
             verifyException(dataNodes, counts, e);
@@ -372,13 +371,7 @@ public class ClusterShardLimitIT extends ESIntegTestCase {
         if (dataNodes == 1) {
             internalCluster().startNode(dataNode());
             assertThat(
-                clusterAdmin().prepareHealth()
-                    .setWaitForEvents(Priority.LANGUID)
-                    .setWaitForNodes(">=2")
-                    .setLocal(true)
-                    .execute()
-                    .actionGet()
-                    .isTimedOut(),
+                clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForNodes(">=2").setLocal(true).get().isTimedOut(),
                 equalTo(false)
             );
             dataNodes = clusterAdmin().prepareState().get().getState().getNodes().getDataNodes().size();

--- a/server/src/internalClusterTest/java/org/elasticsearch/document/AliasedIndexDocumentActionsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/document/AliasedIndexDocumentActionsIT.java
@@ -17,7 +17,7 @@ public class AliasedIndexDocumentActionsIT extends DocumentActionsIT {
     protected void createIndex() {
         logger.info("Creating index [test1] with alias [test]");
         try {
-            indicesAdmin().prepareDelete("test1").execute().actionGet();
+            indicesAdmin().prepareDelete("test1").get();
         } catch (Exception e) {
             // ignore
         }

--- a/server/src/internalClusterTest/java/org/elasticsearch/document/DocumentActionsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/document/DocumentActionsIT.java
@@ -89,7 +89,7 @@ public class DocumentActionsIT extends ESIntegTestCase {
 
         logger.info("Get [type1/1]");
         for (int i = 0; i < 5; i++) {
-            getResult = client().prepareGet("test", "1").execute().actionGet();
+            getResult = client().prepareGet("test", "1").get();
             assertThat(getResult.getIndex(), equalTo(getConcreteIndexName()));
             assertThat("cycle #" + i, getResult.getSourceAsString(), equalTo(Strings.toString(source("1", "test"))));
             assertThat("cycle(map) #" + i, (String) getResult.getSourceAsMap().get("name"), equalTo("test"));
@@ -100,7 +100,7 @@ public class DocumentActionsIT extends ESIntegTestCase {
 
         logger.info("Get [type1/1] with script");
         for (int i = 0; i < 5; i++) {
-            getResult = client().prepareGet("test", "1").setStoredFields("name").execute().actionGet();
+            getResult = client().prepareGet("test", "1").setStoredFields("name").get();
             assertThat(getResult.getIndex(), equalTo(getConcreteIndexName()));
             assertThat(getResult.isExists(), equalTo(true));
             assertThat(getResult.getSourceAsBytes(), nullValue());
@@ -114,7 +114,7 @@ public class DocumentActionsIT extends ESIntegTestCase {
         }
 
         logger.info("Delete [type1/1]");
-        DeleteResponse deleteResponse = client().prepareDelete("test", "1").execute().actionGet();
+        DeleteResponse deleteResponse = client().prepareDelete("test", "1").get();
         assertThat(deleteResponse.getIndex(), equalTo(getConcreteIndexName()));
         assertThat(deleteResponse.getId(), equalTo("1"));
         logger.info("Refreshing");
@@ -132,7 +132,7 @@ public class DocumentActionsIT extends ESIntegTestCase {
         client().index(new IndexRequest("test").id("2").source(source("2", "test2"))).actionGet();
 
         logger.info("Flushing");
-        FlushResponse flushResult = indicesAdmin().prepareFlush("test").execute().actionGet();
+        FlushResponse flushResult = indicesAdmin().prepareFlush("test").get();
         assertThat(flushResult.getSuccessfulShards(), equalTo(numShards.totalNumShards));
         assertThat(flushResult.getFailedShards(), equalTo(0));
         logger.info("Refreshing");
@@ -187,8 +187,7 @@ public class DocumentActionsIT extends ESIntegTestCase {
             .add(client().prepareIndex().setIndex("test").setCreate(true).setSource(source("4", "test")))
             .add(client().prepareDelete().setIndex("test").setId("1"))
             .add(client().prepareIndex().setIndex("test").setSource("{ xxx }", XContentType.JSON)) // failure
-            .execute()
-            .actionGet();
+            .get();
 
         assertThat(bulkResponse.hasFailures(), equalTo(true));
         assertThat(bulkResponse.getItems().length, equalTo(6));
@@ -223,7 +222,7 @@ public class DocumentActionsIT extends ESIntegTestCase {
         assertThat(bulkResponse.getItems()[5].getIndex(), equalTo(getConcreteIndexName()));
 
         waitForRelocation(ClusterHealthStatus.GREEN);
-        RefreshResponse refreshResponse = indicesAdmin().prepareRefresh("test").execute().actionGet();
+        RefreshResponse refreshResponse = indicesAdmin().prepareRefresh("test").get();
         assertNoFailures(refreshResponse);
         assertThat(refreshResponse.getSuccessfulShards(), equalTo(numShards.totalNumShards));
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/explain/ExplainActionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/explain/ExplainActionIT.java
@@ -295,7 +295,7 @@ public class ExplainActionIT extends ESIntegTestCase {
         refresh();
 
         TermsQueryBuilder termsLookupQuery = QueryBuilders.termsLookupQuery("user", new TermsLookup("twitter", "2", "followers"));
-        ExplainResponse response = client().prepareExplain("twitter", "1").setQuery(termsLookupQuery).execute().actionGet();
+        ExplainResponse response = client().prepareExplain("twitter", "1").setQuery(termsLookupQuery).get();
 
         Explanation explanation = response.getExplanation();
         assertNotNull(explanation);

--- a/server/src/internalClusterTest/java/org/elasticsearch/gateway/GatewayIndexStateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/gateway/GatewayIndexStateIT.java
@@ -89,11 +89,10 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
                     .endObject()
                     .endObject()
             )
-            .execute()
-            .actionGet();
+            .get();
 
         logger.info("--> verify meta _routing required exists");
-        MappingMetadata mappingMd = clusterAdmin().prepareState().execute().actionGet().getState().metadata().index("test").mapping();
+        MappingMetadata mappingMd = clusterAdmin().prepareState().get().getState().metadata().index("test").mapping();
         assertThat(mappingMd.routingRequired(), equalTo(true));
 
         logger.info("--> restarting nodes...");
@@ -103,7 +102,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         ensureYellow();
 
         logger.info("--> verify meta _routing required exists");
-        mappingMd = clusterAdmin().prepareState().execute().actionGet().getState().metadata().index("test").mapping();
+        mappingMd = clusterAdmin().prepareState().get().getState().metadata().index("test").mapping();
         assertThat(mappingMd.routingRequired(), equalTo(true));
     }
 
@@ -119,7 +118,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         logger.info("--> waiting for green status");
         ensureGreen();
 
-        ClusterStateResponse stateResponse = clusterAdmin().prepareState().execute().actionGet();
+        ClusterStateResponse stateResponse = clusterAdmin().prepareState().get();
         assertThat(stateResponse.getState().metadata().index("test").getState(), equalTo(IndexMetadata.State.OPEN));
         assertThat(stateResponse.getState().routingTable().index("test").size(), equalTo(test.numPrimaries));
         assertThat(
@@ -133,7 +132,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         logger.info("--> closing test index...");
         assertAcked(indicesAdmin().prepareClose("test"));
 
-        stateResponse = clusterAdmin().prepareState().execute().actionGet();
+        stateResponse = clusterAdmin().prepareState().get();
         assertThat(stateResponse.getState().metadata().index("test").getState(), equalTo(IndexMetadata.State.CLOSE));
         assertThat(stateResponse.getState().routingTable().index("test"), notNullValue());
 
@@ -142,14 +141,14 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
 
         logger.info("--> trying to index into a closed index ...");
         try {
-            client().prepareIndex("test").setId("1").setSource("field1", "value1").execute().actionGet();
+            client().prepareIndex("test").setId("1").setSource("field1", "value1").get();
             fail();
         } catch (IndexClosedException e) {
             // all is well
         }
 
         logger.info("--> creating another index (test2) by indexing into it");
-        client().prepareIndex("test2").setId("1").setSource("field1", "value1").execute().actionGet();
+        client().prepareIndex("test2").setId("1").setSource("field1", "value1").get();
         logger.info("--> verifying that the state is green");
         ensureGreen();
 
@@ -159,7 +158,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         logger.info("--> verifying that the state is green");
         ensureGreen();
 
-        stateResponse = clusterAdmin().prepareState().execute().actionGet();
+        stateResponse = clusterAdmin().prepareState().get();
         assertThat(stateResponse.getState().metadata().index("test").getState(), equalTo(IndexMetadata.State.OPEN));
         assertThat(stateResponse.getState().routingTable().index("test").size(), equalTo(test.numPrimaries));
         assertThat(
@@ -168,12 +167,12 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         );
 
         logger.info("--> trying to get the indexed document on the first index");
-        GetResponse getResponse = client().prepareGet("test", "1").execute().actionGet();
+        GetResponse getResponse = client().prepareGet("test", "1").get();
         assertThat(getResponse.isExists(), equalTo(true));
 
         logger.info("--> closing test index...");
         assertAcked(indicesAdmin().prepareClose("test"));
-        stateResponse = clusterAdmin().prepareState().execute().actionGet();
+        stateResponse = clusterAdmin().prepareState().get();
         assertThat(stateResponse.getState().metadata().index("test").getState(), equalTo(IndexMetadata.State.CLOSE));
         assertThat(stateResponse.getState().routingTable().index("test"), notNullValue());
 
@@ -182,25 +181,25 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         logger.info("--> waiting for two nodes and green status");
         ensureGreen();
 
-        stateResponse = clusterAdmin().prepareState().execute().actionGet();
+        stateResponse = clusterAdmin().prepareState().get();
         assertThat(stateResponse.getState().metadata().index("test").getState(), equalTo(IndexMetadata.State.CLOSE));
         assertThat(stateResponse.getState().routingTable().index("test"), notNullValue());
 
         logger.info("--> trying to index into a closed index ...");
         try {
-            client().prepareIndex("test").setId("1").setSource("field1", "value1").execute().actionGet();
+            client().prepareIndex("test").setId("1").setSource("field1", "value1").get();
             fail();
         } catch (IndexClosedException e) {
             // all is well
         }
 
         logger.info("--> opening index...");
-        indicesAdmin().prepareOpen("test").execute().actionGet();
+        indicesAdmin().prepareOpen("test").get();
 
         logger.info("--> waiting for green status");
         ensureGreen();
 
-        stateResponse = clusterAdmin().prepareState().execute().actionGet();
+        stateResponse = clusterAdmin().prepareState().get();
         assertThat(stateResponse.getState().metadata().index("test").getState(), equalTo(IndexMetadata.State.OPEN));
         assertThat(stateResponse.getState().routingTable().index("test").size(), equalTo(test.numPrimaries));
         assertThat(
@@ -209,11 +208,11 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         );
 
         logger.info("--> trying to get the indexed document on the first round (before close and shutdown)");
-        getResponse = client().prepareGet("test", "1").execute().actionGet();
+        getResponse = client().prepareGet("test", "1").get();
         assertThat(getResponse.isExists(), equalTo(true));
 
         logger.info("--> indexing a simple document");
-        client().prepareIndex("test").setId("2").setSource("field1", "value1").execute().actionGet();
+        client().prepareIndex("test").setId("2").setSource("field1", "value1").get();
     }
 
     public void testJustMasterNode() throws Exception {
@@ -223,7 +222,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         internalCluster().startNode(nonDataNode());
 
         logger.info("--> create an index");
-        indicesAdmin().prepareCreate("test").setWaitForActiveShards(ActiveShardCount.NONE).execute().actionGet();
+        indicesAdmin().prepareCreate("test").setWaitForActiveShards(ActiveShardCount.NONE).get();
 
         logger.info("--> restarting master node");
         internalCluster().fullRestart(new RestartCallback() {
@@ -234,15 +233,11 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         });
 
         logger.info("--> waiting for test index to be created");
-        ClusterHealthResponse health = clusterAdmin().prepareHealth()
-            .setWaitForEvents(Priority.LANGUID)
-            .setIndices("test")
-            .execute()
-            .actionGet();
+        ClusterHealthResponse health = clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setIndices("test").get();
         assertThat(health.isTimedOut(), equalTo(false));
 
         logger.info("--> verify we have an index");
-        ClusterStateResponse clusterStateResponse = clusterAdmin().prepareState().setIndices("test").execute().actionGet();
+        ClusterStateResponse clusterStateResponse = clusterAdmin().prepareState().setIndices("test").get();
         assertThat(clusterStateResponse.getState().metadata().hasIndex("test"), equalTo(true));
     }
 
@@ -254,9 +249,9 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         internalCluster().startDataOnlyNode();
 
         logger.info("--> create an index");
-        indicesAdmin().prepareCreate("test").execute().actionGet();
+        indicesAdmin().prepareCreate("test").get();
 
-        client().prepareIndex("test").setSource("field1", "value1").execute().actionGet();
+        client().prepareIndex("test").setSource("field1", "value1").get();
     }
 
     public void testTwoNodesSingleDoc() throws Exception {
@@ -273,8 +268,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
             .setWaitForNodes("2")
-            .execute()
-            .actionGet();
+            .get();
         assertThat(health.isTimedOut(), equalTo(false));
 
         logger.info("--> verify 1 doc in the index");
@@ -285,20 +279,15 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         logger.info("--> closing test index...");
         assertAcked(indicesAdmin().prepareClose("test"));
 
-        ClusterStateResponse stateResponse = clusterAdmin().prepareState().execute().actionGet();
+        ClusterStateResponse stateResponse = clusterAdmin().prepareState().get();
         assertThat(stateResponse.getState().metadata().index("test").getState(), equalTo(IndexMetadata.State.CLOSE));
         assertThat(stateResponse.getState().routingTable().index("test"), notNullValue());
 
         logger.info("--> opening the index...");
-        indicesAdmin().prepareOpen("test").execute().actionGet();
+        indicesAdmin().prepareOpen("test").get();
 
         logger.info("--> waiting for green status");
-        health = clusterAdmin().prepareHealth()
-            .setWaitForEvents(Priority.LANGUID)
-            .setWaitForGreenStatus()
-            .setWaitForNodes("2")
-            .execute()
-            .actionGet();
+        health = clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().setWaitForNodes("2").get();
         assertThat(health.isTimedOut(), equalTo(false));
 
         logger.info("--> verify 1 doc in the index");
@@ -339,7 +328,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
                 final String otherNode = nodes.get(0);
                 logger.info("--> delete index and verify it is deleted");
                 final Client client = client(otherNode);
-                client.admin().indices().prepareDelete(indexName).execute().actionGet();
+                client.admin().indices().prepareDelete(indexName).get();
                 assertFalse(indexExists(indexName, client));
                 logger.info("--> index deleted");
                 return super.onNodeStopped(nodeName);

--- a/server/src/internalClusterTest/java/org/elasticsearch/gateway/RecoverAfterNodesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/gateway/RecoverAfterNodesIT.java
@@ -37,8 +37,7 @@ public class RecoverAfterNodesIT extends ESIntegTestCase {
                 .cluster()
                 .prepareState()
                 .setLocal(true)
-                .execute()
-                .actionGet()
+                .get()
                 .getState()
                 .blocks()
                 .global(ClusterBlockLevel.METADATA_WRITE);
@@ -56,81 +55,33 @@ public class RecoverAfterNodesIT extends ESIntegTestCase {
         logger.info("--> start master_node (1)");
         Client master1 = startNode(Settings.builder().put(RECOVER_AFTER_DATA_NODES_SETTING.getKey(), 2).put(masterOnlyNode()));
         assertThat(
-            master1.admin()
-                .cluster()
-                .prepareState()
-                .setLocal(true)
-                .execute()
-                .actionGet()
-                .getState()
-                .blocks()
-                .global(ClusterBlockLevel.METADATA_WRITE),
+            master1.admin().cluster().prepareState().setLocal(true).get().getState().blocks().global(ClusterBlockLevel.METADATA_WRITE),
             hasItem(GatewayService.STATE_NOT_RECOVERED_BLOCK)
         );
 
         logger.info("--> start data_node (1)");
         Client data1 = startNode(Settings.builder().put(RECOVER_AFTER_DATA_NODES_SETTING.getKey(), 2).put(dataOnlyNode()));
         assertThat(
-            master1.admin()
-                .cluster()
-                .prepareState()
-                .setLocal(true)
-                .execute()
-                .actionGet()
-                .getState()
-                .blocks()
-                .global(ClusterBlockLevel.METADATA_WRITE),
+            master1.admin().cluster().prepareState().setLocal(true).get().getState().blocks().global(ClusterBlockLevel.METADATA_WRITE),
             hasItem(GatewayService.STATE_NOT_RECOVERED_BLOCK)
         );
         assertThat(
-            data1.admin()
-                .cluster()
-                .prepareState()
-                .setLocal(true)
-                .execute()
-                .actionGet()
-                .getState()
-                .blocks()
-                .global(ClusterBlockLevel.METADATA_WRITE),
+            data1.admin().cluster().prepareState().setLocal(true).get().getState().blocks().global(ClusterBlockLevel.METADATA_WRITE),
             hasItem(GatewayService.STATE_NOT_RECOVERED_BLOCK)
         );
 
         logger.info("--> start master_node (2)");
         Client master2 = startNode(Settings.builder().put(RECOVER_AFTER_DATA_NODES_SETTING.getKey(), 2).put(masterOnlyNode()));
         assertThat(
-            master2.admin()
-                .cluster()
-                .prepareState()
-                .setLocal(true)
-                .execute()
-                .actionGet()
-                .getState()
-                .blocks()
-                .global(ClusterBlockLevel.METADATA_WRITE),
+            master2.admin().cluster().prepareState().setLocal(true).get().getState().blocks().global(ClusterBlockLevel.METADATA_WRITE),
             hasItem(GatewayService.STATE_NOT_RECOVERED_BLOCK)
         );
         assertThat(
-            data1.admin()
-                .cluster()
-                .prepareState()
-                .setLocal(true)
-                .execute()
-                .actionGet()
-                .getState()
-                .blocks()
-                .global(ClusterBlockLevel.METADATA_WRITE),
+            data1.admin().cluster().prepareState().setLocal(true).get().getState().blocks().global(ClusterBlockLevel.METADATA_WRITE),
             hasItem(GatewayService.STATE_NOT_RECOVERED_BLOCK)
         );
         assertThat(
-            master2.admin()
-                .cluster()
-                .prepareState()
-                .setLocal(true)
-                .execute()
-                .actionGet()
-                .getState()
-                .blocks()
-                .global(ClusterBlockLevel.METADATA_WRITE),
+            master2.admin().cluster().prepareState().setLocal(true).get().getState().blocks().global(ClusterBlockLevel.METADATA_WRITE),
             hasItem(GatewayService.STATE_NOT_RECOVERED_BLOCK)
         );
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/gateway/RecoveryFromGatewayIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/gateway/RecoveryFromGatewayIT.java
@@ -99,28 +99,23 @@ public class RecoveryFromGatewayIT extends ESIntegTestCase {
         client().prepareIndex("test")
             .setId("10990239")
             .setSource(jsonBuilder().startObject().startArray("appAccountIds").value(14).value(179).endArray().endObject())
-            .execute()
-            .actionGet();
+            .get();
         client().prepareIndex("test")
             .setId("10990473")
             .setSource(jsonBuilder().startObject().startArray("appAccountIds").value(14).endArray().endObject())
-            .execute()
-            .actionGet();
+            .get();
         client().prepareIndex("test")
             .setId("10990513")
             .setSource(jsonBuilder().startObject().startArray("appAccountIds").value(14).value(179).endArray().endObject())
-            .execute()
-            .actionGet();
+            .get();
         client().prepareIndex("test")
             .setId("10990695")
             .setSource(jsonBuilder().startObject().startArray("appAccountIds").value(14).endArray().endObject())
-            .execute()
-            .actionGet();
+            .get();
         client().prepareIndex("test")
             .setId("11026351")
             .setSource(jsonBuilder().startObject().startArray("appAccountIds").value(14).endArray().endObject())
-            .execute()
-            .actionGet();
+            .get();
 
         refresh();
         assertHitCount(prepareSearch().setSize(0).setQuery(termQuery("appAccountIds", 179)), 2);
@@ -134,7 +129,7 @@ public class RecoveryFromGatewayIT extends ESIntegTestCase {
         ensureYellow();
         primaryTerms = assertAndCapturePrimaryTerms(primaryTerms);
 
-        indicesAdmin().prepareRefresh().execute().actionGet();
+        indicesAdmin().prepareRefresh().get();
         assertHitCount(prepareSearch().setSize(0).setQuery(termQuery("appAccountIds", 179)), 2);
 
         internalCluster().fullRestart();
@@ -143,7 +138,7 @@ public class RecoveryFromGatewayIT extends ESIntegTestCase {
         ensureYellow();
         primaryTerms = assertAndCapturePrimaryTerms(primaryTerms);
 
-        indicesAdmin().prepareRefresh().execute().actionGet();
+        indicesAdmin().prepareRefresh().get();
         assertHitCount(prepareSearch().setSize(0).setQuery(termQuery("appAccountIds", 179)), 2);
     }
 
@@ -275,17 +270,9 @@ public class RecoveryFromGatewayIT extends ESIntegTestCase {
 
     public void testSingleNodeWithFlush() throws Exception {
         internalCluster().startNode();
-        client().prepareIndex("test")
-            .setId("1")
-            .setSource(jsonBuilder().startObject().field("field", "value1").endObject())
-            .execute()
-            .actionGet();
+        client().prepareIndex("test").setId("1").setSource(jsonBuilder().startObject().field("field", "value1").endObject()).get();
         flush();
-        client().prepareIndex("test")
-            .setId("2")
-            .setSource(jsonBuilder().startObject().field("field", "value2").endObject())
-            .execute()
-            .actionGet();
+        client().prepareIndex("test").setId("2").setSource(jsonBuilder().startObject().field("field", "value2").endObject()).get();
         refresh();
 
         assertHitCount(prepareSearch().setSize(0).setQuery(matchAllQuery()), 2);
@@ -320,17 +307,9 @@ public class RecoveryFromGatewayIT extends ESIntegTestCase {
         final String firstNode = internalCluster().startNode();
         internalCluster().startNode();
 
-        client().prepareIndex("test")
-            .setId("1")
-            .setSource(jsonBuilder().startObject().field("field", "value1").endObject())
-            .execute()
-            .actionGet();
+        client().prepareIndex("test").setId("1").setSource(jsonBuilder().startObject().field("field", "value1").endObject()).get();
         flush();
-        client().prepareIndex("test")
-            .setId("2")
-            .setSource(jsonBuilder().startObject().field("field", "value2").endObject())
-            .execute()
-            .actionGet();
+        client().prepareIndex("test").setId("2").setSource(jsonBuilder().startObject().field("field", "value2").endObject()).get();
         refresh();
 
         logger.info("Running Cluster Health (wait for the shards to startup)");
@@ -378,18 +357,10 @@ public class RecoveryFromGatewayIT extends ESIntegTestCase {
         Settings node2DataPathSettings = internalCluster().dataPathSettings(nodes.get(1));
 
         assertAcked(indicesAdmin().prepareCreate("test"));
-        client().prepareIndex("test")
-            .setId("1")
-            .setSource(jsonBuilder().startObject().field("field", "value1").endObject())
-            .execute()
-            .actionGet();
-        indicesAdmin().prepareFlush().execute().actionGet();
-        client().prepareIndex("test")
-            .setId("2")
-            .setSource(jsonBuilder().startObject().field("field", "value2").endObject())
-            .execute()
-            .actionGet();
-        indicesAdmin().prepareRefresh().execute().actionGet();
+        client().prepareIndex("test").setId("1").setSource(jsonBuilder().startObject().field("field", "value1").endObject()).get();
+        indicesAdmin().prepareFlush().get();
+        client().prepareIndex("test").setId("2").setSource(jsonBuilder().startObject().field("field", "value2").endObject()).get();
+        indicesAdmin().prepareRefresh().get();
 
         logger.info("--> running cluster_health (wait for the shards to startup)");
         ensureGreen();
@@ -405,16 +376,12 @@ public class RecoveryFromGatewayIT extends ESIntegTestCase {
         internalCluster().stopRandomDataNode();
 
         logger.info("--> one node is closed - start indexing data into the second one");
-        client().prepareIndex("test")
-            .setId("3")
-            .setSource(jsonBuilder().startObject().field("field", "value3").endObject())
-            .execute()
-            .actionGet();
+        client().prepareIndex("test").setId("3").setSource(jsonBuilder().startObject().field("field", "value3").endObject()).get();
         // TODO: remove once refresh doesn't fail immediately if there a master block:
         // https://github.com/elastic/elasticsearch/issues/9997
         // clusterAdmin().prepareHealth("test").setWaitForYellowStatus().get();
         logger.info("--> refreshing all indices after indexing is complete");
-        indicesAdmin().prepareRefresh().execute().actionGet();
+        indicesAdmin().prepareRefresh().get();
 
         logger.info("--> checking if documents exist, there should be 3");
         for (int i = 0; i < 10; i++) {
@@ -442,9 +409,8 @@ public class RecoveryFromGatewayIT extends ESIntegTestCase {
                     .endObject()
                     .endObject()
             )
-            .execute()
-            .actionGet();
-        indicesAdmin().prepareAliases().addAlias("test", "test_alias", QueryBuilders.termQuery("field", "value")).execute().actionGet();
+            .get();
+        indicesAdmin().prepareAliases().addAlias("test", "test_alias", QueryBuilders.termQuery("field", "value")).get();
 
         logger.info("--> stopping the second node");
         internalCluster().stopRandomDataNode();
@@ -465,7 +431,7 @@ public class RecoveryFromGatewayIT extends ESIntegTestCase {
             assertHitCount(prepareSearch().setSize(0).setQuery(matchAllQuery()), 3);
         }
 
-        ClusterState state = clusterAdmin().prepareState().execute().actionGet().getState();
+        ClusterState state = clusterAdmin().prepareState().get().getState();
         assertThat(state.metadata().templates().get("template_1").patterns(), equalTo(Collections.singletonList("te*")));
         assertThat(state.metadata().index("test").getAliases().get("test_alias"), notNullValue());
         assertThat(state.metadata().index("test").getAliases().get("test_alias").filter(), notNullValue());
@@ -495,7 +461,7 @@ public class RecoveryFromGatewayIT extends ESIntegTestCase {
         logger.info("--> indexing docs");
         int numDocs = randomIntBetween(1, 1024);
         for (int i = 0; i < numDocs; i++) {
-            client(primaryNode).prepareIndex("test").setSource("field", "value").execute().actionGet();
+            client(primaryNode).prepareIndex("test").setSource("field", "value").get();
         }
 
         client(primaryNode).admin().indices().prepareFlush("test").setForce(true).get();
@@ -528,7 +494,7 @@ public class RecoveryFromGatewayIT extends ESIntegTestCase {
             public Settings onNodeStopped(String nodeName) throws Exception {
                 // index some more documents; we expect to reuse the files that already exist on the replica
                 for (int i = 0; i < moreDocs; i++) {
-                    client(primaryNode).prepareIndex("test").setSource("field", "value").execute().actionGet();
+                    client(primaryNode).prepareIndex("test").setSource("field", "value").get();
                 }
 
                 // prevent a sequence-number-based recovery from being possible

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/engine/InternalEngineMergeIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/engine/InternalEngineMergeIT.java
@@ -41,7 +41,7 @@ public class InternalEngineMergeIT extends ESIntegTestCase {
                         .source(jsonBuilder().startObject().field("l", randomLong()).endObject())
                 );
             }
-            BulkResponse response = request.execute().actionGet();
+            BulkResponse response = request.get();
             refresh();
             assertNoFailures(response);
             IndicesStatsResponse stats = indicesAdmin().prepareStats("test").setSegments(true).setMerge(true).get();

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/mapper/CopyToMapperIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/mapper/CopyToMapperIntegrationIT.java
@@ -34,7 +34,7 @@ public class CopyToMapperIntegrationIT extends ESIntegTestCase {
         for (int i = 0; i < recordCount * 2; i++) {
             client().prepareIndex("test-idx").setId(Integer.toString(i)).setSource("test_field", "test " + i, "even", i % 2 == 0).get();
         }
-        indicesAdmin().prepareRefresh("test-idx").execute().actionGet();
+        indicesAdmin().prepareRefresh("test-idx").get();
 
         SubAggCollectionMode aggCollectionMode = randomFrom(SubAggCollectionMode.values());
 
@@ -43,8 +43,7 @@ public class CopyToMapperIntegrationIT extends ESIntegTestCase {
             .addAggregation(
                 AggregationBuilders.terms("test_raw").field("test_field_raw").size(recordCount * 2).collectMode(aggCollectionMode)
             )
-            .execute()
-            .actionGet();
+            .get();
 
         assertThat(response.getHits().getTotalHits().value, equalTo((long) recordCount));
 
@@ -66,7 +65,7 @@ public class CopyToMapperIntegrationIT extends ESIntegTestCase {
         );
         assertAcked(indicesAdmin().prepareCreate("test-idx").setMapping(mapping));
         client().prepareIndex("test-idx").setId("1").setSource("foo", "bar").get();
-        indicesAdmin().prepareRefresh("test-idx").execute().actionGet();
+        indicesAdmin().prepareRefresh("test-idx").get();
         assertHitCount(prepareSearch("test-idx").setQuery(QueryBuilders.termQuery("root.top.child", "bar")), 1L);
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/store/CorruptedFileIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/store/CorruptedFileIT.java
@@ -406,7 +406,7 @@ public class CorruptedFileIT extends ESIntegTestCase {
         }
         indexRandom(true, builders);
         ensureGreen();
-        assertAllSuccessful(indicesAdmin().prepareFlush().setForce(true).execute().actionGet());
+        assertAllSuccessful(indicesAdmin().prepareFlush().setForce(true).get());
         // we have to flush at least once here since we don't corrupt the translog
         assertHitCount(prepareSearch().setSize(0), numDocs);
 
@@ -545,7 +545,7 @@ public class CorruptedFileIT extends ESIntegTestCase {
         }
         indexRandom(true, builders);
         ensureGreen();
-        assertAllSuccessful(indicesAdmin().prepareFlush().setForce(true).execute().actionGet());
+        assertAllSuccessful(indicesAdmin().prepareFlush().setForce(true).get());
         // we have to flush at least once here since we don't corrupt the translog
         assertHitCount(prepareSearch().setSize(0), numDocs);
 
@@ -612,7 +612,7 @@ public class CorruptedFileIT extends ESIntegTestCase {
         }
         indexRandom(true, builders);
         ensureGreen();
-        assertAllSuccessful(indicesAdmin().prepareFlush().setForce(true).execute().actionGet());
+        assertAllSuccessful(indicesAdmin().prepareFlush().setForce(true).get());
         // we have to flush at least once here since we don't corrupt the translog
         assertHitCount(prepareSearch().setSize(0), numDocs);
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/suggest/stats/SuggestStatsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/suggest/stats/SuggestStatsIT.java
@@ -42,7 +42,7 @@ public class SuggestStatsIT extends ESIntegTestCase {
 
     public void testSimpleStats() throws Exception {
         // clear all stats first
-        indicesAdmin().prepareStats().clear().execute().actionGet();
+        indicesAdmin().prepareStats().clear().get();
         final int numNodes = cluster().numDataNodes();
         assertThat(numNodes, greaterThanOrEqualTo(2));
         final int shardsIdx1 = randomIntBetween(1, 10); // we make sure each node gets at least a single shard...
@@ -79,7 +79,7 @@ public class SuggestStatsIT extends ESIntegTestCase {
         }
         long endTime = System.currentTimeMillis();
 
-        IndicesStatsResponse indicesStats = indicesAdmin().prepareStats().execute().actionGet();
+        IndicesStatsResponse indicesStats = indicesAdmin().prepareStats().get();
         final SearchStats.Stats suggest = indicesStats.getTotal().getSearch().getTotal();
 
         // check current
@@ -105,7 +105,7 @@ public class SuggestStatsIT extends ESIntegTestCase {
         // the upperbound is num shards * total time since we do searches in parallel
         assertThat(suggest.getSuggestTimeInMillis(), lessThanOrEqualTo(totalShards * (endTime - startTime)));
 
-        NodesStatsResponse nodeStats = clusterAdmin().prepareNodesStats().execute().actionGet();
+        NodesStatsResponse nodeStats = clusterAdmin().prepareNodesStats().get();
         Set<String> nodeIdsWithIndex = nodeIdsWithIndex("test1", "test2");
         int num = 0;
         for (NodeStats stat : nodeStats.getNodes()) {
@@ -138,7 +138,7 @@ public class SuggestStatsIT extends ESIntegTestCase {
     }
 
     private Set<String> nodeIdsWithIndex(String... indices) {
-        ClusterState state = clusterAdmin().prepareState().execute().actionGet().getState();
+        ClusterState state = clusterAdmin().prepareState().get().getState();
         GroupShardsIterator<ShardIterator> allAssignedShardsGrouped = state.routingTable().allAssignedShardsGrouped(indices, true);
         Set<String> nodes = new HashSet<>();
         for (ShardIterator shardIterator : allAssignedShardsGrouped) {
@@ -153,7 +153,7 @@ public class SuggestStatsIT extends ESIntegTestCase {
     }
 
     protected int numAssignedShards(String... indices) {
-        ClusterState state = clusterAdmin().prepareState().execute().actionGet().getState();
+        ClusterState state = clusterAdmin().prepareState().get().getState();
         GroupShardsIterator<?> allAssignedShardsGrouped = state.routingTable().allAssignedShardsGrouped(indices, true);
         return allAssignedShardsGrouped.size();
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/indexing/IndexActionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indexing/IndexActionIT.java
@@ -103,15 +103,15 @@ public class IndexActionIT extends ESIntegTestCase {
         createIndex("test");
         ensureGreen();
 
-        DocWriteResponse indexResponse = client().prepareIndex("test").setId("1").setSource("field1", "value1_1").execute().actionGet();
+        DocWriteResponse indexResponse = client().prepareIndex("test").setId("1").setSource("field1", "value1_1").get();
         assertEquals(DocWriteResponse.Result.CREATED, indexResponse.getResult());
 
-        indexResponse = client().prepareIndex("test").setId("1").setSource("field1", "value1_2").execute().actionGet();
+        indexResponse = client().prepareIndex("test").setId("1").setSource("field1", "value1_2").get();
         assertEquals(DocWriteResponse.Result.UPDATED, indexResponse.getResult());
 
-        client().prepareDelete("test", "1").execute().actionGet();
+        client().prepareDelete("test", "1").get();
 
-        indexResponse = client().prepareIndex("test").setId("1").setSource("field1", "value1_2").execute().actionGet();
+        indexResponse = client().prepareIndex("test").setId("1").setSource("field1", "value1_2").get();
         assertEquals(DocWriteResponse.Result.CREATED, indexResponse.getResult());
 
     }
@@ -120,14 +120,14 @@ public class IndexActionIT extends ESIntegTestCase {
         createIndex("test");
         ensureGreen();
 
-        DocWriteResponse indexResponse = client().prepareIndex("test").setId("1").setSource("field1", "value1_1").execute().actionGet();
+        DocWriteResponse indexResponse = client().prepareIndex("test").setId("1").setSource("field1", "value1_1").get();
         assertEquals(DocWriteResponse.Result.CREATED, indexResponse.getResult());
 
-        client().prepareDelete("test", "1").execute().actionGet();
+        client().prepareDelete("test", "1").get();
 
         flush();
 
-        indexResponse = client().prepareIndex("test").setId("1").setSource("field1", "value1_2").execute().actionGet();
+        indexResponse = client().prepareIndex("test").setId("1").setSource("field1", "value1_2").get();
         assertEquals(DocWriteResponse.Result.CREATED, indexResponse.getResult());
     }
 
@@ -174,8 +174,7 @@ public class IndexActionIT extends ESIntegTestCase {
             .setSource("field1", "value1_1")
             .setVersion(123)
             .setVersionType(VersionType.EXTERNAL)
-            .execute()
-            .actionGet();
+            .get();
         assertEquals(DocWriteResponse.Result.CREATED, indexResponse.getResult());
     }
 
@@ -185,8 +184,7 @@ public class IndexActionIT extends ESIntegTestCase {
 
         BulkResponse bulkResponse = client().prepareBulk()
             .add(client().prepareIndex("test").setId("1").setSource("field1", "value1_1"))
-            .execute()
-            .actionGet();
+            .get();
         assertThat(bulkResponse.hasFailures(), equalTo(false));
         assertThat(bulkResponse.getItems().length, equalTo(1));
         IndexResponse indexResponse = bulkResponse.getItems()[0].getResponse();
@@ -264,7 +262,7 @@ public class IndexActionIT extends ESIntegTestCase {
 
     public void testDocumentWithBlankFieldName() {
         Exception e = expectThrows(DocumentParsingException.class, () -> {
-            client().prepareIndex("test").setId("1").setSource("", "value1_2").execute().actionGet();
+            client().prepareIndex("test").setId("1").setSource("", "value1_2").get();
         });
         assertThat(e.getMessage(), containsString("failed to parse"));
         assertThat(e.getCause().getMessage(), containsString("field name cannot be an empty string"));

--- a/server/src/internalClusterTest/java/org/elasticsearch/indexlifecycle/IndexLifecycleActionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indexlifecycle/IndexLifecycleActionIT.java
@@ -79,7 +79,7 @@ public class IndexLifecycleActionIT extends ESIntegTestCase {
         final String node2 = getLocalNodeId(server_2);
 
         // explicitly call reroute, so shards will get relocated to the new node (we delay it in ES in case other nodes join)
-        clusterAdmin().prepareReroute().execute().actionGet();
+        clusterAdmin().prepareReroute().get();
 
         clusterHealth = clusterAdmin().health(
             new ClusterHealthRequest(new String[] {}).waitForGreenStatus().waitForNodes("2").waitForNoRelocatingShards(true)
@@ -120,7 +120,7 @@ public class IndexLifecycleActionIT extends ESIntegTestCase {
         final String node3 = getLocalNodeId(server_3);
 
         // explicitly call reroute, so shards will get relocated to the new node (we delay it in ES in case other nodes join)
-        clusterAdmin().prepareReroute().execute().actionGet();
+        clusterAdmin().prepareReroute().get();
 
         clusterHealth = clusterAdmin().prepareHealth()
             .setWaitForGreenStatus()
@@ -203,7 +203,7 @@ public class IndexLifecycleActionIT extends ESIntegTestCase {
 
         logger.info("Deleting index [test]");
         // last, lets delete the index
-        AcknowledgedResponse deleteIndexResponse = indicesAdmin().prepareDelete("test").execute().actionGet();
+        AcknowledgedResponse deleteIndexResponse = indicesAdmin().prepareDelete("test").get();
         assertThat(deleteIndexResponse.isAcknowledged(), equalTo(true));
 
         clusterState = clusterAdmin().prepareState().get().getState();

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/IndexingMemoryControllerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/IndexingMemoryControllerIT.java
@@ -99,7 +99,7 @@ public class IndexingMemoryControllerIT extends ESSingleNodeTestCase {
             client().prepareIndex("index").setId(Integer.toString(i)).setSource("field", "value").get();
         }
         // Force merge so we know all merges are done before we start deleting:
-        ForceMergeResponse r = client().admin().indices().prepareForceMerge().setMaxNumSegments(1).execute().actionGet();
+        ForceMergeResponse r = client().admin().indices().prepareForceMerge().setMaxNumSegments(1).get();
         assertNoFailures(r);
         final RefreshStats refreshStats = shard.refreshStats();
         for (int i = 0; i < 100; i++) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/IndicesOptionsIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/IndicesOptionsIntegrationIT.java
@@ -403,12 +403,12 @@ public class IndicesOptionsIntegrationIT extends ESIntegTestCase {
 
     public void testAllMissingStrict() throws Exception {
         createIndex("test1");
-        expectThrows(IndexNotFoundException.class, () -> prepareSearch("test2").setQuery(matchAllQuery()).execute().actionGet());
+        expectThrows(IndexNotFoundException.class, () -> prepareSearch("test2").setQuery(matchAllQuery()).get());
 
-        expectThrows(IndexNotFoundException.class, () -> prepareSearch("test2", "test3").setQuery(matchAllQuery()).execute().actionGet());
+        expectThrows(IndexNotFoundException.class, () -> prepareSearch("test2", "test3").setQuery(matchAllQuery()).get());
 
         // you should still be able to run empty searches without things blowing up
-        prepareSearch().setQuery(matchAllQuery()).execute().actionGet();
+        prepareSearch().setQuery(matchAllQuery()).get();
     }
 
     // For now don't handle closed indices

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/analysis/PreBuiltAnalyzerIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/analysis/PreBuiltAnalyzerIntegrationIT.java
@@ -86,7 +86,7 @@ public class PreBuiltAnalyzerIntegrationIT extends ESIntegTestCase {
         int amountOfIndicesToClose = randomInt(numIndices - 1);
         for (int i = 0; i < amountOfIndicesToClose; i++) {
             String indexName = indexNames.get(i);
-            indicesAdmin().prepareClose(indexName).execute().actionGet();
+            indicesAdmin().prepareClose(indexName).get();
         }
 
         ensureGreen();

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/mapping/SimpleGetMappingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/mapping/SimpleGetMappingsIT.java
@@ -41,7 +41,7 @@ public class SimpleGetMappingsIT extends ESIntegTestCase {
 
     public void testGetMappingsWhereThereAreNone() {
         createIndex("index");
-        GetMappingsResponse response = indicesAdmin().prepareGetMappings().execute().actionGet();
+        GetMappingsResponse response = indicesAdmin().prepareGetMappings().get();
         assertThat(response.mappings().containsKey("index"), equalTo(true));
         assertEquals(MappingMetadata.EMPTY_MAPPINGS, response.mappings().get("index"));
     }
@@ -59,42 +59,41 @@ public class SimpleGetMappingsIT extends ESIntegTestCase {
     }
 
     public void testSimpleGetMappings() throws Exception {
-        indicesAdmin().prepareCreate("indexa").setMapping(getMappingForType()).execute().actionGet();
-        indicesAdmin().prepareCreate("indexb").setMapping(getMappingForType()).execute().actionGet();
+        indicesAdmin().prepareCreate("indexa").setMapping(getMappingForType()).get();
+        indicesAdmin().prepareCreate("indexb").setMapping(getMappingForType()).get();
 
         ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
-            .execute()
-            .actionGet();
+            .get();
         assertThat(clusterHealth.isTimedOut(), equalTo(false));
 
         // Get all mappings
-        GetMappingsResponse response = indicesAdmin().prepareGetMappings().execute().actionGet();
+        GetMappingsResponse response = indicesAdmin().prepareGetMappings().get();
         assertThat(response.mappings().size(), equalTo(2));
         assertThat(response.mappings().get("indexa"), notNullValue());
         assertThat(response.mappings().get("indexb"), notNullValue());
 
         // Get all mappings, via wildcard support
-        response = indicesAdmin().prepareGetMappings("*").execute().actionGet();
+        response = indicesAdmin().prepareGetMappings("*").get();
         assertThat(response.mappings().size(), equalTo(2));
         assertThat(response.mappings().get("indexa"), notNullValue());
         assertThat(response.mappings().get("indexb"), notNullValue());
 
         // Get mappings in indexa
-        response = indicesAdmin().prepareGetMappings("indexa").execute().actionGet();
+        response = indicesAdmin().prepareGetMappings("indexa").get();
         assertThat(response.mappings().size(), equalTo(1));
         assertThat(response.mappings().get("indexa"), notNullValue());
     }
 
     public void testGetMappingsWithBlocks() throws IOException {
-        indicesAdmin().prepareCreate("test").setMapping(getMappingForType()).execute().actionGet();
+        indicesAdmin().prepareCreate("test").setMapping(getMappingForType()).get();
         ensureGreen();
 
         for (String block : Arrays.asList(SETTING_BLOCKS_READ, SETTING_BLOCKS_WRITE, SETTING_READ_ONLY)) {
             try {
                 enableIndexBlock("test", block);
-                GetMappingsResponse response = indicesAdmin().prepareGetMappings().execute().actionGet();
+                GetMappingsResponse response = indicesAdmin().prepareGetMappings().get();
                 assertThat(response.mappings().size(), equalTo(1));
                 assertNotNull(response.mappings().get("test"));
             } finally {

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/mapping/UpdateMappingIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/mapping/UpdateMappingIntegrationIT.java
@@ -62,9 +62,8 @@ public class UpdateMappingIntegrationIT extends ESIntegTestCase {
     public void testDynamicUpdates() throws Exception {
         indicesAdmin().prepareCreate("test")
             .setSettings(indexSettings(1, 0).put(MapperService.INDEX_MAPPING_TOTAL_FIELDS_LIMIT_SETTING.getKey(), Long.MAX_VALUE))
-            .execute()
-            .actionGet();
-        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+            .get();
+        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
         updateClusterSettings(
             Settings.builder().put(MappingUpdatedAction.INDICES_MAPPING_DYNAMIC_TIMEOUT_SETTING.getKey(), TimeValue.timeValueMinutes(5))
         );
@@ -84,9 +83,9 @@ public class UpdateMappingIntegrationIT extends ESIntegTestCase {
         indexRandom(true, false, indexRequests);
 
         logger.info("checking all the documents are there");
-        RefreshResponse refreshResponse = indicesAdmin().prepareRefresh().execute().actionGet();
+        RefreshResponse refreshResponse = indicesAdmin().prepareRefresh().get();
         assertThat(refreshResponse.getFailedShards(), equalTo(0));
-        SearchResponse response = prepareSearch("test").setSize(0).execute().actionGet();
+        SearchResponse response = prepareSearch("test").setSize(0).get();
         assertThat(response.getHits().getTotalHits().value, equalTo((long) recCount));
 
         logger.info("checking all the fields are in the mappings");
@@ -103,30 +102,30 @@ public class UpdateMappingIntegrationIT extends ESIntegTestCase {
     public void testUpdateMappingWithoutType() {
         indicesAdmin().prepareCreate("test").setSettings(indexSettings(1, 0)).setMapping("""
             {"properties":{"body":{"type":"text"}}}
-            """).execute().actionGet();
-        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+            """).get();
+        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
 
         AcknowledgedResponse putMappingResponse = indicesAdmin().preparePutMapping("test").setSource("""
             {"properties":{"date":{"type":"integer"}}}
-            """, XContentType.JSON).execute().actionGet();
+            """, XContentType.JSON).get();
 
         assertThat(putMappingResponse.isAcknowledged(), equalTo(true));
 
-        GetMappingsResponse getMappingsResponse = indicesAdmin().prepareGetMappings("test").execute().actionGet();
+        GetMappingsResponse getMappingsResponse = indicesAdmin().prepareGetMappings("test").get();
         assertThat(getMappingsResponse.mappings().get("test").source().toString(), equalTo("""
             {"_doc":{"properties":{"body":{"type":"text"},"date":{"type":"integer"}}}}"""));
     }
 
     public void testUpdateMappingWithoutTypeMultiObjects() {
         createIndex("test", 1, 0);
-        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
 
         AcknowledgedResponse putMappingResponse = indicesAdmin().preparePutMapping("test").setSource("""
-            {"properties":{"date":{"type":"integer"}}}""", XContentType.JSON).execute().actionGet();
+            {"properties":{"date":{"type":"integer"}}}""", XContentType.JSON).get();
 
         assertThat(putMappingResponse.isAcknowledged(), equalTo(true));
 
-        GetMappingsResponse getMappingsResponse = indicesAdmin().prepareGetMappings("test").execute().actionGet();
+        GetMappingsResponse getMappingsResponse = indicesAdmin().prepareGetMappings("test").get();
         assertThat(getMappingsResponse.mappings().get("test").source().toString(), equalTo("""
             {"_doc":{"properties":{"date":{"type":"integer"}}}}"""));
     }
@@ -134,13 +133,13 @@ public class UpdateMappingIntegrationIT extends ESIntegTestCase {
     public void testUpdateMappingWithConflicts() {
         indicesAdmin().prepareCreate("test").setSettings(indexSettings(2, 0)).setMapping("""
             {"properties":{"body":{"type":"text"}}}
-            """).execute().actionGet();
-        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+            """).get();
+        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
 
         try {
             indicesAdmin().preparePutMapping("test").setSource("""
                 {"_doc":{"properties":{"body":{"type":"integer"}}}}
-                """, XContentType.JSON).execute().actionGet();
+                """, XContentType.JSON).get();
             fail("Expected MergeMappingException");
         } catch (IllegalArgumentException e) {
             assertThat(e.getMessage(), containsString("mapper [body] cannot be changed from type [text] to [integer]"));
@@ -150,11 +149,11 @@ public class UpdateMappingIntegrationIT extends ESIntegTestCase {
     public void testUpdateMappingWithNormsConflicts() {
         indicesAdmin().prepareCreate("test").setMapping("""
             {"properties":{"body":{"type":"text", "norms": false }}}
-            """).execute().actionGet();
+            """).get();
         try {
             indicesAdmin().preparePutMapping("test").setSource("""
                 {"_doc":{"properties":{"body":{"type":"text", "norms": true }}}}
-                """, XContentType.JSON).execute().actionGet();
+                """, XContentType.JSON).get();
             fail("Expected MergeMappingException");
         } catch (IllegalArgumentException e) {
             assertThat(e.getMessage(), containsString("Cannot update parameter [norms] from [false] to [true]"));
@@ -166,12 +165,12 @@ public class UpdateMappingIntegrationIT extends ESIntegTestCase {
      */
     public void testUpdateMappingNoChanges() {
         indicesAdmin().prepareCreate("test").setSettings(indexSettings(2, 0)).setMapping("""
-            {"properties":{"body":{"type":"text"}}}""").execute().actionGet();
-        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+            {"properties":{"body":{"type":"text"}}}""").get();
+        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
 
         AcknowledgedResponse putMappingResponse = indicesAdmin().preparePutMapping("test").setSource("""
             {"_doc":{"properties":{"body":{"type":"text"}}}}
-            """, XContentType.JSON).execute().actionGet();
+            """, XContentType.JSON).get();
 
         // no changes, we return
         assertThat(putMappingResponse.isAcknowledged(), equalTo(true));

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/memory/breaker/CircuitBreakerServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/memory/breaker/CircuitBreakerServiceIT.java
@@ -293,7 +293,7 @@ public class CircuitBreakerServiceIT extends ESIntegTestCase {
 
     /** Issues a cache clear and waits 30 seconds for the field data breaker to be cleared */
     public void clearFieldData() throws Exception {
-        indicesAdmin().prepareClearCache().setFieldDataCache(true).execute().actionGet();
+        indicesAdmin().prepareClearCache().setFieldDataCache(true).get();
         assertBusy(() -> {
             NodesStatsResponse resp = clusterAdmin().prepareNodesStats().clear().setBreaker(true).get(new TimeValue(15, TimeUnit.SECONDS));
             for (NodeStats nStats : resp.getNodes()) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/memory/breaker/RandomExceptionCircuitBreakerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/memory/breaker/RandomExceptionCircuitBreakerIT.java
@@ -61,7 +61,7 @@ public class RandomExceptionCircuitBreakerIT extends ESIntegTestCase {
     }
 
     public void testBreakerWithRandomExceptions() throws IOException, InterruptedException, ExecutionException {
-        for (NodeStats node : clusterAdmin().prepareNodesStats().clear().setBreaker(true).execute().actionGet().getNodes()) {
+        for (NodeStats node : clusterAdmin().prepareNodesStats().clear().setBreaker(true).get().getNodes()) {
             assertThat("Breaker is not set to 0", node.getBreaker().getStats(CircuitBreaker.FIELDDATA).getEstimated(), equalTo(0L));
         }
 
@@ -108,7 +108,7 @@ public class RandomExceptionCircuitBreakerIT extends ESIntegTestCase {
             .put(EXCEPTION_LOW_LEVEL_RATIO_KEY, lowLevelRate)
             .put(MockEngineSupport.WRAP_READER_RATIO.getKey(), 1.0d);
         logger.info("creating index: [test] using settings: [{}]", settings.build());
-        CreateIndexResponse response = indicesAdmin().prepareCreate("test").setSettings(settings).setMapping(mapping).execute().actionGet();
+        CreateIndexResponse response = indicesAdmin().prepareCreate("test").setSettings(settings).setMapping(mapping).get();
         final int numDocs;
         if (response.isShardsAcknowledged() == false) {
             /* some seeds just won't let you create the index at all and we enter a ping-pong mode
@@ -146,7 +146,7 @@ public class RandomExceptionCircuitBreakerIT extends ESIntegTestCase {
             refreshResponse.getTotalShards()
         );
         final int numSearches = scaledRandomIntBetween(50, 150);
-        NodesStatsResponse resp = clusterAdmin().prepareNodesStats().clear().setBreaker(true).execute().actionGet();
+        NodesStatsResponse resp = clusterAdmin().prepareNodesStats().clear().setBreaker(true).get();
         for (NodeStats stats : resp.getNodes()) {
             assertThat("Breaker is set to 0", stats.getBreaker().getStats(CircuitBreaker.FIELDDATA).getEstimated(), equalTo(0L));
         }
@@ -172,7 +172,7 @@ public class RandomExceptionCircuitBreakerIT extends ESIntegTestCase {
                 // breaker adjustment code, it should show up here by the breaker
                 // estimate being either positive or negative.
                 ensureGreen("test");  // make sure all shards are there - there could be shards that are still starting up.
-                assertAllSuccessful(indicesAdmin().prepareClearCache("test").setFieldDataCache(true).execute().actionGet());
+                assertAllSuccessful(indicesAdmin().prepareClearCache("test").setFieldDataCache(true).get());
 
                 // Since .cleanUp() is no longer called on cache clear, we need to call it on each node manually
                 for (String node : internalCluster().getNodeNames()) {
@@ -181,7 +181,7 @@ public class RandomExceptionCircuitBreakerIT extends ESIntegTestCase {
                     // Clean up the cache, ensuring that entries' listeners have been called
                     fdCache.getCache().refresh();
                 }
-                NodesStatsResponse nodeStats = clusterAdmin().prepareNodesStats().clear().setBreaker(true).execute().actionGet();
+                NodesStatsResponse nodeStats = clusterAdmin().prepareNodesStats().clear().setBreaker(true).get();
                 for (NodeStats stats : nodeStats.getNodes()) {
                     assertThat(
                         "Breaker reset to 0 last search success: " + success + " mapping: " + mapping,

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexPrimaryRelocationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexPrimaryRelocationIT.java
@@ -64,14 +64,12 @@ public class IndexPrimaryRelocationIT extends ESIntegTestCase {
             logger.info("--> [iteration {}] relocating from {} to {} ", i, relocationSource.getName(), relocationTarget.getName());
             clusterAdmin().prepareReroute()
                 .add(new MoveAllocationCommand("test", 0, relocationSource.getId(), relocationTarget.getId()))
-                .execute()
-                .actionGet();
+                .get();
             ClusterHealthResponse clusterHealthResponse = clusterAdmin().prepareHealth()
                 .setTimeout(TimeValue.timeValueSeconds(60))
                 .setWaitForEvents(Priority.LANGUID)
                 .setWaitForNoRelocatingShards(true)
-                .execute()
-                .actionGet();
+                .get();
             if (clusterHealthResponse.isTimedOut()) {
                 final String hotThreads = clusterAdmin().prepareNodesHotThreads()
                     .setIgnoreIdleThreads(false)

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/settings/UpdateNumberOfReplicasIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/settings/UpdateNumberOfReplicasIT.java
@@ -40,8 +40,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
-            .execute()
-            .actionGet();
+            .get();
         logger.info("Done Cluster Health, status {}", clusterHealth.getStatus());
 
         NumShards numShards = getNumShards("test");
@@ -73,8 +72,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForYellowStatus()
             .setWaitForActiveShards(numShards.numPrimaries * 2)
-            .execute()
-            .actionGet();
+            .get();
         logger.info("Done Cluster Health, status {}", clusterHealth.getStatus());
         assertThat(clusterHealth.isTimedOut(), equalTo(false));
         assertThat(clusterHealth.getStatus(), equalTo(ClusterHealthStatus.YELLOW));
@@ -107,8 +105,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
             .setWaitForGreenStatus()
             .setWaitForNoRelocatingShards(true)
             .setWaitForNodes(">=3")
-            .execute()
-            .actionGet();
+            .get();
         logger.info("Done Cluster Health, status {}", clusterHealth.getStatus());
         assertThat(clusterHealth.isTimedOut(), equalTo(false));
         assertThat(clusterHealth.getStatus(), equalTo(ClusterHealthStatus.GREEN));
@@ -130,8 +127,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
             .setWaitForGreenStatus()
             .setWaitForNoRelocatingShards(true)
             .setWaitForNodes(">=3")
-            .execute()
-            .actionGet();
+            .get();
         logger.info("Done Cluster Health, status {}", clusterHealth.getStatus());
         assertThat(clusterHealth.isTimedOut(), equalTo(false));
         assertThat(clusterHealth.getStatus(), equalTo(ClusterHealthStatus.GREEN));
@@ -165,8 +161,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
             .setWaitForActiveShards(numShards.numPrimaries * 2)
-            .execute()
-            .actionGet();
+            .get();
         logger.info("--> done cluster health, status {}", clusterHealth.getStatus());
         assertThat(clusterHealth.isTimedOut(), equalTo(false));
         assertThat(clusterHealth.getStatus(), equalTo(ClusterHealthStatus.GREEN));
@@ -181,8 +176,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
                 .setWaitForEvents(Priority.LANGUID)
                 .setWaitForGreenStatus()
                 .setWaitForActiveShards(numShards.numPrimaries * 2)
-                .execute()
-                .actionGet();
+                .get();
             logger.info("--> done cluster health, status {}", clusterHealth.getStatus());
             assertThat(clusterHealth.isTimedOut(), equalTo(false));
             assertThat(clusterHealth.getStatus(), equalTo(ClusterHealthStatus.GREEN));
@@ -202,8 +196,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
             .setWaitForGreenStatus()
             .setWaitForActiveShards(numShards.numPrimaries * 3)
             .setWaitForNodes(">=3")
-            .execute()
-            .actionGet();
+            .get();
         logger.info("--> done cluster health, status {}", clusterHealth.getStatus());
         assertThat(clusterHealth.isTimedOut(), equalTo(false));
         assertThat(clusterHealth.getStatus(), equalTo(ClusterHealthStatus.GREEN));
@@ -229,8 +222,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
             .setWaitForGreenStatus()
             .setWaitForActiveShards(numShards.numPrimaries * 2)
             .setWaitForNodes(">=2")
-            .execute()
-            .actionGet();
+            .get();
         logger.info("--> done cluster health, status {}", clusterHealth.getStatus());
         assertThat(clusterHealth.isTimedOut(), equalTo(false));
         assertThat(clusterHealth.getStatus(), equalTo(ClusterHealthStatus.GREEN));
@@ -256,8 +248,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
             .setWaitForGreenStatus()
             .setWaitForNodes(">=1")
             .setWaitForActiveShards(numShards.numPrimaries)
-            .execute()
-            .actionGet();
+            .get();
         logger.info("--> done cluster health, status {}", clusterHealth.getStatus());
         assertThat(clusterHealth.isTimedOut(), equalTo(false));
         assertThat(clusterHealth.getStatus(), equalTo(ClusterHealthStatus.GREEN));
@@ -286,8 +277,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
             .setWaitForActiveShards(numShards.numPrimaries * 2)
-            .execute()
-            .actionGet();
+            .get();
         logger.info("--> done cluster health, status {}", clusterHealth.getStatus());
         assertThat(clusterHealth.isTimedOut(), equalTo(false));
         assertThat(clusterHealth.getStatus(), equalTo(ClusterHealthStatus.GREEN));
@@ -302,8 +292,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
                 .setWaitForEvents(Priority.LANGUID)
                 .setWaitForGreenStatus()
                 .setWaitForActiveShards(numShards.numPrimaries * 2)
-                .execute()
-                .actionGet();
+                .get();
             logger.info("--> done cluster health, status {}", clusterHealth.getStatus());
             assertThat(clusterHealth.isTimedOut(), equalTo(false));
             assertThat(clusterHealth.getStatus(), equalTo(ClusterHealthStatus.GREEN));
@@ -321,8 +310,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
             .setWaitForActiveShards(numShards.numPrimaries * 3)
-            .execute()
-            .actionGet();
+            .get();
         logger.info("--> done cluster health, status {}", clusterHealth.getStatus());
         assertThat(clusterHealth.isTimedOut(), equalTo(false));
         assertThat(clusterHealth.getStatus(), equalTo(ClusterHealthStatus.GREEN));
@@ -348,8 +336,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
             .setWaitForGreenStatus()
             .setWaitForNodes(">=2")
             .setWaitForActiveShards(numShards.numPrimaries * 2)
-            .execute()
-            .actionGet();
+            .get();
         logger.info("--> done cluster health, status {}", clusterHealth.getStatus());
         assertThat(clusterHealth.isTimedOut(), equalTo(false));
         assertThat(clusterHealth.getStatus(), equalTo(ClusterHealthStatus.GREEN));
@@ -375,8 +362,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
             .setWaitForYellowStatus()
             .setWaitForNodes(">=1")
             .setWaitForActiveShards(numShards.numPrimaries)
-            .execute()
-            .actionGet();
+            .get();
         logger.info("--> done cluster health, status {}", clusterHealth.getStatus());
         assertThat(clusterHealth.isTimedOut(), equalTo(false));
         assertThat(clusterHealth.getStatus(), equalTo(ClusterHealthStatus.YELLOW));
@@ -396,8 +382,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
             .setWaitForActiveShards(numShards.numPrimaries * 3)
-            .execute()
-            .actionGet();
+            .get();
         logger.info("--> done cluster health, status {}", clusterHealth.getStatus());
         assertThat(clusterHealth.isTimedOut(), equalTo(false));
         assertThat(clusterHealth.getStatus(), equalTo(ClusterHealthStatus.GREEN));
@@ -418,8 +403,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
             .setWaitForActiveShards(numShards.numPrimaries * 4)
-            .execute()
-            .actionGet();
+            .get();
         logger.info("--> done cluster health, status {}", clusterHealth.getStatus());
         assertThat(clusterHealth.isTimedOut(), equalTo(false));
         assertThat(clusterHealth.getStatus(), equalTo(ClusterHealthStatus.GREEN));
@@ -444,8 +428,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         try {
             indicesAdmin().prepareUpdateSettings("test")
                 .setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, value))
-                .execute()
-                .actionGet();
+                .get();
             fail("should have thrown an exception about the replica shard count");
         } catch (IllegalArgumentException e) {
             assertEquals("Failed to parse value [" + value + "] for setting [index.number_of_replicas] must be >= 0", e.getMessage());

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/settings/UpdateSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/settings/UpdateSettingsIT.java
@@ -62,13 +62,10 @@ public class UpdateSettingsIT extends ESIntegTestCase {
         createIndex("test");
         IllegalArgumentException exception = expectThrows(
             IllegalArgumentException.class,
-            () -> indicesAdmin().prepareUpdateSettings("test")
-                .setSettings(Settings.builder().put("index.dummy", "boom"))
-                .execute()
-                .actionGet()
+            () -> indicesAdmin().prepareUpdateSettings("test").setSettings(Settings.builder().put("index.dummy", "boom")).get()
         );
         assertEquals(exception.getCause().getMessage(), "this setting goes boom");
-        IndexMetadata indexMetadata = clusterAdmin().prepareState().execute().actionGet().getState().metadata().index("test");
+        IndexMetadata indexMetadata = clusterAdmin().prepareState().get().getState().metadata().index("test");
         assertNotEquals(indexMetadata.getSettings().get("index.dummy"), "invalid dynamic value");
     }
 
@@ -209,51 +206,35 @@ public class UpdateSettingsIT extends ESIntegTestCase {
 
             iae = expectThrows(
                 IllegalArgumentException.class,
-                () -> indicesAdmin().prepareUpdateSettings("test")
-                    .setSettings(Settings.builder().put("index.acc.test.pw", "asdf"))
-                    .execute()
-                    .actionGet()
+                () -> indicesAdmin().prepareUpdateSettings("test").setSettings(Settings.builder().put("index.acc.test.pw", "asdf")).get()
             );
             assertEquals("missing required setting [index.acc.test.user] for setting [index.acc.test.pw]", iae.getMessage());
 
             // user has no dependency
-            indicesAdmin().prepareUpdateSettings("test")
-                .setSettings(Settings.builder().put("index.acc.test.user", "asdf"))
-                .execute()
-                .actionGet();
+            indicesAdmin().prepareUpdateSettings("test").setSettings(Settings.builder().put("index.acc.test.user", "asdf")).get();
 
             // now we are consistent
-            indicesAdmin().prepareUpdateSettings("test")
-                .setSettings(Settings.builder().put("index.acc.test.pw", "test"))
-                .execute()
-                .actionGet();
+            indicesAdmin().prepareUpdateSettings("test").setSettings(Settings.builder().put("index.acc.test.pw", "test")).get();
 
             // now try to remove it and make sure it fails
             iae = expectThrows(
                 IllegalArgumentException.class,
-                () -> indicesAdmin().prepareUpdateSettings("test")
-                    .setSettings(Settings.builder().putNull("index.acc.test.user"))
-                    .execute()
-                    .actionGet()
+                () -> indicesAdmin().prepareUpdateSettings("test").setSettings(Settings.builder().putNull("index.acc.test.user")).get()
             );
             assertEquals("missing required setting [index.acc.test.user] for setting [index.acc.test.pw]", iae.getMessage());
 
             // now we are consistent
             indicesAdmin().prepareUpdateSettings("test")
                 .setSettings(Settings.builder().putNull("index.acc.test.pw").putNull("index.acc.test.user"))
-                .execute()
-                .actionGet();
+                .get();
         }
     }
 
     public void testResetDefaultWithWildcard() {
         createIndex("test");
 
-        indicesAdmin().prepareUpdateSettings("test")
-            .setSettings(Settings.builder().put("index.refresh_interval", -1))
-            .execute()
-            .actionGet();
-        IndexMetadata indexMetadata = clusterAdmin().prepareState().execute().actionGet().getState().metadata().index("test");
+        indicesAdmin().prepareUpdateSettings("test").setSettings(Settings.builder().put("index.refresh_interval", -1)).get();
+        IndexMetadata indexMetadata = clusterAdmin().prepareState().get().getState().metadata().index("test");
         assertEquals(indexMetadata.getSettings().get("index.refresh_interval"), "-1");
         for (IndicesService service : internalCluster().getInstances(IndicesService.class)) {
             IndexService indexService = service.indexService(resolveIndex("test"));
@@ -261,8 +242,8 @@ public class UpdateSettingsIT extends ESIntegTestCase {
                 assertEquals(indexService.getIndexSettings().getRefreshInterval().millis(), -1);
             }
         }
-        indicesAdmin().prepareUpdateSettings("test").setSettings(Settings.builder().putNull("index.ref*")).execute().actionGet();
-        indexMetadata = clusterAdmin().prepareState().execute().actionGet().getState().metadata().index("test");
+        indicesAdmin().prepareUpdateSettings("test").setSettings(Settings.builder().putNull("index.ref*")).get();
+        indexMetadata = clusterAdmin().prepareState().get().getState().metadata().index("test");
         assertNull(indexMetadata.getSettings().get("index.refresh_interval"));
         for (IndicesService service : internalCluster().getInstances(IndicesService.class)) {
             IndexService indexService = service.indexService(resolveIndex("test"));
@@ -281,9 +262,8 @@ public class UpdateSettingsIT extends ESIntegTestCase {
                     .put("index.translog.flush_threshold_size", "1024b")
                     .put("index.translog.generation_threshold_size", "4096b")
             )
-            .execute()
-            .actionGet();
-        IndexMetadata indexMetadata = clusterAdmin().prepareState().execute().actionGet().getState().metadata().index("test");
+            .get();
+        IndexMetadata indexMetadata = clusterAdmin().prepareState().get().getState().metadata().index("test");
         assertEquals(indexMetadata.getSettings().get("index.refresh_interval"), "-1");
         for (IndicesService service : internalCluster().getInstances(IndicesService.class)) {
             IndexService indexService = service.indexService(resolveIndex("test"));
@@ -293,11 +273,8 @@ public class UpdateSettingsIT extends ESIntegTestCase {
                 assertEquals(indexService.getIndexSettings().getGenerationThresholdSize().getBytes(), 4096);
             }
         }
-        indicesAdmin().prepareUpdateSettings("test")
-            .setSettings(Settings.builder().putNull("index.refresh_interval"))
-            .execute()
-            .actionGet();
-        indexMetadata = clusterAdmin().prepareState().execute().actionGet().getState().metadata().index("test");
+        indicesAdmin().prepareUpdateSettings("test").setSettings(Settings.builder().putNull("index.refresh_interval")).get();
+        indexMetadata = clusterAdmin().prepareState().get().getState().metadata().index("test");
         assertNull(indexMetadata.getSettings().get("index.refresh_interval"));
         for (IndicesService service : internalCluster().getInstances(IndicesService.class)) {
             IndexService indexService = service.indexService(resolveIndex("test"));
@@ -319,8 +296,7 @@ public class UpdateSettingsIT extends ESIntegTestCase {
                         .put("index.refresh_interval", -1) // this one can change
                         .put("index.fielddata.cache", "none")
                 ) // this one can't
-                .execute()
-                .actionGet()
+                .get()
         );
         expectThrows(
             IllegalArgumentException.class,
@@ -330,10 +306,9 @@ public class UpdateSettingsIT extends ESIntegTestCase {
                         .put("index.refresh_interval", -1) // this one can change
                         .put("index.final", "no")
                 ) // this one can't
-                .execute()
-                .actionGet()
+                .get()
         );
-        IndexMetadata indexMetadata = clusterAdmin().prepareState().execute().actionGet().getState().metadata().index("test");
+        IndexMetadata indexMetadata = clusterAdmin().prepareState().get().getState().metadata().index("test");
         assertThat(indexMetadata.getSettings().get("index.refresh_interval"), nullValue());
         assertThat(indexMetadata.getSettings().get("index.fielddata.cache"), nullValue());
         assertThat(indexMetadata.getSettings().get("index.final"), nullValue());
@@ -346,10 +321,9 @@ public class UpdateSettingsIT extends ESIntegTestCase {
 
         indicesAdmin().prepareUpdateSettings("test")
             .setSettings(Settings.builder().put("index.refresh_interval", -1)) // this one can change
-            .execute()
-            .actionGet();
+            .get();
 
-        indexMetadata = clusterAdmin().prepareState().execute().actionGet().getState().metadata().index("test");
+        indexMetadata = clusterAdmin().prepareState().get().getState().metadata().index("test");
         assertThat(indexMetadata.getSettings().get("index.refresh_interval"), equalTo("-1"));
         // Now verify via dedicated get settings api:
         getSettingsResponse = indicesAdmin().prepareGetSettings("test").get();
@@ -362,18 +336,14 @@ public class UpdateSettingsIT extends ESIntegTestCase {
             .setTimeout("30s")
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
-            .execute()
-            .actionGet();
+            .get();
         assertThat(health.isTimedOut(), equalTo(false));
 
-        indicesAdmin().prepareClose("test").execute().actionGet();
+        indicesAdmin().prepareClose("test").get();
 
-        indicesAdmin().prepareUpdateSettings("test")
-            .setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1))
-            .execute()
-            .actionGet();
+        indicesAdmin().prepareUpdateSettings("test").setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)).get();
 
-        indexMetadata = clusterAdmin().prepareState().execute().actionGet().getState().metadata().index("test");
+        indexMetadata = clusterAdmin().prepareState().get().getState().metadata().index("test");
         assertThat(indexMetadata.getNumberOfReplicas(), equalTo(1));
 
         indicesAdmin().prepareUpdateSettings("test")
@@ -382,10 +352,9 @@ public class UpdateSettingsIT extends ESIntegTestCase {
                     .put("index.refresh_interval", "1s") // this one can change
                     .put("index.fielddata.cache", "none")
             ) // this one can't
-            .execute()
-            .actionGet();
+            .get();
 
-        indexMetadata = clusterAdmin().prepareState().execute().actionGet().getState().metadata().index("test");
+        indexMetadata = clusterAdmin().prepareState().get().getState().metadata().index("test");
         assertThat(indexMetadata.getSettings().get("index.refresh_interval"), equalTo("1s"));
         assertThat(indexMetadata.getSettings().get("index.fielddata.cache"), equalTo("none"));
 
@@ -397,11 +366,10 @@ public class UpdateSettingsIT extends ESIntegTestCase {
                         .put("index.refresh_interval", -1) // this one can change
                         .put("index.final", "no")
                 ) // this one really can't
-                .execute()
-                .actionGet()
+                .get()
         );
         assertThat(ex.getMessage(), containsString("final test setting [index.final], not updateable"));
-        indexMetadata = clusterAdmin().prepareState().execute().actionGet().getState().metadata().index("test");
+        indexMetadata = clusterAdmin().prepareState().get().getState().metadata().index("test");
         assertThat(indexMetadata.getSettings().get("index.refresh_interval"), equalTo("1s"));
         assertThat(indexMetadata.getSettings().get("index.final"), nullValue());
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/state/CloseIndexDisableCloseAllIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/state/CloseIndexDisableCloseAllIT.java
@@ -47,7 +47,7 @@ public class CloseIndexDisableCloseAllIT extends ESIntegTestCase {
     }
 
     private void assertIndexIsClosed(String... indices) {
-        ClusterStateResponse clusterStateResponse = clusterAdmin().prepareState().execute().actionGet();
+        ClusterStateResponse clusterStateResponse = clusterAdmin().prepareState().get();
         for (String index : indices) {
             IndexMetadata indexMetadata = clusterStateResponse.getState().metadata().indices().get(index);
             assertNotNull(indexMetadata);

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/state/OpenCloseIndexIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/state/OpenCloseIndexIT.java
@@ -50,47 +50,43 @@ public class OpenCloseIndexIT extends ESIntegTestCase {
     public void testSimpleCloseOpen() {
         Client client = client();
         createIndex("test1");
-        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
+        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().get();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
 
-        AcknowledgedResponse closeIndexResponse = client.admin().indices().prepareClose("test1").execute().actionGet();
+        AcknowledgedResponse closeIndexResponse = client.admin().indices().prepareClose("test1").get();
         assertThat(closeIndexResponse.isAcknowledged(), equalTo(true));
         assertIndexIsClosed("test1");
 
-        OpenIndexResponse openIndexResponse = client.admin().indices().prepareOpen("test1").execute().actionGet();
+        OpenIndexResponse openIndexResponse = client.admin().indices().prepareOpen("test1").get();
         assertThat(openIndexResponse.isAcknowledged(), equalTo(true));
         assertThat(openIndexResponse.isShardsAcknowledged(), equalTo(true));
         assertIndexIsOpened("test1");
     }
 
     public void testSimpleOpenMissingIndex() {
-        Exception e = expectThrows(IndexNotFoundException.class, () -> indicesAdmin().prepareOpen("test1").execute().actionGet());
+        Exception e = expectThrows(IndexNotFoundException.class, () -> indicesAdmin().prepareOpen("test1").get());
         assertThat(e.getMessage(), is("no such index [test1]"));
     }
 
     public void testOpenOneMissingIndex() {
         Client client = client();
         createIndex("test1");
-        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
+        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().get();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
-        Exception e = expectThrows(
-            IndexNotFoundException.class,
-            () -> client.admin().indices().prepareOpen("test1", "test2").execute().actionGet()
-        );
+        Exception e = expectThrows(IndexNotFoundException.class, () -> client.admin().indices().prepareOpen("test1", "test2").get());
         assertThat(e.getMessage(), is("no such index [test2]"));
     }
 
     public void testOpenOneMissingIndexIgnoreMissing() {
         Client client = client();
         createIndex("test1");
-        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
+        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().get();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
         OpenIndexResponse openIndexResponse = client.admin()
             .indices()
             .prepareOpen("test1", "test2")
             .setIndicesOptions(IndicesOptions.lenientExpandOpen())
-            .execute()
-            .actionGet();
+            .get();
         assertThat(openIndexResponse.isAcknowledged(), equalTo(true));
         assertThat(openIndexResponse.isShardsAcknowledged(), equalTo(true));
         assertIndexIsOpened("test1");
@@ -99,20 +95,20 @@ public class OpenCloseIndexIT extends ESIntegTestCase {
     public void testCloseOpenMultipleIndices() {
         Client client = client();
         createIndex("test1", "test2", "test3");
-        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
+        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().get();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
 
-        AcknowledgedResponse closeIndexResponse1 = client.admin().indices().prepareClose("test1").execute().actionGet();
+        AcknowledgedResponse closeIndexResponse1 = client.admin().indices().prepareClose("test1").get();
         assertThat(closeIndexResponse1.isAcknowledged(), equalTo(true));
-        AcknowledgedResponse closeIndexResponse2 = client.admin().indices().prepareClose("test2").execute().actionGet();
+        AcknowledgedResponse closeIndexResponse2 = client.admin().indices().prepareClose("test2").get();
         assertThat(closeIndexResponse2.isAcknowledged(), equalTo(true));
         assertIndexIsClosed("test1", "test2");
         assertIndexIsOpened("test3");
 
-        OpenIndexResponse openIndexResponse1 = client.admin().indices().prepareOpen("test1").execute().actionGet();
+        OpenIndexResponse openIndexResponse1 = client.admin().indices().prepareOpen("test1").get();
         assertThat(openIndexResponse1.isAcknowledged(), equalTo(true));
         assertThat(openIndexResponse1.isShardsAcknowledged(), equalTo(true));
-        OpenIndexResponse openIndexResponse2 = client.admin().indices().prepareOpen("test2").execute().actionGet();
+        OpenIndexResponse openIndexResponse2 = client.admin().indices().prepareOpen("test2").get();
         assertThat(openIndexResponse2.isAcknowledged(), equalTo(true));
         assertThat(openIndexResponse2.isShardsAcknowledged(), equalTo(true));
         assertIndexIsOpened("test1", "test2", "test3");
@@ -121,15 +117,15 @@ public class OpenCloseIndexIT extends ESIntegTestCase {
     public void testCloseOpenWildcard() {
         Client client = client();
         createIndex("test1", "test2", "a");
-        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
+        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().get();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
 
-        AcknowledgedResponse closeIndexResponse = client.admin().indices().prepareClose("test*").execute().actionGet();
+        AcknowledgedResponse closeIndexResponse = client.admin().indices().prepareClose("test*").get();
         assertThat(closeIndexResponse.isAcknowledged(), equalTo(true));
         assertIndexIsClosed("test1", "test2");
         assertIndexIsOpened("a");
 
-        OpenIndexResponse openIndexResponse = client.admin().indices().prepareOpen("test*").execute().actionGet();
+        OpenIndexResponse openIndexResponse = client.admin().indices().prepareOpen("test*").get();
         assertThat(openIndexResponse.isAcknowledged(), equalTo(true));
         assertThat(openIndexResponse.isShardsAcknowledged(), equalTo(true));
         assertIndexIsOpened("test1", "test2", "a");
@@ -138,14 +134,14 @@ public class OpenCloseIndexIT extends ESIntegTestCase {
     public void testCloseOpenAll() {
         Client client = client();
         createIndex("test1", "test2", "test3");
-        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
+        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().get();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
 
-        AcknowledgedResponse closeIndexResponse = client.admin().indices().prepareClose("_all").execute().actionGet();
+        AcknowledgedResponse closeIndexResponse = client.admin().indices().prepareClose("_all").get();
         assertThat(closeIndexResponse.isAcknowledged(), equalTo(true));
         assertIndexIsClosed("test1", "test2", "test3");
 
-        OpenIndexResponse openIndexResponse = client.admin().indices().prepareOpen("_all").execute().actionGet();
+        OpenIndexResponse openIndexResponse = client.admin().indices().prepareOpen("_all").get();
         assertThat(openIndexResponse.isAcknowledged(), equalTo(true));
         assertThat(openIndexResponse.isShardsAcknowledged(), equalTo(true));
         assertIndexIsOpened("test1", "test2", "test3");
@@ -154,40 +150,37 @@ public class OpenCloseIndexIT extends ESIntegTestCase {
     public void testCloseOpenAllWildcard() {
         Client client = client();
         createIndex("test1", "test2", "test3");
-        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
+        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().get();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
 
-        AcknowledgedResponse closeIndexResponse = client.admin().indices().prepareClose("*").execute().actionGet();
+        AcknowledgedResponse closeIndexResponse = client.admin().indices().prepareClose("*").get();
         assertThat(closeIndexResponse.isAcknowledged(), equalTo(true));
         assertIndexIsClosed("test1", "test2", "test3");
 
-        OpenIndexResponse openIndexResponse = client.admin().indices().prepareOpen("*").execute().actionGet();
+        OpenIndexResponse openIndexResponse = client.admin().indices().prepareOpen("*").get();
         assertThat(openIndexResponse.isAcknowledged(), equalTo(true));
         assertThat(openIndexResponse.isShardsAcknowledged(), equalTo(true));
         assertIndexIsOpened("test1", "test2", "test3");
     }
 
     public void testOpenNoIndex() {
-        Exception e = expectThrows(ActionRequestValidationException.class, () -> indicesAdmin().prepareOpen().execute().actionGet());
+        Exception e = expectThrows(ActionRequestValidationException.class, () -> indicesAdmin().prepareOpen().get());
         assertThat(e.getMessage(), containsString("index is missing"));
     }
 
     public void testOpenNullIndex() {
-        Exception e = expectThrows(
-            ActionRequestValidationException.class,
-            () -> indicesAdmin().prepareOpen((String[]) null).execute().actionGet()
-        );
+        Exception e = expectThrows(ActionRequestValidationException.class, () -> indicesAdmin().prepareOpen((String[]) null).get());
         assertThat(e.getMessage(), containsString("index is missing"));
     }
 
     public void testOpenAlreadyOpenedIndex() {
         Client client = client();
         createIndex("test1");
-        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
+        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().get();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
 
         // no problem if we try to open an index that's already in open state
-        OpenIndexResponse openIndexResponse1 = client.admin().indices().prepareOpen("test1").execute().actionGet();
+        OpenIndexResponse openIndexResponse1 = client.admin().indices().prepareOpen("test1").get();
         assertThat(openIndexResponse1.isAcknowledged(), equalTo(true));
         assertThat(openIndexResponse1.isShardsAcknowledged(), equalTo(true));
         assertIndexIsOpened("test1");
@@ -196,22 +189,17 @@ public class OpenCloseIndexIT extends ESIntegTestCase {
     public void testSimpleCloseOpenAlias() {
         Client client = client();
         createIndex("test1");
-        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
+        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().get();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
 
-        AcknowledgedResponse aliasesResponse = client.admin()
-            .indices()
-            .prepareAliases()
-            .addAlias("test1", "test1-alias")
-            .execute()
-            .actionGet();
+        AcknowledgedResponse aliasesResponse = client.admin().indices().prepareAliases().addAlias("test1", "test1-alias").get();
         assertThat(aliasesResponse.isAcknowledged(), equalTo(true));
 
-        AcknowledgedResponse closeIndexResponse = client.admin().indices().prepareClose("test1-alias").execute().actionGet();
+        AcknowledgedResponse closeIndexResponse = client.admin().indices().prepareClose("test1-alias").get();
         assertThat(closeIndexResponse.isAcknowledged(), equalTo(true));
         assertIndexIsClosed("test1");
 
-        OpenIndexResponse openIndexResponse = client.admin().indices().prepareOpen("test1-alias").execute().actionGet();
+        OpenIndexResponse openIndexResponse = client.admin().indices().prepareOpen("test1-alias").get();
         assertThat(openIndexResponse.isAcknowledged(), equalTo(true));
         assertThat(openIndexResponse.isShardsAcknowledged(), equalTo(true));
         assertIndexIsOpened("test1");
@@ -220,29 +208,19 @@ public class OpenCloseIndexIT extends ESIntegTestCase {
     public void testCloseOpenAliasMultipleIndices() {
         Client client = client();
         createIndex("test1", "test2");
-        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
+        ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth().setWaitForGreenStatus().get();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
 
-        AcknowledgedResponse aliasesResponse1 = client.admin()
-            .indices()
-            .prepareAliases()
-            .addAlias("test1", "test-alias")
-            .execute()
-            .actionGet();
+        AcknowledgedResponse aliasesResponse1 = client.admin().indices().prepareAliases().addAlias("test1", "test-alias").get();
         assertThat(aliasesResponse1.isAcknowledged(), equalTo(true));
-        AcknowledgedResponse aliasesResponse2 = client.admin()
-            .indices()
-            .prepareAliases()
-            .addAlias("test2", "test-alias")
-            .execute()
-            .actionGet();
+        AcknowledgedResponse aliasesResponse2 = client.admin().indices().prepareAliases().addAlias("test2", "test-alias").get();
         assertThat(aliasesResponse2.isAcknowledged(), equalTo(true));
 
-        AcknowledgedResponse closeIndexResponse = client.admin().indices().prepareClose("test-alias").execute().actionGet();
+        AcknowledgedResponse closeIndexResponse = client.admin().indices().prepareClose("test-alias").get();
         assertThat(closeIndexResponse.isAcknowledged(), equalTo(true));
         assertIndexIsClosed("test1", "test2");
 
-        OpenIndexResponse openIndexResponse = client.admin().indices().prepareOpen("test-alias").execute().actionGet();
+        OpenIndexResponse openIndexResponse = client.admin().indices().prepareOpen("test-alias").get();
         assertThat(openIndexResponse.isAcknowledged(), equalTo(true));
         assertThat(openIndexResponse.isShardsAcknowledged(), equalTo(true));
         assertIndexIsOpened("test1", "test2");
@@ -307,7 +285,7 @@ public class OpenCloseIndexIT extends ESIntegTestCase {
 
         int docs = between(10, 100);
         for (int i = 0; i < docs; i++) {
-            client().prepareIndex("test").setId("" + i).setSource("test", "init").execute().actionGet();
+            client().prepareIndex("test").setId("" + i).setSource("test", "init").get();
         }
 
         for (String blockSetting : Arrays.asList(SETTING_BLOCKS_READ, SETTING_BLOCKS_WRITE)) {
@@ -315,12 +293,12 @@ public class OpenCloseIndexIT extends ESIntegTestCase {
                 enableIndexBlock("test", blockSetting);
 
                 // Closing an index is not blocked
-                AcknowledgedResponse closeIndexResponse = indicesAdmin().prepareClose("test").execute().actionGet();
+                AcknowledgedResponse closeIndexResponse = indicesAdmin().prepareClose("test").get();
                 assertAcked(closeIndexResponse);
                 assertIndexIsClosed("test");
 
                 // Opening an index is not blocked
-                OpenIndexResponse openIndexResponse = indicesAdmin().prepareOpen("test").execute().actionGet();
+                OpenIndexResponse openIndexResponse = indicesAdmin().prepareOpen("test").get();
                 assertAcked(openIndexResponse);
                 assertThat(openIndexResponse.isShardsAcknowledged(), equalTo(true));
                 assertIndexIsOpened("test");
@@ -340,7 +318,7 @@ public class OpenCloseIndexIT extends ESIntegTestCase {
             }
         }
 
-        AcknowledgedResponse closeIndexResponse = indicesAdmin().prepareClose("test").execute().actionGet();
+        AcknowledgedResponse closeIndexResponse = indicesAdmin().prepareClose("test").get();
         assertAcked(closeIndexResponse);
         assertIndexIsClosed("test");
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/stats/IndexStatsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/stats/IndexStatsIT.java
@@ -133,11 +133,11 @@ public class IndexStatsIT extends ESIntegTestCase {
                 .setMapping("field", "type=text,fielddata=true", "field2", "type=text,fielddata=true")
         );
         ensureGreen();
-        client().prepareIndex("test").setId("1").setSource("field", "value1", "field2", "value1").execute().actionGet();
-        client().prepareIndex("test").setId("2").setSource("field", "value2", "field2", "value2").execute().actionGet();
-        indicesAdmin().prepareRefresh().execute().actionGet();
+        client().prepareIndex("test").setId("1").setSource("field", "value1", "field2", "value1").get();
+        client().prepareIndex("test").setId("2").setSource("field", "value2", "field2", "value2").get();
+        indicesAdmin().prepareRefresh().get();
 
-        NodesStatsResponse nodesStats = clusterAdmin().prepareNodesStats("data:true").setIndices(true).execute().actionGet();
+        NodesStatsResponse nodesStats = clusterAdmin().prepareNodesStats("data:true").setIndices(true).get();
         assertThat(
             nodesStats.getNodes().get(0).getIndices().getFieldData().getMemorySizeInBytes() + nodesStats.getNodes()
                 .get(1)
@@ -146,14 +146,14 @@ public class IndexStatsIT extends ESIntegTestCase {
                 .getMemorySizeInBytes(),
             equalTo(0L)
         );
-        IndicesStatsResponse indicesStats = indicesAdmin().prepareStats("test").clear().setFieldData(true).execute().actionGet();
+        IndicesStatsResponse indicesStats = indicesAdmin().prepareStats("test").clear().setFieldData(true).get();
         assertThat(indicesStats.getTotal().getFieldData().getMemorySizeInBytes(), equalTo(0L));
 
         // sort to load it to field data...
-        prepareSearch().addSort("field", SortOrder.ASC).execute().actionGet();
-        prepareSearch().addSort("field", SortOrder.ASC).execute().actionGet();
+        prepareSearch().addSort("field", SortOrder.ASC).get();
+        prepareSearch().addSort("field", SortOrder.ASC).get();
 
-        nodesStats = clusterAdmin().prepareNodesStats("data:true").setIndices(true).execute().actionGet();
+        nodesStats = clusterAdmin().prepareNodesStats("data:true").setIndices(true).get();
         assertThat(
             nodesStats.getNodes().get(0).getIndices().getFieldData().getMemorySizeInBytes() + nodesStats.getNodes()
                 .get(1)
@@ -162,18 +162,17 @@ public class IndexStatsIT extends ESIntegTestCase {
                 .getMemorySizeInBytes(),
             greaterThan(0L)
         );
-        indicesStats = indicesAdmin().prepareStats("test").clear().setFieldData(true).execute().actionGet();
+        indicesStats = indicesAdmin().prepareStats("test").clear().setFieldData(true).get();
         assertThat(indicesStats.getTotal().getFieldData().getMemorySizeInBytes(), greaterThan(0L));
 
         // sort to load it to field data...
-        prepareSearch().addSort("field2", SortOrder.ASC).execute().actionGet();
-        prepareSearch().addSort("field2", SortOrder.ASC).execute().actionGet();
+        prepareSearch().addSort("field2", SortOrder.ASC).get();
+        prepareSearch().addSort("field2", SortOrder.ASC).get();
 
         // now check the per field stats
         nodesStats = clusterAdmin().prepareNodesStats("data:true")
             .setIndices(new CommonStatsFlags().set(CommonStatsFlags.Flag.FieldData, true).fieldDataFields("*"))
-            .execute()
-            .actionGet();
+            .get();
         assertThat(
             nodesStats.getNodes().get(0).getIndices().getFieldData().getMemorySizeInBytes() + nodesStats.getNodes()
                 .get(1)
@@ -207,7 +206,7 @@ public class IndexStatsIT extends ESIntegTestCase {
             )
         );
 
-        indicesStats = indicesAdmin().prepareStats("test").clear().setFieldData(true).setFieldDataFields("*").execute().actionGet();
+        indicesStats = indicesAdmin().prepareStats("test").clear().setFieldData(true).setFieldDataFields("*").get();
         assertThat(indicesStats.getTotal().getFieldData().getMemorySizeInBytes(), greaterThan(0L));
         assertThat(indicesStats.getTotal().getFieldData().getFields().get("field"), greaterThan(0L));
         assertThat(
@@ -215,8 +214,8 @@ public class IndexStatsIT extends ESIntegTestCase {
             lessThan(indicesStats.getTotal().getFieldData().getMemorySizeInBytes())
         );
 
-        indicesAdmin().prepareClearCache().setFieldDataCache(true).execute().actionGet();
-        nodesStats = clusterAdmin().prepareNodesStats("data:true").setIndices(true).execute().actionGet();
+        indicesAdmin().prepareClearCache().setFieldDataCache(true).get();
+        nodesStats = clusterAdmin().prepareNodesStats("data:true").setIndices(true).get();
         assertThat(
             nodesStats.getNodes().get(0).getIndices().getFieldData().getMemorySizeInBytes() + nodesStats.getNodes()
                 .get(1)
@@ -225,7 +224,7 @@ public class IndexStatsIT extends ESIntegTestCase {
                 .getMemorySizeInBytes(),
             equalTo(0L)
         );
-        indicesStats = indicesAdmin().prepareStats("test").clear().setFieldData(true).execute().actionGet();
+        indicesStats = indicesAdmin().prepareStats("test").clear().setFieldData(true).get();
         assertThat(indicesStats.getTotal().getFieldData().getMemorySizeInBytes(), equalTo(0L));
 
     }
@@ -237,12 +236,12 @@ public class IndexStatsIT extends ESIntegTestCase {
                 .setMapping("field", "type=text,fielddata=true")
         );
         ensureGreen();
-        clusterAdmin().prepareHealth().setWaitForGreenStatus().execute().actionGet();
-        client().prepareIndex("test").setId("1").setSource("field", "value1").execute().actionGet();
-        client().prepareIndex("test").setId("2").setSource("field", "value2").execute().actionGet();
-        indicesAdmin().prepareRefresh().execute().actionGet();
+        clusterAdmin().prepareHealth().setWaitForGreenStatus().get();
+        client().prepareIndex("test").setId("1").setSource("field", "value1").get();
+        client().prepareIndex("test").setId("2").setSource("field", "value2").get();
+        indicesAdmin().prepareRefresh().get();
 
-        NodesStatsResponse nodesStats = clusterAdmin().prepareNodesStats("data:true").setIndices(true).execute().actionGet();
+        NodesStatsResponse nodesStats = clusterAdmin().prepareNodesStats("data:true").setIndices(true).get();
         assertThat(
             nodesStats.getNodes().get(0).getIndices().getFieldData().getMemorySizeInBytes() + nodesStats.getNodes()
                 .get(1)
@@ -260,20 +259,15 @@ public class IndexStatsIT extends ESIntegTestCase {
             equalTo(0L)
         );
 
-        IndicesStatsResponse indicesStats = indicesAdmin().prepareStats("test")
-            .clear()
-            .setFieldData(true)
-            .setQueryCache(true)
-            .execute()
-            .actionGet();
+        IndicesStatsResponse indicesStats = indicesAdmin().prepareStats("test").clear().setFieldData(true).setQueryCache(true).get();
         assertThat(indicesStats.getTotal().getFieldData().getMemorySizeInBytes(), equalTo(0L));
         assertThat(indicesStats.getTotal().getQueryCache().getMemorySizeInBytes(), equalTo(0L));
 
         // sort to load it to field data and filter to load filter cache
-        prepareSearch().setPostFilter(QueryBuilders.termQuery("field", "value1")).addSort("field", SortOrder.ASC).execute().actionGet();
-        prepareSearch().setPostFilter(QueryBuilders.termQuery("field", "value2")).addSort("field", SortOrder.ASC).execute().actionGet();
+        prepareSearch().setPostFilter(QueryBuilders.termQuery("field", "value1")).addSort("field", SortOrder.ASC).get();
+        prepareSearch().setPostFilter(QueryBuilders.termQuery("field", "value2")).addSort("field", SortOrder.ASC).get();
 
-        nodesStats = clusterAdmin().prepareNodesStats("data:true").setIndices(true).execute().actionGet();
+        nodesStats = clusterAdmin().prepareNodesStats("data:true").setIndices(true).get();
         assertThat(
             nodesStats.getNodes().get(0).getIndices().getFieldData().getMemorySizeInBytes() + nodesStats.getNodes()
                 .get(1)
@@ -291,13 +285,13 @@ public class IndexStatsIT extends ESIntegTestCase {
             greaterThan(0L)
         );
 
-        indicesStats = indicesAdmin().prepareStats("test").clear().setFieldData(true).setQueryCache(true).execute().actionGet();
+        indicesStats = indicesAdmin().prepareStats("test").clear().setFieldData(true).setQueryCache(true).get();
         assertThat(indicesStats.getTotal().getFieldData().getMemorySizeInBytes(), greaterThan(0L));
         assertThat(indicesStats.getTotal().getQueryCache().getMemorySizeInBytes(), greaterThan(0L));
 
-        indicesAdmin().prepareClearCache().execute().actionGet();
+        indicesAdmin().prepareClearCache().get();
         Thread.sleep(100); // Make sure the filter cache entries have been removed...
-        nodesStats = clusterAdmin().prepareNodesStats("data:true").setIndices(true).execute().actionGet();
+        nodesStats = clusterAdmin().prepareNodesStats("data:true").setIndices(true).get();
         assertThat(
             nodesStats.getNodes().get(0).getIndices().getFieldData().getMemorySizeInBytes() + nodesStats.getNodes()
                 .get(1)
@@ -315,7 +309,7 @@ public class IndexStatsIT extends ESIntegTestCase {
             equalTo(0L)
         );
 
-        indicesStats = indicesAdmin().prepareStats("test").clear().setFieldData(true).setQueryCache(true).execute().actionGet();
+        indicesStats = indicesAdmin().prepareStats("test").clear().setFieldData(true).setQueryCache(true).get();
         assertThat(indicesStats.getTotal().getFieldData().getMemorySizeInBytes(), equalTo(0L));
         assertThat(indicesStats.getTotal().getQueryCache().getMemorySizeInBytes(), equalTo(0L));
     }
@@ -497,10 +491,10 @@ public class IndexStatsIT extends ESIntegTestCase {
             client().prepareIndex("test").setId("" + termUpto).setSource("field" + (i % 10), sb.toString()).get();
         }
         refresh();
-        stats = indicesAdmin().prepareStats().execute().actionGet();
+        stats = indicesAdmin().prepareStats().get();
         // nodesStats = clusterAdmin().prepareNodesStats().setIndices(true).get();
 
-        stats = indicesAdmin().prepareStats().execute().actionGet();
+        stats = indicesAdmin().prepareStats().get();
         assertThat(stats.getPrimaries().getIndexing().getTotal().getThrottleTime().millis(), equalTo(0L));
     }
 
@@ -536,7 +530,7 @@ public class IndexStatsIT extends ESIntegTestCase {
                 }
             }
             refresh();
-            stats = indicesAdmin().prepareStats().execute().actionGet();
+            stats = indicesAdmin().prepareStats().get();
             // nodesStats = clusterAdmin().prepareNodesStats().setIndices(true).get();
             done = stats.getPrimaries().getIndexing().getTotal().getThrottleTime().millis() > 0;
             if (System.currentTimeMillis() - start > 300 * 1000) { // Wait 5 minutes for throttling to kick in
@@ -556,9 +550,9 @@ public class IndexStatsIT extends ESIntegTestCase {
         createIndex("test1", "test2");
         ensureGreen();
 
-        client().prepareIndex("test1").setId(Integer.toString(1)).setSource("field", "value").execute().actionGet();
-        client().prepareIndex("test1").setId(Integer.toString(2)).setSource("field", "value").execute().actionGet();
-        client().prepareIndex("test2").setId(Integer.toString(1)).setSource("field", "value").execute().actionGet();
+        client().prepareIndex("test1").setId(Integer.toString(1)).setSource("field", "value").get();
+        client().prepareIndex("test1").setId(Integer.toString(2)).setSource("field", "value").get();
+        client().prepareIndex("test2").setId(Integer.toString(1)).setSource("field", "value").get();
         refresh();
 
         NumShards test1 = getNumShards("test1");
@@ -567,7 +561,7 @@ public class IndexStatsIT extends ESIntegTestCase {
         long test2ExpectedWrites = test2.dataCopies;
         long totalExpectedWrites = test1ExpectedWrites + test2ExpectedWrites;
 
-        IndicesStatsResponse stats = indicesAdmin().prepareStats().execute().actionGet();
+        IndicesStatsResponse stats = indicesAdmin().prepareStats().get();
         assertThat(stats.getPrimaries().getDocs().getCount(), equalTo(3L));
         assertThat(stats.getTotal().getDocs().getCount(), equalTo(totalExpectedWrites));
         assertThat(stats.getPrimaries().getIndexing().getTotal().getIndexCount(), equalTo(3L));
@@ -601,7 +595,7 @@ public class IndexStatsIT extends ESIntegTestCase {
         assertThat(stats.getIndex("test2").getTotal().getSearch().getTotal().getQueryCurrent(), equalTo(0L));
 
         // check flags
-        stats = indicesAdmin().prepareStats().clear().setFlush(true).setRefresh(true).setMerge(true).execute().actionGet();
+        stats = indicesAdmin().prepareStats().clear().setFlush(true).setRefresh(true).setMerge(true).get();
 
         assertThat(stats.getTotal().getDocs(), nullValue());
         assertThat(stats.getTotal().getStore(), nullValue());
@@ -611,19 +605,19 @@ public class IndexStatsIT extends ESIntegTestCase {
         assertThat(stats.getTotal().getRefresh(), notNullValue());
 
         // check get
-        GetResponse getResponse = client().prepareGet("test2", "1").execute().actionGet();
+        GetResponse getResponse = client().prepareGet("test2", "1").get();
         assertThat(getResponse.isExists(), equalTo(true));
 
-        stats = indicesAdmin().prepareStats().execute().actionGet();
+        stats = indicesAdmin().prepareStats().get();
         assertThat(stats.getTotal().getGet().getCount(), equalTo(1L));
         assertThat(stats.getTotal().getGet().getExistsCount(), equalTo(1L));
         assertThat(stats.getTotal().getGet().getMissingCount(), equalTo(0L));
 
         // missing get
-        getResponse = client().prepareGet("test2", "2").execute().actionGet();
+        getResponse = client().prepareGet("test2", "2").get();
         assertThat(getResponse.isExists(), equalTo(false));
 
-        stats = indicesAdmin().prepareStats().execute().actionGet();
+        stats = indicesAdmin().prepareStats().get();
         assertThat(stats.getTotal().getGet().getCount(), equalTo(2L));
         assertThat(stats.getTotal().getGet().getExistsCount(), equalTo(1L));
         assertThat(stats.getTotal().getGet().getMissingCount(), equalTo(1L));
@@ -637,8 +631,7 @@ public class IndexStatsIT extends ESIntegTestCase {
             .setRefresh(true)
             .setMerge(true)
             .clear() // reset defaults
-            .execute()
-            .actionGet();
+            .get();
 
         assertThat(stats.getTotal().getDocs(), nullValue());
         assertThat(stats.getTotal().getStore(), nullValue());
@@ -653,8 +646,7 @@ public class IndexStatsIT extends ESIntegTestCase {
                 .setSource("field", "value")
                 .setVersion(1)
                 .setVersionType(VersionType.EXTERNAL)
-                .execute()
-                .actionGet();
+                .get();
             fail("Expected a version conflict");
         } catch (VersionConflictEngineException e) {}
         try {
@@ -663,8 +655,7 @@ public class IndexStatsIT extends ESIntegTestCase {
                 .setSource("field", "value")
                 .setVersion(1)
                 .setVersionType(VersionType.EXTERNAL)
-                .execute()
-                .actionGet();
+                .get();
             fail("Expected a version conflict");
         } catch (VersionConflictEngineException e) {}
         try {
@@ -673,12 +664,11 @@ public class IndexStatsIT extends ESIntegTestCase {
                 .setSource("field", "value")
                 .setVersion(1)
                 .setVersionType(VersionType.EXTERNAL)
-                .execute()
-                .actionGet();
+                .get();
             fail("Expected a version conflict");
         } catch (VersionConflictEngineException e) {}
 
-        stats = indicesAdmin().prepareStats().execute().actionGet();
+        stats = indicesAdmin().prepareStats().get();
         assertThat(stats.getIndex("test2").getPrimaries().getIndexing().getTotal().getIndexFailedCount(), equalTo(2L));
         assertThat(stats.getPrimaries().getIndexing().getTotal().getIndexFailedCount(), equalTo(3L));
     }
@@ -697,8 +687,7 @@ public class IndexStatsIT extends ESIntegTestCase {
             .setRefresh(true)
             .setMerge(true)
             .clear() // reset defaults
-            .execute()
-            .actionGet();
+            .get();
 
         assertThat(stats.getTotal().getDocs(), nullValue());
         assertThat(stats.getTotal().getStore(), nullValue());
@@ -707,11 +696,11 @@ public class IndexStatsIT extends ESIntegTestCase {
         assertThat(stats.getTotal().getSearch(), nullValue());
 
         for (int i = 0; i < 20; i++) {
-            client().prepareIndex("test_index").setId(Integer.toString(i)).setSource("field", "value").execute().actionGet();
-            indicesAdmin().prepareFlush().execute().actionGet();
+            client().prepareIndex("test_index").setId(Integer.toString(i)).setSource("field", "value").get();
+            indicesAdmin().prepareFlush().get();
         }
-        indicesAdmin().prepareForceMerge().setMaxNumSegments(1).execute().actionGet();
-        stats = indicesAdmin().prepareStats().setMerge(true).execute().actionGet();
+        indicesAdmin().prepareForceMerge().setMaxNumSegments(1).get();
+        stats = indicesAdmin().prepareStats().setMerge(true).get();
 
         assertThat(stats.getTotal().getMerge(), notNullValue());
         assertThat(stats.getTotal().getMerge().getTotal(), greaterThan(0L));
@@ -738,7 +727,7 @@ public class IndexStatsIT extends ESIntegTestCase {
         assertThat(stats.getTotal().getSegments().getVersionMapMemoryInBytes(), greaterThan(0L));
 
         indicesAdmin().prepareFlush().get();
-        indicesAdmin().prepareForceMerge().setMaxNumSegments(1).execute().actionGet();
+        indicesAdmin().prepareForceMerge().setMaxNumSegments(1).get();
         indicesAdmin().prepareRefresh().get();
 
         final boolean includeSegmentFileSizes = randomBoolean();
@@ -765,18 +754,18 @@ public class IndexStatsIT extends ESIntegTestCase {
 
         ensureGreen();
 
-        client().prepareIndex("test_index").setId(Integer.toString(1)).setSource("field", "value").execute().actionGet();
-        client().prepareIndex("test_index").setId(Integer.toString(2)).setSource("field", "value").execute().actionGet();
-        client().prepareIndex("test_index_2").setId(Integer.toString(1)).setSource("field", "value").execute().actionGet();
+        client().prepareIndex("test_index").setId(Integer.toString(1)).setSource("field", "value").get();
+        client().prepareIndex("test_index").setId(Integer.toString(2)).setSource("field", "value").get();
+        client().prepareIndex("test_index_2").setId(Integer.toString(1)).setSource("field", "value").get();
 
-        indicesAdmin().prepareRefresh().execute().actionGet();
+        indicesAdmin().prepareRefresh().get();
         IndicesStatsRequestBuilder builder = indicesAdmin().prepareStats();
         Flag[] values = CommonStatsFlags.SHARD_LEVEL.getFlags();
         for (Flag flag : values) {
             set(flag, builder, false);
         }
 
-        IndicesStatsResponse stats = builder.execute().actionGet();
+        IndicesStatsResponse stats = builder.get();
         for (Flag flag : values) {
             assertThat(isSet(flag, stats.getPrimaries()), equalTo(false));
             assertThat(isSet(flag, stats.getTotal()), equalTo(false));
@@ -785,7 +774,7 @@ public class IndexStatsIT extends ESIntegTestCase {
         for (Flag flag : values) {
             set(flag, builder, true);
         }
-        stats = builder.execute().actionGet();
+        stats = builder.get();
         for (Flag flag : values) {
             assertThat(isSet(flag, stats.getPrimaries()), equalTo(true));
             assertThat(isSet(flag, stats.getTotal()), equalTo(true));
@@ -805,7 +794,7 @@ public class IndexStatsIT extends ESIntegTestCase {
         for (Flag flag : flags) { // set the flags
             set(flag, builder, true);
         }
-        stats = builder.execute().actionGet();
+        stats = builder.get();
         for (Flag flag : flags) { // check the flags
             assertThat(isSet(flag, stats.getPrimaries()), equalTo(true));
             assertThat(isSet(flag, stats.getTotal()), equalTo(true));
@@ -896,35 +885,35 @@ public class IndexStatsIT extends ESIntegTestCase {
 
         ensureGreen();
 
-        client().prepareIndex("test1").setId(Integer.toString(1)).setSource("field", "value").execute().actionGet();
-        client().prepareIndex("test1").setId(Integer.toString(2)).setSource("field", "value").execute().actionGet();
-        client().prepareIndex("test2").setId(Integer.toString(1)).setSource("field", "value").execute().actionGet();
+        client().prepareIndex("test1").setId(Integer.toString(1)).setSource("field", "value").get();
+        client().prepareIndex("test1").setId(Integer.toString(2)).setSource("field", "value").get();
+        client().prepareIndex("test2").setId(Integer.toString(1)).setSource("field", "value").get();
         refresh();
 
         int numShards1 = getNumShards("test1").totalNumShards;
         int numShards2 = getNumShards("test2").totalNumShards;
 
         IndicesStatsRequestBuilder builder = indicesAdmin().prepareStats();
-        IndicesStatsResponse stats = builder.execute().actionGet();
+        IndicesStatsResponse stats = builder.get();
 
         assertThat(stats.getTotalShards(), equalTo(numShards1 + numShards2));
 
-        stats = builder.setIndices("_all").execute().actionGet();
+        stats = builder.setIndices("_all").get();
         assertThat(stats.getTotalShards(), equalTo(numShards1 + numShards2));
 
-        stats = builder.setIndices("_all").execute().actionGet();
+        stats = builder.setIndices("_all").get();
         assertThat(stats.getTotalShards(), equalTo(numShards1 + numShards2));
 
-        stats = builder.setIndices("*").execute().actionGet();
+        stats = builder.setIndices("*").get();
         assertThat(stats.getTotalShards(), equalTo(numShards1 + numShards2));
 
-        stats = builder.setIndices("test1").execute().actionGet();
+        stats = builder.setIndices("test1").get();
         assertThat(stats.getTotalShards(), equalTo(numShards1));
 
-        stats = builder.setIndices("test1", "test2").execute().actionGet();
+        stats = builder.setIndices("test1", "test2").get();
         assertThat(stats.getTotalShards(), equalTo(numShards1 + numShards2));
 
-        stats = builder.setIndices("*2").execute().actionGet();
+        stats = builder.setIndices("*2").get();
         assertThat(stats.getTotalShards(), equalTo(numShards2));
 
     }
@@ -958,32 +947,32 @@ public class IndexStatsIT extends ESIntegTestCase {
         refresh();
 
         IndicesStatsRequestBuilder builder = indicesAdmin().prepareStats();
-        IndicesStatsResponse stats = builder.execute().actionGet();
+        IndicesStatsResponse stats = builder.get();
 
         assertThat(stats.getTotal().completion.getSizeInBytes(), greaterThan(0L));
         assertThat(stats.getTotal().completion.getFields(), is(nullValue()));
 
-        stats = builder.setCompletionFields("bar.completion").execute().actionGet();
+        stats = builder.setCompletionFields("bar.completion").get();
         assertThat(stats.getTotal().completion.getSizeInBytes(), greaterThan(0L));
         assertThat(stats.getTotal().completion.getFields().containsField("bar.completion"), is(true));
         assertThat(stats.getTotal().completion.getFields().get("bar.completion"), greaterThan(0L));
         assertThat(stats.getTotal().completion.getFields().containsField("baz.completion"), is(false));
 
-        stats = builder.setCompletionFields("bar.completion", "baz.completion").execute().actionGet();
+        stats = builder.setCompletionFields("bar.completion", "baz.completion").get();
         assertThat(stats.getTotal().completion.getSizeInBytes(), greaterThan(0L));
         assertThat(stats.getTotal().completion.getFields().containsField("bar.completion"), is(true));
         assertThat(stats.getTotal().completion.getFields().get("bar.completion"), greaterThan(0L));
         assertThat(stats.getTotal().completion.getFields().containsField("baz.completion"), is(true));
         assertThat(stats.getTotal().completion.getFields().get("baz.completion"), greaterThan(0L));
 
-        stats = builder.setCompletionFields("*").execute().actionGet();
+        stats = builder.setCompletionFields("*").get();
         assertThat(stats.getTotal().completion.getSizeInBytes(), greaterThan(0L));
         assertThat(stats.getTotal().completion.getFields().containsField("bar.completion"), is(true));
         assertThat(stats.getTotal().completion.getFields().get("bar.completion"), greaterThan(0L));
         assertThat(stats.getTotal().completion.getFields().containsField("baz.completion"), is(true));
         assertThat(stats.getTotal().completion.getFields().get("baz.completion"), greaterThan(0L));
 
-        stats = builder.setCompletionFields("*r*").execute().actionGet();
+        stats = builder.setCompletionFields("*r*").get();
         assertThat(stats.getTotal().completion.getSizeInBytes(), greaterThan(0L));
         assertThat(stats.getTotal().completion.getFields().containsField("bar.completion"), is(true));
         assertThat(stats.getTotal().completion.getFields().get("bar.completion"), greaterThan(0L));
@@ -996,30 +985,30 @@ public class IndexStatsIT extends ESIntegTestCase {
 
         ensureGreen();
 
-        client().prepareIndex("test1").setId(Integer.toString(1)).setSource("foo", "bar").execute().actionGet();
+        client().prepareIndex("test1").setId(Integer.toString(1)).setSource("foo", "bar").get();
         refresh();
 
-        prepareSearch("_all").setStats("bar", "baz").execute().actionGet();
+        prepareSearch("_all").setStats("bar", "baz").get();
 
         IndicesStatsRequestBuilder builder = indicesAdmin().prepareStats();
-        IndicesStatsResponse stats = builder.execute().actionGet();
+        IndicesStatsResponse stats = builder.get();
 
         assertThat(stats.getTotal().search.getTotal().getQueryCount(), greaterThan(0L));
         assertThat(stats.getTotal().search.getGroupStats(), is(nullValue()));
 
-        stats = builder.setGroups("bar").execute().actionGet();
+        stats = builder.setGroups("bar").get();
         assertThat(stats.getTotal().search.getGroupStats().get("bar").getQueryCount(), greaterThan(0L));
         assertThat(stats.getTotal().search.getGroupStats().containsKey("baz"), is(false));
 
-        stats = builder.setGroups("bar", "baz").execute().actionGet();
+        stats = builder.setGroups("bar", "baz").get();
         assertThat(stats.getTotal().search.getGroupStats().get("bar").getQueryCount(), greaterThan(0L));
         assertThat(stats.getTotal().search.getGroupStats().get("baz").getQueryCount(), greaterThan(0L));
 
-        stats = builder.setGroups("*").execute().actionGet();
+        stats = builder.setGroups("*").get();
         assertThat(stats.getTotal().search.getGroupStats().get("bar").getQueryCount(), greaterThan(0L));
         assertThat(stats.getTotal().search.getGroupStats().get("baz").getQueryCount(), greaterThan(0L));
 
-        stats = builder.setGroups("*r").execute().actionGet();
+        stats = builder.setGroups("*r").get();
         assertThat(stats.getTotal().search.getGroupStats().get("bar").getQueryCount(), greaterThan(0L));
         assertThat(stats.getTotal().search.getGroupStats().containsKey("baz"), is(false));
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/template/IndexTemplateBlocksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/template/IndexTemplateBlocksIT.java
@@ -44,13 +44,12 @@ public class IndexTemplateBlocksIT extends ESIntegTestCase {
                     .endObject()
                     .endObject()
             )
-            .execute()
-            .actionGet();
+            .get();
 
         try {
             setClusterReadOnly(true);
 
-            GetIndexTemplatesResponse response = indicesAdmin().prepareGetTemplates("template_blocks").execute().actionGet();
+            GetIndexTemplatesResponse response = indicesAdmin().prepareGetTemplates("template_blocks").get();
             assertThat(response.getIndexTemplates(), hasSize(1));
 
             assertBlocked(

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/template/SimpleIndexTemplateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/template/SimpleIndexTemplateIT.java
@@ -155,8 +155,7 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
         SearchResponse searchResponse = prepareSearch("test_index").setQuery(termQuery("field1", "value1"))
             .addStoredField("field1")
             .addStoredField("field2")
-            .execute()
-            .actionGet();
+            .get();
 
         assertHitCount(searchResponse, 1);
         assertThat(searchResponse.getHits().getAt(0).field("field1").getValue().toString(), equalTo("value1"));
@@ -170,8 +169,7 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
         searchResponse = prepareSearch("text_index").setQuery(termQuery("field1", "value1"))
             .addStoredField("field1")
             .addStoredField("field2")
-            .execute()
-            .actionGet();
+            .get();
         if (searchResponse.getFailedShards() > 0) {
             logger.warn("failed search {}", Arrays.toString(searchResponse.getShardFailures()));
         }
@@ -181,7 +179,7 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
     }
 
     public void testDeleteIndexTemplate() throws Exception {
-        final int existingTemplates = admin().cluster().prepareState().execute().actionGet().getState().metadata().templates().size();
+        final int existingTemplates = admin().cluster().prepareState().get().getState().metadata().templates().size();
         logger.info("--> put template_1 and template_2");
         indicesAdmin().preparePutTemplate("template_1")
             .setPatterns(Collections.singletonList("te*"))
@@ -203,8 +201,7 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
                     .endObject()
                     .endObject()
             )
-            .execute()
-            .actionGet();
+            .get();
 
         indicesAdmin().preparePutTemplate("template_2")
             .setPatterns(Collections.singletonList("test*"))
@@ -222,13 +219,12 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
                     .endObject()
                     .endObject()
             )
-            .execute()
-            .actionGet();
+            .get();
 
         logger.info("--> explicitly delete template_1");
-        indicesAdmin().prepareDeleteTemplate("template_1").execute().actionGet();
+        indicesAdmin().prepareDeleteTemplate("template_1").get();
 
-        ClusterState state = admin().cluster().prepareState().execute().actionGet().getState();
+        ClusterState state = admin().cluster().prepareState().get().getState();
 
         assertThat(state.metadata().templates().size(), equalTo(1 + existingTemplates));
         assertThat(state.metadata().templates().containsKey("template_2"), equalTo(true));
@@ -255,19 +251,15 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
                     .endObject()
                     .endObject()
             )
-            .execute()
-            .actionGet();
+            .get();
 
         logger.info("--> delete template*");
-        indicesAdmin().prepareDeleteTemplate("template*").execute().actionGet();
-        assertThat(
-            admin().cluster().prepareState().execute().actionGet().getState().metadata().templates().size(),
-            equalTo(existingTemplates)
-        );
+        indicesAdmin().prepareDeleteTemplate("template*").get();
+        assertThat(admin().cluster().prepareState().get().getState().metadata().templates().size(), equalTo(existingTemplates));
 
         logger.info("--> delete * with no templates, make sure we don't get a failure");
-        indicesAdmin().prepareDeleteTemplate("*").execute().actionGet();
-        assertThat(admin().cluster().prepareState().execute().actionGet().getState().metadata().templates().size(), equalTo(0));
+        indicesAdmin().prepareDeleteTemplate("*").get();
+        assertThat(admin().cluster().prepareState().get().getState().metadata().templates().size(), equalTo(0));
     }
 
     public void testThatGetIndexTemplatesWorks() throws Exception {
@@ -293,11 +285,10 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
                     .endObject()
                     .endObject()
             )
-            .execute()
-            .actionGet();
+            .get();
 
         logger.info("--> get template template_1");
-        GetIndexTemplatesResponse getTemplate1Response = indicesAdmin().prepareGetTemplates("template_1").execute().actionGet();
+        GetIndexTemplatesResponse getTemplate1Response = indicesAdmin().prepareGetTemplates("template_1").get();
         assertThat(getTemplate1Response.getIndexTemplates(), hasSize(1));
         assertThat(getTemplate1Response.getIndexTemplates().get(0), is(notNullValue()));
         assertThat(getTemplate1Response.getIndexTemplates().get(0).patterns(), is(Collections.singletonList("te*")));
@@ -305,7 +296,7 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
         assertThat(getTemplate1Response.getIndexTemplates().get(0).getVersion(), is(123));
 
         logger.info("--> get non-existing-template");
-        GetIndexTemplatesResponse getTemplate2Response = indicesAdmin().prepareGetTemplates("non-existing-template").execute().actionGet();
+        GetIndexTemplatesResponse getTemplate2Response = indicesAdmin().prepareGetTemplates("non-existing-template").get();
         assertThat(getTemplate2Response.getIndexTemplates(), hasSize(0));
     }
 
@@ -331,8 +322,7 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
                     .endObject()
                     .endObject()
             )
-            .execute()
-            .actionGet();
+            .get();
 
         logger.info("--> put template_2");
         indicesAdmin().preparePutTemplate("template_2")
@@ -355,8 +345,7 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
                     .endObject()
                     .endObject()
             )
-            .execute()
-            .actionGet();
+            .get();
 
         logger.info("--> put template3");
         indicesAdmin().preparePutTemplate("template3")
@@ -379,11 +368,10 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
                     .endObject()
                     .endObject()
             )
-            .execute()
-            .actionGet();
+            .get();
 
         logger.info("--> get template template_*");
-        GetIndexTemplatesResponse getTemplate1Response = indicesAdmin().prepareGetTemplates("template_*").execute().actionGet();
+        GetIndexTemplatesResponse getTemplate1Response = indicesAdmin().prepareGetTemplates("template_*").get();
         assertThat(getTemplate1Response.getIndexTemplates(), hasSize(2));
 
         List<String> templateNames = new ArrayList<>();
@@ -392,7 +380,7 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
         assertThat(templateNames, containsInAnyOrder("template_1", "template_2"));
 
         logger.info("--> get all templates");
-        getTemplate1Response = indicesAdmin().prepareGetTemplates("template*").execute().actionGet();
+        getTemplate1Response = indicesAdmin().prepareGetTemplates("template*").get();
         assertThat(getTemplate1Response.getIndexTemplates(), hasSize(3));
 
         templateNames = new ArrayList<>();
@@ -402,7 +390,7 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
         assertThat(templateNames, containsInAnyOrder("template_1", "template_2", "template3"));
 
         logger.info("--> get templates template_1 and template_2");
-        getTemplate1Response = indicesAdmin().prepareGetTemplates("template_1", "template_2").execute().actionGet();
+        getTemplate1Response = indicesAdmin().prepareGetTemplates("template_1", "template_2").get();
         assertThat(getTemplate1Response.getIndexTemplates(), hasSize(2));
 
         templateNames = new ArrayList<>();
@@ -852,8 +840,7 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
         SearchResponse searchResponse = prepareSearch("ax").setQuery(termQuery("field1", "value1"))
             .addStoredField("field1")
             .addStoredField("field2")
-            .execute()
-            .actionGet();
+            .get();
 
         assertHitCount(searchResponse, 1);
         assertEquals("value1", searchResponse.getHits().getAt(0).field("field1").getValue().toString());
@@ -863,8 +850,7 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
         searchResponse = prepareSearch("bx").setQuery(termQuery("field1", "value1"))
             .addStoredField("field1")
             .addStoredField("field2")
-            .execute()
-            .actionGet();
+            .get();
 
         assertHitCount(searchResponse, 1);
         assertEquals("value1", searchResponse.getHits().getAt(0).field("field1").getValue().toString());

--- a/server/src/internalClusterTest/java/org/elasticsearch/nodesinfo/SimpleNodesInfoIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/nodesinfo/SimpleNodesInfoIT.java
@@ -41,7 +41,7 @@ public class SimpleNodesInfoIT extends ESIntegTestCase {
         String server2NodeId = internalCluster().getInstance(ClusterService.class, node_2).state().nodes().getLocalNodeId();
         logger.info("--> started nodes: {} and {}", server1NodeId, server2NodeId);
 
-        NodesInfoResponse response = clusterAdmin().prepareNodesInfo().execute().actionGet();
+        NodesInfoResponse response = clusterAdmin().prepareNodesInfo().get();
         assertThat(response.getNodes(), hasSize(2));
         assertThat(response.getNodesMap().get(server1NodeId), notNullValue());
         assertThat(response.getNodesMap().get(server2NodeId), notNullValue());
@@ -80,7 +80,7 @@ public class SimpleNodesInfoIT extends ESIntegTestCase {
         String server2NodeId = internalCluster().getInstance(ClusterService.class, node_2).state().nodes().getLocalNodeId();
         logger.info("--> started nodes: {} and {}", server1NodeId, server2NodeId);
 
-        NodesInfoResponse response = clusterAdmin().prepareNodesInfo().execute().actionGet();
+        NodesInfoResponse response = clusterAdmin().prepareNodesInfo().get();
         assertThat(response.getNodes(), hasSize(2));
         assertThat(response.getNodesMap().get(server1NodeId), notNullValue());
         assertNotNull(response.getNodesMap().get(server1NodeId).getTotalIndexingBuffer());
@@ -91,7 +91,7 @@ public class SimpleNodesInfoIT extends ESIntegTestCase {
         assertThat(response.getNodesMap().get(server2NodeId).getTotalIndexingBuffer().getBytes(), greaterThan(0L));
 
         // again, using only the indices flag
-        response = clusterAdmin().prepareNodesInfo().clear().setIndices(true).execute().actionGet();
+        response = clusterAdmin().prepareNodesInfo().clear().setIndices(true).get();
         assertThat(response.getNodes(), hasSize(2));
         assertThat(response.getNodesMap().get(server1NodeId), notNullValue());
         assertNotNull(response.getNodesMap().get(server1NodeId).getTotalIndexingBuffer());
@@ -118,7 +118,7 @@ public class SimpleNodesInfoIT extends ESIntegTestCase {
         String server2NodeId = internalCluster().getInstance(ClusterService.class, node_2).state().nodes().getLocalNodeId();
         logger.info("--> started nodes: {} and {}", server1NodeId, server2NodeId);
 
-        NodesInfoResponse response = clusterAdmin().prepareNodesInfo().execute().actionGet();
+        NodesInfoResponse response = clusterAdmin().prepareNodesInfo().get();
 
         assertThat(response.getNodes(), hasSize(2));
         assertThat(response.getNodesMap().get(server1NodeId), notNullValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/readiness/ReadinessClusterIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/readiness/ReadinessClusterIT.java
@@ -99,16 +99,13 @@ public class ReadinessClusterIT extends ESIntegTestCase {
     }
 
     private void assertMasterNode(Client client, String node) {
-        assertThat(
-            client.admin().cluster().prepareState().execute().actionGet().getState().nodes().getMasterNode().getName(),
-            equalTo(node)
-        );
+        assertThat(client.admin().cluster().prepareState().get().getState().nodes().getMasterNode().getName(), equalTo(node));
     }
 
     private void expectMasterNotFound() {
         expectThrows(
             MasterNotDiscoveredException.class,
-            () -> clusterAdmin().prepareState().setMasterNodeTimeout("100ms").execute().actionGet().getState().nodes().getMasterNodeId()
+            () -> clusterAdmin().prepareState().setMasterNodeTimeout("100ms").get().getState().nodes().getMasterNodeId()
         );
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/recovery/FullRollingRestartIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/recovery/FullRollingRestartIT.java
@@ -49,19 +49,11 @@ public class FullRollingRestartIT extends ESIntegTestCase {
         final String healthTimeout = "1m";
 
         for (int i = 0; i < 1000; i++) {
-            client().prepareIndex("test")
-                .setId(Long.toString(i))
-                .setSource(Map.<String, Object>of("test", "value" + i))
-                .execute()
-                .actionGet();
+            client().prepareIndex("test").setId(Long.toString(i)).setSource(Map.<String, Object>of("test", "value" + i)).get();
         }
         flush();
         for (int i = 1000; i < 2000; i++) {
-            client().prepareIndex("test")
-                .setId(Long.toString(i))
-                .setSource(Map.<String, Object>of("test", "value" + i))
-                .execute()
-                .actionGet();
+            client().prepareIndex("test").setId(Long.toString(i)).setSource(Map.<String, Object>of("test", "value" + i)).get();
         }
 
         logger.info("--> now start adding nodes");
@@ -173,11 +165,7 @@ public class FullRollingRestartIT extends ESIntegTestCase {
         ).get();
 
         for (int i = 0; i < 100; i++) {
-            client().prepareIndex("test")
-                .setId(Long.toString(i))
-                .setSource(Map.<String, Object>of("test", "value" + i))
-                .execute()
-                .actionGet();
+            client().prepareIndex("test").setId(Long.toString(i)).setSource(Map.<String, Object>of("test", "value" + i)).get();
         }
         ensureGreen();
         ClusterState state = clusterAdmin().prepareState().get().getState();

--- a/server/src/internalClusterTest/java/org/elasticsearch/recovery/RecoveryWhileUnderLoadIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/recovery/RecoveryWhileUnderLoadIT.java
@@ -85,7 +85,7 @@ public class RecoveryWhileUnderLoadIT extends ESIntegTestCase {
             indexer.continueIndexing(extraDocs);
             logger.info("--> flushing the index ....");
             // now flush, just to make sure we have some data in the index, not just translog
-            indicesAdmin().prepareFlush().execute().actionGet();
+            indicesAdmin().prepareFlush().get();
 
             logger.info("--> waiting for {} docs to be indexed ...", waitFor);
             waitForDocs(waitFor, indexer);
@@ -144,7 +144,7 @@ public class RecoveryWhileUnderLoadIT extends ESIntegTestCase {
             indexer.continueIndexing(extraDocs);
             logger.info("--> flushing the index ....");
             // now flush, just to make sure we have some data in the index, not just translog
-            indicesAdmin().prepareFlush().execute().actionGet();
+            indicesAdmin().prepareFlush().get();
 
             logger.info("--> waiting for {} docs to be indexed ...", waitFor);
             waitForDocs(waitFor, indexer);
@@ -200,7 +200,7 @@ public class RecoveryWhileUnderLoadIT extends ESIntegTestCase {
             indexer.continueIndexing(extraDocs);
             logger.info("--> flushing the index ....");
             // now flush, just to make sure we have some data in the index, not just translog
-            indicesAdmin().prepareFlush().execute().actionGet();
+            indicesAdmin().prepareFlush().get();
 
             logger.info("--> waiting for {} docs to be indexed ...", waitFor);
             waitForDocs(waitFor, indexer);

--- a/server/src/internalClusterTest/java/org/elasticsearch/recovery/RelocationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/recovery/RelocationIT.java
@@ -122,42 +122,40 @@ public class RelocationIT extends ESIntegTestCase {
 
         logger.info("--> index 10 docs");
         for (int i = 0; i < 10; i++) {
-            client().prepareIndex("test").setId(Integer.toString(i)).setSource("field", "value" + i).execute().actionGet();
+            client().prepareIndex("test").setId(Integer.toString(i)).setSource("field", "value" + i).get();
         }
         logger.info("--> flush so we have an actual index");
-        indicesAdmin().prepareFlush().execute().actionGet();
+        indicesAdmin().prepareFlush().get();
         logger.info("--> index more docs so we have something in the translog");
         for (int i = 10; i < 20; i++) {
-            client().prepareIndex("test").setId(Integer.toString(i)).setSource("field", "value" + i).execute().actionGet();
+            client().prepareIndex("test").setId(Integer.toString(i)).setSource("field", "value" + i).get();
         }
 
         logger.info("--> verifying count");
-        indicesAdmin().prepareRefresh().execute().actionGet();
-        assertThat(prepareSearch("test").setSize(0).execute().actionGet().getHits().getTotalHits().value, equalTo(20L));
+        indicesAdmin().prepareRefresh().get();
+        assertThat(prepareSearch("test").setSize(0).get().getHits().getTotalHits().value, equalTo(20L));
 
         logger.info("--> start another node");
         final String node_2 = internalCluster().startNode();
         ClusterHealthResponse clusterHealthResponse = clusterAdmin().prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForNodes("2")
-            .execute()
-            .actionGet();
+            .get();
         assertThat(clusterHealthResponse.isTimedOut(), equalTo(false));
 
         logger.info("--> relocate the shard from node1 to node2");
-        clusterAdmin().prepareReroute().add(new MoveAllocationCommand("test", 0, node_1, node_2)).execute().actionGet();
+        clusterAdmin().prepareReroute().add(new MoveAllocationCommand("test", 0, node_1, node_2)).get();
 
         clusterHealthResponse = clusterAdmin().prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForNoRelocatingShards(true)
             .setTimeout(ACCEPTABLE_RELOCATION_TIME)
-            .execute()
-            .actionGet();
+            .get();
         assertThat(clusterHealthResponse.isTimedOut(), equalTo(false));
 
         logger.info("--> verifying count again...");
-        indicesAdmin().prepareRefresh().execute().actionGet();
-        assertThat(prepareSearch("test").setSize(0).execute().actionGet().getHits().getTotalHits().value, equalTo(20L));
+        indicesAdmin().prepareRefresh().get();
+        assertThat(prepareSearch("test").setSize(0).get().getHits().getTotalHits().value, equalTo(20L));
     }
 
     public void testRelocationWhileIndexingRandom() throws Exception {
@@ -187,8 +185,7 @@ public class RelocationIT extends ESIntegTestCase {
                     .setWaitForEvents(Priority.LANGUID)
                     .setWaitForNodes(Integer.toString(i))
                     .setWaitForGreenStatus()
-                    .execute()
-                    .actionGet();
+                    .get();
                 assertThat(healthResponse.isTimedOut(), equalTo(false));
             }
         }
@@ -219,8 +216,7 @@ public class RelocationIT extends ESIntegTestCase {
                     .setWaitForEvents(Priority.LANGUID)
                     .setWaitForNoRelocatingShards(true)
                     .setTimeout(ACCEPTABLE_RELOCATION_TIME)
-                    .execute()
-                    .actionGet();
+                    .get();
                 assertThat(clusterHealthResponse.isTimedOut(), equalTo(false));
                 indexer.pauseIndexing();
                 logger.info("--> DONE relocate the shard from {} to {}", fromNode, toNode);
@@ -231,7 +227,7 @@ public class RelocationIT extends ESIntegTestCase {
             logger.info("--> indexing threads stopped");
 
             logger.info("--> refreshing the index");
-            indicesAdmin().prepareRefresh("test").execute().actionGet();
+            indicesAdmin().prepareRefresh("test").get();
             logger.info("--> searching the index");
             boolean ranOnce = false;
             for (int i = 0; i < 10; i++) {
@@ -239,8 +235,7 @@ public class RelocationIT extends ESIntegTestCase {
                 SearchHits hits = prepareSearch("test").setQuery(matchAllQuery())
                     .setSize((int) indexer.totalIndexedDocs())
                     .storedFields()
-                    .execute()
-                    .actionGet()
+                    .get()
                     .getHits();
                 ranOnce = true;
                 if (hits.getTotalHits().value != indexer.totalIndexedDocs()) {
@@ -298,8 +293,7 @@ public class RelocationIT extends ESIntegTestCase {
                     .setWaitForEvents(Priority.LANGUID)
                     .setWaitForNodes(Integer.toString(i + 1))
                     .setWaitForGreenStatus()
-                    .execute()
-                    .actionGet();
+                    .get();
                 assertThat(healthResponse.isTimedOut(), equalTo(false));
             }
         }
@@ -544,10 +538,10 @@ public class RelocationIT extends ESIntegTestCase {
 
         logger.info("--> index 10 docs");
         for (int i = 0; i < 10; i++) {
-            client().prepareIndex("test").setId(Integer.toString(i)).setSource("field", "value" + i).execute().actionGet();
+            client().prepareIndex("test").setId(Integer.toString(i)).setSource("field", "value" + i).get();
         }
         logger.info("--> flush so we have an actual index");
-        indicesAdmin().prepareFlush().execute().actionGet();
+        indicesAdmin().prepareFlush().get();
         logger.info("--> index more docs so we have something in the translog");
         for (int i = 10; i < 20; i++) {
             client().prepareIndex("test")
@@ -562,24 +556,22 @@ public class RelocationIT extends ESIntegTestCase {
         ClusterHealthResponse clusterHealthResponse = clusterAdmin().prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForNodes("2")
-            .execute()
-            .actionGet();
+            .get();
         assertThat(clusterHealthResponse.isTimedOut(), equalTo(false));
 
         logger.info("--> relocate the shard from node1 to node2");
-        clusterAdmin().prepareReroute().add(new MoveAllocationCommand("test", 0, node1, node2)).execute().actionGet();
+        clusterAdmin().prepareReroute().add(new MoveAllocationCommand("test", 0, node1, node2)).get();
 
         clusterHealthResponse = clusterAdmin().prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForNoRelocatingShards(true)
             .setTimeout(ACCEPTABLE_RELOCATION_TIME)
-            .execute()
-            .actionGet();
+            .get();
         assertThat(clusterHealthResponse.isTimedOut(), equalTo(false));
 
         logger.info("--> verifying count");
-        indicesAdmin().prepareRefresh().execute().actionGet();
-        assertThat(prepareSearch("test").setSize(0).execute().actionGet().getHits().getTotalHits().value, equalTo(20L));
+        indicesAdmin().prepareRefresh().get();
+        assertThat(prepareSearch("test").setSize(0).get().getHits().getTotalHits().value, equalTo(20L));
     }
 
     public void testRelocateWhileContinuouslyIndexingAndWaitingForRefresh() throws Exception {
@@ -595,10 +587,10 @@ public class RelocationIT extends ESIntegTestCase {
 
         logger.info("--> index 10 docs");
         for (int i = 0; i < 10; i++) {
-            client().prepareIndex("test").setId(Integer.toString(i)).setSource("field", "value" + i).execute().actionGet();
+            client().prepareIndex("test").setId(Integer.toString(i)).setSource("field", "value" + i).get();
         }
         logger.info("--> flush so we have an actual index");
-        indicesAdmin().prepareFlush().execute().actionGet();
+        indicesAdmin().prepareFlush().get();
         logger.info("--> index more docs so we have something in the translog");
         final List<ActionFuture<DocWriteResponse>> pendingIndexResponses = new ArrayList<>();
         for (int i = 10; i < 20; i++) {
@@ -616,8 +608,7 @@ public class RelocationIT extends ESIntegTestCase {
         ClusterHealthResponse clusterHealthResponse = clusterAdmin().prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForNodes("2")
-            .execute()
-            .actionGet();
+            .get();
         assertThat(clusterHealthResponse.isTimedOut(), equalTo(false));
 
         logger.info("--> relocate the shard from node1 to node2");
@@ -639,17 +630,16 @@ public class RelocationIT extends ESIntegTestCase {
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForNoRelocatingShards(true)
             .setTimeout(ACCEPTABLE_RELOCATION_TIME)
-            .execute()
-            .actionGet();
+            .get();
         assertThat(clusterHealthResponse.isTimedOut(), equalTo(false));
 
         logger.info("--> verifying count");
         assertBusy(() -> {
-            indicesAdmin().prepareRefresh().execute().actionGet();
+            indicesAdmin().prepareRefresh().get();
             assertTrue(pendingIndexResponses.stream().allMatch(ActionFuture::isDone));
         }, 1, TimeUnit.MINUTES);
 
-        assertThat(prepareSearch("test").setSize(0).execute().actionGet().getHits().getTotalHits().value, equalTo(120L));
+        assertThat(prepareSearch("test").setSize(0).get().getHits().getTotalHits().value, equalTo(120L));
     }
 
     public void testRelocationEstablishedPeerRecoveryRetentionLeases() throws Exception {

--- a/server/src/internalClusterTest/java/org/elasticsearch/recovery/SimpleRecoveryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/recovery/SimpleRecoveryIT.java
@@ -38,7 +38,7 @@ public class SimpleRecoveryIT extends ESIntegTestCase {
     }
 
     public void testSimpleRecovery() throws Exception {
-        assertAcked(prepareCreate("test", 1).execute().actionGet());
+        assertAcked(prepareCreate("test", 1).get());
 
         NumShards numShards = getNumShards("test");
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/repositories/IndexSnapshotsServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/repositories/IndexSnapshotsServiceIT.java
@@ -137,7 +137,7 @@ public class IndexSnapshotsServiceIT extends AbstractSnapshotIntegTestCase {
             final SnapshotInfo snapshotInfo = createSnapshot(repoName, Strings.format("snap-%03d", i), snapshotIndices);
             if (snapshotInfo.indices().contains(indexName)) {
                 lastSnapshot = snapshotInfo;
-                ClusterStateResponse clusterStateResponse = admin().cluster().prepareState().execute().actionGet();
+                ClusterStateResponse clusterStateResponse = admin().cluster().prepareState().get();
                 IndexMetadata indexMetadata = clusterStateResponse.getState().metadata().index(indexName);
                 expectedIndexMetadataId = IndexMetaDataGenerations.buildUniqueIdentifier(indexMetadata);
             }

--- a/server/src/internalClusterTest/java/org/elasticsearch/reservedstate/service/FileSettingsServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/reservedstate/service/FileSettingsServiceIT.java
@@ -100,10 +100,7 @@ public class FileSettingsServiceIT extends ESIntegTestCase {
         }""";
 
     private void assertMasterNode(Client client, String node) {
-        assertThat(
-            client.admin().cluster().prepareState().execute().actionGet().getState().nodes().getMasterNode().getName(),
-            equalTo(node)
-        );
+        assertThat(client.admin().cluster().prepareState().get().getState().nodes().getMasterNode().getName(), equalTo(node));
     }
 
     private void writeJSONFile(String node, String json) throws Exception {

--- a/server/src/internalClusterTest/java/org/elasticsearch/routing/AliasResolveRoutingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/routing/AliasResolveRoutingIT.java
@@ -51,7 +51,7 @@ public class AliasResolveRoutingIT extends ESIntegTestCase {
     public void testResolveIndexRouting() {
         createIndex("test1");
         createIndex("test2");
-        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
 
         indicesAdmin().prepareAliases()
             .addAliasAction(AliasActions.add().index("test1").alias("alias"))
@@ -93,7 +93,7 @@ public class AliasResolveRoutingIT extends ESIntegTestCase {
         createIndex("test1");
         createIndex("test2");
         createIndex("test3");
-        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
 
         indicesAdmin().prepareAliases()
             .addAliasAction(AliasActions.add().index("test1").alias("alias"))

--- a/server/src/internalClusterTest/java/org/elasticsearch/routing/PartitionedRoutingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/routing/PartitionedRoutingIT.java
@@ -40,8 +40,7 @@ public class PartitionedRoutingIT extends ESIntegTestCase {
                             .put("index.routing_partition_size", partitionSize)
                     )
                     .setMapping("{\"_routing\":{\"required\":true}}")
-                    .execute()
-                    .actionGet();
+                    .get();
                 ensureGreen();
 
                 Map<String, Set<String>> routingToDocumentIds = generateRoutedDocumentIds(index);
@@ -69,8 +68,7 @@ public class PartitionedRoutingIT extends ESIntegTestCase {
                     .put("index.routing_partition_size", partitionSize)
             )
             .setMapping("{\"_routing\":{\"required\":true}}")
-            .execute()
-            .actionGet();
+            .get();
         ensureGreen();
 
         Map<String, Set<String>> routingToDocumentIds = generateRoutedDocumentIds(index);
@@ -149,8 +147,7 @@ public class PartitionedRoutingIT extends ESIntegTestCase {
                 .setRouting(routing)
                 .setIndices(index)
                 .setSize(100)
-                .execute()
-                .actionGet();
+                .get();
 
             logger.info(
                 "--> routed search on index ["
@@ -185,8 +182,7 @@ public class PartitionedRoutingIT extends ESIntegTestCase {
             SearchResponse response = prepareSearch().setQuery(QueryBuilders.termQuery("_routing", routing))
                 .setIndices(index)
                 .setSize(100)
-                .execute()
-                .actionGet();
+                .get();
 
             assertEquals(expectedShards, response.getTotalShards());
             assertEquals(expectedDocuments, response.getHits().getTotalHits().value);
@@ -203,7 +199,7 @@ public class PartitionedRoutingIT extends ESIntegTestCase {
             String routing = routingEntry.getKey();
 
             for (String id : routingEntry.getValue()) {
-                assertTrue(client().prepareGet(index, id).setRouting(routing).execute().actionGet().isExists());
+                assertTrue(client().prepareGet(index, id).setRouting(routing).get().isExists());
             }
         }
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/routing/SimpleRoutingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/routing/SimpleRoutingIT.java
@@ -76,25 +76,25 @@ public class SimpleRoutingIT extends ESIntegTestCase {
             .get();
         logger.info("--> verifying get with no routing, should not find anything");
         for (int i = 0; i < 5; i++) {
-            assertThat(client().prepareGet("test", "1").execute().actionGet().isExists(), equalTo(false));
+            assertThat(client().prepareGet("test", "1").get().isExists(), equalTo(false));
         }
         logger.info("--> verifying get with routing, should find");
         for (int i = 0; i < 5; i++) {
-            assertThat(client().prepareGet("test", "1").setRouting(routingValue).execute().actionGet().isExists(), equalTo(true));
+            assertThat(client().prepareGet("test", "1").setRouting(routingValue).get().isExists(), equalTo(true));
         }
 
         logger.info("--> deleting with no routing, should not delete anything");
         client().prepareDelete("test", "1").setRefreshPolicy(RefreshPolicy.IMMEDIATE).get();
         for (int i = 0; i < 5; i++) {
-            assertThat(client().prepareGet("test", "1").execute().actionGet().isExists(), equalTo(false));
-            assertThat(client().prepareGet("test", "1").setRouting(routingValue).execute().actionGet().isExists(), equalTo(true));
+            assertThat(client().prepareGet("test", "1").get().isExists(), equalTo(false));
+            assertThat(client().prepareGet("test", "1").setRouting(routingValue).get().isExists(), equalTo(true));
         }
 
         logger.info("--> deleting with routing, should delete");
         client().prepareDelete("test", "1").setRouting(routingValue).setRefreshPolicy(RefreshPolicy.IMMEDIATE).get();
         for (int i = 0; i < 5; i++) {
-            assertThat(client().prepareGet("test", "1").execute().actionGet().isExists(), equalTo(false));
-            assertThat(client().prepareGet("test", "1").setRouting(routingValue).execute().actionGet().isExists(), equalTo(false));
+            assertThat(client().prepareGet("test", "1").get().isExists(), equalTo(false));
+            assertThat(client().prepareGet("test", "1").setRouting(routingValue).get().isExists(), equalTo(false));
         }
 
         logger.info("--> indexing with id [1], and routing [0]");
@@ -106,11 +106,11 @@ public class SimpleRoutingIT extends ESIntegTestCase {
             .get();
         logger.info("--> verifying get with no routing, should not find anything");
         for (int i = 0; i < 5; i++) {
-            assertThat(client().prepareGet("test", "1").execute().actionGet().isExists(), equalTo(false));
+            assertThat(client().prepareGet("test", "1").get().isExists(), equalTo(false));
         }
         logger.info("--> verifying get with routing, should find");
         for (int i = 0; i < 5; i++) {
-            assertThat(client().prepareGet("test", "1").setRouting(routingValue).execute().actionGet().isExists(), equalTo(true));
+            assertThat(client().prepareGet("test", "1").setRouting(routingValue).get().isExists(), equalTo(true));
         }
     }
 
@@ -128,40 +128,26 @@ public class SimpleRoutingIT extends ESIntegTestCase {
             .get();
         logger.info("--> verifying get with no routing, should not find anything");
         for (int i = 0; i < 5; i++) {
-            assertThat(client().prepareGet("test", "1").execute().actionGet().isExists(), equalTo(false));
+            assertThat(client().prepareGet("test", "1").get().isExists(), equalTo(false));
         }
         logger.info("--> verifying get with routing, should find");
         for (int i = 0; i < 5; i++) {
-            assertThat(client().prepareGet("test", "1").setRouting(routingValue).execute().actionGet().isExists(), equalTo(true));
+            assertThat(client().prepareGet("test", "1").setRouting(routingValue).get().isExists(), equalTo(true));
         }
 
         logger.info("--> search with no routing, should fine one");
         for (int i = 0; i < 5; i++) {
-            assertThat(
-                prepareSearch().setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().getTotalHits().value,
-                equalTo(1L)
-            );
+            assertThat(prepareSearch().setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value, equalTo(1L));
         }
 
         logger.info("--> search with wrong routing, should not find");
         for (int i = 0; i < 5; i++) {
             assertThat(
-                prepareSearch().setRouting("1")
-                    .setQuery(QueryBuilders.matchAllQuery())
-                    .execute()
-                    .actionGet()
-                    .getHits()
-                    .getTotalHits().value,
+                prepareSearch().setRouting("1").setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value,
                 equalTo(0L)
             );
             assertThat(
-                prepareSearch().setSize(0)
-                    .setRouting("1")
-                    .setQuery(QueryBuilders.matchAllQuery())
-                    .execute()
-                    .actionGet()
-                    .getHits()
-                    .getTotalHits().value,
+                prepareSearch().setSize(0).setRouting("1").setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value,
                 equalTo(0L)
             );
         }
@@ -169,20 +155,14 @@ public class SimpleRoutingIT extends ESIntegTestCase {
         logger.info("--> search with correct routing, should find");
         for (int i = 0; i < 5; i++) {
             assertThat(
-                prepareSearch().setRouting(routingValue)
-                    .setQuery(QueryBuilders.matchAllQuery())
-                    .execute()
-                    .actionGet()
-                    .getHits()
-                    .getTotalHits().value,
+                prepareSearch().setRouting(routingValue).setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value,
                 equalTo(1L)
             );
             assertThat(
                 prepareSearch().setSize(0)
                     .setRouting(routingValue)
                     .setQuery(QueryBuilders.matchAllQuery())
-                    .execute()
-                    .actionGet()
+                    .get()
                     .getHits()
                     .getTotalHits().value,
                 equalTo(1L)
@@ -200,12 +180,9 @@ public class SimpleRoutingIT extends ESIntegTestCase {
 
         logger.info("--> search with no routing, should fine two");
         for (int i = 0; i < 5; i++) {
+            assertThat(prepareSearch().setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value, equalTo(2L));
             assertThat(
-                prepareSearch().setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().getTotalHits().value,
-                equalTo(2L)
-            );
-            assertThat(
-                prepareSearch().setSize(0).setQuery(QueryBuilders.matchAllQuery()).execute().actionGet().getHits().getTotalHits().value,
+                prepareSearch().setSize(0).setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value,
                 equalTo(2L)
             );
         }
@@ -213,20 +190,14 @@ public class SimpleRoutingIT extends ESIntegTestCase {
         logger.info("--> search with {} routing, should find one", routingValue);
         for (int i = 0; i < 5; i++) {
             assertThat(
-                prepareSearch().setRouting(routingValue)
-                    .setQuery(QueryBuilders.matchAllQuery())
-                    .execute()
-                    .actionGet()
-                    .getHits()
-                    .getTotalHits().value,
+                prepareSearch().setRouting(routingValue).setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value,
                 equalTo(1L)
             );
             assertThat(
                 prepareSearch().setSize(0)
                     .setRouting(routingValue)
                     .setQuery(QueryBuilders.matchAllQuery())
-                    .execute()
-                    .actionGet()
+                    .get()
                     .getHits()
                     .getTotalHits().value,
                 equalTo(1L)
@@ -236,20 +207,14 @@ public class SimpleRoutingIT extends ESIntegTestCase {
         logger.info("--> search with {} routing, should find one", secondRoutingValue);
         for (int i = 0; i < 5; i++) {
             assertThat(
-                prepareSearch().setRouting("1")
-                    .setQuery(QueryBuilders.matchAllQuery())
-                    .execute()
-                    .actionGet()
-                    .getHits()
-                    .getTotalHits().value,
+                prepareSearch().setRouting("1").setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value,
                 equalTo(1L)
             );
             assertThat(
                 prepareSearch().setSize(0)
                     .setRouting(secondRoutingValue)
                     .setQuery(QueryBuilders.matchAllQuery())
-                    .execute()
-                    .actionGet()
+                    .get()
                     .getHits()
                     .getTotalHits().value,
                 equalTo(1L)
@@ -261,8 +226,7 @@ public class SimpleRoutingIT extends ESIntegTestCase {
             assertThat(
                 prepareSearch().setRouting(routingValue, secondRoutingValue)
                     .setQuery(QueryBuilders.matchAllQuery())
-                    .execute()
-                    .actionGet()
+                    .get()
                     .getHits()
                     .getTotalHits().value,
                 equalTo(2L)
@@ -271,8 +235,7 @@ public class SimpleRoutingIT extends ESIntegTestCase {
                 prepareSearch().setSize(0)
                     .setRouting(routingValue, secondRoutingValue)
                     .setQuery(QueryBuilders.matchAllQuery())
-                    .execute()
-                    .actionGet()
+                    .get()
                     .getHits()
                     .getTotalHits().value,
                 equalTo(2L)
@@ -284,8 +247,7 @@ public class SimpleRoutingIT extends ESIntegTestCase {
             assertThat(
                 prepareSearch().setRouting(routingValue, secondRoutingValue, routingValue)
                     .setQuery(QueryBuilders.matchAllQuery())
-                    .execute()
-                    .actionGet()
+                    .get()
                     .getHits()
                     .getTotalHits().value,
                 equalTo(2L)
@@ -294,8 +256,7 @@ public class SimpleRoutingIT extends ESIntegTestCase {
                 prepareSearch().setSize(0)
                     .setRouting(routingValue, secondRoutingValue, routingValue)
                     .setQuery(QueryBuilders.matchAllQuery())
-                    .execute()
-                    .actionGet()
+                    .get()
                     .getHits()
                     .getTotalHits().value,
                 equalTo(2L)
@@ -316,8 +277,7 @@ public class SimpleRoutingIT extends ESIntegTestCase {
                     .endObject()
                     .endObject()
             )
-            .execute()
-            .actionGet();
+            .get();
         ensureGreen();
         String routingValue = findNonMatchingRoutingValue("test", "1");
 
@@ -340,7 +300,7 @@ public class SimpleRoutingIT extends ESIntegTestCase {
 
         logger.info("--> verifying get with routing, should find");
         for (int i = 0; i < 5; i++) {
-            assertThat(client().prepareGet(indexOrAlias(), "1").setRouting(routingValue).execute().actionGet().isExists(), equalTo(true));
+            assertThat(client().prepareGet(indexOrAlias(), "1").setRouting(routingValue).get().isExists(), equalTo(true));
         }
 
         logger.info("--> deleting with no routing, should fail");
@@ -353,34 +313,34 @@ public class SimpleRoutingIT extends ESIntegTestCase {
 
         for (int i = 0; i < 5; i++) {
             try {
-                client().prepareGet(indexOrAlias(), "1").execute().actionGet().isExists();
+                client().prepareGet(indexOrAlias(), "1").get().isExists();
                 fail("get with missing routing when routing is required should fail");
             } catch (RoutingMissingException e) {
                 assertThat(e.status(), equalTo(RestStatus.BAD_REQUEST));
                 assertThat(e.getMessage(), equalTo("routing is required for [test]/[1]"));
             }
-            assertThat(client().prepareGet(indexOrAlias(), "1").setRouting(routingValue).execute().actionGet().isExists(), equalTo(true));
+            assertThat(client().prepareGet(indexOrAlias(), "1").setRouting(routingValue).get().isExists(), equalTo(true));
         }
 
         try {
-            client().prepareUpdate(indexOrAlias(), "1").setDoc(Requests.INDEX_CONTENT_TYPE, "field", "value2").execute().actionGet();
+            client().prepareUpdate(indexOrAlias(), "1").setDoc(Requests.INDEX_CONTENT_TYPE, "field", "value2").get();
             fail("update with missing routing when routing is required should fail");
         } catch (ElasticsearchException e) {
             assertThat(e.unwrapCause(), instanceOf(RoutingMissingException.class));
         }
 
         client().prepareUpdate(indexOrAlias(), "1").setRouting(routingValue).setDoc(Requests.INDEX_CONTENT_TYPE, "field", "value2").get();
-        indicesAdmin().prepareRefresh().execute().actionGet();
+        indicesAdmin().prepareRefresh().get();
 
         for (int i = 0; i < 5; i++) {
             try {
-                client().prepareGet(indexOrAlias(), "1").execute().actionGet().isExists();
+                client().prepareGet(indexOrAlias(), "1").get().isExists();
                 fail();
             } catch (RoutingMissingException e) {
                 assertThat(e.status(), equalTo(RestStatus.BAD_REQUEST));
                 assertThat(e.getMessage(), equalTo("routing is required for [test]/[1]"));
             }
-            GetResponse getResponse = client().prepareGet(indexOrAlias(), "1").setRouting(routingValue).execute().actionGet();
+            GetResponse getResponse = client().prepareGet(indexOrAlias(), "1").setRouting(routingValue).get();
             assertThat(getResponse.isExists(), equalTo(true));
             assertThat(getResponse.getSourceAsMap().get("field"), equalTo("value2"));
         }
@@ -389,13 +349,13 @@ public class SimpleRoutingIT extends ESIntegTestCase {
 
         for (int i = 0; i < 5; i++) {
             try {
-                client().prepareGet(indexOrAlias(), "1").execute().actionGet().isExists();
+                client().prepareGet(indexOrAlias(), "1").get().isExists();
                 fail();
             } catch (RoutingMissingException e) {
                 assertThat(e.status(), equalTo(RestStatus.BAD_REQUEST));
                 assertThat(e.getMessage(), equalTo("routing is required for [test]/[1]"));
             }
-            assertThat(client().prepareGet(indexOrAlias(), "1").setRouting(routingValue).execute().actionGet().isExists(), equalTo(false));
+            assertThat(client().prepareGet(indexOrAlias(), "1").setRouting(routingValue).get().isExists(), equalTo(false));
         }
     }
 
@@ -412,15 +372,13 @@ public class SimpleRoutingIT extends ESIntegTestCase {
                     .endObject()
                     .endObject()
             )
-            .execute()
-            .actionGet();
+            .get();
         ensureGreen();
         {
             String index = indexOrAlias();
             BulkResponse bulkResponse = client().prepareBulk()
                 .add(new IndexRequest(index).id("1").source(Requests.INDEX_CONTENT_TYPE, "field", "value"))
-                .execute()
-                .actionGet();
+                .get();
             assertThat(bulkResponse.getItems().length, equalTo(1));
             assertThat(bulkResponse.hasFailures(), equalTo(true));
 
@@ -437,16 +395,14 @@ public class SimpleRoutingIT extends ESIntegTestCase {
             String index = indexOrAlias();
             BulkResponse bulkResponse = client().prepareBulk()
                 .add(new IndexRequest(index).id("1").routing("0").source(Requests.INDEX_CONTENT_TYPE, "field", "value"))
-                .execute()
-                .actionGet();
+                .get();
             assertThat(bulkResponse.hasFailures(), equalTo(false));
         }
 
         {
             BulkResponse bulkResponse = client().prepareBulk()
                 .add(new UpdateRequest(indexOrAlias(), "1").doc(Requests.INDEX_CONTENT_TYPE, "field", "value2"))
-                .execute()
-                .actionGet();
+                .get();
             assertThat(bulkResponse.getItems().length, equalTo(1));
             assertThat(bulkResponse.hasFailures(), equalTo(true));
 
@@ -462,14 +418,13 @@ public class SimpleRoutingIT extends ESIntegTestCase {
         {
             BulkResponse bulkResponse = client().prepareBulk()
                 .add(new UpdateRequest(indexOrAlias(), "1").doc(Requests.INDEX_CONTENT_TYPE, "field", "value2").routing("0"))
-                .execute()
-                .actionGet();
+                .get();
             assertThat(bulkResponse.hasFailures(), equalTo(false));
         }
 
         {
             String index = indexOrAlias();
-            BulkResponse bulkResponse = client().prepareBulk().add(new DeleteRequest(index).id("1")).execute().actionGet();
+            BulkResponse bulkResponse = client().prepareBulk().add(new DeleteRequest(index).id("1")).get();
             assertThat(bulkResponse.getItems().length, equalTo(1));
             assertThat(bulkResponse.hasFailures(), equalTo(true));
 
@@ -484,7 +439,7 @@ public class SimpleRoutingIT extends ESIntegTestCase {
 
         {
             String index = indexOrAlias();
-            BulkResponse bulkResponse = client().prepareBulk().add(new DeleteRequest(index).id("1").routing("0")).execute().actionGet();
+            BulkResponse bulkResponse = client().prepareBulk().add(new DeleteRequest(index).id("1").routing("0")).get();
             assertThat(bulkResponse.getItems().length, equalTo(1));
             assertThat(bulkResponse.hasFailures(), equalTo(false));
         }
@@ -504,8 +459,7 @@ public class SimpleRoutingIT extends ESIntegTestCase {
                     .endObject()
                     .endObject()
             )
-            .execute()
-            .actionGet();
+            .get();
         ensureGreen();
         String routingValue = findNonMatchingRoutingValue("test", "1");
         logger.info("--> indexing with id [1], and routing [{}]", routingValue);
@@ -519,7 +473,7 @@ public class SimpleRoutingIT extends ESIntegTestCase {
             .get();
 
         logger.info("--> verifying get with id [1] with routing [0], should succeed");
-        assertThat(client().prepareGet(indexOrAlias(), "1").setRouting(routingValue).execute().actionGet().isExists(), equalTo(true));
+        assertThat(client().prepareGet(indexOrAlias(), "1").setRouting(routingValue).get().isExists(), equalTo(true));
 
         logger.info("--> verifying get with id [1], with no routing, should fail");
         try {

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsIT.java
@@ -922,7 +922,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
                         .collectMode(randomFrom(SubAggCollectionMode.values()))
                         .order(BucketOrder.aggregation("stats", true))
                         .subAggregation(stats("stats").field("i"))
-                ).execute().actionGet();
+                ).get();
 
                 fail(
                     "Expected search to fail when trying to sort terms aggregation by multi-valued sug-aggregation "

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fieldcaps/FieldCapabilitiesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fieldcaps/FieldCapabilitiesIT.java
@@ -549,8 +549,7 @@ public class FieldCapabilitiesIT extends ESIntegTestCase {
                     assertNotNull(toNode);
                     clusterAdmin().prepareReroute()
                         .add(new MoveAllocationCommand(shardId.getIndexName(), shardId.id(), fromNode.getId(), toNode.getId()))
-                        .execute()
-                        .actionGet();
+                        .get();
                 }
             }
         }

--- a/server/src/internalClusterTest/java/org/elasticsearch/similarity/SimilarityIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/similarity/SimilarityIT.java
@@ -20,7 +20,7 @@ import static org.hamcrest.Matchers.not;
 public class SimilarityIT extends ESIntegTestCase {
     public void testCustomBM25Similarity() throws Exception {
         try {
-            indicesAdmin().prepareDelete("test").execute().actionGet();
+            indicesAdmin().prepareDelete("test").get();
         } catch (Exception e) {
             // ignore
         }
@@ -45,21 +45,19 @@ public class SimilarityIT extends ESIntegTestCase {
             .setSettings(
                 indexSettings(1, 0).put("similarity.custom.type", "BM25").put("similarity.custom.k1", 2.0f).put("similarity.custom.b", 0.5f)
             )
-            .execute()
-            .actionGet();
+            .get();
 
         client().prepareIndex("test")
             .setId("1")
             .setSource("field1", "the quick brown fox jumped over the lazy dog", "field2", "the quick brown fox jumped over the lazy dog")
             .setRefreshPolicy(IMMEDIATE)
-            .execute()
-            .actionGet();
+            .get();
 
-        SearchResponse bm25SearchResponse = prepareSearch().setQuery(matchQuery("field1", "quick brown fox")).execute().actionGet();
+        SearchResponse bm25SearchResponse = prepareSearch().setQuery(matchQuery("field1", "quick brown fox")).get();
         assertThat(bm25SearchResponse.getHits().getTotalHits().value, equalTo(1L));
         float bm25Score = bm25SearchResponse.getHits().getHits()[0].getScore();
 
-        SearchResponse booleanSearchResponse = prepareSearch().setQuery(matchQuery("field2", "quick brown fox")).execute().actionGet();
+        SearchResponse booleanSearchResponse = prepareSearch().setQuery(matchQuery("field2", "quick brown fox")).get();
         assertThat(booleanSearchResponse.getHits().getTotalHits().value, equalTo(1L));
         float defaultScore = booleanSearchResponse.getHits().getHits()[0].getScore();
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
@@ -960,7 +960,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
 
         logger.info("--> wait for relocations to start");
         assertBusy(
-            () -> assertThat(clusterAdmin().prepareHealth(testIndex).execute().actionGet().getRelocatingShards(), greaterThan(0)),
+            () -> assertThat(clusterAdmin().prepareHealth(testIndex).get().getRelocatingShards(), greaterThan(0)),
             1L,
             TimeUnit.MINUTES
         );
@@ -1317,7 +1317,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
 
         final ConcurrentSnapshotExecutionException cse = expectThrows(
             ConcurrentSnapshotExecutionException.class,
-            () -> clusterAdmin().prepareCreateSnapshot(repoName, "expected-to-fail").execute().actionGet()
+            () -> clusterAdmin().prepareCreateSnapshot(repoName, "expected-to-fail").get()
         );
         assertThat(
             cse.getMessage(),

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/CorruptedBlobStoreRepositoryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/CorruptedBlobStoreRepositoryIT.java
@@ -821,14 +821,14 @@ public class CorruptedBlobStoreRepositoryIT extends AbstractSnapshotIntegTestCas
         logger.info("--> try to delete snapshot");
         final RepositoryException ex = expectThrows(
             RepositoryException.class,
-            () -> clusterAdmin().prepareDeleteSnapshot(repo, existingSnapshot).execute().actionGet()
+            () -> clusterAdmin().prepareDeleteSnapshot(repo, existingSnapshot).get()
         );
         assertThat(ex.getMessage(), containsString("concurrent modification of the index-N file"));
 
         logger.info("--> try to create snapshot");
         final RepositoryException ex2 = expectThrows(
             RepositoryException.class,
-            () -> clusterAdmin().prepareCreateSnapshot(repo, existingSnapshot).execute().actionGet()
+            () -> clusterAdmin().prepareCreateSnapshot(repo, existingSnapshot).get()
         );
         assertThat(ex2.getMessage(), containsString("The repository has been disabled to prevent data corruption"));
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/CustomMetadataContextIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/CustomMetadataContextIT.java
@@ -62,8 +62,7 @@ public class CustomMetadataContextIT extends AbstractSnapshotIntegTestCase {
             .setRestoreGlobalState(true)
             .setIndices("-*")
             .setWaitForCompletion(true)
-            .execute()
-            .actionGet();
+            .get();
 
         logger.info("make sure old repository wasn't restored");
         assertRequestBuilderThrows(clusterAdmin().prepareGetRepositories("test-repo-1"), RepositoryMissingException.class);
@@ -104,8 +103,7 @@ public class CustomMetadataContextIT extends AbstractSnapshotIntegTestCase {
             .setRestoreGlobalState(true)
             .setIndices("-*")
             .setWaitForCompletion(true)
-            .execute()
-            .actionGet();
+            .get();
 
         var metadata = clusterAdmin().prepareState().get().getState().getMetadata();
         logger.info("check that custom persistent metadata [{}] is correctly restored", metadata);

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
@@ -196,10 +196,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
         }
 
         logger.info("--> making sure that snapshot no longer exists");
-        expectThrows(
-            SnapshotMissingException.class,
-            () -> clusterAdmin().prepareGetSnapshots("test-repo").setSnapshots("test-snap").execute().actionGet()
-        );
+        expectThrows(SnapshotMissingException.class, () -> clusterAdmin().prepareGetSnapshots("test-repo").setSnapshots("test-snap").get());
 
         logger.info("--> trigger repository cleanup");
         clusterAdmin().prepareCleanupRepository("test-repo").get();
@@ -240,13 +237,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
         logger.info("--> shutdown one of the nodes");
         internalCluster().stopRandomDataNode();
         assertThat(
-            clusterAdmin().prepareHealth()
-                .setWaitForEvents(Priority.LANGUID)
-                .setTimeout("1m")
-                .setWaitForNodes("<2")
-                .execute()
-                .actionGet()
-                .isTimedOut(),
+            clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setTimeout("1m").setWaitForNodes("<2").get().isTimedOut(),
             equalTo(false)
         );
 
@@ -275,8 +266,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
             () -> clusterAdmin().prepareCreateSnapshot("test-repo", "test-snap-1")
                 .setIndices("test-idx-all", "test-idx-none", "test-idx-some", "test-idx-closed")
                 .setWaitForCompletion(true)
-                .execute()
-                .actionGet()
+                .get()
         );
         assertThat(sne.getMessage(), containsString("Indices don't have primary shards"));
 
@@ -286,8 +276,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
                 .setIndices("test-idx-all", "test-idx-none", "test-idx-some", "test-idx-closed")
                 .setWaitForCompletion(false)
                 .setPartial(true)
-                .execute()
-                .actionGet();
+                .get();
             assertBusy(() -> {
                 SnapshotsStatusResponse snapshotsStatusResponse = clusterAdmin().prepareSnapshotStatus("test-repo")
                     .setSnapshots("test-snap-2")
@@ -321,8 +310,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
                 .setIndices("test-idx-all", "test-idx-none", "test-idx-some", "test-idx-closed")
                 .setWaitForCompletion(true)
                 .setPartial(true)
-                .execute()
-                .actionGet();
+                .get();
             logger.info(
                 "State: [{}], Reason: [{}]",
                 createSnapshotResponse.getSnapshotInfo().state(),
@@ -350,8 +338,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
             .setRestoreGlobalState(false)
             .setIndices("test-idx-all")
             .setWaitForCompletion(true)
-            .execute()
-            .actionGet();
+            .get();
         assertThat(restoreSnapshotResponse.getRestoreInfo(), notNullValue());
         assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), equalTo(6));
         assertThat(restoreSnapshotResponse.getRestoreInfo().successfulShards(), equalTo(6));
@@ -391,8 +378,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
             .setRestoreGlobalState(false)
             .setIndices("test-idx-closed")
             .setWaitForCompletion(true)
-            .execute()
-            .actionGet();
+            .get();
         assertThat(restoreSnapshotResponse.getRestoreInfo(), notNullValue());
         assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), equalTo(4));
         assertThat(restoreSnapshotResponse.getRestoreInfo().successfulShards(), equalTo(4));
@@ -430,13 +416,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
         });
 
         assertThat(
-            clusterAdmin().prepareHealth()
-                .setWaitForEvents(Priority.LANGUID)
-                .setTimeout("1m")
-                .setWaitForNodes("2")
-                .execute()
-                .actionGet()
-                .isTimedOut(),
+            clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setTimeout("1m").setWaitForNodes("2").get().isTimedOut(),
             equalTo(false)
         );
 
@@ -721,7 +701,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
 
         int docs = between(10, 100);
         for (int i = 0; i < docs; i++) {
-            client().prepareIndex(indexName).setSource("test", "init").execute().actionGet();
+            client().prepareIndex(indexName).setSource("test", "init").get();
         }
 
         final Path repoPath = randomRepoPath();
@@ -754,7 +734,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
         // add few docs - less than initially
         docs = between(1, 5);
         for (int i = 0; i < docs; i++) {
-            client().prepareIndex(indexName).setSource("test", "test" + i).execute().actionGet();
+            client().prepareIndex(indexName).setSource("test", "test" + i).get();
         }
 
         // create another snapshot
@@ -806,7 +786,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
 
         int docs = between(10, 100);
         for (int i = 0; i < docs; i++) {
-            client().prepareIndex(indexName).setSource("test", "init").execute().actionGet();
+            client().prepareIndex(indexName).setSource("test", "init").get();
         }
 
         final Path repoPath = randomRepoPath();
@@ -818,7 +798,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
 
         docs = between(1, 5);
         for (int i = 0; i < docs; i++) {
-            client().prepareIndex(indexName).setSource("test", "test" + i).execute().actionGet();
+            client().prepareIndex(indexName).setSource("test", "test" + i).get();
         }
 
         logger.info("--> restart random data node and add new data node to change index allocation");
@@ -835,7 +815,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
 
         // index to some other field to trigger a change in index metadata
         for (int i = 0; i < docs; i++) {
-            client().prepareIndex(indexName).setSource("new_field", "test" + i).execute().actionGet();
+            client().prepareIndex(indexName).setSource("new_field", "test" + i).get();
         }
         createFullSnapshot(repositoryName, snapshot2);
 
@@ -1125,7 +1105,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
         logger.info("--> wait for relocations to start");
 
         assertBusy(
-            () -> assertThat(clusterAdmin().prepareHealth(indexName).execute().actionGet().getRelocatingShards(), greaterThan(0)),
+            () -> assertThat(clusterAdmin().prepareHealth(indexName).get().getRelocatingShards(), greaterThan(0)),
             1L,
             TimeUnit.MINUTES
         );

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/MultiClusterRepoAccessIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/MultiClusterRepoAccessIT.java
@@ -127,7 +127,7 @@ public class MultiClusterRepoAccessIT extends AbstractSnapshotIntegTestCase {
 
         final SnapshotException sne = expectThrows(
             SnapshotException.class,
-            () -> clusterAdmin().prepareCreateSnapshot(repoNameOnFirstCluster, "snap-4").setWaitForCompletion(true).execute().actionGet()
+            () -> clusterAdmin().prepareCreateSnapshot(repoNameOnFirstCluster, "snap-4").setWaitForCompletion(true).get()
         );
         assertThat(sne.getMessage(), containsString("failed to update snapshot in repository"));
         final RepositoryException cause = (RepositoryException) sne.getCause();

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/RepositoryThrottlingStatsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/RepositoryThrottlingStatsIT.java
@@ -61,8 +61,7 @@ public class RepositoryThrottlingStatsIT extends AbstractSnapshotIntegTestCase {
             .setRenamePattern("test-")
             .setRenameReplacement("test2-")
             .setWaitForCompletion(true)
-            .execute()
-            .actionGet();
+            .get();
         assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), greaterThan(0));
         assertDocCount("test-idx", 100);
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/RestoreSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/RestoreSnapshotIT.java
@@ -309,8 +309,7 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
         logger.info("--> restore all indices from the snapshot");
         RestoreSnapshotResponse restoreSnapshotResponse = clusterAdmin().prepareRestoreSnapshot("test-repo", "test-snap")
             .setWaitForCompletion(true)
-            .execute()
-            .actionGet();
+            .get();
         assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), greaterThan(0));
 
         logger.info("--> assert that old mapping is restored");
@@ -319,7 +318,7 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
         assertThat(mappings.sourceAsMap().toString(), not(containsString("foo")));
 
         logger.info("--> assert that old settings are restored");
-        GetSettingsResponse getSettingsResponse = indicesAdmin().prepareGetSettings("test-idx").execute().actionGet();
+        GetSettingsResponse getSettingsResponse = indicesAdmin().prepareGetSettings("test-idx").get();
         assertThat(getSettingsResponse.getSetting("test-idx", "index.refresh_interval"), equalTo("10s"));
     }
 
@@ -352,8 +351,7 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
         RestoreSnapshotResponse restoreSnapshotResponse = clusterAdmin().prepareRestoreSnapshot("test-repo", "test-snap")
             .setWaitForCompletion(true)
             .setRestoreGlobalState(true)
-            .execute()
-            .actionGet();
+            .get();
         // We don't restore any indices here
         assertThat(
             restoreSnapshotResponse.getRestoreInfo().successfulShards(),
@@ -379,8 +377,7 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
             .setWaitForCompletion(true)
             .setRestoreGlobalState(true)
             .setIncludeAliases(false)
-            .execute()
-            .actionGet();
+            .get();
         // We don't restore any indices here
         assertThat(
             restoreSnapshotResponse.getRestoreInfo().successfulShards(),
@@ -431,8 +428,7 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
         RestoreSnapshotResponse restoreSnapshotResponse = clusterAdmin().prepareRestoreSnapshot("test-repo", "test-snap")
             .setWaitForCompletion(true)
             .setRestoreGlobalState(true)
-            .execute()
-            .actionGet();
+            .get();
         // We don't restore any indices here
         assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), equalTo(0));
 
@@ -470,8 +466,7 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
             .setRenamePattern("(.+)")
             .setRenameReplacement("$1-copy")
             .setWaitForCompletion(true)
-            .execute()
-            .actionGet();
+            .get();
         assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), greaterThan(0));
 
         assertDocCount("test-idx-1-copy", 100L);
@@ -487,8 +482,7 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
             .setRenamePattern("(.+)")
             .setRenameReplacement("$1-copy")
             .setWaitForCompletion(true)
-            .execute()
-            .actionGet();
+            .get();
         assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), greaterThan(0));
 
         assertDocCount("test-idx-1-copy", 100L);
@@ -504,8 +498,7 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
             .setRenamePattern("(.+-2)")
             .setRenameReplacement("$1-copy")
             .setWaitForCompletion(true)
-            .execute()
-            .actionGet();
+            .get();
         assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), greaterThan(0));
 
         logger.info("--> delete indices");
@@ -519,8 +512,7 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
                 .setRenamePattern("(.+)")
                 .setRenameReplacement("same-name")
                 .setWaitForCompletion(true)
-                .execute()
-                .actionGet();
+                .get();
             fail("Shouldn't be here");
         } catch (SnapshotRestoreException ex) {
             // Expected
@@ -534,8 +526,7 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
                 .setRenamePattern("test-idx-2")
                 .setRenameReplacement("test-idx-1")
                 .setWaitForCompletion(true)
-                .execute()
-                .actionGet();
+                .get();
             fail("Shouldn't be here");
         } catch (SnapshotRestoreException ex) {
             // Expected
@@ -550,8 +541,7 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
                 .setRenamePattern(".+")
                 .setRenameReplacement("__WRONG__")
                 .setWaitForCompletion(true)
-                .execute()
-                .actionGet();
+                .get();
             fail("Shouldn't be here");
         } catch (InvalidIndexNameException ex) {
             // Expected
@@ -566,8 +556,7 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
                 .setRenamePattern(".+")
                 .setRenameReplacement("alias-3")
                 .setWaitForCompletion(true)
-                .execute()
-                .actionGet();
+                .get();
             fail("Shouldn't be here");
         } catch (InvalidIndexNameException ex) {
             // Expected
@@ -582,8 +571,7 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
                 .setRenamePattern("test-idx")
                 .setRenameReplacement("alias")
                 .setWaitForCompletion(true)
-                .execute()
-                .actionGet();
+                .get();
             fail("Shouldn't be here");
         } catch (SnapshotRestoreException ex) {
             // Expected
@@ -598,8 +586,7 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
                 .setRenamePattern("test-idx-1")
                 .setRenameReplacement("alias-2")
                 .setWaitForCompletion(true)
-                .execute()
-                .actionGet();
+                .get();
             fail("Shouldn't be here");
         } catch (SnapshotRestoreException ex) {
             // Expected
@@ -614,8 +601,7 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
             .setRenameReplacement("alias")
             .setWaitForCompletion(true)
             .setIncludeAliases(false)
-            .execute()
-            .actionGet();
+            .get();
         assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), greaterThan(0));
     }
 
@@ -740,12 +726,11 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
             .setIgnoreIndexSettings("index.analysis.*")
             .setIndexSettings(newIndexSettings)
             .setWaitForCompletion(true)
-            .execute()
-            .actionGet();
+            .get();
         assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), greaterThan(0));
 
         logger.info("--> assert that correct settings are restored");
-        GetSettingsResponse getSettingsResponse = client.admin().indices().prepareGetSettings("test-idx").execute().actionGet();
+        GetSettingsResponse getSettingsResponse = client.admin().indices().prepareGetSettings("test-idx").get();
         assertThat(getSettingsResponse.getSetting("test-idx", INDEX_REFRESH_INTERVAL_SETTING.getKey()), equalTo("5s"));
         // Make sure that number of shards didn't change
         assertThat(getSettingsResponse.getSetting("test-idx", SETTING_NUMBER_OF_SHARDS), equalTo("" + numberOfShards));
@@ -764,12 +749,11 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
             .setIgnoreIndexSettings("*") // delete everything we can delete
             .setIndexSettings(newIndexSettings)
             .setWaitForCompletion(true)
-            .execute()
-            .actionGet();
+            .get();
         assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), greaterThan(0));
 
         logger.info("--> assert that correct settings are restored and index is still functional");
-        getSettingsResponse = client.admin().indices().prepareGetSettings("test-idx").execute().actionGet();
+        getSettingsResponse = client.admin().indices().prepareGetSettings("test-idx").get();
         assertThat(getSettingsResponse.getSetting("test-idx", INDEX_REFRESH_INTERVAL_SETTING.getKey()), equalTo("5s"));
         // Make sure that number of shards didn't change
         assertThat(getSettingsResponse.getSetting("test-idx", SETTING_NUMBER_OF_SHARDS), equalTo("" + numberOfShards));
@@ -839,8 +823,7 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
                 .prepareRestoreSnapshot("test-repo", "test-snap")
                 .setIndexSettings(changedSettings)
                 .setWaitForCompletion(true)
-                .execute()
-                .actionGet();
+                .get();
             assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), greaterThan(0));
 
             ClusterBlocks blocks = client.admin().cluster().prepareState().clear().setBlocks(true).get().getState().blocks();
@@ -906,7 +889,7 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
         final String oldSnapshot = initWithSnapshotVersion(repoName, repoPath, oldVersion);
         final SnapshotRestoreException snapshotRestoreException = expectThrows(
             SnapshotRestoreException.class,
-            () -> clusterAdmin().prepareRestoreSnapshot(repoName, oldSnapshot).execute().actionGet()
+            () -> clusterAdmin().prepareRestoreSnapshot(repoName, oldSnapshot).get()
         );
         assertThat(
             snapshotRestoreException.getMessage(),

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
@@ -188,8 +188,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         logger.info("--> restore all indices from the snapshot");
         RestoreSnapshotResponse restoreSnapshotResponse = clusterAdmin().prepareRestoreSnapshot("test-repo", "test-snap")
             .setWaitForCompletion(true)
-            .execute()
-            .actionGet();
+            .get();
         assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), greaterThan(0));
 
         ensureGreen();
@@ -217,8 +216,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         restoreSnapshotResponse = clusterAdmin().prepareRestoreSnapshot("test-repo", "test-snap")
             .setWaitForCompletion(true)
             .setIndices("test-idx-*", "-test-idx-2")
-            .execute()
-            .actionGet();
+            .get();
         assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), greaterThan(0));
 
         ensureGreen();
@@ -296,8 +294,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         logger.info("--> restore all indices from the snapshot");
         RestoreSnapshotResponse restoreSnapshotResponse = clusterAdmin().prepareRestoreSnapshot("test-repo", "test-snap")
             .setWaitForCompletion(true)
-            .execute()
-            .actionGet();
+            .get();
         assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), greaterThan(0));
 
         ensureGreen();
@@ -314,8 +311,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
             .setRenamePattern("(.+)")
             .setRenameReplacement("$1-copy")
             .setWaitForCompletion(true)
-            .execute()
-            .actionGet();
+            .get();
         assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), greaterThan(0));
 
         String copyRestoreUUID = indicesAdmin().prepareGetSettings("test-copy")
@@ -545,8 +541,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
             .cluster()
             .prepareRestoreSnapshot("test-repo", "test-snap")
             .setWaitForCompletion(true)
-            .execute()
-            .actionGet();
+            .get();
         assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), greaterThan(0));
         assertThat(
             restoreSnapshotResponse.getRestoreInfo().failedShards(),
@@ -750,8 +745,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
             .cluster()
             .prepareRestoreSnapshot("test-repo", "test-snap")
             .setWaitForCompletion(true)
-            .execute()
-            .actionGet();
+            .get();
         assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), greaterThan(0));
         assertThat(restoreSnapshotResponse.getRestoreInfo().failedShards(), equalTo(0));
         assertDocCount("test-idx", 100L);
@@ -839,8 +833,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
             .cluster()
             .prepareRestoreSnapshot("test-repo", lastSnapshot)
             .setWaitForCompletion(true)
-            .execute()
-            .actionGet();
+            .get();
         assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), greaterThan(0));
 
         assertDocCount("test-idx", 10L * numberOfSnapshots);
@@ -911,8 +904,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
             .cluster()
             .prepareRestoreSnapshot("test-repo", "test-snap")
             .setWaitForCompletion(true)
-            .execute()
-            .actionGet();
+            .get();
         assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), greaterThan(0));
         assertDocCount("test-idx", 100L);
     }
@@ -950,7 +942,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         logger.info("--> execution was blocked on node [{}], trying to delete repository", blockedNode);
 
         try {
-            client.admin().cluster().prepareDeleteRepository(randomFrom("test-repo", "test-*", "*")).execute().actionGet();
+            client.admin().cluster().prepareDeleteRepository(randomFrom("test-repo", "test-*", "*")).get();
             fail("shouldn't be able to delete in-use repository");
         } catch (Exception ex) {
             logger.info("--> in-use repository deletion failed");
@@ -1002,8 +994,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
             .cluster()
             .prepareRestoreSnapshot("test-repo", "test-snap")
             .setWaitForCompletion(true)
-            .execute()
-            .actionGet();
+            .get();
         assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), greaterThan(0));
         assertDocCount("test-idx", 100);
     }
@@ -1037,8 +1028,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
             .prepareRestoreSnapshot("readonly-repo", "test-snap")
             .setWaitForCompletion(true)
             .setIndices("test-idx")
-            .execute()
-            .actionGet();
+            .get();
         assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), greaterThan(0));
         assertDocCount("test-idx", 100L);
 
@@ -1118,7 +1108,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         });
 
         logger.info("--> execution was blocked on node [{}], checking snapshot status with specified repository and snapshot", blockedNode);
-        SnapshotsStatusResponse response = client.admin().cluster().prepareSnapshotStatus("test-repo").execute().actionGet();
+        SnapshotsStatusResponse response = client.admin().cluster().prepareSnapshotStatus("test-repo").get();
         assertThat(response.getSnapshots().size(), equalTo(1));
         SnapshotStatus snapshotStatus = response.getSnapshots().get(0);
         assertThat(snapshotStatus.getState(), equalTo(State.STARTED));
@@ -1133,7 +1123,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         }
 
         logger.info("--> checking snapshot status for all currently running and snapshot with empty repository");
-        response = client.admin().cluster().prepareSnapshotStatus().execute().actionGet();
+        response = client.admin().cluster().prepareSnapshotStatus().get();
         assertThat(response.getSnapshots().size(), equalTo(1));
         snapshotStatus = response.getSnapshots().get(0);
         assertThat(snapshotStatus.getState(), equalTo(State.STARTED));
@@ -1148,12 +1138,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         }
 
         logger.info("--> checking that _current returns the currently running snapshot");
-        GetSnapshotsResponse getResponse = client.admin()
-            .cluster()
-            .prepareGetSnapshots("test-repo")
-            .setCurrentSnapshot()
-            .execute()
-            .actionGet();
+        GetSnapshotsResponse getResponse = client.admin().cluster().prepareGetSnapshots("test-repo").setCurrentSnapshot().get();
         assertThat(getResponse.getSnapshots().size(), equalTo(1));
         SnapshotInfo snapshotInfo = getResponse.getSnapshots().get(0);
         assertThat(snapshotInfo.state(), equalTo(SnapshotState.IN_PROGRESS));
@@ -1170,7 +1155,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         logger.info("Number of failed shards [{}]", snapshotInfo.shardFailures().size());
 
         logger.info("--> checking snapshot status again after snapshot is done");
-        response = client.admin().cluster().prepareSnapshotStatus("test-repo").addSnapshots("test-snap").execute().actionGet();
+        response = client.admin().cluster().prepareSnapshotStatus("test-repo").addSnapshots("test-snap").get();
         snapshotStatus = response.getSnapshots().get(0);
         assertThat(snapshotStatus.getIndices().size(), equalTo(1));
         assertThat(snapshotStatus.includeGlobalState(), equalTo(false));
@@ -1183,19 +1168,12 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         assertThat(indexStatus.getShards().size(), equalTo(snapshotInfo.totalShards()));
 
         logger.info("--> checking snapshot status after it is done with empty repository");
-        response = client.admin().cluster().prepareSnapshotStatus().execute().actionGet();
+        response = client.admin().cluster().prepareSnapshotStatus().get();
         assertThat(response.getSnapshots().size(), equalTo(0));
 
         logger.info("--> checking that _current no longer returns the snapshot");
         assertThat(
-            client.admin()
-                .cluster()
-                .prepareGetSnapshots("test-repo")
-                .addSnapshots("_current")
-                .execute()
-                .actionGet()
-                .getSnapshots()
-                .isEmpty(),
+            client.admin().cluster().prepareGetSnapshots("test-repo").addSnapshots("_current").get().getSnapshots().isEmpty(),
             equalTo(true)
         );
 
@@ -1241,7 +1219,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
         logger.info("--> wait for relocations to start");
 
         assertBusy(
-            () -> assertThat(clusterAdmin().prepareHealth("test-idx").execute().actionGet().getRelocatingShards(), greaterThan(0)),
+            () -> assertThat(clusterAdmin().prepareHealth("test-idx").get().getRelocatingShards(), greaterThan(0)),
             1L,
             TimeUnit.MINUTES
         );

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotBrokenSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotBrokenSettingsIT.java
@@ -38,8 +38,7 @@ public class SnapshotBrokenSettingsIT extends AbstractSnapshotIntegTestCase {
             .cluster()
             .prepareUpdateSettings()
             .setPersistentSettings(Settings.builder().put(BrokenSettingPlugin.BROKEN_SETTING.getKey(), value))
-            .execute()
-            .actionGet();
+            .get();
 
         Consumer<String> assertSettingValue = value -> assertThat(
             client.admin()
@@ -47,8 +46,7 @@ public class SnapshotBrokenSettingsIT extends AbstractSnapshotIntegTestCase {
                 .prepareState()
                 .setRoutingTable(false)
                 .setNodes(false)
-                .execute()
-                .actionGet()
+                .get()
                 .getState()
                 .getMetadata()
                 .persistentSettings()

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotCustomPluginStateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotCustomPluginStateIT.java
@@ -157,8 +157,7 @@ public class SnapshotCustomPluginStateIT extends AbstractSnapshotIntegTestCase {
         RestoreSnapshotResponse restoreSnapshotResponse = clusterAdmin().prepareRestoreSnapshot("test-repo", "test-snap-no-global-state")
             .setWaitForCompletion(true)
             .setRestoreGlobalState(false)
-            .execute()
-            .actionGet();
+            .get();
         assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), equalTo(0));
 
         logger.info("--> check that template wasn't restored");
@@ -169,8 +168,7 @@ public class SnapshotCustomPluginStateIT extends AbstractSnapshotIntegTestCase {
         restoreSnapshotResponse = clusterAdmin().prepareRestoreSnapshot("test-repo", "test-snap-with-global-state")
             .setWaitForCompletion(true)
             .setRestoreGlobalState(true)
-            .execute()
-            .actionGet();
+            .get();
         assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), equalTo(0));
 
         if (testTemplate) {
@@ -226,8 +224,7 @@ public class SnapshotCustomPluginStateIT extends AbstractSnapshotIntegTestCase {
         restoreSnapshotResponse = clusterAdmin().prepareRestoreSnapshot("test-repo", "test-snap-no-global-state-with-index")
             .setWaitForCompletion(true)
             .setRestoreGlobalState(false)
-            .execute()
-            .actionGet();
+            .get();
         assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), greaterThan(0));
         assertThat(restoreSnapshotResponse.getRestoreInfo().failedShards(), equalTo(0));
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotStatusApisIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotStatusApisIT.java
@@ -138,10 +138,7 @@ public class SnapshotStatusApisIT extends AbstractSnapshotIntegTestCase {
         logger.info("--> delete snap-${uuid}.dat file for this snapshot to simulate concurrent delete");
         IOUtils.rm(repoPath.resolve(BlobStoreRepository.SNAPSHOT_PREFIX + snapshotInfo.snapshotId().getUUID() + ".dat"));
 
-        expectThrows(
-            SnapshotMissingException.class,
-            () -> clusterAdmin().prepareGetSnapshots("test-repo").setSnapshots("test-snap").execute().actionGet()
-        );
+        expectThrows(SnapshotMissingException.class, () -> clusterAdmin().prepareGetSnapshots("test-repo").setSnapshots("test-snap").get());
     }
 
     public void testExceptionOnMissingShardLevelSnapBlob() throws IOException {
@@ -172,7 +169,7 @@ public class SnapshotStatusApisIT extends AbstractSnapshotIntegTestCase {
 
         expectThrows(
             SnapshotMissingException.class,
-            () -> clusterAdmin().prepareSnapshotStatus("test-repo").setSnapshots("test-snap").execute().actionGet()
+            () -> clusterAdmin().prepareSnapshotStatus("test-repo").setSnapshots("test-snap").get()
         );
     }
 
@@ -459,11 +456,7 @@ public class SnapshotStatusApisIT extends AbstractSnapshotIntegTestCase {
 
         expectThrows(
             SnapshotMissingException.class,
-            () -> clusterAdmin().prepareGetSnapshots("test-repo")
-                .setSnapshots(notExistedSnapshotName)
-                .setIgnoreUnavailable(false)
-                .execute()
-                .actionGet()
+            () -> clusterAdmin().prepareGetSnapshots("test-repo").setSnapshots(notExistedSnapshotName).setIgnoreUnavailable(false).get()
         );
 
         logger.info("--> unblock all data nodes");

--- a/server/src/internalClusterTest/java/org/elasticsearch/update/UpdateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/update/UpdateIT.java
@@ -151,26 +151,24 @@ public class UpdateIT extends ESIntegTestCase {
         UpdateResponse updateResponse = client().prepareUpdate(indexOrAlias(), "1")
             .setUpsert(XContentFactory.jsonBuilder().startObject().field("field", 1).endObject())
             .setScript(fieldIncScript)
-            .execute()
-            .actionGet();
+            .get();
         assertEquals(DocWriteResponse.Result.CREATED, updateResponse.getResult());
         assertThat(updateResponse.getIndex(), equalTo("test"));
 
         for (int i = 0; i < 5; i++) {
-            GetResponse getResponse = client().prepareGet("test", "1").execute().actionGet();
+            GetResponse getResponse = client().prepareGet("test", "1").get();
             assertThat(getResponse.getSourceAsMap().get("field").toString(), equalTo("1"));
         }
 
         updateResponse = client().prepareUpdate(indexOrAlias(), "1")
             .setUpsert(XContentFactory.jsonBuilder().startObject().field("field", 1).endObject())
             .setScript(fieldIncScript)
-            .execute()
-            .actionGet();
+            .get();
         assertEquals(DocWriteResponse.Result.UPDATED, updateResponse.getResult());
         assertThat(updateResponse.getIndex(), equalTo("test"));
 
         for (int i = 0; i < 5; i++) {
-            GetResponse getResponse = client().prepareGet("test", "1").execute().actionGet();
+            GetResponse getResponse = client().prepareGet("test", "1").get();
             assertThat(getResponse.getSourceAsMap().get("field").toString(), equalTo("2"));
         }
     }
@@ -194,13 +192,12 @@ public class UpdateIT extends ESIntegTestCase {
             .setUpsert(XContentFactory.jsonBuilder().startObject().field("balance", openingBalance).endObject())
             .setScriptedUpsert(true)
             .setScript(new Script(ScriptType.INLINE, UPDATE_SCRIPTS, UPSERT_SCRIPT, params))
-            .execute()
-            .actionGet();
+            .get();
         assertEquals(DocWriteResponse.Result.CREATED, updateResponse.getResult());
         assertThat(updateResponse.getIndex(), equalTo("test"));
 
         for (int i = 0; i < 5; i++) {
-            GetResponse getResponse = client().prepareGet("test", "1").execute().actionGet();
+            GetResponse getResponse = client().prepareGet("test", "1").get();
             assertThat(getResponse.getSourceAsMap().get("balance").toString(), equalTo("9"));
         }
 
@@ -209,13 +206,12 @@ public class UpdateIT extends ESIntegTestCase {
             .setUpsert(XContentFactory.jsonBuilder().startObject().field("balance", openingBalance).endObject())
             .setScriptedUpsert(true)
             .setScript(new Script(ScriptType.INLINE, UPDATE_SCRIPTS, UPSERT_SCRIPT, params))
-            .execute()
-            .actionGet();
+            .get();
         assertEquals(DocWriteResponse.Result.UPDATED, updateResponse.getResult());
         assertThat(updateResponse.getIndex(), equalTo("test"));
 
         for (int i = 0; i < 5; i++) {
-            GetResponse getResponse = client().prepareGet("test", "1").execute().actionGet();
+            GetResponse getResponse = client().prepareGet("test", "1").get();
             assertThat(getResponse.getSourceAsMap().get("balance").toString(), equalTo("7"));
         }
     }
@@ -228,8 +224,7 @@ public class UpdateIT extends ESIntegTestCase {
             .setDoc(XContentFactory.jsonBuilder().startObject().field("bar", "baz").endObject())
             .setDocAsUpsert(true)
             .setFetchSource(true)
-            .execute()
-            .actionGet();
+            .get();
         assertThat(updateResponse.getIndex(), equalTo("test"));
         assertThat(updateResponse.getGetResult(), notNullValue());
         assertThat(updateResponse.getGetResult().getIndex(), equalTo("test"));
@@ -259,8 +254,7 @@ public class UpdateIT extends ESIntegTestCase {
             .setUpsert(XContentFactory.jsonBuilder().startObject().field("bar", "baz").endObject())
             .setScript(new Script(ScriptType.INLINE, UPDATE_SCRIPTS, PUT_VALUES_SCRIPT, Collections.singletonMap("extra", "foo")))
             .setFetchSource(true)
-            .execute()
-            .actionGet();
+            .get();
 
         assertThat(updateResponse.getIndex(), equalTo("test"));
         assertThat(updateResponse.getGetResult(), notNullValue());
@@ -272,8 +266,7 @@ public class UpdateIT extends ESIntegTestCase {
             .setUpsert(XContentFactory.jsonBuilder().startObject().field("bar", "baz").endObject())
             .setScript(new Script(ScriptType.INLINE, UPDATE_SCRIPTS, PUT_VALUES_SCRIPT, Collections.singletonMap("extra", "foo")))
             .setFetchSource(true)
-            .execute()
-            .actionGet();
+            .get();
 
         assertThat(updateResponse.getIndex(), equalTo("test"));
         assertThat(updateResponse.getGetResult(), notNullValue());
@@ -287,8 +280,7 @@ public class UpdateIT extends ESIntegTestCase {
             .setUpsert(XContentFactory.jsonBuilder().startObject().field("bar", "baz").endObject())
             .setScript(new Script(ScriptType.INLINE, UPDATE_SCRIPTS, PUT_VALUES_SCRIPT, Collections.singletonMap("extra", "foo")))
             .setFetchSource(true)
-            .execute()
-            .actionGet();
+            .get();
 
         assertThat(updateResponse.getIndex(), equalTo("test"));
         assertThat(updateResponse.getGetResult(), notNullValue());
@@ -305,19 +297,19 @@ public class UpdateIT extends ESIntegTestCase {
         Script fieldIncScript = new Script(ScriptType.INLINE, UPDATE_SCRIPTS, FIELD_INC_SCRIPT, Collections.singletonMap("field", "field"));
         DocumentMissingException ex = expectThrows(
             DocumentMissingException.class,
-            () -> client().prepareUpdate(indexOrAlias(), "1").setScript(fieldIncScript).execute().actionGet()
+            () -> client().prepareUpdate(indexOrAlias(), "1").setScript(fieldIncScript).get()
         );
         assertEquals("[1]: document missing", ex.getMessage());
 
-        client().prepareIndex("test").setId("1").setSource("field", 1).execute().actionGet();
+        client().prepareIndex("test").setId("1").setSource("field", 1).get();
 
-        UpdateResponse updateResponse = client().prepareUpdate(indexOrAlias(), "1").setScript(fieldIncScript).execute().actionGet();
+        UpdateResponse updateResponse = client().prepareUpdate(indexOrAlias(), "1").setScript(fieldIncScript).get();
         assertThat(updateResponse.getVersion(), equalTo(2L));
         assertEquals(DocWriteResponse.Result.UPDATED, updateResponse.getResult());
         assertThat(updateResponse.getIndex(), equalTo("test"));
 
         for (int i = 0; i < 5; i++) {
-            GetResponse getResponse = client().prepareGet("test", "1").execute().actionGet();
+            GetResponse getResponse = client().prepareGet("test", "1").get();
             assertThat(getResponse.getSourceAsMap().get("field").toString(), equalTo("2"));
         }
 
@@ -326,14 +318,13 @@ public class UpdateIT extends ESIntegTestCase {
         params.put("field", "field");
         updateResponse = client().prepareUpdate(indexOrAlias(), "1")
             .setScript(new Script(ScriptType.INLINE, UPDATE_SCRIPTS, FIELD_INC_SCRIPT, params))
-            .execute()
-            .actionGet();
+            .get();
         assertThat(updateResponse.getVersion(), equalTo(3L));
         assertEquals(DocWriteResponse.Result.UPDATED, updateResponse.getResult());
         assertThat(updateResponse.getIndex(), equalTo("test"));
 
         for (int i = 0; i < 5; i++) {
-            GetResponse getResponse = client().prepareGet("test", "1").execute().actionGet();
+            GetResponse getResponse = client().prepareGet("test", "1").get();
             assertThat(getResponse.getSourceAsMap().get("field").toString(), equalTo("5"));
         }
 
@@ -347,14 +338,13 @@ public class UpdateIT extends ESIntegTestCase {
                     Collections.singletonMap("_ctx", Collections.singletonMap("op", "none"))
                 )
             )
-            .execute()
-            .actionGet();
+            .get();
         assertThat(updateResponse.getVersion(), equalTo(3L));
         assertEquals(DocWriteResponse.Result.NOOP, updateResponse.getResult());
         assertThat(updateResponse.getIndex(), equalTo("test"));
 
         for (int i = 0; i < 5; i++) {
-            GetResponse getResponse = client().prepareGet("test", "1").execute().actionGet();
+            GetResponse getResponse = client().prepareGet("test", "1").get();
             assertThat(getResponse.getSourceAsMap().get("field").toString(), equalTo("5"));
         }
 
@@ -368,19 +358,18 @@ public class UpdateIT extends ESIntegTestCase {
                     Collections.singletonMap("_ctx", Collections.singletonMap("op", "delete"))
                 )
             )
-            .execute()
-            .actionGet();
+            .get();
         assertThat(updateResponse.getVersion(), equalTo(4L));
         assertEquals(DocWriteResponse.Result.DELETED, updateResponse.getResult());
         assertThat(updateResponse.getIndex(), equalTo("test"));
 
         for (int i = 0; i < 5; i++) {
-            GetResponse getResponse = client().prepareGet("test", "1").execute().actionGet();
+            GetResponse getResponse = client().prepareGet("test", "1").get();
             assertThat(getResponse.isExists(), equalTo(false));
         }
 
         // check _source parameter
-        client().prepareIndex("test").setId("1").setSource("field1", 1, "field2", 2).execute().actionGet();
+        client().prepareIndex("test").setId("1").setSource("field1", 1, "field2", 2).get();
         updateResponse = client().prepareUpdate(indexOrAlias(), "1")
             .setScript(new Script(ScriptType.INLINE, UPDATE_SCRIPTS, FIELD_INC_SCRIPT, Collections.singletonMap("field", "field1")))
             .setFetchSource("field1", "field2")
@@ -395,24 +384,20 @@ public class UpdateIT extends ESIntegTestCase {
 
         // check updates without script
         // add new field
-        client().prepareIndex("test").setId("1").setSource("field", 1).execute().actionGet();
+        client().prepareIndex("test").setId("1").setSource("field", 1).get();
         client().prepareUpdate(indexOrAlias(), "1")
             .setDoc(XContentFactory.jsonBuilder().startObject().field("field2", 2).endObject())
-            .execute()
-            .actionGet();
+            .get();
         for (int i = 0; i < 5; i++) {
-            GetResponse getResponse = client().prepareGet("test", "1").execute().actionGet();
+            GetResponse getResponse = client().prepareGet("test", "1").get();
             assertThat(getResponse.getSourceAsMap().get("field").toString(), equalTo("1"));
             assertThat(getResponse.getSourceAsMap().get("field2").toString(), equalTo("2"));
         }
 
         // change existing field
-        client().prepareUpdate(indexOrAlias(), "1")
-            .setDoc(XContentFactory.jsonBuilder().startObject().field("field", 3).endObject())
-            .execute()
-            .actionGet();
+        client().prepareUpdate(indexOrAlias(), "1").setDoc(XContentFactory.jsonBuilder().startObject().field("field", 3).endObject()).get();
         for (int i = 0; i < 5; i++) {
-            GetResponse getResponse = client().prepareGet("test", "1").execute().actionGet();
+            GetResponse getResponse = client().prepareGet("test", "1").get();
             assertThat(getResponse.getSourceAsMap().get("field").toString(), equalTo("3"));
             assertThat(getResponse.getSourceAsMap().get("field2").toString(), equalTo("2"));
         }
@@ -427,13 +412,12 @@ public class UpdateIT extends ESIntegTestCase {
         testMap.put("commonkey", testMap2);
         testMap.put("map1", 8);
 
-        client().prepareIndex("test").setId("1").setSource("map", testMap).execute().actionGet();
+        client().prepareIndex("test").setId("1").setSource("map", testMap).get();
         client().prepareUpdate(indexOrAlias(), "1")
             .setDoc(XContentFactory.jsonBuilder().startObject().field("map", testMap3).endObject())
-            .execute()
-            .actionGet();
+            .get();
         for (int i = 0; i < 5; i++) {
-            GetResponse getResponse = client().prepareGet("test", "1").execute().actionGet();
+            GetResponse getResponse = client().prepareGet("test", "1").get();
             Map<String, Object> map1 = get(getResponse.getSourceAsMap(), "map");
             assertThat(map1.size(), equalTo(3));
             assertThat(map1.containsKey("map1"), equalTo(true));
@@ -498,8 +482,7 @@ public class UpdateIT extends ESIntegTestCase {
             client().prepareUpdate(indexOrAlias(), "1")
                 .setDoc(XContentFactory.jsonBuilder().startObject().field("field", 1).endObject())
                 .setScript(fieldIncScript)
-                .execute()
-                .actionGet();
+                .get();
             fail("Should have thrown ActionRequestValidationException");
         } catch (ActionRequestValidationException e) {
             assertThat(e.validationErrors().size(), equalTo(1));
@@ -513,7 +496,7 @@ public class UpdateIT extends ESIntegTestCase {
         ensureGreen();
         Script fieldIncScript = new Script(ScriptType.INLINE, UPDATE_SCRIPTS, FIELD_INC_SCRIPT, Collections.singletonMap("field", "field"));
         try {
-            client().prepareUpdate(indexOrAlias(), "1").setScript(fieldIncScript).setDocAsUpsert(true).execute().actionGet();
+            client().prepareUpdate(indexOrAlias(), "1").setScript(fieldIncScript).setDocAsUpsert(true).get();
             fail("Should have thrown ActionRequestValidationException");
         } catch (ActionRequestValidationException e) {
             assertThat(e.validationErrors().size(), equalTo(1));
@@ -527,26 +510,19 @@ public class UpdateIT extends ESIntegTestCase {
         ensureGreen();
 
         // Index some documents
-        client().prepareIndex()
-            .setIndex("test")
-            .setId("id1")
-            .setRouting("routing1")
-            .setSource("field1", 1, "content", "foo")
-            .execute()
-            .actionGet();
+        client().prepareIndex().setIndex("test").setId("id1").setRouting("routing1").setSource("field1", 1, "content", "foo").get();
 
-        client().prepareIndex().setIndex("test").setId("id2").setSource("field1", 0, "content", "bar").execute().actionGet();
+        client().prepareIndex().setIndex("test").setId("id2").setSource("field1", 0, "content", "bar").get();
 
         // Update the first object and note context variables values
         UpdateResponse updateResponse = client().prepareUpdate("test", "id1")
             .setRouting("routing1")
             .setScript(new Script(ScriptType.INLINE, UPDATE_SCRIPTS, EXTRACT_CTX_SCRIPT, Collections.emptyMap()))
-            .execute()
-            .actionGet();
+            .get();
 
         assertEquals(2, updateResponse.getVersion());
 
-        GetResponse getResponse = client().prepareGet("test", "id1").setRouting("routing1").execute().actionGet();
+        GetResponse getResponse = client().prepareGet("test", "id1").setRouting("routing1").get();
         Map<String, Object> updateContext = get(getResponse.getSourceAsMap(), "update_context");
         assertEquals("test", updateContext.get("_index"));
         assertEquals("id1", updateContext.get("_id"));
@@ -556,12 +532,11 @@ public class UpdateIT extends ESIntegTestCase {
         // Idem with the second object
         updateResponse = client().prepareUpdate("test", "id2")
             .setScript(new Script(ScriptType.INLINE, UPDATE_SCRIPTS, EXTRACT_CTX_SCRIPT, Collections.emptyMap()))
-            .execute()
-            .actionGet();
+            .get();
 
         assertEquals(2, updateResponse.getVersion());
 
-        getResponse = client().prepareGet("test", "id2").execute().actionGet();
+        getResponse = client().prepareGet("test", "id2").get();
         updateContext = get(getResponse.getSourceAsMap(), "update_context");
         assertEquals("test", updateContext.get("_index"));
         assertEquals("id2", updateContext.get("_id"));
@@ -602,14 +577,13 @@ public class UpdateIT extends ESIntegTestCase {
                                     .setScript(fieldIncScript)
                                     .setRetryOnConflict(Integer.MAX_VALUE)
                                     .setUpsert(jsonBuilder().startObject().field("field", 1).endObject());
-                                client().prepareBulk().add(updateRequestBuilder).execute().actionGet();
+                                client().prepareBulk().add(updateRequestBuilder).get();
                             } else {
                                 client().prepareUpdate(indexOrAlias(), Integer.toString(i))
                                     .setScript(fieldIncScript)
                                     .setRetryOnConflict(Integer.MAX_VALUE)
                                     .setUpsert(jsonBuilder().startObject().field("field", 1).endObject())
-                                    .execute()
-                                    .actionGet();
+                                    .get();
                             }
                         }
                         logger.info("Client [{}] issued all [{}] requests.", Thread.currentThread().getName(), numberOfUpdatesPerThread);
@@ -640,7 +614,7 @@ public class UpdateIT extends ESIntegTestCase {
         }
         assertThat(failures.size(), equalTo(0));
         for (int i = 0; i < numberOfUpdatesPerThread; i++) {
-            GetResponse response = client().prepareGet("test", Integer.toString(i)).execute().actionGet();
+            GetResponse response = client().prepareGet("test", Integer.toString(i)).get();
             assertThat(response.getId(), equalTo(Integer.toString(i)));
             assertThat(response.isExists(), equalTo(true));
             assertThat(response.getVersion(), equalTo((long) numberOfThreads));
@@ -849,15 +823,14 @@ public class UpdateIT extends ESIntegTestCase {
                 .setScript(fieldIncScript)
                 .setRetryOnConflict(Integer.MAX_VALUE)
                 .setUpsert(jsonBuilder().startObject().field("field", 1).endObject())
-                .execute()
-                .actionGet();
+                .get();
         }
 
         refresh();
 
         for (int i = 0; i < numberOfIdsPerThread; ++i) {
             int totalFailures = 0;
-            GetResponse response = client().prepareGet("test", Integer.toString(i)).execute().actionGet();
+            GetResponse response = client().prepareGet("test", Integer.toString(i)).get();
             if (response.isExists()) {
                 assertThat(response.getId(), equalTo(Integer.toString(i)));
                 int expectedVersion = (numberOfThreads * numberOfUpdatesPerId * 2) + 1;

--- a/server/src/internalClusterTest/java/org/elasticsearch/validate/SimpleValidateQueryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/validate/SimpleValidateQueryIT.java
@@ -65,56 +65,42 @@ public class SimpleValidateQueryIT extends ESIntegTestCase {
                     .endObject()
                     .endObject()
             )
-            .execute()
-            .actionGet();
+            .get();
 
         refresh();
 
         assertThat(
             indicesAdmin().prepareValidateQuery("test")
                 .setQuery(QueryBuilders.wrapperQuery("foo".getBytes(StandardCharsets.UTF_8)))
-                .execute()
-                .actionGet()
+                .get()
                 .isValid(),
             equalTo(false)
         );
         assertThat(
-            indicesAdmin().prepareValidateQuery("test").setQuery(QueryBuilders.queryStringQuery("_id:1")).execute().actionGet().isValid(),
+            indicesAdmin().prepareValidateQuery("test").setQuery(QueryBuilders.queryStringQuery("_id:1")).get().isValid(),
             equalTo(true)
         );
         assertThat(
-            indicesAdmin().prepareValidateQuery("test").setQuery(QueryBuilders.queryStringQuery("_i:d:1")).execute().actionGet().isValid(),
+            indicesAdmin().prepareValidateQuery("test").setQuery(QueryBuilders.queryStringQuery("_i:d:1")).get().isValid(),
             equalTo(false)
         );
 
         assertThat(
-            indicesAdmin().prepareValidateQuery("test").setQuery(QueryBuilders.queryStringQuery("foo:1")).execute().actionGet().isValid(),
+            indicesAdmin().prepareValidateQuery("test").setQuery(QueryBuilders.queryStringQuery("foo:1")).get().isValid(),
             equalTo(true)
         );
         assertThat(
-            indicesAdmin().prepareValidateQuery("test")
-                .setQuery(QueryBuilders.queryStringQuery("bar:hey").lenient(false))
-                .execute()
-                .actionGet()
-                .isValid(),
+            indicesAdmin().prepareValidateQuery("test").setQuery(QueryBuilders.queryStringQuery("bar:hey").lenient(false)).get().isValid(),
             equalTo(false)
         );
 
         assertThat(
-            indicesAdmin().prepareValidateQuery("test")
-                .setQuery(QueryBuilders.queryStringQuery("nonexistent:hello"))
-                .execute()
-                .actionGet()
-                .isValid(),
+            indicesAdmin().prepareValidateQuery("test").setQuery(QueryBuilders.queryStringQuery("nonexistent:hello")).get().isValid(),
             equalTo(true)
         );
 
         assertThat(
-            indicesAdmin().prepareValidateQuery("test")
-                .setQuery(QueryBuilders.queryStringQuery("foo:1 AND"))
-                .execute()
-                .actionGet()
-                .isValid(),
+            indicesAdmin().prepareValidateQuery("test").setQuery(QueryBuilders.queryStringQuery("foo:1 AND")).get().isValid(),
             equalTo(false)
         );
     }
@@ -149,15 +135,10 @@ public class SimpleValidateQueryIT extends ESIntegTestCase {
                     .endObject()
                     .endObject()
             )
-            .execute()
-            .actionGet();
+            .get();
 
         for (int i = 0; i < 10; i++) {
-            client().prepareIndex("test")
-                .setSource("foo", "text", "bar", i, "baz", "blort")
-                .setId(Integer.toString(i))
-                .execute()
-                .actionGet();
+            client().prepareIndex("test").setSource("foo", "text", "bar", i, "baz", "blort").setId(Integer.toString(i)).get();
         }
         refresh();
 
@@ -167,8 +148,7 @@ public class SimpleValidateQueryIT extends ESIntegTestCase {
                 .prepareValidateQuery("test")
                 .setQuery(QueryBuilders.wrapperQuery("foo".getBytes(StandardCharsets.UTF_8)))
                 .setExplain(true)
-                .execute()
-                .actionGet();
+                .get();
             assertThat(response.isValid(), equalTo(false));
             assertThat(response.getQueryExplanation().size(), equalTo(1));
             assertThat(response.getQueryExplanation().get(0).getError(), containsString("Failed to derive xcontent"));
@@ -182,8 +162,7 @@ public class SimpleValidateQueryIT extends ESIntegTestCase {
                 .prepareValidateQuery("test")
                 .setQuery(QueryBuilders.queryStringQuery("foo"))
                 .setExplain(true)
-                .execute()
-                .actionGet();
+                .get();
             assertThat(response.isValid(), equalTo(true));
             assertThat(response.getQueryExplanation().size(), equalTo(1));
             assertThat(
@@ -357,8 +336,7 @@ public class SimpleValidateQueryIT extends ESIntegTestCase {
             .setQuery(queryBuilder)
             .setExplain(true)
             .setRewrite(withRewrite)
-            .execute()
-            .actionGet();
+            .get();
         assertThat(response.getQueryExplanation().size(), equalTo(1));
         assertThat(response.getQueryExplanation().get(0).getError(), nullValue());
         assertThat(response.getQueryExplanation().get(0).getExplanation(), matcher);
@@ -376,8 +354,7 @@ public class SimpleValidateQueryIT extends ESIntegTestCase {
             .setExplain(true)
             .setRewrite(withRewrite)
             .setAllShards(allShards)
-            .execute()
-            .actionGet();
+            .get();
         assertThat(response.getQueryExplanation().size(), equalTo(matchers.size()));
         for (int i = 0; i < matchers.size(); i++) {
             assertThat(response.getQueryExplanation().get(i).getError(), nullValue());
@@ -395,11 +372,7 @@ public class SimpleValidateQueryIT extends ESIntegTestCase {
         refresh();
 
         TermsQueryBuilder termsLookupQuery = QueryBuilders.termsLookupQuery("user", new TermsLookup("twitter", "1", "followers"));
-        ValidateQueryResponse response = indicesAdmin().prepareValidateQuery("twitter")
-            .setQuery(termsLookupQuery)
-            .setExplain(true)
-            .execute()
-            .actionGet();
+        ValidateQueryResponse response = indicesAdmin().prepareValidateQuery("twitter").setQuery(termsLookupQuery).setExplain(true).get();
         assertThat(response.isValid(), is(true));
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/versioning/ConcurrentDocumentOperationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/versioning/ConcurrentDocumentOperationIT.java
@@ -50,12 +50,12 @@ public class ConcurrentDocumentOperationIT extends ESIntegTestCase {
 
         assertThat(failure.get(), nullValue());
 
-        indicesAdmin().prepareRefresh().execute().actionGet();
+        indicesAdmin().prepareRefresh().get();
 
         logger.info("done indexing, check all have the same field value");
-        Map<String, Object> masterSource = client().prepareGet("test", "1").execute().actionGet().getSourceAsMap();
+        Map<String, Object> masterSource = client().prepareGet("test", "1").get().getSourceAsMap();
         for (int i = 0; i < (cluster().size() * 5); i++) {
-            assertThat(client().prepareGet("test", "1").execute().actionGet().getSourceAsMap(), equalTo(masterSource));
+            assertThat(client().prepareGet("test", "1").get().getSourceAsMap(), equalTo(masterSource));
         }
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/versioning/SimpleVersioningIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/versioning/SimpleVersioningIT.java
@@ -47,11 +47,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
         // Note - external version doesn't throw version conflicts on deletes of non existent records.
         // This is different from internal versioning
 
-        DeleteResponse deleteResponse = client().prepareDelete("test", "1")
-            .setVersion(17)
-            .setVersionType(VersionType.EXTERNAL)
-            .execute()
-            .actionGet();
+        DeleteResponse deleteResponse = client().prepareDelete("test", "1").setVersion(17).setVersionType(VersionType.EXTERNAL).get();
         assertEquals(DocWriteResponse.Result.NOT_FOUND, deleteResponse.getResult());
 
         // this should conflict with the delete command transaction which told us that the object was deleted at version 17.
@@ -70,8 +66,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
             .setSource("field1", "value1_1")
             .setVersion(18)
             .setVersionType(VersionType.EXTERNAL)
-            .execute()
-            .actionGet();
+            .get();
         assertThat(indexResponse.getVersion(), equalTo(18L));
     }
 
@@ -111,7 +106,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
             VersionConflictEngineException.class
         );
 
-        client().admin().indices().prepareRefresh().execute().actionGet();
+        client().admin().indices().prepareRefresh().get();
         if (randomBoolean()) {
             refresh();
         }
@@ -127,11 +122,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
 
         // Delete with a higher or equal version deletes all versions up to the given one.
         long v = randomIntBetween(14, 17);
-        DeleteResponse deleteResponse = client().prepareDelete("test", "1")
-            .setVersion(v)
-            .setVersionType(VersionType.EXTERNAL_GTE)
-            .execute()
-            .actionGet();
+        DeleteResponse deleteResponse = client().prepareDelete("test", "1").setVersion(v).setVersionType(VersionType.EXTERNAL_GTE).get();
         assertEquals(DocWriteResponse.Result.DELETED, deleteResponse.getResult());
         assertThat(deleteResponse.getVersion(), equalTo(v));
 
@@ -142,7 +133,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
         );
 
         // But delete with a higher version is OK.
-        deleteResponse = client().prepareDelete("test", "1").setVersion(18).setVersionType(VersionType.EXTERNAL_GTE).execute().actionGet();
+        deleteResponse = client().prepareDelete("test", "1").setVersion(18).setVersionType(VersionType.EXTERNAL_GTE).get();
         assertEquals(DocWriteResponse.Result.NOT_FOUND, deleteResponse.getResult());
         assertThat(deleteResponse.getVersion(), equalTo(18L));
     }
@@ -156,8 +147,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
             .setSource("field1", "value1_1")
             .setVersion(12)
             .setVersionType(VersionType.EXTERNAL)
-            .execute()
-            .actionGet();
+            .get();
         assertThat(indexResponse.getVersion(), equalTo(12L));
 
         indexResponse = client().prepareIndex("test")
@@ -165,8 +155,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
             .setSource("field1", "value1_1")
             .setVersion(14)
             .setVersionType(VersionType.EXTERNAL)
-            .execute()
-            .actionGet();
+            .get();
         assertThat(indexResponse.getVersion(), equalTo(14L));
 
         assertFutureThrows(
@@ -183,7 +172,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
             refresh();
         }
         for (int i = 0; i < 10; i++) {
-            assertThat(client().prepareGet("test", "1").execute().actionGet().getVersion(), equalTo(14L));
+            assertThat(client().prepareGet("test", "1").get().getVersion(), equalTo(14L));
         }
 
         // deleting with a lower version fails.
@@ -193,11 +182,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
         );
 
         // Delete with a higher version deletes all versions up to the given one.
-        DeleteResponse deleteResponse = client().prepareDelete("test", "1")
-            .setVersion(17)
-            .setVersionType(VersionType.EXTERNAL)
-            .execute()
-            .actionGet();
+        DeleteResponse deleteResponse = client().prepareDelete("test", "1").setVersion(17).setVersionType(VersionType.EXTERNAL).get();
         assertEquals(DocWriteResponse.Result.DELETED, deleteResponse.getResult());
         assertThat(deleteResponse.getVersion(), equalTo(17L));
 
@@ -208,7 +193,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
         );
 
         // But delete with a higher version is OK.
-        deleteResponse = client().prepareDelete("test", "1").setVersion(18).setVersionType(VersionType.EXTERNAL).execute().actionGet();
+        deleteResponse = client().prepareDelete("test", "1").setVersion(18).setVersionType(VersionType.EXTERNAL).get();
         assertEquals(DocWriteResponse.Result.NOT_FOUND, deleteResponse.getResult());
         assertThat(deleteResponse.getVersion(), equalTo(18L));
 
@@ -219,11 +204,10 @@ public class SimpleVersioningIT extends ESIntegTestCase {
             .setSource("field1", "value1_1")
             .setVersion(19)
             .setVersionType(VersionType.EXTERNAL)
-            .execute()
-            .actionGet();
+            .get();
         assertThat(indexResponse.getVersion(), equalTo(19L));
 
-        deleteResponse = client().prepareDelete("test", "1").setVersion(20).setVersionType(VersionType.EXTERNAL).execute().actionGet();
+        deleteResponse = client().prepareDelete("test", "1").setVersion(20).setVersionType(VersionType.EXTERNAL).get();
         assertEquals(DocWriteResponse.Result.DELETED, deleteResponse.getResult());
         assertThat(deleteResponse.getVersion(), equalTo(20L));
 
@@ -237,8 +221,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
             .setSource("field1", "value1_1")
             .setVersion(20)
             .setVersionType(VersionType.EXTERNAL)
-            .execute()
-            .actionGet();
+            .get();
         assertThat(indexResponse.getVersion(), equalTo(20L));
     }
 
@@ -248,7 +231,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
         HashMap<String, Object> newSettings = new HashMap<>();
         newSettings.put("index.gc_deletes", "42");
         try {
-            client().admin().indices().prepareUpdateSettings("test").setSettings(newSettings).execute().actionGet();
+            client().admin().indices().prepareUpdateSettings("test").setSettings(newSettings).get();
             fail("did not hit expected exception");
         } catch (IllegalArgumentException iae) {
             // expected
@@ -268,12 +251,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
             VersionConflictEngineException.class
         );
 
-        DocWriteResponse indexResponse = client().prepareIndex("test")
-            .setId("1")
-            .setSource("field1", "value1_1")
-            .setCreate(true)
-            .execute()
-            .actionGet();
+        DocWriteResponse indexResponse = client().prepareIndex("test").setId("1").setSource("field1", "value1_1").setCreate(true).get();
         assertThat(indexResponse.getVersion(), equalTo(1L));
     }
 
@@ -281,7 +259,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
         createIndex("test");
         ensureGreen();
 
-        DocWriteResponse indexResponse = client().prepareIndex("test").setId("1").setSource("field1", "value1_1").execute().actionGet();
+        DocWriteResponse indexResponse = client().prepareIndex("test").setId("1").setSource("field1", "value1_1").get();
         assertThat(indexResponse.getSeqNo(), equalTo(0L));
         assertThat(indexResponse.getPrimaryTerm(), equalTo(1L));
 
@@ -317,7 +295,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
             VersionConflictEngineException.class
         );
 
-        client().admin().indices().prepareRefresh().execute().actionGet();
+        client().admin().indices().prepareRefresh().get();
         for (int i = 0; i < 10; i++) {
             final GetResponse response = client().prepareGet("test", "1").get();
             assertThat(response.getSeqNo(), equalTo(1L));
@@ -327,13 +305,13 @@ public class SimpleVersioningIT extends ESIntegTestCase {
         // search with versioning
         for (int i = 0; i < 10; i++) {
             // TODO: ADD SEQ NO!
-            SearchResponse searchResponse = prepareSearch().setQuery(matchAllQuery()).setVersion(true).execute().actionGet();
+            SearchResponse searchResponse = prepareSearch().setQuery(matchAllQuery()).setVersion(true).get();
             assertThat(searchResponse.getHits().getAt(0).getVersion(), equalTo(2L));
         }
 
         // search without versioning
         for (int i = 0; i < 10; i++) {
-            SearchResponse searchResponse = prepareSearch().setQuery(matchAllQuery()).execute().actionGet();
+            SearchResponse searchResponse = prepareSearch().setQuery(matchAllQuery()).get();
             assertThat(searchResponse.getHits().getAt(0).getVersion(), equalTo(Versions.NOT_FOUND));
         }
 
@@ -369,11 +347,11 @@ public class SimpleVersioningIT extends ESIntegTestCase {
         DocWriteResponse indexResponse = client().prepareIndex("test").setId("1").setSource("field1", "value1_1").get();
         assertThat(indexResponse.getSeqNo(), equalTo(0L));
 
-        client().admin().indices().prepareFlush().execute().actionGet();
+        client().admin().indices().prepareFlush().get();
         indexResponse = client().prepareIndex("test").setId("1").setSource("field1", "value1_2").setIfSeqNo(0).setIfPrimaryTerm(1).get();
         assertThat(indexResponse.getSeqNo(), equalTo(1L));
 
-        client().admin().indices().prepareFlush().execute().actionGet();
+        client().admin().indices().prepareFlush().get();
         assertRequestBuilderThrows(
             client().prepareIndex("test").setId("1").setSource("field1", "value1_1").setIfSeqNo(0).setIfPrimaryTerm(1),
             VersionConflictEngineException.class
@@ -390,17 +368,13 @@ public class SimpleVersioningIT extends ESIntegTestCase {
         );
 
         for (int i = 0; i < 10; i++) {
-            assertThat(client().prepareGet("test", "1").execute().actionGet().getVersion(), equalTo(2L));
+            assertThat(client().prepareGet("test", "1").get().getVersion(), equalTo(2L));
         }
 
-        client().admin().indices().prepareRefresh().execute().actionGet();
+        client().admin().indices().prepareRefresh().get();
 
         for (int i = 0; i < 10; i++) {
-            SearchResponse searchResponse = prepareSearch().setQuery(matchAllQuery())
-                .setVersion(true)
-                .seqNoAndPrimaryTerm(true)
-                .execute()
-                .actionGet();
+            SearchResponse searchResponse = prepareSearch().setQuery(matchAllQuery()).setVersion(true).seqNoAndPrimaryTerm(true).get();
             assertHitCount(searchResponse, 1);
             assertThat(searchResponse.getHits().getAt(0).getVersion(), equalTo(2L));
             assertThat(searchResponse.getHits().getAt(0).getSeqNo(), equalTo(1L));
@@ -413,8 +387,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
 
         BulkResponse bulkResponse = client().prepareBulk()
             .add(client().prepareIndex("test").setId("1").setSource("field1", "value1_1"))
-            .execute()
-            .actionGet();
+            .get();
         assertThat(bulkResponse.hasFailures(), equalTo(false));
         assertThat(bulkResponse.getItems().length, equalTo(1));
         IndexResponse indexResponse = bulkResponse.getItems()[0].getResponse();
@@ -686,8 +659,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
                                     idVersion.response = client().prepareDelete("test", id)
                                         .setVersion(version)
                                         .setVersionType(VersionType.EXTERNAL)
-                                        .execute()
-                                        .actionGet();
+                                        .get();
                                 } catch (VersionConflictEngineException vcee) {
                                     // OK: our version is too old
                                     assertThat(version, lessThanOrEqualTo(truth.get(id).version));
@@ -744,7 +716,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
             } else {
                 expected = -1;
             }
-            long actualVersion = client().prepareGet("test", id).execute().actionGet().getVersion();
+            long actualVersion = client().prepareGet("test", id).get().getVersion();
             if (actualVersion != expected) {
                 logger.error("--> FAILED: idVersion={} actualVersion= {}", idVersion, actualVersion);
                 failed = true;
@@ -764,7 +736,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
     public void testDeleteNotLost() throws Exception {
 
         // We require only one shard for this test, so that the 2nd delete provokes pruning the deletes map:
-        indicesAdmin().prepareCreate("test").setSettings(Settings.builder().put("index.number_of_shards", 1)).execute().actionGet();
+        indicesAdmin().prepareCreate("test").setSettings(Settings.builder().put("index.number_of_shards", 1)).get();
 
         ensureGreen();
 
@@ -777,8 +749,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
             .setOpType(DocWriteRequest.OpType.INDEX)
             .setVersion(10)
             .setVersionType(VersionType.EXTERNAL)
-            .execute()
-            .actionGet();
+            .get();
 
         if (randomBoolean()) {
             // Force refresh so the add is sometimes visible in the searcher:
@@ -786,20 +757,20 @@ public class SimpleVersioningIT extends ESIntegTestCase {
         }
 
         // Delete it
-        client().prepareDelete("test", "id").setVersion(11).setVersionType(VersionType.EXTERNAL).execute().actionGet();
+        client().prepareDelete("test", "id").setVersion(11).setVersionType(VersionType.EXTERNAL).get();
 
         // Real-time get should reflect delete:
-        assertThat("doc should have been deleted", client().prepareGet("test", "id").execute().actionGet().getVersion(), equalTo(-1L));
+        assertThat("doc should have been deleted", client().prepareGet("test", "id").get().getVersion(), equalTo(-1L));
 
         // ThreadPool.relativeTimeInMillis has default granularity of 200 msec, so we must sleep at least that long; sleep much longer in
         // case system is busy:
         Thread.sleep(1000);
 
         // Delete an unrelated doc (provokes pruning deletes from versionMap)
-        client().prepareDelete("test", "id2").setVersion(11).setVersionType(VersionType.EXTERNAL).execute().actionGet();
+        client().prepareDelete("test", "id2").setVersion(11).setVersionType(VersionType.EXTERNAL).get();
 
         // Real-time get should still reflect delete:
-        assertThat("doc should have been deleted", client().prepareGet("test", "id").execute().actionGet().getVersion(), equalTo(-1L));
+        assertThat("doc should have been deleted", client().prepareGet("test", "id").get().getVersion(), equalTo(-1L));
     }
 
     public void testGCDeletesZero() throws Exception {
@@ -815,8 +786,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
             .setOpType(DocWriteRequest.OpType.INDEX)
             .setVersion(10)
             .setVersionType(VersionType.EXTERNAL)
-            .execute()
-            .actionGet();
+            .get();
 
         if (randomBoolean()) {
             // Force refresh so the add is sometimes visible in the searcher:
@@ -824,10 +794,10 @@ public class SimpleVersioningIT extends ESIntegTestCase {
         }
 
         // Delete it
-        client().prepareDelete("test", "id").setVersion(11).setVersionType(VersionType.EXTERNAL).execute().actionGet();
+        client().prepareDelete("test", "id").setVersion(11).setVersionType(VersionType.EXTERNAL).get();
 
         // Real-time get should reflect delete even though index.gc_deletes is 0:
-        assertThat("doc should have been deleted", client().prepareGet("test", "id").execute().actionGet().getVersion(), equalTo(-1L));
+        assertThat("doc should have been deleted", client().prepareGet("test", "id").get().getVersion(), equalTo(-1L));
     }
 
     public void testSpecialVersioning() {
@@ -838,16 +808,14 @@ public class SimpleVersioningIT extends ESIntegTestCase {
             .setSource("field", "value1")
             .setVersion(0)
             .setVersionType(VersionType.EXTERNAL)
-            .execute()
-            .actionGet();
+            .get();
         assertThat(doc1.getVersion(), equalTo(0L));
         DocWriteResponse doc2 = client().prepareIndex("test")
             .setId("1")
             .setSource("field", "value2")
             .setVersion(Versions.MATCH_ANY)
             .setVersionType(VersionType.INTERNAL)
-            .execute()
-            .actionGet();
+            .get();
         assertThat(doc2.getVersion(), equalTo(1L));
         client().prepareDelete("test", "1").get(); // v2
         DocWriteResponse doc3 = client().prepareIndex("test")
@@ -855,16 +823,14 @@ public class SimpleVersioningIT extends ESIntegTestCase {
             .setSource("field", "value3")
             .setVersion(Versions.MATCH_DELETED)
             .setVersionType(VersionType.INTERNAL)
-            .execute()
-            .actionGet();
+            .get();
         assertThat(doc3.getVersion(), equalTo(3L));
         DocWriteResponse doc4 = client().prepareIndex("test")
             .setId("1")
             .setSource("field", "value4")
             .setVersion(4L)
             .setVersionType(VersionType.EXTERNAL_GTE)
-            .execute()
-            .actionGet();
+            .get();
         assertThat(doc4.getVersion(), equalTo(4L));
         // Make sure that these versions are replicated correctly
         setReplicaCount(1, "test");

--- a/server/src/test/java/org/elasticsearch/action/termvectors/GetTermVectorsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/termvectors/GetTermVectorsTests.java
@@ -168,15 +168,14 @@ public class GetTermVectorsTests extends ESSingleNodeTestCase {
         client().prepareIndex("test")
             .setId(Integer.toString(1))
             .setSource(jsonBuilder().startObject().field("field", queryString).endObject())
-            .execute()
-            .actionGet();
+            .get();
         client().admin().indices().prepareRefresh().get();
         TermVectorsRequestBuilder resp = client().prepareTermVectors("test", Integer.toString(1))
             .setPayloads(true)
             .setOffsets(true)
             .setPositions(true)
             .setSelectedFields();
-        TermVectorsResponse response = resp.execute().actionGet();
+        TermVectorsResponse response = resp.get();
         assertThat("doc id 1 doesn't exists but should", response.isExists(), equalTo(true));
         Fields fields = response.getFields();
         assertThat(fields.size(), equalTo(1));

--- a/server/src/test/java/org/elasticsearch/index/IndexServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexServiceTests.java
@@ -449,14 +449,14 @@ public class IndexServiceTests extends ESSingleNodeTestCase {
         assertNotNull(indexService.getFsyncTask());
         assertTrue(indexService.getFsyncTask().mustReschedule());
 
-        IndexMetadata indexMetadata = clusterAdmin().prepareState().execute().actionGet().getState().metadata().index("test");
+        IndexMetadata indexMetadata = clusterAdmin().prepareState().get().getState().metadata().index("test");
         assertEquals("5s", indexMetadata.getSettings().get(IndexSettings.INDEX_TRANSLOG_SYNC_INTERVAL_SETTING.getKey()));
 
         indicesAdmin().prepareClose("test").get();
         indicesAdmin().prepareUpdateSettings("test")
             .setSettings(Settings.builder().put(IndexSettings.INDEX_TRANSLOG_SYNC_INTERVAL_SETTING.getKey(), "20s"))
             .get();
-        indexMetadata = clusterAdmin().prepareState().execute().actionGet().getState().metadata().index("test");
+        indexMetadata = clusterAdmin().prepareState().get().getState().metadata().index("test");
         assertEquals("20s", indexMetadata.getSettings().get(IndexSettings.INDEX_TRANSLOG_SYNC_INTERVAL_SETTING.getKey()));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeaseStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeaseStatsTests.java
@@ -47,7 +47,7 @@ public class RetentionLeaseStatsTests extends ESSingleNodeTestCase {
             latch.await();
         }
 
-        final IndicesStatsResponse indicesStats = client().admin().indices().prepareStats("index").execute().actionGet();
+        final IndicesStatsResponse indicesStats = client().admin().indices().prepareStats("index").get();
         assertThat(indicesStats.getShards(), arrayWithSize(1));
         final RetentionLeaseStats retentionLeaseStats = indicesStats.getShards()[0].getRetentionLeaseStats();
         assertThat(

--- a/server/src/test/java/org/elasticsearch/test/search/aggregations/bucket/SharedSignificantTermsTestMethods.java
+++ b/server/src/test/java/org/elasticsearch/test/search/aggregations/bucket/SharedSignificantTermsTestMethods.java
@@ -50,7 +50,7 @@ public class SharedSignificantTermsTestMethods {
     private static void checkSignificantTermsAggregationCorrect(ESIntegTestCase testCase) {
         SearchResponse response = prepareSearch(INDEX_NAME).addAggregation(
             terms("class").field(CLASS_FIELD).subAggregation(significantTerms("sig_terms").field(TEXT_FIELD))
-        ).execute().actionGet();
+        ).get();
         assertNoFailures(response);
         StringTerms classes = response.getAggregations().get("class");
         Assert.assertThat(classes.getBuckets().size(), equalTo(2));

--- a/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESBlobStoreRepositoryIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESBlobStoreRepositoryIntegTestCase.java
@@ -366,10 +366,7 @@ public abstract class ESBlobStoreRepositoryIntegTestCase extends ESIntegTestCase
         logger.info("-->  delete snapshot {}:{}", repoName, snapshotName);
         assertAcked(clusterAdmin().prepareDeleteSnapshot(repoName, snapshotName).get());
 
-        expectThrows(
-            SnapshotMissingException.class,
-            () -> clusterAdmin().prepareGetSnapshots(repoName).setSnapshots(snapshotName).execute().actionGet()
-        );
+        expectThrows(SnapshotMissingException.class, () -> clusterAdmin().prepareGetSnapshots(repoName).setSnapshots(snapshotName).get());
 
         expectThrows(SnapshotMissingException.class, () -> clusterAdmin().prepareDeleteSnapshot(repoName, snapshotName).get());
 

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractNumericTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractNumericTestCase.java
@@ -52,7 +52,7 @@ public abstract class AbstractNumericTestCase extends ESIntegTestCase {
         // two docs {value: 0} and {value : 2}, then building a histogram agg with interval 1 and with empty
         // buckets computed.. the empty bucket is the one associated with key "1". then each test will have
         // to check that this bucket exists with the appropriate sub aggregations.
-        prepareCreate("empty_bucket_idx").setMapping("value", "type=integer").execute().actionGet();
+        prepareCreate("empty_bucket_idx").setMapping("value", "type=integer").get();
         builders = new ArrayList<>();
         for (int i = 0; i < 2; i++) {
             builders.add(

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -430,7 +430,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
                 .setPatterns(Collections.singletonList("*"))
                 .setOrder(0)
                 .setSettings(randomSettingsBuilder);
-            assertAcked(putTemplate.execute().actionGet());
+            assertAcked(putTemplate.get());
         }
     }
 
@@ -568,7 +568,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
             try {
                 if (cluster() != null) {
                     if (currentClusterScope != Scope.TEST) {
-                        Metadata metadata = clusterAdmin().prepareState().execute().actionGet().getState().getMetadata();
+                        Metadata metadata = clusterAdmin().prepareState().get().getState().getMetadata();
 
                         final Set<String> persistentKeys = new HashSet<>(metadata.persistentSettings().keySet());
                         assertThat("test leaves persistent cluster metadata behind", persistentKeys, empty());
@@ -835,7 +835,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
     public static void updateIndexSettings(Settings.Builder settingsBuilder, String... index) {
         UpdateSettingsRequestBuilder settingsRequest = indicesAdmin().prepareUpdateSettings(index);
         settingsRequest.setSettings(settingsBuilder);
-        assertAcked(settingsRequest.execute().actionGet());
+        assertAcked(settingsRequest.get());
     }
 
     public static void setReplicaCount(int replicas, String index) {
@@ -1390,53 +1390,53 @@ public abstract class ESIntegTestCase extends ESTestCase {
     /**
      * Syntactic sugar for:
      * <pre>
-     *   client().prepareIndex(index).setSource(source).execute().actionGet();
+     *   client().prepareIndex(index).setSource(source).get();
      * </pre>
      */
     protected final DocWriteResponse index(String index, XContentBuilder source) {
-        return client().prepareIndex(index).setSource(source).execute().actionGet();
+        return client().prepareIndex(index).setSource(source).get();
     }
 
     /**
      * Syntactic sugar for:
      * <pre>
-     *   client().prepareIndex(index).setSource(source).execute().actionGet();
+     *   client().prepareIndex(index).setSource(source).get();
      * </pre>
      */
     protected final DocWriteResponse index(String index, String id, Map<String, Object> source) {
-        return client().prepareIndex(index).setId(id).setSource(source).execute().actionGet();
+        return client().prepareIndex(index).setId(id).setSource(source).get();
     }
 
     /**
      * Syntactic sugar for:
      * <pre>
-     *   return client().prepareIndex(index).setId(id).setSource(source).execute().actionGet();
+     *   return client().prepareIndex(index).setId(id).setSource(source).get();
      * </pre>
      */
     protected final DocWriteResponse index(String index, String id, XContentBuilder source) {
-        return client().prepareIndex(index).setId(id).setSource(source).execute().actionGet();
+        return client().prepareIndex(index).setId(id).setSource(source).get();
     }
 
     /**
      * Syntactic sugar for:
      * <pre>
-     *   return client().prepareIndex(index).setId(id).setSource(source).execute().actionGet();
+     *   return client().prepareIndex(index).setId(id).setSource(source).get();
      * </pre>
      */
     protected final DocWriteResponse indexDoc(String index, String id, Object... source) {
-        return client().prepareIndex(index).setId(id).setSource(source).execute().actionGet();
+        return client().prepareIndex(index).setId(id).setSource(source).get();
     }
 
     /**
      * Syntactic sugar for:
      * <pre>
-     *   return client().prepareIndex(index).setId(id).setSource(source).execute().actionGet();
+     *   return client().prepareIndex(index).setId(id).setSource(source).get();
      * </pre>
      * <p>
      * where source is a JSON String.
      */
     protected final DocWriteResponse index(String index, String id, String source) {
-        return client().prepareIndex(index).setId(id).setSource(source, XContentType.JSON).execute().actionGet();
+        return client().prepareIndex(index).setId(id).setSource(source, XContentType.JSON).get();
     }
 
     /**
@@ -1448,8 +1448,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
         waitForRelocation();
         RefreshResponse actionGet = indicesAdmin().prepareRefresh(indices)
             .setIndicesOptions(IndicesOptions.STRICT_EXPAND_OPEN_HIDDEN_FORBID_CLOSED)
-            .execute()
-            .actionGet();
+            .get();
         assertNoFailures(actionGet);
         return actionGet;
     }
@@ -1467,7 +1466,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
      */
     protected final FlushResponse flush(String... indices) {
         waitForRelocation();
-        FlushResponse actionGet = indicesAdmin().prepareFlush(indices).execute().actionGet();
+        FlushResponse actionGet = indicesAdmin().prepareFlush(indices).get();
         for (DefaultShardOperationFailedException failure : actionGet.getShardFailures()) {
             assertThat("unexpected flush failure " + failure.reason(), failure.status(), equalTo(RestStatus.SERVICE_UNAVAILABLE));
         }
@@ -1479,7 +1478,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
      */
     protected ForceMergeResponse forceMerge() {
         waitForRelocation();
-        ForceMergeResponse actionGet = indicesAdmin().prepareForceMerge().setMaxNumSegments(1).execute().actionGet();
+        ForceMergeResponse actionGet = indicesAdmin().prepareForceMerge().setMaxNumSegments(1).get();
         assertNoFailures(actionGet);
         return actionGet;
     }
@@ -1500,8 +1499,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
             .prepareGetIndex()
             .setIndices(index)
             .setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN_CLOSED)
-            .execute()
-            .actionGet();
+            .get();
         return getIndexResponse.getIndices().length > 0;
     }
 
@@ -1652,7 +1650,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
             } else {
                 logger.info("Index [{}] docs async: [{}] bulk: [{}]", builders.size(), false, false);
                 for (IndexRequestBuilder indexRequestBuilder : builders) {
-                    indexRequestBuilder.execute().actionGet();
+                    indexRequestBuilder.get();
                     postIndexAsyncActions(indicesArray, inFlightAsyncOperations, maybeFlush);
                 }
             }
@@ -1667,7 +1665,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
                 for (IndexRequestBuilder indexRequestBuilder : segmented) {
                     bulkBuilder.add(indexRequestBuilder);
                 }
-                BulkResponse actionGet = bulkBuilder.execute().actionGet();
+                BulkResponse actionGet = bulkBuilder.get();
                 assertThat(actionGet.hasFailures() ? actionGet.buildFailureMessage() : "", actionGet.hasFailures(), equalTo(false));
             }
         }
@@ -1679,7 +1677,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
             Throwable t = ExceptionsHelper.unwrapCause(tuple.v2());
             if (t instanceof EsRejectedExecutionException) {
                 logger.debug("Error indexing doc: " + t.getMessage() + ", reindexing.");
-                tuple.v1().execute().actionGet(); // re-index if rejected
+                tuple.v1().get(); // re-index if rejected
             } else {
                 actualErrors.add(tuple.v2());
             }
@@ -2213,7 +2211,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
      */
     public Set<String> assertAllShardsOnNodes(String index, String... pattern) {
         Set<String> nodes = new HashSet<>();
-        ClusterState clusterState = clusterAdmin().prepareState().execute().actionGet().getState();
+        ClusterState clusterState = clusterAdmin().prepareState().get().getState();
         for (IndexRoutingTable indexRoutingTable : clusterState.routingTable()) {
             for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
                 final IndexShardRoutingTable indexShard = indexRoutingTable.shard(shardId);
@@ -2234,7 +2232,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
      * Asserts that all segments are sorted with the provided {@link Sort}.
      */
     public void assertSortedSegments(String indexName, Sort expectedIndexSort) {
-        IndicesSegmentResponse segmentResponse = indicesAdmin().prepareSegments(indexName).execute().actionGet();
+        IndicesSegmentResponse segmentResponse = indicesAdmin().prepareSegments(indexName).get();
         IndexSegments indexSegments = segmentResponse.getIndices().get(indexName);
         for (IndexShardSegments indexShardSegments : indexSegments.getShards().values()) {
             for (ShardSegments shardSegments : indexShardSegments.shards()) {

--- a/test/framework/src/main/java/org/elasticsearch/test/ExternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ExternalTestCluster.java
@@ -188,14 +188,7 @@ public final class ExternalTestCluster extends TestCluster {
     @Override
     public void ensureEstimatedStats() {
         if (size() > 0) {
-            NodesStatsResponse nodeStats = client().admin()
-                .cluster()
-                .prepareNodesStats()
-                .clear()
-                .setBreaker(true)
-                .setIndices(true)
-                .execute()
-                .actionGet();
+            NodesStatsResponse nodeStats = client().admin().cluster().prepareNodesStats().clear().setBreaker(true).setIndices(true).get();
             for (NodeStats stats : nodeStats.getNodes()) {
                 assertThat(
                     "Fielddata breaker not reset to 0 on node: " + stats.getNode(),

--- a/test/framework/src/main/java/org/elasticsearch/test/TestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/TestCluster.java
@@ -150,7 +150,7 @@ public abstract class TestCluster implements Closeable {
                 // Happens if `action.destructive_requires_name` is set to true
                 // which is the case in the CloseIndexDisableCloseAllTests
                 if ("_all".equals(indices[0])) {
-                    ClusterStateResponse clusterStateResponse = client().admin().cluster().prepareState().execute().actionGet();
+                    ClusterStateResponse clusterStateResponse = client().admin().cluster().prepareState().get();
                     ArrayList<String> concreteIndices = new ArrayList<>();
                     for (IndexMetadata indexMetadata : clusterStateResponse.getState().metadata()) {
                         concreteIndices.add(indexMetadata.getIndex().getName());
@@ -174,7 +174,7 @@ public abstract class TestCluster implements Closeable {
                     continue;
                 }
                 try {
-                    client().admin().indices().prepareDeleteTemplate(indexTemplate.getName()).execute().actionGet();
+                    client().admin().indices().prepareDeleteTemplate(indexTemplate.getName()).get();
                 } catch (IndexTemplateMissingException e) {
                     // ignore
                 }
@@ -194,7 +194,7 @@ public abstract class TestCluster implements Closeable {
             }
             for (String template : templates) {
                 try {
-                    client().admin().indices().prepareDeleteTemplate(template).execute().actionGet();
+                    client().admin().indices().prepareDeleteTemplate(template).get();
                 } catch (IndexTemplateMissingException e) {
                     // ignore
                 }

--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/AutoFollowIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/AutoFollowIT.java
@@ -137,7 +137,7 @@ public class AutoFollowIT extends CcrIntegTestCase {
         putAutoFollowPatterns("my-pattern", new String[] { ".*", "logs-*" });
 
         // Trigger system index creation
-        leaderClient().prepareIndex(FakeSystemIndex.SYSTEM_INDEX_NAME).setSource(Map.of("a", "b")).execute().actionGet();
+        leaderClient().prepareIndex(FakeSystemIndex.SYSTEM_INDEX_NAME).setSource(Map.of("a", "b")).get();
 
         Settings leaderIndexSettings = Settings.builder()
             .put(IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 1)

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/CcrIntegTestCase.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/CcrIntegTestCase.java
@@ -476,7 +476,7 @@ public abstract class CcrIntegTestCase extends ESTestCase {
     }
 
     protected final RefreshResponse refresh(Client client, String... indices) {
-        RefreshResponse actionGet = client.admin().indices().prepareRefresh(indices).execute().actionGet();
+        RefreshResponse actionGet = client.admin().indices().prepareRefresh(indices).get();
         assertNoFailures(actionGet);
         return actionGet;
     }

--- a/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/nodesinfo/ComponentVersionsNodesInfoIT.java
+++ b/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/nodesinfo/ComponentVersionsNodesInfoIT.java
@@ -29,7 +29,7 @@ public class ComponentVersionsNodesInfoIT extends ESIntegTestCase {
         String server1NodeId = internalCluster().getInstance(ClusterService.class, node_1).state().nodes().getLocalNodeId();
         logger.info("--> started nodes: {}", server1NodeId);
 
-        NodesInfoResponse response = clusterAdmin().prepareNodesInfo().execute().actionGet();
+        NodesInfoResponse response = clusterAdmin().prepareNodesInfo().get();
         assertThat(response.getNodesMap().get(server1NodeId), notNullValue());
         assertThat(
             response.getNodesMap().get(server1NodeId).getComponentVersions().keySet(),

--- a/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDeciderIT.java
+++ b/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierAllocationDeciderIT.java
@@ -417,7 +417,7 @@ public class DataTierAllocationDeciderIT extends ESIntegTestCase {
     }
 
     private DataTiersFeatureSetUsage getUsage() {
-        XPackUsageResponse usages = new XPackUsageRequestBuilder(client()).execute().actionGet();
+        XPackUsageResponse usages = new XPackUsageRequestBuilder(client()).get();
         return usages.getUsages()
             .stream()
             .filter(u -> u instanceof DataTiersFeatureSetUsage)

--- a/x-pack/plugin/frozen-indices/src/internalClusterTest/java/org/elasticsearch/index/engine/frozen/FrozenIndexTests.java
+++ b/x-pack/plugin/frozen-indices/src/internalClusterTest/java/org/elasticsearch/index/engine/frozen/FrozenIndexTests.java
@@ -322,8 +322,8 @@ public class FrozenIndexTests extends ESSingleNodeTestCase {
 
     public void testCanMatch() throws IOException {
         createIndex("index");
-        client().prepareIndex("index").setId("1").setSource("field", "2010-01-05T02:00").setRefreshPolicy(IMMEDIATE).execute().actionGet();
-        client().prepareIndex("index").setId("2").setSource("field", "2010-01-06T02:00").setRefreshPolicy(IMMEDIATE).execute().actionGet();
+        client().prepareIndex("index").setId("1").setSource("field", "2010-01-05T02:00").setRefreshPolicy(IMMEDIATE).get();
+        client().prepareIndex("index").setId("2").setSource("field", "2010-01-06T02:00").setRefreshPolicy(IMMEDIATE).get();
         {
             IndicesService indexServices = getInstanceFromNode(IndicesService.class);
             Index index = resolveIndex("index");
@@ -508,7 +508,7 @@ public class FrozenIndexTests extends ESSingleNodeTestCase {
     public void testFreezeIndexIncreasesIndexSettingsVersion() {
         final String index = "test";
         createIndex(index, indexSettings(1, 0).build());
-        client().prepareIndex(index).setSource("field", "value").execute().actionGet();
+        client().prepareIndex(index).setSource("field", "value").get();
 
         final long settingsVersion = clusterAdmin().prepareState().get().getState().metadata().index(index).getSettingsVersion();
 

--- a/x-pack/plugin/graph/src/internalClusterTest/java/org/elasticsearch/xpack/graph/test/GraphTests.java
+++ b/x-pack/plugin/graph/src/internalClusterTest/java/org/elasticsearch/xpack/graph/test/GraphTests.java
@@ -99,7 +99,7 @@ public class GraphTests extends ESSingleNodeTestCase {
         indicesAdmin().prepareRefresh("test").get();
         // Ensure single segment with no deletes. Hopefully solves test instability in
         // issue https://github.com/elastic/x-pack-elasticsearch/issues/918
-        ForceMergeResponse actionGet = indicesAdmin().prepareForceMerge("test").setFlush(true).setMaxNumSegments(1).execute().actionGet();
+        ForceMergeResponse actionGet = indicesAdmin().prepareForceMerge("test").setFlush(true).setMaxNumSegments(1).get();
         indicesAdmin().prepareRefresh("test").get();
         assertAllSuccessful(actionGet);
         for (IndexShardSegments seg : indicesAdmin().prepareSegments().get().getIndices().get("test")) {

--- a/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/IndexLifecycleInitialisationTests.java
+++ b/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/IndexLifecycleInitialisationTests.java
@@ -183,8 +183,7 @@ public class IndexLifecycleInitialisationTests extends ESIntegTestCase {
         assertNotNull(indexLifecycleService.getScheduledJob());
         assertBusy(() -> {
             LifecycleExecutionState lifecycleState = clusterAdmin().prepareState()
-                .execute()
-                .actionGet()
+                .get()
                 .getState()
                 .getMetadata()
                 .index("test")
@@ -415,8 +414,7 @@ public class IndexLifecycleInitialisationTests extends ESIntegTestCase {
         assertBusy(() -> assertTrue(indexExists("test")));
         assertBusy(() -> {
             LifecycleExecutionState lifecycleState = clusterAdmin().prepareState()
-                .execute()
-                .actionGet()
+                .get()
                 .getState()
                 .getMetadata()
                 .index("test")

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ClassificationIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ClassificationIT.java
@@ -838,8 +838,7 @@ public class ClassificationIT extends MlNativeDataFrameAnalyticsIntegTestCase {
         // Delete the config straight from the config index
         DeleteResponse deleteResponse = client().prepareDelete(".ml-config", DataFrameAnalyticsConfig.documentId(jobId))
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
-            .execute()
-            .actionGet();
+            .get();
         assertThat(deleteResponse.status(), equalTo(RestStatus.OK));
 
         // Now calling the _delete_expired_data API should remove unused state

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeAutodetectIntegTestCase.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeAutodetectIntegTestCase.java
@@ -271,8 +271,7 @@ abstract class MlNativeAutodetectIntegTestCase extends MlNativeIntegTestCase {
         // Refresh the annotations index so that recently indexed annotation docs are visible.
         indicesAdmin().prepareRefresh(AnnotationIndex.LATEST_INDEX_NAME)
             .setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN_CLOSED_HIDDEN)
-            .execute()
-            .actionGet();
+            .get();
 
         SearchRequest searchRequest = new SearchRequest(AnnotationIndex.READ_ALIAS_NAME).indicesOptions(
             IndicesOptions.LENIENT_EXPAND_OPEN_CLOSED_HIDDEN

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RegressionIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RegressionIT.java
@@ -436,8 +436,7 @@ public class RegressionIT extends MlNativeDataFrameAnalyticsIntegTestCase {
         // Delete the config straight from the config index
         DeleteResponse deleteResponse = client().prepareDelete(".ml-config", DataFrameAnalyticsConfig.documentId(jobId))
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
-            .execute()
-            .actionGet();
+            .get();
         assertThat(deleteResponse.status(), equalTo(RestStatus.OK));
 
         // Now calling the _delete_expired_data API should remove unused state

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/license/MachineLearningLicensingIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/license/MachineLearningLicensingIT.java
@@ -540,11 +540,7 @@ public class MachineLearningLicensingIT extends BaseMlIntegTestCase {
         AcknowledgedResponse putPipelineResponse = putPipelineListener.actionGet();
         assertTrue(putPipelineResponse.isAcknowledged());
 
-        client().prepareIndex("infer_license_test")
-            .setPipeline("test_infer_license_pipeline")
-            .setSource("{}", XContentType.JSON)
-            .execute()
-            .actionGet();
+        client().prepareIndex("infer_license_test").setPipeline("test_infer_license_pipeline").setSource("{}", XContentType.JSON).get();
 
         String simulateSource = Strings.format("""
             {
@@ -573,11 +569,7 @@ public class MachineLearningLicensingIT extends BaseMlIntegTestCase {
 
         // Inference against the previous pipeline should still work
         try {
-            client().prepareIndex("infer_license_test")
-                .setPipeline("test_infer_license_pipeline")
-                .setSource("{}", XContentType.JSON)
-                .execute()
-                .actionGet();
+            client().prepareIndex("infer_license_test").setPipeline("test_infer_license_pipeline").setSource("{}", XContentType.JSON).get();
         } catch (ElasticsearchSecurityException ex) {
             fail(ex.getMessage());
         }
@@ -601,8 +593,7 @@ public class MachineLearningLicensingIT extends BaseMlIntegTestCase {
             client().prepareIndex("infer_license_test")
                 .setPipeline("test_infer_license_pipeline_again")
                 .setSource("{}", XContentType.JSON)
-                .execute()
-                .actionGet();
+                .get();
         });
         assertThat(e.status(), is(RestStatus.FORBIDDEN));
         assertThat(e.getMessage(), containsString("non-compliant"));
@@ -645,16 +636,11 @@ public class MachineLearningLicensingIT extends BaseMlIntegTestCase {
 
         // both ingest pipelines should work
 
-        client().prepareIndex("infer_license_test")
-            .setPipeline("test_infer_license_pipeline")
-            .setSource("{}", XContentType.JSON)
-            .execute()
-            .actionGet();
+        client().prepareIndex("infer_license_test").setPipeline("test_infer_license_pipeline").setSource("{}", XContentType.JSON).get();
         client().prepareIndex("infer_license_test")
             .setPipeline("test_infer_license_pipeline_again")
             .setSource("{}", XContentType.JSON)
-            .execute()
-            .actionGet();
+            .get();
     }
 
     public void testMachineLearningInferModelRestricted() {

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AnnotationIndexIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AnnotationIndexIT.java
@@ -323,8 +323,7 @@ public class AnnotationIndexIT extends MlSingleNodeTestCase {
         GetIndexResponse getIndexResponse = indicesAdmin().prepareGetIndex()
             .setIndices(AnnotationIndex.LATEST_INDEX_NAME)
             .setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN)
-            .execute()
-            .actionGet();
+            .get();
         return Arrays.asList(getIndexResponse.getIndices()).contains(expectedName);
     }
 

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AutodetectResultProcessorIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AutodetectResultProcessorIT.java
@@ -777,8 +777,7 @@ public class AutodetectResultProcessorIT extends MlSingleNodeTestCase {
         // Refresh the annotations index so that recently indexed annotation docs are visible.
         indicesAdmin().prepareRefresh(AnnotationIndex.LATEST_INDEX_NAME)
             .setIndicesOptions(IndicesOptions.STRICT_EXPAND_OPEN_HIDDEN_FORBID_CLOSED)
-            .execute()
-            .actionGet();
+            .get();
 
         SearchRequest searchRequest = new SearchRequest(AnnotationIndex.READ_ALIAS_NAME);
         List<Annotation> annotations = new ArrayList<>();

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/CategorizeTextDistributedIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/CategorizeTextDistributedIT.java
@@ -70,12 +70,12 @@ public class CategorizeTextDistributedIT extends BaseMlIntegTestCase {
                     .setSource(Map.of("message", "Aug 29, 2019 2:02:51 PM org.apache.coyote.http11.Http11BaseProtocol stop"));
                 bulkRequestBuilder.add(indexRequestBuilder);
             }
-            bulkRequestBuilder.execute().actionGet();
+            bulkRequestBuilder.get();
         }
-        client().admin().indices().prepareRefresh(indexName).execute().actionGet();
+        client().admin().indices().prepareRefresh(indexName).get();
 
         // Confirm the theory that all 3 nodes will have a shard on
-        IndicesStatsResponse indicesStatsResponse = client().admin().indices().prepareStats(indexName).execute().actionGet();
+        IndicesStatsResponse indicesStatsResponse = client().admin().indices().prepareStats(indexName).get();
         Set<String> nodesWithShards = Arrays.stream(indicesStatsResponse.getShards())
             .map(ShardStats::getShardRouting)
             .map(ShardRouting::currentNodeId)

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DatafeedCcsIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DatafeedCcsIT.java
@@ -190,8 +190,7 @@ public class DatafeedCcsIT extends AbstractMultiClustersTestCase {
         try {
             SearchResponse response = client(LOCAL_CLUSTER).prepareSearch(".ml-notifications*")
                 .setQuery(new MatchPhraseQueryBuilder("message", message))
-                .execute()
-                .actionGet();
+                .get();
             return response.getHits().getTotalHits().value > 0;
         } catch (ElasticsearchException e) {
             return false;

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/JobResultsProviderIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/JobResultsProviderIT.java
@@ -1040,7 +1040,7 @@ public class JobResultsProviderIT extends MlSingleNodeTestCase {
                 bulkRequest.add(indexRequest);
             }
         }
-        BulkResponse response = bulkRequest.execute().actionGet();
+        BulkResponse response = bulkRequest.get();
         if (response.hasFailures()) {
             throw new IllegalStateException(Strings.toString(response));
         }
@@ -1065,7 +1065,7 @@ public class JobResultsProviderIT extends MlSingleNodeTestCase {
                 bulkRequest.add(indexRequest);
             }
         }
-        bulkRequest.execute().actionGet();
+        bulkRequest.get();
     }
 
     private void indexModelSizeStats(ModelSizeStats modelSizeStats) {
@@ -1115,6 +1115,6 @@ public class JobResultsProviderIT extends MlSingleNodeTestCase {
                 bulkRequest.add(indexRequest);
             }
         }
-        bulkRequest.execute().actionGet();
+        bulkRequest.get();
     }
 }

--- a/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/ProfilingTestCase.java
+++ b/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/ProfilingTestCase.java
@@ -115,7 +115,7 @@ public abstract class ProfilingTestCase extends ESIntegTestCase {
 
     protected final void bulkIndex(String file) throws Exception {
         byte[] bulkData = read(file);
-        BulkResponse response = client().prepareBulk().add(bulkData, 0, bulkData.length, XContentType.JSON).execute().actionGet();
+        BulkResponse response = client().prepareBulk().add(bulkData, 0, bulkData.length, XContentType.JSON).get();
         assertFalse(response.hasFailures());
     }
 

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/SecurityCachePermissionTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/SecurityCachePermissionTests.java
@@ -49,7 +49,7 @@ public class SecurityCachePermissionTests extends SecurityIntegTestCase {
     public void testThatTermsFilterQueryDoesntLeakData() {
         SearchResponse response = prepareSearch("data").setQuery(
             QueryBuilders.constantScoreQuery(QueryBuilders.termsLookupQuery("token", new TermsLookup("tokens", "1", "tokens")))
-        ).execute().actionGet();
+        ).get();
         assertThat(response.isTimedOut(), is(false));
         assertThat(response.getHits().getHits().length, is(1));
 
@@ -65,8 +65,7 @@ public class SecurityCachePermissionTests extends SecurityIntegTestCase {
                 .setQuery(
                     QueryBuilders.constantScoreQuery(QueryBuilders.termsLookupQuery("token", new TermsLookup("tokens", "1", "tokens")))
                 )
-                .execute()
-                .actionGet();
+                .get();
             fail("search phase exception should have been thrown! response was:\n" + response.toString());
         } catch (ElasticsearchSecurityException e) {
             assertThat(e.toString(), containsString("ElasticsearchSecurityException: action"));

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/apikey/ApiKeySingleNodeTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/apikey/ApiKeySingleNodeTests.java
@@ -752,8 +752,7 @@ public class ApiKeySingleNodeTests extends SecuritySingleNodeTestCase {
                 )
             )
             .setRefreshPolicy(randomFrom(NONE, WAIT_UNTIL, IMMEDIATE))
-            .execute()
-            .actionGet();
+            .get();
         final String encoded = Base64.getEncoder()
             .encodeToString(
                 (createAdminKeyResponse.getId() + ":" + createAdminKeyResponse.getKey().toString()).getBytes(StandardCharsets.UTF_8)

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authz/store/NativePrivilegeStoreCacheTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authz/store/NativePrivilegeStoreCacheTests.java
@@ -122,8 +122,7 @@ public class NativePrivilegeStoreCacheTests extends SecuritySingleNodeTestCase {
 
         ApplicationPrivilegeDescriptor[] privileges = new GetPrivilegesRequestBuilder(client).application("app-2")
             .privileges("write")
-            .execute()
-            .actionGet()
+            .get()
             .privileges();
 
         assertEquals(1, privileges.length);
@@ -138,18 +137,17 @@ public class NativePrivilegeStoreCacheTests extends SecuritySingleNodeTestCase {
                 .add(new DeleteRequest(SECURITY_MAIN_ALIAS, DOC_TYPE_VALUE + "_app-2:write"))
                 .add(new DeleteRequest(SECURITY_MAIN_ALIAS, DOC_TYPE_VALUE + "_app-2:admin"))
                 .setRefreshPolicy(IMMEDIATE)
-                .execute()
-                .actionGet()
+                .get()
                 .hasFailures()
         );
 
         // We can still get the privileges because it is cached
-        privileges = new GetPrivilegesRequestBuilder(client).application("app-2").privileges("read").execute().actionGet().privileges();
+        privileges = new GetPrivilegesRequestBuilder(client).application("app-2").privileges("read").get().privileges();
 
         assertEquals(1, privileges.length);
 
         // We can get all app-2 privileges because cache is keyed by application
-        privileges = new GetPrivilegesRequestBuilder(client).application("app-2").execute().actionGet().privileges();
+        privileges = new GetPrivilegesRequestBuilder(client).application("app-2").get().privileges();
 
         assertEquals(3, privileges.length);
 
@@ -161,14 +159,14 @@ public class NativePrivilegeStoreCacheTests extends SecuritySingleNodeTestCase {
         assertFalse(clearPrivilegesCacheResponse.hasFailures());
 
         // app-2 is no longer found
-        privileges = new GetPrivilegesRequestBuilder(client).application("app-2").privileges("read").execute().actionGet().privileges();
+        privileges = new GetPrivilegesRequestBuilder(client).application("app-2").privileges("read").get().privileges();
         assertEquals(0, privileges.length);
     }
 
     public void testPopulationOfCacheWhenLoadingPrivilegesForAllApplications() {
         final Client client = client();
 
-        ApplicationPrivilegeDescriptor[] privileges = new GetPrivilegesRequestBuilder(client).execute().actionGet().privileges();
+        ApplicationPrivilegeDescriptor[] privileges = new GetPrivilegesRequestBuilder(client).get().privileges();
 
         assertEquals(6, privileges.length);
 
@@ -176,18 +174,15 @@ public class NativePrivilegeStoreCacheTests extends SecuritySingleNodeTestCase {
         deleteApplicationPrivilege("app-2", "read");
 
         // A direct read should also get nothing
-        assertEquals(
-            0,
-            new GetPrivilegesRequestBuilder(client).application("app-2").privileges("read").execute().actionGet().privileges().length
-        );
+        assertEquals(0, new GetPrivilegesRequestBuilder(client).application("app-2").privileges("read").get().privileges().length);
 
         // The wildcard expression expansion should be invalidated
-        assertEquals(5, new GetPrivilegesRequestBuilder(client).execute().actionGet().privileges().length);
+        assertEquals(5, new GetPrivilegesRequestBuilder(client).get().privileges().length);
 
         // Now put it back and wild expression expansion should be invalidated again
         addApplicationPrivilege("app-2", "read", "r:e:f:g", "r:t:u:v");
 
-        assertEquals(6, new GetPrivilegesRequestBuilder(client).execute().actionGet().privileges().length);
+        assertEquals(6, new GetPrivilegesRequestBuilder(client).get().privileges().length);
 
         // Delete the privilege again which invalidate the wildcard expansion
         deleteApplicationPrivilege("app-2", "read");
@@ -199,45 +194,31 @@ public class NativePrivilegeStoreCacheTests extends SecuritySingleNodeTestCase {
                 .add(new DeleteRequest(SECURITY_MAIN_ALIAS, DOC_TYPE_VALUE + "_app-1:write"))
                 .add(new DeleteRequest(SECURITY_MAIN_ALIAS, DOC_TYPE_VALUE + "_app-2:write"))
                 .setRefreshPolicy(IMMEDIATE)
-                .execute()
-                .actionGet()
+                .get()
                 .hasFailures()
         );
 
         // app-2 write privilege will not be found since cache is invalidated and backing document is gone
-        assertEquals(
-            0,
-            new GetPrivilegesRequestBuilder(client).application("app-2").privileges("write").execute().actionGet().privileges().length
-        );
+        assertEquals(0, new GetPrivilegesRequestBuilder(client).application("app-2").privileges("write").get().privileges().length);
 
         // app-1 write privilege is still found since it is cached even when the backing document is gone
-        assertEquals(
-            1,
-            new GetPrivilegesRequestBuilder(client).application("app-1").privileges("write").execute().actionGet().privileges().length
-        );
+        assertEquals(1, new GetPrivilegesRequestBuilder(client).application("app-1").privileges("write").get().privileges().length);
     }
 
     public void testSuffixWildcard() {
         final Client client = client();
 
         // Populate the cache with suffix wildcard
-        assertEquals(6, new GetPrivilegesRequestBuilder(client).application("app-*").execute().actionGet().privileges().length);
+        assertEquals(6, new GetPrivilegesRequestBuilder(client).application("app-*").get().privileges().length);
 
         // Delete a backing document
         assertEquals(
             RestStatus.OK,
-            client.prepareDelete(SECURITY_MAIN_ALIAS, DOC_TYPE_VALUE + "_app-1:read")
-                .setRefreshPolicy(IMMEDIATE)
-                .execute()
-                .actionGet()
-                .status()
+            client.prepareDelete(SECURITY_MAIN_ALIAS, DOC_TYPE_VALUE + "_app-1:read").setRefreshPolicy(IMMEDIATE).get().status()
         );
 
         // A direct get privilege with no wildcard should still hit the cache without needing it to be in the names cache
-        assertEquals(
-            1,
-            new GetPrivilegesRequestBuilder(client).application("app-1").privileges("read").execute().actionGet().privileges().length
-        );
+        assertEquals(1, new GetPrivilegesRequestBuilder(client).application("app-1").privileges("read").get().privileges().length);
     }
 
     public void testHasPrivileges() {
@@ -383,8 +364,7 @@ public class NativePrivilegeStoreCacheTests extends SecuritySingleNodeTestCase {
             singleton(privilegeName),
             new DeletePrivilegesRequestBuilder(client()).application(applicationName)
                 .privileges(new String[] { privilegeName })
-                .execute()
-                .actionGet()
+                .get()
                 .found()
         );
     }

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authz/store/NativePrivilegeStoreSingleNodeTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authz/store/NativePrivilegeStoreSingleNodeTests.java
@@ -82,7 +82,7 @@ public class NativePrivilegeStoreSingleNodeTests extends SecuritySingleNodeTestC
         // Disable expensive query
         new ClusterUpdateSettingsRequestBuilder(client(), ClusterUpdateSettingsAction.INSTANCE).setTransientSettings(
             Settings.builder().put(ALLOW_EXPENSIVE_QUERIES.getKey(), false)
-        ).execute().actionGet();
+        ).get();
 
         try {
             // Prove that expensive queries are indeed disabled
@@ -96,9 +96,7 @@ public class NativePrivilegeStoreSingleNodeTests extends SecuritySingleNodeTestC
             );
 
             // Get privileges work with wildcard application name
-            final GetPrivilegesResponse getPrivilegesResponse = new GetPrivilegesRequestBuilder(client()).application("yourapp*")
-                .execute()
-                .actionGet();
+            final GetPrivilegesResponse getPrivilegesResponse = new GetPrivilegesRequestBuilder(client()).application("yourapp*").get();
             assertThat(getPrivilegesResponse.privileges(), arrayWithSize(4));
             assertThat(
                 Arrays.stream(getPrivilegesResponse.privileges())
@@ -124,13 +122,12 @@ public class NativePrivilegeStoreSingleNodeTests extends SecuritySingleNodeTestC
                     }
                   ]
                 }
-                """), XContentType.JSON).execute().actionGet();
+                """), XContentType.JSON).get();
 
             new PutUserRequestBuilder(client(), PutUserAction.INSTANCE).username("app_user")
                 .password(TEST_PASSWORD_SECURE_STRING, getFastStoredHashAlgoForTests())
                 .roles("app_user_role")
-                .execute()
-                .actionGet();
+                .get();
 
             Client appUserClient;
             appUserClient = client().filterWithHeader(
@@ -192,7 +189,7 @@ public class NativePrivilegeStoreSingleNodeTests extends SecuritySingleNodeTestC
             // Reset setting since test suite expects things in a clean slate
             new ClusterUpdateSettingsRequestBuilder(client(), ClusterUpdateSettingsAction.INSTANCE).setTransientSettings(
                 Settings.builder().putNull(ALLOW_EXPENSIVE_QUERIES.getKey())
-            ).execute().actionGet();
+            ).get();
         }
     }
 }

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/profile/ProfileIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/profile/ProfileIntegTests.java
@@ -779,8 +779,7 @@ public class ProfileIntegTests extends AbstractProfileIntegTestCase {
     public void testGetUsersWithProfileUid() throws IOException {
         new ChangePasswordRequestBuilder(client()).username(ElasticUser.NAME)
             .password(TEST_PASSWORD_SECURE_STRING.clone().getChars(), Hasher.BCRYPT)
-            .execute()
-            .actionGet();
+            .get();
 
         final Profile elasticUserProfile = doActivateProfile(ElasticUser.NAME, TEST_PASSWORD_SECURE_STRING);
         final Profile nativeRacUserProfile = doActivateProfile(RAC_USER_NAME, NATIVE_RAC_USER_PASSWORD);

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/profile/SecurityDomainIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/profile/SecurityDomainIntegTests.java
@@ -320,9 +320,7 @@ public class SecurityDomainIntegTests extends AbstractProfileIntegTestCase {
         ).execute(CreateApiKeyAction.INSTANCE, createApiKeyRequest).actionGet();
 
         final XContentTestUtils.JsonMapView getResponseView = XContentTestUtils.createJsonMapView(
-            new ByteArrayInputStream(
-                client().prepareGet(SECURITY_MAIN_ALIAS, createApiKeyResponse.getId()).execute().actionGet().getSourceAsBytes()
-            )
+            new ByteArrayInputStream(client().prepareGet(SECURITY_MAIN_ALIAS, createApiKeyResponse.getId()).get().getSourceAsBytes())
         );
 
         // domain info is captured
@@ -338,7 +336,7 @@ public class SecurityDomainIntegTests extends AbstractProfileIntegTestCase {
                             (createApiKeyResponse.getId() + ":" + createApiKeyResponse.getKey()).getBytes(StandardCharsets.UTF_8)
                         )
             )
-        ).admin().cluster().prepareHealth().execute().actionGet();
+        ).admin().cluster().prepareHealth().get();
     }
 
     public void testDomainCaptureForServiceToken() {
@@ -355,10 +353,7 @@ public class SecurityDomainIntegTests extends AbstractProfileIntegTestCase {
 
         final XContentTestUtils.JsonMapView responseView = XContentTestUtils.createJsonMapView(
             new ByteArrayInputStream(
-                client().prepareGet(SECURITY_MAIN_ALIAS, "service_account_token-elastic/fleet-server/" + tokenName)
-                    .execute()
-                    .actionGet()
-                    .getSourceAsBytes()
+                client().prepareGet(SECURITY_MAIN_ALIAS, "service_account_token-elastic/fleet-server/" + tokenName).get().getSourceAsBytes()
             )
         );
 
@@ -369,8 +364,7 @@ public class SecurityDomainIntegTests extends AbstractProfileIntegTestCase {
             .admin()
             .cluster()
             .prepareHealth()
-            .execute()
-            .actionGet();
+            .get();
     }
 
     private void assertAccessToken(CreateTokenResponse createTokenResponse) throws IOException {
@@ -378,9 +372,8 @@ public class SecurityDomainIntegTests extends AbstractProfileIntegTestCase {
             .admin()
             .cluster()
             .prepareHealth()
-            .execute()
-            .actionGet();
-        final SearchResponse searchResponse = prepareSearch(SecuritySystemIndices.SECURITY_TOKENS_ALIAS).execute().actionGet();
+            .get();
+        final SearchResponse searchResponse = prepareSearch(SecuritySystemIndices.SECURITY_TOKENS_ALIAS).get();
 
         final String encodedAuthentication = createTokenResponse.getAuthentication().encode();
         for (SearchHit searchHit : searchResponse.getHits().getHits()) {

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/transport/filter/IpFilteringUpdateTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/transport/filter/IpFilteringUpdateTests.java
@@ -145,7 +145,7 @@ public class IpFilteringUpdateTests extends SecurityIntegTestCase {
                     expectThrows(
                         IllegalArgumentException.class,
                         settingName,
-                        () -> clusterAdmin().prepareUpdateSettings().setPersistentSettings(settings).execute().actionGet()
+                        () -> clusterAdmin().prepareUpdateSettings().setPersistentSettings(settings).get()
                     ).getMessage(),
                     allOf(containsString("invalid IP filter"), containsString(invalidValue))
                 );

--- a/x-pack/plugin/slm/src/internalClusterTest/java/org/elasticsearch/xpack/slm/SLMFileSettingsIT.java
+++ b/x-pack/plugin/slm/src/internalClusterTest/java/org/elasticsearch/xpack/slm/SLMFileSettingsIT.java
@@ -150,10 +150,7 @@ public class SLMFileSettingsIT extends AbstractSnapshotIntegTestCase {
     }
 
     private void assertMasterNode(Client client, String node) {
-        assertThat(
-            client.admin().cluster().prepareState().execute().actionGet().getState().nodes().getMasterNode().getName(),
-            equalTo(node)
-        );
+        assertThat(client.admin().cluster().prepareState().get().getState().nodes().getMasterNode().getName(), equalTo(node));
     }
 
     private void writeJSONFile(String node, String json) throws Exception {

--- a/x-pack/plugin/slm/src/internalClusterTest/java/org/elasticsearch/xpack/slm/SLMSnapshotBlockingIntegTests.java
+++ b/x-pack/plugin/slm/src/internalClusterTest/java/org/elasticsearch/xpack/slm/SLMSnapshotBlockingIntegTests.java
@@ -424,8 +424,7 @@ public class SLMSnapshotBlockingIntegTests extends AbstractSnapshotIntegTestCase
                 try {
                     GetSnapshotsResponse snapshotsStatusResponse = clusterAdmin().prepareGetSnapshots(REPO)
                         .setSnapshots(successfulSnapshotName.get())
-                        .execute()
-                        .actionGet();
+                        .get();
                     snapshotInfo = snapshotsStatusResponse.getSnapshots().get(0);
                 } catch (SnapshotMissingException sme) {
                     throw new AssertionError(sme);

--- a/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/ShapeQueryOverShapeTests.java
+++ b/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/ShapeQueryOverShapeTests.java
@@ -259,7 +259,7 @@ public class ShapeQueryOverShapeTests extends ShapeQueryTestCase {
 
     public void testContainsShapeQuery() {
 
-        indicesAdmin().prepareCreate("test_contains").setMapping("location", "type=shape").execute().actionGet();
+        indicesAdmin().prepareCreate("test_contains").setMapping("location", "type=shape").get();
 
         String doc = """
             {"location" : {"type":"envelope", "coordinates":[ [-100.0, 100.0], [100.0, -100.0]]}}""";

--- a/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/ShapeQueryTestCase.java
+++ b/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/ShapeQueryTestCase.java
@@ -310,7 +310,7 @@ public abstract class ShapeQueryTestCase extends ESSingleNodeTestCase {
     }
 
     public void testDistanceQuery() throws Exception {
-        indicesAdmin().prepareCreate("test_distance").setMapping("location", "type=shape").execute().actionGet();
+        indicesAdmin().prepareCreate("test_distance").setMapping("location", "type=shape").get();
         ensureGreen();
 
         Circle circle = new Circle(1, 0, 10);

--- a/x-pack/plugin/voting-only-node/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/votingonly/VotingOnlyNodePluginTests.java
+++ b/x-pack/plugin/voting-only-node/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/votingonly/VotingOnlyNodePluginTests.java
@@ -152,7 +152,7 @@ public class VotingOnlyNodePluginTests extends ESIntegTestCase {
         expectThrows(
             MasterNotDiscoveredException.class,
             () -> assertThat(
-                clusterAdmin().prepareState().setMasterNodeTimeout("100ms").execute().actionGet().getState().nodes().getMasterNodeId(),
+                clusterAdmin().prepareState().setMasterNodeTimeout("100ms").get().getState().nodes().getMasterNodeId(),
                 nullValue()
             )
         );
@@ -229,8 +229,7 @@ public class VotingOnlyNodePluginTests extends ESIntegTestCase {
             .cluster()
             .prepareRestoreSnapshot("test-repo", "test-snap")
             .setWaitForCompletion(true)
-            .execute()
-            .actionGet();
+            .get();
         assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), greaterThan(0));
 
         ensureGreen();

--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/actions/email/EmailAttachmentTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/actions/email/EmailAttachmentTests.java
@@ -196,7 +196,7 @@ public class EmailAttachmentTests extends AbstractWatcherIntegrationTestCase {
             try {
                 searchResponse = prepareSearch(HistoryStoreField.DATA_STREAM + "*").setQuery(
                     QueryBuilders.termQuery("watch_id", "_test_id")
-                ).execute().actionGet();
+                ).get();
             } catch (SearchPhaseExecutionException e) {
                 if (e.getCause() instanceof NoShardAvailableActionException) {
                     // Nothing has created the index yet

--- a/x-pack/qa/third-party/active-directory/src/test/java/org/elasticsearch/xpack/security/authc/ldap/AbstractAdLdapRealmTestCase.java
+++ b/x-pack/qa/third-party/active-directory/src/test/java/org/elasticsearch/xpack/security/authc/ldap/AbstractAdLdapRealmTestCase.java
@@ -258,8 +258,7 @@ public abstract class AbstractAdLdapRealmTestCase extends SecurityIntegTestCase 
 
         DocWriteResponse indexResponse = client.prepareIndex(index)
             .setSource(jsonBuilder().startObject().field("name", "value").endObject())
-            .execute()
-            .actionGet();
+            .get();
 
         assertEquals(
             "user " + user + " should have write access to index " + index,
@@ -281,7 +280,7 @@ public abstract class AbstractAdLdapRealmTestCase extends SecurityIntegTestCase 
         authenticateUser(client, user, 3);
 
         try {
-            client.prepareIndex(index).setSource(jsonBuilder().startObject().field("name", "value").endObject()).execute().actionGet();
+            client.prepareIndex(index).setSource(jsonBuilder().startObject().field("name", "value").endObject()).get();
             fail("Write access to index " + index + " should not be allowed for user " + user);
         } catch (ElasticsearchSecurityException e) {
             // expected


### PR DESCRIPTION
Cleaning this up a little even though it's still quite horrible. `.get()` in this API actually means `actionGet()` so to speak. I think a good first step to cleaning this up is to at least reduce the duplication though and save 1k lines.
