### PR TITLE
[CI] Fix for mlt/25_docs_one_shard/Basic mlt query with docs - explicitly on same shard

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mlt/25_docs_one_shard.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mlt/25_docs_one_shard.yml
@@ -1,9 +1,5 @@
 ---
 "Basic mlt query with docs - explicitly on same shard":
-  - skip:
-      version: "all"
-      reason: temporarily disabling for investigation
-
   - do:
       indices.create:
         index: mlt_one_shard_test_index

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mlt/25_docs_one_shard.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/mlt/25_docs_one_shard.yml
@@ -7,7 +7,7 @@
           settings:
             index:
               number_of_shards: 1
-              number_of_replicas: 0
+              number_of_replicas: 1
 
   - do:
       index:


### PR DESCRIPTION
Set number of replicas to 1 so the test can run against serverless