### PR TITLE
Link to troubleshooting docs from other disco pages

### DIFF
--- a/docs/reference/modules/discovery/quorums.asciidoc
+++ b/docs/reference/modules/discovery/quorums.asciidoc
@@ -15,7 +15,7 @@ those of the other piece.
 
 Elasticsearch allows you to add and remove master-eligible nodes to a running
 cluster. In many cases you can do this simply by starting or stopping the nodes
-as required. See <<add-elasticsearch-nodes>>.
+as required. See <<add-elasticsearch-nodes>> for more information.
 
 As nodes are added or removed Elasticsearch maintains an optimal level of fault
 tolerance by updating the cluster's <<modules-discovery-voting,voting
@@ -33,10 +33,17 @@ This means that if there are three or four master-eligible nodes, the cluster
 can tolerate one of them being unavailable. If there are two or fewer
 master-eligible nodes, they must all remain available.
 
-After a node has joined or left the cluster the elected master must issue a
-cluster-state update that adjusts the voting configuration to match, and this
-can take a short time to complete. It is important to wait for this adjustment
-to complete before removing more nodes from the cluster.
+If you stop half or more of the nodes in the voting configuration at the same
+time then the cluster will be unavailable until you bring enough nodes back
+online to form a quorum again. While the cluster is unavailable, any remaining
+nodes will report in their logs that they cannot discover or elect a master
+node. See <<discovery-troubleshooting>> for more information.
+
+After a master-eligible node has joined or left the cluster the elected master
+may issue a cluster-state update that adjusts the voting configuration to match,
+and this can take a short time to complete. It is important to wait for this
+adjustment to complete before removing more nodes from the cluster. See
+<<modules-discovery-removing-nodes>> for more information.
 
 [discrete]
 ==== Master elections

--- a/docs/reference/modules/discovery/quorums.asciidoc
+++ b/docs/reference/modules/discovery/quorums.asciidoc
@@ -26,6 +26,9 @@ voting configuration have responded. Usually the voting configuration is the
 same as the set of all the master-eligible nodes that are currently in the
 cluster. However, there are some situations in which they may be different.
 
+// tag::quorums-and-availability[]
+[IMPORTANT]
+====
 To be sure that the cluster remains available you **must not stop half or more
 of the nodes in the voting configuration at the same time**. As long as more
 than half of the voting nodes are available the cluster can still work normally.
@@ -38,6 +41,8 @@ time then the cluster will be unavailable until you bring enough nodes back
 online to form a quorum again. While the cluster is unavailable, any remaining
 nodes will report in their logs that they cannot discover or elect a master
 node. See <<discovery-troubleshooting>> for more information.
+====
+// end::quorums-and-availability[]
 
 After a master-eligible node has joined or left the cluster the elected master
 may issue a cluster-state update that adjusts the voting configuration to match,

--- a/docs/reference/modules/discovery/voting.asciidoc
+++ b/docs/reference/modules/discovery/voting.asciidoc
@@ -11,12 +11,7 @@ Usually the voting configuration is the same as the set of all the
 master-eligible nodes that are currently in the cluster. However, there are some
 situations in which they may be different.
 
-IMPORTANT: To ensure the cluster remains available, you **must not stop half or
-more of the nodes in the voting configuration at the same time**. As long as more
-than half of the voting nodes are available, the cluster can work normally. For
-example, if there are three or four master-eligible nodes, the cluster
-can tolerate one unavailable node. If there are two or fewer master-eligible
-nodes, they must all remain available.
+include::quorums.asciidoc[tag=quorums-and-availability]
 
 After a node joins or leaves the cluster, {es} reacts by automatically making
 corresponding changes to the voting configuration in order to ensure that the


### PR DESCRIPTION
I have several times struggled to find the docs about restoring from a
snapshot if a quorum cannot be found. That info is on the discovery
troubleshooting page, but it seems I expect it to be on somewhere like
the quorums or voting docs pages instead. This commit adds links from
those pages to the troubleshooting page.