### PR TITLE
Trigger parent circuit breaker when building scorers in filters aggregation

### DIFF
--- a/docs/changelog/102511.yaml
+++ b/docs/changelog/102511.yaml
@@ -1,5 +1,5 @@
 pr: 102511
 summary: Trigger parent circuit breaker when building scorers in filters aggregation
 area: Aggregations
-type: enhancement
+type: bug
 issues: []

--- a/docs/changelog/102511.yaml
+++ b/docs/changelog/102511.yaml
@@ -1,0 +1,5 @@
+pr: 102511
+summary: Trigger parent circuit breaker when building scorers in filters aggregation
+area: Aggregations
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorBase.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorBase.java
@@ -142,8 +142,9 @@ public abstract class AggregatorBase extends Aggregator {
      * @return the cumulative size in bytes allocated by this aggregator to service this request
      */
     protected long addRequestCircuitBreakerBytes(long bytes) {
-        // Only use the potential to circuit break if bytes are being incremented
-        if (bytes > 0) {
+        // Only use the potential to circuit break if bytes are being incremented, In the case of 0
+        // bytes, it will trigger the parent circuit breaker.
+        if (bytes >= 0) {
             context.breaker().addEstimateBytesAndMaybeBreak(bytes, "<agg [" + name + "]>");
         } else {
             context.breaker().addWithoutBreaking(bytes);


### PR DESCRIPTION
We have no means to estimate the size of a scorer in a filters aggregation, still can be big and lead to out of memory errors. This PR proposes to call the parent circuit breaker when creating them so we have a chance to circuit break in case we have many large queries. Note we can still go out of memory in case of  one extremely large query.