### PR TITLE
[Transform] Implement exponential backoff for transform state persistence retrying

### DIFF
--- a/docs/changelog/102512.yaml
+++ b/docs/changelog/102512.yaml
@@ -1,0 +1,6 @@
+pr: 102512
+summary: Implement exponential backoff for transform state persistence retrying
+area: Transform
+type: enhancement
+issues:
+ - 102528

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexer.java
@@ -357,7 +357,7 @@ class ClientTransformIndexer extends TransformIndexer {
                             + statsExc.getMessage()
                     );
 
-                    if (failureHandler.handleStatePersistenceFailure(statsExc, getConfig().getSettings()) == false) {
+                    if (failureHandler.handleStatePersistenceFailure(statsExc, getConfig().getSettings())) {
                         // get the current seqNo and primary term, however ignore the stored state
                         transformsConfigManager.getTransformStoredDoc(
                             transformConfig.getId(),

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformFailureHandler.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformFailureHandler.java
@@ -93,6 +93,7 @@ class TransformFailureHandler {
      *
      * @param e the exception caught
      * @param settingsConfig The settings
+     * @return true if there is at least one more retry to be made, false otherwise
      */
     boolean handleStatePersistenceFailure(Exception e, SettingsConfig settingsConfig) {
         // we use the same setting for retries, however a separate counter, because the failure
@@ -106,9 +107,9 @@ class TransformFailureHandler {
                 e,
                 "task encountered more than " + numFailureRetries + " failures updating internal state; latest failure: " + e.getMessage()
             );
-            return true;
+            return false;
         }
-        return false;
+        return true;
     }
 
     /**

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformFailureHandler.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformFailureHandler.java
@@ -100,7 +100,7 @@ class TransformFailureHandler {
         // counter for search/index gets reset after a successful bulk index request
         int numFailureRetries = getNumFailureRetries(settingsConfig);
 
-        final int failureCount = context.incrementAndGetStatePersistenceFailureCount(e);
+        int failureCount = context.incrementAndGetStatePersistenceFailureCount(e);
 
         if (numFailureRetries != -1 && failureCount > numFailureRetries) {
             fail(

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
@@ -18,6 +18,7 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.logging.LoggerMessageFormat;
 import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
@@ -45,6 +46,7 @@ import org.elasticsearch.xpack.transform.notifications.TransformAuditor;
 import org.elasticsearch.xpack.transform.persistence.TransformConfigManager;
 import org.elasticsearch.xpack.transform.transforms.Function.ChangeCollector;
 import org.elasticsearch.xpack.transform.transforms.RetentionPolicyToDeleteByQueryRequestConverter.RetentionPolicyException;
+import org.elasticsearch.xpack.transform.transforms.scheduling.TransformSchedulingUtils;
 
 import java.time.Instant;
 import java.util.Collection;
@@ -83,8 +85,9 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
     private static final long RETENTION_OF_CHECKPOINTS_MS = 864000000L; // 10 days
     private static final long CHECKPOINT_CLEANUP_INTERVAL = 100L; // every 100 checkpoints
 
-    // constant for triggering state persistence, hardcoded for now
-    public static final long DEFAULT_TRIGGER_SAVE_STATE_INTERVAL_MS = 60_000; // 60s
+    // Constant for triggering state persistence, used when there are no state persistence errors.
+    // In face of errors, exponential backoff scheme is used.
+    public static final TimeValue DEFAULT_TRIGGER_SAVE_STATE_INTERVAL_MS = TimeValue.timeValueSeconds(60);
 
     protected final TransformConfigManager transformsConfigManager;
     private final CheckpointProvider checkpointProvider;
@@ -189,8 +192,13 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
         if (saveStateListeners.get() != null) {
             return true;
         }
-
-        return TimeUnit.NANOSECONDS.toMillis(getTimeNanos()) > lastSaveStateMilliseconds + DEFAULT_TRIGGER_SAVE_STATE_INTERVAL_MS;
+        long currentTimeMilliseconds = TimeUnit.NANOSECONDS.toMillis(getTimeNanos());
+        long nextSaveStateMilliseconds = TransformSchedulingUtils.calculateNextScheduledTime(
+            lastSaveStateMilliseconds,
+            DEFAULT_TRIGGER_SAVE_STATE_INTERVAL_MS,
+            context.getStatePersistenceFailureCount()
+        );
+        return currentTimeMilliseconds > nextSaveStateMilliseconds;
     }
 
     public TransformConfig getConfig() {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
@@ -87,7 +87,7 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
 
     // Constant for triggering state persistence, used when there are no state persistence errors.
     // In face of errors, exponential backoff scheme is used.
-    public static final TimeValue DEFAULT_TRIGGER_SAVE_STATE_INTERVAL_MS = TimeValue.timeValueSeconds(60);
+    public static final TimeValue DEFAULT_TRIGGER_SAVE_STATE_INTERVAL = TimeValue.timeValueSeconds(60);
 
     protected final TransformConfigManager transformsConfigManager;
     private final CheckpointProvider checkpointProvider;
@@ -195,7 +195,7 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
         long currentTimeMilliseconds = TimeUnit.NANOSECONDS.toMillis(getTimeNanos());
         long nextSaveStateMilliseconds = TransformSchedulingUtils.calculateNextScheduledTime(
             lastSaveStateMilliseconds,
-            DEFAULT_TRIGGER_SAVE_STATE_INTERVAL_MS,
+            DEFAULT_TRIGGER_SAVE_STATE_INTERVAL,
             context.getStatePersistenceFailureCount()
         );
         return currentTimeMilliseconds > nextSaveStateMilliseconds;

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/scheduling/TransformScheduledTask.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/scheduling/TransformScheduledTask.java
@@ -10,8 +10,9 @@ package org.elasticsearch.xpack.transform.transforms.scheduling;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xpack.transform.Transform;
 
-import java.time.Duration;
 import java.util.Objects;
+
+import static org.elasticsearch.xpack.transform.transforms.scheduling.TransformSchedulingUtils.calculateNextScheduledTime;
 
 /**
  * {@link TransformScheduledTask} is a structure describing the scheduled task in the queue.
@@ -19,15 +20,6 @@ import java.util.Objects;
  * This class is immutable.
  */
 final class TransformScheduledTask {
-
-    /**
-     * Minimum delay that can be applied after a failure.
-     */
-    private static final long MIN_DELAY_MILLIS = Duration.ofSeconds(5).toMillis();
-    /**
-     * Maximum delay that can be applied after a failure.
-     */
-    private static final long MAX_DELAY_MILLIS = Duration.ofHours(1).toMillis();
 
     private final String transformId;
     private final TimeValue frequency;
@@ -67,29 +59,6 @@ final class TransformScheduledTask {
             calculateNextScheduledTime(lastTriggeredTimeMillis, frequency, failureCount),
             listener
         );
-    }
-
-    // Visible for testing
-
-    /**
-     * Calculates the appropriate next scheduled time taking number of failures into account.
-     * This method implements exponential backoff approach.
-     *
-     * @param lastTriggeredTimeMillis the last time (in millis) the task was triggered
-     * @param frequency               the frequency of the transform
-     * @param failureCount            the number of failures that happened since the task was triggered
-     * @return next scheduled time for a task
-     */
-    static long calculateNextScheduledTime(Long lastTriggeredTimeMillis, TimeValue frequency, int failureCount) {
-        final long baseTime = lastTriggeredTimeMillis != null ? lastTriggeredTimeMillis : System.currentTimeMillis();
-
-        if (failureCount == 0) {
-            return baseTime + (frequency != null ? frequency : Transform.DEFAULT_TRANSFORM_FREQUENCY).millis();
-        }
-
-        // Math.min(failureCount, 32) is applied in order to avoid overflow.
-        long delayMillis = Math.min(Math.max((1L << Math.min(failureCount, 32)) * 1000, MIN_DELAY_MILLIS), MAX_DELAY_MILLIS);
-        return baseTime + delayMillis;
     }
 
     String getTransformId() {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/scheduling/TransformSchedulingUtils.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/scheduling/TransformSchedulingUtils.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.transform.transforms.scheduling;
+
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.xpack.transform.Transform;
+
+import java.time.Duration;
+
+public final class TransformSchedulingUtils {
+
+    /**
+     * Minimum delay that can be applied after a failure.
+     */
+    private static final long MIN_DELAY_MILLIS = Duration.ofSeconds(5).toMillis();
+    /**
+     * Maximum delay that can be applied after a failure.
+     */
+    private static final long MAX_DELAY_MILLIS = Duration.ofHours(1).toMillis();
+
+    /**
+     * Calculates the appropriate next scheduled time taking number of failures into account.
+     * This method implements exponential backoff approach.
+     *
+     * @param lastTriggeredTimeMillis the last time (in millis) the task was triggered
+     * @param frequency               the frequency of the transform
+     * @param failureCount            the number of failures that happened since the task was triggered
+     * @return next scheduled time for a task
+     */
+    public static long calculateNextScheduledTime(Long lastTriggeredTimeMillis, TimeValue frequency, int failureCount) {
+        final long baseTime = lastTriggeredTimeMillis != null ? lastTriggeredTimeMillis : System.currentTimeMillis();
+
+        if (failureCount == 0) {
+            return baseTime + (frequency != null ? frequency : Transform.DEFAULT_TRANSFORM_FREQUENCY).millis();
+        }
+
+        // Math.min(failureCount, 32) is applied in order to avoid overflow.
+        long delayMillis = Math.min(Math.max((1L << Math.min(failureCount, 32)) * 1000, MIN_DELAY_MILLIS), MAX_DELAY_MILLIS);
+        return baseTime + delayMillis;
+    }
+}

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerFailureOnStatePersistenceTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerFailureOnStatePersistenceTests.java
@@ -281,7 +281,6 @@ public class TransformIndexerFailureOnStatePersistenceTests extends ESTestCase {
                     }
                 );
             }
-
         }
 
         // test reset on success

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/scheduling/TransformScheduledTaskTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/scheduling/TransformScheduledTaskTests.java
@@ -9,13 +9,9 @@ package org.elasticsearch.xpack.transform.transforms.scheduling;
 
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.transform.Transform;
 import org.elasticsearch.xpack.transform.transforms.scheduling.TransformScheduler.Listener;
 
-import java.time.Instant;
-
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 
 public class TransformScheduledTaskTests extends ESTestCase {
@@ -62,50 +58,5 @@ public class TransformScheduledTaskTests extends ESTestCase {
             // Verify that the next scheduled time is calculated properly when failure count is greater than 0
             assertThat(task.getNextScheduledTimeMillis(), is(equalTo(105000L)));
         }
-    }
-
-    public void testCalculateNextScheduledTimeExponentialBackoff() {
-        long lastTriggeredTimeMillis = Instant.now().toEpochMilli();
-        long[] expectedDelayMillis = {
-            Transform.DEFAULT_TRANSFORM_FREQUENCY.millis(),    // normal schedule
-            5000,    // 5s
-            5000,    // 5s
-            8000,    // 8s
-            16000,   // 16s
-            32000,   // 32s
-            64000,   // ~1min
-            128000,  // ~2min
-            256000,  // ~4min
-            512000,  // ~8.5min
-            1024000, // ~17min
-            2048000, // ~34min
-            3600000, // 1h
-            3600000, // 1h
-            3600000, // 1h
-            3600000  // 1h
-        };
-        for (int failureCount = 0; failureCount < 1000; ++failureCount) {
-            assertThat(
-                "failureCount = " + failureCount,
-                TransformScheduledTask.calculateNextScheduledTime(lastTriggeredTimeMillis, null, failureCount),
-                is(equalTo(lastTriggeredTimeMillis + expectedDelayMillis[Math.min(failureCount, expectedDelayMillis.length - 1)]))
-            );
-        }
-    }
-
-    public void testCalculateNextScheduledTime() {
-        long now = Instant.now().toEpochMilli();
-        assertThat(
-            TransformScheduledTask.calculateNextScheduledTime(null, TimeValue.timeValueSeconds(10), 0),
-            is(greaterThanOrEqualTo(now + 10_000))
-        );
-        assertThat(
-            TransformScheduledTask.calculateNextScheduledTime(now, null, 0),
-            is(equalTo(now + Transform.DEFAULT_TRANSFORM_FREQUENCY.millis()))
-        );
-        assertThat(
-            TransformScheduledTask.calculateNextScheduledTime(null, null, 0),
-            is(greaterThanOrEqualTo(now + Transform.DEFAULT_TRANSFORM_FREQUENCY.millis()))
-        );
     }
 }

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/scheduling/TransformSchedulingUtilsTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/scheduling/TransformSchedulingUtilsTests.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.transform.transforms.scheduling;
+
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.transform.Transform;
+
+import java.time.Instant;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+
+public class TransformSchedulingUtilsTests extends ESTestCase {
+
+    public void testCalculateNextScheduledTimeExponentialBackoff() {
+        long lastTriggeredTimeMillis = Instant.now().toEpochMilli();
+        long[] expectedDelayMillis = {
+            Transform.DEFAULT_TRANSFORM_FREQUENCY.millis(),    // normal schedule
+            5000,    // 5s
+            5000,    // 5s
+            8000,    // 8s
+            16000,   // 16s
+            32000,   // 32s
+            64000,   // ~1min
+            128000,  // ~2min
+            256000,  // ~4min
+            512000,  // ~8.5min
+            1024000, // ~17min
+            2048000, // ~34min
+            3600000, // 1h
+            3600000, // 1h
+            3600000, // 1h
+            3600000  // 1h
+        };
+        for (int failureCount = 0; failureCount < 1000; ++failureCount) {
+            assertThat(
+                "failureCount = " + failureCount,
+                TransformSchedulingUtils.calculateNextScheduledTime(lastTriggeredTimeMillis, null, failureCount),
+                is(equalTo(lastTriggeredTimeMillis + expectedDelayMillis[Math.min(failureCount, expectedDelayMillis.length - 1)]))
+            );
+        }
+    }
+
+    public void testCalculateNextScheduledTime() {
+        long now = Instant.now().toEpochMilli();
+        assertThat(
+            TransformSchedulingUtils.calculateNextScheduledTime(null, TimeValue.timeValueSeconds(10), 0),
+            is(greaterThanOrEqualTo(now + 10_000))
+        );
+        assertThat(
+            TransformSchedulingUtils.calculateNextScheduledTime(now, null, 0),
+            is(equalTo(now + Transform.DEFAULT_TRANSFORM_FREQUENCY.millis()))
+        );
+        assertThat(
+            TransformSchedulingUtils.calculateNextScheduledTime(null, null, 0),
+            is(greaterThanOrEqualTo(now + Transform.DEFAULT_TRANSFORM_FREQUENCY.millis()))
+        );
+    }
+}


### PR DESCRIPTION
Currently, transform state persistence failures are being retried with a constant interval (60s).
This is different to how other types of failures are retried (exponential backoff).
This PR implements exponential backoff for state persistence failures retrying.

Additionally, this PR:
- extracts `calculateNextScheduledTime` method to a separate class so that it can be re-used
- exchanges the semantics of `true` and `false` in the return type of `handleStatePersistenceFailure` method (`true` means "ok to retry" from now on)

Closes https://github.com/elastic/elasticsearch/issues/102528