### PR TITLE
Remove Closeable interface from TestCluster

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/discovery/single/SingleNodeDiscoveryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/discovery/single/SingleNodeDiscoveryIT.java
@@ -74,22 +74,21 @@ public class SingleNodeDiscoveryIT extends ESIntegTestCase {
                 return null;
             }
         };
-        try (
-            InternalTestCluster other = new InternalTestCluster(
-                randomLong(),
-                createTempDir(),
-                false,
-                false,
-                1,
-                1,
-                internalCluster().getClusterName(),
-                configurationSource,
-                0,
-                "other",
-                Arrays.asList(getTestTransportPlugin(), MockHttpTransport.TestPlugin.class),
-                Function.identity()
-            )
-        ) {
+        final InternalTestCluster other = new InternalTestCluster(
+            randomLong(),
+            createTempDir(),
+            false,
+            false,
+            1,
+            1,
+            internalCluster().getClusterName(),
+            configurationSource,
+            0,
+            "other",
+            Arrays.asList(getTestTransportPlugin(), MockHttpTransport.TestPlugin.class),
+            Function.identity()
+        );
+        try {
             other.beforeTest(random());
             final ClusterState first = internalCluster().getInstance(ClusterService.class).state();
             final ClusterState second = other.getInstance(ClusterService.class).state();
@@ -97,6 +96,8 @@ public class SingleNodeDiscoveryIT extends ESIntegTestCase {
             assertThat(second.nodes().getSize(), equalTo(1));
             assertThat(first.nodes().getMasterNodeId(), not(equalTo(second.nodes().getMasterNodeId())));
             assertThat(first.metadata().clusterUUID(), not(equalTo(second.metadata().clusterUUID())));
+        } finally {
+            other.close();
         }
     }
 
@@ -140,27 +141,27 @@ public class SingleNodeDiscoveryIT extends ESIntegTestCase {
                 return null;
             }
         };
-        try (
-            InternalTestCluster other = new InternalTestCluster(
-                randomLong(),
-                createTempDir(),
-                false,
-                false,
-                1,
-                1,
-                internalCluster().getClusterName(),
-                configurationSource,
-                0,
-                "other",
-                Arrays.asList(getTestTransportPlugin(), MockHttpTransport.TestPlugin.class),
-                Function.identity()
-            );
-            var ignored = mockAppender.capturing(JoinHelper.class)
-        ) {
+        final InternalTestCluster other = new InternalTestCluster(
+            randomLong(),
+            createTempDir(),
+            false,
+            false,
+            1,
+            1,
+            internalCluster().getClusterName(),
+            configurationSource,
+            0,
+            "other",
+            Arrays.asList(getTestTransportPlugin(), MockHttpTransport.TestPlugin.class),
+            Function.identity()
+        );
+        try (var ignored = mockAppender.capturing(JoinHelper.class)) {
             other.beforeTest(random());
             final ClusterState first = internalCluster().getInstance(ClusterService.class).state();
             assertThat(first.nodes().getSize(), equalTo(1));
             assertBusy(mockAppender::assertAllExpectationsMatched);
+        } finally {
+            other.close();
         }
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/MultiClusterRepoAccessIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/MultiClusterRepoAccessIT.java
@@ -82,7 +82,7 @@ public class MultiClusterRepoAccessIT extends AbstractSnapshotIntegTestCase {
 
     @After
     public void stopSecondCluster() throws IOException {
-        IOUtils.close(secondCluster);
+        IOUtils.close(secondCluster::close);
     }
 
     @Override

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractMultiClustersTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractMultiClustersTestCase.java
@@ -239,7 +239,7 @@ public abstract class AbstractMultiClustersTestCase extends ESTestCase {
 
         @Override
         public void close() throws IOException {
-            IOUtils.close(clusters.values());
+            IOUtils.close(CloseableTestClusterWrapper.wrap(clusters.values()));
         }
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/CloseableTestClusterWrapper.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/CloseableTestClusterWrapper.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.test;
+
+import org.elasticsearch.common.collect.Iterators;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+/**
+ * Adapter to make one or more {@link TestCluster} instances compatible with things like try-with-resources blocks and IOUtils.
+ */
+// NB it is deliberate that TestCluster does not implement AutoCloseable or Closeable, because if we do that then IDEs tell us that we
+// should be using a try-with-resources block everywhere and that is almost never correct. The lifecycle of these clusters is managed by the
+// test framework itself and should not be touched by most test code. This class provides adapters for the few cases where you do want to
+// auto-close these things.
+public record CloseableTestClusterWrapper(TestCluster testCluster) implements Closeable {
+    @Override
+    public void close() throws IOException {
+        testCluster().close();
+    }
+
+    public static Iterable<Closeable> wrap(Iterable<? extends TestCluster> clusters) {
+        return () -> Iterators.map(clusters.iterator(), CloseableTestClusterWrapper::new);
+    }
+
+    public static Iterable<Closeable> wrap(TestCluster... clusters) {
+        return wrap(() -> Iterators.forArray(clusters));
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -521,16 +521,16 @@ public abstract class ESIntegTestCase extends ESTestCase {
         TestCluster testCluster = clusters.remove(clazz); // remove this cluster first
         clearClusters(); // all leftovers are gone by now... this is really just a double safety if we miss something somewhere
         switch (currentClusterScope) {
-            case SUITE:
+            case SUITE -> {
                 if (testCluster == null) { // only build if it's not there yet
                     testCluster = buildWithPrivateContext(currentClusterScope, seed);
                 }
-                break;
-            case TEST:
+            }
+            case TEST -> {
                 // close the previous one and create a new one
-                IOUtils.closeWhileHandlingException(testCluster);
+                IOUtils.closeWhileHandlingException(testCluster::close);
                 testCluster = buildTestCluster(currentClusterScope, seed);
-                break;
+            }
         }
         clusters.put(clazz, testCluster);
         return testCluster;
@@ -538,7 +538,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
 
     private static void clearClusters() throws Exception {
         if (clusters.isEmpty() == false) {
-            IOUtils.close(clusters.values());
+            IOUtils.close(CloseableTestClusterWrapper.wrap(clusters.values()));
             clusters.clear();
         }
         if (restClient != null) {

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -528,7 +528,9 @@ public abstract class ESIntegTestCase extends ESTestCase {
             }
             case TEST -> {
                 // close the previous one and create a new one
-                IOUtils.closeWhileHandlingException(testCluster::close);
+                if (testCluster != null) {
+                    IOUtils.closeWhileHandlingException(testCluster::close);
+                }
                 testCluster = buildTestCluster(currentClusterScope, seed);
             }
         }

--- a/test/framework/src/main/java/org/elasticsearch/test/TestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/TestCluster.java
@@ -30,7 +30,6 @@ import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.indices.IndexTemplateMissingException;
 import org.elasticsearch.repositories.RepositoryMissingException;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
@@ -44,7 +43,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
  * Base test cluster that exposes the basis to run tests against any elasticsearch cluster, whose layout
  * (e.g. number of nodes) is predefined and cannot be changed during the tests execution
  */
-public abstract class TestCluster implements Closeable {
+public abstract class TestCluster {
 
     protected final Logger logger = LogManager.getLogger(getClass());
     private final long seed;
@@ -126,7 +125,10 @@ public abstract class TestCluster implements Closeable {
     /**
      * Closes the current cluster
      */
-    @Override
+    // NB this is deliberately not implementing AutoCloseable or Closeable, because if we do that then IDEs tell us that we should be using
+    // a try-with-resources block and that is almost never correct. The lifecycle of these clusters is managed by the test framework itself
+    // and should not be touched by most test code. CloseableTestClusterWrapper provides adapters for the few cases where you do want to
+    // auto-close these things.
     public abstract void close() throws IOException;
 
     /**

--- a/test/framework/src/test/java/org/elasticsearch/test/test/InternalTestClusterTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/test/InternalTestClusterTests.java
@@ -21,6 +21,7 @@ import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.CloseableTestClusterWrapper;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.test.MockHttpTransport;
@@ -237,7 +238,7 @@ public class InternalTestClusterTests extends ESTestCase {
             cluster0.afterTest();
             cluster1.afterTest();
         } finally {
-            IOUtils.close(cluster0, cluster1);
+            IOUtils.close(CloseableTestClusterWrapper.wrap(List.of(cluster0, cluster1)));
         }
     }
 

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/CcrIntegTestCase.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/CcrIntegTestCase.java
@@ -67,6 +67,7 @@ import org.elasticsearch.snapshots.RestoreService;
 import org.elasticsearch.snapshots.Snapshot;
 import org.elasticsearch.tasks.TaskInfo;
 import org.elasticsearch.test.BackgroundIndexer;
+import org.elasticsearch.test.CloseableTestClusterWrapper;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.InternalSettingsPlugin;
@@ -905,7 +906,7 @@ public abstract class CcrIntegTestCase extends ESTestCase {
 
         @Override
         public void close() throws IOException {
-            IOUtils.close(leaderCluster, followerCluster);
+            IOUtils.close(CloseableTestClusterWrapper.wrap(leaderCluster, followerCluster));
         }
     }
 }


### PR DESCRIPTION
Today `TestCluster` implements `AutoCloseable` which means that IDEs
tell us that we should be using a try-with-resources block everywhere
and that is almost never correct. The lifecycle of these clusters is
managed by the test framework itself and should not be touched by most
test code.

This commit removes the interface from `TestCluster` to avoid this
confusion throughout the whole test suite, and introduces a small
adapter for the cases where we do need to treat these things as
`Closeable`.