### PR TITLE
[8.4] [DOCS] Fix docs for user profiles (#102452)

### DIFF
--- a/x-pack/docs/en/rest-api/security/has-privileges-user-profile.asciidoc
+++ b/x-pack/docs/en/rest-api/security/has-privileges-user-profile.asciidoc
@@ -85,27 +85,33 @@ requested set of cluster, index, and application privileges:
 
 [source,console]
 --------------------------------------------------
-POST /_security/user/_has_privileges
+POST /_security/profile/_has_privileges
 {
-  "uids": ["u_LQPnxDxEjIH0GOUoFkZr5Y57YUwSkL9Joiq-g4OCbPc_0", "u_rzRnxDgEHIH0GOUoFkZr5Y27YUwSk19Joiq=g4OCxxB_1"],
-  "cluster": [ "monitor", "create_snapshot", "manage_ml" ],
-  "index" : [
-    {
-      "names": [ "suppliers", "products" ],
-      "privileges": [ "create_doc"]
-    },
-    {
-      "names": [ "inventory" ],
-      "privileges" : [ "read", "write" ]
-    }
+  "uids": [
+    "u_LQPnxDxEjIH0GOUoFkZr5Y57YUwSkL9Joiq-g4OCbPc_0",
+    "u_rzRnxDgEHIH0GOUoFkZr5Y27YUwSk19Joiq=g4OCxxB_1",
+    "u_does-not-exist_0"
   ],
-  "application": [
-    {
-      "application": "inventory_manager",
-      "privileges" : [ "read", "data:write/inventory" ],
-      "resources" : [ "product/1852563" ]
-    }
-  ]
+  "privileges": {
+    "cluster": [ "monitor", "create_snapshot", "manage_ml" ],
+    "index" : [
+      {
+        "names": [ "suppliers", "products" ],
+        "privileges": [ "create_doc"]
+      },
+      {
+        "names": [ "inventory" ],
+        "privileges" : [ "read", "write" ]
+      }
+    ],
+    "application": [
+      {
+        "application": "inventory_manager",
+        "privileges" : [ "read", "data:write/inventory" ],
+        "resources" : [ "product/1852563" ]
+      }
+    ]
+  }
 }
 --------------------------------------------------
 // TEST[skip:TODO setup and tests will be possible once the profile uid is predictable]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.4`:
 - [[DOCS] Fix docs for user profiles (#102452)](https://github.com/elastic/elasticsearch/pull/102452)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)