### PR TITLE
Remove explicit SearchResponse references from `org.elasticsearch.indices` and  `org.elasticsearch.indexing`

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/indexing/IndexActionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indexing/IndexActionIT.java
@@ -11,7 +11,6 @@ import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.index.IndexResponse;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.cluster.metadata.MetadataCreateIndexService;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.index.mapper.DocumentParsingException;
@@ -28,6 +27,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicIntegerArray;
 
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
@@ -55,17 +55,18 @@ public class IndexActionIT extends ESIntegTestCase {
             for (int j = 0; j < numOfChecks; j++) {
                 try {
                     logger.debug("running search with all types");
-                    SearchResponse response = prepareSearch("test").get();
-                    if (response.getHits().getTotalHits().value != numOfDocs) {
-                        final String message = "Count is "
-                            + response.getHits().getTotalHits().value
-                            + " but "
-                            + numOfDocs
-                            + " was expected. "
-                            + ElasticsearchAssertions.formatShardStatus(response);
-                        logger.error("{}. search response: \n{}", message, response);
-                        fail(message);
-                    }
+                    assertResponse(prepareSearch("test"), response -> {
+                        if (response.getHits().getTotalHits().value != numOfDocs) {
+                            final String message = "Count is "
+                                + response.getHits().getTotalHits().value
+                                + " but "
+                                + numOfDocs
+                                + " was expected. "
+                                + ElasticsearchAssertions.formatShardStatus(response);
+                            logger.error("{}. search response: \n{}", message, response);
+                            fail(message);
+                        }
+                    });
                 } catch (Exception e) {
                     logger.error("search for all docs types failed", e);
                     if (firstError == null) {
@@ -74,17 +75,18 @@ public class IndexActionIT extends ESIntegTestCase {
                 }
                 try {
                     logger.debug("running search with a specific type");
-                    SearchResponse response = prepareSearch("test").get();
-                    if (response.getHits().getTotalHits().value != numOfDocs) {
-                        final String message = "Count is "
-                            + response.getHits().getTotalHits().value
-                            + " but "
-                            + numOfDocs
-                            + " was expected. "
-                            + ElasticsearchAssertions.formatShardStatus(response);
-                        logger.error("{}. search response: \n{}", message, response);
-                        fail(message);
-                    }
+                    assertResponse(prepareSearch("test"), response -> {
+                        if (response.getHits().getTotalHits().value != numOfDocs) {
+                            final String message = "Count is "
+                                + response.getHits().getTotalHits().value
+                                + " but "
+                                + numOfDocs
+                                + " was expected. "
+                                + ElasticsearchAssertions.formatShardStatus(response);
+                            logger.error("{}. search response: \n{}", message, response);
+                            fail(message);
+                        }
+                    });
                 } catch (Exception e) {
                     logger.error("search for all docs of a specific type failed", e);
                     if (firstError == null) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/IndicesRequestCacheIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/IndicesRequestCacheIT.java
@@ -10,7 +10,6 @@ package org.elasticsearch.indices;
 
 import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.action.admin.indices.forcemerge.ForceMergeResponse;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.settings.Settings;
@@ -35,7 +34,8 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.dateHist
 import static org.elasticsearch.search.aggregations.AggregationBuilders.dateRange;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.filter;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 
@@ -59,23 +59,8 @@ public class IndicesRequestCacheIT extends ESIntegTestCase {
         // This is not a random example: serialization with time zones writes shared strings
         // which used to not work well with the query cache because of the handles stream output
         // see #9500
-        final SearchResponse r1 = client.prepareSearch("index")
-            .setSize(0)
-            .setSearchType(SearchType.QUERY_THEN_FETCH)
-            .addAggregation(
-                dateHistogram("histo").field("f").timeZone(ZoneId.of("+01:00")).minDocCount(0).calendarInterval(DateHistogramInterval.MONTH)
-            )
-            .get();
-        assertNoFailures(r1);
-
-        // The cached is actually used
-        assertThat(
-            indicesAdmin().prepareStats("index").setRequestCache(true).get().getTotal().getRequestCache().getMemorySizeInBytes(),
-            greaterThan(0L)
-        );
-
-        for (int i = 0; i < 10; ++i) {
-            final SearchResponse r2 = client.prepareSearch("index")
+        assertNoFailuresAndResponse(
+            client.prepareSearch("index")
                 .setSize(0)
                 .setSearchType(SearchType.QUERY_THEN_FETCH)
                 .addAggregation(
@@ -83,21 +68,42 @@ public class IndicesRequestCacheIT extends ESIntegTestCase {
                         .timeZone(ZoneId.of("+01:00"))
                         .minDocCount(0)
                         .calendarInterval(DateHistogramInterval.MONTH)
-                )
-                .get();
-            assertNoFailures(r2);
-            Histogram h1 = r1.getAggregations().get("histo");
-            Histogram h2 = r2.getAggregations().get("histo");
-            final List<? extends Bucket> buckets1 = h1.getBuckets();
-            final List<? extends Bucket> buckets2 = h2.getBuckets();
-            assertEquals(buckets1.size(), buckets2.size());
-            for (int j = 0; j < buckets1.size(); ++j) {
-                final Bucket b1 = buckets1.get(j);
-                final Bucket b2 = buckets2.get(j);
-                assertEquals(b1.getKey(), b2.getKey());
-                assertEquals(b1.getDocCount(), b2.getDocCount());
+                ),
+            r1 -> {
+                // The cached is actually used
+                assertThat(
+                    indicesAdmin().prepareStats("index").setRequestCache(true).get().getTotal().getRequestCache().getMemorySizeInBytes(),
+                    greaterThan(0L)
+                );
+
+                for (int i = 0; i < 10; ++i) {
+                    assertNoFailuresAndResponse(
+                        client.prepareSearch("index")
+                            .setSize(0)
+                            .setSearchType(SearchType.QUERY_THEN_FETCH)
+                            .addAggregation(
+                                dateHistogram("histo").field("f")
+                                    .timeZone(ZoneId.of("+01:00"))
+                                    .minDocCount(0)
+                                    .calendarInterval(DateHistogramInterval.MONTH)
+                            ),
+                        r2 -> {
+                            Histogram h1 = r1.getAggregations().get("histo");
+                            Histogram h2 = r2.getAggregations().get("histo");
+                            final List<? extends Bucket> buckets1 = h1.getBuckets();
+                            final List<? extends Bucket> buckets2 = h2.getBuckets();
+                            assertEquals(buckets1.size(), buckets2.size());
+                            for (int j = 0; j < buckets1.size(); ++j) {
+                                final Bucket b1 = buckets1.get(j);
+                                final Bucket b2 = buckets2.get(j);
+                                assertEquals(b1.getKey(), b2.getKey());
+                                assertEquals(b1.getDocCount(), b2.getDocCount());
+                            }
+                        }
+                    );
+                }
             }
-        }
+        );
     }
 
     public void testQueryRewrite() throws Exception {
@@ -133,35 +139,43 @@ public class IndicesRequestCacheIT extends ESIntegTestCase {
 
         assertCacheState(client, "index", 0, 0);
 
-        final SearchResponse r1 = client.prepareSearch("index")
-            .setSearchType(SearchType.QUERY_THEN_FETCH)
-            .setSize(0)
-            .setQuery(QueryBuilders.rangeQuery("s").gte("2016-03-19").lte("2016-03-25"))
-            // to ensure that query is executed even if it rewrites to match_no_docs
-            .addAggregation(new GlobalAggregationBuilder("global"))
-            .get();
-        ElasticsearchAssertions.assertAllSuccessful(r1);
-        assertThat(r1.getHits().getTotalHits().value, equalTo(7L));
+        assertResponse(
+            client.prepareSearch("index")
+                .setSearchType(SearchType.QUERY_THEN_FETCH)
+                .setSize(0)
+                .setQuery(QueryBuilders.rangeQuery("s").gte("2016-03-19").lte("2016-03-25"))
+                // to ensure that query is executed even if it rewrites to match_no_docs
+                .addAggregation(new GlobalAggregationBuilder("global")),
+            response -> {
+                ElasticsearchAssertions.assertAllSuccessful(response);
+                assertThat(response.getHits().getTotalHits().value, equalTo(7L));
+            }
+        );
         assertCacheState(client, "index", 0, 5);
+        assertResponse(
+            client.prepareSearch("index")
+                .setSearchType(SearchType.QUERY_THEN_FETCH)
+                .setSize(0)
+                .setQuery(QueryBuilders.rangeQuery("s").gte("2016-03-20").lte("2016-03-26"))
+                .addAggregation(new GlobalAggregationBuilder("global")),
+            response -> {
+                ElasticsearchAssertions.assertAllSuccessful(response);
+                assertThat(response.getHits().getTotalHits().value, equalTo(7L));
 
-        final SearchResponse r2 = client.prepareSearch("index")
-            .setSearchType(SearchType.QUERY_THEN_FETCH)
-            .setSize(0)
-            .setQuery(QueryBuilders.rangeQuery("s").gte("2016-03-20").lte("2016-03-26"))
-            .addAggregation(new GlobalAggregationBuilder("global"))
-            .get();
-        ElasticsearchAssertions.assertAllSuccessful(r2);
-        assertThat(r2.getHits().getTotalHits().value, equalTo(7L));
+            }
+        );
         assertCacheState(client, "index", 3, 7);
-
-        final SearchResponse r3 = client.prepareSearch("index")
-            .setSearchType(SearchType.QUERY_THEN_FETCH)
-            .setSize(0)
-            .setQuery(QueryBuilders.rangeQuery("s").gte("2016-03-21").lte("2016-03-27"))
-            .addAggregation(new GlobalAggregationBuilder("global"))
-            .get();
-        ElasticsearchAssertions.assertAllSuccessful(r3);
-        assertThat(r3.getHits().getTotalHits().value, equalTo(7L));
+        assertResponse(
+            client.prepareSearch("index")
+                .setSearchType(SearchType.QUERY_THEN_FETCH)
+                .setSize(0)
+                .setQuery(QueryBuilders.rangeQuery("s").gte("2016-03-21").lte("2016-03-27"))
+                .addAggregation(new GlobalAggregationBuilder("global")),
+            response -> {
+                ElasticsearchAssertions.assertAllSuccessful(response);
+                assertThat(response.getHits().getTotalHits().value, equalTo(7L));
+            }
+        );
         assertCacheState(client, "index", 6, 9);
     }
 
@@ -195,31 +209,40 @@ public class IndicesRequestCacheIT extends ESIntegTestCase {
 
         assertCacheState(client, "index", 0, 0);
 
-        final SearchResponse r1 = client.prepareSearch("index")
-            .setSearchType(SearchType.QUERY_THEN_FETCH)
-            .setSize(0)
-            .setQuery(QueryBuilders.rangeQuery("s").gte("2016-03-19").lte("2016-03-28"))
-            .get();
-        ElasticsearchAssertions.assertAllSuccessful(r1);
-        assertThat(r1.getHits().getTotalHits().value, equalTo(8L));
+        assertResponse(
+            client.prepareSearch("index")
+                .setSearchType(SearchType.QUERY_THEN_FETCH)
+                .setSize(0)
+                .setQuery(QueryBuilders.rangeQuery("s").gte("2016-03-19").lte("2016-03-28")),
+            response -> {
+                ElasticsearchAssertions.assertAllSuccessful(response);
+                assertThat(response.getHits().getTotalHits().value, equalTo(8L));
+            }
+        );
         assertCacheState(client, "index", 0, 1);
 
-        final SearchResponse r2 = client.prepareSearch("index")
-            .setSearchType(SearchType.QUERY_THEN_FETCH)
-            .setSize(0)
-            .setQuery(QueryBuilders.rangeQuery("s").gte("2016-03-19").lte("2016-03-28"))
-            .get();
-        ElasticsearchAssertions.assertAllSuccessful(r2);
-        assertThat(r2.getHits().getTotalHits().value, equalTo(8L));
+        assertResponse(
+            client.prepareSearch("index")
+                .setSearchType(SearchType.QUERY_THEN_FETCH)
+                .setSize(0)
+                .setQuery(QueryBuilders.rangeQuery("s").gte("2016-03-19").lte("2016-03-28")),
+            response -> {
+                ElasticsearchAssertions.assertAllSuccessful(response);
+                assertThat(response.getHits().getTotalHits().value, equalTo(8L));
+            }
+        );
         assertCacheState(client, "index", 1, 1);
 
-        final SearchResponse r3 = client.prepareSearch("index")
-            .setSearchType(SearchType.QUERY_THEN_FETCH)
-            .setSize(0)
-            .setQuery(QueryBuilders.rangeQuery("s").gte("2016-03-19").lte("2016-03-28"))
-            .get();
-        ElasticsearchAssertions.assertAllSuccessful(r3);
-        assertThat(r3.getHits().getTotalHits().value, equalTo(8L));
+        assertResponse(
+            client.prepareSearch("index")
+                .setSearchType(SearchType.QUERY_THEN_FETCH)
+                .setSize(0)
+                .setQuery(QueryBuilders.rangeQuery("s").gte("2016-03-19").lte("2016-03-28")),
+            response -> {
+                ElasticsearchAssertions.assertAllSuccessful(response);
+                assertThat(response.getHits().getTotalHits().value, equalTo(8L));
+            }
+        );
         assertCacheState(client, "index", 2, 1);
     }
 
@@ -253,35 +276,44 @@ public class IndicesRequestCacheIT extends ESIntegTestCase {
 
         assertCacheState(client, "index", 0, 0);
 
-        final SearchResponse r1 = client.prepareSearch("index")
-            .setSearchType(SearchType.QUERY_THEN_FETCH)
-            .setSize(0)
-            .setQuery(QueryBuilders.rangeQuery("d").gte("2013-01-01T00:00:00").lte("now"))
-            // to ensure that query is executed even if it rewrites to match_no_docs
-            .addAggregation(new GlobalAggregationBuilder("global"))
-            .get();
-        ElasticsearchAssertions.assertAllSuccessful(r1);
-        assertThat(r1.getHits().getTotalHits().value, equalTo(9L));
+        assertResponse(
+            client.prepareSearch("index")
+                .setSearchType(SearchType.QUERY_THEN_FETCH)
+                .setSize(0)
+                .setQuery(QueryBuilders.rangeQuery("d").gte("2013-01-01T00:00:00").lte("now"))
+                // to ensure that query is executed even if it rewrites to match_no_docs
+                .addAggregation(new GlobalAggregationBuilder("global")),
+            response -> {
+                ElasticsearchAssertions.assertAllSuccessful(response);
+                assertThat(response.getHits().getTotalHits().value, equalTo(9L));
+            }
+        );
         assertCacheState(client, "index", 0, 1);
 
-        final SearchResponse r2 = client.prepareSearch("index")
-            .setSearchType(SearchType.QUERY_THEN_FETCH)
-            .setSize(0)
-            .setQuery(QueryBuilders.rangeQuery("d").gte("2013-01-01T00:00:00").lte("now"))
-            .addAggregation(new GlobalAggregationBuilder("global"))
-            .get();
-        ElasticsearchAssertions.assertAllSuccessful(r2);
-        assertThat(r2.getHits().getTotalHits().value, equalTo(9L));
+        assertResponse(
+            client.prepareSearch("index")
+                .setSearchType(SearchType.QUERY_THEN_FETCH)
+                .setSize(0)
+                .setQuery(QueryBuilders.rangeQuery("d").gte("2013-01-01T00:00:00").lte("now"))
+                .addAggregation(new GlobalAggregationBuilder("global")),
+            response -> {
+                ElasticsearchAssertions.assertAllSuccessful(response);
+                assertThat(response.getHits().getTotalHits().value, equalTo(9L));
+            }
+        );
         assertCacheState(client, "index", 1, 1);
 
-        final SearchResponse r3 = client.prepareSearch("index")
-            .setSearchType(SearchType.QUERY_THEN_FETCH)
-            .setSize(0)
-            .setQuery(QueryBuilders.rangeQuery("d").gte("2013-01-01T00:00:00").lte("now"))
-            .addAggregation(new GlobalAggregationBuilder("global"))
-            .get();
-        ElasticsearchAssertions.assertAllSuccessful(r3);
-        assertThat(r3.getHits().getTotalHits().value, equalTo(9L));
+        assertResponse(
+            client.prepareSearch("index")
+                .setSearchType(SearchType.QUERY_THEN_FETCH)
+                .setSize(0)
+                .setQuery(QueryBuilders.rangeQuery("d").gte("2013-01-01T00:00:00").lte("now"))
+                .addAggregation(new GlobalAggregationBuilder("global")),
+            response -> {
+                ElasticsearchAssertions.assertAllSuccessful(response);
+                assertThat(response.getHits().getTotalHits().value, equalTo(9L));
+            }
+        );
         assertCacheState(client, "index", 2, 1);
     }
 
@@ -324,13 +356,16 @@ public class IndicesRequestCacheIT extends ESIntegTestCase {
         assertCacheState(client, "index-2", 0, 0);
         assertCacheState(client, "index-3", 0, 0);
 
-        final SearchResponse r1 = client.prepareSearch("index-*")
-            .setSearchType(SearchType.QUERY_THEN_FETCH)
-            .setSize(0)
-            .setQuery(QueryBuilders.rangeQuery("d").gte("now-7d/d").lte("now"))
-            .get();
-        ElasticsearchAssertions.assertAllSuccessful(r1);
-        assertThat(r1.getHits().getTotalHits().value, equalTo(8L));
+        assertResponse(
+            client.prepareSearch("index-*")
+                .setSearchType(SearchType.QUERY_THEN_FETCH)
+                .setSize(0)
+                .setQuery(QueryBuilders.rangeQuery("d").gte("now-7d/d").lte("now")),
+            response -> {
+                ElasticsearchAssertions.assertAllSuccessful(response);
+                assertThat(response.getHits().getTotalHits().value, equalTo(8L));
+            }
+        );
         assertCacheState(client, "index-1", 0, 1);
         assertCacheState(client, "index-2", 0, 1);
         // Because the query will INTERSECT with the 3rd index it will not be
@@ -338,24 +373,30 @@ public class IndicesRequestCacheIT extends ESIntegTestCase {
         // cache miss or cache hit since queries containing now can't be cached
         assertCacheState(client, "index-3", 0, 0);
 
-        final SearchResponse r2 = client.prepareSearch("index-*")
-            .setSearchType(SearchType.QUERY_THEN_FETCH)
-            .setSize(0)
-            .setQuery(QueryBuilders.rangeQuery("d").gte("now-7d/d").lte("now"))
-            .get();
-        ElasticsearchAssertions.assertAllSuccessful(r2);
-        assertThat(r2.getHits().getTotalHits().value, equalTo(8L));
+        assertResponse(
+            client.prepareSearch("index-*")
+                .setSearchType(SearchType.QUERY_THEN_FETCH)
+                .setSize(0)
+                .setQuery(QueryBuilders.rangeQuery("d").gte("now-7d/d").lte("now")),
+            response -> {
+                ElasticsearchAssertions.assertAllSuccessful(response);
+                assertThat(response.getHits().getTotalHits().value, equalTo(8L));
+            }
+        );
         assertCacheState(client, "index-1", 1, 1);
         assertCacheState(client, "index-2", 1, 1);
         assertCacheState(client, "index-3", 0, 0);
 
-        final SearchResponse r3 = client.prepareSearch("index-*")
-            .setSearchType(SearchType.QUERY_THEN_FETCH)
-            .setSize(0)
-            .setQuery(QueryBuilders.rangeQuery("d").gte("now-7d/d").lte("now"))
-            .get();
-        ElasticsearchAssertions.assertAllSuccessful(r3);
-        assertThat(r3.getHits().getTotalHits().value, equalTo(8L));
+        assertResponse(
+            client.prepareSearch("index-*")
+                .setSearchType(SearchType.QUERY_THEN_FETCH)
+                .setSize(0)
+                .setQuery(QueryBuilders.rangeQuery("d").gte("now-7d/d").lte("now")),
+            response -> {
+                ElasticsearchAssertions.assertAllSuccessful(response);
+                assertThat(response.getHits().getTotalHits().value, equalTo(8L));
+            }
+        );
         assertCacheState(client, "index-1", 2, 1);
         assertCacheState(client, "index-2", 2, 1);
         assertCacheState(client, "index-3", 0, 0);
@@ -391,70 +432,88 @@ public class IndicesRequestCacheIT extends ESIntegTestCase {
         assertCacheState(client, "index", 0, 0);
 
         // If size > 0 we should no cache by default
-        final SearchResponse r1 = client.prepareSearch("index")
-            .setSearchType(SearchType.QUERY_THEN_FETCH)
-            .setSize(1)
-            .setQuery(QueryBuilders.rangeQuery("s").gte("2016-03-19").lte("2016-03-25"))
-            .get();
-        ElasticsearchAssertions.assertAllSuccessful(r1);
-        assertThat(r1.getHits().getTotalHits().value, equalTo(7L));
+        assertResponse(
+            client.prepareSearch("index")
+                .setSearchType(SearchType.QUERY_THEN_FETCH)
+                .setSize(1)
+                .setQuery(QueryBuilders.rangeQuery("s").gte("2016-03-19").lte("2016-03-25")),
+            response -> {
+                ElasticsearchAssertions.assertAllSuccessful(response);
+                assertThat(response.getHits().getTotalHits().value, equalTo(7L));
+            }
+        );
         assertCacheState(client, "index", 0, 0);
 
         // If search type is DFS_QUERY_THEN_FETCH we should not cache
-        final SearchResponse r2 = client.prepareSearch("index")
-            .setSearchType(SearchType.DFS_QUERY_THEN_FETCH)
-            .setSize(0)
-            .setQuery(QueryBuilders.rangeQuery("s").gte("2016-03-20").lte("2016-03-26"))
-            .get();
-        ElasticsearchAssertions.assertAllSuccessful(r2);
-        assertThat(r2.getHits().getTotalHits().value, equalTo(7L));
+        assertResponse(
+            client.prepareSearch("index")
+                .setSearchType(SearchType.DFS_QUERY_THEN_FETCH)
+                .setSize(0)
+                .setQuery(QueryBuilders.rangeQuery("s").gte("2016-03-20").lte("2016-03-26")),
+            response -> {
+                ElasticsearchAssertions.assertAllSuccessful(response);
+                assertThat(response.getHits().getTotalHits().value, equalTo(7L));
+            }
+        );
         assertCacheState(client, "index", 0, 0);
 
         // If search type is DFS_QUERY_THEN_FETCH we should not cache even if
         // the cache flag is explicitly set on the request
-        final SearchResponse r3 = client.prepareSearch("index")
-            .setSearchType(SearchType.DFS_QUERY_THEN_FETCH)
-            .setSize(0)
-            .setRequestCache(true)
-            .setQuery(QueryBuilders.rangeQuery("s").gte("2016-03-20").lte("2016-03-26"))
-            .get();
-        ElasticsearchAssertions.assertAllSuccessful(r3);
-        assertThat(r3.getHits().getTotalHits().value, equalTo(7L));
+        assertResponse(
+            client.prepareSearch("index")
+                .setSearchType(SearchType.DFS_QUERY_THEN_FETCH)
+                .setSize(0)
+                .setRequestCache(true)
+                .setQuery(QueryBuilders.rangeQuery("s").gte("2016-03-20").lte("2016-03-26")),
+            response -> {
+                ElasticsearchAssertions.assertAllSuccessful(response);
+                assertThat(response.getHits().getTotalHits().value, equalTo(7L));
+            }
+        );
         assertCacheState(client, "index", 0, 0);
 
         // If the request has an non-filter aggregation containing now we should not cache
-        final SearchResponse r5 = client.prepareSearch("index")
-            .setSearchType(SearchType.QUERY_THEN_FETCH)
-            .setSize(0)
-            .setRequestCache(true)
-            .setQuery(QueryBuilders.rangeQuery("s").gte("2016-03-20").lte("2016-03-26"))
-            .addAggregation(dateRange("foo").field("s").addRange("now-10y", "now"))
-            .get();
-        ElasticsearchAssertions.assertAllSuccessful(r5);
-        assertThat(r5.getHits().getTotalHits().value, equalTo(7L));
+        assertResponse(
+            client.prepareSearch("index")
+                .setSearchType(SearchType.QUERY_THEN_FETCH)
+                .setSize(0)
+                .setRequestCache(true)
+                .setQuery(QueryBuilders.rangeQuery("s").gte("2016-03-20").lte("2016-03-26"))
+                .addAggregation(dateRange("foo").field("s").addRange("now-10y", "now")),
+            response -> {
+                ElasticsearchAssertions.assertAllSuccessful(response);
+                assertThat(response.getHits().getTotalHits().value, equalTo(7L));
+            }
+        );
         assertCacheState(client, "index", 0, 0);
 
         // If size > 1 and cache flag is set on the request we should cache
-        final SearchResponse r6 = client.prepareSearch("index")
-            .setSearchType(SearchType.QUERY_THEN_FETCH)
-            .setSize(1)
-            .setRequestCache(true)
-            .setQuery(QueryBuilders.rangeQuery("s").gte("2016-03-21").lte("2016-03-27"))
-            .get();
-        ElasticsearchAssertions.assertAllSuccessful(r6);
-        assertThat(r6.getHits().getTotalHits().value, equalTo(7L));
+        assertResponse(
+            client.prepareSearch("index")
+                .setSearchType(SearchType.QUERY_THEN_FETCH)
+                .setSize(1)
+                .setRequestCache(true)
+                .setQuery(QueryBuilders.rangeQuery("s").gte("2016-03-21").lte("2016-03-27")),
+            response -> {
+                ElasticsearchAssertions.assertAllSuccessful(response);
+                assertThat(response.getHits().getTotalHits().value, equalTo(7L));
+            }
+        );
         assertCacheState(client, "index", 0, 2);
 
         // If the request has a filter aggregation containing now we should cache since it gets rewritten
-        final SearchResponse r4 = client.prepareSearch("index")
-            .setSearchType(SearchType.QUERY_THEN_FETCH)
-            .setSize(0)
-            .setRequestCache(true)
-            .setQuery(QueryBuilders.rangeQuery("s").gte("2016-03-20").lte("2016-03-26"))
-            .addAggregation(filter("foo", QueryBuilders.rangeQuery("s").from("now-10y").to("now")))
-            .get();
-        ElasticsearchAssertions.assertAllSuccessful(r4);
-        assertThat(r4.getHits().getTotalHits().value, equalTo(7L));
+        assertResponse(
+            client.prepareSearch("index")
+                .setSearchType(SearchType.QUERY_THEN_FETCH)
+                .setSize(0)
+                .setRequestCache(true)
+                .setQuery(QueryBuilders.rangeQuery("s").gte("2016-03-20").lte("2016-03-26"))
+                .addAggregation(filter("foo", QueryBuilders.rangeQuery("s").from("now-10y").to("now"))),
+            response -> {
+                ElasticsearchAssertions.assertAllSuccessful(response);
+                assertThat(response.getHits().getTotalHits().value, equalTo(7L));
+            }
+        );
         assertCacheState(client, "index", 0, 4);
     }
 
@@ -476,32 +535,40 @@ public class IndicesRequestCacheIT extends ESIntegTestCase {
 
         assertCacheState(client, "index", 0, 0);
 
-        SearchResponse r1 = client.prepareSearch("index")
-            .setSearchType(SearchType.QUERY_THEN_FETCH)
-            .setSize(0)
-            .setQuery(QueryBuilders.rangeQuery("created_at").gte("now-7d/d"))
-            .get();
-        ElasticsearchAssertions.assertAllSuccessful(r1);
-        assertThat(r1.getHits().getTotalHits().value, equalTo(1L));
+        assertResponse(
+            client.prepareSearch("index")
+                .setSearchType(SearchType.QUERY_THEN_FETCH)
+                .setSize(0)
+                .setQuery(QueryBuilders.rangeQuery("created_at").gte("now-7d/d")),
+            response -> {
+                ElasticsearchAssertions.assertAllSuccessful(response);
+                assertThat(response.getHits().getTotalHits().value, equalTo(1L));
+            }
+        );
         assertCacheState(client, "index", 0, 1);
 
-        r1 = client.prepareSearch("index")
-            .setSearchType(SearchType.QUERY_THEN_FETCH)
-            .setSize(0)
-            .setQuery(QueryBuilders.rangeQuery("created_at").gte("now-7d/d"))
-            .get();
-        ElasticsearchAssertions.assertAllSuccessful(r1);
-        assertThat(r1.getHits().getTotalHits().value, equalTo(1L));
+        assertResponse(
+            client.prepareSearch("index")
+                .setSearchType(SearchType.QUERY_THEN_FETCH)
+                .setSize(0)
+                .setQuery(QueryBuilders.rangeQuery("created_at").gte("now-7d/d")),
+            response -> {
+                ElasticsearchAssertions.assertAllSuccessful(response);
+                assertThat(response.getHits().getTotalHits().value, equalTo(1L));
+            }
+        );
         assertCacheState(client, "index", 1, 1);
 
-        r1 = client.prepareSearch("last_week").setSearchType(SearchType.QUERY_THEN_FETCH).setSize(0).get();
-        ElasticsearchAssertions.assertAllSuccessful(r1);
-        assertThat(r1.getHits().getTotalHits().value, equalTo(1L));
+        assertResponse(client.prepareSearch("last_week").setSearchType(SearchType.QUERY_THEN_FETCH).setSize(0), response -> {
+            ElasticsearchAssertions.assertAllSuccessful(response);
+            assertThat(response.getHits().getTotalHits().value, equalTo(1L));
+        });
         assertCacheState(client, "index", 1, 2);
 
-        r1 = client.prepareSearch("last_week").setSearchType(SearchType.QUERY_THEN_FETCH).setSize(0).get();
-        ElasticsearchAssertions.assertAllSuccessful(r1);
-        assertThat(r1.getHits().getTotalHits().value, equalTo(1L));
+        assertResponse(client.prepareSearch("last_week").setSearchType(SearchType.QUERY_THEN_FETCH).setSize(0), response -> {
+            ElasticsearchAssertions.assertAllSuccessful(response);
+            assertThat(response.getHits().getTotalHits().value, equalTo(1L));
+        });
         assertCacheState(client, "index", 2, 2);
     }
 
@@ -519,14 +586,13 @@ public class IndicesRequestCacheIT extends ESIntegTestCase {
         int expectedMisses = 0;
         for (int i = 0; i < 5; i++) {
             boolean profile = i % 2 == 0;
-            SearchResponse resp = client.prepareSearch("index")
-                .setRequestCache(true)
-                .setProfile(profile)
-                .setQuery(QueryBuilders.termQuery("k", "hello"))
-                .get();
-            assertNoFailures(resp);
-            ElasticsearchAssertions.assertAllSuccessful(resp);
-            assertThat(resp.getHits().getTotalHits().value, equalTo(1L));
+            assertNoFailuresAndResponse(
+                client.prepareSearch("index").setRequestCache(true).setProfile(profile).setQuery(QueryBuilders.termQuery("k", "hello")),
+                response -> {
+                    ElasticsearchAssertions.assertAllSuccessful(response);
+                    assertThat(response.getHits().getTotalHits().value, equalTo(1L));
+                }
+            );
             if (profile == false) {
                 if (i == 1) {
                     expectedMisses++;

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/mapping/UpdateMappingIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/mapping/UpdateMappingIntegrationIT.java
@@ -11,7 +11,6 @@ package org.elasticsearch.indices.mapping;
 import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse;
 import org.elasticsearch.action.admin.indices.refresh.RefreshResponse;
 import org.elasticsearch.action.index.IndexRequestBuilder;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.action.index.MappingUpdatedAction;
@@ -48,6 +47,7 @@ import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_BLOCKS_WR
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_READ_ONLY;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertBlocked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
@@ -85,8 +85,7 @@ public class UpdateMappingIntegrationIT extends ESIntegTestCase {
         logger.info("checking all the documents are there");
         RefreshResponse refreshResponse = indicesAdmin().prepareRefresh().get();
         assertThat(refreshResponse.getFailedShards(), equalTo(0));
-        SearchResponse response = prepareSearch("test").setSize(0).get();
-        assertThat(response.getHits().getTotalHits().value, equalTo((long) recCount));
+        assertHitCount(prepareSearch("test").setSize(0), recCount);
 
         logger.info("checking all the fields are in the mappings");
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/memory/breaker/CircuitBreakerServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/memory/breaker/CircuitBreakerServiceIT.java
@@ -17,7 +17,6 @@ import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchRequestBuilder;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.Requests;
 import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
@@ -51,6 +50,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.ESIntegTestCase.Scope.TEST;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.Matchers.equalTo;
@@ -277,11 +277,10 @@ public class CircuitBreakerServiceIT extends ESIntegTestCase {
 
         // A terms aggregation on the "test" field should trip the bucket circuit breaker
         try {
-            SearchResponse resp = client.prepareSearch("cb-test")
-                .setQuery(matchAllQuery())
-                .addAggregation(terms("my_terms").field("test"))
-                .get();
-            assertTrue("there should be shard failures", resp.getFailedShards() > 0);
+            assertResponse(
+                client.prepareSearch("cb-test").setQuery(matchAllQuery()).addAggregation(terms("my_terms").field("test")),
+                response -> assertTrue("there should be shard failures", response.getFailedShards() > 0)
+            );
             fail("aggregation should have tripped the breaker");
         } catch (Exception e) {
             Throwable cause = e.getCause();

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/state/OpenCloseIndexIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/state/OpenCloseIndexIT.java
@@ -14,7 +14,6 @@ import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.indices.open.OpenIndexResponse;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
 import org.elasticsearch.action.index.IndexRequestBuilder;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.internal.Client;
@@ -39,8 +38,7 @@ import static org.elasticsearch.indices.state.CloseIndexIT.assertIndexIsClosed;
 import static org.elasticsearch.indices.state.CloseIndexIT.assertIndexIsOpened;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertBlocked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCountAndNoFailures;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -274,9 +272,7 @@ public class OpenCloseIndexIT extends ESIntegTestCase {
         // check the index still contains the records that we indexed
         indicesAdmin().prepareOpen("test").execute().get();
         ensureGreen();
-        SearchResponse searchResponse = prepareSearch().setQuery(QueryBuilders.matchQuery("test", "init")).get();
-        assertNoFailures(searchResponse);
-        assertHitCount(searchResponse, docs);
+        assertHitCountAndNoFailures(prepareSearch().setQuery(QueryBuilders.matchQuery("test", "init")), docs);
     }
 
     public void testOpenCloseIndexWithBlocks() {

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/template/SimpleIndexTemplateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/template/SimpleIndexTemplateIT.java
@@ -17,7 +17,6 @@ import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.fieldcaps.FieldCapabilities;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse;
 import org.elasticsearch.action.index.IndexRequest;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.common.ParsingException;
@@ -49,6 +48,7 @@ import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertRequestBuilderThrows;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
@@ -152,30 +152,31 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
         client().prepareIndex("test_index").setId("1").setSource("field1", "value1", "field2", "value 2").setRefreshPolicy(IMMEDIATE).get();
 
         ensureGreen();
-        SearchResponse searchResponse = prepareSearch("test_index").setQuery(termQuery("field1", "value1"))
-            .addStoredField("field1")
-            .addStoredField("field2")
-            .get();
-
-        assertHitCount(searchResponse, 1);
-        assertThat(searchResponse.getHits().getAt(0).field("field1").getValue().toString(), equalTo("value1"));
-        // field2 is not stored.
-        assertThat(searchResponse.getHits().getAt(0).field("field2"), nullValue());
+        assertResponse(
+            prepareSearch("test_index").setQuery(termQuery("field1", "value1")).addStoredField("field1").addStoredField("field2"),
+            searchResponse -> {
+                assertHitCount(searchResponse, 1);
+                assertThat(searchResponse.getHits().getAt(0).field("field1").getValue().toString(), equalTo("value1"));
+                // field2 is not stored.
+                assertThat(searchResponse.getHits().getAt(0).field("field2"), nullValue());
+            }
+        );
 
         client().prepareIndex("text_index").setId("1").setSource("field1", "value1", "field2", "value 2").setRefreshPolicy(IMMEDIATE).get();
 
         ensureGreen();
         // now only match on one template (template_1)
-        searchResponse = prepareSearch("text_index").setQuery(termQuery("field1", "value1"))
-            .addStoredField("field1")
-            .addStoredField("field2")
-            .get();
-        if (searchResponse.getFailedShards() > 0) {
-            logger.warn("failed search {}", Arrays.toString(searchResponse.getShardFailures()));
-        }
-        assertHitCount(searchResponse, 1);
-        assertThat(searchResponse.getHits().getAt(0).field("field1").getValue().toString(), equalTo("value1"));
-        assertThat(searchResponse.getHits().getAt(0).field("field2").getValue().toString(), equalTo("value 2"));
+        assertResponse(
+            prepareSearch("text_index").setQuery(termQuery("field1", "value1")).addStoredField("field1").addStoredField("field2"),
+            searchResponse -> {
+                if (searchResponse.getFailedShards() > 0) {
+                    logger.warn("failed search {}", Arrays.toString(searchResponse.getShardFailures()));
+                }
+                assertHitCount(searchResponse, 1);
+                assertThat(searchResponse.getHits().getAt(0).field("field1").getValue().toString(), equalTo("value1"));
+                assertThat(searchResponse.getHits().getAt(0).field("field2").getValue().toString(), equalTo("value 2"));
+            }
+        );
     }
 
     public void testDeleteIndexTemplate() throws Exception {
@@ -502,20 +503,22 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
         assertHitCount(prepareSearch("simple_alias"), 5L);
         assertHitCount(prepareSearch("templated_alias-test_index"), 5L);
 
-        SearchResponse searchResponse = prepareSearch("filtered_alias").get();
-        assertHitCount(searchResponse, 1L);
-        assertThat(searchResponse.getHits().getAt(0).getSourceAsMap().get("type"), equalTo("type2"));
+        assertResponse(prepareSearch("filtered_alias"), response -> {
+            assertHitCount(response, 1L);
+            assertThat(response.getHits().getAt(0).getSourceAsMap().get("type"), equalTo("type2"));
+        });
 
         // Search the complex filter alias
-        searchResponse = prepareSearch("complex_filtered_alias").get();
-        assertHitCount(searchResponse, 3L);
+        assertResponse(prepareSearch("complex_filtered_alias"), response -> {
+            assertHitCount(response, 3L);
 
-        Set<String> types = new HashSet<>();
-        for (SearchHit searchHit : searchResponse.getHits().getHits()) {
-            types.add(searchHit.getSourceAsMap().get("type").toString());
-        }
-        assertThat(types.size(), equalTo(3));
-        assertThat(types, containsInAnyOrder("typeX", "typeY", "typeZ"));
+            Set<String> types = new HashSet<>();
+            for (SearchHit searchHit : response.getHits().getHits()) {
+                types.add(searchHit.getSourceAsMap().get("type").toString());
+            }
+            assertThat(types.size(), equalTo(3));
+            assertThat(types, containsInAnyOrder("typeX", "typeY", "typeZ"));
+        });
     }
 
     public void testIndexTemplateWithAliasesInSource() {
@@ -546,9 +549,10 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
 
         assertHitCount(prepareSearch("test_index"), 2L);
 
-        SearchResponse searchResponse = prepareSearch("my_alias").get();
-        assertHitCount(searchResponse, 1L);
-        assertThat(searchResponse.getHits().getAt(0).getSourceAsMap().get("field"), equalTo("value2"));
+        assertResponse(prepareSearch("my_alias"), response -> {
+            assertHitCount(response, 1L);
+            assertThat(response.getHits().getAt(0).getSourceAsMap().get("field"), equalTo("value2"));
+        });
     }
 
     public void testIndexTemplateWithAliasesSource() {
@@ -582,9 +586,10 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
         assertHitCount(prepareSearch("test_index"), 2L);
         assertHitCount(prepareSearch("alias1"), 2L);
 
-        SearchResponse searchResponse = prepareSearch("alias2").get();
-        assertHitCount(searchResponse, 1L);
-        assertThat(searchResponse.getHits().getAt(0).getSourceAsMap().get("field"), equalTo("value2"));
+        assertResponse(prepareSearch("alias2"), response -> {
+            assertHitCount(response, 1L);
+            assertThat(response.getHits().getAt(0).getSourceAsMap().get("field"), equalTo("value2"));
+        });
     }
 
     public void testDuplicateAlias() throws Exception {
@@ -837,24 +842,24 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
         ensureGreen();
 
         // ax -> matches template
-        SearchResponse searchResponse = prepareSearch("ax").setQuery(termQuery("field1", "value1"))
-            .addStoredField("field1")
-            .addStoredField("field2")
-            .get();
-
-        assertHitCount(searchResponse, 1);
-        assertEquals("value1", searchResponse.getHits().getAt(0).field("field1").getValue().toString());
-        assertNull(searchResponse.getHits().getAt(0).field("field2"));
+        assertResponse(
+            prepareSearch("ax").setQuery(termQuery("field1", "value1")).addStoredField("field1").addStoredField("field2"),
+            response -> {
+                assertHitCount(response, 1);
+                assertEquals("value1", response.getHits().getAt(0).field("field1").getValue().toString());
+                assertNull(response.getHits().getAt(0).field("field2"));
+            }
+        );
 
         // bx -> matches template
-        searchResponse = prepareSearch("bx").setQuery(termQuery("field1", "value1"))
-            .addStoredField("field1")
-            .addStoredField("field2")
-            .get();
-
-        assertHitCount(searchResponse, 1);
-        assertEquals("value1", searchResponse.getHits().getAt(0).field("field1").getValue().toString());
-        assertNull(searchResponse.getHits().getAt(0).field("field2"));
+        assertResponse(
+            prepareSearch("bx").setQuery(termQuery("field1", "value1")).addStoredField("field1").addStoredField("field2"),
+            response -> {
+                assertHitCount(response, 1);
+                assertEquals("value1", response.getHits().getAt(0).field("field1").getValue().toString());
+                assertNull(response.getHits().getAt(0).field("field2"));
+            }
+        );
     }
 
     public void testPartitionedTemplate() throws Exception {


### PR DESCRIPTION
relates https://github.com/elastic/elasticsearch/issues/102030
