### PR TITLE
[Profiling] Make request params optional

### DIFF
--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/GetStackTracesRequestTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/GetStackTracesRequestTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.profiling;
 
-import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
@@ -119,8 +118,10 @@ public class GetStackTracesRequestTests extends ESTestCase {
         )) {
 
             GetStackTracesRequest request = new GetStackTracesRequest();
-            ParsingException ex = expectThrows(ParsingException.class, () -> request.parseXContent(content));
-            assertEquals("Unknown key for a VALUE_NUMBER in [sample-size].", ex.getMessage());
+            request.parseXContent(content);
+
+            // Expect the default value
+            assertEquals(Integer.valueOf(20_000), request.getSampleSize());
         }
     }
 

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/GetStackTracesRequestTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/GetStackTracesRequestTests.java
@@ -28,7 +28,7 @@ import static java.util.Collections.emptyList;
 
 public class GetStackTracesRequestTests extends ESTestCase {
     public void testSerialization() throws IOException {
-        Integer sampleSize = randomBoolean() ? randomIntBetween(0, Integer.MAX_VALUE) : null;
+        Integer sampleSize = randomIntBetween(1, Integer.MAX_VALUE);
         Double requestedDuration = randomBoolean() ? randomDoubleBetween(0.001d, Double.MAX_VALUE, true) : null;
         Double customCostFactor = randomBoolean() ? randomDoubleBetween(0.1d, 5.0d, true) : null;
         QueryBuilder query = randomBoolean() ? new BoolQueryBuilder() : null;

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/RestGetStackTracesActionTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/RestGetStackTracesActionTests.java
@@ -39,7 +39,7 @@ public class RestGetStackTracesActionTests extends RestActionTestCase {
         verifyingClient.setExecuteLocallyVerifier((actionType, request) -> {
             assertThat(request, instanceOf(GetStackTracesRequest.class));
             GetStackTracesRequest getStackTracesRequest = (GetStackTracesRequest) request;
-            assertThat(getStackTracesRequest.getSampleSize(), nullValue());
+            assertThat(getStackTracesRequest.getSampleSize(), is(20_000)); // expect the default value
             assertThat(getStackTracesRequest.getQuery(), nullValue());
             executeCalled.set(true);
             return new GetStackTracesResponse(
@@ -49,7 +49,7 @@ public class RestGetStackTracesActionTests extends RestActionTestCase {
                 Collections.emptyMap(),
                 0,
                 1.0d,
-                0
+                0L
             );
         });
         RestRequest profilingRequest = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.POST)
@@ -65,7 +65,7 @@ public class RestGetStackTracesActionTests extends RestActionTestCase {
         verifyingClient.setExecuteLocallyVerifier((actionType, request) -> {
             assertThat(request, instanceOf(GetStackTracesRequest.class));
             GetStackTracesRequest getStackTracesRequest = (GetStackTracesRequest) request;
-            assertThat(getStackTracesRequest.getSampleSize(), is(10000));
+            assertThat(getStackTracesRequest.getSampleSize(), is(10_000));
             assertThat(getStackTracesRequest.getQuery(), notNullValue(QueryBuilder.class));
             executeCalled.set(true);
             return new GetStackTracesResponse(
@@ -75,7 +75,7 @@ public class RestGetStackTracesActionTests extends RestActionTestCase {
                 Collections.emptyMap(),
                 0,
                 0.0d,
-                0
+                0L
             );
         });
         RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.POST)


### PR DESCRIPTION
Instead of requiring parameters we make them optional with reasonable default values.
This avoids the chicken and egg problem (when adding new params to Kibana and ES) and keeps API backwards compatibility.

New parameters have to be optional.
Old parameters are made optional.
Unknown parameters are ignored (logged with a warning).
