### PR TITLE
Remove explicit SearchResponse references from `org.elasticsearch.similarity` and  `org.elasticsearch.versioning`

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/similarity/SimilarityIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/similarity/SimilarityIT.java
@@ -10,9 +10,9 @@ package org.elasticsearch.similarity;
 
 import org.elasticsearch.test.ESIntegTestCase;
 
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
 import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;

--- a/server/src/internalClusterTest/java/org/elasticsearch/similarity/SimilarityIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/similarity/SimilarityIT.java
@@ -8,9 +8,9 @@
 
 package org.elasticsearch.similarity;
 
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.test.ESIntegTestCase;
 
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
 import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
@@ -53,14 +53,14 @@ public class SimilarityIT extends ESIntegTestCase {
             .setRefreshPolicy(IMMEDIATE)
             .get();
 
-        SearchResponse bm25SearchResponse = prepareSearch().setQuery(matchQuery("field1", "quick brown fox")).get();
-        assertThat(bm25SearchResponse.getHits().getTotalHits().value, equalTo(1L));
-        float bm25Score = bm25SearchResponse.getHits().getHits()[0].getScore();
-
-        SearchResponse booleanSearchResponse = prepareSearch().setQuery(matchQuery("field2", "quick brown fox")).get();
-        assertThat(booleanSearchResponse.getHits().getTotalHits().value, equalTo(1L));
-        float defaultScore = booleanSearchResponse.getHits().getHits()[0].getScore();
-
-        assertThat(bm25Score, not(equalTo(defaultScore)));
+        assertResponse(prepareSearch().setQuery(matchQuery("field1", "quick brown fox")), bm25SearchResponse -> {
+            assertThat(bm25SearchResponse.getHits().getTotalHits().value, equalTo(1L));
+            float bm25Score = bm25SearchResponse.getHits().getHits()[0].getScore();
+            assertResponse(prepareSearch().setQuery(matchQuery("field2", "quick brown fox")), booleanSearchResponse -> {
+                assertThat(booleanSearchResponse.getHits().getTotalHits().value, equalTo(1L));
+                float defaultScore = booleanSearchResponse.getHits().getHits()[0].getScore();
+                assertThat(bm25Score, not(equalTo(defaultScore)));
+            });
+        });
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/versioning/SimpleVersioningIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/versioning/SimpleVersioningIT.java
@@ -305,14 +305,18 @@ public class SimpleVersioningIT extends ESIntegTestCase {
         // search with versioning
         for (int i = 0; i < 10; i++) {
             // TODO: ADD SEQ NO!
-            assertResponse(prepareSearch().setQuery(matchAllQuery()).setVersion(true), response ->
-            assertThat(response.getHits().getAt(0).getVersion(), equalTo(2L)));
+            assertResponse(
+                prepareSearch().setQuery(matchAllQuery()).setVersion(true),
+                response -> assertThat(response.getHits().getAt(0).getVersion(), equalTo(2L))
+            );
         }
 
         // search without versioning
         for (int i = 0; i < 10; i++) {
-            assertResponse(prepareSearch().setQuery(matchAllQuery()), response ->
-            assertThat(response.getHits().getAt(0).getVersion(), equalTo(Versions.NOT_FOUND)));
+            assertResponse(
+                prepareSearch().setQuery(matchAllQuery()),
+                response -> assertThat(response.getHits().getAt(0).getVersion(), equalTo(Versions.NOT_FOUND))
+            );
         }
 
         DeleteResponse deleteResponse = client().prepareDelete("test", "1").setIfSeqNo(1).setIfPrimaryTerm(1).get();


### PR DESCRIPTION
relates https://github.com/elastic/elasticsearch/issues/102030