### PR TITLE
Fix connector index pattern version name

### DIFF
--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorTemplateRegistry.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorTemplateRegistry.java
@@ -36,14 +36,14 @@ public class ConnectorTemplateRegistry extends IndexTemplateRegistry {
     public static final NodeFeature CONNECTOR_TEMPLATES_FEATURE = new NodeFeature("elastic-connectors.templates");
 
     // This number must be incremented when we make changes to built-in templates.
-    static final int REGISTRY_VERSION = 2;
+    static final int REGISTRY_VERSION = 3;
 
     // Connector indices constants
 
-    public static final String CONNECTOR_INDEX_NAME_PATTERN = ".elastic-connectors-v" + REGISTRY_VERSION;
+    public static final String CONNECTOR_INDEX_NAME_PATTERN = ".elastic-connectors-v1";
     public static final String CONNECTOR_TEMPLATE_NAME = "elastic-connectors";
 
-    public static final String CONNECTOR_SYNC_JOBS_INDEX_NAME_PATTERN = ".elastic-connectors-sync-jobs-v" + REGISTRY_VERSION;
+    public static final String CONNECTOR_SYNC_JOBS_INDEX_NAME_PATTERN = ".elastic-connectors-sync-jobs-v1";
     public static final String CONNECTOR_SYNC_JOBS_TEMPLATE_NAME = "elastic-connectors-sync-jobs";
 
     public static final String ACCESS_CONTROL_INDEX_NAME_PATTERN = ".search-acl-filter-*";


### PR DESCRIPTION
This fixes the connector index pattern name, which was accidentally borked by a registry version increment yesterday. The pattern is independent from the registry version.