### PR TITLE
Change `@timestamp` field type to `date_nanos` in Logs data streams

### DIFF
--- a/docs/changelog/102548.yaml
+++ b/docs/changelog/102548.yaml
@@ -1,0 +1,5 @@
+pr: 102548
+summary: Change @timestamp field type to `date_nanos` in Logs data streams
+area: Data streams
+type: enhancement
+issues: []

--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/EcsLogsDataStreamIT.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/EcsLogsDataStreamIT.java
@@ -97,7 +97,8 @@ public class EcsLogsDataStreamIT extends DisabledSecurityDataStreamTestCase {
             assertThat(((List<String>) fields.get("message")).get(0), is("Non-zero metrics in the last 30s"));
 
             Map<String, Object> properties = getMappingProperties(client, backingIndex);
-            assertThat(getValueFromPath(properties, List.of("@timestamp", "type")), is("date"));
+            // The @timestamp field mapping should be "date_nano"s, as its ECS mapping is overridden by logs@mappings
+            assertThat(getValueFromPath(properties, List.of("@timestamp", "type")), is("date_nanos"));
             assertThat(getValueFromPath(properties, List.of("message", "type")), is("match_only_text"));
             assertThat(
                 getValueFromPath(properties, List.of("kubernetes", "properties", "pod", "properties", "name", "type")),

--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/LogsDataStreamIT.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/LogsDataStreamIT.java
@@ -46,6 +46,7 @@ public class LogsDataStreamIT extends DisabledSecurityDataStreamTestCase {
         // Extend the mapping and verify
         putMapping(client, backingIndex);
         Map<String, Object> mappingProperties = getMappingProperties(client, backingIndex);
+        assertThat(getValueFromPath(mappingProperties, List.of("@timestamp", "type")), equalTo("date_nanos"));
         assertThat(getValueFromPath(mappingProperties, List.of("@timestamp", "ignore_malformed")), equalTo(false));
         assertThat(getValueFromPath(mappingProperties, List.of("numeric_field", "type")), equalTo("integer"));
 
@@ -225,7 +226,7 @@ public class LogsDataStreamIT extends DisabledSecurityDataStreamTestCase {
 
         // Verify mapping from custom logs
         Map<String, Object> mappingProperties = getMappingProperties(client, backingIndex);
-        assertThat(getValueFromPath(mappingProperties, List.of("@timestamp", "type")), equalTo("date"));
+        assertThat(getValueFromPath(mappingProperties, List.of("@timestamp", "type")), equalTo("date_nanos"));
 
         // no timestamp - testing default pipeline's @timestamp set processor
         {
@@ -243,18 +244,26 @@ public class LogsDataStreamIT extends DisabledSecurityDataStreamTestCase {
                       }
                     }
                   },
-                  "fields": ["@timestamp", "custom_timestamp"]
+                  "fields": [
+                    {
+                      "field": "@timestamp",
+                      "format": "strict_date_optional_time"
+                    },
+                    {
+                      "field": "custom_timestamp"
+                    }
+                  ]
                 }
                 """);
             Map<String, Object> source = ((Map<String, Map<String, Object>>) results.get(0)).get("_source");
-            String timestamp = (String) source.get("@timestamp");
-            assertThat(timestamp, matchesRegex("[0-9-]+T[0-9:.]+Z"));
-            assertThat(source.get("custom_timestamp"), is(timestamp));
+            String timestampInMillis = (String) source.get("@timestamp");
+            assertThat(timestampInMillis, matchesRegex("[0-9-]+T[0-9:.]+Z"));
+            assertThat(source.get("custom_timestamp"), is(timestampInMillis));
 
             Map<String, Object> fields = ((Map<String, Map<String, Object>>) results.get(0)).get("fields");
-            timestamp = ((List<String>) fields.get("@timestamp")).get(0);
-            assertThat(timestamp, matchesRegex("[0-9-]+T[0-9:.]+Z"));
-            assertThat(((List<Object>) fields.get("custom_timestamp")).get(0), is(timestamp));
+            timestampInMillis = ((List<String>) fields.get("@timestamp")).get(0);
+            assertThat(timestampInMillis, matchesRegex("[0-9-]+T[0-9:.]+Z"));
+            assertThat(((List<Object>) fields.get("custom_timestamp")).get(0), is(timestampInMillis));
         }
 
         // verify that when a document is ingested with a timestamp, it does not get overridden

--- a/x-pack/plugin/core/template-resources/src/main/resources/logs@mappings.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/logs@mappings.json
@@ -4,7 +4,7 @@
       "date_detection": false,
       "properties": {
         "@timestamp": {
-          "type": "date"
+          "type": "date_nanos"
         },
         "data_stream.type": {
           "type": "constant_keyword",


### PR DESCRIPTION
Changing the `@timestamp` field type for Logs data streams in order to support nanosecond precision.

### Implementation

Logs data streams have two sources defining the `@timestamp` field - [`ecs@mappings`](https://github.com/elastic/elasticsearch/blob/99cacab7dc67e77e6b9f1ea3f80b8aff65e18001/x-pack/plugin/core/template-resources/src/main/resources/ecs%40mappings.json#L9) and [`logs@mappings`](https://github.com/elastic/elasticsearch/blob/99cacab7dc67e77e6b9f1ea3f80b8aff65e18001/x-pack/plugin/core/template-resources/src/main/resources/logs%40mappings.json#L7).
As long as there is no formal[ support for `date_nanos` timestamps in ECS](https://github.com/elastic/ecs/issues/1065), we can only change it for `logs-*-*` data streams through `logs@mappings`, which will take precedence as it is an explicit mapping, as opposed to the ECS dynamic mappings.

### Risks

What stems from the above is that the change proposed here introduces an incompatibility of the default Logs index template with ECS. 
Although `date` and `date_nanos` types are mostly compatible and interchangeable, there is a risk of breaking specific client behaviors with this change. 
Even though the value returned through searches is always a string, there may still be inconsistencies created when switching from `date` to `date_nanos`, for example:
- By default, the value returned from date fields will be formatted according to the [`format`](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-date-format.html) that is associated with it. Since we don't define explicit format for `@timestamp` (before or within this change), the returned string will be formatted according to the default format. Since the default format for `date` is [`strict_date_optional_time`](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-date-format.html#strict-date-time) and the default format for `date_nanos` is [`strict_date_optional_time_nanos`](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-date-format.html#strict-date-time-nanos), the returned value will be different, for example - `2023-11-23T12:51:54.048204Z` instead of `2023-11-23T12:51:54.048Z`. While not a huge risk, this may fail clients that run verifications on the returned value format. Even only breaking tests that assert for specific values is unpleasant.
- A worse issue may occur when a numeric format (like `epoch_millis`) is specified in the search request and the client fails to parse it due to its different length, like the [issue](https://github.com/elastic/kibana/issues/88290) that was recently fixed in Kibana, where the TypeScript library failed to parse the nanoseconds date representation as it was too long.

### Still missing

- [ ] documentation of this change, risks, and way to restore
- [ ] testing data stream with mixed indices - some with `date` timestamp and some with `date_nanos` timestamp
- [ ] testing restoration to `date` type through `logs@custom`