### PR TITLE
Check docker env by probing docker

### DIFF
--- a/modules/repository-s3/src/internalClusterTest/java/org/elasticsearch/repositories/s3/S3RepositoryThirdPartyTests.java
+++ b/modules/repository-s3/src/internalClusterTest/java/org/elasticsearch/repositories/s3/S3RepositoryThirdPartyTests.java
@@ -12,6 +12,7 @@ import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
 import com.amazonaws.services.s3.model.ListMultipartUploadsRequest;
 import com.amazonaws.services.s3.model.MultipartUpload;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
@@ -54,6 +55,7 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
 
 @ThreadLeakFilters(filters = { TestContainersThreadFilter.class })
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE) // https://github.com/elastic/elasticsearch/issues/102482
 public class S3RepositoryThirdPartyTests extends AbstractThirdPartyRepositoryTestCase {
     static final boolean USE_FIXTURE = Booleans.parseBoolean(System.getProperty("tests.use.fixture", "true"));
 

--- a/modules/repository-s3/src/yamlRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3ClientYamlTestSuiteIT.java
+++ b/modules/repository-s3/src/yamlRestTest/java/org/elasticsearch/repositories/s3/RepositoryS3ClientYamlTestSuiteIT.java
@@ -15,6 +15,7 @@ import fixture.s3.S3HttpFixtureWithSessionToken;
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.fixtures.testcontainers.TestContainersThreadFilter;
@@ -24,6 +25,7 @@ import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
 @ThreadLeakFilters(filters = { TestContainersThreadFilter.class })
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE) // https://github.com/elastic/elasticsearch/issues/102482
 public class RepositoryS3ClientYamlTestSuiteIT extends AbstractRepositoryS3ClientYamlTestSuiteIT {
 
     public static final S3HttpFixture s3Fixture = new S3HttpFixture();

--- a/test/fixtures/minio-fixture/src/main/java/org/elasticsearch/test/fixtures/minio/MinioTestContainer.java
+++ b/test/fixtures/minio-fixture/src/main/java/org/elasticsearch/test/fixtures/minio/MinioTestContainer.java
@@ -10,6 +10,7 @@ package org.elasticsearch.test.fixtures.minio;
 
 import org.elasticsearch.test.fixtures.testcontainers.DockerEnvironmentAwareTestContainer;
 import org.junit.rules.TestRule;
+import org.testcontainers.DockerClientFactory;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 
 public class MinioTestContainer extends DockerEnvironmentAwareTestContainer implements TestRule {
@@ -17,8 +18,21 @@ public class MinioTestContainer extends DockerEnvironmentAwareTestContainer impl
     private static final int servicePort = 9000;
     private final boolean enabled;
 
+    /**
+     * see <a href="https://github.com/elastic/elasticsearch/issues/102532">https://github.com/elastic/elasticsearch/issues/102532</a>
+     * */
+    private static boolean isDockerAvailable() {
+        try {
+            DockerClientFactory.instance().client();
+            return true;
+        } catch (Throwable ex) {
+            LOGGER.warn("Probing docker has failed; disabling test", ex);
+            return false;
+        }
+    }
+
     public MinioTestContainer() {
-        this(true);
+        this(true && isDockerAvailable());
     }
 
     public MinioTestContainer(boolean enabled) {

--- a/test/fixtures/minio-fixture/src/main/java/org/elasticsearch/test/fixtures/minio/MinioTestContainer.java
+++ b/test/fixtures/minio-fixture/src/main/java/org/elasticsearch/test/fixtures/minio/MinioTestContainer.java
@@ -10,7 +10,6 @@ package org.elasticsearch.test.fixtures.minio;
 
 import org.elasticsearch.test.fixtures.testcontainers.DockerEnvironmentAwareTestContainer;
 import org.junit.rules.TestRule;
-import org.testcontainers.DockerClientFactory;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 
 public class MinioTestContainer extends DockerEnvironmentAwareTestContainer implements TestRule {
@@ -18,21 +17,8 @@ public class MinioTestContainer extends DockerEnvironmentAwareTestContainer impl
     private static final int servicePort = 9000;
     private final boolean enabled;
 
-    /**
-     * see <a href="https://github.com/elastic/elasticsearch/issues/102532">https://github.com/elastic/elasticsearch/issues/102532</a>
-     * */
-    private static boolean isDockerAvailable() {
-        try {
-            DockerClientFactory.instance().client();
-            return true;
-        } catch (Throwable ex) {
-            LOGGER.warn("Probing docker has failed; disabling test", ex);
-            return false;
-        }
-    }
-
     public MinioTestContainer() {
-        this(true && isDockerAvailable());
+        this(true);
     }
 
     public MinioTestContainer(boolean enabled) {

--- a/test/fixtures/minio-fixture/src/main/java/org/elasticsearch/test/fixtures/testcontainers/DockerEnvironmentAwareTestContainer.java
+++ b/test/fixtures/minio-fixture/src/main/java/org/elasticsearch/test/fixtures/testcontainers/DockerEnvironmentAwareTestContainer.java
@@ -12,6 +12,7 @@ import org.elasticsearch.test.fixtures.minio.MinioTestContainer;
 import org.junit.Assume;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 
@@ -30,9 +31,23 @@ public class DockerEnvironmentAwareTestContainer extends GenericContainer<MinioT
     private static final String DOCKER_ON_LINUX_EXCLUSIONS_FILE = ".ci/dockerOnLinuxExclusions";
 
     private static final boolean CI = Boolean.parseBoolean(System.getProperty("CI", "false"));
-    private static final boolean EXCLUDED_OS = CI == false || isExcludedOs();
+    private static final boolean EXCLUDED_OS = isExcludedOs();
+    private static final boolean DOCKER_PROBING_SUCCESSFUL = isDockerAvailable();
 
     protected static final Logger LOGGER = LoggerFactory.getLogger(DockerEnvironmentAwareTestContainer.class);
+
+    /**
+     * see <a href="https://github.com/elastic/elasticsearch/issues/102532">https://github.com/elastic/elasticsearch/issues/102532</a>
+     * */
+    private static boolean isDockerAvailable() {
+        try {
+            DockerClientFactory.instance().client();
+            return true;
+        } catch (Throwable ex) {
+            LOGGER.warn("Probing docker has failed; disabling test", ex);
+            return false;
+        }
+    }
 
     public DockerEnvironmentAwareTestContainer(ImageFromDockerfile imageFromDockerfile) {
         super(imageFromDockerfile);
@@ -40,12 +55,9 @@ public class DockerEnvironmentAwareTestContainer extends GenericContainer<MinioT
 
     @Override
     public void start() {
-        Assume.assumeTrue("Docker is not available", shouldDockerBeAvailable());
+        Assume.assumeFalse("Docker support excluded on OS", EXCLUDED_OS);
+        Assume.assumeTrue("Docker probing succesful", DOCKER_PROBING_SUCCESSFUL);
         super.start();
-    }
-
-    private boolean shouldDockerBeAvailable() {
-        return CI == false || (EXCLUDED_OS == false);
     }
 
     static String deriveId(Map<String, String> values) {
@@ -53,6 +65,10 @@ public class DockerEnvironmentAwareTestContainer extends GenericContainer<MinioT
     }
 
     private static boolean isExcludedOs() {
+        if (CI) {
+            // we dont exclude OS outside of CI environment
+            return false;
+        }
         if (System.getProperty("os.name").toLowerCase().startsWith("windows")) {
             return true;
         }


### PR DESCRIPTION
For now we probe ddocker functionality when using minio testcontainer.
We need to adjust our docker availability matrix.
Also disabled thread checks for now.

Should mute tests and address #102532