### PR TITLE
Added beat.stats.libbeat.pipeline.queue.max_events

### DIFF
--- a/docs/changelog/102570.yaml
+++ b/docs/changelog/102570.yaml
@@ -1,0 +1,5 @@
+pr: 102570
+summary: Added `beat.stats.libbeat.pipeline.queue.max_events`
+area: Monitoring
+type: enhancement
+issues: []

--- a/x-pack/plugin/core/template-resources/src/main/resources/monitoring-beats-mb.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/monitoring-beats-mb.json
@@ -838,6 +838,9 @@
                           "properties": {
                             "acked": {
                               "type": "long"
+                            },
+                            "max_events": {
+                              "type": "long"
                             }
                           }
                         }
@@ -1928,6 +1931,10 @@
                             "acked": {
                               "type": "alias",
                               "path": "beat.stats.libbeat.pipeline.queue.acked"
+                            },
+                            "max_events": {
+                              "type": "alias",
+                              "path": "beat.stats.libbeat.pipeline.queue.max_events"
                             }
                           }
                         }

--- a/x-pack/plugin/core/template-resources/src/main/resources/monitoring-beats.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/monitoring-beats.json
@@ -854,6 +854,9 @@
                           "properties": {
                             "acked": {
                               "type": "long"
+                            },
+                            "max_events": {
+                              "type": "long"
                             }
                           }
                         }

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java
@@ -77,7 +77,7 @@ public class MonitoringTemplateRegistry extends IndexTemplateRegistry {
      * writes monitoring data in ECS format as of 8.0. These templates define the ECS schema as well as alias fields for the old monitoring
      * mappings that point to the corresponding ECS fields.
      */
-    public static final int STACK_MONITORING_REGISTRY_VERSION = 8_00_00_99 + 10;
+    public static final int STACK_MONITORING_REGISTRY_VERSION = 8_00_00_99 + 11;
     private static final String STACK_MONITORING_REGISTRY_VERSION_VARIABLE = "xpack.stack.monitoring.template.release.version";
     private static final String STACK_TEMPLATE_VERSION = "8";
     private static final String STACK_TEMPLATE_VERSION_VARIABLE = "xpack.stack.monitoring.template.version";


### PR DESCRIPTION
Added `beat.stats.libbeat.pipeline.queue.max_events` to elastic agent mappings as introduced/exposed in https://github.com/elastic/beats/pull/37189
