### PR TITLE
Fix this-escape -Werror

### DIFF
--- a/test/fixtures/minio-fixture/src/main/java/org/elasticsearch/test/fixtures/minio/MinioTestContainer.java
+++ b/test/fixtures/minio-fixture/src/main/java/org/elasticsearch/test/fixtures/minio/MinioTestContainer.java
@@ -12,7 +12,7 @@ import org.elasticsearch.test.fixtures.testcontainers.DockerEnvironmentAwareTest
 import org.junit.rules.TestRule;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 
-public class MinioTestContainer extends DockerEnvironmentAwareTestContainer implements TestRule {
+public final class MinioTestContainer extends DockerEnvironmentAwareTestContainer implements TestRule {
 
     private static final int servicePort = 9000;
     private final boolean enabled;


### PR DESCRIPTION
Using newer java versions expose a -Werror failure in building MinioTestContainer