### PR TITLE
[Profiling] Add new optional CO2 request params

### DIFF
--- a/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/GetFlameGraphActionIT.java
+++ b/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/GetFlameGraphActionIT.java
@@ -9,7 +9,7 @@ package org.elasticsearch.xpack.profiling;
 
 public class GetFlameGraphActionIT extends ProfilingTestCase {
     public void testGetStackTracesUnfiltered() throws Exception {
-        GetStackTracesRequest request = new GetStackTracesRequest(10, 1.0d, 1.0d, null, null, null);
+        GetStackTracesRequest request = new GetStackTracesRequest(10, 1.0d, 1.0d, null, null, null, null, null, null);
         GetFlamegraphResponse response = client().execute(GetFlamegraphAction.INSTANCE, request).get();
         // only spot-check top level properties - detailed tests are done in unit tests
         assertEquals(297, response.getSize());

--- a/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/GetStackTracesActionIT.java
+++ b/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/GetStackTracesActionIT.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 public class GetStackTracesActionIT extends ProfilingTestCase {
     public void testGetStackTracesUnfiltered() throws Exception {
-        GetStackTracesRequest request = new GetStackTracesRequest(10, 1.0d, 1.0d, null, null, null);
+        GetStackTracesRequest request = new GetStackTracesRequest(10, 1.0d, 1.0d, null, null, null, null, null, null);
         request.setAdjustSampleCount(true);
         GetStackTracesResponse response = client().execute(GetStackTracesAction.INSTANCE, request).get();
         assertEquals(40, response.getTotalSamples());
@@ -50,7 +50,10 @@ public class GetStackTracesActionIT extends ProfilingTestCase {
             1.0d,
             query,
             "apm-test-*",
-            "transaction.profiler_stack_trace_ids"
+            "transaction.profiler_stack_trace_ids",
+            null,
+            null,
+            null
         );
         GetStackTracesResponse response = client().execute(GetStackTracesAction.INSTANCE, request).get();
         assertEquals(43, response.getTotalFrames());
@@ -84,7 +87,10 @@ public class GetStackTracesActionIT extends ProfilingTestCase {
             1.0d,
             query,
             "apm-test-*",
-            "transaction.profiler_stack_trace_ids"
+            "transaction.profiler_stack_trace_ids",
+            null,
+            null,
+            null
         );
         GetStackTracesResponse response = client().execute(GetStackTracesAction.INSTANCE, request).get();
         assertEquals(0, response.getTotalFrames());

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/CostCalculator.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/CostCalculator.java
@@ -28,7 +28,7 @@ final class CostCalculator {
     ) {
         this.instanceTypeService = instanceTypeService;
         this.hostMetadata = hostMetadata;
-        this.samplingDurationInSeconds = samplingDurationInSeconds;
+        this.samplingDurationInSeconds = samplingDurationInSeconds > 0 ? samplingDurationInSeconds : 1.0d; // avoid division by zero
         this.customCostFactor = customCostFactor == null ? DEFAULT_CUSTOM_COST_FACTOR : customCostFactor;
     }
 

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetStackTracesRequest.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetStackTracesRequest.java
@@ -264,7 +264,7 @@ public class GetStackTracesRequest extends ActionRequest implements IndicesReque
                 // generating description lazily since the query could be large
                 StringBuilder sb = new StringBuilder();
                 appendField(sb, "indices", indices);
-                appendField(sb, "stackTraceIds", stackTraceIds);
+                appendField(sb, "stacktrace_ids", stackTraceIds);
                 appendField(sb, "sample_size", sampleSize);
                 appendField(sb, "requested_duration", requestedDuration);
                 appendField(sb, "custom_cost_factor", customCostFactor);

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStackTracesAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStackTracesAction.java
@@ -150,6 +150,9 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
         GetStackTracesResponseBuilder responseBuilder = new GetStackTracesResponseBuilder();
         responseBuilder.setRequestedDuration(request.getRequestedDuration());
         responseBuilder.setCustomCostFactor(request.getCustomCostFactor());
+        responseBuilder.setCustomCO2PerKWH(request.getCustomCO2PerKWH());
+        responseBuilder.setCustomDatacenterPUE(request.getCustomDatacenterPUE());
+        responseBuilder.setCustomPerCoreWatt(request.getCustomPerCoreWatt());
         Client client = new ParentTaskAssigningClient(this.nodeClient, transportService.getLocalNode(), submitTask);
         if (request.getIndices() == null) {
             searchProfilingEvents(client, request, submitListener, responseBuilder);
@@ -516,11 +519,18 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
         public void calculateCO2AndCosts() {
             // Do the CO2 and cost calculation in parallel to waiting for frame metadata.
             StopWatch watch = new StopWatch("calculateCO2AndCosts");
-            CO2Calculator co2Calculator = new CO2Calculator(instanceTypeService, hostsTable, responseBuilder.requestedDuration);
+            CO2Calculator co2Calculator = new CO2Calculator(
+                instanceTypeService,
+                hostsTable,
+                responseBuilder.getRequestedDuration(),
+                responseBuilder.customCO2PerKWH,
+                responseBuilder.customDatacenterPUE,
+                responseBuilder.customPerCoreWatt
+            );
             CostCalculator costCalculator = new CostCalculator(
                 instanceTypeService,
                 hostsTable,
-                responseBuilder.requestedDuration,
+                responseBuilder.getRequestedDuration(),
                 responseBuilder.customCostFactor
             );
             Map<String, TraceEvent> events = responseBuilder.stackTraceEvents;
@@ -727,8 +737,11 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
         private List<HostEventCount> hostEventCounts;
         private double samplingRate;
         private long totalSamples;
-        private double requestedDuration;
+        private Double requestedDuration;
         private Double customCostFactor;
+        private Double customCO2PerKWH;
+        private Double customDatacenterPUE;
+        private Double customPerCoreWatt;
 
         public void setStackTraces(Map<String, StackTrace> stackTraces) {
             this.stackTraces = stackTraces;
@@ -786,8 +799,28 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
             this.requestedDuration = requestedDuration;
         }
 
+        public double getRequestedDuration() {
+            if (requestedDuration != null) {
+                return requestedDuration;
+            }
+            // If "requested_duration" wasn't specified, we use the time range from the query response.
+            return end.getEpochSecond() - start.getEpochSecond();
+        }
+
         public void setCustomCostFactor(Double customCostFactor) {
             this.customCostFactor = customCostFactor;
+        }
+
+        public void setCustomCO2PerKWH(Double customCO2PerKWH) {
+            this.customCO2PerKWH = customCO2PerKWH;
+        }
+
+        public void setCustomDatacenterPUE(Double customDatacenterPUE) {
+            this.customDatacenterPUE = customDatacenterPUE;
+        }
+
+        public void setCustomPerCoreWatt(Double customPerCoreWatt) {
+            this.customPerCoreWatt = customPerCoreWatt;
         }
 
         public void setTotalSamples(long totalSamples) {

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/CO2CalculatorTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/CO2CalculatorTests.java
@@ -73,7 +73,7 @@ public class CO2CalculatorTests extends ESTestCase {
         double samplingDurationInSeconds = 1_800.0d; // 30 minutes
         long samples = 100_000L; // 100k samples
         double annualCoreHours = CostCalculator.annualCoreHours(samplingDurationInSeconds, samples, 20.0d);
-        CO2Calculator co2Calculator = new CO2Calculator(instanceTypeService, hostsTable, samplingDurationInSeconds);
+        CO2Calculator co2Calculator = new CO2Calculator(instanceTypeService, hostsTable, samplingDurationInSeconds, null, null, null);
 
         checkCO2Calculation(co2Calculator.getAnnualCO2Tons(HOST_ID_A, samples), annualCoreHours, 0.000002213477d);
         checkCO2Calculation(co2Calculator.getAnnualCO2Tons(HOST_ID_B, samples), annualCoreHours, 1.1d, 0.00004452d, 7.0d);

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/GetStackTracesRequestTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/GetStackTracesRequestTests.java
@@ -29,12 +29,22 @@ import static java.util.Collections.emptyList;
 
 public class GetStackTracesRequestTests extends ESTestCase {
     public void testSerialization() throws IOException {
-        Integer sampleSize = randomBoolean() ? randomIntBetween(0, Integer.MAX_VALUE) : null;
+        Integer sampleSize = randomIntBetween(1, Integer.MAX_VALUE);
         Double requestedDuration = randomBoolean() ? randomDoubleBetween(0.001d, Double.MAX_VALUE, true) : null;
         Double customCostFactor = randomBoolean() ? randomDoubleBetween(0.1d, 5.0d, true) : null;
         QueryBuilder query = randomBoolean() ? new BoolQueryBuilder() : null;
 
-        GetStackTracesRequest request = new GetStackTracesRequest(sampleSize, requestedDuration, customCostFactor, query, null, null);
+        GetStackTracesRequest request = new GetStackTracesRequest(
+            sampleSize,
+            requestedDuration,
+            customCostFactor,
+            query,
+            null,
+            null,
+            null,
+            null,
+            null
+        );
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             request.writeTo(out);
             try (NamedWriteableAwareStreamInput in = new NamedWriteableAwareStreamInput(out.bytes().streamInput(), writableRegistry())) {
@@ -98,6 +108,9 @@ public class GetStackTracesRequestTests extends ESTestCase {
             assertEquals("stacktraces", request.getStackTraceIds());
             // a basic check suffices here
             assertEquals("@timestamp", ((RangeQueryBuilder) request.getQuery()).fieldName());
+
+            // Expect the default values
+            assertEquals(null, request.getRequestedDuration());
         }
     }
 
@@ -125,21 +138,41 @@ public class GetStackTracesRequestTests extends ESTestCase {
     }
 
     public void testValidateWrongSampleSize() {
-        GetStackTracesRequest request = new GetStackTracesRequest(randomIntBetween(Integer.MIN_VALUE, 0), 1.0d, 1.0d, null, null, null);
+        GetStackTracesRequest request = new GetStackTracesRequest(
+            randomIntBetween(Integer.MIN_VALUE, 0),
+            1.0d,
+            1.0d,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        );
         List<String> validationErrors = request.validate().validationErrors();
         assertEquals(1, validationErrors.size());
-        assertTrue(validationErrors.get(0).contains("[sample_size] must be greater or equals than 1"));
+        assertTrue(validationErrors.get(0).contains("[sample_size] must be greater than 0,"));
     }
 
     public void testValidateStacktraceWithoutIndices() {
-        GetStackTracesRequest request = new GetStackTracesRequest(1, 1.0d, 1.0d, null, null, randomAlphaOfLength(3));
+        GetStackTracesRequest request = new GetStackTracesRequest(1, 1.0d, 1.0d, null, null, randomAlphaOfLength(3), null, null, null);
         List<String> validationErrors = request.validate().validationErrors();
         assertEquals(1, validationErrors.size());
         assertEquals("[stacktrace_ids] must not be set", validationErrors.get(0));
     }
 
     public void testValidateIndicesWithoutStacktraces() {
-        GetStackTracesRequest request = new GetStackTracesRequest(null, 1.0d, 1.0d, null, randomAlphaOfLength(5), randomFrom("", null));
+        GetStackTracesRequest request = new GetStackTracesRequest(
+            null,
+            1.0d,
+            1.0d,
+            null,
+            randomAlphaOfLength(5),
+            randomFrom("", null),
+            null,
+            null,
+            null
+        );
         List<String> validationErrors = request.validate().validationErrors();
         assertEquals(1, validationErrors.size());
         assertEquals("[stacktrace_ids] is mandatory", validationErrors.get(0));
@@ -147,7 +180,17 @@ public class GetStackTracesRequestTests extends ESTestCase {
 
     public void testConsidersCustomIndicesInRelatedIndices() {
         String customIndex = randomAlphaOfLength(5);
-        GetStackTracesRequest request = new GetStackTracesRequest(1, 1.0d, 1.0d, null, customIndex, randomAlphaOfLength(3));
+        GetStackTracesRequest request = new GetStackTracesRequest(
+            1,
+            1.0d,
+            1.0d,
+            null,
+            customIndex,
+            randomAlphaOfLength(3),
+            null,
+            null,
+            null
+        );
         String[] indices = request.indices();
         assertEquals(4, indices.length);
         assertTrue("custom index not contained in indices list", Set.of(indices).contains(customIndex));
@@ -155,7 +198,7 @@ public class GetStackTracesRequestTests extends ESTestCase {
 
     public void testConsidersDefaultIndicesInRelatedIndices() {
         String customIndex = randomAlphaOfLength(5);
-        GetStackTracesRequest request = new GetStackTracesRequest(1, 1.0d, 1.0d, null, null, null);
+        GetStackTracesRequest request = new GetStackTracesRequest(1, 1.0d, 1.0d, null, null, null, null, null, null);
         String[] indices = request.indices();
         assertEquals(15, indices.length);
     }

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/ResamplerTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/ResamplerTests.java
@@ -30,7 +30,7 @@ public class ResamplerTests extends ESTestCase {
         int requestedSamples = 20_000;
         int actualTotalSamples = 10_000;
 
-        GetStackTracesRequest request = new GetStackTracesRequest(requestedSamples, 1.0d, 1.0d, null, null, null);
+        GetStackTracesRequest request = new GetStackTracesRequest(requestedSamples, 1.0d, 1.0d, null, null, null, null, null, null);
         request.setAdjustSampleCount(false);
 
         Resampler resampler = createResampler(request, sampleRate, actualTotalSamples);
@@ -45,7 +45,7 @@ public class ResamplerTests extends ESTestCase {
         int requestedSamples = 20_000;
         int actualTotalSamples = 10_000;
 
-        GetStackTracesRequest request = new GetStackTracesRequest(requestedSamples, 1.0d, 1.0d, null, null, null);
+        GetStackTracesRequest request = new GetStackTracesRequest(requestedSamples, 1.0d, 1.0d, null, null, null, null, null, null);
         request.setAdjustSampleCount(true);
 
         Resampler resampler = createResampler(request, sampleRate, actualTotalSamples);
@@ -60,7 +60,7 @@ public class ResamplerTests extends ESTestCase {
         int requestedSamples = 20_000;
         int actualTotalSamples = 40_000;
 
-        GetStackTracesRequest request = new GetStackTracesRequest(requestedSamples, 1.0d, 1.0d, null, null, null);
+        GetStackTracesRequest request = new GetStackTracesRequest(requestedSamples, 1.0d, 1.0d, null, null, null, null, null, null);
         request.setAdjustSampleCount(false);
 
         Resampler resampler = createResampler(request, sampleRate, actualTotalSamples);
@@ -84,6 +84,9 @@ public class ResamplerTests extends ESTestCase {
                 new RangeQueryBuilder("@timestamp").lt("2023-10-19 15:33:00").gte("2023-09-20 15:31:52").format("yyyy-MM-dd HH:mm:ss")
             ),
             null,
+            null,
+            null,
+            null,
             null
         );
 
@@ -100,7 +103,7 @@ public class ResamplerTests extends ESTestCase {
         int requestedSamples = 20_000;
         int actualTotalSamples = 40_000;
 
-        GetStackTracesRequest request = new GetStackTracesRequest(requestedSamples, 1.0d, 1.0d, null, null, null);
+        GetStackTracesRequest request = new GetStackTracesRequest(requestedSamples, 1.0d, 1.0d, null, null, null, null, null, null);
         request.setAdjustSampleCount(true);
 
         Resampler resampler = createResampler(request, sampleRate, actualTotalSamples);

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/RestGetStackTracesActionTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/RestGetStackTracesActionTests.java
@@ -39,7 +39,7 @@ public class RestGetStackTracesActionTests extends RestActionTestCase {
         verifyingClient.setExecuteLocallyVerifier((actionType, request) -> {
             assertThat(request, instanceOf(GetStackTracesRequest.class));
             GetStackTracesRequest getStackTracesRequest = (GetStackTracesRequest) request;
-            assertThat(getStackTracesRequest.getSampleSize(), nullValue());
+            assertThat(getStackTracesRequest.getSampleSize(), is(20_000)); // expect the default value
             assertThat(getStackTracesRequest.getQuery(), nullValue());
             executeCalled.set(true);
             return new GetStackTracesResponse(
@@ -49,7 +49,7 @@ public class RestGetStackTracesActionTests extends RestActionTestCase {
                 Collections.emptyMap(),
                 0,
                 1.0d,
-                0
+                0L
             );
         });
         RestRequest profilingRequest = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.POST)
@@ -65,7 +65,7 @@ public class RestGetStackTracesActionTests extends RestActionTestCase {
         verifyingClient.setExecuteLocallyVerifier((actionType, request) -> {
             assertThat(request, instanceOf(GetStackTracesRequest.class));
             GetStackTracesRequest getStackTracesRequest = (GetStackTracesRequest) request;
-            assertThat(getStackTracesRequest.getSampleSize(), is(10000));
+            assertThat(getStackTracesRequest.getSampleSize(), is(10_000));
             assertThat(getStackTracesRequest.getQuery(), notNullValue(QueryBuilder.class));
             executeCalled.set(true);
             return new GetStackTracesResponse(
@@ -75,7 +75,7 @@ public class RestGetStackTracesActionTests extends RestActionTestCase {
                 Collections.emptyMap(),
                 0,
                 0.0d,
-                0
+                0L
             );
         });
         RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.POST)


### PR DESCRIPTION
This PR adds the request params

    co2_per_kwh
    datacenter_pue
    per_core_watt

The values can be customized in the Kibana Advanced Settings.
