### PR TITLE
Fix DISSECT with empty patterns

### DIFF
--- a/docs/changelog/102580.yaml
+++ b/docs/changelog/102580.yaml
@@ -1,0 +1,6 @@
+pr: 102580
+summary: Fix DISSECT with empty patterns
+area: ES|QL
+type: bug
+issues:
+ - 102577

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/dissect.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/dissect.csv-spec
@@ -166,3 +166,25 @@ a:keyword | b:keyword | d:keyword
 b c d     | b         | d
 ;
 
+
+multipleEmptyPatterns#[skip:-8.11.99]
+ROW a="b c d e"| DISSECT a "%{b} %{} %{} %{e}";
+
+a:keyword | b:keyword | e:keyword
+b c d e   | b         | e
+;
+
+firstEmptyPattern#[skip:-8.11.99]
+ROW a="x b c d"| DISSECT a "%{} %{b} %{} %{d}";
+
+a:keyword   | b:keyword | d:keyword
+x b c d     | b         | d
+;
+
+
+lastEmptyPattern#[skip:-8.11.99]
+ROW a="b c d x"| DISSECT a "%{b} %{} %{d} %{}";
+
+a:keyword  | b:keyword | d:keyword
+b c d x    | b         | d
+;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/dissect.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/dissect.csv-spec
@@ -158,3 +158,11 @@ emp_no:integer | a:keyword            | b:keyword         | c:keyword
 10005          | null                 | null              | null 
 10006          | [Principal, Senior]  | [Support, Team]   | [Engineer, Lead]
 ;
+
+emptyPattern#[skip:-8.11.99]
+ROW a="b c d"| DISSECT a "%{b} %{} %{d}";
+
+a:keyword | b:keyword | d:keyword
+b c d     | b         | d
+;
+

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/LogicalPlanBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/LogicalPlanBuilder.java
@@ -134,13 +134,12 @@ public class LogicalPlanBuilder extends ExpressionBuilder {
                         referenceKeys.iterator().next()
                     );
                 }
-                List<Attribute> keys = parser.outputKeys()
-                    .stream()
-                    .filter(x -> x.isEmpty() == false)
-                    .map(x -> new ReferenceAttribute(src, x, DataTypes.KEYWORD))
-                    .map(Attribute.class::cast)
-                    .toList();
-
+                List<Attribute> keys = new ArrayList<>();
+                for (var x : parser.outputKeys()) {
+                    if (x.isEmpty() == false) {
+                        keys.add(new ReferenceAttribute(src, x, DataTypes.KEYWORD));
+                    }
+                }
                 return new Dissect(src, p, expression(ctx.primaryExpression()), new Dissect.Parser(pattern, appendSeparator, parser), keys);
             } catch (DissectException e) {
                 throw new ParsingException(src, "Invalid pattern for dissect: [{}]", pattern);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/LogicalPlanBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/LogicalPlanBuilder.java
@@ -136,6 +136,7 @@ public class LogicalPlanBuilder extends ExpressionBuilder {
                 }
                 List<Attribute> keys = parser.outputKeys()
                     .stream()
+                    .filter(x -> x.isEmpty() == false)
                     .map(x -> new ReferenceAttribute(src, x, DataTypes.KEYWORD))
                     .map(Attribute.class::cast)
                     .toList();

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/StatementParserTests.java
@@ -636,6 +636,7 @@ public class StatementParserTests extends ESTestCase {
             "from a | dissect foo \"%{bar}\" append_separator=3",
             "Invalid value for dissect append_separator: expected a string, but was [3]"
         );
+        expectError("from a | dissect foo \"%{}\"", "Invalid pattern for dissect: [%{}]");
     }
 
     public void testGrokPattern() {


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/102577

Ignore empty DISSECT patterns, eg. `DISSECT a "%{a} %{} %{b}"` will only return two fields (`a` and `b`) and will ignore the empty pattern (discarding the corresponding values).