### PR TITLE
Log exceptions thrown during chunked encoding

### DIFF
--- a/server/src/main/java/org/elasticsearch/http/DefaultRestChannel.java
+++ b/server/src/main/java/org/elasticsearch/http/DefaultRestChannel.java
@@ -23,7 +23,6 @@ import org.elasticsearch.core.Releasables;
 import org.elasticsearch.rest.AbstractRestChannel;
 import org.elasticsearch.rest.ChunkedRestResponseBody;
 import org.elasticsearch.rest.LoggingChunkedRestResponseBody;
-import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.RestStatus;
@@ -40,7 +39,7 @@ import static org.elasticsearch.tasks.Task.X_OPAQUE_ID_HTTP_HEADER;
  * The default rest channel for incoming requests. This class implements the basic logic for sending a rest
  * response. It will set necessary headers nad ensure that bytes are released after the response is sent.
  */
-public class DefaultRestChannel extends AbstractRestChannel implements RestChannel {
+public class DefaultRestChannel extends AbstractRestChannel {
 
     static final String CLOSE = "close";
     static final String CONNECTION = "connection";

--- a/server/src/main/java/org/elasticsearch/rest/ChunkedRestResponseBody.java
+++ b/server/src/main/java/org/elasticsearch/rest/ChunkedRestResponseBody.java
@@ -20,6 +20,8 @@ import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.core.Streams;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
 
@@ -35,6 +37,8 @@ import java.util.Iterator;
  * instead serialize only as much of the response as can be flushed to the network right away.
  */
 public interface ChunkedRestResponseBody extends Releasable {
+
+    Logger logger = LogManager.getLogger(ChunkedRestResponseBody.class);
 
     /**
      * @return true once this response has been written fully.
@@ -126,6 +130,9 @@ public interface ChunkedRestResponseBody extends Releasable {
                     );
                     target = null;
                     return result;
+                } catch (Exception e) {
+                    logger.error("failure encoding chunk", e);
+                    throw e;
                 } finally {
                     if (target != null) {
                         assert false : "failure encoding chunk";
@@ -212,6 +219,9 @@ public interface ChunkedRestResponseBody extends Releasable {
                     );
                     currentOutput = null;
                     return result;
+                } catch (Exception e) {
+                    logger.error("failure encoding text chunk", e);
+                    throw e;
                 } finally {
                     if (currentOutput != null) {
                         assert false : "failure encoding text chunk";


### PR DESCRIPTION
Today on exception we `assert false` in the `finally` block, but that
means we don't get to see the exception that caused the problem. This
commit adds a little extra logging to help there.