### PR TITLE
Record chunked response size before sending last chunk

### DIFF
--- a/qa/smoke-test-http/src/javaRestTest/java/org/elasticsearch/http/HttpStatsIT.java
+++ b/qa/smoke-test-http/src/javaRestTest/java/org/elasticsearch/http/HttpStatsIT.java
@@ -52,8 +52,6 @@ public class HttpStatsIT extends HttpSmokeTestCase {
         assertHttpStats(new XContentTestUtils.JsonMapView((Map<String, Object>) nodesMap.get(nodeId)));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/102547")
-    @SuppressWarnings("unchecked")
     public void testClusterInfoHttpStats() throws IOException {
         internalCluster().ensureAtLeastNumDataNodes(3);
         performHttpRequests();


### PR DESCRIPTION
We expect that the HTTP response stats should reflect the responses
received by the client, but today we record that a chunked-encoded
response was sent _after_ sending the last chunk, which might mean that
the client can receive the complete response body and then retrieve
stats that do not include that response. With this commit we record the
stats before sending the last chunk.

Closes #102547