### PR TITLE
Add org.opensaml.security to X-Pack Security module-info

### DIFF
--- a/x-pack/plugin/security/src/main/java/module-info.java
+++ b/x-pack/plugin/security/src/main/java/module-info.java
@@ -33,6 +33,7 @@ module org.elasticsearch.security {
     requires org.opensaml.core;
     requires org.opensaml.saml;
     requires org.opensaml.saml.impl;
+    requires org.opensaml.security;
     requires org.opensaml.security.impl;
     requires org.opensaml.xmlsec.impl;
     requires org.opensaml.xmlsec;


### PR DESCRIPTION
My IntelliJ was refusing to compile SamlObjectHandler.java unless this extra line was added to module-info.java.

This doesn't currently affect official builds, nor anyone else's IntelliJ builds it would seem. However, I thought that since eventually some other change will make this necessary it doesn't hurt to add it now, and might save others time.