### PR TITLE
Add support for invalidation timestamp in QueryApiKey

### DIFF
--- a/docs/changelog/102590.yaml
+++ b/docs/changelog/102590.yaml
@@ -1,0 +1,5 @@
+pr: 102590
+summary: Add support for invalidation timestamp in `QueryApiKey`
+area: Security
+type: enhancement
+issues: []

--- a/docs/changelog/102590.yaml
+++ b/docs/changelog/102590.yaml
@@ -1,5 +1,0 @@
-pr: 102590
-summary: Add support for invalidation timestamp in `QueryApiKey`
-area: Security
-type: enhancement
-issues: []

--- a/docs/reference/rest-api/security/get-api-keys.asciidoc
+++ b/docs/reference/rest-api/security/get-api-keys.asciidoc
@@ -175,7 +175,7 @@ A successful call returns a JSON structure that contains the information of the 
 <4> Creation time for the API key in milliseconds
 <5> Optional expiration time for the API key in milliseconds
 <6> Invalidation status for the API key. If the key has been invalidated, it has
-a value of `true`. Otherwise, it is `false`.
+a value of `true` and an additional field with the `invalidation` time in milliseconds. Otherwise, it is `false`.
 <7> Principal for which this API key was created
 <8> Realm name of the principal for which this API key was created
 <9> Metadata of the API key

--- a/docs/reference/rest-api/security/query-api-key.asciidoc
+++ b/docs/reference/rest-api/security/query-api-key.asciidoc
@@ -78,7 +78,7 @@ Indicates whether the API key is invalidated. If `true`, the key is invalidated.
 Defaults to `false`.
 
 `invalidation`::
-Invalidation time of the API key in milliseconds.
+Invalidation time of the API key in milliseconds. This field is only set for invalidated API keys.
 
 `username`::
 Username of the API key owner.

--- a/docs/reference/rest-api/security/query-api-key.asciidoc
+++ b/docs/reference/rest-api/security/query-api-key.asciidoc
@@ -77,6 +77,9 @@ Expiration time of the API key in milliseconds.
 Indicates whether the API key is invalidated. If `true`, the key is invalidated.
 Defaults to `false`.
 
+`invalidation`::
+Invalidation time of the API key in milliseconds.
+
 `username`::
 Username of the API key owner.
 

--- a/x-pack/plugin/security/qa/security-basic/src/javaRestTest/java/org/elasticsearch/xpack/security/QueryApiKeyIT.java
+++ b/x-pack/plugin/security/qa/security-basic/src/javaRestTest/java/org/elasticsearch/xpack/security/QueryApiKeyIT.java
@@ -387,6 +387,12 @@ public class QueryApiKeyIT extends SecurityInBasicRestTestCase {
         // Create an invalidated API key
         createAndInvalidateApiKey("test-exists-4", authHeader);
 
+        // Get the invalidated API key
+        assertQuery(authHeader, """
+            {"query": {"exists": {"field": "invalidation" }}}""", apiKeys -> {
+            assertThat(apiKeys.stream().map(k -> (String) k.get("name")).toList(), containsInAnyOrder("test-exists-4"));
+        });
+
         // Ensure the short-lived key is expired
         final long elapsed = Instant.now().toEpochMilli() - startTime;
         if (elapsed < 10) {
@@ -401,6 +407,11 @@ public class QueryApiKeyIT extends SecurityInBasicRestTestCase {
                   "must": {
                     "term": {
                       "invalidated": false
+                    }
+                  },
+                  "must_not": {
+                    "exists": {
+                      "field": "invalidation"
                     }
                   },
                   "should": [

--- a/x-pack/plugin/security/qa/security-basic/src/javaRestTest/java/org/elasticsearch/xpack/security/QueryApiKeyIT.java
+++ b/x-pack/plugin/security/qa/security-basic/src/javaRestTest/java/org/elasticsearch/xpack/security/QueryApiKeyIT.java
@@ -129,7 +129,7 @@ public class QueryApiKeyIT extends SecurityInBasicRestTestCase {
             { "query": { "prefix": {"api_key_hash": "{PBKDF2}10000$"} } }""");
 
         // Search for fields that are not allowed in Query DSL but used internally by the service itself
-        final String fieldName = randomFrom("doc_type", "api_key_invalidated");
+        final String fieldName = randomFrom("doc_type", "api_key_invalidated", "invalidation_time");
         assertQueryError(API_KEY_ADMIN_AUTH_HEADER, 400, Strings.format("""
             { "query": { "term": {"%s": "%s"} } }""", fieldName, randomAlphaOfLengthBetween(3, 8)));
 

--- a/x-pack/plugin/security/qa/security-basic/src/javaRestTest/java/org/elasticsearch/xpack/security/QueryApiKeyIT.java
+++ b/x-pack/plugin/security/qa/security-basic/src/javaRestTest/java/org/elasticsearch/xpack/security/QueryApiKeyIT.java
@@ -164,6 +164,7 @@ public class QueryApiKeyIT extends SecurityInBasicRestTestCase {
         final String queryString = randomFrom("""
             {"query": { "term": {"name": "temporary-key-1"} } }""", Strings.format("""
             {"query":{"bool":{"must":[{"term":{"name":{"value":"temporary-key-1"}}},\
+            {"range": {"invalidation": {"lte": "now"}}},
             {"term":{"invalidated":{"value":"%s"}}}]}}}
             """, randomBoolean()));
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/ApiKeyBoolQueryBuilder.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/ApiKeyBoolQueryBuilder.java
@@ -37,6 +37,7 @@ public class ApiKeyBoolQueryBuilder extends BoolQueryBuilder {
         "doc_type",
         "name",
         "api_key_invalidated",
+        "invalidation_time",
         "creation_time",
         "expiration_time"
     );

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/ApiKeyFieldNameTranslators.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/ApiKeyFieldNameTranslators.java
@@ -24,6 +24,7 @@ public class ApiKeyFieldNameTranslators {
             new ExactFieldNameTranslator(s -> "creation_time", "creation"),
             new ExactFieldNameTranslator(s -> "expiration_time", "expiration"),
             new ExactFieldNameTranslator(s -> "api_key_invalidated", "invalidated"),
+            new ExactFieldNameTranslator(s -> "invalidation_time", "invalidation"),
             new PrefixFieldNameTranslator(s -> "metadata_flattened" + s.substring(8), "metadata.")
         );
     }


### PR DESCRIPTION
This is a follow up PR from https://github.com/elastic/elasticsearch/pull/102472. This adds the ability to use `invalidation` timestamp as a valid [query value](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-query-api-key.html#security-api-query-api-key-request-body) in the QueryApiKey API.