### PR TITLE
Add apm api for asynchronous counters (always increasing)

### DIFF
--- a/docs/changelog/102598.yaml
+++ b/docs/changelog/102598.yaml
@@ -1,0 +1,5 @@
+pr: 102598
+summary: Add apm api for asynchronous counters (always increasing)
+area: Infra/Core
+type: enhancement
+issues: []

--- a/modules/apm/src/main/java/module-info.java
+++ b/modules/apm/src/main/java/module-info.java
@@ -16,4 +16,5 @@ module org.elasticsearch.telemetry.apm {
     requires io.opentelemetry.api;
 
     exports org.elasticsearch.telemetry.apm;
+    exports org.elasticsearch.telemetry.apm.internal.metrics;
 }

--- a/modules/apm/src/main/java/module-info.java
+++ b/modules/apm/src/main/java/module-info.java
@@ -16,5 +16,4 @@ module org.elasticsearch.telemetry.apm {
     requires io.opentelemetry.api;
 
     exports org.elasticsearch.telemetry.apm;
-    exports org.elasticsearch.telemetry.apm.internal.metrics;
 }

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/APMMeterRegistry.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/APMMeterRegistry.java
@@ -12,19 +12,23 @@ import io.opentelemetry.api.metrics.Meter;
 
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.common.util.concurrent.ReleasableLock;
+import org.elasticsearch.telemetry.apm.internal.metrics.DoubleAsyncCounterAdapter;
 import org.elasticsearch.telemetry.apm.internal.metrics.DoubleCounterAdapter;
 import org.elasticsearch.telemetry.apm.internal.metrics.DoubleGaugeAdapter;
 import org.elasticsearch.telemetry.apm.internal.metrics.DoubleHistogramAdapter;
 import org.elasticsearch.telemetry.apm.internal.metrics.DoubleUpDownCounterAdapter;
+import org.elasticsearch.telemetry.apm.internal.metrics.LongAsyncCounterAdapter;
 import org.elasticsearch.telemetry.apm.internal.metrics.LongCounterAdapter;
 import org.elasticsearch.telemetry.apm.internal.metrics.LongGaugeAdapter;
 import org.elasticsearch.telemetry.apm.internal.metrics.LongHistogramAdapter;
 import org.elasticsearch.telemetry.apm.internal.metrics.LongUpDownCounterAdapter;
+import org.elasticsearch.telemetry.metric.DoubleAsyncCounter;
 import org.elasticsearch.telemetry.metric.DoubleCounter;
 import org.elasticsearch.telemetry.metric.DoubleGauge;
 import org.elasticsearch.telemetry.metric.DoubleHistogram;
 import org.elasticsearch.telemetry.metric.DoubleUpDownCounter;
 import org.elasticsearch.telemetry.metric.DoubleWithAttributes;
+import org.elasticsearch.telemetry.metric.LongAsyncCounter;
 import org.elasticsearch.telemetry.metric.LongCounter;
 import org.elasticsearch.telemetry.metric.LongGauge;
 import org.elasticsearch.telemetry.metric.LongHistogram;
@@ -48,6 +52,8 @@ public class APMMeterRegistry implements MeterRegistry {
     private final Registrar<DoubleGaugeAdapter> doubleGauges = new Registrar<>();
     private final Registrar<DoubleHistogramAdapter> doubleHistograms = new Registrar<>();
     private final Registrar<LongCounterAdapter> longCounters = new Registrar<>();
+    private final Registrar<LongAsyncCounterAdapter> longAsynchronousCounters = new Registrar<>();
+    private final Registrar<DoubleAsyncCounterAdapter> doubleAsynchronousCounters = new Registrar<>();
     private final Registrar<LongUpDownCounterAdapter> longUpDownCounters = new Registrar<>();
     private final Registrar<LongGaugeAdapter> longGauges = new Registrar<>();
     private final Registrar<LongHistogramAdapter> longHistograms = new Registrar<>();
@@ -128,6 +134,35 @@ public class APMMeterRegistry implements MeterRegistry {
     }
 
     @Override
+    public LongAsyncCounter registerLongAsyncCounter(String name, String description, String unit, Supplier<LongWithAttributes> observer) {
+        try (ReleasableLock lock = registerLock.acquire()) {
+            return longAsynchronousCounters.register(new LongAsyncCounterAdapter(meter, name, description, unit, observer));
+        }
+    }
+
+    @Override
+    public LongAsyncCounter getLongAsyncCounter(String name) {
+        return longAsynchronousCounters.get(name);
+    }
+
+    @Override
+    public DoubleAsyncCounter registerDoubleAsyncCounter(
+        String name,
+        String description,
+        String unit,
+        Supplier<DoubleWithAttributes> observer
+    ) {
+        try (ReleasableLock lock = registerLock.acquire()) {
+            return doubleAsynchronousCounters.register(new DoubleAsyncCounterAdapter(meter, name, description, unit, observer));
+        }
+    }
+
+    @Override
+    public DoubleAsyncCounter getDoubleAsyncCounter(String name) {
+        return doubleAsynchronousCounters.get(name);
+    }
+
+    @Override
     public LongCounter getLongCounter(String name) {
         return longCounters.get(name);
     }
@@ -179,6 +214,7 @@ public class APMMeterRegistry implements MeterRegistry {
 
     /**
      * A typed wrapper for a instrument that
+     *
      * @param <T>
      */
     private static class Registrar<T extends AbstractInstrument<?>> {

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/APMMeterRegistry.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/APMMeterRegistry.java
@@ -214,7 +214,6 @@ public class APMMeterRegistry implements MeterRegistry {
 
     /**
      * A typed wrapper for a instrument that
-     *
      * @param <T>
      */
     private static class Registrar<T extends AbstractInstrument<?>> {

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/metrics/DoubleAsyncCounterAdapter.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/metrics/DoubleAsyncCounterAdapter.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.telemetry.apm.internal.metrics;
+
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.ObservableDoubleCounter;
+
+import org.elasticsearch.common.util.concurrent.ReleasableLock;
+import org.elasticsearch.telemetry.apm.AbstractInstrument;
+import org.elasticsearch.telemetry.metric.DoubleAsyncCounter;
+import org.elasticsearch.telemetry.metric.DoubleWithAttributes;
+
+import java.util.Objects;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
+
+public class DoubleAsyncCounterAdapter extends AbstractInstrument<ObservableDoubleCounter> implements DoubleAsyncCounter {
+    private final Supplier<DoubleWithAttributes> observer;
+    private final ReleasableLock closedLock = new ReleasableLock(new ReentrantLock());
+    private boolean closed = false;
+
+    public DoubleAsyncCounterAdapter(Meter meter, String name, String description, String unit, Supplier<DoubleWithAttributes> observer) {
+        super(meter, name, description, unit);
+        this.observer = observer;
+    }
+
+    @Override
+    protected ObservableDoubleCounter buildInstrument(Meter meter) {
+        var builder = Objects.requireNonNull(meter).counterBuilder(getName());
+        return builder.setDescription(getDescription()).setUnit(getUnit()).ofDoubles().buildWithCallback(measurement -> {
+            DoubleWithAttributes observation;
+            try {
+                observation = observer.get();
+            } catch (RuntimeException err) {
+                assert false : "observer must not throw [" + err.getMessage() + "]";
+                return;
+            }
+            measurement.record(observation.value(), OtelHelper.fromMap(observation.attributes()));
+        });
+    }
+
+    @Override
+    public void close() throws Exception {
+        try (ReleasableLock lock = closedLock.acquire()) {
+            if (closed == false) {
+                getInstrument().close();
+            }
+            closed = true;
+        }
+    }
+}

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/metrics/LongAsyncCounterAdapter.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/metrics/LongAsyncCounterAdapter.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.telemetry.apm.internal.metrics;
+
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.ObservableLongCounter;
+
+import org.elasticsearch.common.util.concurrent.ReleasableLock;
+import org.elasticsearch.telemetry.apm.AbstractInstrument;
+import org.elasticsearch.telemetry.metric.LongAsyncCounter;
+import org.elasticsearch.telemetry.metric.LongWithAttributes;
+
+import java.util.Objects;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
+
+public class LongAsyncCounterAdapter extends AbstractInstrument<ObservableLongCounter> implements LongAsyncCounter {
+    private final Supplier<LongWithAttributes> observer;
+    private final ReleasableLock closedLock = new ReleasableLock(new ReentrantLock());
+    private boolean closed = false;
+
+    public LongAsyncCounterAdapter(Meter meter, String name, String description, String unit, Supplier<LongWithAttributes> observer) {
+        super(meter, name, description, unit);
+        this.observer = observer;
+    }
+
+    @Override
+    protected ObservableLongCounter buildInstrument(Meter meter) {
+        var builder = Objects.requireNonNull(meter).counterBuilder(getName());
+        return builder.setDescription(getDescription()).setUnit(getUnit()).buildWithCallback(measurement -> {
+            LongWithAttributes observation;
+            try {
+                observation = observer.get();
+            } catch (RuntimeException err) {
+                assert false : "observer must not throw [" + err.getMessage() + "]";
+                return;
+            }
+            measurement.record(observation.value(), OtelHelper.fromMap(observation.attributes()));
+        });
+    }
+
+    @Override
+    public void close() throws Exception {
+        try (ReleasableLock lock = closedLock.acquire()) {
+            if (closed == false) {
+                getInstrument().close();
+            }
+            closed = true;
+        }
+    }
+}

--- a/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/RecordingOtelMeter.java
+++ b/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/RecordingOtelMeter.java
@@ -110,14 +110,34 @@ public class RecordingOtelMeter implements Meter {
 
         @Override
         public ObservableLongCounter buildWithCallback(Consumer<ObservableLongMeasurement> callback) {
-            unimplemented();
-            return null;
+            LongAsyncCounterRecorder longAsyncCounter = new LongAsyncCounterRecorder(name, callback);
+            recorder.register(longAsyncCounter, longAsyncCounter.getInstrument(), name, description, unit);
+            callbacks.add(longAsyncCounter);
+            return longAsyncCounter;
         }
 
         @Override
         public ObservableLongMeasurement buildObserver() {
             unimplemented();
             return null;
+        }
+    }
+
+    private class LongAsyncCounterRecorder extends AbstractInstrument implements ObservableLongCounter, Callback, OtelInstrument {
+        final Consumer<ObservableLongMeasurement> callback;
+
+        LongAsyncCounterRecorder(String name, Consumer<ObservableLongMeasurement> callback) {
+            super(name, InstrumentType.LONG_ASYNC_COUNTER);
+            this.callback = callback;
+        }
+
+        @Override
+        public void close() {
+            callbacks.remove(this);
+        }
+
+        public void doCall() {
+            callback.accept(new LongMeasurementRecorder(name, instrument));
         }
     }
 
@@ -172,14 +192,34 @@ public class RecordingOtelMeter implements Meter {
 
         @Override
         public ObservableDoubleCounter buildWithCallback(Consumer<ObservableDoubleMeasurement> callback) {
-            unimplemented();
-            return null;
+            DoubleAsyncCounterRecorder doubleAsyncCounter = new DoubleAsyncCounterRecorder(name, callback);
+            recorder.register(doubleAsyncCounter, doubleAsyncCounter.getInstrument(), name, description, unit);
+            callbacks.add(doubleAsyncCounter);
+            return doubleAsyncCounter;
         }
 
         @Override
         public ObservableDoubleMeasurement buildObserver() {
             unimplemented();
             return null;
+        }
+    }
+
+    private class DoubleAsyncCounterRecorder extends AbstractInstrument implements ObservableDoubleCounter, Callback, OtelInstrument {
+        final Consumer<ObservableDoubleMeasurement> callback;
+
+        DoubleAsyncCounterRecorder(String name, Consumer<ObservableDoubleMeasurement> callback) {
+            super(name, InstrumentType.DOUBLE_ASYNC_COUNTER);
+            this.callback = callback;
+        }
+
+        @Override
+        public void close() {
+            callbacks.remove(this);
+        }
+
+        public void doCall() {
+            callback.accept(new DoubleMeasurementRecorder(name, instrument));
         }
     }
 

--- a/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/internal/metrics/AsyncCountersAdapterTests.java
+++ b/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/internal/metrics/AsyncCountersAdapterTests.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.telemetry.apm.internal.metrics;
+
+import org.elasticsearch.telemetry.Measurement;
+import org.elasticsearch.telemetry.apm.APMMeterRegistry;
+import org.elasticsearch.telemetry.apm.RecordingOtelMeter;
+import org.elasticsearch.telemetry.metric.DoubleAsyncCounter;
+import org.elasticsearch.telemetry.metric.DoubleWithAttributes;
+import org.elasticsearch.telemetry.metric.LongAsyncCounter;
+import org.elasticsearch.telemetry.metric.LongWithAttributes;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Before;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+public class AsyncCountersAdapterTests extends ESTestCase {
+    RecordingOtelMeter otelMeter;
+    APMMeterRegistry registry;
+
+    @Before
+    public void init() {
+        otelMeter = new RecordingOtelMeter();
+        registry = new APMMeterRegistry(otelMeter);
+    }
+
+    // testing that a value reported is then used in a callback
+    public void testLongAsyncCounter() throws Exception {
+        AtomicReference<LongWithAttributes> attrs = new AtomicReference<>();
+        LongAsyncCounter longAsyncCounter = registry.registerLongAsyncCounter("name", "desc", "unit", attrs::get);
+
+        attrs.set(new LongWithAttributes(1L, Map.of("k", 1L)));
+
+        otelMeter.collectMetrics();
+
+        List<Measurement> metrics = otelMeter.getRecorder().getMeasurements(longAsyncCounter);
+        assertThat(metrics, hasSize(1));
+        assertThat(metrics.get(0).attributes(), equalTo(Map.of("k", 1L)));
+        assertThat(metrics.get(0).getLong(), equalTo(1L));
+
+        attrs.set(new LongWithAttributes(2L, Map.of("k", 5L)));
+
+        otelMeter.getRecorder().resetCalls();
+        otelMeter.collectMetrics();
+
+        metrics = otelMeter.getRecorder().getMeasurements(longAsyncCounter);
+        assertThat(metrics, hasSize(1));
+        assertThat(metrics.get(0).attributes(), equalTo(Map.of("k", 5L)));
+        assertThat(metrics.get(0).getLong(), equalTo(2L));
+
+        longAsyncCounter.close();
+
+        otelMeter.getRecorder().resetCalls();
+        otelMeter.collectMetrics();
+
+        metrics = otelMeter.getRecorder().getMeasurements(longAsyncCounter);
+        assertThat(metrics, hasSize(0));
+    }
+
+    public void testDoubleAsyncAdapter() throws Exception {
+        AtomicReference<DoubleWithAttributes> attrs = new AtomicReference<>();
+        DoubleAsyncCounter doubleAsyncCounter = registry.registerDoubleAsyncCounter("name", "desc", "unit", attrs::get);
+
+        attrs.set(new DoubleWithAttributes(1.0, Map.of("k", 1.0)));
+
+        otelMeter.collectMetrics();
+
+        List<Measurement> metrics = otelMeter.getRecorder().getMeasurements(doubleAsyncCounter);
+        assertThat(metrics, hasSize(1));
+        assertThat(metrics.get(0).attributes(), equalTo(Map.of("k", 1.0)));
+        assertThat(metrics.get(0).getDouble(), equalTo(1.0));
+
+        attrs.set(new DoubleWithAttributes(2.0, Map.of("k", 5.0)));
+
+        otelMeter.getRecorder().resetCalls();
+        otelMeter.collectMetrics();
+
+        metrics = otelMeter.getRecorder().getMeasurements(doubleAsyncCounter);
+        assertThat(metrics, hasSize(1));
+        assertThat(metrics.get(0).attributes(), equalTo(Map.of("k", 5.0)));
+        assertThat(metrics.get(0).getDouble(), equalTo(2.0));
+
+        doubleAsyncCounter.close();
+
+        otelMeter.getRecorder().resetCalls();
+        otelMeter.collectMetrics();
+
+        metrics = otelMeter.getRecorder().getMeasurements(doubleAsyncCounter);
+        assertThat(metrics, hasSize(0));
+    }
+}

--- a/server/src/main/java/org/elasticsearch/telemetry/metric/DoubleAsyncCounter.java
+++ b/server/src/main/java/org/elasticsearch/telemetry/metric/DoubleAsyncCounter.java
@@ -9,8 +9,7 @@
 package org.elasticsearch.telemetry.metric;
 
 /**
- * A monotonically increasing metric that uses a long.  Useful for integral values such as the number of bytes received,
- * number of requests, etc.
+ * A monotonically increasing double based on a callback.
  */
 public interface DoubleAsyncCounter extends Instrument, AutoCloseable {
 

--- a/server/src/main/java/org/elasticsearch/telemetry/metric/DoubleAsyncCounter.java
+++ b/server/src/main/java/org/elasticsearch/telemetry/metric/DoubleAsyncCounter.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.telemetry.metric;
+
+/**
+ * A monotonically increasing metric that uses a long.  Useful for integral values such as the number of bytes received,
+ * number of requests, etc.
+ */
+public interface DoubleAsyncCounter extends Instrument, AutoCloseable {
+
+    /**
+     * Noop counter for use in tests.
+     */
+    DoubleAsyncCounter NOOP = new DoubleAsyncCounter() {
+        @Override
+        public void close() throws Exception {
+
+        }
+
+        @Override
+        public String getName() {
+            return "noop";
+        }
+
+    };
+}

--- a/server/src/main/java/org/elasticsearch/telemetry/metric/LongAsyncCounter.java
+++ b/server/src/main/java/org/elasticsearch/telemetry/metric/LongAsyncCounter.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.telemetry.metric;
+
+/**
+ * A monotonically increasing metric that uses a long.  Useful for integral values such as the number of bytes received,
+ * number of requests, etc.
+ */
+public interface LongAsyncCounter extends Instrument, AutoCloseable {
+
+    /**
+     * Noop counter for use in tests.
+     */
+    LongAsyncCounter NOOP = new LongAsyncCounter() {
+        @Override
+        public void close() throws Exception {
+
+        }
+
+        @Override
+        public String getName() {
+            return "noop";
+        }
+    };
+}

--- a/server/src/main/java/org/elasticsearch/telemetry/metric/LongAsyncCounter.java
+++ b/server/src/main/java/org/elasticsearch/telemetry/metric/LongAsyncCounter.java
@@ -9,8 +9,7 @@
 package org.elasticsearch.telemetry.metric;
 
 /**
- * A monotonically increasing metric that uses a long.  Useful for integral values such as the number of bytes received,
- * number of requests, etc.
+ * A monotonically increasing long metric based on a callback.
  */
 public interface LongAsyncCounter extends Instrument, AutoCloseable {
 

--- a/server/src/main/java/org/elasticsearch/telemetry/metric/MeterRegistry.java
+++ b/server/src/main/java/org/elasticsearch/telemetry/metric/MeterRegistry.java
@@ -96,6 +96,7 @@ public interface MeterRegistry {
      * @param name name of the counter
      * @param description description of purpose
      * @param unit the unit (bytes, sec, hour)
+     * @param observer a callback to provide a metric value upon observation (metric interval)
      */
     LongAsyncCounter registerLongAsyncCounter(String name, String description, String unit, Supplier<LongWithAttributes> observer);
 
@@ -111,6 +112,7 @@ public interface MeterRegistry {
      * @param name name of the counter
      * @param description description of purpose
      * @param unit the unit (bytes, sec, hour)
+     * @param observer a callback to provide a metric value upon observation (metric interval)
      */
     DoubleAsyncCounter registerDoubleAsyncCounter(String name, String description, String unit, Supplier<DoubleWithAttributes> observer);
 

--- a/server/src/main/java/org/elasticsearch/telemetry/metric/MeterRegistry.java
+++ b/server/src/main/java/org/elasticsearch/telemetry/metric/MeterRegistry.java
@@ -92,6 +92,36 @@ public interface MeterRegistry {
     LongCounter registerLongCounter(String name, String description, String unit);
 
     /**
+     * Register a {@link LongAsyncCounter} with an asynchronous callback.  The returned object may be reused.
+     * @param name name of the counter
+     * @param description description of purpose
+     * @param unit the unit (bytes, sec, hour)
+     */
+    LongAsyncCounter registerLongAsyncCounter(String name, String description, String unit, Supplier<LongWithAttributes> observer);
+
+    /**
+     * Retrieved a previously registered {@link LongAsyncCounter}.
+     * @param name name of the counter
+     * @return the registered meter.
+     */
+    LongAsyncCounter getLongAsyncCounter(String name);
+
+    /**
+     * Register a {@link DoubleAsyncCounter} with an asynchronous callback.  The returned object may be reused.
+     * @param name name of the counter
+     * @param description description of purpose
+     * @param unit the unit (bytes, sec, hour)
+     */
+    DoubleAsyncCounter registerDoubleAsyncCounter(String name, String description, String unit, Supplier<DoubleWithAttributes> observer);
+
+    /**
+     * Retrieved a previously registered {@link DoubleAsyncCounter}.
+     * @param name name of the counter
+     * @return the registered meter.
+     */
+    DoubleAsyncCounter getDoubleAsyncCounter(String name);
+
+    /**
      * Retrieved a previously registered {@link LongCounter}.
      * @param name name of the counter
      * @return the registered meter.
@@ -194,6 +224,36 @@ public interface MeterRegistry {
         @Override
         public LongCounter registerLongCounter(String name, String description, String unit) {
             return LongCounter.NOOP;
+        }
+
+        @Override
+        public LongAsyncCounter registerLongAsyncCounter(
+            String name,
+            String description,
+            String unit,
+            Supplier<LongWithAttributes> observer
+        ) {
+            return LongAsyncCounter.NOOP;
+        }
+
+        @Override
+        public LongAsyncCounter getLongAsyncCounter(String name) {
+            return LongAsyncCounter.NOOP;
+        }
+
+        @Override
+        public DoubleAsyncCounter registerDoubleAsyncCounter(
+            String name,
+            String description,
+            String unit,
+            Supplier<DoubleWithAttributes> observer
+        ) {
+            return DoubleAsyncCounter.NOOP;
+        }
+
+        @Override
+        public DoubleAsyncCounter getDoubleAsyncCounter(String name) {
+            return DoubleAsyncCounter.NOOP;
         }
 
         @Override

--- a/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/MetricsApmIT.java
+++ b/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/MetricsApmIT.java
@@ -62,6 +62,8 @@ public class MetricsApmIT extends ESRestTestCase {
             Map.ofEntries(
                 assertion("testDoubleCounter", m -> (Double) m.get("value"), closeTo(1.0, 0.001)),
                 assertion("testLongCounter", m -> (Double) m.get("value"), closeTo(1.0, 0.001)),
+                assertion("testAsyncDoubleCounter", m -> (Double) m.get("value"), closeTo(1.0, 0.001)),
+                assertion("testAsyncLongCounter", m -> (Integer) m.get("value"), equalTo(1)),
                 assertion("testDoubleGauge", m -> (Double) m.get("value"), closeTo(1.0, 0.001)),
                 assertion("testLongGauge", m -> (Integer) m.get("value"), equalTo(1)),
                 assertion(

--- a/test/external-modules/apm-integration/src/main/java/org/elasticsearch/test/apmintegration/TestMeterUsages.java
+++ b/test/external-modules/apm-integration/src/main/java/org/elasticsearch/test/apmintegration/TestMeterUsages.java
@@ -47,7 +47,7 @@ public class TestMeterUsages {
         longHistogram.record(1);
         longHistogram.record(2);
 
-        //triggers gauges and async counters
+        // triggers gauges and async counters
         doubleWithAttributes.set(new DoubleWithAttributes(1.0, Map.of()));
         longWithAttributes.set(new LongWithAttributes(1, Map.of()));
     }

--- a/test/external-modules/apm-integration/src/main/java/org/elasticsearch/test/apmintegration/TestMeterUsages.java
+++ b/test/external-modules/apm-integration/src/main/java/org/elasticsearch/test/apmintegration/TestMeterUsages.java
@@ -34,6 +34,9 @@ public class TestMeterUsages {
         this.longHistogram = meterRegistry.registerLongHistogram("testLongHistogram", "test", "unit");
         meterRegistry.registerDoubleGauge("testDoubleGauge", "test", "unit", doubleWithAttributes::get);
         meterRegistry.registerLongGauge("testLongGauge", "test", "unit", longWithAttributes::get);
+
+        meterRegistry.registerLongAsyncCounter("testAsyncLongCounter", "test", "unit", longWithAttributes::get);
+        meterRegistry.registerDoubleGauge("testAsyncDoubleCounter", "test", "unit", doubleWithAttributes::get);
     }
 
     public void testUponRequest() {
@@ -43,6 +46,8 @@ public class TestMeterUsages {
         doubleHistogram.record(2.0);
         longHistogram.record(1);
         longHistogram.record(2);
+
+        //triggers gauges and async counters
         doubleWithAttributes.set(new DoubleWithAttributes(1.0, Map.of()));
         longWithAttributes.set(new LongWithAttributes(1, Map.of()));
     }

--- a/test/framework/src/main/java/org/elasticsearch/telemetry/InstrumentType.java
+++ b/test/framework/src/main/java/org/elasticsearch/telemetry/InstrumentType.java
@@ -8,11 +8,13 @@
 
 package org.elasticsearch.telemetry;
 
+import org.elasticsearch.telemetry.metric.DoubleAsyncCounter;
 import org.elasticsearch.telemetry.metric.DoubleCounter;
 import org.elasticsearch.telemetry.metric.DoubleGauge;
 import org.elasticsearch.telemetry.metric.DoubleHistogram;
 import org.elasticsearch.telemetry.metric.DoubleUpDownCounter;
 import org.elasticsearch.telemetry.metric.Instrument;
+import org.elasticsearch.telemetry.metric.LongAsyncCounter;
 import org.elasticsearch.telemetry.metric.LongCounter;
 import org.elasticsearch.telemetry.metric.LongGauge;
 import org.elasticsearch.telemetry.metric.LongHistogram;
@@ -27,6 +29,8 @@ import java.util.Objects;
 public enum InstrumentType {
     DOUBLE_COUNTER(true),
     LONG_COUNTER(false),
+    LONG_ASYNC_COUNTER(false),
+    DOUBLE_ASYNC_COUNTER(true),
     DOUBLE_UP_DOWN_COUNTER(true),
     LONG_UP_DOWN_COUNTER(false),
     DOUBLE_HISTOGRAM(true),
@@ -48,6 +52,10 @@ public enum InstrumentType {
             return InstrumentType.DOUBLE_COUNTER;
         } else if (instrument instanceof LongCounter) {
             return InstrumentType.LONG_COUNTER;
+        } else if (instrument instanceof LongAsyncCounter) {
+            return InstrumentType.LONG_ASYNC_COUNTER;
+        } else if (instrument instanceof DoubleAsyncCounter) {
+            return InstrumentType.DOUBLE_ASYNC_COUNTER;
         } else if (instrument instanceof DoubleUpDownCounter) {
             return InstrumentType.DOUBLE_UP_DOWN_COUNTER;
         } else if (instrument instanceof LongUpDownCounter) {

--- a/test/framework/src/main/java/org/elasticsearch/telemetry/RecordingInstruments.java
+++ b/test/framework/src/main/java/org/elasticsearch/telemetry/RecordingInstruments.java
@@ -10,12 +10,14 @@ package org.elasticsearch.telemetry;
 
 import org.elasticsearch.common.util.concurrent.ReleasableLock;
 import org.elasticsearch.core.Tuple;
+import org.elasticsearch.telemetry.metric.DoubleAsyncCounter;
 import org.elasticsearch.telemetry.metric.DoubleCounter;
 import org.elasticsearch.telemetry.metric.DoubleGauge;
 import org.elasticsearch.telemetry.metric.DoubleHistogram;
 import org.elasticsearch.telemetry.metric.DoubleUpDownCounter;
 import org.elasticsearch.telemetry.metric.DoubleWithAttributes;
 import org.elasticsearch.telemetry.metric.Instrument;
+import org.elasticsearch.telemetry.metric.LongAsyncCounter;
 import org.elasticsearch.telemetry.metric.LongCounter;
 import org.elasticsearch.telemetry.metric.LongGauge;
 import org.elasticsearch.telemetry.metric.LongHistogram;
@@ -166,6 +168,28 @@ public class RecordingInstruments {
         public void incrementBy(long inc, Map<String, Object> attributes) {
             call(inc, attributes);
         }
+    }
+
+    public static class RecordingAsyncLongCounter extends CallbackRecordingInstrument implements LongAsyncCounter {
+
+        public RecordingAsyncLongCounter(String name, Supplier<LongWithAttributes> observer, MetricRecorder<Instrument> recorder) {
+            super(name, () -> {
+                var observation = observer.get();
+                return new Tuple<>(observation.value(), observation.attributes());
+            }, recorder);
+        }
+
+    }
+
+    public static class RecordingAsyncDoubleCounter extends CallbackRecordingInstrument implements DoubleAsyncCounter {
+
+        public RecordingAsyncDoubleCounter(String name, Supplier<DoubleWithAttributes> observer, MetricRecorder<Instrument> recorder) {
+            super(name, () -> {
+                var observation = observer.get();
+                return new Tuple<>(observation.value(), observation.attributes());
+            }, recorder);
+        }
+
     }
 
     public static class RecordingLongGauge extends CallbackRecordingInstrument implements LongGauge {

--- a/test/framework/src/main/java/org/elasticsearch/telemetry/RecordingMeterRegistry.java
+++ b/test/framework/src/main/java/org/elasticsearch/telemetry/RecordingMeterRegistry.java
@@ -8,12 +8,14 @@
 
 package org.elasticsearch.telemetry;
 
+import org.elasticsearch.telemetry.metric.DoubleAsyncCounter;
 import org.elasticsearch.telemetry.metric.DoubleCounter;
 import org.elasticsearch.telemetry.metric.DoubleGauge;
 import org.elasticsearch.telemetry.metric.DoubleHistogram;
 import org.elasticsearch.telemetry.metric.DoubleUpDownCounter;
 import org.elasticsearch.telemetry.metric.DoubleWithAttributes;
 import org.elasticsearch.telemetry.metric.Instrument;
+import org.elasticsearch.telemetry.metric.LongAsyncCounter;
 import org.elasticsearch.telemetry.metric.LongCounter;
 import org.elasticsearch.telemetry.metric.LongGauge;
 import org.elasticsearch.telemetry.metric.LongHistogram;
@@ -104,6 +106,36 @@ public class RecordingMeterRegistry implements MeterRegistry {
         LongCounter instrument = buildLongCounter(name, description, unit);
         recorder.register(instrument, InstrumentType.fromInstrument(instrument), name, description, unit);
         return instrument;
+    }
+
+    @Override
+    public LongAsyncCounter registerLongAsyncCounter(String name, String description, String unit, Supplier<LongWithAttributes> observer) {
+        LongAsyncCounter instrument = new RecordingInstruments.RecordingAsyncLongCounter(name, observer, recorder);
+        recorder.register(instrument, InstrumentType.fromInstrument(instrument), name, description, unit);
+        return instrument;
+    }
+
+    @Override
+    public LongAsyncCounter getLongAsyncCounter(String name) {
+        return (LongAsyncCounter) recorder.getInstrument(InstrumentType.LONG_ASYNC_COUNTER, name);
+    }
+
+    @Override
+    public DoubleAsyncCounter registerDoubleAsyncCounter(
+        String name,
+        String description,
+        String unit,
+        Supplier<DoubleWithAttributes> observer
+    ) {
+        DoubleAsyncCounter instrument = new RecordingInstruments.RecordingAsyncDoubleCounter(name, observer, recorder);
+        recorder.register(instrument, InstrumentType.fromInstrument(instrument), name, description, unit);
+        return instrument;
+    }
+
+    @Override
+    public DoubleAsyncCounter getDoubleAsyncCounter(String name) {
+        return (DoubleAsyncCounter) recorder.getInstrument(InstrumentType.DOUBLE_ASYNC_COUNTER, name);
+
     }
 
     @Override


### PR DESCRIPTION
asynchronous counters (available in otel) are instruments which allow to update the counter's value with the callback style api. The callback has to report always the latest value. Upon restart the value might go back to 0, but in the backend apm server will know that since the value is always increasing.