### PR TITLE
[LTR] Better handling of missing parameters.

### DIFF
--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/CustomMustacheFactory.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/CustomMustacheFactory.java
@@ -63,14 +63,10 @@ public final class CustomMustacheFactory extends DefaultMustacheFactory {
 
     private final Encoder encoder;
 
-    public CustomMustacheFactory(String mediaType) {
+    private CustomMustacheFactory(String mediaType, boolean detectMissingParams) {
         super();
-        setObjectHandler(new CustomReflectionObjectHandler());
+        setObjectHandler(new CustomReflectionObjectHandler(detectMissingParams));
         this.encoder = createEncoder(mediaType);
-    }
-
-    public CustomMustacheFactory() {
-        this(DEFAULT_MEDIA_TYPE);
     }
 
     @Override
@@ -95,12 +91,15 @@ public final class CustomMustacheFactory extends DefaultMustacheFactory {
         return new CustomMustacheVisitor(this);
     }
 
+    public static Builder builder() {
+        return new Builder();
+    }
+
     class CustomMustacheVisitor extends DefaultMustacheVisitor {
 
         CustomMustacheVisitor(DefaultMustacheFactory df) {
             super(df);
         }
-
         @Override
         public void iterable(TemplateContext templateContext, String variable, Mustache mustache) {
             if (ToJsonCode.match(variable)) {
@@ -358,6 +357,29 @@ public final class CustomMustacheFactory extends DefaultMustacheFactory {
         @Override
         public void encode(String s, Writer writer) throws IOException {
             writer.write(URLEncoder.encode(s, StandardCharsets.UTF_8));
+        }
+    }
+
+    /**
+     * Build a new {@link CustomMustacheFactory} object.
+     */
+    static class Builder {
+        private String mediaType = DEFAULT_MEDIA_TYPE;
+        private boolean detectMissingParams = false;
+
+        private Builder() {}
+
+        public Builder mediaType(String mediaType) {
+            this.mediaType = mediaType;
+            return this;
+        }
+
+        public Builder detectMissingParams(boolean detectMissingParams) {
+            this.detectMissingParams = detectMissingParams;
+            return this;
+        }
+        public CustomMustacheFactory build() {
+            return new CustomMustacheFactory(mediaType, detectMissingParams);
         }
     }
 }

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/CustomMustacheFactory.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/CustomMustacheFactory.java
@@ -47,6 +47,7 @@ public final class CustomMustacheFactory extends DefaultMustacheFactory {
     static final String X_WWW_FORM_URLENCODED_MEDIA_TYPE = "application/x-www-form-urlencoded";
 
     private static final String DEFAULT_MEDIA_TYPE = JSON_MEDIA_TYPE;
+    private static final boolean DEFAULT_DETECT_MISSING_PARAMS = false;
 
     private static final Map<String, Supplier<Encoder>> ENCODERS = Map.of(
         V7_JSON_MEDIA_TYPE_WITH_CHARSET,
@@ -366,7 +367,7 @@ public final class CustomMustacheFactory extends DefaultMustacheFactory {
      */
     static class Builder {
         private String mediaType = DEFAULT_MEDIA_TYPE;
-        private boolean detectMissingParams = false;
+        private boolean detectMissingParams = DEFAULT_DETECT_MISSING_PARAMS;
 
         private Builder() {}
 

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/CustomMustacheFactory.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/CustomMustacheFactory.java
@@ -100,6 +100,7 @@ public final class CustomMustacheFactory extends DefaultMustacheFactory {
         CustomMustacheVisitor(DefaultMustacheFactory df) {
             super(df);
         }
+
         @Override
         public void iterable(TemplateContext templateContext, String variable, Mustache mustache) {
             if (ToJsonCode.match(variable)) {
@@ -378,6 +379,7 @@ public final class CustomMustacheFactory extends DefaultMustacheFactory {
             this.detectMissingParams = detectMissingParams;
             return this;
         }
+
         public CustomMustacheFactory build() {
             return new CustomMustacheFactory(mediaType, detectMissingParams);
         }

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/CustomMustacheFactory.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/CustomMustacheFactory.java
@@ -64,6 +64,26 @@ public final class CustomMustacheFactory extends DefaultMustacheFactory {
 
     private final Encoder encoder;
 
+    /**
+     * Initializes a CustomMustacheFactory object with a specified mediaType.
+     *
+     * @deprecated Use {@link #builder()} instead to retrieve a {@link Builder} object that can be used to create a factory.
+     */
+    @Deprecated
+    public CustomMustacheFactory(String mediaType) {
+        this(mediaType, DEFAULT_DETECT_MISSING_PARAMS);
+    }
+
+    /**
+     * Default constructor for the factory.
+     *
+     * @deprecated Use {@link #builder()} instead to retrieve a {@link Builder} object that can be used to create a factory.
+     */
+    @Deprecated
+    public CustomMustacheFactory() {
+        this(DEFAULT_MEDIA_TYPE, DEFAULT_DETECT_MISSING_PARAMS);
+    }
+
     private CustomMustacheFactory(String mediaType, boolean detectMissingParams) {
         super();
         setObjectHandler(new CustomReflectionObjectHandler(detectMissingParams));
@@ -365,7 +385,7 @@ public final class CustomMustacheFactory extends DefaultMustacheFactory {
     /**
      * Build a new {@link CustomMustacheFactory} object.
      */
-    static class Builder {
+    public static class Builder {
         private String mediaType = DEFAULT_MEDIA_TYPE;
         private boolean detectMissingParams = DEFAULT_DETECT_MISSING_PARAMS;
 
@@ -376,6 +396,12 @@ public final class CustomMustacheFactory extends DefaultMustacheFactory {
             return this;
         }
 
+        /**
+         * Sets the behavior for handling missing parameters during template execution.
+         *
+         * @param detectMissingParams If true, an exception is thrown when executing the template with missing parameters.
+         *                            If false, the template gracefully handles missing parameters without throwing an exception.
+         */
         public Builder detectMissingParams(boolean detectMissingParams) {
             this.detectMissingParams = detectMissingParams;
             return this;

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/CustomReflectionObjectHandler.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/CustomReflectionObjectHandler.java
@@ -60,23 +60,6 @@ final class CustomReflectionObjectHandler extends ReflectionObjectHandler {
         return detectMissingParams ? new DetectMissingParamsGuardedBinding(this, name, tc, code) : super.createBinding(name, tc, code);
     }
 
-    static class DetectMissingParamsGuardedBinding extends GuardedBinding {
-        private final Code code;
-
-        DetectMissingParamsGuardedBinding(ObjectHandler oh, String name, TemplateContext tc, Code code) {
-            super(oh, name, tc, code);
-            this.code = code;
-        }
-
-        protected synchronized Wrapper getWrapper(String name, List<Object> scopes) {
-            Wrapper wrapper = super.getWrapper(name, scopes);
-            if (wrapper instanceof MissingWrapper && code instanceof ValueCode) {
-                throw new MustacheScriptEngine.InvalidParameterException("Parameter [" + name + "] is missing");
-            }
-            return wrapper;
-        }
-    }
-
     @Override
     @SuppressWarnings("rawtypes")
     protected AccessibleObject findMember(Class sClass, String name) {
@@ -93,6 +76,23 @@ final class CustomReflectionObjectHandler extends ReflectionObjectHandler {
          * "you will never find success going down this path, so don't bother trying"
          */
         return null;
+    }
+
+    static class DetectMissingParamsGuardedBinding extends GuardedBinding {
+        private final Code code;
+
+        DetectMissingParamsGuardedBinding(ObjectHandler oh, String name, TemplateContext tc, Code code) {
+            super(oh, name, tc, code);
+            this.code = code;
+        }
+
+        protected synchronized Wrapper getWrapper(String name, List<Object> scopes) {
+            Wrapper wrapper = super.getWrapper(name, scopes);
+            if (wrapper instanceof MissingWrapper && code instanceof ValueCode) {
+                throw new MustacheInvalidParameterException("Parameter [" + name + "] is missing");
+            }
+            return wrapper;
+        }
     }
 
     static final class ArrayMap extends AbstractMap<Object, Object> implements Iterable<Object> {

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/CustomReflectionObjectHandler.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/CustomReflectionObjectHandler.java
@@ -62,10 +62,12 @@ final class CustomReflectionObjectHandler extends ReflectionObjectHandler {
 
     static class DetectMissingParamsGuardedBinding extends GuardedBinding {
         private final Code code;
+
         DetectMissingParamsGuardedBinding(ObjectHandler oh, String name, TemplateContext tc, Code code) {
             super(oh, name, tc, code);
             this.code = code;
         }
+
         protected synchronized Wrapper getWrapper(String name, List<Object> scopes) {
             Wrapper wrapper = super.getWrapper(name, scopes);
             if (wrapper instanceof MissingWrapper && code instanceof ValueCode) {

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/CustomReflectionObjectHandler.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/CustomReflectionObjectHandler.java
@@ -49,6 +49,7 @@ final class CustomReflectionObjectHandler extends ReflectionObjectHandler {
         }
     }
 
+    @Override
     public Wrapper find(String name, List<Object> scopes) {
         Wrapper wrapper = super.find(name, scopes);
 

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/CustomReflectionObjectHandler.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/CustomReflectionObjectHandler.java
@@ -8,7 +8,9 @@
 
 package org.elasticsearch.script.mustache;
 
+import com.github.mustachejava.reflect.MissingWrapper;
 import com.github.mustachejava.reflect.ReflectionObjectHandler;
+import com.github.mustachejava.util.Wrapper;
 
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.util.Maps;
@@ -19,10 +21,16 @@ import java.lang.reflect.Array;
 import java.util.AbstractMap;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 final class CustomReflectionObjectHandler extends ReflectionObjectHandler {
+    private final boolean detectMissingParams;
+
+    CustomReflectionObjectHandler(boolean detectMissingParams) {
+        this.detectMissingParams = detectMissingParams;
+    }
 
     @Override
     public Object coerce(Object object) {
@@ -39,6 +47,16 @@ final class CustomReflectionObjectHandler extends ReflectionObjectHandler {
         } else {
             return super.coerce(object);
         }
+    }
+
+    public Wrapper find(String name, List<Object> scopes) {
+        Wrapper wrapper = super.find(name, scopes);
+
+        if (detectMissingParams && wrapper instanceof MissingWrapper) {
+            throw new MustacheScriptEngine.InvalidParameterException("Parameter [" + name + "] is missing");
+        }
+
+        return wrapper;
     }
 
     @Override

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MustacheInvalidParameterException.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MustacheInvalidParameterException.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.script.mustache;
+
+import com.github.mustachejava.MustacheException;
+
+public class MustacheInvalidParameterException extends MustacheException {
+    MustacheInvalidParameterException(String message) {
+        super(message, null, null);
+    }
+}

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MustacheScriptEngine.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MustacheScriptEngine.java
@@ -117,7 +117,7 @@ public final class MustacheScriptEngine implements ScriptEngine {
             try {
                 template.execute(writer, params);
             } catch (Exception e) {
-                if (logException(e)) {
+                if (shouldLogException(e)) {
                     logger.error(() -> format("Error running %s", template), e);
                 }
                 throw new GeneralScriptException("Error running " + template, e);
@@ -125,11 +125,11 @@ public final class MustacheScriptEngine implements ScriptEngine {
             return writer.toString();
         }
 
-        public boolean logException(Throwable e) {
+        public boolean shouldLogException(Throwable e) {
             if (e instanceof InvalidParameterException) {
                 return false;
             }
-            return e.getCause() == null || logException(e.getCause());
+            return e.getCause() == null || shouldLogException(e.getCause());
         }
     }
 

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MustacheScriptEngine.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MustacheScriptEngine.java
@@ -38,6 +38,10 @@ import static org.elasticsearch.core.Strings.format;
  * {@link Mustache} object can then be re-used for subsequent executions.
  */
 public final class MustacheScriptEngine implements ScriptEngine {
+    /**
+     * Compiler option to enable detection of missing parameters.
+     */
+    public static final String DETECT_MISSING_PARAMS_OPTION = "detect_missing_params";
     private static final Logger logger = LogManager.getLogger(MustacheScriptEngine.class);
 
     public static final String NAME = "mustache";
@@ -81,8 +85,8 @@ public final class MustacheScriptEngine implements ScriptEngine {
             builder.mediaType(options.get(Script.CONTENT_TYPE_OPTION));
         }
 
-        if (options.containsKey(Script.DETECT_MISSING_PARAMS_OPTION)) {
-            builder.detectMissingParams(Boolean.valueOf(options.get(Script.DETECT_MISSING_PARAMS_OPTION)));
+        if (options.containsKey(DETECT_MISSING_PARAMS_OPTION)) {
+            builder.detectMissingParams(Boolean.valueOf(options.get(DETECT_MISSING_PARAMS_OPTION)));
         }
 
         return builder.build();
@@ -126,13 +130,8 @@ public final class MustacheScriptEngine implements ScriptEngine {
         }
 
         public boolean shouldLogException(Throwable e) {
-            return e.getCause() != null && e.getCause() instanceof InvalidParameterException == false;
+            return e.getCause() != null && e.getCause() instanceof MustacheInvalidParameterException == false;
         }
     }
 
-    static class InvalidParameterException extends MustacheException {
-        InvalidParameterException(String message) {
-            super(message, null, null);
-        }
-    }
 }

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MustacheScriptEngine.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MustacheScriptEngine.java
@@ -126,10 +126,7 @@ public final class MustacheScriptEngine implements ScriptEngine {
         }
 
         public boolean shouldLogException(Throwable e) {
-            if (e instanceof InvalidParameterException) {
-                return false;
-            }
-            return e.getCause() == null || shouldLogException(e.getCause());
+            return e.getCause() != null && e.getCause() instanceof InvalidParameterException == false;
         }
     }
 

--- a/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/MustacheScriptEngineTests.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/MustacheScriptEngineTests.java
@@ -200,8 +200,8 @@ public class MustacheScriptEngineTests extends ESTestCase {
         assertThat(TemplateScript.execute(), equalTo("{\"match_all\":{}}"));
     }
 
-    public void testDetectMissingParam() throws IOException {
-        Map<String, String> scriptOptions = Map.ofEntries(Map.entry(Script.DETECT_MISSING_PARAMS_OPTION, "true"));
+    public void testDetectMissingParam() {
+        Map<String, String> scriptOptions = Map.ofEntries(Map.entry(MustacheScriptEngine.DETECT_MISSING_PARAMS_OPTION, "true"));
 
         // fails when a param is missing and the DETECT_MISSING_PARAMS_OPTION option is set to true.
         {
@@ -209,7 +209,7 @@ public class MustacheScriptEngineTests extends ESTestCase {
             TemplateScript.Factory compiled = qe.compile(null, source, TemplateScript.CONTEXT, scriptOptions);
             Map<String, Object> params = Collections.emptyMap();
             GeneralScriptException e = expectThrows(GeneralScriptException.class, () -> compiled.newInstance(params).execute());
-            assertThat(e.getRootCause(), instanceOf(MustacheScriptEngine.InvalidParameterException.class));
+            assertThat(e.getRootCause(), instanceOf(MustacheInvalidParameterException.class));
             assertThat(e.getRootCause().getMessage(), startsWith("Parameter [query_string] is missing"));
         }
 
@@ -218,7 +218,7 @@ public class MustacheScriptEngineTests extends ESTestCase {
             String source = "{\"match\": { \"field\": \"{{query_string}}\" }";
             TemplateScript.Factory compiled = qe.compile(null, source, TemplateScript.CONTEXT, scriptOptions);
             GeneralScriptException e = expectThrows(GeneralScriptException.class, () -> compiled.newInstance(null).execute());
-            assertThat(e.getRootCause(), instanceOf(MustacheScriptEngine.InvalidParameterException.class));
+            assertThat(e.getRootCause(), instanceOf(MustacheInvalidParameterException.class));
             assertThat(e.getRootCause().getMessage(), startsWith("Parameter [query_string] is missing"));
         }
 
@@ -239,7 +239,7 @@ public class MustacheScriptEngineTests extends ESTestCase {
         }
     }
 
-    public void testMissingParam() throws IOException {
+    public void testMissingParam() {
         Map<String, String> scriptOptions = Collections.emptyMap();
         String source = "{\"match\": { \"field\": \"{{query_string}}\" }";
         TemplateScript.Factory compiled = qe.compile(null, source, TemplateScript.CONTEXT, scriptOptions);

--- a/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/MustacheScriptEngineTests.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/MustacheScriptEngineTests.java
@@ -227,6 +227,16 @@ public class MustacheScriptEngineTests extends ESTestCase {
         }
     }
 
+    public void testMissingParam() throws IOException {
+        Map<String, String> scriptOptions = Collections.emptyMap();
+        String source = "{\"match\": { \"field\": \"{{query_string}}\" }";
+        TemplateScript.Factory compiled = qe.compile(null, source, TemplateScript.CONTEXT, scriptOptions);
+
+        // When the DETECT_MISSING_PARAMS_OPTION is not specified, missing variable is replaced with an empty string.
+        assertThat(compiled.newInstance(Collections.emptyMap()).execute(), equalTo("{\"match\": { \"field\": \"\" }"));
+        assertThat(compiled.newInstance(null).execute(), equalTo("{\"match\": { \"field\": \"\" }"));
+    }
+
     public void testParseTemplateAsSingleStringWithConditionalClause() throws IOException {
         String templateString = """
             {

--- a/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/MustacheScriptEngineTests.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/MustacheScriptEngineTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.script.mustache;
 
 import com.github.mustachejava.MustacheFactory;
 
+import org.elasticsearch.script.GeneralScriptException;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.TemplateScript;
 import org.elasticsearch.test.ESTestCase;
@@ -18,10 +19,13 @@ import org.junit.Before;
 
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.startsWith;
 
 /**
  * Mustache based templating test
@@ -33,7 +37,7 @@ public class MustacheScriptEngineTests extends ESTestCase {
     @Before
     public void setup() {
         qe = new MustacheScriptEngine();
-        factory = new CustomMustacheFactory();
+        factory = CustomMustacheFactory.builder().build();
     }
 
     public void testSimpleParameterReplace() {
@@ -194,6 +198,33 @@ public class MustacheScriptEngineTests extends ESTestCase {
         TemplateScript.Factory compiled = qe.compile(null, script.getIdOrCode(), TemplateScript.CONTEXT, Map.of());
         TemplateScript TemplateScript = compiled.newInstance(script.getParams());
         assertThat(TemplateScript.execute(), equalTo("{\"match_all\":{}}"));
+    }
+
+    public void testDetectMissingParam() throws IOException {
+        Map<String, String> scriptOptions = Map.ofEntries(Map.entry(Script.DETECT_MISSING_PARAMS_OPTION, "true"));
+        String source = "{\"match\": { \"field\": \"{{query_string}}\" }";
+        TemplateScript.Factory compiled = qe.compile(null, source, TemplateScript.CONTEXT, scriptOptions);
+
+        // fails when a param is missing and the DETECT_MISSING_PARAMS_OPTION option is set to true.
+        {
+            Map<String, Object> params = Collections.emptyMap();
+            GeneralScriptException e = expectThrows(GeneralScriptException.class, () -> compiled.newInstance(params).execute());
+            assertThat(e.getRootCause(), instanceOf(MustacheScriptEngine.InvalidParameterException.class));
+            assertThat(e.getRootCause().getMessage(), startsWith("Parameter [query_string] is missing"));
+        }
+
+        // fails when params is null and the DETECT_MISSING_PARAMS_OPTION option is set to true.
+        {
+            GeneralScriptException e = expectThrows(GeneralScriptException.class, () -> compiled.newInstance(null).execute());
+            assertThat(e.getRootCause(), instanceOf(MustacheScriptEngine.InvalidParameterException.class));
+            assertThat(e.getRootCause().getMessage(), startsWith("Parameter [query_string] is missing"));
+        }
+
+        // works as expected when params are specified and the DETECT_MISSING_PARAMS_OPTION option is set to true
+        {
+            Map<String, Object> params = Map.ofEntries(Map.entry("query_string", "foo"));
+            assertThat(compiled.newInstance(params).execute(), equalTo("{\"match\": { \"field\": \"foo\" }"));
+        }
     }
 
     public void testParseTemplateAsSingleStringWithConditionalClause() throws IOException {

--- a/server/src/main/java/org/elasticsearch/script/Script.java
+++ b/server/src/main/java/org/elasticsearch/script/Script.java
@@ -95,11 +95,6 @@ public final class Script implements ToXContentObject, Writeable {
     public static final String CONTENT_TYPE_OPTION = "content_type";
 
     /**
-     * Compiler option to enable missing parameters detection.
-     */
-    public static final String DETECT_MISSING_PARAMS_OPTION = "detect_missing_params";
-
-    /**
      * Standard {@link ParseField} for outer level of script queries.
      */
     public static final ParseField SCRIPT_PARSE_FIELD = new ParseField("script");

--- a/server/src/main/java/org/elasticsearch/script/Script.java
+++ b/server/src/main/java/org/elasticsearch/script/Script.java
@@ -95,6 +95,11 @@ public final class Script implements ToXContentObject, Writeable {
     public static final String CONTENT_TYPE_OPTION = "content_type";
 
     /**
+     * Compiler option to enable missing parameters detection.
+     */
+    public static final String DETECT_MISSING_PARAMS_OPTION = "detect_missing_params";
+
+    /**
      * Standard {@link ParseField} for outer level of script queries.
      */
     public static final ParseField SCRIPT_PARSE_FIELD = new ParseField("script");

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/LearnToRankConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/LearnToRankConfig.java
@@ -18,7 +18,6 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.ml.MlConfigVersion;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ltr.LearnToRankFeatureExtractorBuilder;
-import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ltr.QueryExtractorBuilder;
 import org.elasticsearch.xpack.core.ml.utils.NamedXContentObjectHelper;
 
 import java.io.IOException;
@@ -92,18 +91,6 @@ public class LearnToRankConfig extends RegressionConfig implements Rewriteable<L
     public List<LearnToRankFeatureExtractorBuilder> getFeatureExtractorBuilders() {
         return featureExtractorBuilders;
     }
-
-    public List<QueryExtractorBuilder> getQueryFeatureExtractorBuilders() {
-        List<QueryExtractorBuilder> queryExtractorBuilders = new ArrayList<>();
-        for (LearnToRankFeatureExtractorBuilder featureExtractorBuilder : getFeatureExtractorBuilders()) {
-            if (featureExtractorBuilder instanceof QueryExtractorBuilder queryExtractorBuilder) {
-                queryExtractorBuilders.add(queryExtractorBuilder);
-            }
-        }
-
-        return queryExtractorBuilders;
-    }
-
 
     @Override
     public String getResultsField() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/LearnToRankConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/LearnToRankConfig.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel;
 
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.query.QueryRewriteContext;
@@ -17,6 +18,7 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.ml.MlConfigVersion;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ltr.LearnToRankFeatureExtractorBuilder;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ltr.QueryExtractorBuilder;
 import org.elasticsearch.xpack.core.ml.utils.NamedXContentObjectHelper;
 
 import java.io.IOException;
@@ -91,6 +93,18 @@ public class LearnToRankConfig extends RegressionConfig implements Rewriteable<L
         return featureExtractorBuilders;
     }
 
+    public List<QueryExtractorBuilder> getQueryFeatureExtractorBuilders() {
+        List<QueryExtractorBuilder> queryExtractorBuilders = new ArrayList<>();
+        for (LearnToRankFeatureExtractorBuilder featureExtractorBuilder : getFeatureExtractorBuilders()) {
+            if (featureExtractorBuilder instanceof QueryExtractorBuilder queryExtractorBuilder) {
+                queryExtractorBuilders.add(queryExtractorBuilder);
+            }
+        }
+
+        return queryExtractorBuilders;
+    }
+
+
     @Override
     public String getResultsField() {
         return DEFAULT_RESULTS_FIELD;
@@ -161,6 +175,11 @@ public class LearnToRankConfig extends RegressionConfig implements Rewriteable<L
     @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(), featureExtractorBuilders);
+    }
+
+    @Override
+    public final String toString() {
+        return Strings.toString(this);
     }
 
     @Override

--- a/x-pack/plugin/ml/build.gradle
+++ b/x-pack/plugin/ml/build.gradle
@@ -1,4 +1,5 @@
 import org.elasticsearch.gradle.VersionProperties
+import org.elasticsearch.gradle.internal.dra.DraResolvePlugin
 
 apply plugin: 'elasticsearch.internal-es-plugin'
 apply plugin: 'elasticsearch.internal-cluster-test'
@@ -72,7 +73,6 @@ esplugin.bundleSpec.exclude 'platform/licenses/**'
 }
 
 dependencies {
-  compileOnly project(':modules:lang-mustache')
   compileOnly project(':modules:lang-painless:spi')
   compileOnly project(path: xpackModule('core'))
   compileOnly project(path: xpackModule('autoscaling'))
@@ -92,6 +92,7 @@ dependencies {
   testImplementation project(path: xpackModule('wildcard'))
   // ml deps
   api project(':libs:elasticsearch-grok')
+  api project(':modules:lang-mustache')
   api "org.apache.commons:commons-math3:3.6.1"
   api "com.ibm.icu:icu4j:${versions.icu4j}"
   api "org.apache.lucene:lucene-analysis-icu:${versions.lucene}"

--- a/x-pack/plugin/ml/build.gradle
+++ b/x-pack/plugin/ml/build.gradle
@@ -1,5 +1,4 @@
 import org.elasticsearch.gradle.VersionProperties
-import org.elasticsearch.gradle.internal.dra.DraResolvePlugin
 
 apply plugin: 'elasticsearch.internal-es-plugin'
 apply plugin: 'elasticsearch.internal-cluster-test'
@@ -73,6 +72,7 @@ esplugin.bundleSpec.exclude 'platform/licenses/**'
 }
 
 dependencies {
+  compileOnly project(':modules:lang-mustache')
   compileOnly project(':modules:lang-painless:spi')
   compileOnly project(path: xpackModule('core'))
   compileOnly project(path: xpackModule('autoscaling'))

--- a/x-pack/plugin/ml/qa/basic-multi-node/build.gradle
+++ b/x-pack/plugin/ml/qa/basic-multi-node/build.gradle
@@ -3,6 +3,10 @@ import org.elasticsearch.gradle.internal.info.BuildParams
 
 apply plugin: 'elasticsearch.legacy-java-rest-test'
 
+dependencies {
+  javaRestTestImplementation(project(':modules:lang-mustache'))
+}
+
 testClusters.configureEach {
   testDistribution = 'DEFAULT'
   numberOfNodes = 3

--- a/x-pack/plugin/ml/qa/disabled/build.gradle
+++ b/x-pack/plugin/ml/qa/disabled/build.gradle
@@ -2,10 +2,9 @@ import org.elasticsearch.gradle.internal.info.BuildParams
 
 apply plugin: 'elasticsearch.legacy-java-rest-test'
 
-//dependencies {
-//  testImplementation project(":x-pack:plugin:core")
-//  testImplementation project(path: xpackModule('ml'))
-//}
+dependencies {
+  javaRestTestImplementation(project(':modules:lang-mustache'))
+}
 
 testClusters.configureEach {
   testDistribution = 'DEFAULT'

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/build.gradle
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/build.gradle
@@ -1,4 +1,3 @@
-import org.elasticsearch.gradle.internal.info.BuildParams
 apply plugin: 'elasticsearch.legacy-java-rest-test'
 
 dependencies {
@@ -6,6 +5,7 @@ dependencies {
   javaRestTestImplementation(testArtifact(project(xpackModule('ml'))))
   javaRestTestImplementation(testArtifact(project(xpackModule('security'))))
   javaRestTestImplementation project(path: ':modules:ingest-common')
+  javaRestTestImplementation(project(':modules:lang-mustache'))
   javaRestTestImplementation project(path: ':modules:reindex')
   javaRestTestImplementation project(path: ':modules:transport-netty4')
   javaRestTestImplementation project(path: xpackModule('autoscaling'))

--- a/x-pack/plugin/ml/qa/single-node-tests/build.gradle
+++ b/x-pack/plugin/ml/qa/single-node-tests/build.gradle
@@ -2,6 +2,10 @@ import org.elasticsearch.gradle.internal.info.BuildParams
 
 apply plugin: 'elasticsearch.legacy-java-rest-test'
 
+dependencies {
+  javaRestTestImplementation(project(':modules:lang-mustache'))
+}
+
 testClusters.configureEach {
   testDistribution = 'DEFAULT'
   setting 'xpack.security.enabled', 'false'

--- a/x-pack/plugin/ml/src/main/java/module-info.java
+++ b/x-pack/plugin/ml/src/main/java/module-info.java
@@ -17,6 +17,7 @@ module org.elasticsearch.ml {
     requires org.elasticsearch.grok;
     requires org.elasticsearch.server;
     requires org.elasticsearch.xcontent;
+    requires org.elasticsearch.mustache;
     requires org.apache.httpcomponents.httpcore;
     requires org.apache.httpcomponents.httpclient;
     requires org.apache.httpcomponents.httpasyncclient;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ltr/LearnToRankService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ltr/LearnToRankService.java
@@ -189,14 +189,14 @@ public class LearnToRankService {
                 QueryProvider.fromXContent(parser, false, INFERENCE_CONFIG_QUERY_BAD_FORMAT)
             );
         } catch (GeneralScriptException e) {
-            if (e.getRootCause() instanceof MustacheInvalidParameterException == false) {
-                throw e;
+            if (e.getRootCause().getClass().getName().equals(MustacheInvalidParameterException.class.getName())) {
+                // Can't use instanceof since it return unexpected result.
+                return new QueryExtractorBuilder(
+                    queryExtractorBuilder.featureName(),
+                    QueryProvider.fromParsedQuery(new MatchNoneQueryBuilder())
+                );
             }
-
-            return new QueryExtractorBuilder(
-                queryExtractorBuilder.featureName(),
-                QueryProvider.fromParsedQuery(new MatchNoneQueryBuilder())
-            );
+            throw e;
         }
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ltr/LearnToRankService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ltr/LearnToRankService.java
@@ -15,6 +15,8 @@ import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.script.TemplateScript;
+import org.elasticsearch.script.mustache.MustacheInvalidParameterException;
+import org.elasticsearch.script.mustache.MustacheScriptEngine;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
@@ -46,7 +48,7 @@ import static org.elasticsearch.xpack.core.ml.job.messages.Messages.INFERENCE_CO
 
 public class LearnToRankService {
     private static final Map<String, String> SCRIPT_OPTIONS = Map.ofEntries(
-        entry(Script.DETECT_MISSING_PARAMS_OPTION, Boolean.TRUE.toString())
+        entry(MustacheScriptEngine.DETECT_MISSING_PARAMS_OPTION, Boolean.TRUE.toString())
     );
     private final ModelLoadingService modelLoadingService;
     private final TrainedModelProvider trainedModelProvider;
@@ -187,6 +189,10 @@ public class LearnToRankService {
                 QueryProvider.fromXContent(parser, false, INFERENCE_CONFIG_QUERY_BAD_FORMAT)
             );
         } catch (GeneralScriptException e) {
+            if (e.getRootCause() instanceof MustacheInvalidParameterException == false) {
+                throw(e);
+            }
+
             return new QueryExtractorBuilder(
                 queryExtractorBuilder.featureName(),
                 QueryProvider.fromParsedQuery(new MatchNoneQueryBuilder())

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ltr/LearnToRankService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ltr/LearnToRankService.java
@@ -190,7 +190,7 @@ public class LearnToRankService {
             );
         } catch (GeneralScriptException e) {
             if (e.getRootCause() instanceof MustacheInvalidParameterException == false) {
-                throw(e);
+                throw e;
             }
 
             return new QueryExtractorBuilder(

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ltr/LearnToRankService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ltr/LearnToRankService.java
@@ -126,11 +126,6 @@ public class LearnToRankService {
             return config;
         }
 
-        if (params == null || params.isEmpty()) {
-            // TODO: better handling of missing parameters.
-            return config;
-        }
-
         List<LearnToRankFeatureExtractorBuilder> featureExtractorBuilders = new ArrayList<>();
 
         for (LearnToRankFeatureExtractorBuilder featureExtractorBuilder : config.getFeatureExtractorBuilders()) {
@@ -178,6 +173,8 @@ public class LearnToRankService {
 
         Script script = new Script(ScriptType.INLINE, DEFAULT_TEMPLATE_LANG, templateSource, Collections.emptyMap());
         String parsedTemplate = scriptService.compile(script, TemplateScript.CONTEXT).newInstance(params).execute();
+        System.out.println(templateSource);
+        System.out.println(parsedTemplate);
         // TODO: handle missing params.
         XContentParser parser = XContentType.JSON.xContent().createParser(parserConfiguration, parsedTemplate);
 


### PR DESCRIPTION
### Description 

Currently, params are are replaced by an empty string in query feature extractors when they are missing.

Example: `{ "match": { "field" : "{{param_value}}"}` will be rewritten into `{ "match": { "field" : ""}`

Instead we want the query to always return `0` for the feature (ultimately feature are casted to double, so `0` makes sense). So we would like the query to be rewritten into a `match_none` query.

### Example:

The following config:

```
"learn_to_rank": {
  "feature_extractors": [
    { "query_extractor": { "feature_name": "product_match", "query": {  "match": { "title" : "{{fulltext_search}}" } } } },
    { "query_extractor": { "feature_name": "product_match", "query": {  "term": { "category" : "{{category_id}}" } } } }
  ]
}
```

will be executed as 

```
"learn_to_rank": {
  "feature_extractors": [
    { "query_extractor": { "feature_name": "product_match", "query": {  "match": { "title" : "a super search" } } } },
    { "query_extractor": { "feature_name": "product_match", "query": {  "match_none" : {} } }
  ]
}
```

when called using the following rescorer call:

```
{
  "rescorer" : {
    "model_id" : "my-model",
    "params" : {
      "fulltext_search": "a super search"
    }
  }
}
```

### Implementation detail:

To implement the feature a new `DETECT_MISSING_PARAMS_OPTION` option has been added to compile a mustache script directly into the `MustacheScriptEngine`.


### Example usage:

```
    Map<String, String> SCRIPT_OPTIONS = Map.ofEntries(
        entry(Script.DETECT_MISSING_PARAMS_OPTION, Boolean.TRUE.toString())
    );
    new Script(ScriptType.INLINE, DEFAULT_TEMPLATE_LANG, templateSource, SCRIPT_OPTIONS, Collections.emptyMap());
    String parsedTemplate = scriptService.compile(script, TemplateScript.CONTEXT).newInstance(params).execute();
```

When this options is used an exception is raised when calling `execute` if one of the param present into the template is missing. The option is disabled by default, so the behavior of the `MustacheScriptEngine` is backward compatible.



