### PR TITLE
[Transform] Consider search context missing exceptions as recoverable

### DIFF
--- a/docs/changelog/102602.yaml
+++ b/docs/changelog/102602.yaml
@@ -1,0 +1,5 @@
+pr: 102602
+summary: Consider search context missing exceptions as recoverable
+area: Transform
+type: bug
+issues: []

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/utils/ExceptionRootCauseFinder.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/utils/ExceptionRootCauseFinder.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.transform.utils;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.search.SearchContextMissingException;
 import org.elasticsearch.tasks.TaskCancelledException;
 
 import java.util.Collection;
@@ -80,6 +81,10 @@ public final class ExceptionRootCauseFinder {
             // A TaskCancelledException occurs if a sub-action of a search encounters a circuit
             // breaker exception. In this case the overall search task is cancelled.
             if (elasticsearchException instanceof TaskCancelledException) {
+                return false;
+            }
+            // We can safely retry SearchContextMissingException instead of failing the transform.
+            if (elasticsearchException instanceof SearchContextMissingException) {
                 return false;
             }
             return true;

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/utils/ExceptionRootCauseFinderTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/utils/ExceptionRootCauseFinderTests.java
@@ -21,6 +21,8 @@ import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.translog.TranslogException;
 import org.elasticsearch.indices.IndexClosedException;
 import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.search.SearchContextMissingException;
+import org.elasticsearch.search.internal.ShardSearchContextId;
 import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentLocation;
@@ -160,6 +162,11 @@ public class ExceptionRootCauseFinderTests extends ESTestCase {
         assertFalse(ExceptionRootCauseFinder.isExceptionIrrecoverable(new TaskCancelledException("cancelled task")));
         assertFalse(
             ExceptionRootCauseFinder.isExceptionIrrecoverable(
+                new SearchContextMissingException(new ShardSearchContextId("session-id", 123, null))
+            )
+        );
+        assertFalse(
+            ExceptionRootCauseFinder.isExceptionIrrecoverable(
                 new CircuitBreakingException("circuit broken", CircuitBreaker.Durability.TRANSIENT)
             )
         );
@@ -175,5 +182,4 @@ public class ExceptionRootCauseFinderTests extends ESTestCase {
         assertEquals(t.getClass(), expectedClass);
         assertEquals(t.getMessage(), message);
     }
-
 }


### PR DESCRIPTION
A search context missing exception has REST status 404 (not found), which makes it irrecoverable as far as transforms is concerned. This means that a transform that suffers such an exception will fail without doing any retries.

This PR makes this exception type retryable so that we do not give up prematurely by looking at the REST status (404) only.