### PR TITLE
[8.11] Synchronize Coordinator#onClusterStateApplied (#100986)

### DIFF
--- a/docs/changelog/100986.yaml
+++ b/docs/changelog/100986.yaml
@@ -1,0 +1,6 @@
+pr: 100986
+summary: Synchronize Coordinator#onClusterStateApplied
+area: Cluster Coordination
+type: bug
+issues:
+ - 99023

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -414,10 +414,12 @@ public class Coordinator extends AbstractLifecycleComponent implements ClusterSt
 
     private void onClusterStateApplied() {
         assert ThreadPool.assertCurrentThreadPool(ClusterApplierService.CLUSTER_UPDATE_THREAD_NAME);
-        if (getMode() != Mode.CANDIDATE) {
-            joinHelper.onClusterStateApplied();
-            closeElectionScheduler();
-            peerFinder.closePeers();
+        synchronized (mutex) {
+            if (mode != Mode.CANDIDATE) {
+                joinHelper.onClusterStateApplied();
+                closeElectionScheduler();
+                peerFinder.closePeers();
+            }
         }
         if (getLocalNode().isMasterNode()) {
             joinReasonService.onClusterStateApplied(applierState.nodes());


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Synchronize Coordinator#onClusterStateApplied (#100986)