### PR TITLE
Fix ref counts for MultiSearchResponse not released in tests

### DIFF
--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
@@ -1846,10 +1846,14 @@ public class DataStreamIT extends ESIntegTestCase {
             String expectedErrorMessage = "no such index [" + dataStream + "]";
             if (requestBuilder instanceof MultiSearchRequestBuilder) {
                 MultiSearchResponse multiSearchResponse = ((MultiSearchRequestBuilder) requestBuilder).get();
-                assertThat(multiSearchResponse.getResponses().length, equalTo(1));
-                assertThat(multiSearchResponse.getResponses()[0].isFailure(), is(true));
-                assertThat(multiSearchResponse.getResponses()[0].getFailure(), instanceOf(IllegalArgumentException.class));
-                assertThat(multiSearchResponse.getResponses()[0].getFailure().getMessage(), equalTo(expectedErrorMessage));
+                try {
+                    assertThat(multiSearchResponse.getResponses().length, equalTo(1));
+                    assertThat(multiSearchResponse.getResponses()[0].isFailure(), is(true));
+                    assertThat(multiSearchResponse.getResponses()[0].getFailure(), instanceOf(IllegalArgumentException.class));
+                    assertThat(multiSearchResponse.getResponses()[0].getFailure().getMessage(), equalTo(expectedErrorMessage));
+                } finally {
+                    multiSearchResponse.decRef();
+                }
             } else if (requestBuilder instanceof ValidateQueryRequestBuilder) {
                 Exception e = expectThrows(IndexNotFoundException.class, requestBuilder::get);
                 assertThat(e.getMessage(), equalTo(expectedErrorMessage));
@@ -1862,7 +1866,11 @@ public class DataStreamIT extends ESIntegTestCase {
                 assertHitCount(searchRequestBuilder, expectedCount);
             } else if (requestBuilder instanceof MultiSearchRequestBuilder) {
                 MultiSearchResponse multiSearchResponse = ((MultiSearchRequestBuilder) requestBuilder).get();
-                assertThat(multiSearchResponse.getResponses()[0].isFailure(), is(false));
+                try {
+                    assertThat(multiSearchResponse.getResponses()[0].isFailure(), is(false));
+                } finally {
+                    multiSearchResponse.decRef();
+                }
             } else {
                 requestBuilder.get();
             }

--- a/modules/percolator/src/internalClusterTest/java/org/elasticsearch/percolator/PercolatorQuerySearchIT.java
+++ b/modules/percolator/src/internalClusterTest/java/org/elasticsearch/percolator/PercolatorQuerySearchIT.java
@@ -1094,7 +1094,7 @@ public class PercolatorQuerySearchIT extends ESIntegTestCase {
         prepareIndex("test").setId("5").setSource(jsonBuilder().startObject().field("field1", "c").endObject()).get();
         indicesAdmin().prepareRefresh().get();
 
-        MultiSearchResponse response = client().prepareMultiSearch()
+        final MultiSearchResponse response = client().prepareMultiSearch()
             .add(
                 prepareSearch("test").setQuery(
                     new PercolateQueryBuilder(
@@ -1137,36 +1137,40 @@ public class PercolatorQuerySearchIT extends ESIntegTestCase {
                     .setQuery(new PercolateQueryBuilder("query", "test", "6", null, null, null))
             )
             .get();
+        try {
 
-        MultiSearchResponse.Item item = response.getResponses()[0];
-        assertHitCount(item.getResponse(), 2L);
-        assertSearchHits(item.getResponse(), "1", "4");
-        assertThat(item.getFailureMessage(), nullValue());
+            MultiSearchResponse.Item item = response.getResponses()[0];
+            assertHitCount(item.getResponse(), 2L);
+            assertSearchHits(item.getResponse(), "1", "4");
+            assertThat(item.getFailureMessage(), nullValue());
 
-        item = response.getResponses()[1];
-        assertHitCount(item.getResponse(), 2L);
-        assertSearchHits(item.getResponse(), "2", "4");
-        assertThat(item.getFailureMessage(), nullValue());
+            item = response.getResponses()[1];
+            assertHitCount(item.getResponse(), 2L);
+            assertSearchHits(item.getResponse(), "2", "4");
+            assertThat(item.getFailureMessage(), nullValue());
 
-        item = response.getResponses()[2];
-        assertHitCount(item.getResponse(), 4L);
-        assertSearchHits(item.getResponse(), "1", "2", "3", "4");
-        assertThat(item.getFailureMessage(), nullValue());
+            item = response.getResponses()[2];
+            assertHitCount(item.getResponse(), 4L);
+            assertSearchHits(item.getResponse(), "1", "2", "3", "4");
+            assertThat(item.getFailureMessage(), nullValue());
 
-        item = response.getResponses()[3];
-        assertHitCount(item.getResponse(), 1L);
-        assertSearchHits(item.getResponse(), "4");
-        assertThat(item.getFailureMessage(), nullValue());
+            item = response.getResponses()[3];
+            assertHitCount(item.getResponse(), 1L);
+            assertSearchHits(item.getResponse(), "4");
+            assertThat(item.getFailureMessage(), nullValue());
 
-        item = response.getResponses()[4];
-        assertHitCount(item.getResponse(), 2L);
-        assertSearchHits(item.getResponse(), "2", "4");
-        assertThat(item.getFailureMessage(), nullValue());
+            item = response.getResponses()[4];
+            assertHitCount(item.getResponse(), 2L);
+            assertSearchHits(item.getResponse(), "2", "4");
+            assertThat(item.getFailureMessage(), nullValue());
 
-        item = response.getResponses()[5];
-        assertThat(item.getResponse(), nullValue());
-        assertThat(item.getFailureMessage(), notNullValue());
-        assertThat(item.getFailureMessage(), containsString("[test/6] couldn't be found"));
+            item = response.getResponses()[5];
+            assertThat(item.getResponse(), nullValue());
+            assertThat(item.getFailureMessage(), notNullValue());
+            assertThat(item.getFailureMessage(), containsString("[test/6] couldn't be found"));
+        } finally {
+            response.decRef();
+        }
     }
 
     public void testDisallowExpensiveQueries() throws IOException {

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/IndicesOptionsIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/IndicesOptionsIntegrationIT.java
@@ -675,9 +675,13 @@ public class IndicesOptionsIntegrationIT extends ESIntegTestCase {
         if (fail) {
             if (requestBuilder instanceof MultiSearchRequestBuilder multiSearchRequestBuilder) {
                 MultiSearchResponse multiSearchResponse = multiSearchRequestBuilder.get();
-                assertThat(multiSearchResponse.getResponses().length, equalTo(1));
-                assertThat(multiSearchResponse.getResponses()[0].isFailure(), is(true));
-                assertThat(multiSearchResponse.getResponses()[0].getResponse(), nullValue());
+                try {
+                    assertThat(multiSearchResponse.getResponses().length, equalTo(1));
+                    assertThat(multiSearchResponse.getResponses()[0].isFailure(), is(true));
+                    assertThat(multiSearchResponse.getResponses()[0].getResponse(), nullValue());
+                } finally {
+                    multiSearchResponse.decRef();
+                }
             } else {
                 try {
                     requestBuilder.get();
@@ -689,8 +693,12 @@ public class IndicesOptionsIntegrationIT extends ESIntegTestCase {
                 assertHitCount(searchRequestBuilder, expectedCount);
             } else if (requestBuilder instanceof MultiSearchRequestBuilder multiSearchRequestBuilder) {
                 MultiSearchResponse multiSearchResponse = multiSearchRequestBuilder.get();
-                assertThat(multiSearchResponse.getResponses().length, equalTo(1));
-                assertThat(multiSearchResponse.getResponses()[0].getResponse(), notNullValue());
+                try {
+                    assertThat(multiSearchResponse.getResponses().length, equalTo(1));
+                    assertThat(multiSearchResponse.getResponses()[0].getResponse(), notNullValue());
+                } finally {
+                    multiSearchResponse.decRef();
+                }
             } else {
                 requestBuilder.get();
             }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/basic/TransportTwoNodesSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/basic/TransportTwoNodesSearchIT.java
@@ -358,14 +358,18 @@ public class TransportTwoNodesSearchIT extends ESIntegTestCase {
             .add(prepareSearch("test").setQuery(QueryBuilders.termQuery("nid", 2)))
             .add(prepareSearch("test").setQuery(QueryBuilders.matchAllQuery()))
             .get();
-        assertThat(response.getResponses().length, equalTo(3));
-        assertThat(response.getResponses()[0].getFailureMessage(), notNullValue());
+        try {
+            assertThat(response.getResponses().length, equalTo(3));
+            assertThat(response.getResponses()[0].getFailureMessage(), notNullValue());
 
-        assertThat(response.getResponses()[1].getFailureMessage(), nullValue());
-        assertThat(response.getResponses()[1].getResponse().getHits().getHits().length, equalTo(1));
+            assertThat(response.getResponses()[1].getFailureMessage(), nullValue());
+            assertThat(response.getResponses()[1].getResponse().getHits().getHits().length, equalTo(1));
 
-        assertThat(response.getResponses()[2].getFailureMessage(), nullValue());
-        assertThat(response.getResponses()[2].getResponse().getHits().getHits().length, equalTo(10));
+            assertThat(response.getResponses()[2].getFailureMessage(), nullValue());
+            assertThat(response.getResponses()[2].getResponse().getHits().getHits().length, equalTo(10));
+        } finally {
+            response.decRef();
+        }
 
         logger.info("Done Testing failed search");
     }
@@ -375,7 +379,7 @@ public class TransportTwoNodesSearchIT extends ESIntegTestCase {
 
         logger.info("Start Testing failed multi search with a wrong query");
 
-        MultiSearchResponse response = client().prepareMultiSearch()
+        final MultiSearchResponse response = client().prepareMultiSearch()
             // Add custom score query with bogus script
             .add(
                 prepareSearch("test").setQuery(
@@ -388,15 +392,18 @@ public class TransportTwoNodesSearchIT extends ESIntegTestCase {
             .add(prepareSearch("test").setQuery(QueryBuilders.termQuery("nid", 2)))
             .add(prepareSearch("test").setQuery(QueryBuilders.matchAllQuery()))
             .get();
-        assertThat(response.getResponses().length, equalTo(3));
-        assertThat(response.getResponses()[0].getFailureMessage(), notNullValue());
+        try {
+            assertThat(response.getResponses().length, equalTo(3));
+            assertThat(response.getResponses()[0].getFailureMessage(), notNullValue());
 
-        assertThat(response.getResponses()[1].getFailureMessage(), nullValue());
-        assertThat(response.getResponses()[1].getResponse().getHits().getHits().length, equalTo(1));
+            assertThat(response.getResponses()[1].getFailureMessage(), nullValue());
+            assertThat(response.getResponses()[1].getResponse().getHits().getHits().length, equalTo(1));
 
-        assertThat(response.getResponses()[2].getFailureMessage(), nullValue());
-        assertThat(response.getResponses()[2].getResponse().getHits().getHits().length, equalTo(10));
-
+            assertThat(response.getResponses()[2].getFailureMessage(), nullValue());
+            assertThat(response.getResponses()[2].getResponse().getHits().getHits().length, equalTo(10));
+        } finally {
+            response.decRef();
+        }
         logger.info("Done Testing failed search");
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/profile/query/QueryProfilerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/profile/query/QueryProfilerIT.java
@@ -123,47 +123,55 @@ public class QueryProfilerIT extends ESIntegTestCase {
             .setSearchType(SearchType.QUERY_THEN_FETCH)
             .setRequestCache(false);
 
-        MultiSearchResponse.Item[] responses = client().prepareMultiSearch().add(vanilla).add(profile).get().getResponses();
+        MultiSearchResponse response = client().prepareMultiSearch().add(vanilla).add(profile).get();
+        try {
+            MultiSearchResponse.Item[] responses = response.getResponses();
 
-        SearchResponse vanillaResponse = responses[0].getResponse();
-        SearchResponse profileResponse = responses[1].getResponse();
+            SearchResponse vanillaResponse = responses[0].getResponse();
+            SearchResponse profileResponse = responses[1].getResponse();
 
-        assertThat(vanillaResponse.getFailedShards(), equalTo(0));
-        assertThat(profileResponse.getFailedShards(), equalTo(0));
-        assertThat(vanillaResponse.getSuccessfulShards(), equalTo(profileResponse.getSuccessfulShards()));
+            assertThat(vanillaResponse.getFailedShards(), equalTo(0));
+            assertThat(profileResponse.getFailedShards(), equalTo(0));
+            assertThat(vanillaResponse.getSuccessfulShards(), equalTo(profileResponse.getSuccessfulShards()));
 
-        float vanillaMaxScore = vanillaResponse.getHits().getMaxScore();
-        float profileMaxScore = profileResponse.getHits().getMaxScore();
-        if (Float.isNaN(vanillaMaxScore)) {
-            assertTrue("Vanilla maxScore is NaN but Profile is not [" + profileMaxScore + "]", Float.isNaN(profileMaxScore));
-        } else {
-            assertEquals(
-                "Profile maxScore of [" + profileMaxScore + "] is not close to Vanilla maxScore [" + vanillaMaxScore + "]",
-                vanillaMaxScore,
-                profileMaxScore,
-                0.001
-            );
-        }
-
-        if (vanillaResponse.getHits().getTotalHits().value != profileResponse.getHits().getTotalHits().value) {
-            Set<SearchHit> vanillaSet = new HashSet<>(Arrays.asList(vanillaResponse.getHits().getHits()));
-            Set<SearchHit> profileSet = new HashSet<>(Arrays.asList(profileResponse.getHits().getHits()));
-            if (vanillaResponse.getHits().getTotalHits().value > profileResponse.getHits().getTotalHits().value) {
-                vanillaSet.removeAll(profileSet);
-                fail("Vanilla hits were larger than profile hits.  Non-overlapping elements were: " + vanillaSet.toString());
+            float vanillaMaxScore = vanillaResponse.getHits().getMaxScore();
+            float profileMaxScore = profileResponse.getHits().getMaxScore();
+            if (Float.isNaN(vanillaMaxScore)) {
+                assertTrue("Vanilla maxScore is NaN but Profile is not [" + profileMaxScore + "]", Float.isNaN(profileMaxScore));
             } else {
-                profileSet.removeAll(vanillaSet);
-                fail("Profile hits were larger than vanilla hits.  Non-overlapping elements were: " + profileSet.toString());
+                assertEquals(
+                    "Profile maxScore of [" + profileMaxScore + "] is not close to Vanilla maxScore [" + vanillaMaxScore + "]",
+                    vanillaMaxScore,
+                    profileMaxScore,
+                    0.001
+                );
             }
+
+            if (vanillaResponse.getHits().getTotalHits().value != profileResponse.getHits().getTotalHits().value) {
+                Set<SearchHit> vanillaSet = new HashSet<>(Arrays.asList(vanillaResponse.getHits().getHits()));
+                Set<SearchHit> profileSet = new HashSet<>(Arrays.asList(profileResponse.getHits().getHits()));
+                if (vanillaResponse.getHits().getTotalHits().value > profileResponse.getHits().getTotalHits().value) {
+                    vanillaSet.removeAll(profileSet);
+                    fail("Vanilla hits were larger than profile hits.  Non-overlapping elements were: " + vanillaSet.toString());
+                } else {
+                    profileSet.removeAll(vanillaSet);
+                    fail("Profile hits were larger than vanilla hits.  Non-overlapping elements were: " + profileSet.toString());
+                }
+            }
+
+            SearchHit[] vanillaHits = vanillaResponse.getHits().getHits();
+            SearchHit[] profileHits = profileResponse.getHits().getHits();
+
+            for (int j = 0; j < vanillaHits.length; j++) {
+                assertThat(
+                    "Profile hit #" + j + " has a different ID from Vanilla",
+                    vanillaHits[j].getId(),
+                    equalTo(profileHits[j].getId())
+                );
+            }
+        } finally {
+            response.decRef();
         }
-
-        SearchHit[] vanillaHits = vanillaResponse.getHits().getHits();
-        SearchHit[] profileHits = profileResponse.getHits().getHits();
-
-        for (int j = 0; j < vanillaHits.length; j++) {
-            assertThat("Profile hit #" + j + " has a different ID from Vanilla", vanillaHits[j].getId(), equalTo(profileHits[j].getId()));
-        }
-
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/action/search/ExpandSearchPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/ExpandSearchPhaseTests.java
@@ -102,9 +102,15 @@ public class ExpandSearchPhaseTests extends ESTestCase {
                         mSearchResponses.add(new MultiSearchResponse.Item(mockSearchPhaseContext.searchResponse.get(), null));
                     }
 
-                    listener.onResponse(
-                        new MultiSearchResponse(mSearchResponses.toArray(new MultiSearchResponse.Item[0]), randomIntBetween(1, 10000))
+                    var response = new MultiSearchResponse(
+                        mSearchResponses.toArray(new MultiSearchResponse.Item[0]),
+                        randomIntBetween(1, 10000)
                     );
+                    try {
+                        listener.onResponse(response);
+                    } finally {
+                        response.decRef();
+                    }
                 }
             };
 
@@ -164,14 +170,17 @@ public class ExpandSearchPhaseTests extends ESTestCase {
                     ShardSearchFailure.EMPTY_ARRAY,
                     SearchResponse.Clusters.EMPTY
                 );
-                listener.onResponse(
-                    new MultiSearchResponse(
-                        new MultiSearchResponse.Item[] {
-                            new MultiSearchResponse.Item(null, new RuntimeException("boom")),
-                            new MultiSearchResponse.Item(searchResponse, null) },
-                        randomIntBetween(1, 10000)
-                    )
+                var response = new MultiSearchResponse(
+                    new MultiSearchResponse.Item[] {
+                        new MultiSearchResponse.Item(null, new RuntimeException("boom")),
+                        new MultiSearchResponse.Item(searchResponse, null) },
+                    randomIntBetween(1, 10000)
                 );
+                try {
+                    listener.onResponse(response);
+                } finally {
+                    response.decRef();
+                }
             }
         };
 

--- a/server/src/test/java/org/elasticsearch/action/search/FetchLookupFieldsPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/FetchLookupFieldsPhaseTests.java
@@ -119,7 +119,12 @@ public class FetchLookupFieldsPhaseTests extends ESTestCase {
                         null
                     );
                 }
-                listener.onResponse(new MultiSearchResponse(responses, randomNonNegativeLong()));
+                var response = new MultiSearchResponse(responses, randomNonNegativeLong());
+                try {
+                    listener.onResponse(response);
+                } finally {
+                    response.decRef();
+                }
             }
         };
 

--- a/server/src/test/java/org/elasticsearch/action/search/MultiSearchActionTookTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/MultiSearchActionTookTests.java
@@ -93,19 +93,23 @@ public class MultiSearchActionTookTests extends ESTestCase {
 
         TransportMultiSearchAction action = createTransportMultiSearchAction(controlledClock, expected);
 
-        action.doExecute(mock(Task.class), multiSearchRequest, new ActionListener<MultiSearchResponse>() {
+        action.doExecute(mock(Task.class), multiSearchRequest, new ActionListener<>() {
             @Override
             public void onResponse(MultiSearchResponse multiSearchResponse) {
-                if (controlledClock) {
-                    assertThat(
-                        TimeUnit.MILLISECONDS.convert(expected.get(), TimeUnit.NANOSECONDS),
-                        equalTo(multiSearchResponse.getTook().getMillis())
-                    );
-                } else {
-                    assertThat(
-                        multiSearchResponse.getTook().getMillis(),
-                        greaterThanOrEqualTo(TimeUnit.MILLISECONDS.convert(expected.get(), TimeUnit.NANOSECONDS))
-                    );
+                try {
+                    if (controlledClock) {
+                        assertThat(
+                            TimeUnit.MILLISECONDS.convert(expected.get(), TimeUnit.NANOSECONDS),
+                            equalTo(multiSearchResponse.getTook().getMillis())
+                        );
+                    } else {
+                        assertThat(
+                            multiSearchResponse.getTook().getMillis(),
+                            greaterThanOrEqualTo(TimeUnit.MILLISECONDS.convert(expected.get(), TimeUnit.NANOSECONDS))
+                        );
+                    }
+                } finally {
+                    multiSearchResponse.decRef();
                 }
             }
 

--- a/server/src/test/java/org/elasticsearch/action/search/MultiSearchRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/MultiSearchRequestTests.java
@@ -194,29 +194,33 @@ public class MultiSearchRequestTests extends ESTestCase {
                 new MultiSearchResponse.Item(null, new IllegalStateException("baaaaaazzzz")) },
             tookInMillis
         );
+        try {
 
-        assertEquals(XContentHelper.stripWhitespace(Strings.format("""
-            {
-              "took": %s,
-              "responses": [
+            assertEquals(XContentHelper.stripWhitespace(Strings.format("""
                 {
-                  "error": {
-                    "root_cause": [ { "type": "illegal_state_exception", "reason": "foobar" } ],
-                    "type": "illegal_state_exception",
-                    "reason": "foobar"
-                  },
-                  "status": 500
-                },
-                {
-                  "error": {
-                    "root_cause": [ { "type": "illegal_state_exception", "reason": "baaaaaazzzz" } ],
-                    "type": "illegal_state_exception",
-                    "reason": "baaaaaazzzz"
-                  },
-                  "status": 500
-                }
-              ]
-            }""", tookInMillis)), Strings.toString(response));
+                  "took": %s,
+                  "responses": [
+                    {
+                      "error": {
+                        "root_cause": [ { "type": "illegal_state_exception", "reason": "foobar" } ],
+                        "type": "illegal_state_exception",
+                        "reason": "foobar"
+                      },
+                      "status": 500
+                    },
+                    {
+                      "error": {
+                        "root_cause": [ { "type": "illegal_state_exception", "reason": "baaaaaazzzz" } ],
+                        "type": "illegal_state_exception",
+                        "reason": "baaaaaazzzz"
+                      },
+                      "status": 500
+                    }
+                  ]
+                }""", tookInMillis)), Strings.toString(response));
+        } finally {
+            response.decRef();
+        }
     }
 
     public void testMaxConcurrentSearchRequests() {

--- a/server/src/test/java/org/elasticsearch/action/search/MultiSearchResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/MultiSearchResponseTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.action.search;
 
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.core.RefCounted;
 import org.elasticsearch.search.internal.InternalSearchResponse;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.ToXContent;
@@ -119,6 +120,7 @@ public class MultiSearchResponseTests extends ESTestCase {
             .numberOfTestRuns(20)
             .supportsUnknownFields(supportsUnknownFields())
             .assertEqualsConsumer(this::assertEqualInstances)
+            .dispose(RefCounted::decRef)
             .test();
     }
 
@@ -138,6 +140,7 @@ public class MultiSearchResponseTests extends ESTestCase {
             // exceptions are not of the same type whenever parsed back
             .assertToXContentEquivalence(false)
             .assertEqualsConsumer(this::assertEqualInstances)
+            .dispose(RefCounted::decRef)
             .test();
     }
 

--- a/server/src/test/java/org/elasticsearch/action/search/TransportMultiSearchActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/TransportMultiSearchActionTests.java
@@ -102,7 +102,7 @@ public class TransportMultiSearchActionTests extends ESTestCase {
 
             PlainActionFuture<MultiSearchResponse> future = new PlainActionFuture<>();
             action.execute(task, multiSearchRequest, future);
-            future.get();
+            future.get().decRef();
             assertEquals(numSearchRequests, counter.get());
         } finally {
             assertTrue(ESTestCase.terminate(threadPool));
@@ -205,9 +205,13 @@ public class TransportMultiSearchActionTests extends ESTestCase {
             }
 
             MultiSearchResponse response = ActionTestUtils.executeBlocking(action, multiSearchRequest);
-            assertThat(response.getResponses().length, equalTo(numSearchRequests));
-            assertThat(requests.size(), equalTo(numSearchRequests));
-            assertThat(errorHolder.get(), nullValue());
+            try {
+                assertThat(response.getResponses().length, equalTo(numSearchRequests));
+                assertThat(requests.size(), equalTo(numSearchRequests));
+                assertThat(errorHolder.get(), nullValue());
+            } finally {
+                response.decRef();
+            }
         } finally {
             assertTrue(ESTestCase.terminate(threadPool));
         }

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/CoordinatorTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/CoordinatorTests.java
@@ -92,24 +92,34 @@ public class CoordinatorTests extends ESTestCase {
         for (int i = 0; i < 5; i++) {
             responseItems[i] = new MultiSearchResponse.Item(emptyResponse, null);
         }
-        lookupFunction.capturedConsumers.get(0).accept(new MultiSearchResponse(responseItems, 1L), null);
-        assertThat(coordinator.queue.size(), equalTo(0));
-        assertThat(coordinator.getRemoteRequestsCurrent(), equalTo(1));
-        assertThat(lookupFunction.capturedRequests.size(), equalTo(2));
+        final MultiSearchResponse res1 = new MultiSearchResponse(responseItems, 1L);
+        try {
+            lookupFunction.capturedConsumers.get(0).accept(res1, null);
+            assertThat(coordinator.queue.size(), equalTo(0));
+            assertThat(coordinator.getRemoteRequestsCurrent(), equalTo(1));
+            assertThat(lookupFunction.capturedRequests.size(), equalTo(2));
 
-        // Replying last response, resulting in an empty queue and no outstanding requests.
-        responseItems = new MultiSearchResponse.Item[5];
-        for (int i = 0; i < 5; i++) {
-            responseItems[i] = new MultiSearchResponse.Item(emptyResponse, null);
-        }
-        lookupFunction.capturedConsumers.get(1).accept(new MultiSearchResponse(responseItems, 1L), null);
-        assertThat(coordinator.queue.size(), equalTo(0));
-        assertThat(coordinator.getRemoteRequestsCurrent(), equalTo(0));
-        assertThat(lookupFunction.capturedRequests.size(), equalTo(2));
+            // Replying last response, resulting in an empty queue and no outstanding requests.
+            responseItems = new MultiSearchResponse.Item[5];
+            for (int i = 0; i < 5; i++) {
+                responseItems[i] = new MultiSearchResponse.Item(emptyResponse, null);
+            }
+            var res2 = new MultiSearchResponse(responseItems, 1L);
+            try {
+                lookupFunction.capturedConsumers.get(1).accept(res2, null);
+                assertThat(coordinator.queue.size(), equalTo(0));
+                assertThat(coordinator.getRemoteRequestsCurrent(), equalTo(0));
+                assertThat(lookupFunction.capturedRequests.size(), equalTo(2));
 
-        // All individual action listeners for the search requests should have been invoked:
-        for (ActionListener<SearchResponse> searchActionListener : searchActionListeners) {
-            Mockito.verify(searchActionListener).onResponse(Mockito.eq(emptyResponse));
+                // All individual action listeners for the search requests should have been invoked:
+                for (ActionListener<SearchResponse> searchActionListener : searchActionListeners) {
+                    Mockito.verify(searchActionListener).onResponse(Mockito.eq(emptyResponse));
+                }
+            } finally {
+                res2.decRef();
+            }
+        } finally {
+            res1.decRef();
         }
     }
 
@@ -187,14 +197,19 @@ public class CoordinatorTests extends ESTestCase {
         for (int i = 0; i < 5; i++) {
             responseItems[i] = new MultiSearchResponse.Item(null, e);
         }
-        lookupFunction.capturedConsumers.get(0).accept(new MultiSearchResponse(responseItems, 1L), null);
-        assertThat(coordinator.queue.size(), equalTo(0));
-        assertThat(coordinator.getRemoteRequestsCurrent(), equalTo(0));
-        assertThat(lookupFunction.capturedRequests.size(), equalTo(1));
+        var res = new MultiSearchResponse(responseItems, 1L);
+        try {
+            lookupFunction.capturedConsumers.get(0).accept(res, null);
+            assertThat(coordinator.queue.size(), equalTo(0));
+            assertThat(coordinator.getRemoteRequestsCurrent(), equalTo(0));
+            assertThat(lookupFunction.capturedRequests.size(), equalTo(1));
 
-        // All individual action listeners for the search requests should have been invoked:
-        for (ActionListener<SearchResponse> searchActionListener : searchActionListeners) {
-            Mockito.verify(searchActionListener).onFailure(Mockito.eq(e));
+            // All individual action listeners for the search requests should have been invoked:
+            for (ActionListener<SearchResponse> searchActionListener : searchActionListeners) {
+                Mockito.verify(searchActionListener).onFailure(Mockito.eq(e));
+            }
+        } finally {
+            res.decRef();
         }
     }
 
@@ -239,16 +254,16 @@ public class CoordinatorTests extends ESTestCase {
         assertThat(lookupFunction.capturedConsumers.size(), is(1));
 
         // Fulfill the captured consumer which will schedule the next item in the queue.
-        lookupFunction.capturedConsumers.get(0)
-            .accept(
-                new MultiSearchResponse(new MultiSearchResponse.Item[] { new MultiSearchResponse.Item(emptySearchResponse(), null) }, 1L),
-                null
-            );
-
-        // Ensure queue was drained and that the item in it was scheduled
-        assertThat(coordinator.queue.size(), equalTo(0));
-        assertThat(lookupFunction.capturedRequests.size(), equalTo(2));
-        assertThat(lookupFunction.capturedRequests.get(1).requests().get(0), sameInstance(searchRequest));
+        var res = new MultiSearchResponse(new MultiSearchResponse.Item[] { new MultiSearchResponse.Item(emptySearchResponse(), null) }, 1L);
+        try {
+            lookupFunction.capturedConsumers.get(0).accept(res, null);
+            // Ensure queue was drained and that the item in it was scheduled
+            assertThat(coordinator.queue.size(), equalTo(0));
+            assertThat(lookupFunction.capturedRequests.size(), equalTo(2));
+            assertThat(lookupFunction.capturedRequests.get(1).requests().get(0), sameInstance(searchRequest));
+        } finally {
+            res.decRef();
+        }
     }
 
     public void testLookupFunction() {
@@ -302,29 +317,48 @@ public class CoordinatorTests extends ESTestCase {
         Map<String, List<Tuple<Integer, SearchRequest>>> itemsPerIndex = new HashMap<>();
         Map<String, Tuple<MultiSearchResponse, Exception>> shardResponses = new HashMap<>();
 
-        MultiSearchResponse.Item item1 = new MultiSearchResponse.Item(emptySearchResponse(), null);
-        itemsPerIndex.put("index1", List.of(new Tuple<>(0, null), new Tuple<>(1, null), new Tuple<>(2, null)));
-        shardResponses.put("index1", new Tuple<>(new MultiSearchResponse(new MultiSearchResponse.Item[] { item1, item1, item1 }, 1), null));
+        try {
+            MultiSearchResponse.Item item1 = new MultiSearchResponse.Item(emptySearchResponse(), null);
+            itemsPerIndex.put("index1", List.of(new Tuple<>(0, null), new Tuple<>(1, null), new Tuple<>(2, null)));
+            shardResponses.put(
+                "index1",
+                new Tuple<>(new MultiSearchResponse(new MultiSearchResponse.Item[] { item1, item1, item1 }, 1), null)
+            );
 
-        Exception failure = new RuntimeException();
-        itemsPerIndex.put("index2", List.of(new Tuple<>(3, null), new Tuple<>(4, null), new Tuple<>(5, null)));
-        shardResponses.put("index2", new Tuple<>(null, failure));
+            Exception failure = new RuntimeException();
+            itemsPerIndex.put("index2", List.of(new Tuple<>(3, null), new Tuple<>(4, null), new Tuple<>(5, null)));
+            shardResponses.put("index2", new Tuple<>(null, failure));
 
-        MultiSearchResponse.Item item2 = new MultiSearchResponse.Item(emptySearchResponse(), null);
-        itemsPerIndex.put("index3", List.of(new Tuple<>(6, null), new Tuple<>(7, null), new Tuple<>(8, null)));
-        shardResponses.put("index3", new Tuple<>(new MultiSearchResponse(new MultiSearchResponse.Item[] { item2, item2, item2 }, 1), null));
+            MultiSearchResponse.Item item2 = new MultiSearchResponse.Item(emptySearchResponse(), null);
+            itemsPerIndex.put("index3", List.of(new Tuple<>(6, null), new Tuple<>(7, null), new Tuple<>(8, null)));
+            shardResponses.put(
+                "index3",
+                new Tuple<>(new MultiSearchResponse(new MultiSearchResponse.Item[] { item2, item2, item2 }, 1), null)
+            );
 
-        MultiSearchResponse result = Coordinator.reduce(9, itemsPerIndex, shardResponses);
-        assertThat(result.getResponses().length, equalTo(9));
-        assertThat(result.getResponses()[0], sameInstance(item1));
-        assertThat(result.getResponses()[1], sameInstance(item1));
-        assertThat(result.getResponses()[2], sameInstance(item1));
-        assertThat(result.getResponses()[3].getFailure(), sameInstance(failure));
-        assertThat(result.getResponses()[4].getFailure(), sameInstance(failure));
-        assertThat(result.getResponses()[5].getFailure(), sameInstance(failure));
-        assertThat(result.getResponses()[6], sameInstance(item2));
-        assertThat(result.getResponses()[7], sameInstance(item2));
-        assertThat(result.getResponses()[8], sameInstance(item2));
+            MultiSearchResponse result = Coordinator.reduce(9, itemsPerIndex, shardResponses);
+            try {
+                assertThat(result.getResponses().length, equalTo(9));
+                assertThat(result.getResponses()[0], sameInstance(item1));
+                assertThat(result.getResponses()[1], sameInstance(item1));
+                assertThat(result.getResponses()[2], sameInstance(item1));
+                assertThat(result.getResponses()[3].getFailure(), sameInstance(failure));
+                assertThat(result.getResponses()[4].getFailure(), sameInstance(failure));
+                assertThat(result.getResponses()[5].getFailure(), sameInstance(failure));
+                assertThat(result.getResponses()[6], sameInstance(item2));
+                assertThat(result.getResponses()[7], sameInstance(item2));
+                assertThat(result.getResponses()[8], sameInstance(item2));
+            } finally {
+                result.decRef();
+            }
+        } finally {
+            for (Tuple<MultiSearchResponse, Exception> value : shardResponses.values()) {
+                var res = value.v1();
+                if (res != null) {
+                    res.decRef();
+                }
+            }
+        }
     }
 
     private static SearchResponse emptySearchResponse() {
@@ -360,7 +394,12 @@ public class CoordinatorTests extends ESTestCase {
             for (int i = 0; i < items.length; i++) {
                 items[i] = new MultiSearchResponse.Item(emptySearchResponse(), null);
             }
-            responseConsumer.accept(new MultiSearchResponse(items, 0L), null);
+            var res = new MultiSearchResponse(items, 0L);
+            try {
+                responseConsumer.accept(res, null);
+            } finally {
+                res.decRef();
+            }
         }), 5, 2, 20);
         try {
 

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/EnrichShardMultiSearchActionTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/EnrichShardMultiSearchActionTests.java
@@ -58,16 +58,20 @@ public class EnrichShardMultiSearchActionTests extends ESSingleNodeTestCase {
             request.add(searchRequest);
         }
 
-        MultiSearchResponse result = client().execute(
+        final MultiSearchResponse result = client().execute(
             EnrichShardMultiSearchAction.INSTANCE,
             new EnrichShardMultiSearchAction.Request(request)
         ).actionGet();
-        assertThat(result.getResponses().length, equalTo(numSearches));
-        for (int i = 0; i < numSearches; i++) {
-            assertThat(result.getResponses()[i].isFailure(), is(false));
-            assertThat(result.getResponses()[i].getResponse().getHits().getTotalHits().value, equalTo(1L));
-            assertThat(result.getResponses()[i].getResponse().getHits().getHits()[0].getSourceAsMap().size(), equalTo(1));
-            assertThat(result.getResponses()[i].getResponse().getHits().getHits()[0].getSourceAsMap().get("key1"), equalTo("value1"));
+        try {
+            assertThat(result.getResponses().length, equalTo(numSearches));
+            for (int i = 0; i < numSearches; i++) {
+                assertThat(result.getResponses()[i].isFailure(), is(false));
+                assertThat(result.getResponses()[i].getResponse().getHits().getTotalHits().value, equalTo(1L));
+                assertThat(result.getResponses()[i].getResponse().getHits().getHits()[0].getSourceAsMap().size(), equalTo(1));
+                assertThat(result.getResponses()[i].getResponse().getHits().getHits()[0].getSourceAsMap().get("key1"), equalTo("value1"));
+            }
+        } finally {
+            result.decRef();
         }
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProviderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProviderTests.java
@@ -748,67 +748,72 @@ public class JobResultsProviderTests extends ESTestCase {
         );
         SearchResponse responseFoo = createSearchResponse(sourceFoo);
         SearchResponse responseBar = createSearchResponse(sourceBar);
-        MultiSearchResponse multiSearchResponse = new MultiSearchResponse(
+        final MultiSearchResponse multiSearchResponse = new MultiSearchResponse(
             new MultiSearchResponse.Item[] {
                 new MultiSearchResponse.Item(responseFoo, null),
                 new MultiSearchResponse.Item(responseBar, null) },
             randomNonNegativeLong()
         );
 
-        Client client = getBasicMockedClient();
-        when(client.prepareMultiSearch()).thenReturn(new MultiSearchRequestBuilder(client, MultiSearchAction.INSTANCE));
-        doAnswer(invocationOnMock -> {
-            MultiSearchRequest multiSearchRequest = (MultiSearchRequest) invocationOnMock.getArguments()[0];
-            assertThat(multiSearchRequest.requests(), hasSize(2));
-            assertThat(multiSearchRequest.requests().get(0).source().query().getName(), equalTo("ids"));
-            assertThat(multiSearchRequest.requests().get(1).source().query().getName(), equalTo("ids"));
-            @SuppressWarnings("unchecked")
-            ActionListener<MultiSearchResponse> actionListener = (ActionListener<MultiSearchResponse>) invocationOnMock.getArguments()[1];
-            actionListener.onResponse(multiSearchResponse);
-            return null;
-        }).when(client).multiSearch(any(), any());
-        when(client.prepareSearch(AnomalyDetectorsIndex.jobResultsAliasedName("foo"))).thenReturn(
-            new SearchRequestBuilder(client, SearchAction.INSTANCE).setIndices(AnomalyDetectorsIndex.jobResultsAliasedName("foo"))
-        );
-        when(client.prepareSearch(AnomalyDetectorsIndex.jobResultsAliasedName("bar"))).thenReturn(
-            new SearchRequestBuilder(client, SearchAction.INSTANCE).setIndices(AnomalyDetectorsIndex.jobResultsAliasedName("bar"))
-        );
+        try {
+            Client client = getBasicMockedClient();
+            when(client.prepareMultiSearch()).thenReturn(new MultiSearchRequestBuilder(client, MultiSearchAction.INSTANCE));
+            doAnswer(invocationOnMock -> {
+                MultiSearchRequest multiSearchRequest = (MultiSearchRequest) invocationOnMock.getArguments()[0];
+                assertThat(multiSearchRequest.requests(), hasSize(2));
+                assertThat(multiSearchRequest.requests().get(0).source().query().getName(), equalTo("ids"));
+                assertThat(multiSearchRequest.requests().get(1).source().query().getName(), equalTo("ids"));
+                @SuppressWarnings("unchecked")
+                ActionListener<MultiSearchResponse> actionListener = (ActionListener<MultiSearchResponse>) invocationOnMock
+                    .getArguments()[1];
+                actionListener.onResponse(multiSearchResponse);
+                return null;
+            }).when(client).multiSearch(any(), any());
+            when(client.prepareSearch(AnomalyDetectorsIndex.jobResultsAliasedName("foo"))).thenReturn(
+                new SearchRequestBuilder(client, SearchAction.INSTANCE).setIndices(AnomalyDetectorsIndex.jobResultsAliasedName("foo"))
+            );
+            when(client.prepareSearch(AnomalyDetectorsIndex.jobResultsAliasedName("bar"))).thenReturn(
+                new SearchRequestBuilder(client, SearchAction.INSTANCE).setIndices(AnomalyDetectorsIndex.jobResultsAliasedName("bar"))
+            );
 
-        JobResultsProvider provider = createProvider(client);
-        ExponentialAverageCalculationContext contextFoo = new ExponentialAverageCalculationContext(
-            600.0,
-            Instant.ofEpochMilli(100000600),
-            60.0
-        );
-        ExponentialAverageCalculationContext contextBar = new ExponentialAverageCalculationContext(
-            700.0,
-            Instant.ofEpochMilli(100000700),
-            70.0
-        );
-        provider.datafeedTimingStats(
-            List.of("foo", "bar"),
-            null,
-            ActionTestUtils.assertNoFailureListener(
-                statsByJobId -> assertThat(
-                    statsByJobId,
-                    equalTo(
-                        Map.of(
-                            "foo",
-                            new DatafeedTimingStats("foo", 6, 66, 666.0, contextFoo),
-                            "bar",
-                            new DatafeedTimingStats("bar", 7, 77, 777.0, contextBar)
+            JobResultsProvider provider = createProvider(client);
+            ExponentialAverageCalculationContext contextFoo = new ExponentialAverageCalculationContext(
+                600.0,
+                Instant.ofEpochMilli(100000600),
+                60.0
+            );
+            ExponentialAverageCalculationContext contextBar = new ExponentialAverageCalculationContext(
+                700.0,
+                Instant.ofEpochMilli(100000700),
+                70.0
+            );
+            provider.datafeedTimingStats(
+                List.of("foo", "bar"),
+                null,
+                ActionTestUtils.assertNoFailureListener(
+                    statsByJobId -> assertThat(
+                        statsByJobId,
+                        equalTo(
+                            Map.of(
+                                "foo",
+                                new DatafeedTimingStats("foo", 6, 66, 666.0, contextFoo),
+                                "bar",
+                                new DatafeedTimingStats("bar", 7, 77, 777.0, contextBar)
+                            )
                         )
                     )
                 )
-            )
-        );
+            );
 
-        verify(client).threadPool();
-        verify(client).prepareMultiSearch();
-        verify(client).multiSearch(any(MultiSearchRequest.class), any());
-        verify(client).prepareSearch(AnomalyDetectorsIndex.jobResultsAliasedName("foo"));
-        verify(client).prepareSearch(AnomalyDetectorsIndex.jobResultsAliasedName("bar"));
-        verifyNoMoreInteractions(client);
+            verify(client).threadPool();
+            verify(client).prepareMultiSearch();
+            verify(client).multiSearch(any(MultiSearchRequest.class), any());
+            verify(client).prepareSearch(AnomalyDetectorsIndex.jobResultsAliasedName("foo"));
+            verify(client).prepareSearch(AnomalyDetectorsIndex.jobResultsAliasedName("bar"));
+            verifyNoMoreInteractions(client);
+        } finally {
+            multiSearchResponse.decRef();
+        }
     }
 
     public void testDatafeedTimingStats_Ok() throws IOException {
@@ -949,7 +954,11 @@ public class JobResultsProviderTests extends ESTestCase {
                 new MultiSearchResponse.Item[] { new MultiSearchResponse.Item(response, null) },
                 randomNonNegativeLong()
             );
-            actionListener.onResponse(mresponse);
+            try {
+                actionListener.onResponse(mresponse);
+            } finally {
+                mresponse.decRef();
+            }
             return null;
         }).when(client).multiSearch(any(), any());
         doAnswer(invocationOnMock -> {

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/action/SearchActionTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/action/SearchActionTests.java
@@ -678,14 +678,17 @@ public class SearchActionTests extends ESTestCase {
         SearchResponse response = mock(SearchResponse.class);
         MultiSearchResponse.Item item = new MultiSearchResponse.Item(response, null);
         MultiSearchResponse msearchResponse = new MultiSearchResponse(new MultiSearchResponse.Item[] { item }, 1);
-
-        // a mock SearchResponse, so does not need to be decRef'd
-        SearchResponse r = TransportRollupSearchAction.processResponses(
-            result,
-            msearchResponse,
-            InternalAggregationTestCase.emptyReduceContextBuilder()
-        );
-        assertThat(r, equalTo(response));
+        try {
+            // a mock SearchResponse, so does not need to be decRef'd
+            SearchResponse r = TransportRollupSearchAction.processResponses(
+                result,
+                msearchResponse,
+                InternalAggregationTestCase.emptyReduceContextBuilder()
+            );
+            assertThat(r, equalTo(response));
+        } finally {
+            msearchResponse.decRef();
+        }
     }
 
     public void testRollupOnly() throws Exception {
@@ -738,20 +741,23 @@ public class SearchActionTests extends ESTestCase {
         when(response.getAggregations()).thenReturn(mockAggs);
         MultiSearchResponse.Item item = new MultiSearchResponse.Item(response, null);
         MultiSearchResponse msearchResponse = new MultiSearchResponse(new MultiSearchResponse.Item[] { item }, 1);
-
-        SearchResponse r = TransportRollupSearchAction.processResponses(
-            result,
-            msearchResponse,
-            InternalAggregationTestCase.emptyReduceContextBuilder()
-        );
         try {
-            assertNotNull(r);
-            Aggregations responseAggs = r.getAggregations();
-            Avg avg = responseAggs.get("foo");
-            assertThat(avg.getValue(), IsEqual.equalTo(5.0));
+            SearchResponse r = TransportRollupSearchAction.processResponses(
+                result,
+                msearchResponse,
+                InternalAggregationTestCase.emptyReduceContextBuilder()
+            );
+            try {
+                assertNotNull(r);
+                Aggregations responseAggs = r.getAggregations();
+                Avg avg = responseAggs.get("foo");
+                assertThat(avg.getValue(), IsEqual.equalTo(5.0));
+            } finally {
+                // this SearchResponse is not a mock, so we decRef
+                r.decRef();
+            }
         } finally {
-            // this SearchResponse is not a mock, so we decRef
-            r.decRef();
+            msearchResponse.decRef();
         }
     }
 
@@ -793,16 +799,19 @@ public class SearchActionTests extends ESTestCase {
             Collections.emptySet()
         );
         MultiSearchResponse msearchResponse = new MultiSearchResponse(new MultiSearchResponse.Item[0], 1);
-
-        RuntimeException e = expectThrows(
-            RuntimeException.class,
-            () -> TransportRollupSearchAction.processResponses(
-                result,
-                msearchResponse,
-                InternalAggregationTestCase.emptyReduceContextBuilder()
-            )
-        );
-        assertThat(e.getMessage(), equalTo("MSearch response was empty, cannot unroll RollupSearch results"));
+        try {
+            RuntimeException e = expectThrows(
+                RuntimeException.class,
+                () -> TransportRollupSearchAction.processResponses(
+                    result,
+                    msearchResponse,
+                    InternalAggregationTestCase.emptyReduceContextBuilder()
+                )
+            );
+            assertThat(e.getMessage(), equalTo("MSearch response was empty, cannot unroll RollupSearch results"));
+        } finally {
+            msearchResponse.decRef();
+        }
     }
 
     public void testBoth() throws Exception {
@@ -869,27 +878,30 @@ public class SearchActionTests extends ESTestCase {
         when(responseWithout.getAggregations()).thenReturn(mockAggsWithout);
         MultiSearchResponse.Item rolledResponse = new MultiSearchResponse.Item(responseWithout, null);
 
-        MultiSearchResponse msearchResponse = new MultiSearchResponse(
+        final MultiSearchResponse msearchResponse = new MultiSearchResponse(
             new MultiSearchResponse.Item[] { unrolledResponse, rolledResponse },
             123
         );
-
-        SearchResponse response = TransportRollupSearchAction.processResponses(
-            separateIndices,
-            msearchResponse,
-            InternalAggregationTestCase.emptyReduceContextBuilder(
-                new AggregatorFactories.Builder().addAggregator(new MaxAggregationBuilder("foo"))
-                    .addAggregator(new MaxAggregationBuilder("foo." + RollupField.COUNT_FIELD))
-            )
-        );
         try {
-            assertNotNull(response);
-            Aggregations responseAggs = response.getAggregations();
-            assertNotNull(responseAggs);
-            Avg avg = responseAggs.get("foo");
-            assertThat(avg.getValue(), IsEqual.equalTo(5.0));
+            SearchResponse response = TransportRollupSearchAction.processResponses(
+                separateIndices,
+                msearchResponse,
+                InternalAggregationTestCase.emptyReduceContextBuilder(
+                    new AggregatorFactories.Builder().addAggregator(new MaxAggregationBuilder("foo"))
+                        .addAggregator(new MaxAggregationBuilder("foo." + RollupField.COUNT_FIELD))
+                )
+            );
+            try {
+                assertNotNull(response);
+                Aggregations responseAggs = response.getAggregations();
+                assertNotNull(responseAggs);
+                Avg avg = responseAggs.get("foo");
+                assertThat(avg.getValue(), IsEqual.equalTo(5.0));
+            } finally {
+                response.decRef();
+            }
         } finally {
-            response.decRef();
+            msearchResponse.decRef();
         }
     }
 }

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DateMathExpressionIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DateMathExpressionIntegTests.java
@@ -83,7 +83,11 @@ public class DateMathExpressionIntegTests extends SecurityIntegTestCase {
         MultiSearchResponse multiSearchResponse = client.prepareMultiSearch()
             .add(client.prepareSearch(expression).setQuery(QueryBuilders.matchAllQuery()).request())
             .get();
-        assertThat(multiSearchResponse.getResponses()[0].getResponse().getHits().getTotalHits().value, is(1L));
+        try {
+            assertThat(multiSearchResponse.getResponses()[0].getResponse().getHits().getTotalHits().value, is(1L));
+        } finally {
+            multiSearchResponse.decRef();
+        }
 
         UpdateResponse updateResponse = client.prepareUpdate(expression, response.getId())
             .setDoc(Requests.INDEX_CONTENT_TYPE, "new", "field")

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DocumentLevelSecurityTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DocumentLevelSecurityTests.java
@@ -449,68 +449,90 @@ public class DocumentLevelSecurityTests extends SecurityIntegTestCase {
         prepareIndex("test2").setId("3").setSource("field3", "value3", "id", 3).get();
         indicesAdmin().prepareRefresh("test1", "test2").get();
 
-        MultiSearchResponse response = client().filterWithHeader(
-            Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD))
-        )
-            .prepareMultiSearch()
-            .add(prepareSearch("test1").setQuery(QueryBuilders.matchAllQuery()))
-            .add(prepareSearch("test2").setQuery(QueryBuilders.matchAllQuery()))
-            .get();
-        assertFalse(response.getResponses()[0].isFailure());
-        assertThat(response.getResponses()[0].getResponse().getHits().getTotalHits().value, is(1L));
-        assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(2));
-        assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
-        assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("id"), is(1));
-
-        assertFalse(response.getResponses()[1].isFailure());
-        assertThat(response.getResponses()[1].getResponse().getHits().getTotalHits().value, is(1L));
-        assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(2));
-        assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
-        assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("id"), is(1));
-
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2", USERS_PASSWD)))
-            .prepareMultiSearch()
-            .add(prepareSearch("test1").setQuery(QueryBuilders.matchAllQuery()))
-            .add(prepareSearch("test2").setQuery(QueryBuilders.matchAllQuery()))
-            .get();
-        assertFalse(response.getResponses()[0].isFailure());
-        assertThat(response.getResponses()[0].getResponse().getHits().getTotalHits().value, is(1L));
-        assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(2));
-        assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field2"), is("value2"));
-        assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("id"), is(2));
-
-        assertFalse(response.getResponses()[1].isFailure());
-        assertThat(response.getResponses()[1].getResponse().getHits().getTotalHits().value, is(1L));
-        assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(2));
-        assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field2"), is("value2"));
-        assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("id"), is(2));
-
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user3", USERS_PASSWD)))
-            .prepareMultiSearch()
-            .add(
-                prepareSearch("test1").addSort(SortBuilders.fieldSort("id").sortMode(SortMode.MIN)).setQuery(QueryBuilders.matchAllQuery())
+        {
+            final MultiSearchResponse response = client().filterWithHeader(
+                Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD))
             )
-            .add(
-                prepareSearch("test2").addSort(SortBuilders.fieldSort("id").sortMode(SortMode.MIN)).setQuery(QueryBuilders.matchAllQuery())
-            )
-            .get();
-        assertFalse(response.getResponses()[0].isFailure());
-        assertThat(response.getResponses()[0].getResponse().getHits().getTotalHits().value, is(2L));
-        assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(2));
-        assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
-        assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("id"), is(1));
-        assertThat(response.getResponses()[0].getResponse().getHits().getAt(1).getSourceAsMap().size(), is(2));
-        assertThat(response.getResponses()[0].getResponse().getHits().getAt(1).getSourceAsMap().get("field2"), is("value2"));
-        assertThat(response.getResponses()[0].getResponse().getHits().getAt(1).getSourceAsMap().get("id"), is(2));
+                .prepareMultiSearch()
+                .add(prepareSearch("test1").setQuery(QueryBuilders.matchAllQuery()))
+                .add(prepareSearch("test2").setQuery(QueryBuilders.matchAllQuery()))
+                .get();
+            try {
+                assertFalse(response.getResponses()[0].isFailure());
+                assertThat(response.getResponses()[0].getResponse().getHits().getTotalHits().value, is(1L));
+                assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(2));
+                assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
+                assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("id"), is(1));
 
-        assertFalse(response.getResponses()[1].isFailure());
-        assertThat(response.getResponses()[1].getResponse().getHits().getTotalHits().value, is(2L));
-        assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(2));
-        assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
-        assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("id"), is(1));
-        assertThat(response.getResponses()[1].getResponse().getHits().getAt(1).getSourceAsMap().size(), is(2));
-        assertThat(response.getResponses()[1].getResponse().getHits().getAt(1).getSourceAsMap().get("field2"), is("value2"));
-        assertThat(response.getResponses()[1].getResponse().getHits().getAt(1).getSourceAsMap().get("id"), is(2));
+                assertFalse(response.getResponses()[1].isFailure());
+                assertThat(response.getResponses()[1].getResponse().getHits().getTotalHits().value, is(1L));
+                assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(2));
+                assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
+                assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("id"), is(1));
+            } finally {
+                response.decRef();
+            }
+        }
+        {
+            final MultiSearchResponse response = client().filterWithHeader(
+                Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2", USERS_PASSWD))
+            )
+                .prepareMultiSearch()
+                .add(prepareSearch("test1").setQuery(QueryBuilders.matchAllQuery()))
+                .add(prepareSearch("test2").setQuery(QueryBuilders.matchAllQuery()))
+                .get();
+            try {
+                assertFalse(response.getResponses()[0].isFailure());
+                assertThat(response.getResponses()[0].getResponse().getHits().getTotalHits().value, is(1L));
+                assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(2));
+                assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field2"), is("value2"));
+                assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("id"), is(2));
+
+                assertFalse(response.getResponses()[1].isFailure());
+                assertThat(response.getResponses()[1].getResponse().getHits().getTotalHits().value, is(1L));
+                assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(2));
+                assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field2"), is("value2"));
+                assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("id"), is(2));
+            } finally {
+                response.decRef();
+            }
+        }
+        {
+            MultiSearchResponse response = client().filterWithHeader(
+                Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user3", USERS_PASSWD))
+            )
+                .prepareMultiSearch()
+                .add(
+                    prepareSearch("test1").addSort(SortBuilders.fieldSort("id").sortMode(SortMode.MIN))
+                        .setQuery(QueryBuilders.matchAllQuery())
+                )
+                .add(
+                    prepareSearch("test2").addSort(SortBuilders.fieldSort("id").sortMode(SortMode.MIN))
+                        .setQuery(QueryBuilders.matchAllQuery())
+                )
+                .get();
+            try {
+                assertFalse(response.getResponses()[0].isFailure());
+                assertThat(response.getResponses()[0].getResponse().getHits().getTotalHits().value, is(2L));
+                assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(2));
+                assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
+                assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("id"), is(1));
+                assertThat(response.getResponses()[0].getResponse().getHits().getAt(1).getSourceAsMap().size(), is(2));
+                assertThat(response.getResponses()[0].getResponse().getHits().getAt(1).getSourceAsMap().get("field2"), is("value2"));
+                assertThat(response.getResponses()[0].getResponse().getHits().getAt(1).getSourceAsMap().get("id"), is(2));
+
+                assertFalse(response.getResponses()[1].isFailure());
+                assertThat(response.getResponses()[1].getResponse().getHits().getTotalHits().value, is(2L));
+                assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(2));
+                assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
+                assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("id"), is(1));
+                assertThat(response.getResponses()[1].getResponse().getHits().getAt(1).getSourceAsMap().size(), is(2));
+                assertThat(response.getResponses()[1].getResponse().getHits().getAt(1).getSourceAsMap().get("field2"), is("value2"));
+                assertThat(response.getResponses()[1].getResponse().getHits().getAt(1).getSourceAsMap().get("id"), is(2));
+            } finally {
+                response.decRef();
+            }
+        }
     }
 
     public void testPercolateQueryWithIndexedDocWithDLS() {

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/FieldLevelSecurityTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/FieldLevelSecurityTests.java
@@ -925,132 +925,188 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
         indicesAdmin().prepareRefresh("test1", "test2").get();
 
         // user1 is granted access to field1 only
-        MultiSearchResponse response = client().filterWithHeader(
-            Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD))
-        )
-            .prepareMultiSearch()
-            .add(prepareSearch("test1").setQuery(QueryBuilders.matchAllQuery()))
-            .add(prepareSearch("test2").setQuery(QueryBuilders.matchAllQuery()))
-            .get();
-        assertFalse(response.getResponses()[0].isFailure());
-        assertThat(response.getResponses()[0].getResponse().getHits().getTotalHits().value, is(1L));
-        assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(1));
-        assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
-        assertThat(response.getResponses()[1].getResponse().getHits().getTotalHits().value, is(1L));
-        assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(1));
-        assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
+        {
+            final MultiSearchResponse response = client().filterWithHeader(
+                Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD))
+            )
+                .prepareMultiSearch()
+                .add(prepareSearch("test1").setQuery(QueryBuilders.matchAllQuery()))
+                .add(prepareSearch("test2").setQuery(QueryBuilders.matchAllQuery()))
+                .get();
+            try {
+                assertFalse(response.getResponses()[0].isFailure());
+                assertThat(response.getResponses()[0].getResponse().getHits().getTotalHits().value, is(1L));
+                assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(1));
+                assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
+                assertThat(response.getResponses()[1].getResponse().getHits().getTotalHits().value, is(1L));
+                assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(1));
+                assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
+            } finally {
+                response.decRef();
+            }
+        }
 
-        // user2 is granted access to field2 only
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2", USERS_PASSWD)))
-            .prepareMultiSearch()
-            .add(prepareSearch("test1").setQuery(QueryBuilders.matchAllQuery()))
-            .add(prepareSearch("test2").setQuery(QueryBuilders.matchAllQuery()))
-            .get();
-        assertFalse(response.getResponses()[0].isFailure());
-        assertThat(response.getResponses()[0].getResponse().getHits().getTotalHits().value, is(1L));
-        assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(1));
-        assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field2"), is("value2"));
-        assertThat(response.getResponses()[1].getResponse().getHits().getTotalHits().value, is(1L));
-        assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(1));
-        assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field2"), is("value2"));
-
-        // user3 is granted access to field1 and field2
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user3", USERS_PASSWD)))
-            .prepareMultiSearch()
-            .add(prepareSearch("test1").setQuery(QueryBuilders.matchAllQuery()))
-            .add(prepareSearch("test2").setQuery(QueryBuilders.matchAllQuery()))
-            .get();
-        assertFalse(response.getResponses()[0].isFailure());
-        assertThat(response.getResponses()[0].getResponse().getHits().getTotalHits().value, is(1L));
-        assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(2));
-        assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
-        assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field2"), is("value2"));
-        assertThat(response.getResponses()[1].getResponse().getHits().getTotalHits().value, is(1L));
-        assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(2));
-        assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
-        assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field2"), is("value2"));
-
-        // user4 is granted access to no fields, so the search response does say the doc exist, but no fields are returned
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user4", USERS_PASSWD)))
-            .prepareMultiSearch()
-            .add(prepareSearch("test1").setQuery(QueryBuilders.matchAllQuery()))
-            .add(prepareSearch("test2").setQuery(QueryBuilders.matchAllQuery()))
-            .get();
-        assertFalse(response.getResponses()[0].isFailure());
-        assertThat(response.getResponses()[0].getResponse().getHits().getTotalHits().value, is(1L));
-        assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(0));
-        assertThat(response.getResponses()[1].getResponse().getHits().getTotalHits().value, is(1L));
-        assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(0));
-
-        // user5 has no field level security configured, so all fields are returned
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user5", USERS_PASSWD)))
-            .prepareMultiSearch()
-            .add(prepareSearch("test1").setQuery(QueryBuilders.matchAllQuery()))
-            .add(prepareSearch("test2").setQuery(QueryBuilders.matchAllQuery()))
-            .get();
-        assertFalse(response.getResponses()[0].isFailure());
-        assertThat(response.getResponses()[0].getResponse().getHits().getTotalHits().value, is(1L));
-        assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(3));
-        assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
-        assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field2"), is("value2"));
-        assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field3"), is("value3"));
-        assertThat(response.getResponses()[1].getResponse().getHits().getTotalHits().value, is(1L));
-        assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(3));
-        assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
-        assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field2"), is("value2"));
-        assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field3"), is("value3"));
-
-        // user6 has access to field*
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user6", USERS_PASSWD)))
-            .prepareMultiSearch()
-            .add(prepareSearch("test1").setQuery(QueryBuilders.matchAllQuery()))
-            .add(prepareSearch("test2").setQuery(QueryBuilders.matchAllQuery()))
-            .get();
-        assertFalse(response.getResponses()[0].isFailure());
-        assertThat(response.getResponses()[0].getResponse().getHits().getTotalHits().value, is(1L));
-        assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(3));
-        assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
-        assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field2"), is("value2"));
-        assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field3"), is("value3"));
-        assertThat(response.getResponses()[1].getResponse().getHits().getTotalHits().value, is(1L));
-        assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(3));
-        assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
-        assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field2"), is("value2"));
-        assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field3"), is("value3"));
-
-        // user7 has roles with field level security and without field level security
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user7", USERS_PASSWD)))
-            .prepareMultiSearch()
-            .add(prepareSearch("test1").setQuery(QueryBuilders.matchAllQuery()))
-            .add(prepareSearch("test2").setQuery(QueryBuilders.matchAllQuery()))
-            .get();
-        assertFalse(response.getResponses()[0].isFailure());
-        assertThat(response.getResponses()[0].getResponse().getHits().getTotalHits().value, is(1L));
-        assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(3));
-        assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
-        assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field2"), is("value2"));
-        assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field3"), is("value3"));
-        assertThat(response.getResponses()[1].getResponse().getHits().getTotalHits().value, is(1L));
-        assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(3));
-        assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
-        assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field2"), is("value2"));
-        assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field3"), is("value3"));
-
-        // user8 has roles with field level security with access to field1 and field2
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user8", USERS_PASSWD)))
-            .prepareMultiSearch()
-            .add(prepareSearch("test1").setQuery(QueryBuilders.matchAllQuery()))
-            .add(prepareSearch("test2").setQuery(QueryBuilders.matchAllQuery()))
-            .get();
-        assertFalse(response.getResponses()[0].isFailure());
-        assertThat(response.getResponses()[0].getResponse().getHits().getTotalHits().value, is(1L));
-        assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(2));
-        assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
-        assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field2"), is("value2"));
-        assertThat(response.getResponses()[1].getResponse().getHits().getTotalHits().value, is(1L));
-        assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(2));
-        assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
-        assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field2"), is("value2"));
+        {
+            // user2 is granted access to field2 only
+            MultiSearchResponse response = client().filterWithHeader(
+                Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2", USERS_PASSWD))
+            )
+                .prepareMultiSearch()
+                .add(prepareSearch("test1").setQuery(QueryBuilders.matchAllQuery()))
+                .add(prepareSearch("test2").setQuery(QueryBuilders.matchAllQuery()))
+                .get();
+            try {
+                assertFalse(response.getResponses()[0].isFailure());
+                assertThat(response.getResponses()[0].getResponse().getHits().getTotalHits().value, is(1L));
+                assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(1));
+                assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field2"), is("value2"));
+                assertThat(response.getResponses()[1].getResponse().getHits().getTotalHits().value, is(1L));
+                assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(1));
+                assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field2"), is("value2"));
+            } finally {
+                response.decRef();
+            }
+        }
+        {
+            // user3 is granted access to field1 and field2
+            MultiSearchResponse response = client().filterWithHeader(
+                Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user3", USERS_PASSWD))
+            )
+                .prepareMultiSearch()
+                .add(prepareSearch("test1").setQuery(QueryBuilders.matchAllQuery()))
+                .add(prepareSearch("test2").setQuery(QueryBuilders.matchAllQuery()))
+                .get();
+            try {
+                assertFalse(response.getResponses()[0].isFailure());
+                assertThat(response.getResponses()[0].getResponse().getHits().getTotalHits().value, is(1L));
+                assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(2));
+                assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
+                assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field2"), is("value2"));
+                assertThat(response.getResponses()[1].getResponse().getHits().getTotalHits().value, is(1L));
+                assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(2));
+                assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
+                assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field2"), is("value2"));
+            } finally {
+                response.decRef();
+            }
+        }
+        {
+            // user4 is granted access to no fields, so the search response does say the doc exist, but no fields are returned
+            MultiSearchResponse response = client().filterWithHeader(
+                Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user4", USERS_PASSWD))
+            )
+                .prepareMultiSearch()
+                .add(prepareSearch("test1").setQuery(QueryBuilders.matchAllQuery()))
+                .add(prepareSearch("test2").setQuery(QueryBuilders.matchAllQuery()))
+                .get();
+            try {
+                assertFalse(response.getResponses()[0].isFailure());
+                assertThat(response.getResponses()[0].getResponse().getHits().getTotalHits().value, is(1L));
+                assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(0));
+                assertThat(response.getResponses()[1].getResponse().getHits().getTotalHits().value, is(1L));
+                assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(0));
+            } finally {
+                response.decRef();
+            }
+        }
+        {
+            // user5 has no field level security configured, so all fields are returned
+            MultiSearchResponse response = client().filterWithHeader(
+                Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user5", USERS_PASSWD))
+            )
+                .prepareMultiSearch()
+                .add(prepareSearch("test1").setQuery(QueryBuilders.matchAllQuery()))
+                .add(prepareSearch("test2").setQuery(QueryBuilders.matchAllQuery()))
+                .get();
+            try {
+                assertFalse(response.getResponses()[0].isFailure());
+                assertThat(response.getResponses()[0].getResponse().getHits().getTotalHits().value, is(1L));
+                assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(3));
+                assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
+                assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field2"), is("value2"));
+                assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field3"), is("value3"));
+                assertThat(response.getResponses()[1].getResponse().getHits().getTotalHits().value, is(1L));
+                assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(3));
+                assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
+                assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field2"), is("value2"));
+                assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field3"), is("value3"));
+            } finally {
+                response.decRef();
+            }
+        }
+        {
+            // user6 has access to field*
+            MultiSearchResponse response = client().filterWithHeader(
+                Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user6", USERS_PASSWD))
+            )
+                .prepareMultiSearch()
+                .add(prepareSearch("test1").setQuery(QueryBuilders.matchAllQuery()))
+                .add(prepareSearch("test2").setQuery(QueryBuilders.matchAllQuery()))
+                .get();
+            try {
+                assertFalse(response.getResponses()[0].isFailure());
+                assertThat(response.getResponses()[0].getResponse().getHits().getTotalHits().value, is(1L));
+                assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(3));
+                assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
+                assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field2"), is("value2"));
+                assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field3"), is("value3"));
+                assertThat(response.getResponses()[1].getResponse().getHits().getTotalHits().value, is(1L));
+                assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(3));
+                assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
+                assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field2"), is("value2"));
+                assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field3"), is("value3"));
+            } finally {
+                response.decRef();
+            }
+        }
+        {
+            // user7 has roles with field level security and without field level security
+            MultiSearchResponse response = client().filterWithHeader(
+                Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user7", USERS_PASSWD))
+            )
+                .prepareMultiSearch()
+                .add(prepareSearch("test1").setQuery(QueryBuilders.matchAllQuery()))
+                .add(prepareSearch("test2").setQuery(QueryBuilders.matchAllQuery()))
+                .get();
+            try {
+                assertFalse(response.getResponses()[0].isFailure());
+                assertThat(response.getResponses()[0].getResponse().getHits().getTotalHits().value, is(1L));
+                assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(3));
+                assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
+                assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field2"), is("value2"));
+                assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field3"), is("value3"));
+                assertThat(response.getResponses()[1].getResponse().getHits().getTotalHits().value, is(1L));
+                assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(3));
+                assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
+                assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field2"), is("value2"));
+                assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field3"), is("value3"));
+            } finally {
+                response.decRef();
+            }
+        }
+        {
+            // user8 has roles with field level security with access to field1 and field2
+            MultiSearchResponse response = client().filterWithHeader(
+                Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user8", USERS_PASSWD))
+            )
+                .prepareMultiSearch()
+                .add(prepareSearch("test1").setQuery(QueryBuilders.matchAllQuery()))
+                .add(prepareSearch("test2").setQuery(QueryBuilders.matchAllQuery()))
+                .get();
+            try {
+                assertFalse(response.getResponses()[0].isFailure());
+                assertThat(response.getResponses()[0].getResponse().getHits().getTotalHits().value, is(1L));
+                assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(2));
+                assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
+                assertThat(response.getResponses()[0].getResponse().getHits().getAt(0).getSourceAsMap().get("field2"), is("value2"));
+                assertThat(response.getResponses()[1].getResponse().getHits().getTotalHits().value, is(1L));
+                assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().size(), is(2));
+                assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field1"), is("value1"));
+                assertThat(response.getResponses()[1].getResponse().getHits().getAt(0).getSourceAsMap().get("field2"), is("value2"));
+            } finally {
+                response.decRef();
+            }
+        }
     }
 
     public void testScroll() throws Exception {

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/KibanaUserRoleIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/KibanaUserRoleIntegTests.java
@@ -113,12 +113,16 @@ public class KibanaUserRoleIntegTests extends NativeRealmIntegTestCase {
         MultiSearchResponse multiSearchResponse = client().prepareMultiSearch()
             .add(prepareSearch(index).setQuery(QueryBuilders.matchAllQuery()))
             .get();
-        final long multiHits = multiSearchResponse.getResponses()[0].getResponse().getHits().getTotalHits().value;
-        assertThat(hits, greaterThan(0L));
-        multiSearchResponse = client().filterWithHeader(
-            singletonMap("Authorization", UsernamePasswordToken.basicAuthHeaderValue("kibana_user", USERS_PASSWD))
-        ).prepareMultiSearch().add(prepareSearch(index).setQuery(QueryBuilders.matchAllQuery())).get();
-        assertEquals(multiSearchResponse.getResponses()[0].getResponse().getHits().getTotalHits().value, multiHits);
+        try {
+            final long multiHits = multiSearchResponse.getResponses()[0].getResponse().getHits().getTotalHits().value;
+            assertThat(hits, greaterThan(0L));
+            multiSearchResponse = client().filterWithHeader(
+                singletonMap("Authorization", UsernamePasswordToken.basicAuthHeaderValue("kibana_user", USERS_PASSWD))
+            ).prepareMultiSearch().add(prepareSearch(index).setQuery(QueryBuilders.matchAllQuery())).get();
+            assertEquals(multiSearchResponse.getResponses()[0].getResponse().getHits().getTotalHits().value, multiHits);
+        } finally {
+            multiSearchResponse.decRef();
+        }
     }
 
     public void testGetIndex() throws Exception {

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/MultipleIndicesPermissionsTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/MultipleIndicesPermissionsTests.java
@@ -170,16 +170,20 @@ public class MultipleIndicesPermissionsTests extends SecurityIntegTestCase {
             .add(client.prepareSearch("test"))
             .add(client.prepareSearch("test1"))
             .get();
-        MultiSearchResponse.Item[] items = msearchResponse.getResponses();
-        assertThat(items.length, is(2));
-        assertThat(items[0].isFailure(), is(false));
-        searchResponse = items[0].getResponse();
-        assertNoFailures(searchResponse);
-        assertHitCount(searchResponse, 1);
-        assertThat(items[1].isFailure(), is(false));
-        searchResponse = items[1].getResponse();
-        assertNoFailures(searchResponse);
-        assertHitCount(searchResponse, 1);
+        try {
+            MultiSearchResponse.Item[] items = msearchResponse.getResponses();
+            assertThat(items.length, is(2));
+            assertThat(items[0].isFailure(), is(false));
+            searchResponse = items[0].getResponse();
+            assertNoFailures(searchResponse);
+            assertHitCount(searchResponse, 1);
+            assertThat(items[1].isFailure(), is(false));
+            searchResponse = items[1].getResponse();
+            assertNoFailures(searchResponse);
+            assertHitCount(searchResponse, 1);
+        } finally {
+            msearchResponse.decRef();
+        }
     }
 
     public void testMonitorRestrictedWildcards() throws Exception {

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/SecurityClearScrollTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/SecurityClearScrollTests.java
@@ -79,7 +79,11 @@ public class SecurityClearScrollTests extends SecurityIntegTestCase {
             multiSearchRequestBuilder.add(prepareSearch("index").setScroll("10m").setSize(1));
         }
         MultiSearchResponse multiSearchResponse = multiSearchRequestBuilder.get();
-        scrollIds = getScrollIds(multiSearchResponse);
+        try {
+            scrollIds = getScrollIds(multiSearchResponse);
+        } finally {
+            multiSearchResponse.decRef();
+        }
     }
 
     @After

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authz/ReadActionsTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authz/ReadActionsTests.java
@@ -211,28 +211,36 @@ public class ReadActionsTests extends SecurityIntegTestCase {
                 .add(new SearchRequest(new String[] {}))
                 .add(new SearchRequest("index1"))
                 .get();
-            assertEquals(2, multiSearchResponse.getResponses().length);
-            assertFalse(multiSearchResponse.getResponses()[0].isFailure());
-            SearchResponse searchResponse = multiSearchResponse.getResponses()[0].getResponse();
-            assertThat(searchResponse.getHits().getTotalHits().value, greaterThan(0L));
-            assertReturnedIndices(searchResponse, "test1", "test2", "test3");
-            assertTrue(multiSearchResponse.getResponses()[1].isFailure());
-            Exception exception = multiSearchResponse.getResponses()[1].getFailure();
-            assertThat(exception, instanceOf(ElasticsearchSecurityException.class));
-            assertAuthorizationExceptionDefaultUsers(exception, SearchAction.NAME);
+            try {
+                assertEquals(2, multiSearchResponse.getResponses().length);
+                assertFalse(multiSearchResponse.getResponses()[0].isFailure());
+                SearchResponse searchResponse = multiSearchResponse.getResponses()[0].getResponse();
+                assertThat(searchResponse.getHits().getTotalHits().value, greaterThan(0L));
+                assertReturnedIndices(searchResponse, "test1", "test2", "test3");
+                assertTrue(multiSearchResponse.getResponses()[1].isFailure());
+                Exception exception = multiSearchResponse.getResponses()[1].getFailure();
+                assertThat(exception, instanceOf(ElasticsearchSecurityException.class));
+                assertAuthorizationExceptionDefaultUsers(exception, SearchAction.NAME);
+            } finally {
+                multiSearchResponse.decRef();
+            }
         }
         {
             MultiSearchResponse multiSearchResponse = client().prepareMultiSearch()
                 .add(new SearchRequest(new String[] {}))
                 .add(new SearchRequest("index1").indicesOptions(IndicesOptions.fromOptions(true, true, true, randomBoolean())))
                 .get();
-            assertEquals(2, multiSearchResponse.getResponses().length);
-            assertFalse(multiSearchResponse.getResponses()[0].isFailure());
-            SearchResponse searchResponse = multiSearchResponse.getResponses()[0].getResponse();
-            assertThat(searchResponse.getHits().getTotalHits().value, greaterThan(0L));
-            assertReturnedIndices(searchResponse, "test1", "test2", "test3");
-            assertFalse(multiSearchResponse.getResponses()[1].isFailure());
-            assertNoSearchHits(multiSearchResponse.getResponses()[1].getResponse());
+            try {
+                assertEquals(2, multiSearchResponse.getResponses().length);
+                assertFalse(multiSearchResponse.getResponses()[0].isFailure());
+                SearchResponse searchResponse = multiSearchResponse.getResponses()[0].getResponse();
+                assertThat(searchResponse.getHits().getTotalHits().value, greaterThan(0L));
+                assertReturnedIndices(searchResponse, "test1", "test2", "test3");
+                assertFalse(multiSearchResponse.getResponses()[1].isFailure());
+                assertNoSearchHits(multiSearchResponse.getResponses()[1].getResponse());
+            } finally {
+                multiSearchResponse.decRef();
+            }
         }
     }
 
@@ -243,28 +251,36 @@ public class ReadActionsTests extends SecurityIntegTestCase {
                 .add(new SearchRequest(new String[] {}))
                 .add(new SearchRequest("missing"))
                 .get();
-            assertEquals(2, multiSearchResponse.getResponses().length);
-            assertFalse(multiSearchResponse.getResponses()[0].isFailure());
-            SearchResponse searchResponse = multiSearchResponse.getResponses()[0].getResponse();
-            assertThat(searchResponse.getHits().getTotalHits().value, greaterThan(0L));
-            assertReturnedIndices(searchResponse, "test1", "test2", "test3");
-            assertTrue(multiSearchResponse.getResponses()[1].isFailure());
-            Exception exception = multiSearchResponse.getResponses()[1].getFailure();
-            assertThat(exception, instanceOf(ElasticsearchSecurityException.class));
-            assertAuthorizationExceptionDefaultUsers(exception, SearchAction.NAME);
+            try {
+                assertEquals(2, multiSearchResponse.getResponses().length);
+                assertFalse(multiSearchResponse.getResponses()[0].isFailure());
+                SearchResponse searchResponse = multiSearchResponse.getResponses()[0].getResponse();
+                assertThat(searchResponse.getHits().getTotalHits().value, greaterThan(0L));
+                assertReturnedIndices(searchResponse, "test1", "test2", "test3");
+                assertTrue(multiSearchResponse.getResponses()[1].isFailure());
+                Exception exception = multiSearchResponse.getResponses()[1].getFailure();
+                assertThat(exception, instanceOf(ElasticsearchSecurityException.class));
+                assertAuthorizationExceptionDefaultUsers(exception, SearchAction.NAME);
+            } finally {
+                multiSearchResponse.decRef();
+            }
         }
         {
             MultiSearchResponse multiSearchResponse = client().prepareMultiSearch()
                 .add(new SearchRequest(new String[] {}))
                 .add(new SearchRequest("missing").indicesOptions(IndicesOptions.fromOptions(true, true, true, randomBoolean())))
                 .get();
-            assertEquals(2, multiSearchResponse.getResponses().length);
-            assertFalse(multiSearchResponse.getResponses()[0].isFailure());
-            SearchResponse searchResponse = multiSearchResponse.getResponses()[0].getResponse();
-            assertThat(searchResponse.getHits().getTotalHits().value, greaterThan(0L));
-            assertReturnedIndices(searchResponse, "test1", "test2", "test3");
-            assertFalse(multiSearchResponse.getResponses()[1].isFailure());
-            assertNoSearchHits(multiSearchResponse.getResponses()[1].getResponse());
+            try {
+                assertEquals(2, multiSearchResponse.getResponses().length);
+                assertFalse(multiSearchResponse.getResponses()[0].isFailure());
+                SearchResponse searchResponse = multiSearchResponse.getResponses()[0].getResponse();
+                assertThat(searchResponse.getHits().getTotalHits().value, greaterThan(0L));
+                assertReturnedIndices(searchResponse, "test1", "test2", "test3");
+                assertFalse(multiSearchResponse.getResponses()[1].isFailure());
+                assertNoSearchHits(multiSearchResponse.getResponses()[1].getResponse());
+            } finally {
+                multiSearchResponse.decRef();
+            }
         }
     }
 
@@ -277,13 +293,17 @@ public class ReadActionsTests extends SecurityIntegTestCase {
                 .add(new SearchRequest(new String[] {}))
                 .add(new SearchRequest("test4"))
                 .get();
-            assertFalse(multiSearchResponse.getResponses()[0].isFailure());
-            assertReturnedIndices(multiSearchResponse.getResponses()[0].getResponse(), "test1", "test2", "test3");
-            assertTrue(multiSearchResponse.getResponses()[1].isFailure());
-            assertThat(
-                multiSearchResponse.getResponses()[1].getFailure().toString(),
-                equalTo("[test4] org.elasticsearch.index.IndexNotFoundException: no such index [test4]")
-            );
+            try {
+                assertFalse(multiSearchResponse.getResponses()[0].isFailure());
+                assertReturnedIndices(multiSearchResponse.getResponses()[0].getResponse(), "test1", "test2", "test3");
+                assertTrue(multiSearchResponse.getResponses()[1].isFailure());
+                assertThat(
+                    multiSearchResponse.getResponses()[1].getFailure().toString(),
+                    equalTo("[test4] org.elasticsearch.index.IndexNotFoundException: no such index [test4]")
+                );
+            } finally {
+                multiSearchResponse.decRef();
+            }
         }
         {
             // we set ignore_unavailable and allow_no_indices to true, no errors returned, second item doesn't have hits.
@@ -291,8 +311,12 @@ public class ReadActionsTests extends SecurityIntegTestCase {
                 .add(new SearchRequest(new String[] {}))
                 .add(new SearchRequest("test4").indicesOptions(IndicesOptions.fromOptions(true, true, true, randomBoolean())))
                 .get();
-            assertReturnedIndices(multiSearchResponse.getResponses()[0].getResponse(), "test1", "test2", "test3");
-            assertNoSearchHits(multiSearchResponse.getResponses()[1].getResponse());
+            try {
+                assertReturnedIndices(multiSearchResponse.getResponses()[0].getResponse(), "test1", "test2", "test3");
+                assertNoSearchHits(multiSearchResponse.getResponses()[1].getResponse());
+            } finally {
+                multiSearchResponse.decRef();
+            }
         }
     }
 
@@ -303,26 +327,34 @@ public class ReadActionsTests extends SecurityIntegTestCase {
                 .add(new SearchRequest(new String[] {}))
                 .add(new SearchRequest("index*"))
                 .get();
-            assertEquals(2, multiSearchResponse.getResponses().length);
-            assertFalse(multiSearchResponse.getResponses()[0].isFailure());
-            SearchResponse searchResponse = multiSearchResponse.getResponses()[0].getResponse();
-            assertThat(searchResponse.getHits().getTotalHits().value, greaterThan(0L));
-            assertReturnedIndices(searchResponse, "test1", "test2", "test3");
-            assertNoSearchHits(multiSearchResponse.getResponses()[1].getResponse());
+            try {
+                assertEquals(2, multiSearchResponse.getResponses().length);
+                assertFalse(multiSearchResponse.getResponses()[0].isFailure());
+                SearchResponse searchResponse = multiSearchResponse.getResponses()[0].getResponse();
+                assertThat(searchResponse.getHits().getTotalHits().value, greaterThan(0L));
+                assertReturnedIndices(searchResponse, "test1", "test2", "test3");
+                assertNoSearchHits(multiSearchResponse.getResponses()[1].getResponse());
+            } finally {
+                multiSearchResponse.decRef();
+            }
         }
         {
             MultiSearchResponse multiSearchResponse = client().prepareMultiSearch()
                 .add(new SearchRequest(new String[] {}))
                 .add(new SearchRequest("index*").indicesOptions(IndicesOptions.fromOptions(randomBoolean(), false, true, randomBoolean())))
                 .get();
-            assertEquals(2, multiSearchResponse.getResponses().length);
-            assertFalse(multiSearchResponse.getResponses()[0].isFailure());
-            SearchResponse searchResponse = multiSearchResponse.getResponses()[0].getResponse();
-            assertThat(searchResponse.getHits().getTotalHits().value, greaterThan(0L));
-            assertReturnedIndices(searchResponse, "test1", "test2", "test3");
-            assertTrue(multiSearchResponse.getResponses()[1].isFailure());
-            Exception exception = multiSearchResponse.getResponses()[1].getFailure();
-            assertThat(exception, instanceOf(IndexNotFoundException.class));
+            try {
+                assertEquals(2, multiSearchResponse.getResponses().length);
+                assertFalse(multiSearchResponse.getResponses()[0].isFailure());
+                SearchResponse searchResponse = multiSearchResponse.getResponses()[0].getResponse();
+                assertThat(searchResponse.getHits().getTotalHits().value, greaterThan(0L));
+                assertReturnedIndices(searchResponse, "test1", "test2", "test3");
+                assertTrue(multiSearchResponse.getResponses()[1].isFailure());
+                Exception exception = multiSearchResponse.getResponses()[1].getFailure();
+                assertThat(exception, instanceOf(IndexNotFoundException.class));
+            } finally {
+                multiSearchResponse.decRef();
+            }
         }
     }
 


### PR DESCRIPTION
Part of the effort to fix search response leaks is to fix these. Fixed all that I could easily find in tests. Production changes incoming once the dependencies for those are fixed.

part of #102030 but no fancy utility here like for search responses since we don't have so many use cases an none of them are tricky.