### PR TITLE
Cleanup GetResponse

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/document/DocumentActionsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/document/DocumentActionsIT.java
@@ -101,7 +101,7 @@ public class DocumentActionsIT extends ESIntegTestCase {
             getResult = client().prepareGet("test", "1").setStoredFields("name").get();
             assertThat(getResult.getIndex(), equalTo(getConcreteIndexName()));
             assertThat(getResult.isExists(), equalTo(true));
-            assertThat(getResult.getSourceAsBytes(), nullValue());
+            assertThat(getResult.getSourceAsBytesRef(), nullValue());
             assertThat(getResult.getField("name").getValues().get(0).toString(), equalTo("test"));
         }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/explain/ExplainActionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/explain/ExplainActionIT.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.io.stream.InputStreamStreamInput;
 import org.elasticsearch.common.io.stream.OutputStreamStreamOutput;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.get.GetResult;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.TermsQueryBuilder;
 import org.elasticsearch.indices.TermsLookup;
@@ -175,8 +176,10 @@ public class ExplainActionIT extends ESIntegTestCase {
         assertThat(response.getExplanation().getValue(), equalTo(1.0f));
         assertThat(response.getGetResult().isExists(), equalTo(true));
         assertThat(response.getGetResult().getId(), equalTo("1"));
-        assertThat(response.getGetResult().getSource().size(), equalTo(1));
-        assertThat(((Map<String, Object>) response.getGetResult().getSource().get("obj1")).get("field1").toString(), equalTo("value1"));
+        GetResult documentFields12 = response.getGetResult();
+        assertThat(documentFields12.sourceAsMap().size(), equalTo(1));
+        GetResult documentFields11 = response.getGetResult();
+        assertThat(((Map<String, Object>) documentFields11.sourceAsMap().get("obj1")).get("field1").toString(), equalTo("value1"));
 
         response = client().prepareExplain(indexOrAlias(), "1")
             .setQuery(QueryBuilders.matchAllQuery())
@@ -184,7 +187,8 @@ public class ExplainActionIT extends ESIntegTestCase {
             .get();
         assertNotNull(response);
         assertTrue(response.isMatch());
-        assertThat(((Map<String, Object>) response.getGetResult().getSource().get("obj1")).get("field1").toString(), equalTo("value1"));
+        GetResult documentFields1 = response.getGetResult();
+        assertThat(((Map<String, Object>) documentFields1.sourceAsMap().get("obj1")).get("field1").toString(), equalTo("value1"));
     }
 
     public void testExplainWithFilteredAlias() {
@@ -227,8 +231,10 @@ public class ExplainActionIT extends ESIntegTestCase {
         assertThat(response.getGetResult(), notNullValue());
         assertThat(response.getGetResult().getIndex(), equalTo("test"));
         assertThat(response.getGetResult().getId(), equalTo("1"));
-        assertThat(response.getGetResult().getSource(), notNullValue());
-        assertThat(response.getGetResult().getSource().get("field1"), equalTo("value1"));
+        GetResult documentFields11 = response.getGetResult();
+        assertThat(documentFields11.sourceAsMap(), notNullValue());
+        GetResult documentFields1 = response.getGetResult();
+        assertThat(documentFields1.sourceAsMap().get("field1"), equalTo("value1"));
     }
 
     public void testExplainDateRangeInQueryString() {

--- a/server/src/internalClusterTest/java/org/elasticsearch/explain/ExplainActionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/explain/ExplainActionIT.java
@@ -15,7 +15,6 @@ import org.elasticsearch.common.io.stream.InputStreamStreamInput;
 import org.elasticsearch.common.io.stream.OutputStreamStreamOutput;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.index.get.GetResult;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.TermsQueryBuilder;
 import org.elasticsearch.indices.TermsLookup;
@@ -176,10 +175,8 @@ public class ExplainActionIT extends ESIntegTestCase {
         assertThat(response.getExplanation().getValue(), equalTo(1.0f));
         assertThat(response.getGetResult().isExists(), equalTo(true));
         assertThat(response.getGetResult().getId(), equalTo("1"));
-        GetResult documentFields12 = response.getGetResult();
-        assertThat(documentFields12.sourceAsMap().size(), equalTo(1));
-        GetResult documentFields11 = response.getGetResult();
-        assertThat(((Map<String, Object>) documentFields11.sourceAsMap().get("obj1")).get("field1").toString(), equalTo("value1"));
+        assertThat(response.getGetResult().sourceAsMap().size(), equalTo(1));
+        assertThat(((Map<String, Object>) response.getGetResult().sourceAsMap().get("obj1")).get("field1").toString(), equalTo("value1"));
 
         response = client().prepareExplain(indexOrAlias(), "1")
             .setQuery(QueryBuilders.matchAllQuery())
@@ -187,8 +184,7 @@ public class ExplainActionIT extends ESIntegTestCase {
             .get();
         assertNotNull(response);
         assertTrue(response.isMatch());
-        GetResult documentFields1 = response.getGetResult();
-        assertThat(((Map<String, Object>) documentFields1.sourceAsMap().get("obj1")).get("field1").toString(), equalTo("value1"));
+        assertThat(((Map<String, Object>) response.getGetResult().sourceAsMap().get("obj1")).get("field1").toString(), equalTo("value1"));
     }
 
     public void testExplainWithFilteredAlias() {
@@ -231,10 +227,8 @@ public class ExplainActionIT extends ESIntegTestCase {
         assertThat(response.getGetResult(), notNullValue());
         assertThat(response.getGetResult().getIndex(), equalTo("test"));
         assertThat(response.getGetResult().getId(), equalTo("1"));
-        GetResult documentFields11 = response.getGetResult();
-        assertThat(documentFields11.sourceAsMap(), notNullValue());
-        GetResult documentFields1 = response.getGetResult();
-        assertThat(documentFields1.sourceAsMap().get("field1"), equalTo("value1"));
+        assertThat(response.getGetResult().sourceAsMap(), notNullValue());
+        assertThat(response.getGetResult().sourceAsMap().get("field1"), equalTo("value1"));
     }
 
     public void testExplainDateRangeInQueryString() {

--- a/server/src/internalClusterTest/java/org/elasticsearch/get/GetActionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/get/GetActionIT.java
@@ -100,7 +100,7 @@ public class GetActionIT extends ESIntegTestCase {
         assertThat(response.getIndex(), equalTo("test"));
         Set<String> fields = new HashSet<>(response.getFields().keySet());
         assertThat(fields, equalTo(Collections.<String>emptySet()));
-        assertThat(response.getSourceAsBytes(), nullValue());
+        assertThat(response.getSourceAsBytesRef(), nullValue());
 
         logger.info("--> realtime get 1 (no source, explicit)");
         response = client().prepareGet(indexOrAlias(), "1").setFetchSource(false).get();
@@ -108,7 +108,7 @@ public class GetActionIT extends ESIntegTestCase {
         assertThat(response.getIndex(), equalTo("test"));
         fields = new HashSet<>(response.getFields().keySet());
         assertThat(fields, equalTo(Collections.<String>emptySet()));
-        assertThat(response.getSourceAsBytes(), nullValue());
+        assertThat(response.getSourceAsBytesRef(), nullValue());
 
         logger.info("--> realtime get 1 (no type)");
         response = client().prepareGet(indexOrAlias(), "1").get();
@@ -121,7 +121,7 @@ public class GetActionIT extends ESIntegTestCase {
         response = client().prepareGet(indexOrAlias(), "1").setStoredFields("field1").get();
         assertThat(response.isExists(), equalTo(true));
         assertThat(response.getIndex(), equalTo("test"));
-        assertThat(response.getSourceAsBytes(), nullValue());
+        assertThat(response.getSourceAsBytesRef(), nullValue());
         assertThat(response.getField("field1").getValues().get(0).toString(), equalTo("value1"));
         assertThat(response.getField("field2"), nullValue());
 
@@ -155,7 +155,7 @@ public class GetActionIT extends ESIntegTestCase {
         response = client().prepareGet(indexOrAlias(), "1").setStoredFields("field1").get();
         assertThat(response.isExists(), equalTo(true));
         assertThat(response.getIndex(), equalTo("test"));
-        assertThat(response.getSourceAsBytes(), nullValue());
+        assertThat(response.getSourceAsBytesRef(), nullValue());
         assertThat(response.getField("field1").getValues().get(0).toString(), equalTo("value1"));
         assertThat(response.getField("field2"), nullValue());
 
@@ -163,7 +163,7 @@ public class GetActionIT extends ESIntegTestCase {
         response = client().prepareGet(indexOrAlias(), "1").setStoredFields("field1").setFetchSource(true).get();
         assertThat(response.isExists(), equalTo(true));
         assertThat(response.getIndex(), equalTo("test"));
-        assertThat(response.getSourceAsBytes(), not(nullValue()));
+        assertThat(response.getSourceAsBytesRef(), not(nullValue()));
         assertThat(response.getField("field1").getValues().get(0).toString(), equalTo("value1"));
         assertThat(response.getField("field2"), nullValue());
 
@@ -268,7 +268,7 @@ public class GetActionIT extends ESIntegTestCase {
             .get();
 
         assertThat(response.getResponses().length, equalTo(2));
-        assertThat(response.getResponses()[0].getResponse().getSourceAsBytes(), nullValue());
+        assertThat(response.getResponses()[0].getResponse().getSourceAsBytesRef(), nullValue());
         assertThat(response.getResponses()[0].getResponse().getField("field").getValues().get(0).toString(), equalTo("value1"));
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/mget/SimpleMgetIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/mget/SimpleMgetIT.java
@@ -170,7 +170,7 @@ public class SimpleMgetIT extends ESIntegTestCase {
                 assertThat(((Map<String, Object>) source.get("included")).size(), equalTo(1));
                 assertThat(((Map<String, Object>) source.get("included")), hasKey("field"));
             } else {
-                assertThat(responseItem.getResponse().getSourceAsBytes(), nullValue());
+                assertThat(responseItem.getResponse().getSourceAsBytesRef(), nullValue());
             }
         }
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/nested/SimpleNestedIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/nested/SimpleNestedIT.java
@@ -77,7 +77,7 @@ public class SimpleNestedIT extends ESIntegTestCase {
         waitForRelocation(ClusterHealthStatus.GREEN);
         GetResponse getResponse = client().prepareGet("test", "1").get();
         assertThat(getResponse.isExists(), equalTo(true));
-        assertThat(getResponse.getSourceAsBytes(), notNullValue());
+        assertThat(getResponse.getSourceAsBytesRef(), notNullValue());
         refresh();
         // check the numDocs
         assertDocumentCount("test", 3);

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/nested/VectorNestedIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/nested/VectorNestedIT.java
@@ -62,7 +62,7 @@ public class VectorNestedIT extends ESIntegTestCase {
         waitForRelocation(ClusterHealthStatus.GREEN);
         GetResponse getResponse = client().prepareGet("test", "1").get();
         assertThat(getResponse.isExists(), equalTo(true));
-        assertThat(getResponse.getSourceAsBytes(), notNullValue());
+        assertThat(getResponse.getSourceAsBytesRef(), notNullValue());
         refresh();
 
         assertResponse(

--- a/server/src/main/java/org/elasticsearch/action/get/GetResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/get/GetResponse.java
@@ -89,13 +89,6 @@ public class GetResponse extends ActionResponse implements Iterable<DocumentFiel
     }
 
     /**
-     * The source of the document if exists.
-     */
-    public byte[] getSourceAsBytes() {
-        return getResult.source();
-    }
-
-    /**
      * Returns the internal source bytes, as they are returned without munging (for example,
      * might still be compressed).
      */
@@ -132,7 +125,7 @@ public class GetResponse extends ActionResponse implements Iterable<DocumentFiel
     }
 
     public Map<String, Object> getSource() {
-        return getResult.getSource();
+        return getResult.sourceAsMap();
     }
 
     public Map<String, DocumentField> getFields() {

--- a/server/src/main/java/org/elasticsearch/index/get/GetResult.java
+++ b/server/src/main/java/org/elasticsearch/index/get/GetResult.java
@@ -52,17 +52,16 @@ public class GetResult implements Writeable, Iterable<DocumentField>, ToXContent
     private static final String FOUND = "found";
     private static final String FIELDS = "fields";
 
-    private String index;
-    private String id;
-    private long version;
-    private long seqNo;
-    private long primaryTerm;
-    private boolean exists;
+    private final String index;
+    private final String id;
+    private final long version;
+    private final long seqNo;
+    private final long primaryTerm;
+    private final boolean exists;
     private final Map<String, DocumentField> documentFields;
     private final Map<String, DocumentField> metaFields;
     private Map<String, Object> sourceAsMap;
     private BytesReference source;
-    private byte[] sourceAsBytes;
 
     public GetResult(StreamInput in) throws IOException {
         index = in.readString();
@@ -156,20 +155,6 @@ public class GetResult implements Writeable, Iterable<DocumentField>, ToXContent
     }
 
     /**
-     * The source of the document if exists.
-     */
-    public byte[] source() {
-        if (source == null) {
-            return null;
-        }
-        if (sourceAsBytes != null) {
-            return sourceAsBytes;
-        }
-        this.sourceAsBytes = BytesReference.toBytes(sourceRef());
-        return this.sourceAsBytes;
-    }
-
-    /**
      * Returns bytes reference, also un compress the source if needed.
      */
     public BytesReference sourceRef() {
@@ -227,10 +212,6 @@ public class GetResult implements Writeable, Iterable<DocumentField>, ToXContent
 
         sourceAsMap = Source.fromBytes(source).source();
         return sourceAsMap;
-    }
-
-    public Map<String, Object> getSource() {
-        return sourceAsMap();
     }
 
     public Map<String, DocumentField> getMetadataFields() {


### PR DESCRIPTION
We will want to ref-count this one eventually to save memory. We can take a few steps towards that goal here today. Removing the test-only `byte[]` source return that doesn't play well with pooled + making fields final where possible.

sort of relates #102030 