### PR TITLE
[ML] Add OpenAI error response handler

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/RetryingHttpSender.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/RetryingHttpSender.java
@@ -105,8 +105,8 @@ public class RetryingHttpSender implements Retrier {
 
         @Override
         public boolean shouldRetry(Exception e) {
-            if (e instanceof RetryException) {
-                return ((RetryException) e).shouldRetry();
+            if (e instanceof RetryException retry) {
+                return retry.shouldRetry();
             }
 
             return false;

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/openai/OpenAiClient.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/openai/OpenAiClient.java
@@ -11,7 +11,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.inference.InferenceResults;
-import org.elasticsearch.xpack.inference.external.http.retry.AlwaysRetryingResponseHandler;
 import org.elasticsearch.xpack.inference.external.http.retry.ResponseHandler;
 import org.elasticsearch.xpack.inference.external.http.retry.RetrySettings;
 import org.elasticsearch.xpack.inference.external.http.retry.RetryingHttpSender;
@@ -19,6 +18,7 @@ import org.elasticsearch.xpack.inference.external.http.sender.Sender;
 import org.elasticsearch.xpack.inference.external.request.openai.OpenAiEmbeddingsRequest;
 import org.elasticsearch.xpack.inference.external.response.openai.OpenAiEmbeddingsResponseEntity;
 import org.elasticsearch.xpack.inference.services.ServiceComponents;
+import org.elasticsearch.xpack.inference.services.openai.OpenAiResponseHandler;
 
 import java.io.IOException;
 import java.util.List;
@@ -44,7 +44,7 @@ public class OpenAiClient {
     }
 
     private static ResponseHandler createEmbeddingsHandler() {
-        return new AlwaysRetryingResponseHandler(
+        return new OpenAiResponseHandler(
             "openai text embedding",
             // TODO this is a hack to get the response to fit within List<InferenceResults> and will be addressed in a follow up PR
             result -> List.of(OpenAiEmbeddingsResponseEntity.fromResponse(result))

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/response/openai/OpenAiErrorResponseEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/response/openai/OpenAiErrorResponseEntity.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.external.response.openai;
+
+import org.elasticsearch.xcontent.XContentFactory;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
+import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.inference.external.http.HttpResult;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class OpenAiErrorResponseEntity {
+
+    private final String errorMessage;
+
+    private OpenAiErrorResponseEntity(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    /**
+     * An example error response for invalid auth would look like
+     * <code>
+     *     {
+     *       "error": {
+     *         "message": "You didn't provide an API key...",
+     *         "type": "invalid_request_error",
+     *         "param": null,
+     *         "code": null
+     *       }
+     *     }
+     * </code>
+     *
+     *
+     * @param response The error response
+     * @return An error entity if the response is JSON with the above structure
+     * or null if the response does not contain the error.message field
+     */
+    @SuppressWarnings("unchecked")
+    public static OpenAiErrorResponseEntity fromResponse(HttpResult response) {
+        try (
+            XContentParser jsonParser = XContentFactory.xContent(XContentType.JSON)
+                .createParser(XContentParserConfiguration.EMPTY, response.body())
+        ) {
+            var responseMap = jsonParser.map();
+            var error = (Map<String, Object>) responseMap.get("error");
+            if (error != null) {
+                var message = (String) error.get("message");
+                if (message != null) {
+                    return new OpenAiErrorResponseEntity(message);
+                }
+            }
+        } catch (IOException e) {
+            // swallow the error
+        }
+
+        return null;
+    }
+}

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/OpenAiResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/OpenAiResponseHandler.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.services.openai;
+
+import org.apache.http.RequestLine;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.core.CheckedFunction;
+import org.elasticsearch.inference.InferenceResults;
+import org.elasticsearch.xpack.inference.external.http.HttpResult;
+import org.elasticsearch.xpack.inference.external.http.retry.ResponseHandler;
+import org.elasticsearch.xpack.inference.external.http.retry.RetryException;
+import org.elasticsearch.xpack.inference.external.response.openai.OpenAiErrorResponseEntity;
+import org.elasticsearch.xpack.inference.logging.ThrottlerManager;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+import static org.elasticsearch.core.Strings.format;
+import static org.elasticsearch.xpack.inference.external.http.HttpUtils.checkForEmptyBody;
+
+public class OpenAiResponseHandler implements ResponseHandler {
+
+    protected final String requestType;
+    private final CheckedFunction<HttpResult, List<? extends InferenceResults>, IOException> parseFunction;
+
+    public OpenAiResponseHandler(
+        String requestType,
+        CheckedFunction<HttpResult, List<? extends InferenceResults>, IOException> parseFunction
+    ) {
+        this.requestType = Objects.requireNonNull(requestType);
+        this.parseFunction = Objects.requireNonNull(parseFunction);
+    }
+
+    @Override
+    public void validateResponse(ThrottlerManager throttlerManager, Logger logger, HttpRequestBase request, HttpResult result)
+        throws RetryException {
+        checkForFailureStatusCode(request, result);
+        checkForEmptyBody(throttlerManager, logger, request, result);
+    }
+
+    @Override
+    public List<? extends InferenceResults> parseResult(HttpResult result) throws RetryException {
+        try {
+            return parseFunction.apply(result);
+        } catch (Exception e) {
+            throw new RetryException(true, e);
+        }
+    }
+
+    @Override
+    public String getRequestType() {
+        return requestType;
+    }
+
+    /**
+     * Validates the status code throws an RetryException if not in the range [200, 300).
+     *
+     * The OpenAI API error codes are document at https://platform.openai.com/docs/guides/error-codes/api-errors
+     * @param request The http request
+     * @param result  The http response and body
+     * @throws RetryException Throws if status code is {@code >= 300 or < 200 }
+     */
+    static void checkForFailureStatusCode(HttpRequestBase request, HttpResult result) throws RetryException {
+        int statusCode = result.response().getStatusLine().getStatusCode();
+        if (statusCode >= 200 && statusCode < 300) {
+            return;
+        }
+
+        // handle error codes
+        if (statusCode >= 500) {
+            String errorMsg = buildErrorMessageWithResponse(
+                "Received a server error status code for request [%s] status [%s]",
+                request.getRequestLine(),
+                statusCode,
+                result
+            );
+            throw new RetryException(false, errorMsg);
+        } else if (statusCode == 429) {
+            String errorMsg = buildErrorMessageWithResponse(
+                "Received a rate limit status code for request [%s] status [%s]",
+                request.getRequestLine(),
+                statusCode,
+                result
+            );
+            throw new RetryException(false, errorMsg); // TODO back off and retry
+        } else if (statusCode == 401) {
+            String errorMsg = buildErrorMessageWithResponse(
+                "Received a authentication error status code for request [%s] status [%s]",
+                request.getRequestLine(),
+                statusCode,
+                result
+            );
+            throw new RetryException(false, errorMsg);
+        } else if (statusCode >= 300 && statusCode < 400) {
+            String errorMsg = buildErrorMessageWithResponse(
+                "Unhandled redirection for request [%s] status [%s]",
+                request.getRequestLine(),
+                statusCode,
+                result
+            );
+            throw new RetryException(false, errorMsg);
+        } else {
+            String errorMsg = buildErrorMessageWithResponse(
+                "Received an unsuccessful status code for request [%s] status [%s]",
+                request.getRequestLine(),
+                statusCode,
+                result
+            );
+            throw new RetryException(false, errorMsg);
+        }
+    }
+
+    static String buildErrorMessageWithResponse(String baseMessage, RequestLine requestLine, int statusCode, HttpResult response) {
+        var errorEntity = OpenAiErrorResponseEntity.fromResponse(response);
+
+        if (errorEntity == null) {
+            return format(baseMessage, requestLine, statusCode);
+        } else {
+            var base = format(baseMessage, requestLine, statusCode);
+            return base + ". Error message: [" + errorEntity.getErrorMessage() + "]";
+        }
+
+    }
+}

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/response/openai/OpenAiErrorResponseEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/response/openai/OpenAiErrorResponseEntityTests.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.external.response.openai;
+
+import org.apache.http.HttpResponse;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.inference.external.http.HttpResult;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.mockito.Mockito.mock;
+
+public class OpenAiErrorResponseEntityTests extends ESTestCase {
+    public void testFromResponse() {
+        String responseJson = """
+            {
+                "error": {
+                    "message": "You didn't provide an API key",
+                    "type": "invalid_request_error",
+                    "param": null,
+                    "code": null
+                }
+            }
+            """;
+
+        OpenAiErrorResponseEntity errorMessage = OpenAiErrorResponseEntity.fromResponse(
+            new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
+        );
+        assertEquals("You didn't provide an API key", errorMessage.getErrorMessage());
+    }
+
+    public void testFromResponse_noMessage() {
+        String responseJson = """
+            {
+                "error": {
+                    "type": "invalid_request_error"
+                }
+            }
+            """;
+
+        OpenAiErrorResponseEntity errorMessage = OpenAiErrorResponseEntity.fromResponse(
+            new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
+        );
+        assertNull(errorMessage);
+    }
+
+    public void testFromResponse_noErro() {
+        String responseJson = """
+            {
+                "something": {
+                    "not": "relevant"
+                }
+            }
+            """;
+
+        OpenAiErrorResponseEntity errorMessage = OpenAiErrorResponseEntity.fromResponse(
+            new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
+        );
+        assertNull(errorMessage);
+    }
+}

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/OpenAiResponseHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/OpenAiResponseHandlerTests.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.services.openai;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.inference.external.http.HttpResult;
+import org.elasticsearch.xpack.inference.external.http.retry.RetryException;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class OpenAiResponseHandlerTests extends ESTestCase {
+
+    public void testCheckForFailureStatusCode() {
+        var statusLine = mock(StatusLine.class);
+        when(statusLine.getStatusCode()).thenReturn(200).thenReturn(503).thenReturn(429).thenReturn(401).thenReturn(300).thenReturn(402);
+
+        var httpResponse = mock(HttpResponse.class);
+        when(httpResponse.getStatusLine()).thenReturn(statusLine);
+
+        var httpRequest = mock(HttpRequestBase.class);
+
+        var httpResult = new HttpResult(httpResponse, new byte[] {});
+
+        // 200 ok
+        OpenAiResponseHandler.checkForFailureStatusCode(httpRequest, httpResult);
+        // 503
+        var retryException = expectThrows(
+            RetryException.class,
+            () -> OpenAiResponseHandler.checkForFailureStatusCode(httpRequest, httpResult)
+        );
+        assertFalse(retryException.shouldRetry());
+        assertThat(retryException.getMessage(), containsString("Received a server error status code for request [null] status [503]"));
+        // 429
+        retryException = expectThrows(RetryException.class, () -> OpenAiResponseHandler.checkForFailureStatusCode(httpRequest, httpResult));
+        assertFalse(retryException.shouldRetry());
+        assertThat(retryException.getMessage(), containsString("Received a rate limit status code for request [null] status [429]"));
+        // 401
+        retryException = expectThrows(RetryException.class, () -> OpenAiResponseHandler.checkForFailureStatusCode(httpRequest, httpResult));
+        assertFalse(retryException.shouldRetry());
+        assertThat(
+            retryException.getMessage(),
+            containsString("Received a authentication error status code for request [null] status [401]")
+        );
+        // 300
+        retryException = expectThrows(RetryException.class, () -> OpenAiResponseHandler.checkForFailureStatusCode(httpRequest, httpResult));
+        assertFalse(retryException.shouldRetry());
+        assertThat(retryException.getMessage(), containsString("Unhandled redirection for request [null] status [300]"));
+        // 402
+        retryException = expectThrows(RetryException.class, () -> OpenAiResponseHandler.checkForFailureStatusCode(httpRequest, httpResult));
+        assertFalse(retryException.shouldRetry());
+        assertThat(retryException.getMessage(), containsString("Received an unsuccessful status code for request [null] status [402]"));
+    }
+}


### PR DESCRIPTION
Creates more specific error messages depending on the cause and incorporates the OpenAI error message extracted from the response.

Currently all errors are not retryable, retry on 429 will be implemented in a follow up.