### PR TITLE
[main] Update path-settings.asciidoc (#102615)

### DIFF
--- a/docs/reference/setup/important-settings/path-settings.asciidoc
+++ b/docs/reference/setup/important-settings/path-settings.asciidoc
@@ -127,6 +127,6 @@ double the size of your cluster so it will only work if you have the capacity to
 expand your cluster like this.
 
 If you currently use multiple data paths but your cluster is not highly
-available then the you can migrate to a non-deprecated configuration by taking
+available then you can migrate to a non-deprecated configuration by taking
 a snapshot, creating a new cluster with the desired configuration and restoring
 the snapshot into it.


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.11` to `main`:
 - [Update path-settings.asciidoc (#102615)](https://github.com/elastic/elasticsearch/pull/102615)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)