### PR TITLE
[8.11] [DOCS] ES|QL: add full-text search limitation (#102150)

### DIFF
--- a/docs/reference/esql/esql-limitations.asciidoc
+++ b/docs/reference/esql/esql-limitations.asciidoc
@@ -74,6 +74,35 @@ values, with the exception of nested fields. Nested fields are not returned at
 all.
 
 [discrete]
+[[esql-limitations-full-text-search]]
+=== Full-text search is not supported
+
+Because of <<esql-limitations-text-fields,the way {esql} treats `text` values>>,
+full-text search is not yet supported. Queries on `text` fields are like queries
+on `keyword` fields: they are case-sensitive and need to match the full string.
+
+For example, after indexing a field of type `text` with the value `Elasticsearch
+query language`, the following `WHERE` clause does not match because the `LIKE`
+operator is case-sensitive:
+[source,esql]
+----
+| WHERE field LIKE "elasticsearch query language"
+----
+
+The following `WHERE` clause does not match either, because the `LIKE` operator
+tries to match the whole string:
+[source,esql]
+----
+| WHERE field LIKE "Elasticsearch"
+----
+
+As a workaround, use wildcards and regular expressions. For example:
+[source,esql]
+----
+| WHERE field RLIKE "[Ee]lasticsearch.*"
+----
+
+[discrete]
 [[esql-limitations-text-fields]]
 === `text` fields behave like `keyword` fields
 


### PR DESCRIPTION
Backports the following commits to 8.11:
 - [DOCS] ES|QL: add full-text search limitation (#102150)