### PR TITLE
Revert non-semantic NodeInfo

### DIFF
--- a/docs/changelog/102636.yaml
+++ b/docs/changelog/102636.yaml
@@ -1,5 +1,0 @@
-pr: 102636
-summary: Revert non-semantic `NodeInfo`
-area: Infra/Core
-type: regression
-issues: []

--- a/docs/changelog/102636.yaml
+++ b/docs/changelog/102636.yaml
@@ -1,0 +1,5 @@
+pr: 102636
+summary: Revert non-semantic `NodeInfo`
+area: Infra/Core
+type: regression
+issues: []

--- a/server/src/main/java/org/elasticsearch/node/NodeService.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeService.java
@@ -10,6 +10,7 @@ package org.elasticsearch.node;
 
 import org.elasticsearch.Build;
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.node.info.ComponentVersionNumber;
 import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
@@ -117,7 +118,8 @@ public class NodeService implements Closeable {
         boolean indices
     ) {
         return new NodeInfo(
-            Build.current().version(),
+            // TODO: revert to Build.current().version() when Kibana is updated
+            Version.CURRENT.toString(),
             TransportVersion.current(),
             IndexVersion.current(),
             findComponentVersions(),


### PR DESCRIPTION
Minimal change to revert https://github.com/elastic/elasticsearch/pull/100746 (a full revert was not possible due to TransportVersion change).
Reason: it appears that serverless Kibana is still relying on semantic versions.