### PR TITLE
Fix InternalEngineTests.testMergeThreadLogging

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -2573,28 +2573,40 @@ public class InternalEngineTests extends EngineTestCase {
         }
     }
 
-    private static class MockMTAppender extends AbstractAppender {
+    private static class MockMergeThreadAppender extends AbstractAppender {
+
         private final List<String> messages = Collections.synchronizedList(new ArrayList<>());
+        private final AtomicBoolean luceneMergeSchedulerEnded = new AtomicBoolean();
 
         List<String> messages() {
             return List.copyOf(messages);
         }
 
-        MockMTAppender(final String name) throws IllegalAccessException {
+        public boolean mergeCompleted() {
+            return luceneMergeSchedulerEnded.get();
+        }
+
+        MockMergeThreadAppender(final String name) throws IllegalAccessException {
             super(name, RegexFilter.createFilter(".*(\n.*)*", new String[0], false, null, null), null, false, Property.EMPTY_ARRAY);
         }
 
         @Override
         public void append(LogEvent event) {
             final String formattedMessage = event.getMessage().getFormattedMessage();
-            if (event.getLevel() == Level.TRACE && formattedMessage.startsWith("merge thread")) {
-                messages.add(formattedMessage);
+            if (event.getLevel() == Level.TRACE && event.getMarker().getName().contains("[index][0]")) {
+                if (formattedMessage.startsWith("merge thread")) {
+                    messages.add(formattedMessage);
+                } else if (event.getLoggerName().endsWith(".MS")
+                    && formattedMessage.contains("MS: merge thread")
+                    && formattedMessage.endsWith("end")) {
+                    luceneMergeSchedulerEnded.set(true);
+                }
             }
         }
     }
 
     public void testMergeThreadLogging() throws Exception {
-        final MockMTAppender mockAppender = new MockMTAppender("testMergeThreadLogging");
+        final MockMergeThreadAppender mockAppender = new MockMergeThreadAppender("testMergeThreadLogging");
         mockAppender.start();
 
         Logger rootLogger = LogManager.getRootLogger();
@@ -2613,26 +2625,29 @@ public class InternalEngineTests extends EngineTestCase {
                 engine.index(indexForDoc(testParsedDocument("3", null, testDocument(), B_1, null)));
                 engine.index(indexForDoc(testParsedDocument("4", null, testDocument(), B_1, null)));
                 engine.forceMerge(true, 1, false, UUIDs.randomBase64UUID());
-                engine.flushAndClose();
 
                 assertBusy(() -> {
                     assertThat(engine.getMergeStats().getTotal(), greaterThan(0L));
                     assertThat(engine.getMergeStats().getCurrent(), equalTo(0L));
                 });
-            }
 
-            assertBusy(() -> {
-                List<String> threadMsgs = mockAppender.messages().stream().filter(line -> line.startsWith("merge thread")).toList();
-                assertThat("messages:" + threadMsgs, threadMsgs.size(), greaterThanOrEqualTo(3));
-                assertThat(
-                    threadMsgs,
-                    containsInRelativeOrder(
-                        matchesRegex("^merge thread .* start$"),
-                        matchesRegex("^merge thread .* merge segment.*$"),
-                        matchesRegex("^merge thread .* end$")
-                    )
-                );
-            });
+                assertBusy(() -> {
+                    List<String> threadMsgs = mockAppender.messages().stream().filter(line -> line.startsWith("merge thread")).toList();
+                    assertThat("messages:" + threadMsgs, threadMsgs.size(), greaterThanOrEqualTo(3));
+                    assertThat(
+                        threadMsgs,
+                        containsInRelativeOrder(
+                            matchesRegex("^merge thread .* start$"),
+                            matchesRegex("^merge thread .* merge segment.*$"),
+                            matchesRegex("^merge thread .* end$")
+                        )
+                    );
+                    assertThat(mockAppender.mergeCompleted(), is(true));
+                });
+
+                Loggers.setLevel(rootLogger, savedLevel);
+                engine.close();
+            }
         } finally {
             Loggers.setLevel(rootLogger, savedLevel);
             Loggers.removeAppender(rootLogger, mockAppender);

--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -2599,8 +2599,8 @@ public class InternalEngineTests extends EngineTestCase {
                 } else if (event.getLoggerName().endsWith(".MS")
                     && formattedMessage.contains("MS: merge thread")
                     && formattedMessage.endsWith("end")) {
-                    luceneMergeSchedulerEnded.set(true);
-                }
+                        luceneMergeSchedulerEnded.set(true);
+                    }
             }
         }
     }


### PR DESCRIPTION
The test has to wait for all merge thread log messages (include Lucene ones) to be seen before reset the log level and stop the appender.

Previous attempt wasn't enough: the test failure in https://github.com/elastic/elasticsearch/issues/90071#issuecomment-1638128883 shows that Lucene's merge scheduler thread can log after the Elasticsearch one, and if the appender has been closed in the meanwhile it can fail the test.

```java
1> [2023-07-17T11:33:12,559][TRACE][o.e.i.e.Engine           ] [testMergeThreadLogging] [index][0] rollback indexWriter done
  1> [2023-07-17T11:33:12,559][DEBUG][o.e.i.e.Engine           ] [testMergeThreadLogging] [index][0] engine closed [api]
  1> [2023-07-17T11:33:12,562][DEBUG][o.e.i.s.Store            ] [testMergeThreadLogging] [index][0] store reference count on close: 0
  1> [2023-07-17T11:33:12,562][TRACE][o.e.i.e.I.EngineMergeScheduler] [[index] [index][0] merge thread elasticsearch[[index][0]: Lucene Merge Thread #0] end
  1> [2023-07-17T11:33:12,562][TRACE][o.e.i.e.E.MS             ] [[index] [index][0] elasticsearch[[index][0]: Lucene Merge Thread #0] MS: merge thread elasticsearch[[index][0]: Lucene Merge Thread #0] end
  1> 2023-07-17 11:33:12,568 elasticsearch[[index][0]: Lucene Merge Thread #0] ERROR Attempted to append to non-started appender testMergeThreadLogging
  1> [2023-07-17T11:33:12,589][WARN ][o.e.i.e.Engine           ] [org.elasticsearch.index.engine.InternalEngineTests] [index][0] failed engine [merge failed]
  1> org.apache.lucene.index.MergePolicy$MergeException: org.apache.logging.log4j.core.appender.AppenderLoggingException: Attempted to append to non-started appender testMergeThreadLogging
  1> 	at org.elasticsearch.index.engine.InternalEngine$EngineMergeScheduler$2.doRun(InternalEngine.java:2780) ~[main/:?]
  1> 	at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:983) ~[main/:?]
  1> 	at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:26) ~[main/:?]
  1> 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
  1> 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
  1> 	at java.lang.Thread.run(Thread.java:833) ~[?:?]
  1> Caused by: org.apache.logging.log4j.core.appender.AppenderLoggingException: Attempted to append to non-started appender testMergeThreadLogging
```

This pull request ensure that the appender saw the Merge Scheduler `end` message before resetting the log level and close the engine.

Closes #90071