### PR TITLE
Disable parallelism for composite agg against high cardinality fields 

### DIFF
--- a/docs/changelog/102644.yaml
+++ b/docs/changelog/102644.yaml
@@ -1,0 +1,5 @@
+pr: 102644
+summary: Disable parallelism for composite agg against high cardinality fields
+area: Aggregations
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregationBuilder.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.ToLongFunction;
 
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
@@ -301,5 +302,15 @@ public class CompositeAggregationBuilder extends AbstractAggregationBuilder<Comp
     @Override
     public TransportVersion getMinimalSupportedVersion() {
         return TransportVersions.ZERO;
+    }
+
+    @Override
+    public boolean supportsParallelCollection(ToLongFunction<String> fieldCardinalityResolver) {
+        for (CompositeValuesSourceBuilder<?> source : sources) {
+            if (source.supportsParallelCollection(fieldCardinalityResolver) == false) {
+                return false;
+            }
+        }
+        return super.supportsParallelCollection(fieldCardinalityResolver);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeValuesSourceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeValuesSourceBuilder.java
@@ -26,6 +26,7 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import java.io.IOException;
 import java.time.ZoneId;
 import java.util.Objects;
+import java.util.function.ToLongFunction;
 
 /**
  * A {@link ValuesSource} builder for {@link CompositeAggregationBuilder}
@@ -324,5 +325,13 @@ public abstract class CompositeValuesSourceBuilder<AB extends CompositeValuesSou
      */
     protected ZoneId timeZone() {
         return null;
+    }
+
+    /**
+     * Return false if this composite source does not support parallel collection.
+     * As a result, a request including such aggregation is always executed sequentially despite concurrency is enabled for the query phase.
+     */
+    public boolean supportsParallelCollection(ToLongFunction<String> fieldCardinalityResolver) {
+        return true;
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregationBuilder.java
@@ -38,6 +38,8 @@ import java.util.Objects;
 import java.util.function.ToLongFunction;
 
 public class TermsAggregationBuilder extends ValuesSourceAggregationBuilder<TermsAggregationBuilder> {
+    public static final int KEY_ORDER_CONCURRENCY_THRESHOLD = 50;
+
     public static final String NAME = "terms";
     public static final ValuesSourceRegistry.RegistryKey<TermsAggregatorSupplier> REGISTRY_KEY = new ValuesSourceRegistry.RegistryKey<>(
         NAME,
@@ -147,7 +149,7 @@ public class TermsAggregationBuilder extends ValuesSourceAggregationBuilder<Term
             long cardinality = fieldCardinalityResolver.applyAsLong(field());
             if (cardinality != -1) {
                 if (InternalOrder.isKeyOrder(order)) {
-                    if (cardinality <= 50) {
+                    if (cardinality <= KEY_ORDER_CONCURRENCY_THRESHOLD) {
                         return super.supportsParallelCollection(fieldCardinalityResolver);
                     }
                 } else {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/AggregatorFactoriesTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/AggregatorFactoriesTests.java
@@ -344,13 +344,6 @@ public class AggregatorFactoriesTests extends ESTestCase {
         }
         {
             AggregatorFactories.Builder builder = new AggregatorFactories.Builder();
-            builder.addAggregator(
-                new CompositeAggregationBuilder("composite", Collections.singletonList(new TermsValuesSourceBuilder("name")))
-            );
-            assertTrue(builder.supportsParallelCollection(randomCardinality));
-        }
-        {
-            AggregatorFactories.Builder builder = new AggregatorFactories.Builder();
             builder.addAggregator(new FilterAggregationBuilder("terms", new MatchAllQueryBuilder()) {
                 @Override
                 public boolean isInSortOrderExecutionRequired() {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/AggregatorFactoriesTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/AggregatorFactoriesTests.java
@@ -24,8 +24,6 @@ import org.elasticsearch.index.query.TermsQueryBuilder;
 import org.elasticsearch.index.query.WrapperQueryBuilder;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.search.SearchModule;
-import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregationBuilder;
-import org.elasticsearch.search.aggregations.bucket.composite.TermsValuesSourceBuilder;
 import org.elasticsearch.search.aggregations.bucket.filter.FilterAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.nested.NestedAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.terms.SignificantTermsAggregationBuilder;
@@ -46,7 +44,6 @@ import org.elasticsearch.xcontent.json.JsonXContent;
 
 import java.io.IOException;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregationBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregationBuilderTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInter
 import org.elasticsearch.search.sort.SortOrder;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class CompositeAggregationBuilderTests extends BaseAggregationTestCase<CompositeAggregationBuilder> {
@@ -107,5 +108,38 @@ public class CompositeAggregationBuilderTests extends BaseAggregationTestCase<Co
             }
         }
         return new CompositeAggregationBuilder(randomAlphaOfLength(10), sources);
+    }
+
+    public void testSupportsParallelCollection() {
+        assertTrue(
+            new CompositeAggregationBuilder(randomAlphaOfLength(10), Collections.singletonList(randomDateHistogramSourceBuilder()))
+                .supportsParallelCollection(null)
+        );
+        assertTrue(
+            new CompositeAggregationBuilder(randomAlphaOfLength(10), Collections.singletonList(randomHistogramSourceBuilder()))
+                .supportsParallelCollection(null)
+        );
+        assertTrue(
+            new CompositeAggregationBuilder(randomAlphaOfLength(10), Collections.singletonList(randomGeoTileGridValuesSourceBuilder()))
+                .supportsParallelCollection(null)
+        );
+        assertFalse(
+            new CompositeAggregationBuilder(randomAlphaOfLength(10), Collections.singletonList(new TermsValuesSourceBuilder("name")))
+                .supportsParallelCollection(field -> -1)
+        );
+        assertTrue(
+            new CompositeAggregationBuilder(randomAlphaOfLength(10), Collections.singletonList(new TermsValuesSourceBuilder("name")))
+                .supportsParallelCollection(field -> randomIntBetween(0, 50))
+        );
+        assertFalse(
+            new CompositeAggregationBuilder(randomAlphaOfLength(10), Collections.singletonList(new TermsValuesSourceBuilder("name")))
+                .supportsParallelCollection(field -> randomIntBetween(51, 100))
+        );
+        assertFalse(
+            new CompositeAggregationBuilder(
+                randomAlphaOfLength(10),
+                Collections.singletonList(new TermsValuesSourceBuilder("name").script(new Script("id")))
+            ).supportsParallelCollection(field -> randomIntBetween(-1, 100))
+        );
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregationBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregationBuilderTests.java
@@ -141,5 +141,11 @@ public class CompositeAggregationBuilderTests extends BaseAggregationTestCase<Co
                 Collections.singletonList(new TermsValuesSourceBuilder("name").script(new Script("id")))
             ).supportsParallelCollection(field -> randomIntBetween(-1, 100))
         );
+        assertFalse(
+            new CompositeAggregationBuilder(
+                randomAlphaOfLength(10),
+                List.of(randomDateHistogramSourceBuilder(), new TermsValuesSourceBuilder("name"))
+            ).supportsParallelCollection(field -> randomIntBetween(51, 100))
+        );
     }
 }


### PR DESCRIPTION
We have observed that terms agg against high cardinality fields don't get much gain from parallelism.
On the contrary, they may cause overhead due to work duplication across the different threads.

This commit disables parallelism for composite agg when the source is terms against a high cardinality field, or a script.