### PR TITLE
Enable randomizations in CompositeAggregationBuilderTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregationBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregationBuilderTests.java
@@ -93,11 +93,9 @@ public class CompositeAggregationBuilderTests extends BaseAggregationTestCase<Co
     @Override
     protected CompositeAggregationBuilder createTestAggregatorBuilder() {
         int numSources = randomIntBetween(1, 10);
-        numSources = 1;
         List<CompositeValuesSourceBuilder<?>> sources = new ArrayList<>();
         for (int i = 0; i < numSources; i++) {
             int type = randomIntBetween(0, 3);
-            type = 3;
             switch (type) {
                 case 0 -> sources.add(randomTermsSourceBuilder());
                 case 1 -> sources.add(randomDateHistogramSourceBuilder());


### PR DESCRIPTION
There were two randomizations that have been off for a long time, but there should be no reason for that. This commit re-enables the randomizations.
