### PR TITLE
Mark OwningChannelActionListener for removal

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/OwningChannelActionListener.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/OwningChannelActionListener.java
@@ -18,7 +18,7 @@ import org.elasticsearch.transport.TransportResponse;
  *
  * Deprecated: use {@link ChannelActionListener} instead and ensure responses sent to it are properly closed after.
  */
-@Deprecated
+@Deprecated(forRemoval = true)
 public final class OwningChannelActionListener<Response extends TransportResponse> implements ActionListener<Response> {
     private final ChannelActionListener<Response> listener;
 


### PR DESCRIPTION
Make IntelliJ's warnings about using this workaround more strident.