### PR TITLE
[Profiling] Add new request param 'cost_per_core_hour'

### DIFF
--- a/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/GetFlameGraphActionIT.java
+++ b/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/GetFlameGraphActionIT.java
@@ -9,7 +9,7 @@ package org.elasticsearch.xpack.profiling;
 
 public class GetFlameGraphActionIT extends ProfilingTestCase {
     public void testGetStackTracesUnfiltered() throws Exception {
-        GetStackTracesRequest request = new GetStackTracesRequest(10, 1.0d, 1.0d, null, null, null, null, null, null);
+        GetStackTracesRequest request = new GetStackTracesRequest(10, 1.0d, 1.0d, null, null, null, null, null, null, null);
         GetFlamegraphResponse response = client().execute(GetFlamegraphAction.INSTANCE, request).get();
         // only spot-check top level properties - detailed tests are done in unit tests
         assertEquals(297, response.getSize());

--- a/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/GetStackTracesActionIT.java
+++ b/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/GetStackTracesActionIT.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 public class GetStackTracesActionIT extends ProfilingTestCase {
     public void testGetStackTracesUnfiltered() throws Exception {
-        GetStackTracesRequest request = new GetStackTracesRequest(10, 1.0d, 1.0d, null, null, null, null, null, null);
+        GetStackTracesRequest request = new GetStackTracesRequest(10, 1.0d, 1.0d, null, null, null, null, null, null, null);
         request.setAdjustSampleCount(true);
         GetStackTracesResponse response = client().execute(GetStackTracesAction.INSTANCE, request).get();
         assertEquals(40, response.getTotalSamples());
@@ -53,6 +53,7 @@ public class GetStackTracesActionIT extends ProfilingTestCase {
             "transaction.profiler_stack_trace_ids",
             null,
             null,
+            null,
             null
         );
         GetStackTracesResponse response = client().execute(GetStackTracesAction.INSTANCE, request).get();
@@ -88,6 +89,7 @@ public class GetStackTracesActionIT extends ProfilingTestCase {
             query,
             "apm-test-*",
             "transaction.profiler_stack_trace_ids",
+            null,
             null,
             null,
             null

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetStackTracesRequest.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetStackTracesRequest.java
@@ -42,6 +42,7 @@ public class GetStackTracesRequest extends ActionRequest implements IndicesReque
     public static final ParseField CUSTOM_CO2_PER_KWH = new ParseField("co2_per_kwh");
     public static final ParseField CUSTOM_DATACENTER_PUE = new ParseField("datacenter_pue");
     public static final ParseField CUSTOM_PER_CORE_WATT = new ParseField("per_core_watt");
+    public static final ParseField CUSTOM_COST_PER_CORE_HOUR = new ParseField("cost_per_core_hour");
     private static final int DEFAULT_SAMPLE_SIZE = 20_000;
 
     private QueryBuilder query;
@@ -53,6 +54,7 @@ public class GetStackTracesRequest extends ActionRequest implements IndicesReque
     private Double customCO2PerKWH;
     private Double customDatacenterPUE;
     private Double customPerCoreWatt;
+    private Double customCostPerCoreHour;
 
     // We intentionally don't expose this field via the REST API, but we can control behavior within Elasticsearch.
     // Once we have migrated all client-side code to dedicated APIs (such as the flamegraph API), we can adjust
@@ -60,7 +62,7 @@ public class GetStackTracesRequest extends ActionRequest implements IndicesReque
     private Boolean adjustSampleCount;
 
     public GetStackTracesRequest() {
-        this(null, null, null, null, null, null, null, null, null);
+        this(null, null, null, null, null, null, null, null, null, null);
     }
 
     public GetStackTracesRequest(
@@ -72,7 +74,8 @@ public class GetStackTracesRequest extends ActionRequest implements IndicesReque
         String stackTraceIds,
         Double customCO2PerKWH,
         Double customDatacenterPUE,
-        Double customPerCoreWatt
+        Double customPerCoreWatt,
+        Double customCostPerCoreHour
     ) {
         this.sampleSize = sampleSize;
         this.requestedDuration = requestedDuration;
@@ -83,6 +86,7 @@ public class GetStackTracesRequest extends ActionRequest implements IndicesReque
         this.customCO2PerKWH = customCO2PerKWH;
         this.customDatacenterPUE = customDatacenterPUE;
         this.customPerCoreWatt = customPerCoreWatt;
+        this.customCostPerCoreHour = customCostPerCoreHour;
     }
 
     public GetStackTracesRequest(StreamInput in) throws IOException {
@@ -96,6 +100,7 @@ public class GetStackTracesRequest extends ActionRequest implements IndicesReque
         this.customCO2PerKWH = in.readOptionalDouble();
         this.customDatacenterPUE = in.readOptionalDouble();
         this.customPerCoreWatt = in.readOptionalDouble();
+        this.customCostPerCoreHour = in.readOptionalDouble();
     }
 
     @Override
@@ -110,6 +115,7 @@ public class GetStackTracesRequest extends ActionRequest implements IndicesReque
         out.writeOptionalDouble(customCO2PerKWH);
         out.writeOptionalDouble(customDatacenterPUE);
         out.writeOptionalDouble(customPerCoreWatt);
+        out.writeOptionalDouble(customCostPerCoreHour);
     }
 
     public Integer getSampleSize() {
@@ -133,6 +139,10 @@ public class GetStackTracesRequest extends ActionRequest implements IndicesReque
     }
 
     public Double getCustomPerCoreWatt() {
+        return customPerCoreWatt;
+    }
+
+    public Double getCustomCostPerCoreHour() {
         return customPerCoreWatt;
     }
 
@@ -187,6 +197,8 @@ public class GetStackTracesRequest extends ActionRequest implements IndicesReque
                     this.customDatacenterPUE = parser.doubleValue();
                 } else if (CUSTOM_PER_CORE_WATT.match(currentFieldName, parser.getDeprecationHandler())) {
                     this.customPerCoreWatt = parser.doubleValue();
+                } else if (CUSTOM_COST_PER_CORE_HOUR.match(currentFieldName, parser.getDeprecationHandler())) {
+                    this.customCostPerCoreHour = parser.doubleValue();
                 } else {
                     throw new ParsingException(
                         parser.getTokenLocation(),
@@ -244,6 +256,7 @@ public class GetStackTracesRequest extends ActionRequest implements IndicesReque
         validationException = requirePositive(CUSTOM_CO2_PER_KWH, customCO2PerKWH, validationException);
         validationException = requirePositive(CUSTOM_DATACENTER_PUE, customDatacenterPUE, validationException);
         validationException = requirePositive(CUSTOM_PER_CORE_WATT, customPerCoreWatt, validationException);
+        validationException = requirePositive(CUSTOM_COST_PER_CORE_HOUR, customCostPerCoreHour, validationException);
         return validationException;
     }
 
@@ -271,6 +284,7 @@ public class GetStackTracesRequest extends ActionRequest implements IndicesReque
                 appendField(sb, "co2_per_kwh", customCO2PerKWH);
                 appendField(sb, "datacenter_pue", customDatacenterPUE);
                 appendField(sb, "per_core_watt", customPerCoreWatt);
+                appendField(sb, "cost_per_core_hour", customCostPerCoreHour);
                 appendField(sb, "query", query);
                 return sb.toString();
             }

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStackTracesAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStackTracesAction.java
@@ -153,6 +153,7 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
         responseBuilder.setCustomCO2PerKWH(request.getCustomCO2PerKWH());
         responseBuilder.setCustomDatacenterPUE(request.getCustomDatacenterPUE());
         responseBuilder.setCustomPerCoreWatt(request.getCustomPerCoreWatt());
+        responseBuilder.setCustomCostPerCoreHour(request.getCustomCostPerCoreHour());
         Client client = new ParentTaskAssigningClient(this.nodeClient, transportService.getLocalNode(), submitTask);
         if (request.getIndices() == null) {
             searchProfilingEvents(client, request, submitListener, responseBuilder);
@@ -531,7 +532,8 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
                 instanceTypeService,
                 hostsTable,
                 responseBuilder.getRequestedDuration(),
-                responseBuilder.awsCostFactor
+                responseBuilder.awsCostFactor,
+                responseBuilder.customCostPerCoreHour
             );
             Map<String, TraceEvent> events = responseBuilder.stackTraceEvents;
             List<String> missingStackTraces = new ArrayList<>();
@@ -742,6 +744,7 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
         private Double customCO2PerKWH;
         private Double customDatacenterPUE;
         private Double customPerCoreWatt;
+        private Double customCostPerCoreHour;
 
         public void setStackTraces(Map<String, StackTrace> stackTraces) {
             this.stackTraces = stackTraces;
@@ -821,6 +824,10 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
 
         public void setCustomPerCoreWatt(Double customPerCoreWatt) {
             this.customPerCoreWatt = customPerCoreWatt;
+        }
+
+        public void setCustomCostPerCoreHour(Double customCostPerCoreHour) {
+            this.customCostPerCoreHour = customCostPerCoreHour;
         }
 
         public void setTotalSamples(long totalSamples) {

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/CostCalculatorTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/CostCalculatorTests.java
@@ -49,7 +49,7 @@ public class CostCalculatorTests extends ESTestCase {
         double samplingDurationInSeconds = 1_800.0d; // 30 minutes
         long samples = 100_000L; // 100k samples
         double annualCoreHours = CostCalculator.annualCoreHours(samplingDurationInSeconds, samples, 20.0d);
-        CostCalculator costCalculator = new CostCalculator(instanceTypeService, hostsTable, samplingDurationInSeconds, null);
+        CostCalculator costCalculator = new CostCalculator(instanceTypeService, hostsTable, samplingDurationInSeconds, null, null);
 
         // Checks whether the cost calculation is based on the pre-calculated lookup data.
         checkCostCalculation(costCalculator.annualCostsUSD(HOST_ID_A, samples), annualCoreHours, 0.061d);

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/GetStackTracesRequestTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/GetStackTracesRequestTests.java
@@ -43,6 +43,7 @@ public class GetStackTracesRequestTests extends ESTestCase {
             null,
             null,
             null,
+            null,
             null
         );
         try (BytesStreamOutput out = new BytesStreamOutput()) {
@@ -147,6 +148,7 @@ public class GetStackTracesRequestTests extends ESTestCase {
             null,
             null,
             null,
+            null,
             null
         );
         List<String> validationErrors = request.validate().validationErrors();
@@ -155,7 +157,18 @@ public class GetStackTracesRequestTests extends ESTestCase {
     }
 
     public void testValidateStacktraceWithoutIndices() {
-        GetStackTracesRequest request = new GetStackTracesRequest(1, 1.0d, 1.0d, null, null, randomAlphaOfLength(3), null, null, null);
+        GetStackTracesRequest request = new GetStackTracesRequest(
+            1,
+            1.0d,
+            1.0d,
+            null,
+            null,
+            randomAlphaOfLength(3),
+            null,
+            null,
+            null,
+            null
+        );
         List<String> validationErrors = request.validate().validationErrors();
         assertEquals(1, validationErrors.size());
         assertEquals("[stacktrace_ids] must not be set", validationErrors.get(0));
@@ -169,6 +182,7 @@ public class GetStackTracesRequestTests extends ESTestCase {
             null,
             randomAlphaOfLength(5),
             randomFrom("", null),
+            null,
             null,
             null,
             null
@@ -189,6 +203,7 @@ public class GetStackTracesRequestTests extends ESTestCase {
             randomAlphaOfLength(3),
             null,
             null,
+            null,
             null
         );
         String[] indices = request.indices();
@@ -198,7 +213,7 @@ public class GetStackTracesRequestTests extends ESTestCase {
 
     public void testConsidersDefaultIndicesInRelatedIndices() {
         String customIndex = randomAlphaOfLength(5);
-        GetStackTracesRequest request = new GetStackTracesRequest(1, 1.0d, 1.0d, null, null, null, null, null, null);
+        GetStackTracesRequest request = new GetStackTracesRequest(1, 1.0d, 1.0d, null, null, null, null, null, null, null);
         String[] indices = request.indices();
         assertEquals(15, indices.length);
     }

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/ResamplerTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/ResamplerTests.java
@@ -30,7 +30,7 @@ public class ResamplerTests extends ESTestCase {
         int requestedSamples = 20_000;
         int actualTotalSamples = 10_000;
 
-        GetStackTracesRequest request = new GetStackTracesRequest(requestedSamples, 1.0d, 1.0d, null, null, null, null, null, null);
+        GetStackTracesRequest request = new GetStackTracesRequest(requestedSamples, 1.0d, 1.0d, null, null, null, null, null, null, null);
         request.setAdjustSampleCount(false);
 
         Resampler resampler = createResampler(request, sampleRate, actualTotalSamples);
@@ -45,7 +45,7 @@ public class ResamplerTests extends ESTestCase {
         int requestedSamples = 20_000;
         int actualTotalSamples = 10_000;
 
-        GetStackTracesRequest request = new GetStackTracesRequest(requestedSamples, 1.0d, 1.0d, null, null, null, null, null, null);
+        GetStackTracesRequest request = new GetStackTracesRequest(requestedSamples, 1.0d, 1.0d, null, null, null, null, null, null, null);
         request.setAdjustSampleCount(true);
 
         Resampler resampler = createResampler(request, sampleRate, actualTotalSamples);
@@ -60,7 +60,7 @@ public class ResamplerTests extends ESTestCase {
         int requestedSamples = 20_000;
         int actualTotalSamples = 40_000;
 
-        GetStackTracesRequest request = new GetStackTracesRequest(requestedSamples, 1.0d, 1.0d, null, null, null, null, null, null);
+        GetStackTracesRequest request = new GetStackTracesRequest(requestedSamples, 1.0d, 1.0d, null, null, null, null, null, null, null);
         request.setAdjustSampleCount(false);
 
         Resampler resampler = createResampler(request, sampleRate, actualTotalSamples);
@@ -87,6 +87,7 @@ public class ResamplerTests extends ESTestCase {
             null,
             null,
             null,
+            null,
             null
         );
 
@@ -103,7 +104,7 @@ public class ResamplerTests extends ESTestCase {
         int requestedSamples = 20_000;
         int actualTotalSamples = 40_000;
 
-        GetStackTracesRequest request = new GetStackTracesRequest(requestedSamples, 1.0d, 1.0d, null, null, null, null, null, null);
+        GetStackTracesRequest request = new GetStackTracesRequest(requestedSamples, 1.0d, 1.0d, null, null, null, null, null, null, null);
         request.setAdjustSampleCount(true);
 
         Resampler resampler = createResampler(request, sampleRate, actualTotalSamples);


### PR DESCRIPTION
This parameter allows users to override the default cost-per-core-hour value (will be added to Kibana Advanced Settings in 8.12).
