### PR TITLE
Address test issues in TermsTests#testSupportsConcurrentExecution

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/BaseAggregationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/BaseAggregationTestCase.java
@@ -26,7 +26,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.function.ToLongFunction;
 
 import static org.elasticsearch.test.EqualsHashCodeTestUtils.checkEqualsAndHashCode;
 import static org.hamcrest.Matchers.equalTo;
@@ -60,13 +59,13 @@ public abstract class BaseAggregationTestCase<AB extends AbstractAggregationBuil
     }
 
     public void testSupportsConcurrentExecution() {
-        ToLongFunction<String> fieldCardinality = name -> randomIntBetween(-1, 100);
+        int cardinality = randomIntBetween(-1, 100);
         AB builder = createTestAggregatorBuilder();
-        boolean supportsConcurrency = builder.supportsParallelCollection(fieldCardinality);
+        boolean supportsConcurrency = builder.supportsParallelCollection(field -> cardinality);
         AggregationBuilder bucketBuilder = new HistogramAggregationBuilder("test");
-        assertTrue(bucketBuilder.supportsParallelCollection(fieldCardinality));
+        assertTrue(bucketBuilder.supportsParallelCollection(field -> cardinality));
         bucketBuilder.subAggregation(builder);
-        assertThat(bucketBuilder.supportsParallelCollection(fieldCardinality), equalTo(supportsConcurrency));
+        assertThat(bucketBuilder.supportsParallelCollection(field -> cardinality), equalTo(supportsConcurrency));
     }
 
     /**


### PR DESCRIPTION
The cardinality function needs to return the same value from both calls, or it ends up comparing two different scenarios.

Closes #102652