### PR TITLE
REST test framework: add historical features from production code

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -288,9 +288,15 @@ public abstract class ESRestTestCase extends ESTestCase {
 
             assert semanticNodeVersions.isEmpty() == false || serverless;
 
+            // Historical features information is unavailable when using legacy test plugins
+            boolean hasHistoricalFeaturesInformation = System.getProperty("tests.features.metadata.path") != null;
+            var providers = hasHistoricalFeaturesInformation
+                ? List.of(new RestTestLegacyFeatures(), new ESRestTestCaseHistoricalFeatures())
+                : List.of(new RestTestLegacyFeatures());
+
             testFeatureService = new TestFeatureService(
-                // TODO (ES-7313): add new ESRestTestCaseHistoricalFeatures() too
-                List.of(new RestTestLegacyFeatures()),
+                hasHistoricalFeaturesInformation,
+                providers,
                 semanticNodeVersions,
                 ClusterFeatures.calculateAllNodeFeatures(getClusterStateFeatures().values())
             );

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/TestFeatureService.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/TestFeatureService.java
@@ -9,12 +9,12 @@
 package org.elasticsearch.test.rest;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.core.Strings;
 import org.elasticsearch.features.FeatureData;
 import org.elasticsearch.features.FeatureSpecification;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Locale;
 import java.util.NavigableMap;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -37,17 +37,15 @@ class TestFeatureService {
         var errorMessage = hasHistoricalFeaturesInformation
             ? "Check the feature has been added to the correct FeatureSpecification in the relevant module or, if this is a "
                 + "legacy feature used only in tests, to a test-only FeatureSpecification"
-            : "This test seems to run on the legacy test plugins; historical features from production code will not be available."
+            : "This test is running on the legacy test framework; historical features from production code will not be available."
                 + " You need to port the test to the new test plugins in order to use historical features from production code."
                 + " If this is a legacy feature used only in tests, you can add it to a test-only FeatureSpecification";
         this.historicalFeaturesPredicate = minNodeVersion.<Predicate<String>>map(v -> featureId -> {
-            assert allHistoricalFeatures.contains(featureId)
-                : String.format(Locale.ROOT, "Unknown historical feature %s: %s", featureId, errorMessage);
+            assert allHistoricalFeatures.contains(featureId) : Strings.format("Unknown historical feature %s: %s", featureId, errorMessage);
             return hasHistoricalFeature(historicalFeatures, v, featureId);
         }).orElse(featureId -> {
             // We can safely assume that new non-semantic versions (serverless) support all historical features
-            assert allHistoricalFeatures.contains(featureId)
-                : String.format(Locale.ROOT, "Unknown historical feature %s: %s", featureId, errorMessage);
+            assert allHistoricalFeatures.contains(featureId) : Strings.format("Unknown historical feature %s: %s", featureId, errorMessage);
             return true;
         });
         this.clusterStateFeatures = clusterStateFeatures;

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/TestFeatureService.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/TestFeatureService.java
@@ -28,24 +28,23 @@ class TestFeatureService {
         Collection<Version> nodeVersions,
         Set<String> clusterStateFeatures
     ) {
-
-        var message = hasHistoricalFeaturesInformation
-            ? "Check the feature has been added to the correct FeatureSpecification in the relevant module or, if this is a "
-                + "legacy feature used only in tests, to a test-only FeatureSpecification"
-            : "This test seems to run on the legacy test plugins; historical features from production code will not be available."
-                + " You need to port the test to the new test plugins in order to use historical features from production code."
-                + " If this is a legacy feature used only in tests, you can add it to a test-only FeatureSpecification";
-
         var minNodeVersion = nodeVersions.stream().min(Version::compareTo);
         var featureData = FeatureData.createFromSpecifications(specs);
         var historicalFeatures = featureData.getHistoricalFeatures();
         var allHistoricalFeatures = historicalFeatures.lastEntry() == null ? Set.of() : historicalFeatures.lastEntry().getValue();
+
+        var errorMessage = hasHistoricalFeaturesInformation
+            ? "Check the feature has been added to the correct FeatureSpecification in the relevant module or, if this is a "
+            + "legacy feature used only in tests, to a test-only FeatureSpecification"
+            : "This test seems to run on the legacy test plugins; historical features from production code will not be available."
+            + " You need to port the test to the new test plugins in order to use historical features from production code."
+            + " If this is a legacy feature used only in tests, you can add it to a test-only FeatureSpecification";
         this.historicalFeaturesPredicate = minNodeVersion.<Predicate<String>>map(v -> featureId -> {
-            assert allHistoricalFeatures.contains(featureId) : String.format("Unknown historical feature %s: %s", featureId, message);
+            assert allHistoricalFeatures.contains(featureId) : String.format("Unknown historical feature %s: %s", featureId, errorMessage);
             return hasHistoricalFeature(historicalFeatures, v, featureId);
         }).orElse(featureId -> {
             // We can safely assume that new non-semantic versions (serverless) support all historical features
-            assert allHistoricalFeatures.contains(featureId) : String.format("Unknown historical feature %s: %s", featureId, message);
+            assert allHistoricalFeatures.contains(featureId) : String.format("Unknown historical feature %s: %s", featureId, errorMessage);
             return true;
         });
         this.clusterStateFeatures = clusterStateFeatures;

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/TestFeatureService.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/TestFeatureService.java
@@ -22,18 +22,30 @@ class TestFeatureService {
     private final Predicate<String> historicalFeaturesPredicate;
     private final Set<String> clusterStateFeatures;
 
-    TestFeatureService(List<? extends FeatureSpecification> specs, Collection<Version> nodeVersions, Set<String> clusterStateFeatures) {
+    TestFeatureService(
+        boolean hasHistoricalFeaturesInformation,
+        List<? extends FeatureSpecification> specs,
+        Collection<Version> nodeVersions,
+        Set<String> clusterStateFeatures
+    ) {
+
+        var message = hasHistoricalFeaturesInformation
+            ? "Check the feature has been added to the correct FeatureSpecification in the relevant module or, if it is a "
+                + "legacy feature used only in tests, to a test-only FeatureSpecification"
+            : "This test seems to run on the legacy test plugins; historical features from production code will not be available."
+                + " You need to port the test to the new test plugins in order to use historical features from production code."
+                + " If it is a legacy feature used only in tests, you can add it to a test-only FeatureSpecification";
 
         var minNodeVersion = nodeVersions.stream().min(Version::compareTo);
         var featureData = FeatureData.createFromSpecifications(specs);
         var historicalFeatures = featureData.getHistoricalFeatures();
         var allHistoricalFeatures = historicalFeatures.lastEntry() == null ? Set.of() : historicalFeatures.lastEntry().getValue();
         this.historicalFeaturesPredicate = minNodeVersion.<Predicate<String>>map(v -> featureId -> {
-            assert allHistoricalFeatures.contains(featureId) : "Unknown historical feature " + featureId;
+            assert allHistoricalFeatures.contains(featureId) : String.format("Unknown historical feature %s: %s", featureId, message);
             return hasHistoricalFeature(historicalFeatures, v, featureId);
         }).orElse(featureId -> {
             // We can safely assume that new non-semantic versions (serverless) support all historical features
-            assert allHistoricalFeatures.contains(featureId) : "Unknown historical feature " + featureId;
+            assert allHistoricalFeatures.contains(featureId) : String.format("Unknown historical feature %s: %s", featureId, message);
             return true;
         });
         this.clusterStateFeatures = clusterStateFeatures;

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/TestFeatureService.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/TestFeatureService.java
@@ -14,6 +14,7 @@ import org.elasticsearch.features.FeatureSpecification;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.NavigableMap;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -35,16 +36,18 @@ class TestFeatureService {
 
         var errorMessage = hasHistoricalFeaturesInformation
             ? "Check the feature has been added to the correct FeatureSpecification in the relevant module or, if this is a "
-            + "legacy feature used only in tests, to a test-only FeatureSpecification"
+                + "legacy feature used only in tests, to a test-only FeatureSpecification"
             : "This test seems to run on the legacy test plugins; historical features from production code will not be available."
-            + " You need to port the test to the new test plugins in order to use historical features from production code."
-            + " If this is a legacy feature used only in tests, you can add it to a test-only FeatureSpecification";
+                + " You need to port the test to the new test plugins in order to use historical features from production code."
+                + " If this is a legacy feature used only in tests, you can add it to a test-only FeatureSpecification";
         this.historicalFeaturesPredicate = minNodeVersion.<Predicate<String>>map(v -> featureId -> {
-            assert allHistoricalFeatures.contains(featureId) : String.format("Unknown historical feature %s: %s", featureId, errorMessage);
+            assert allHistoricalFeatures.contains(featureId)
+                : String.format(Locale.ROOT, "Unknown historical feature %s: %s", featureId, errorMessage);
             return hasHistoricalFeature(historicalFeatures, v, featureId);
         }).orElse(featureId -> {
             // We can safely assume that new non-semantic versions (serverless) support all historical features
-            assert allHistoricalFeatures.contains(featureId) : String.format("Unknown historical feature %s: %s", featureId, errorMessage);
+            assert allHistoricalFeatures.contains(featureId)
+                : String.format(Locale.ROOT, "Unknown historical feature %s: %s", featureId, errorMessage);
             return true;
         });
         this.clusterStateFeatures = clusterStateFeatures;

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/TestFeatureService.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/TestFeatureService.java
@@ -30,11 +30,11 @@ class TestFeatureService {
     ) {
 
         var message = hasHistoricalFeaturesInformation
-            ? "Check the feature has been added to the correct FeatureSpecification in the relevant module or, if it is a "
+            ? "Check the feature has been added to the correct FeatureSpecification in the relevant module or, if this is a "
                 + "legacy feature used only in tests, to a test-only FeatureSpecification"
             : "This test seems to run on the legacy test plugins; historical features from production code will not be available."
                 + " You need to port the test to the new test plugins in order to use historical features from production code."
-                + " If it is a legacy feature used only in tests, you can add it to a test-only FeatureSpecification";
+                + " If this is a legacy feature used only in tests, you can add it to a test-only FeatureSpecification";
 
         var minNodeVersion = nodeVersions.stream().min(Version::compareTo);
         var featureData = FeatureData.createFromSpecifications(specs);


### PR DESCRIPTION
Check if we can use features from prod code (legacy tests do not support them). When OK, `TestFeatureService` uses `ESRestTestCaseHistoricalFeatures` as a provider, which reads historical features extracted by modules at build time (https://github.com/elastic/elasticsearch/pull/102110).

When a historical feature has not be found, we output specific error messages for legacy/new tests