### PR TITLE
Mute failing pit with index filter ccs yaml tests

### DIFF
--- a/qa/ccs-common-rest/build.gradle
+++ b/qa/ccs-common-rest/build.gradle
@@ -41,6 +41,7 @@ tasks.named("yamlRestTest") {
       'search.aggregation/50_filter/Standard queries get cached',
       'search.aggregation/50_filter/Terms lookup gets cached', // terms lookup by "index" doesn't seem to work correctly
       'search.aggregation/70_adjacency_matrix/Terms lookup', // terms lookup by "index" doesn't seem to work correctly
+      'search/350_point_in_time/point-in-time with index filter'
     ].join(',')
 }
 

--- a/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCase.java
+++ b/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCase.java
@@ -442,7 +442,6 @@ public abstract class ESClientYamlSuiteTestCase extends ESRestTestCase {
         return RequestOptions.DEFAULT;
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/99153")
     public void test() throws IOException {
         // skip test if it matches one of the blacklist globs
         for (BlacklistedPathPatternMatcher blacklistedPathMatcher : blacklistPathMatchers) {


### PR DESCRIPTION
search/350_point_in_time/point-in-time with index filter is failing often, hence this commit mutes it.

Relates to #102596