### PR TITLE
ESQL: Share constant null Blocks

### DIFF
--- a/docs/changelog/102673.yaml
+++ b/docs/changelog/102673.yaml
@@ -1,0 +1,5 @@
+pr: 102673
+summary: "ESQL: Share constant null Blocks"
+area: ES|QL
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/mapper/BlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BlockLoader.java
@@ -136,7 +136,7 @@ public interface BlockLoader {
     class ConstantNullsReader implements AllReader {
         @Override
         public Block read(BlockFactory factory, Docs docs) throws IOException {
-            return factory.constantNulls(docs.count());
+            return factory.constantNulls();
         }
 
         @Override
@@ -170,7 +170,7 @@ public interface BlockLoader {
                 return new ColumnAtATimeReader() {
                     @Override
                     public Block read(BlockFactory factory, Docs docs) {
-                        return factory.constantBytes(value, docs.count());
+                        return factory.constantBytes(value);
                     }
 
                     @Override
@@ -389,13 +389,13 @@ public interface BlockLoader {
         /**
          * Build a block that contains only {@code null}.
          */
-        Block constantNulls(int size);
+        Block constantNulls();
 
         /**
          * Build a block that contains {@code value} repeated
          * {@code size} times.
          */
-        Block constantBytes(BytesRef value, int size);
+        Block constantBytes(BytesRef value);
 
         /**
          * Build a reader for reading keyword ordinals.

--- a/server/src/test/java/org/elasticsearch/index/mapper/BlockSourceReaderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/BlockSourceReaderTests.java
@@ -64,7 +64,7 @@ public class BlockSourceReaderTests extends ESTestCase {
             StoredFieldLoader.fromSpec(loader.rowStrideStoredFieldSpec()).getLoader(ctx, null),
             loader.rowStrideStoredFieldSpec().requiresSource() ? SourceLoader.FROM_STORED_SOURCE.leaf(ctx.reader(), null) : null
         );
-        BlockLoader.Builder builder = loader.builder(TestBlock.FACTORY, 1);
+        BlockLoader.Builder builder = loader.builder(TestBlock.factory(ctx.reader().numDocs()), 1);
         storedFields.advanceTo(0);
         reader.read(0, storedFields, builder);
         TestBlock block = (TestBlock) builder.build();

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/AbstractScriptFieldTypeTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/AbstractScriptFieldTypeTestCase.java
@@ -388,7 +388,8 @@ public abstract class AbstractScriptFieldTypeTestCase extends MapperServiceTestC
         BlockLoader loader = fieldType.blockLoader(blContext());
         List<Object> all = new ArrayList<>();
         for (LeafReaderContext ctx : reader.leaves()) {
-            TestBlock block = (TestBlock) loader.columnAtATimeReader(ctx).read(TestBlock.FACTORY, TestBlock.docs(ctx));
+            TestBlock block = (TestBlock) loader.columnAtATimeReader(ctx)
+                .read(TestBlock.factory(ctx.reader().numDocs()), TestBlock.docs(ctx));
             for (int i = 0; i < block.size(); i++) {
                 all.add(block.get(i));
             }
@@ -402,7 +403,7 @@ public abstract class AbstractScriptFieldTypeTestCase extends MapperServiceTestC
         List<Object> all = new ArrayList<>();
         for (LeafReaderContext ctx : reader.leaves()) {
             BlockLoader.RowStrideReader blockReader = loader.rowStrideReader(ctx);
-            BlockLoader.Builder builder = loader.builder(TestBlock.FACTORY, ctx.reader().numDocs());
+            BlockLoader.Builder builder = loader.builder(TestBlock.factory(ctx.reader().numDocs()), ctx.reader().numDocs());
             for (int i = 0; i < ctx.reader().numDocs(); i++) {
                 blockReader.read(i, null, builder);
             }

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
@@ -1292,7 +1292,8 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
                 TestBlock block;
                 if (columnReader) {
                     if (supportsColumnAtATimeReader(mapper.fieldType("field"))) {
-                        block = (TestBlock) loader.columnAtATimeReader(ctx).read(TestBlock.factory(ctx.reader().numDocs()), TestBlock.docs(0));
+                        block = (TestBlock) loader.columnAtATimeReader(ctx)
+                            .read(TestBlock.factory(ctx.reader().numDocs()), TestBlock.docs(0));
                     } else {
                         assertNull(loader.columnAtATimeReader(ctx));
                         return;

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
@@ -1292,7 +1292,7 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
                 TestBlock block;
                 if (columnReader) {
                     if (supportsColumnAtATimeReader(mapper.fieldType("field"))) {
-                        block = (TestBlock) loader.columnAtATimeReader(ctx).read(TestBlock.FACTORY, TestBlock.docs(0));
+                        block = (TestBlock) loader.columnAtATimeReader(ctx).read(TestBlock.factory(ctx.reader().numDocs()), TestBlock.docs(0));
                     } else {
                         assertNull(loader.columnAtATimeReader(ctx));
                         return;
@@ -1303,7 +1303,7 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
                         loader.rowStrideStoredFieldSpec().requiresSource() ? SourceLoader.FROM_STORED_SOURCE.leaf(ctx.reader(), null) : null
                     );
                     storedFieldsLoader.advanceTo(0);
-                    BlockLoader.Builder builder = loader.builder(TestBlock.FACTORY, 1);
+                    BlockLoader.Builder builder = loader.builder(TestBlock.factory(ctx.reader().numDocs()), 1);
                     loader.rowStrideReader(ctx).read(0, storedFieldsLoader, builder);
                     block = (TestBlock) builder.build();
                 }

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/TestBlock.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/TestBlock.java
@@ -21,131 +21,133 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 public class TestBlock implements BlockLoader.Block {
-    public static BlockLoader.BlockFactory FACTORY = new BlockLoader.BlockFactory() {
-        @Override
-        public BlockLoader.BooleanBuilder booleansFromDocValues(int expectedCount) {
-            return booleans(expectedCount);
-        }
-
-        @Override
-        public BlockLoader.BooleanBuilder booleans(int expectedCount) {
-            class BooleansBuilder extends TestBlock.Builder implements BlockLoader.BooleanBuilder {
-                @Override
-                public BooleansBuilder appendBoolean(boolean value) {
-                    add(value);
-                    return this;
-                }
+    public static BlockLoader.BlockFactory factory(int pageSize) {
+        return new BlockLoader.BlockFactory() {
+            @Override
+            public BlockLoader.BooleanBuilder booleansFromDocValues(int expectedCount) {
+                return booleans(expectedCount);
             }
-            return new BooleansBuilder();
-        }
 
-        @Override
-        public BlockLoader.BytesRefBuilder bytesRefsFromDocValues(int expectedCount) {
-            return bytesRefs(expectedCount);
-        }
-
-        @Override
-        public BlockLoader.BytesRefBuilder bytesRefs(int expectedCount) {
-            class BytesRefsBuilder extends TestBlock.Builder implements BlockLoader.BytesRefBuilder {
-                @Override
-                public BytesRefsBuilder appendBytesRef(BytesRef value) {
-                    add(BytesRef.deepCopyOf(value));
-                    return this;
-                }
-            }
-            return new BytesRefsBuilder();
-        }
-
-        @Override
-        public BlockLoader.DoubleBuilder doublesFromDocValues(int expectedCount) {
-            return doubles(expectedCount);
-        }
-
-        @Override
-        public BlockLoader.DoubleBuilder doubles(int expectedCount) {
-            class DoublesBuilder extends TestBlock.Builder implements BlockLoader.DoubleBuilder {
-                @Override
-                public DoublesBuilder appendDouble(double value) {
-                    add(value);
-                    return this;
-                }
-            }
-            return new DoublesBuilder();
-        }
-
-        @Override
-        public BlockLoader.IntBuilder intsFromDocValues(int expectedCount) {
-            return ints(expectedCount);
-        }
-
-        @Override
-        public BlockLoader.IntBuilder ints(int expectedCount) {
-            class IntsBuilder extends TestBlock.Builder implements BlockLoader.IntBuilder {
-                @Override
-                public IntsBuilder appendInt(int value) {
-                    add(value);
-                    return this;
-                }
-            }
-            return new IntsBuilder();
-        }
-
-        @Override
-        public BlockLoader.LongBuilder longsFromDocValues(int expectedCount) {
-            return longs(expectedCount);
-        }
-
-        @Override
-        public BlockLoader.LongBuilder longs(int expectedCount) {
-            class LongsBuilder extends TestBlock.Builder implements BlockLoader.LongBuilder {
-                @Override
-                public LongsBuilder appendLong(long value) {
-                    add(value);
-                    return this;
-                }
-            }
-            return new LongsBuilder();
-        }
-
-        @Override
-        public BlockLoader.Builder nulls(int expectedCount) {
-            return longs(expectedCount);
-        }
-
-        @Override
-        public BlockLoader.Block constantNulls(int size) {
-            BlockLoader.LongBuilder builder = longs(size);
-            for (int i = 0; i < size; i++) {
-                builder.appendNull();
-            }
-            return builder.build();
-        }
-
-        @Override
-        public BlockLoader.Block constantBytes(BytesRef value, int size) {
-            BlockLoader.BytesRefBuilder builder = bytesRefs(size);
-            for (int i = 0; i < size; i++) {
-                builder.appendBytesRef(value);
-            }
-            return builder.build();
-        }
-
-        @Override
-        public BlockLoader.SingletonOrdinalsBuilder singletonOrdinalsBuilder(SortedDocValues ordinals, int count) {
-            class SingletonOrdsBuilder extends TestBlock.Builder implements BlockLoader.SingletonOrdinalsBuilder {
-                @Override
-                public SingletonOrdsBuilder appendOrd(int value) {
-                    try {
-                        add(ordinals.lookupOrd(value));
+            @Override
+            public BlockLoader.BooleanBuilder booleans(int expectedCount) {
+                class BooleansBuilder extends TestBlock.Builder implements BlockLoader.BooleanBuilder {
+                    @Override
+                    public BooleansBuilder appendBoolean(boolean value) {
+                        add(value);
                         return this;
-                    } catch (IOException e) {
-                        throw new UncheckedIOException(e);
                     }
                 }
+                return new BooleansBuilder();
             }
-            return new SingletonOrdsBuilder();
-        }
-    };
+
+            @Override
+            public BlockLoader.BytesRefBuilder bytesRefsFromDocValues(int expectedCount) {
+                return bytesRefs(expectedCount);
+            }
+
+            @Override
+            public BlockLoader.BytesRefBuilder bytesRefs(int expectedCount) {
+                class BytesRefsBuilder extends TestBlock.Builder implements BlockLoader.BytesRefBuilder {
+                    @Override
+                    public BytesRefsBuilder appendBytesRef(BytesRef value) {
+                        add(BytesRef.deepCopyOf(value));
+                        return this;
+                    }
+                }
+                return new BytesRefsBuilder();
+            }
+
+            @Override
+            public BlockLoader.DoubleBuilder doublesFromDocValues(int expectedCount) {
+                return doubles(expectedCount);
+            }
+
+            @Override
+            public BlockLoader.DoubleBuilder doubles(int expectedCount) {
+                class DoublesBuilder extends TestBlock.Builder implements BlockLoader.DoubleBuilder {
+                    @Override
+                    public DoublesBuilder appendDouble(double value) {
+                        add(value);
+                        return this;
+                    }
+                }
+                return new DoublesBuilder();
+            }
+
+            @Override
+            public BlockLoader.IntBuilder intsFromDocValues(int expectedCount) {
+                return ints(expectedCount);
+            }
+
+            @Override
+            public BlockLoader.IntBuilder ints(int expectedCount) {
+                class IntsBuilder extends TestBlock.Builder implements BlockLoader.IntBuilder {
+                    @Override
+                    public IntsBuilder appendInt(int value) {
+                        add(value);
+                        return this;
+                    }
+                }
+                return new IntsBuilder();
+            }
+
+            @Override
+            public BlockLoader.LongBuilder longsFromDocValues(int expectedCount) {
+                return longs(expectedCount);
+            }
+
+            @Override
+            public BlockLoader.LongBuilder longs(int expectedCount) {
+                class LongsBuilder extends TestBlock.Builder implements BlockLoader.LongBuilder {
+                    @Override
+                    public LongsBuilder appendLong(long value) {
+                        add(value);
+                        return this;
+                    }
+                }
+                return new LongsBuilder();
+            }
+
+            @Override
+            public BlockLoader.Builder nulls(int expectedCount) {
+                return longs(expectedCount);
+            }
+
+            @Override
+            public BlockLoader.Block constantNulls() {
+                BlockLoader.LongBuilder builder = longs(pageSize);
+                for (int i = 0; i < pageSize; i++) {
+                    builder.appendNull();
+                }
+                return builder.build();
+            }
+
+            @Override
+            public BlockLoader.Block constantBytes(BytesRef value) {
+                BlockLoader.BytesRefBuilder builder = bytesRefs(pageSize);
+                for (int i = 0; i < pageSize; i++) {
+                    builder.appendBytesRef(value);
+                }
+                return builder.build();
+            }
+
+            @Override
+            public BlockLoader.SingletonOrdinalsBuilder singletonOrdinalsBuilder(SortedDocValues ordinals, int count) {
+                class SingletonOrdsBuilder extends TestBlock.Builder implements BlockLoader.SingletonOrdinalsBuilder {
+                    @Override
+                    public SingletonOrdsBuilder appendOrd(int value) {
+                        try {
+                            add(ordinals.lookupOrd(value));
+                            return this;
+                        } catch (IOException e) {
+                            throw new UncheckedIOException(e);
+                        }
+                    }
+                }
+                return new SingletonOrdsBuilder();
+            }
+        };
+    }
 
     public static final BlockLoader.Docs docs(int... docs) {
         return new BlockLoader.Docs() {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Page.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Page.java
@@ -82,7 +82,7 @@ public final class Page implements Writeable {
     private Page(Page prev, Block[] toAdd) {
         for (Block block : toAdd) {
             if (prev.positionCount != block.getPositionCount()) {
-                throw new IllegalArgumentException("Block does not have same position count");
+                throw new IllegalArgumentException("Block [" + block + "] does not have same position count");
             }
         }
         this.positionCount = prev.positionCount;

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/ValuesSourceReaderOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/ValuesSourceReaderOperatorTests.java
@@ -83,10 +83,12 @@ import static org.elasticsearch.compute.lucene.LuceneSourceOperatorTests.mockSea
 import static org.elasticsearch.test.MapMatcher.assertMap;
 import static org.elasticsearch.test.MapMatcher.matchesMap;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
 
 /**
  * Tests for {@link ValuesSourceReaderOperator}. Turns off {@link HandleLimitFS}
@@ -1221,5 +1223,42 @@ public class ValuesSourceReaderOperatorTests extends OperatorTestCase {
             false,
             false
         );
+    }
+
+    public void testNullsShared() {
+        DriverContext driverContext = driverContext();
+        int[] pages = new int[] { 0 };
+        try (
+            Driver d = new Driver(
+                driverContext,
+                simpleInput(driverContext.blockFactory(), 10),
+                List.of(
+                    new ValuesSourceReaderOperator.Factory(
+                        List.of(
+                            new ValuesSourceReaderOperator.FieldInfo("null1", List.of(BlockLoader.CONSTANT_NULLS)),
+                            new ValuesSourceReaderOperator.FieldInfo("null2", List.of(BlockLoader.CONSTANT_NULLS))
+                        ),
+                        List.of(new ValuesSourceReaderOperator.ShardContext(reader, () -> SourceLoader.FROM_STORED_SOURCE)),
+                        0
+                    ).get(driverContext)
+                ),
+                new PageConsumerOperator(page -> {
+                    try {
+                        assertThat(page.getBlockCount(), equalTo(3));
+                        assertThat(page.getBlock(1).areAllValuesNull(), equalTo(true));
+                        assertThat(page.getBlock(2).areAllValuesNull(), equalTo(true));
+                        assertThat(page.getBlock(1), sameInstance(page.getBlock(2)));
+                        pages[0]++;
+                    } finally {
+                        page.releaseBlocks();
+                    }
+                }),
+                () -> {}
+            )
+        ) {
+            runDriver(d);
+        }
+        assertThat(pages[0], greaterThan(0));
+        assertDriverContext(driverContext);
     }
 }

--- a/x-pack/plugin/mapper-constant-keyword/src/test/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapperTests.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/test/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapperTests.java
@@ -256,7 +256,7 @@ public class ConstantKeywordFieldMapperTests extends MapperTestCase {
             iw.close();
             try (DirectoryReader reader = DirectoryReader.open(directory)) {
                 TestBlock block = (TestBlock) loader.columnAtATimeReader(reader.leaves().get(0))
-                    .read(TestBlock.FACTORY, new BlockLoader.Docs() {
+                    .read(TestBlock.factory(reader.numDocs()), new BlockLoader.Docs() {
                         @Override
                         public int count() {
                             return 1;


### PR DESCRIPTION
This speeds up loading empty fields by sharing the `ConstantNullBlock` across all colunms that are always null. It turns out that creating these constant null blocks can get expensive - but mostly when you are creating thousands of them per Page. But that's a thing that happens!

The overhead happens to be related to memory tracking - these are many small allocations that trigger the real memory breaker a lot. Even if that weren't true the sharing is pretty simple so let's do it!

This does speed up performance a bit:

```
|                 Min Throughput |   7.23463 |   8.13522 |   0.90058 | ops/s |  +12.45% |
|                Mean Throughput |   9.32052 |  10.7259  |   1.40541 | ops/s |  +15.08% |
|              Median Throughput |   9.52468 |  10.9539  |   1.4292  | ops/s |  +15.01% |
|                 Max Throughput |   9.68817 |  11.3629  |   1.6747  | ops/s |  +17.29% |
|        50th percentile latency |  64.4631  |  51.8855  | -12.5776  |    ms |  -19.51% |
|        90th percentile latency |  74.1094  |  59.6878  | -14.4215  |    ms |  -19.46% |
|        99th percentile latency |  84.0474  |  70.384   | -13.6634  |    ms |  -16.26% |
|      99.9th percentile latency |  98.6236  |  89.8988  |  -8.72481 |    ms |   -8.85% |
|       100th percentile latency | 120.631   | 106.72    | -13.9113  |    ms |  -11.53% |
|   50th percentile service time |  64.4631  |  51.8855  | -12.5776  |    ms |  -19.51% |
|   90th percentile service time |  74.1094  |  59.6878  | -14.4215  |    ms |  -19.46% |
|   99th percentile service time |  84.0474  |  70.384   | -13.6634  |    ms |  -16.26% |
| 99.9th percentile service time |  98.6236  |  89.8988  |  -8.72481 |    ms |   -8.85% |
|  100th percentile service time | 120.631   | 106.72    | -13.9113  |    ms |  -11.53% |
|                     error rate |   0       |   0       |   0       |     % |    0.00% |
```
