### PR TITLE
Fix RefCountedFuture accidentally releasing objects

### DIFF
--- a/server/src/main/java/org/elasticsearch/client/internal/support/AbstractClient.java
+++ b/server/src/main/java/org/elasticsearch/client/internal/support/AbstractClient.java
@@ -1618,11 +1618,11 @@ public abstract class AbstractClient implements Client {
             }
         }
 
-        private final AtomicBoolean gotCalled = new AtomicBoolean(false);
+        private final AtomicBoolean getCalled = new AtomicBoolean(false);
 
         @Override
         public R get() throws InterruptedException, ExecutionException {
-            final boolean firstCall = gotCalled.compareAndSet(false, true);
+            final boolean firstCall = getCalled.compareAndSet(false, true);
             if (firstCall == false) {
                 final IllegalStateException ise = new IllegalStateException("must only call .get() once per instance to avoid leaks");
                 assert false : ise;

--- a/server/src/main/java/org/elasticsearch/client/internal/support/AbstractClient.java
+++ b/server/src/main/java/org/elasticsearch/client/internal/support/AbstractClient.java
@@ -1612,16 +1612,17 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public final void onResponse(R result) {
-            if (set(result)) {
-                result.mustIncRef();
+            result.mustIncRef();
+            if (set(result) == false) {
+                result.decRef();
             }
         }
 
-        private final AtomicBoolean getCalled = new AtomicBoolean(false);
+        private final AtomicBoolean gotCalled = new AtomicBoolean(false);
 
         @Override
         public R get() throws InterruptedException, ExecutionException {
-            final boolean firstCall = getCalled.compareAndSet(false, true);
+            final boolean firstCall = gotCalled.compareAndSet(false, true);
             if (firstCall == false) {
                 final IllegalStateException ise = new IllegalStateException("must only call .get() once per instance to avoid leaks");
                 assert false : ise;


### PR DESCRIPTION
We need to optimistically increment the reference here. Otherwise, we might release on the thread waiting on the future before we increment on the future-completing thread, causing a broken ref-count of 0.

>non-issue since this hasn't made it into a release yet.