### PR TITLE
Include product name in net-new system indices exception

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/SystemIndices.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndices.java
@@ -530,7 +530,7 @@ public class SystemIndices {
             );
         } else {
             return new IllegalArgumentException(
-                "Indices " + Arrays.toString(names.toArray(Strings.EMPTY_ARRAY)) + " use and access is reserved for system operations"
+                "Indices " + Arrays.toString(names.toArray(Strings.EMPTY_ARRAY)) + " may not be accessed by product [" + product + "]"
             );
         }
     }


### PR DESCRIPTION
This PR includes the product value passed via the header in the exception message for accessing net-new system indices similar to the error message for accesing system data streams. Without the product value, the two error messages from the `if` and `else` branches are identical.
