### PR TITLE
[8.10] [DOCS] Fixes link in PUT datafeeds API docs. (#102684)

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/put-datafeed.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-datafeed.asciidoc
@@ -26,8 +26,9 @@ Instantiates a {dfeed}.
 [[ml-put-datafeed-desc]]
 == {api-description-title}
 
-{ml-docs}/ml-dfeeds.html[{dfeeds-cap}] retrieve data from {es} for analysis by
-an {anomaly-job}. You can associate only one {dfeed} to each {anomaly-job}.
+{ml-docs}/ml-ad-run-jobs.html#ml-ad-datafeeds[{dfeeds-cap}] retrieve data from 
+{es} for analysis by an {anomaly-job}. You can associate only one {dfeed} to 
+each {anomaly-job}.
 
 The {dfeed} contains a query that runs at a defined interval (`frequency`). If
 you are concerned about delayed data, you can add a delay (`query_delay`) at


### PR DESCRIPTION
Backports the following commits to 8.10:
 - [DOCS] Fixes link in PUT datafeeds API docs. (#102684)