### PR TITLE
Create a NodeServiceLocator to help with circular references during node construction

### DIFF
--- a/server/src/main/java/org/elasticsearch/node/NodeServiceLocator.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeServiceLocator.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.node;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+public class NodeServiceLocator {
+
+    private final Map<Class<?>, ServiceReference<?>> serviceAccessors = new HashMap<>();
+    private boolean accessible;
+
+    private class ServiceReference<T> extends AtomicReference<T> {
+        private final Class<T> cls;
+        private T service;
+
+        private ServiceReference(Class<T> cls) {
+            this.cls = cls;
+        }
+
+        public T getService() {
+            // fast path no-sync check
+            if (service != null) {
+                return service;
+            }
+
+            T service = get();
+            if (accessible == false) throw new IllegalStateException("Service cannot be accessed here");
+            if (service == null) throw new IllegalStateException("No instance of " + cls + " provided");
+            return this.service = service;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> Supplier<T> requestService(Class<T> service) {
+        return (Supplier<T>) (Supplier<?>) serviceAccessors.computeIfAbsent(service, ServiceReference::new)::getService;
+    }
+
+    @SuppressWarnings("unchecked")
+    <T> void setService(Class<T> cls, T service) {
+        ((ServiceReference<Object>) serviceAccessors.computeIfAbsent(cls, ServiceReference::new)).set(service);
+    }
+
+    void setAccessible() {
+        accessible = true;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/snapshots/InternalSnapshotsInfoService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/InternalSnapshotsInfoService.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.node.NodeServiceLocator;
 import org.elasticsearch.repositories.IndexId;
 import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.repositories.Repository;
@@ -85,14 +86,27 @@ public final class InternalSnapshotsInfoService implements ClusterStateListener,
     private final Object mutex;
 
     public InternalSnapshotsInfoService(
+        final NodeServiceLocator serviceLocator,
+        final Settings settings,
+        final ClusterService clusterService
+    ) {
+        this(
+            settings,
+            clusterService,
+            serviceLocator.requestService(RepositoriesService.class),
+            serviceLocator.requestService(RerouteService.class)
+        );
+    }
+
+    public InternalSnapshotsInfoService(
         final Settings settings,
         final ClusterService clusterService,
-        final Supplier<RepositoriesService> repositoriesServiceSupplier,
-        final Supplier<RerouteService> rerouteServiceSupplier
+        final Supplier<RepositoriesService> repositoriesService,
+        final Supplier<RerouteService> rerouteService
     ) {
         this.threadPool = clusterService.getClusterApplierService().threadPool();
-        this.repositoriesService = repositoriesServiceSupplier;
-        this.rerouteService = rerouteServiceSupplier;
+        this.repositoriesService = repositoriesService;
+        this.rerouteService = rerouteService;
         this.knownSnapshotShards = ImmutableOpenMap.of();
         this.unknownSnapshotShards = new LinkedHashSet<>();
         this.failedSnapshotShards = new LinkedHashSet<>();

--- a/server/src/test/java/org/elasticsearch/cluster/InternalClusterInfoServiceSchedulingTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/InternalClusterInfoServiceSchedulingTests.java
@@ -67,7 +67,9 @@ public class InternalClusterInfoServiceSchedulingTests extends ESTestCase {
             fail("master service should not run any tasks");
         });
 
-        final ClusterService clusterService = new ClusterService(settings, clusterSettings, masterService, clusterApplierService);
+        final ClusterService clusterService = new ClusterService(settings, clusterSettings, masterService, () -> {
+            throw new IllegalStateException();
+        }, clusterApplierService);
 
         final FakeClusterInfoServiceClient client = new FakeClusterInfoServiceClient(threadPool);
         final InternalClusterInfoService clusterInfoService = new InternalClusterInfoService(settings, clusterService, threadPool, client);

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/ClusterAllocationSimulationTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/ClusterAllocationSimulationTests.java
@@ -271,7 +271,13 @@ public class ClusterAllocationSimulationTests extends ESAllocationTestCase {
         applierService.setNodeConnectionsService(ClusterServiceUtils.createNoOpNodeConnectionsService());
         applierService.setInitialState(unassignedClusterState);
 
-        final var clusterService = new ClusterService(settings, clusterSettings, masterService, applierService);
+        final var clusterService = new ClusterService(
+            settings,
+            clusterSettings,
+            masterService,
+            () -> { throw new IllegalStateException(); },
+            applierService
+        );
         clusterService.start();
 
         final var clusterInfoService = new TestClusterInfoService(clusterService);

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocatorTests.java
@@ -131,6 +131,9 @@ public class DesiredBalanceShardsAllocatorTests extends ESAllocationTestCase {
             settings,
             clusterSettings,
             new FakeThreadPoolMasterService(LOCAL_NODE_ID, threadPool, deterministicTaskQueue::scheduleNow),
+            () -> {
+                throw new IllegalStateException();
+            },
             new ClusterApplierService(LOCAL_NODE_ID, settings, clusterSettings, threadPool) {
                 @Override
                 protected PrioritizedEsThreadPoolExecutor createThreadPoolExecutor() {

--- a/server/src/test/java/org/elasticsearch/gateway/GatewayServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/GatewayServiceTests.java
@@ -100,6 +100,9 @@ public class GatewayServiceTests extends ESTestCase {
             settings,
             clusterSettings,
             new FakeThreadPoolMasterService(initialState.nodes().getLocalNodeId(), threadPool, deterministicTaskQueue::scheduleNow),
+            () -> {
+                throw new IllegalStateException();
+            },
             new ClusterApplierService(initialState.nodes().getLocalNodeId(), settings, clusterSettings, threadPool) {
                 @Override
                 protected PrioritizedEsThreadPoolExecutor createThreadPoolExecutor() {

--- a/server/src/test/java/org/elasticsearch/indices/cluster/ClusterStateChanges.java
+++ b/server/src/test/java/org/elasticsearch/indices/cluster/ClusterStateChanges.java
@@ -188,7 +188,7 @@ public class ClusterStateChanges {
             }
         };
         // mocks
-        clusterService = new ClusterService(SETTINGS, clusterSettings, masterService, null);
+        clusterService = new ClusterService(SETTINGS, clusterSettings, masterService, () -> { throw new IllegalStateException(); }, null);
         resetMasterService();
         masterService.start();
 

--- a/server/src/test/java/org/elasticsearch/reservedstate/service/FileSettingsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/reservedstate/service/FileSettingsServiceTests.java
@@ -68,12 +68,14 @@ public class FileSettingsServiceTests extends ESTestCase {
 
         threadpool = new TestThreadPool("file_settings_service_tests");
 
+        RerouteService reroute = mock(RerouteService.class);
         clusterService = spy(
             new ClusterService(
                 Settings.builder().put(NODE_NAME_SETTING.getKey(), "test").build(),
                 new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
                 threadpool,
-                new TaskManager(Settings.EMPTY, threadpool, Set.of())
+                new TaskManager(Settings.EMPTY, threadpool, Set.of()),
+                () -> reroute
             )
         );
 
@@ -83,7 +85,6 @@ public class FileSettingsServiceTests extends ESTestCase {
             .build();
         doAnswer((Answer<ClusterState>) invocation -> clusterState).when(clusterService).state();
 
-        clusterService.setRerouteService(mock(RerouteService.class));
         clusterService.setNodeConnectionsService(mock(NodeConnectionsService.class));
         clusterService.getClusterApplierService().setInitialState(clusterState);
         clusterService.getMasterService().setClusterStatePublisher((e, pl, al) -> {

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
@@ -1613,6 +1613,7 @@ public class SnapshotResiliencyTests extends ESTestCase {
                     settings,
                     clusterSettings,
                     masterService,
+                    () -> (reason, priority, listener) -> listener.onResponse(null),
                     new ClusterApplierService(node.getName(), settings, clusterSettings, threadPool) {
                         @Override
                         protected PrioritizedEsThreadPoolExecutor createThreadPoolExecutor() {
@@ -1642,7 +1643,6 @@ public class SnapshotResiliencyTests extends ESTestCase {
                         }
                     }
                 );
-                clusterService.setRerouteService((reason, priority, listener) -> listener.onResponse(null));
                 recoverySettings = new RecoverySettings(settings, clusterSettings);
                 mockTransport = new DisruptableMockTransport(node, deterministicTaskQueue) {
                     @Override

--- a/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
@@ -1115,7 +1115,13 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
                     this::onNode,
                     threadPool
                 );
-                clusterService = new ClusterService(settings, clusterSettings, masterService, clusterApplierService);
+                clusterService = new ClusterService(
+                    settings,
+                    clusterSettings,
+                    masterService,
+                    () -> { throw new IllegalStateException(); },
+                    clusterApplierService
+                );
                 featureService = new FeatureService(List.of());
                 masterHistoryService = new MasterHistoryService(transportService, threadPool, clusterService);
                 clusterService.setNodeConnectionsService(


### PR DESCRIPTION
Create a helper class to manage lazily-specified service references. This can be expanded out to other late-bound references later on