### PR TITLE
Fix reference count handling in TransportSingleShardAction

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/ActionRunnable.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionRunnable.java
@@ -62,11 +62,8 @@ public abstract class ActionRunnable<Response> extends AbstractRunnable {
     /**
      * Same as {@link #supply(ActionListener, CheckedSupplier)} but the supplier always returns an object of reference counted result type
      * which will have its reference count decremented after invoking the listener.
-     * @param listener Listener to invoke
-     * @param supplier Supplier that provides the reference counted value to pass to the listener
-     * @return Wrapped {@code Runnable}
      */
-    public static <T extends RefCounted> ActionRunnable<T> supplyRefCounted(
+    public static <T extends RefCounted> ActionRunnable<T> supplyAndDecRef(
         ActionListener<T> listener,
         CheckedSupplier<T, Exception> supplier
     ) {

--- a/server/src/main/java/org/elasticsearch/action/support/single/shard/TransportSingleShardAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/single/shard/TransportSingleShardAction.java
@@ -109,7 +109,7 @@ public abstract class TransportSingleShardAction<Request extends SingleShardRequ
     protected abstract Response shardOperation(Request request, ShardId shardId) throws IOException;
 
     protected void asyncShardOperation(Request request, ShardId shardId, ActionListener<Response> listener) throws IOException {
-        getExecutor(request, shardId).execute(ActionRunnable.supply(listener, () -> shardOperation(request, shardId)));
+        getExecutor(request, shardId).execute(ActionRunnable.supplyRefCounted(listener, () -> shardOperation(request, shardId)));
     }
 
     protected abstract Writeable.Reader<Response> getResponseReader();

--- a/server/src/main/java/org/elasticsearch/action/support/single/shard/TransportSingleShardAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/single/shard/TransportSingleShardAction.java
@@ -109,7 +109,7 @@ public abstract class TransportSingleShardAction<Request extends SingleShardRequ
     protected abstract Response shardOperation(Request request, ShardId shardId) throws IOException;
 
     protected void asyncShardOperation(Request request, ShardId shardId, ActionListener<Response> listener) throws IOException {
-        getExecutor(request, shardId).execute(ActionRunnable.supplyRefCounted(listener, () -> shardOperation(request, shardId)));
+        getExecutor(request, shardId).execute(ActionRunnable.supplyAndDecRef(listener, () -> shardOperation(request, shardId)));
     }
 
     protected abstract Writeable.Reader<Response> getResponseReader();

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -41,7 +41,6 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
-import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.RefCounted;
 import org.elasticsearch.core.Releasable;
@@ -654,22 +653,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         CheckedSupplier<T, Exception> executable,
         ActionListener<T> listener
     ) {
-        executor.execute(ActionRunnable.wrap(listener, new CheckedConsumer<>() {
-            @Override
-            public void accept(ActionListener<T> l) throws Exception {
-                var res = executable.get();
-                try {
-                    l.onResponse(res);
-                } finally {
-                    res.decRef();
-                }
-            }
-
-            @Override
-            public String toString() {
-                return executable.toString();
-            }
-        }));
+        executor.execute(ActionRunnable.supplyRefCounted(listener, executable));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -653,7 +653,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         CheckedSupplier<T, Exception> executable,
         ActionListener<T> listener
     ) {
-        executor.execute(ActionRunnable.supplyRefCounted(listener, executable));
+        executor.execute(ActionRunnable.supplyAndDecRef(listener, executable));
     }
 
     /**


### PR DESCRIPTION
Just like in the search service, we need to only release the reference after passing the supplied object to the listener.
Since this is the same pattern in the `TransportSingleShardAction` and in `SearchService` and we will likely have more spots like this in the near future I extracted the logic to a new utility.

> non-issue since this had no impact on released versions yet.