### PR TITLE
Fix race condition when reporting the time interval between two executions in the real memory circuit breaker

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerService.java
+++ b/server/src/main/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerService.java
@@ -613,8 +613,7 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
                 if (locked != null) {
                     attemptNoCopy = ++this.attemptNo;
                     long begin = timeSupplier.getAsLong();
-                    timeInterval = begin - lastCheckTime;
-                    leader = timeInterval >= minimumInterval;
+                    leader = begin >= lastCheckTime + minimumInterval;
                     overLimitTriggered(leader);
                     if (leader) {
                         long initialCollectionCount = gcCountSupplier.getAsLong();
@@ -646,6 +645,8 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
                         this.lastCheckTime = now;
                         allocationDuration = now - begin;
                         this.attemptNo = 0;
+                    } else {
+                        timeInterval = begin - lastCheckTime;
                     }
                 }
             } catch (InterruptedException e) {


### PR DESCRIPTION
We are currently computing this value outside of the lock but the `lastCheckTime` can be updated by another thread reporting wrong values. This change make sure we compute the value inside the lock.