### PR TITLE
Update IronBank BASE_IMAGE with ironbank prefix

### DIFF
--- a/distribution/docker/src/docker/Dockerfile
+++ b/distribution/docker/src/docker/Dockerfile
@@ -21,7 +21,7 @@
 
 <% if (docker_base == 'iron_bank') { %>
 ARG BASE_REGISTRY=registry1.dso.mil
-ARG BASE_IMAGE=redhat/ubi/ubi9
+ARG BASE_IMAGE=ironbank/redhat/ubi/ubi9
 ARG BASE_TAG=9.2
 <% } %>
 


### PR DESCRIPTION
This supports local testing.  It should not be included in hardening_manifest.yml, which injects the scope at runtime.

Prompted by https://repo1.dso.mil/dsop/elastic/elasticsearch/elasticsearch/-/merge_requests/140#note_1690926
Documentation https://docs-ironbank.dso.mil/hardening/choosing-base-image/