### PR TITLE
[8.11] Fix leaking blocks in BlockUtils (#102716)

### DIFF
--- a/docs/changelog/102716.yaml
+++ b/docs/changelog/102716.yaml
@@ -1,0 +1,5 @@
+pr: 102716
+summary: Fix leaking blocks in `BlockUtils`
+area: ES|QL
+type: bug
+issues: []

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockUtils.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockUtils.java
@@ -151,7 +151,17 @@ public final class BlockUtils {
                     wrappers[j].append.accept(values.get(j));
                 }
             }
-            return Arrays.stream(wrappers).map(b -> b.builder.build()).toArray(Block[]::new);
+            final Block[] blocks = new Block[wrappers.length];
+            try {
+                for (int i = 0; i < blocks.length; i++) {
+                    blocks[i] = wrappers[i].builder.build();
+                }
+                return blocks;
+            } finally {
+                if (blocks[blocks.length - 1] == null) {
+                    Releasables.closeExpectNoException(blocks);
+                }
+            }
         } finally {
             Releasables.closeExpectNoException(wrappers);
         }


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Fix leaking blocks in BlockUtils (#102716)