### PR TITLE
ESQL: Load stored fields sequentially

### DIFF
--- a/docs/changelog/102727.yaml
+++ b/docs/changelog/102727.yaml
@@ -1,0 +1,5 @@
+pr: 102727
+summary: "ESQL: Load stored fields sequentially"
+area: ES|QL
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/fieldvisitor/StoredFieldLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/fieldvisitor/StoredFieldLoader.java
@@ -14,6 +14,7 @@ import org.apache.lucene.index.StoredFields;
 import org.elasticsearch.common.CheckedBiConsumer;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.lucene.index.SequentialStoredFieldsLeafReader;
+import org.elasticsearch.index.mapper.BlockLoader;
 import org.elasticsearch.search.fetch.StoredFieldsSpec;
 
 import java.io.IOException;
@@ -71,6 +72,29 @@ public abstract class StoredFieldLoader {
             }
         };
     }
+
+    /**
+     * Creates a new StoredFieldLoader using a StoredFieldsSpec that is optimized
+     * for loading documents in order.
+     */
+    public static StoredFieldLoader fromSpecSequential(StoredFieldsSpec spec) {
+        if (spec.noRequirements()) {
+            return StoredFieldLoader.empty();
+        }
+        List<String> fieldsToLoad = fieldsToLoad(spec.requiresSource(), spec.requiredStoredFields());
+        return new StoredFieldLoader() {
+            @Override
+            public LeafStoredFieldLoader getLoader(LeafReaderContext ctx, int[] docs) throws IOException {
+                return new ReaderStoredFieldLoader(sequentialReader(ctx), spec.requiresSource(), spec.requiredStoredFields());
+            }
+
+            @Override
+            public List<String> fieldsToLoad() {
+                return fieldsToLoad;
+            }
+        };
+    }
+
 
     /**
      * Creates a StoredFieldLoader tuned for sequential reads of _source

--- a/server/src/main/java/org/elasticsearch/index/fieldvisitor/StoredFieldLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/fieldvisitor/StoredFieldLoader.java
@@ -14,7 +14,6 @@ import org.apache.lucene.index.StoredFields;
 import org.elasticsearch.common.CheckedBiConsumer;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.lucene.index.SequentialStoredFieldsLeafReader;
-import org.elasticsearch.index.mapper.BlockLoader;
 import org.elasticsearch.search.fetch.StoredFieldsSpec;
 
 import java.io.IOException;
@@ -94,7 +93,6 @@ public abstract class StoredFieldLoader {
             }
         };
     }
-
 
     /**
      * Creates a StoredFieldLoader tuned for sequential reads of _source

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/ValuesSourceReaderOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/ValuesSourceReaderOperator.java
@@ -184,11 +184,9 @@ public class ValuesSourceReaderOperator extends AbstractPageMappingOperator {
             if (useSequentialStoredFieldsReader(docVector.docs())) {
                 storedFieldLoader = StoredFieldLoader.fromSpecSequential(storedFieldsSpec);
                 trackStoredFields(storedFieldsSpec, true);
-                System.err.println("sequential");
             } else {
                 storedFieldLoader = StoredFieldLoader.fromSpec(storedFieldsSpec);
                 trackStoredFields(storedFieldsSpec, false);
-                System.err.println("non-sequential");
             }
             BlockLoaderStoredFieldsFromLeafLoader storedFields = new BlockLoaderStoredFieldsFromLeafLoader(
                 // TODO enable the optimization by passing non-null to docs if correct

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/ValuesSourceReaderOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/ValuesSourceReaderOperatorTests.java
@@ -1035,7 +1035,7 @@ public class ValuesSourceReaderOperatorTests extends OperatorTestCase {
             assertMap(
                 readers,
                 matchesMap().entry(name + ":row_stride:BlockSourceReader." + type, count)
-                    .entry("stored_fields[requires_source:true, fields:0]", count)
+                    .entry("stored_fields[requires_source:true, fields:0, sequential: " + (false == forcedRowByRow) + "]", count)
             );
         }
 
@@ -1051,7 +1051,7 @@ public class ValuesSourceReaderOperatorTests extends OperatorTestCase {
             assertMap(
                 readers,
                 matchesMap().entry(name + ":row_stride:BlockStoredFieldsReader." + type, count)
-                    .entry("stored_fields[requires_source:false, fields:1]", count)
+                    .entry("stored_fields[requires_source:false, fields:1, sequential: " + (false == forcedRowByRow) + "]", count)
             );
         }
 


### PR DESCRIPTION
The lucene APIs can load stored fields more quickly if flip them into "sequential" mode - but it's only faster when you are loading a dense set of documents - all bunched up. This flips the stored field loading code to use a sequential reader when the documents are fully dense - literally just counting without gaps - which is precisely what the fetch phase does.
