### PR TITLE
Allow match field in enrich fields

### DIFF
--- a/docs/changelog/102734.yaml
+++ b/docs/changelog/102734.yaml
@@ -1,0 +1,5 @@
+pr: 102734
+summary: Allow match field in enrich fields
+area: ES|QL
+type: bug
+issues: []

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -259,8 +259,10 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
             List<NamedExpression> enrichFields,
             EnrichPolicy policy
         ) {
-            Map<String, Attribute> fieldMap = mapping.stream().collect(Collectors.toMap(NamedExpression::name, Function.identity()));
-            fieldMap.remove(policy.getMatchField());
+            Set<String> policyEnrichFieldSet = new HashSet<>(policy.getEnrichFields());
+            Map<String, Attribute> fieldMap = mapping.stream()
+                .filter(e -> policyEnrichFieldSet.contains(e.name()))
+                .collect(Collectors.toMap(NamedExpression::name, Function.identity()));
             List<NamedExpression> result = new ArrayList<>();
             if (enrichFields == null || enrichFields.isEmpty()) {
                 // use the policy to infer the enrich fields

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/62_extra_enrich.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/62_extra_enrich.yml
@@ -1,0 +1,70 @@
+---
+"Enrich fields includes match field":
+  - skip:
+      version: " - 8.11.99"
+      reason: "enrich match field was mistakenly excluded in 8.11"
+  - do:
+      indices.create:
+        index: departments
+        body:
+          mappings:
+            properties:
+              name:
+                type: keyword
+              employees:
+                type: integer
+
+  - do:
+      bulk:
+        index: departments
+        refresh: true
+        body:
+          - { "index": { } }
+          - { "name": "engineering", "employees": 1024 }
+          - { "index": { } }
+          - { "name": "marketing", "employees": 56 }
+  - do:
+      cluster.health:
+        wait_for_no_initializing_shards: true
+        wait_for_events: languid
+
+  - do:
+      enrich.put_policy:
+        name: departments-policy
+        body:
+          match:
+            indices: [ "departments" ]
+            match_field: "name"
+            enrich_fields: [ "name", "employees" ]
+
+  - do:
+      enrich.execute_policy:
+        name: departments-policy
+  - do:
+      esql.query:
+        body:
+          query: 'ROW name="engineering" | ENRICH departments-policy | LIMIT 10 | KEEP name, employees'
+
+  - match: { columns.0.name: "name" }
+  - match: { columns.0.type: "keyword" }
+  - match: { columns.1.name: "employees" }
+  - match: { columns.1.type: "integer" }
+
+  - length: { values: 1 }
+  - match: { values.0.0: "engineering" }
+  - match: { values.0.1: 1024 }
+
+  - do:
+      esql.query:
+        body:
+          query: 'ROW name="sales" | ENRICH departments-policy ON name WITH department=name | WHERE name=department | KEEP name, department | LIMIT 10'
+
+  - match: { columns.0.name: "name" }
+  - match: { columns.0.type: "keyword" }
+  - match: { columns.1.name: "department" }
+  - match: { columns.1.type: "keyword" }
+  - length: { values: 0 }
+
+  - do:
+      enrich.delete_policy:
+        name: departments-policy

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/62_extra_enrich.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/62_extra_enrich.yml
@@ -57,7 +57,7 @@
   - do:
       esql.query:
         body:
-          query: 'ROW name="sales" | ENRICH departments-policy ON name WITH department=name | WHERE name=department | KEEP name, department | LIMIT 10'
+          query: 'ROW name="sales" | ENRICH departments-policy ON name WITH department=name | WHERE name==department | KEEP name, department | LIMIT 10'
 
   - match: { columns.0.name: "name" }
   - match: { columns.0.type: "keyword" }


### PR DESCRIPTION
It's perfectly fine for the match field of an enrich policy to be included in the enrich fields. However ESQL enrich consistently fails on such an enrich policy because it mistakenly excludes the match field from the enrich mapping during resolution.