### PR TITLE
[Profiling] Report in status API if docs exist

### DIFF
--- a/docs/changelog/102735.yaml
+++ b/docs/changelog/102735.yaml
@@ -1,0 +1,5 @@
+pr: 102735
+summary: "[Profiling] Report in status API if docs exist"
+area: Application
+type: enhancement
+issues: []

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetStatusAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetStatusAction.java
@@ -35,6 +35,7 @@ public class GetStatusAction extends ActionType<GetStatusAction.Response> {
         private boolean resourceManagementEnabled;
         private boolean resourcesCreated;
         private boolean pre891Data;
+        private boolean hasData;
         private boolean timedOut;
 
         public Response(StreamInput in) throws IOException {
@@ -44,13 +45,21 @@ public class GetStatusAction extends ActionType<GetStatusAction.Response> {
             resourcesCreated = in.readBoolean();
             pre891Data = in.readBoolean();
             timedOut = in.readBoolean();
+            hasData = in.readBoolean();
         }
 
-        public Response(boolean profilingEnabled, boolean resourceManagementEnabled, boolean resourcesCreated, boolean pre891Data) {
+        public Response(
+            boolean profilingEnabled,
+            boolean resourceManagementEnabled,
+            boolean resourcesCreated,
+            boolean pre891Data,
+            boolean hasData
+        ) {
             this.profilingEnabled = profilingEnabled;
             this.resourceManagementEnabled = resourceManagementEnabled;
             this.resourcesCreated = resourcesCreated;
             this.pre891Data = pre891Data;
+            this.hasData = hasData;
         }
 
         public void setTimedOut(boolean timedOut) {
@@ -66,7 +75,11 @@ public class GetStatusAction extends ActionType<GetStatusAction.Response> {
             builder.startObject();
             builder.startObject("profiling").field("enabled", profilingEnabled).endObject();
             builder.startObject("resource_management").field("enabled", resourceManagementEnabled).endObject();
-            builder.startObject("resources").field("created", resourcesCreated).field("pre_8_9_1_data", pre891Data).endObject();
+            builder.startObject("resources")
+                .field("created", resourcesCreated)
+                .field("pre_8_9_1_data", pre891Data)
+                .field("has_data", hasData)
+                .endObject();
             builder.endObject();
             return builder;
         }
@@ -78,6 +91,7 @@ public class GetStatusAction extends ActionType<GetStatusAction.Response> {
             out.writeBoolean(resourcesCreated);
             out.writeBoolean(pre891Data);
             out.writeBoolean(timedOut);
+            out.writeBoolean(hasData);
         }
 
         @Override
@@ -89,12 +103,13 @@ public class GetStatusAction extends ActionType<GetStatusAction.Response> {
                 && resourceManagementEnabled == response.resourceManagementEnabled
                 && resourcesCreated == response.resourcesCreated
                 && pre891Data == response.pre891Data
+                && hasData == response.hasData
                 && timedOut == response.timedOut;
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(profilingEnabled, resourceManagementEnabled, resourcesCreated, pre891Data, timedOut);
+            return Objects.hash(profilingEnabled, resourceManagementEnabled, resourcesCreated, pre891Data, hasData, timedOut);
         }
 
         @Override

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStatusAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStatusAction.java
@@ -16,6 +16,8 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateObserver;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.DataStream;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -24,6 +26,10 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.node.NodeClosedException;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -39,6 +45,7 @@ public class TransportGetStatusAction extends TransportMasterNodeAction<GetStatu
     public TransportGetStatusAction(
         TransportService transportService,
         ClusterService clusterService,
+        IndicesService indicesService,
         ThreadPool threadPool,
         ActionFilters actionFilters,
         IndexNameExpressionResolver indexNameExpressionResolver
@@ -54,7 +61,7 @@ public class TransportGetStatusAction extends TransportMasterNodeAction<GetStatu
             GetStatusAction.Response::new,
             EsExecutors.DIRECT_EXECUTOR_SERVICE
         );
-        this.resolver = new StatusResolver(clusterService);
+        this.resolver = new StatusResolver(clusterService, indicesService);
     }
 
     @Override
@@ -93,7 +100,6 @@ public class TransportGetStatusAction extends TransportMasterNodeAction<GetStatu
         private final DiscoveryNode localNode;
 
         private final ClusterService clusterService;
-
         private final StatusResolver resolver;
 
         private StatusListener(
@@ -128,9 +134,11 @@ public class TransportGetStatusAction extends TransportMasterNodeAction<GetStatu
 
     private static class StatusResolver {
         private final ClusterService clusterService;
+        private final IndicesService indicesService;
 
-        private StatusResolver(ClusterService clusterService) {
+        private StatusResolver(ClusterService clusterService, IndicesService indicesService) {
             this.clusterService = clusterService;
+            this.indicesService = indicesService;
         }
 
         private GetStatusAction.Response getResponse(ClusterState state) {
@@ -150,7 +158,30 @@ public class TransportGetStatusAction extends TransportMasterNodeAction<GetStatu
             boolean dataStreamsPre891 = ProfilingDataStreamManager.isAnyResourceTooOld(state, indexStateResolver);
             boolean anyPre891Data = indicesPre891 || dataStreamsPre891;
 
-            return new GetStatusAction.Response(pluginEnabled, resourceManagementEnabled, resourcesCreated, anyPre891Data);
+            return new GetStatusAction.Response(pluginEnabled, resourceManagementEnabled, resourcesCreated, anyPre891Data, hasData(state));
+        }
+
+        private boolean hasData(ClusterState state) {
+            DataStream dataStream = state.metadata().dataStreams().get(EventsIndex.FULL_INDEX.getName());
+            if (dataStream == null) {
+                return false;
+            }
+            for (Index index : dataStream.getIndices()) {
+                IndexMetadata meta = state.metadata().index(index);
+                if (meta == null) {
+                    return false;
+                }
+                // It should not happen that we have index metadata but no corresponding index service. Be extra defensive and skip.
+                IndexService indexService = indicesService.indexService(meta.getIndex());
+                if (indexService != null) {
+                    for (IndexShard indexShard : indexService) {
+                        if (indexShard.isReadAllowed() && indexShard.docStats().getCount() > 0L) {
+                            return true;
+                        }
+                    }
+                }
+            }
+            return false;
         }
 
         private boolean getValue(ClusterState state, Setting<Boolean> setting) {

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStatusAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStatusAction.java
@@ -169,7 +169,7 @@ public class TransportGetStatusAction extends TransportMasterNodeAction<GetStatu
             for (Index index : dataStream.getIndices()) {
                 IndexMetadata meta = state.metadata().index(index);
                 if (meta == null) {
-                    return false;
+                    continue;
                 }
                 // It should not happen that we have index metadata but no corresponding index service. Be extra defensive and skip.
                 IndexService indexService = indicesService.indexService(meta.getIndex());


### PR DESCRIPTION
With this commit we add a new field `has_data` to the profiling status API. This field is true iff there is at least one profiling event. As profiling events are the aggregate root in the profiling domain model, it is sufficient to check for presence of documents in that data stream.