### PR TITLE
[Profiling] Notify early about task cancellation

### DIFF
--- a/docs/changelog/102740.yaml
+++ b/docs/changelog/102740.yaml
@@ -1,0 +1,5 @@
+pr: 102740
+summary: "[Profiling] Notify early about task cancellation"
+area: Application
+type: enhancement
+issues: []

--- a/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/ProfilingTestCase.java
+++ b/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/ProfilingTestCase.java
@@ -81,7 +81,6 @@ public abstract class ProfilingTestCase extends ESIntegTestCase {
             .execute()
             .get();
         assertTrue("Creation of [" + name + "] is not acknowledged.", response.isAcknowledged());
-        assertTrue("Shards for [" + name + "] are not acknowledged.", response.isShardsAcknowledged());
     }
 
     /**

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStackTracesAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStackTracesAction.java
@@ -41,7 +41,9 @@ import org.elasticsearch.search.aggregations.metrics.SumAggregationBuilder;
 import org.elasticsearch.search.collapse.CollapseBuilder;
 import org.elasticsearch.search.sort.FieldSortBuilder;
 import org.elasticsearch.search.sort.SortOrder;
+import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.ObjectPath;
@@ -156,13 +158,30 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
         responseBuilder.setCustomCostPerCoreHour(request.getCustomCostPerCoreHour());
         Client client = new ParentTaskAssigningClient(this.nodeClient, transportService.getLocalNode(), submitTask);
         if (request.getIndices() == null) {
-            searchProfilingEvents(client, request, submitListener, responseBuilder);
+            searchProfilingEvents(submitTask, client, request, submitListener, responseBuilder);
         } else {
-            searchGenericEvents(client, request, submitListener, responseBuilder);
+            searchGenericEvents(submitTask, client, request, submitListener, responseBuilder);
+        }
+    }
+
+    /**
+     * Checks whether a task has been cancelled and notifies the provided listener if required.
+     * @param task The task to check. May be a cancelable task.
+     * @param listener Listener to notify.
+     * @return <code>true</code> iff the task has been cancelled. Callers must terminate as early as possible.
+     */
+    private boolean mayNotifyOfCancellation(Task task, ActionListener<GetStackTracesResponse> listener) {
+        if (task instanceof CancellableTask && ((CancellableTask) task).isCancelled()) {
+            log.info("{} got cancelled.", task);
+            listener.onFailure(new TaskCancelledException("get stacktraces task cancelled"));
+            return true;
+        } else {
+            return false;
         }
     }
 
     private void searchProfilingEvents(
+        Task submitTask,
         Client client,
         GetStackTracesRequest request,
         ActionListener<GetStackTracesResponse> submitListener,
@@ -185,7 +204,7 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
                     resampledIndex
                 );
                 log.debug(watch::report);
-                searchEventGroupedByStackTrace(client, request, submitListener, responseBuilder, resampledIndex);
+                searchEventGroupedByStackTrace(submitTask, client, request, submitListener, responseBuilder, resampledIndex);
             }, e -> {
                 // All profiling-events data streams are created lazily. In a relatively empty cluster it can happen that there are so few
                 // data that we need to resort to the "full" events stream. As this is an edge case we'd rather fail instead of prematurely
@@ -194,7 +213,7 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
                     String missingIndex = ((IndexNotFoundException) e).getIndex().getName();
                     EventsIndex fullIndex = EventsIndex.FULL_INDEX;
                     log.debug("Index [{}] does not exist. Using [{}] instead.", missingIndex, fullIndex.getName());
-                    searchEventGroupedByStackTrace(client, request, submitListener, responseBuilder, fullIndex);
+                    searchEventGroupedByStackTrace(submitTask, client, request, submitListener, responseBuilder, fullIndex);
                 } else {
                     submitListener.onFailure(e);
                 }
@@ -202,6 +221,7 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
     }
 
     private void searchGenericEvents(
+        Task submitTask,
         Client client,
         GetStackTracesRequest request,
         ActionListener<GetStackTracesResponse> submitListener,
@@ -217,7 +237,7 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
             .addAggregation(
                 new CountedTermsAggregationBuilder("group_by").size(MAX_TRACE_EVENTS_RESULT_SIZE).field(request.getStackTraceIds())
             )
-            .execute(handleEventsGroupedByStackTrace(client, responseBuilder, submitListener, searchResponse -> {
+            .execute(handleEventsGroupedByStackTrace(submitTask, client, responseBuilder, submitListener, searchResponse -> {
                 long totalSamples = 0;
                 StringTerms stacktraces = searchResponse.getAggregations().get("group_by");
 
@@ -248,6 +268,7 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
     }
 
     private void searchEventGroupedByStackTrace(
+        Task submitTask,
         Client client,
         GetStackTracesRequest request,
         ActionListener<GetStackTracesResponse> submitListener,
@@ -284,7 +305,7 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
                     )
             )
             .addAggregation(new SumAggregationBuilder("total_count").field("Stacktrace.count"))
-            .execute(handleEventsGroupedByStackTrace(client, responseBuilder, submitListener, searchResponse -> {
+            .execute(handleEventsGroupedByStackTrace(submitTask, client, responseBuilder, submitListener, searchResponse -> {
                 long totalCount = getAggValueAsLong(searchResponse, "total_count");
 
                 Resampler resampler = new Resampler(request, responseBuilder.getSamplingRate(), totalCount);
@@ -338,6 +359,7 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
     }
 
     private ActionListener<SearchResponse> handleEventsGroupedByStackTrace(
+        Task submitTask,
         Client client,
         GetStackTracesResponseBuilder responseBuilder,
         ActionListener<GetStackTracesResponse> submitListener,
@@ -355,7 +377,7 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
                 responseBuilder.setStart(Instant.ofEpochMilli(minTime));
                 responseBuilder.setEnd(Instant.ofEpochMilli(maxTime));
                 responseBuilder.setStackTraceEvents(stackTraceEvents);
-                retrieveStackTraces(client, responseBuilder, submitListener);
+                retrieveStackTraces(submitTask, client, responseBuilder, submitListener);
             } else {
                 submitListener.onResponse(responseBuilder.build());
             }
@@ -376,10 +398,14 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
     }
 
     private void retrieveStackTraces(
+        Task submitTask,
         Client client,
         GetStackTracesResponseBuilder responseBuilder,
         ActionListener<GetStackTracesResponse> submitListener
     ) {
+        if (mayNotifyOfCancellation(submitTask, submitListener)) {
+            return;
+        }
         List<String> eventIds = new ArrayList<>(responseBuilder.getStackTraceEvents().keySet());
         List<List<String>> slicedEventIds = sliced(eventIds, desiredSlices);
         ClusterState clusterState = clusterService.state();
@@ -392,6 +418,7 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
         }
 
         StackTraceHandler handler = new StackTraceHandler(
+            submitTask,
             clusterState,
             client,
             responseBuilder,
@@ -451,6 +478,7 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
 
     private class StackTraceHandler {
         private final AtomicInteger expectedResponses;
+        private final Task submitTask;
         private final ClusterState clusterState;
         private final Client client;
         private final GetStackTracesResponseBuilder responseBuilder;
@@ -467,6 +495,7 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
         private final Map<String, HostMetadata> hostMetadata;
 
         private StackTraceHandler(
+            Task submitTask,
             ClusterState clusterState,
             Client client,
             GetStackTracesResponseBuilder responseBuilder,
@@ -475,6 +504,7 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
             int expectedResponses,
             int expectedHosts
         ) {
+            this.submitTask = submitTask;
             this.clusterState = clusterState;
             this.stackTracePerId = new ConcurrentHashMap<>(stackTraceCount);
             this.expectedResponses = new AtomicInteger(expectedResponses);
@@ -572,6 +602,7 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
                 );
                 log.debug(watch::report);
                 retrieveStackTraceDetails(
+                    submitTask,
                     clusterState,
                     client,
                     responseBuilder,
@@ -584,6 +615,7 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
     }
 
     private void retrieveStackTraceDetails(
+        Task submitTask,
         ClusterState clusterState,
         Client client,
         GetStackTracesResponseBuilder responseBuilder,
@@ -591,6 +623,10 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
         List<String> executableIds,
         ActionListener<GetStackTracesResponse> submitListener
     ) {
+        if (mayNotifyOfCancellation(submitTask, submitListener)) {
+            return;
+        }
+
         List<List<String>> slicedStackFrameIds = sliced(stackFrameIds, desiredDetailSlices);
         List<List<String>> slicedExecutableIds = sliced(executableIds, desiredDetailSlices);
         List<Index> stackFrameIndices = resolver.resolve(


### PR DESCRIPTION
With this commit we add explicit checks in selected places of `TransportGetStackTracesAction` whether the parent task has been cancelled. This can happen for example when a request times out and the client closes the TCP connection. While parent task cancellation is checked explicitly before making internal calls (such as an mget) this can lead to excessive log output due to the nature of these requests (we usually send multiple of them concurrently). With the explicit checks, the listener is notified as early as possible and request processing is cancelled, thus reducing log output. Note that this is only best effort as a task might be cancelled in between our explicit check and the one done by the internal client.