### PR TITLE
[TEST] Use default_shards in downsampling

### DIFF
--- a/x-pack/plugin/downsample/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/downsample/60_settings.yml
+++ b/x-pack/plugin/downsample/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/downsample/60_settings.yml
@@ -94,7 +94,8 @@
 "Downsample datastream with tier preference":
   - skip:
       version: " - 8.4.99"
-      reason: "rollup renamed to downsample in 8.5.0"
+      features: default_shards
+      reason: "rollup renamed to downsample in 8.5.0, avoid globalTemplateIndexSettings with overlapping index pattern"
 
   - do:
       indices.put_index_template:


### PR DESCRIPTION
Index patter in a TSDS conflicts with a global template matching all indexes, `(global => [*])`. This is sometimes added in ESClientYamlSuiteTestCase, leading to flaky warnings. To avoid this, use feature default_shards.

Fixes #102489
