### PR TITLE
Disable concurrency when synthetic source is enabled

### DIFF
--- a/modules/lang-painless/src/internalClusterTest/java/org/elasticsearch/painless/search/SyntheticSourceIT.java
+++ b/modules/lang-painless/src/internalClusterTest/java/org/elasticsearch/painless/search/SyntheticSourceIT.java
@@ -10,7 +10,6 @@ package org.elasticsearch.painless.search;
 
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.support.WriteRequest;
-import org.elasticsearch.core.CheckedFunction;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.painless.PainlessPlugin;
 import org.elasticsearch.plugins.Plugin;
@@ -31,12 +30,12 @@ public class SyntheticSourceIT extends ESIntegTestCase {
         return Collections.singleton(PainlessPlugin.class);
     }
 
-    public void testText() throws Exception {
-        createIndex(b -> b.field("type", "text").field("store", true));
+    public void testSearchUsingRuntimeField() throws Exception {
+        createIndex();
 
         int numDocs = between(1000, 5000);
         for (int i = 0; i < numDocs; i++) {
-            IndexRequestBuilder indexRequest = client().prepareIndex("test").setSource("id", "" + i, "field", "n" + i);
+            IndexRequestBuilder indexRequest = client().prepareIndex("test").setSource("id", "" + i);
             if (randomInt(100) < 5) {
                 indexRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
             }
@@ -46,7 +45,7 @@ public class SyntheticSourceIT extends ESIntegTestCase {
         assertNoFailures(client().prepareSearch("test").setQuery(QueryBuilders.rangeQuery("long_id").from(0)));
     }
 
-    private void createIndex(CheckedFunction<XContentBuilder, XContentBuilder, IOException> fieldMapping) throws IOException {
+    private void createIndex() throws IOException {
         XContentBuilder mapping = JsonXContent.contentBuilder();
         mapping.startObject();
         {
@@ -63,9 +62,6 @@ public class SyntheticSourceIT extends ESIntegTestCase {
             mapping.endObject();
             mapping.startObject("properties");
             mapping.startObject("id").field("type", "keyword").endObject();
-            mapping.startObject("field");
-            fieldMapping.apply(mapping);
-            mapping.endObject();
             mapping.endObject();
         }
         mapping.endObject();

--- a/modules/lang-painless/src/internalClusterTest/java/org/elasticsearch/painless/search/SyntheticSourceIT.java
+++ b/modules/lang-painless/src/internalClusterTest/java/org/elasticsearch/painless/search/SyntheticSourceIT.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.painless.search;
+
+import org.elasticsearch.action.index.IndexRequestBuilder;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.core.CheckedFunction;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.painless.PainlessPlugin;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.json.JsonXContent;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+
+public class SyntheticSourceIT extends ESIntegTestCase {
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Collections.singleton(PainlessPlugin.class);
+    }
+
+    public void testText() throws Exception {
+        createIndex(b -> b.field("type", "text").field("store", true));
+
+        int numDocs = between(1000, 5000);
+        for (int i = 0; i < numDocs; i++) {
+            IndexRequestBuilder indexRequest = client().prepareIndex("test").setSource("id", "" + i, "field", "n" + i);
+            if (randomInt(100) < 5) {
+                indexRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+            }
+            indexRequest.get();
+        }
+        client().admin().indices().prepareRefresh("test").get();
+        assertNoFailures(client().prepareSearch("test").setQuery(QueryBuilders.rangeQuery("long_id").from(0)));
+    }
+
+    private void createIndex(CheckedFunction<XContentBuilder, XContentBuilder, IOException> fieldMapping) throws IOException {
+        XContentBuilder mapping = JsonXContent.contentBuilder();
+        mapping.startObject();
+        {
+            mapping.startObject("_source");
+            mapping.field("mode", "synthetic");
+            mapping.endObject();
+        }
+        {
+            mapping.startObject("runtime");
+            mapping.startObject("long_id");
+            mapping.field("type", "long");
+            mapping.field("script", "emit(Long.parseLong(params._source.id));");
+            mapping.endObject();
+            mapping.endObject();
+            mapping.startObject("properties");
+            mapping.startObject("id").field("type", "keyword").endObject();
+            mapping.startObject("field");
+            fieldMapping.apply(mapping);
+            mapping.endObject();
+            mapping.endObject();
+        }
+        mapping.endObject();
+
+        assertAcked(client().admin().indices().prepareCreate("test").setMapping(mapping).get());
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
@@ -32,6 +32,7 @@ import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.fielddata.FieldDataContext;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexOrdinalsFieldData;
+import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.IdLoader;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NestedLookup;
@@ -167,7 +168,7 @@ final class DefaultSearchContext extends SearchContext {
 
             Engine.Searcher engineSearcher = readerContext.acquireSearcher("search");
             int maximumNumberOfSlices;
-            if (indexService.mapperService().documentMapper().sourceMapper().isSynthetic()) {
+            if (hasSyntheticSource(indexService)) {
                 // accessing synthetic source is not thread safe
                 maximumNumberOfSlices = 1;
             } else {
@@ -219,6 +220,14 @@ final class DefaultSearchContext extends SearchContext {
                 close();
             }
         }
+    }
+
+    private static boolean hasSyntheticSource(IndexService indexService) {
+        DocumentMapper documentMapper = indexService.mapperService().documentMapper();
+        if (documentMapper != null) {
+            return documentMapper.sourceMapper().isSynthetic();
+        }
+        return false;
     }
 
     static long getFieldCardinality(String field, IndexService indexService, DirectoryReader directoryReader) {

--- a/server/src/test/java/org/elasticsearch/search/DefaultSearchContextTests.java
+++ b/server/src/test/java/org/elasticsearch/search/DefaultSearchContextTests.java
@@ -395,6 +395,8 @@ public class DefaultSearchContextTests extends ESTestCase {
         when(indexShard.getThreadPool()).thenReturn(threadPool);
 
         IndexService indexService = mock(IndexService.class);
+        MapperService mapperService = mock(MapperService.class);
+        when(indexService.mapperService()).thenReturn(mapperService);
 
         try (Directory dir = newDirectory(); RandomIndexWriter w = new RandomIndexWriter(random(), dir)) {
 


### PR DESCRIPTION
Accessing synthetic source is not thread safe therefore we disable concurrency in this case.

I label it as non-issue as it has not been released.

fixes https://github.com/elastic/elasticsearch/issues/102679