### PR TITLE
[8.11][TEST] Use default_shards in downsampling

### DIFF
--- a/x-pack/plugin/downsample/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/downsample/60_settings.yml
+++ b/x-pack/plugin/downsample/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/downsample/60_settings.yml
@@ -93,10 +93,9 @@
 ---
 "Downsample datastream with tier preference":
   - skip:
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/97150"
-#      version: " - 8.4.99"
-#      reason: "rollup renamed to downsample in 8.5.0"
+     version: " - 8.4.99"
+     features: default_shards
+     reason: "rollup renamed to downsample in 8.5.0, avoid globalTemplateIndexSettings with overlapping index pattern"
 
   - do:
       indices.put_index_template:


### PR DESCRIPTION
Backport #102743 to 8.11 branch