### PR TITLE
Add simple stress test to EnrichMultiNodeIT

### DIFF
--- a/x-pack/plugin/enrich/src/internalClusterTest/java/org/elasticsearch/xpack/enrich/EnrichMultiNodeIT.java
+++ b/x-pack/plugin/enrich/src/internalClusterTest/java/org/elasticsearch/xpack/enrich/EnrichMultiNodeIT.java
@@ -23,6 +23,7 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Strings;
 import org.elasticsearch.ingest.common.IngestCommonPlugin;
 import org.elasticsearch.plugins.Plugin;
@@ -53,6 +54,7 @@ import static org.elasticsearch.test.NodeRoles.nonMasterNode;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsInRelativeOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
@@ -82,6 +84,7 @@ public class EnrichMultiNodeIT extends ESIntegTestCase {
             // TODO Change this to run with security enabled
             // https://github.com/elastic/elasticsearch/issues/75940
             .put(XPackSettings.SECURITY_ENABLED.getKey(), false)
+            .put("thread_pool.write.size", 2)
             .build();
     }
 
@@ -133,6 +136,25 @@ public class EnrichMultiNodeIT extends ESIntegTestCase {
         createAndExecutePolicy();
         createPipeline();
         enrich(keys, randomFrom(nodes));
+    }
+
+    public void testStressEnrich() {
+        List<String> nodes = internalCluster().startNodes(
+            3,
+            Settings.builder().put("enrich.coordinator_proxy.max_concurrent_requests", 1).build()
+        );
+        int indices = randomIntBetween(5, 10);
+        final Map<String, List<String>> keys = Maps.newHashMapWithExpectedSize(indices);
+        for (int i = 0; i < indices; i++) {
+            final String indexName = "index-" + i;
+            List<String> k = createSourceIndex(indexName, 64);
+            final String policyName = "policy-" + i;
+            createAndExecutePolicy(policyName, indexName);
+            final String pipelineName = "pipeline-" + i;
+            createPipeline(policyName, pipelineName);
+            keys.put(pipelineName, k);
+        }
+        enrich(keys, randomFrom(nodes), 50);
     }
 
     public void testEnrichDedicatedIngestNode() {
@@ -210,13 +232,19 @@ public class EnrichMultiNodeIT extends ESIntegTestCase {
     }
 
     private static void enrich(List<String> keys, String coordinatingNode) {
-        int numDocs = 256;
+        enrich(Map.of(PIPELINE_NAME, keys), coordinatingNode, 256);
+    }
+
+    private static void enrich(Map<String, List<String>> keys, String coordinatingNode, int numDocs) {
+        final String[] executedPipeline = new String[2 * numDocs];
         BulkRequest bulkRequest = new BulkRequest("my-index");
         for (int i = 0; i < numDocs; i++) {
+            final String pipeline = randomFrom(keys.keySet());
+            executedPipeline[i] = pipeline;
             IndexRequest indexRequest = new IndexRequest();
             indexRequest.id(Integer.toString(i));
-            indexRequest.setPipeline(PIPELINE_NAME);
-            indexRequest.source(Map.of(MATCH_FIELD, randomFrom(keys)));
+            indexRequest.setPipeline(pipeline);
+            indexRequest.source(Map.of(MATCH_FIELD, randomFrom(keys.get(pipeline))));
             bulkRequest.add(indexRequest);
         }
         BulkResponse bulkResponse = client(coordinatingNode).bulk(bulkRequest).actionGet();
@@ -231,7 +259,7 @@ public class EnrichMultiNodeIT extends ESIntegTestCase {
             Map<String, Object> source = getResponse.getSourceAsMap();
             Map<?, ?> userEntry = (Map<?, ?>) source.get("user");
             assertThat(userEntry.size(), equalTo(DECORATE_FIELDS.length + 1));
-            assertThat(keys.contains(userEntry.get(MATCH_FIELD)), is(true));
+            assertThat(keys.get(executedPipeline[i]), containsInRelativeOrder(userEntry.get(MATCH_FIELD)));
             for (String field : DECORATE_FIELDS) {
                 assertThat(userEntry.get(field), notNullValue());
             }
@@ -250,6 +278,10 @@ public class EnrichMultiNodeIT extends ESIntegTestCase {
     }
 
     private static List<String> createSourceIndex(int numDocs) {
+        return createSourceIndex(SOURCE_INDEX_NAME, numDocs);
+    }
+
+    private static List<String> createSourceIndex(String indexName, int numDocs) {
         Set<String> keys = new HashSet<>();
         for (int i = 0; i < numDocs; i++) {
             String key;
@@ -257,7 +289,7 @@ public class EnrichMultiNodeIT extends ESIntegTestCase {
                 key = randomAlphaOfLength(16);
             } while (keys.add(key) == false);
 
-            IndexRequest indexRequest = new IndexRequest(SOURCE_INDEX_NAME);
+            IndexRequest indexRequest = new IndexRequest(indexName);
             indexRequest.create(true);
             indexRequest.id(key);
             indexRequest.source(
@@ -274,23 +306,27 @@ public class EnrichMultiNodeIT extends ESIntegTestCase {
             );
             client().index(indexRequest).actionGet();
         }
-        indicesAdmin().refresh(new RefreshRequest(SOURCE_INDEX_NAME)).actionGet();
+        indicesAdmin().refresh(new RefreshRequest(indexName)).actionGet();
         return List.copyOf(keys);
     }
 
     private static void createAndExecutePolicy() {
+        createAndExecutePolicy(POLICY_NAME, SOURCE_INDEX_NAME);
+    }
+
+    private static void createAndExecutePolicy(String policyName, String indexName) {
         EnrichPolicy enrichPolicy = new EnrichPolicy(
             EnrichPolicy.MATCH_TYPE,
             null,
-            List.of(SOURCE_INDEX_NAME),
+            List.of(indexName),
             MATCH_FIELD,
             List.of(DECORATE_FIELDS)
         );
-        PutEnrichPolicyAction.Request request = new PutEnrichPolicyAction.Request(POLICY_NAME, enrichPolicy);
+        PutEnrichPolicyAction.Request request = new PutEnrichPolicyAction.Request(policyName, enrichPolicy);
         client().execute(PutEnrichPolicyAction.INSTANCE, request).actionGet();
         final ActionFuture<ExecuteEnrichPolicyAction.Response> policyExecuteFuture = client().execute(
             ExecuteEnrichPolicyAction.INSTANCE,
-            new ExecuteEnrichPolicyAction.Request(POLICY_NAME)
+            new ExecuteEnrichPolicyAction.Request(policyName)
         );
         // Make sure we can deserialize enrich policy execution task status
         final List<TaskInfo> tasks = clusterAdmin().prepareListTasks().setActions(EnrichPolicyExecutor.TASK_ACTION).get().getTasks();
@@ -307,11 +343,15 @@ public class EnrichMultiNodeIT extends ESIntegTestCase {
     }
 
     private static void createPipeline() {
+        createPipeline(POLICY_NAME, PIPELINE_NAME);
+    }
+
+    private static void createPipeline(String policyName, String pipelineName) {
         String pipelineBody = Strings.format("""
             {
               "processors": [ { "enrich": { "policy_name": "%s", "field": "%s", "target_field": "user" } } ]
-            }""", POLICY_NAME, MATCH_FIELD);
-        PutPipelineRequest request = new PutPipelineRequest(PIPELINE_NAME, new BytesArray(pipelineBody), XContentType.JSON);
+            }""", policyName, MATCH_FIELD);
+        PutPipelineRequest request = new PutPipelineRequest(pipelineName, new BytesArray(pipelineBody), XContentType.JSON);
         clusterAdmin().putPipeline(request).actionGet();
     }
 }


### PR DESCRIPTION
Add a simple test that forces enrich tasks to queue up to guard against bugs around holding on to multi search responses in this logic, now that we are introducing ref counting to them.
The changes here are done in a way that leaves existing tests completely unchanged.

relates #102479
