### PR TITLE
Close rather than stop HttpServerTransport on shutdown

### DIFF
--- a/docs/changelog/102759.yaml
+++ b/docs/changelog/102759.yaml
@@ -1,0 +1,6 @@
+pr: 102759
+summary: Close rather than stop `HttpServerTransport` on shutdown
+area: Infra/Node Lifecycle
+type: bug
+issues:
+ - 102501

--- a/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
@@ -460,6 +460,8 @@ class Elasticsearch {
     }
 
     private static void shutdown() {
+        ElasticsearchProcess.markStopping();
+
         if (INSTANCE == null) {
             return; // never got far enough
         }

--- a/server/src/main/java/org/elasticsearch/bootstrap/ElasticsearchProcess.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/ElasticsearchProcess.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.bootstrap;
+
+/**
+ * Helper class to determine if the ES process is shutting down
+ */
+public class ElasticsearchProcess {
+    private static volatile boolean stopping;
+
+    static void markStopping() {
+        stopping = true;
+    }
+
+    public static boolean isStopping() {
+        return stopping;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/common/component/Lifecycle.java
+++ b/server/src/main/java/org/elasticsearch/common/component/Lifecycle.java
@@ -8,6 +8,8 @@
 
 package org.elasticsearch.common.component;
 
+import org.elasticsearch.bootstrap.ElasticsearchProcess;
+
 /**
  * Lifecycle state. Allows the following transitions:
  * <ul>
@@ -103,7 +105,11 @@ public final class Lifecycle {
             case STARTED -> false;
             case STOPPED -> {
                 assert false : "STOPPED -> STARTED";
-                throw new IllegalStateException("Can't move to started state when stopped");
+                throw new IllegalStateException(
+                    ElasticsearchProcess.isStopping()
+                        ? "Can't start lifecycle object when the Elasticsearch process is shutting down"
+                        : "Can't move to started state when stopped"
+                );
             }
             case CLOSED -> {
                 assert false : "CLOSED -> STARTED";

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -575,10 +575,7 @@ public class Node implements Closeable {
      */
     public void prepareForClose() {
         HttpServerTransport httpServerTransport = injector.getInstance(HttpServerTransport.class);
-        FutureTask<Void> stopper = new FutureTask<>(() -> {
-            httpServerTransport.stop();
-            return null;
-        });
+        FutureTask<Void> stopper = new FutureTask<>(httpServerTransport::close, null);
         new Thread(stopper, "http-server-transport-stop").start();
 
         if (terminationHandler != null) {

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -401,16 +401,7 @@ public class Node implements Closeable {
             }
         }
 
-        var httpTransport = injector.getInstance(HttpServerTransport.class);
-        try {
-            httpTransport.start();
-        } catch (IllegalStateException e) {
-            if (httpTransport.lifecycleState() == Lifecycle.State.CLOSED) {
-                throw new IllegalStateException("Node is shutting down, cannot complete startup", e);
-            } else {
-                throw e;
-            }
-        }
+        injector.getInstance(HttpServerTransport.class).start();
 
         if (WRITE_PORTS_FILE_SETTING.get(settings())) {
             TransportService transport = injector.getInstance(TransportService.class);

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -401,7 +401,16 @@ public class Node implements Closeable {
             }
         }
 
-        injector.getInstance(HttpServerTransport.class).start();
+        var httpTransport = injector.getInstance(HttpServerTransport.class);
+        try {
+            httpTransport.start();
+        } catch (IllegalStateException e) {
+            if (httpTransport.lifecycleState() == Lifecycle.State.CLOSED) {
+                throw new IllegalStateException("Node is shutting down, cannot complete startup", e);
+            } else {
+                throw e;
+            }
+        }
 
         if (WRITE_PORTS_FILE_SETTING.get(settings())) {
             TransportService transport = injector.getInstance(TransportService.class);

--- a/server/src/test/java/org/elasticsearch/node/NodeTests.java
+++ b/server/src/test/java/org/elasticsearch/node/NodeTests.java
@@ -23,7 +23,6 @@ import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.gateway.PersistedClusterStateService;
-import org.elasticsearch.http.HttpServerTransport;
 import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.engine.Engine.Searcher;
@@ -79,7 +78,6 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.Matchers.startsWith;
 import static org.mockito.Mockito.mock;
 
 @LuceneTestCase.SuppressFileSystems(value = "ExtrasFS")
@@ -336,7 +334,7 @@ public class NodeTests extends ESTestCase {
 
     public void testStartOnClosedTransport() throws IOException {
         try (Node node = new MockNode(baseSettings().build(), basePlugins())) {
-            node.injector().getInstance(HttpServerTransport.class).close();
+            node.prepareForClose();
             expectThrows(AssertionError.class, node::start);    // this would be IllegalStateException in a real Node with assertions off
         }
     }


### PR DESCRIPTION
Call `close` rather than `stop` on HttpServerTransport on shutdown. This will not throw an exception if the node has not yet fully started up before it is shut down.

This will result instead in [start](https://github.com/elastic/elasticsearch/blob/964d5e4b688a83c9c7fce6af9bf0a4ed696b5885/server/src/main/java/org/elasticsearch/node/Node.java#L404) throwing an exception in the `Node.start()` method. This exception is now caught, and a clearer exception message is given in this case.

This resolves #102501