### PR TITLE
Drop the symlink env test on windows without privileges

### DIFF
--- a/server/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
+++ b/server/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
@@ -42,9 +42,11 @@ import org.elasticsearch.test.MockLogAppender;
 import org.elasticsearch.test.NodeRoles;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.hamcrest.Matchers;
+import org.junit.AssumptionViolatedException;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystemException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -640,7 +642,16 @@ public class NodeEnvironmentTests extends ESTestCase {
         Path dataPath = tempDir.resolve("data");
         Files.createDirectories(dataPath);
         Path symLinkPath = tempDir.resolve("data_symlink");
-        Files.createSymbolicLink(symLinkPath, dataPath);
+        try {
+            Files.createSymbolicLink(symLinkPath, dataPath);
+        } catch (FileSystemException e) {
+            if (IOUtils.WINDOWS && e.getMessage().equals("A required privilege is not held by the client")) {
+                throw new AssumptionViolatedException("Symlinks on windows needs admin privileges", e);
+            } else {
+                throw e;
+            }
+        }
+
         NodeEnvironment env = newNodeEnvironment(new String[] { symLinkPath.toString() }, "/tmp", Settings.EMPTY);
 
         assertTrue(Files.exists(symLinkPath));


### PR DESCRIPTION
Creating symlinks on windows [requires admin privileges](https://learn.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/create-symbolic-links), so it doesn't make sense to run the symlink test on windows if this throws.

This fixes #102355