### PR TITLE
[CI] Fix for SearchCancellationIT

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/SearchCancellationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/SearchCancellationIT.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.search;
 
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.search.MultiSearchResponse;
@@ -50,8 +49,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 
-@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.SUITE)
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/102257")
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST)
 public class SearchCancellationIT extends AbstractSearchCancellationTestCase {
 
     @Override
@@ -288,12 +286,11 @@ public class SearchCancellationIT extends AbstractSearchCancellationTestCase {
                     assertTrue("All SearchShardTasks should then be cancelled", shardQueryTask.isCancelled());
                 }
             }, 30, TimeUnit.SECONDS);
-            shardTaskLatch.countDown(); // unblock the shardTasks, allowing the test to conclude.
         } finally {
+            shardTaskLatch.countDown(); // unblock the shardTasks, allowing the test to conclude.
             searchThread.join();
-            for (ScriptedBlockPlugin plugin : plugins) {
-                plugin.setBeforeExecution(() -> {});
-            }
+            plugins.forEach(plugin -> plugin.setBeforeExecution(() -> {}));
+            searchShardBlockingPlugins.forEach(plugin -> plugin.setRunOnNewReaderContext((ReaderContext c) -> {}));
         }
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractSearchCancellationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractSearchCancellationTestCase.java
@@ -210,7 +210,7 @@ public class AbstractSearchCancellationTestCase extends ESIntegTestCase {
             }
         }
 
-        public void waitForBlock(int timeout, TimeUnit timeUnit) {
+        public void waitForLock(int timeout, TimeUnit timeUnit) {
             try {
                 assertTrue(shouldBlock.tryAcquire(timeout, timeUnit));
                 shouldBlock.release(1);
@@ -227,7 +227,7 @@ public class AbstractSearchCancellationTestCase extends ESIntegTestCase {
             LeafStoredFieldsLookup fieldsLookup = (LeafStoredFieldsLookup) params.get("_fields");
             LogManager.getLogger(AbstractSearchCancellationTestCase.class).info("Blocking on the document {}", fieldsLookup.get("_id"));
             hits.incrementAndGet();
-            waitForBlock(10, TimeUnit.SECONDS);
+            waitForLock(10, TimeUnit.SECONDS);
             return true;
         }
 
@@ -247,7 +247,7 @@ public class AbstractSearchCancellationTestCase extends ESIntegTestCase {
             }
             logIfBlocked("Blocking in reduce");
             hits.incrementAndGet();
-            waitForBlock(10, TimeUnit.SECONDS);
+            waitForLock(10, TimeUnit.SECONDS);
             return 42;
         }
 
@@ -258,7 +258,7 @@ public class AbstractSearchCancellationTestCase extends ESIntegTestCase {
             }
             logIfBlocked("Blocking in map");
             hits.incrementAndGet();
-            waitForBlock(10, TimeUnit.SECONDS);
+            waitForLock(10, TimeUnit.SECONDS);
             return 1;
         }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractSearchCancellationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractSearchCancellationTestCase.java
@@ -202,7 +202,7 @@ public class AbstractSearchCancellationTestCase extends ESIntegTestCase {
             );
         }
 
-        public void tryBlock(String logMessage) {
+        public void tryBlockOnce(String logMessage) {
             if (shouldBlock.tryAcquire(1) == false) {
                 LogManager.getLogger(AbstractSearchCancellationTestCase.class).info(logMessage);
             } else {
@@ -245,7 +245,7 @@ public class AbstractSearchCancellationTestCase extends ESIntegTestCase {
             if (runnable != null) {
                 runnable.run();
             }
-            tryBlock("Blocking in reduce");
+            tryBlockOnce("Blocking in reduce");
             hits.incrementAndGet();
             waitForBlock(10, TimeUnit.SECONDS);
             return 42;
@@ -256,7 +256,7 @@ public class AbstractSearchCancellationTestCase extends ESIntegTestCase {
             if (runnable != null) {
                 runnable.run();
             }
-            tryBlock("Blocking in map");
+            tryBlockOnce("Blocking in map");
             hits.incrementAndGet();
             waitForBlock(10, TimeUnit.SECONDS);
             return 1;

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractSearchCancellationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractSearchCancellationTestCase.java
@@ -202,7 +202,7 @@ public class AbstractSearchCancellationTestCase extends ESIntegTestCase {
             );
         }
 
-        public void tryBlockOnce(String logMessage) {
+        public void logIfBlocked(String logMessage) {
             if (shouldBlock.tryAcquire(1) == false) {
                 LogManager.getLogger(AbstractSearchCancellationTestCase.class).info(logMessage);
             } else {
@@ -245,7 +245,7 @@ public class AbstractSearchCancellationTestCase extends ESIntegTestCase {
             if (runnable != null) {
                 runnable.run();
             }
-            tryBlockOnce("Blocking in reduce");
+            logIfBlocked("Blocking in reduce");
             hits.incrementAndGet();
             waitForBlock(10, TimeUnit.SECONDS);
             return 42;
@@ -256,7 +256,7 @@ public class AbstractSearchCancellationTestCase extends ESIntegTestCase {
             if (runnable != null) {
                 runnable.run();
             }
-            tryBlockOnce("Blocking in map");
+            logIfBlocked("Blocking in map");
             hits.incrementAndGet();
             waitForBlock(10, TimeUnit.SECONDS);
             return 1;


### PR DESCRIPTION
This PR addresses 2 issues: 
* Isolate each test execution
* Make sure to countdown the `shardTaskLatch` even if something in the code block above fails (so that the threads proceed and shards are unblocked)

While looking at some of the errors reported in the parent ticket (e.g. [this one](https://gradle-enterprise.elastic.co/s/76fkjfpj3jnn4/console-log/task/:server:internalClusterTest?anchor=475&page=1)), we noticed the following exception: 
```
[2023-11-18T14:31:27,538][INFO ][o.e.s.SearchCancellationIT] [testCancellationOfScrollSearches] [SearchCancellationIT#testCancellationOfScrollSearches]: cleaning up after test
 com.carrotsearch.randomizedtesting.RandomizedRunner$QueueUncaughtExceptionsHandler uncaughtException
WARNING: Uncaught exception in thread: Thread[#4078,elasticsearch[node_s0][search][T#3],5,TGRP-SearchCancellationIT]
java.lang.AssertionError
	at __randomizedtesting.SeedInfo.seed([FC306E39C540E390]:0)
	at org.junit.Assert.fail(Assert.java:86)
	at org.junit.Assert.assertTrue(Assert.java:41)
	at org.junit.Assert.assertTrue(Assert.java:52)
	at org.elasticsearch.test.ESTestCase.safeAwait(ESTestCase.java:2063)
	at org.elasticsearch.search.SearchCancellationIT.lambda$testCancelFailedSearchWhenPartialResultDisallowed$2(SearchCancellationIT.java:260)
	at org.elasticsearch.test.AbstractSearchCancellationTestCase$SearchShardBlockingPlugin$1.onNewReaderContext(AbstractSearchCancellationTestCase.java:285)
	at org.elasticsearch.index.shard.SearchOperationListener$CompositeListener.onNewReaderContext(SearchOperationListener.java:188)
	at org.elasticsearch.search.SearchService.createAndPutReaderContext(SearchService.java:963)
	at org.elasticsearch.search.SearchService.createOrGetReaderContext(SearchService.java:930)
	at org.elasticsearch.search.SearchService.executeQueryPhase(SearchService.java:661)
	at org.elasticsearch.search.SearchService.lambda$executeQueryPhase$2(SearchService.java:543)
	at org.elasticsearch.action.ActionRunnable$2.accept(ActionRunnable.java:51)
	at org.elasticsearch.action.ActionRunnable$2.accept(ActionRunnable.java:48)
	at org.elasticsearch.action.ActionRunnable$3.doRun(ActionRunnable.java:73)
	at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:26)
	at org.elasticsearch.common.util.concurrent.TimedRunnable.doRun(TimedRunnable.java:33)
	at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:983)
	at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:26)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```
This implies that a failure on one test (`testCancellationOfScrollSearches`) was dependent on a method defined in another (`testCancelFailedSearchWhenPartialResultDisallowed`). This is because we reuse the same cluster for all tests 
```
@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.SUITE)
```
and because the `plugin.setRunOnNewReaderContext` set for the `SearchShardBlockingPlugin` is never properly cleared. 

As part of this PR we also unmute the test to check if there are any new failures - and perform a minor refactoring on how the `shouldBlock` is defined in `AbstractSearchCancellationTestCase` (thanks @original-brownbear !)

Closes https://github.com/elastic/elasticsearch/issues/102257