### PR TITLE
ESQL: Simplify refCount semantics of Block::expand

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayBlock.java
@@ -80,6 +80,7 @@ public final class BooleanArrayBlock extends AbstractArrayBlock implements Boole
     @Override
     public BooleanBlock expand() {
         if (firstValueIndexes == null) {
+            incRef();
             return this;
         }
         // TODO use reference counting to share the values

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayBlock.java
@@ -83,6 +83,7 @@ public final class BytesRefArrayBlock extends AbstractArrayBlock implements Byte
     @Override
     public BytesRefBlock expand() {
         if (firstValueIndexes == null) {
+            incRef();
             return this;
         }
         // TODO use reference counting to share the values

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayBlock.java
@@ -80,6 +80,7 @@ public final class DoubleArrayBlock extends AbstractArrayBlock implements Double
     @Override
     public DoubleBlock expand() {
         if (firstValueIndexes == null) {
+            incRef();
             return this;
         }
         // TODO use reference counting to share the values

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayBlock.java
@@ -80,6 +80,7 @@ public final class IntArrayBlock extends AbstractArrayBlock implements IntBlock 
     @Override
     public IntBlock expand() {
         if (firstValueIndexes == null) {
+            incRef();
             return this;
         }
         // TODO use reference counting to share the values

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayBlock.java
@@ -80,6 +80,7 @@ public final class LongArrayBlock extends AbstractArrayBlock implements LongBloc
     @Override
     public LongBlock expand() {
         if (firstValueIndexes == null) {
+            incRef();
             return this;
         }
         // TODO use reference counting to share the values

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AbstractVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AbstractVectorBlock.java
@@ -57,6 +57,7 @@ abstract class AbstractVectorBlock extends AbstractBlock {
 
     @Override
     public final Block expand() {
+        incRef();
         return this;
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Block.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Block.java
@@ -145,8 +145,9 @@ public interface Block extends Accountable, BlockLoader.Block, NamedWriteable, R
     /**
      * Expand multivalued fields into one row per value. Returns the
      * block if there aren't any multivalued fields to expand.
+     *
+     * The returned block needs to be closed by the caller to release the block's resources.
      */
-    // TODO: We should use refcounting instead of either deep copies or returning the same identical block.
     Block expand();
 
     /**

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Block.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Block.java
@@ -143,10 +143,8 @@ public interface Block extends Accountable, BlockLoader.Block, NamedWriteable, R
     }
 
     /**
-     * Expand multivalued fields into one row per value. Returns the
-     * block if there aren't any multivalued fields to expand.
-     *
-     * The returned block needs to be closed by the caller to release the block's resources.
+     * Expand multivalued fields into one row per value. Returns the same block if there aren't any multivalued
+     * fields to expand. The returned block needs to be closed by the caller to release the block's resources.
      */
     Block expand();
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ConstantNullBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ConstantNullBlock.java
@@ -99,6 +99,7 @@ public final class ConstantNullBlock extends AbstractBlock implements BooleanBlo
 
     @Override
     public Block expand() {
+        incRef();
         return this;
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
@@ -101,6 +101,7 @@ $endif$
     @Override
     public $Type$Block expand() {
         if (firstValueIndexes == null) {
+            incRef();
             return this;
         }
         // TODO use reference counting to share the values

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/MvExpandOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/MvExpandOperator.java
@@ -92,16 +92,8 @@ public class MvExpandOperator implements Operator {
              */
             logger.trace("starting {}", prev);
             expandingBlock = prev.getBlock(channel);
-            if (expandingBlock.mayHaveMultivaluedFields() == false) {
-                logger.trace("can't have multivalued fields");
-                noops++;
-                Page result = prev;
-                prev = null;
-
-                releaseAndClearState();
-                return result;
-            }
             expandedBlock = expandingBlock.expand();
+
             if (expandedBlock == expandingBlock) {
                 // The expand was a noop - just return the previous page and clear state.
                 logger.trace("expanded to same");

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockMultiValuedTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockMultiValuedTests.java
@@ -152,9 +152,7 @@ public class BlockMultiValuedTests extends ESTestCase {
     }
 
     private void assertExpanded(Block orig) {
-        Block expanded = null;
-        try (orig) {
-            expanded = orig.expand();
+        try (orig; Block expanded = orig.expand()) {
             assertThat(expanded.getPositionCount(), equalTo(orig.getTotalValueCount() + orig.nullValuesCount()));
             assertThat(expanded.getTotalValueCount(), equalTo(orig.getTotalValueCount()));
 
@@ -171,10 +169,6 @@ public class BlockMultiValuedTests extends ESTestCase {
                     assertThat(expanded.getValueCount(np), equalTo(1));
                     assertThat(BasicBlockTests.valuesAtPositions(expanded, np, ++np).get(0), equalTo(List.of(ov)));
                 }
-            }
-        } finally {
-            if (expanded != orig) {
-                Releasables.close(expanded);
             }
         }
     }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockMultiValuedTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockMultiValuedTests.java
@@ -17,7 +17,6 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.compute.operator.DriverContext;
-import org.elasticsearch.core.Releasables;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.After;
 


### PR DESCRIPTION
Now that Blocks are refcounted, we can make it so the returned block always has to be closed/decRef'd by the caller, even if it points to the same block.