### PR TITLE
ESQL: no deep copy in expand

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayBlock.java
@@ -80,6 +80,7 @@ public final class BooleanArrayBlock extends AbstractArrayBlock implements Boole
     @Override
     public BooleanBlock expand() {
         if (firstValueIndexes == null) {
+            incRef();
             return this;
         }
         // TODO use reference counting to share the values

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayBlock.java
@@ -83,6 +83,10 @@ public final class BooleanArrayBlock extends AbstractArrayBlock implements Boole
             incRef();
             return this;
         }
+        if (nullsMask == null) {
+            incRef();
+            return new BooleanArrayBlock.Expanded();
+        }
         // TODO use reference counting to share the values
         try (var builder = blockFactory.newBooleanBlockBuilder(firstValueIndexes[getPositionCount()])) {
             for (int pos = 0; pos < getPositionCount(); pos++) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayBlock.java
@@ -139,4 +139,152 @@ public final class BooleanArrayBlock extends AbstractArrayBlock implements Boole
     public void closeInternal() {
         blockFactory.adjustBreaker(-ramBytesUsed(), true);
     }
+
+    final class Expanded implements BooleanBlock {
+        private Expanded() {}
+
+        @Override
+        public int getFirstValueIndex(int position) {
+            return position;
+        }
+
+        @Override
+        public int getValueCount(int position) {
+            return isNull(position) ? 0 : 1;
+        }
+
+        @Override
+        public boolean isNull(int position) {
+            // TODO: add null mask
+            return false;
+        }
+
+        @Override
+        public boolean mayHaveNulls() {
+            // TODO: add null mask
+            return false;
+        }
+
+        @Override
+        public int nullValuesCount() {
+            // TODO: add null mask
+            return 0;
+        }
+
+        @Override
+        public boolean areAllValuesNull() {
+            return nullValuesCount() == getPositionCount();
+        }
+
+        @Override
+        public BlockFactory blockFactory() {
+            return blockFactory;
+        }
+
+        @Override
+        public int getTotalValueCount() {
+            return getPositionCount();
+        }
+
+        @Override
+        public int getPositionCount() {
+            return BooleanArrayBlock.this.getTotalValueCount();
+        }
+
+        @Override
+        public boolean mayHaveMultivaluedFields() {
+            return false;
+        }
+
+        @Override
+        public MvOrdering mvOrdering() {
+            return MvOrdering.DEDUPLICATED_AND_SORTED_ASCENDING;
+        }
+
+        @Override
+        public BooleanVector asVector() {
+            return null;
+        }
+
+        @Override
+        public boolean getBoolean(int valueIndex) {
+            return values[valueIndex];
+        }
+
+        // TODO: avoid deep copying and incRef instead.
+        @Override
+        public BooleanBlock filter(int... positions) {
+            try (var builder = blockFactory.newBooleanBlockBuilder(positions.length)) {
+                for (int pos : positions) {
+                    if (isNull(pos)) {
+                        builder.appendNull();
+                        continue;
+                    }
+                    builder.appendBoolean(getBoolean(getFirstValueIndex(pos)));
+                }
+                return builder.mvOrdering(mvOrdering()).build();
+            }
+        }
+
+        @Override
+        public ElementType elementType() {
+            return BooleanArrayBlock.this.elementType();
+        }
+
+        @Override
+        public BooleanBlock expand() {
+            incRef();
+            return this;
+        }
+
+        @Override
+        public long ramBytesUsed() {
+            return BooleanArrayBlock.this.ramBytesUsed();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            throw new AssertionError("TODO");
+        }
+
+        @Override
+        public int hashCode() {
+            throw new AssertionError("TODO");
+        }
+
+        @Override
+        public String toString() {
+            return getClass().getSimpleName() + "[positions=" + getPositionCount() + ", values=" + Arrays.toString(values) + ']';
+        }
+
+        @Override
+        public boolean isReleased() {
+            return hasReferences() == false;
+        }
+
+        @Override
+        public void incRef() {
+            BooleanArrayBlock.this.incRef();
+        }
+
+        @Override
+        public boolean tryIncRef() {
+            return BooleanArrayBlock.this.tryIncRef();
+        }
+
+        @Override
+        public boolean decRef() {
+            return BooleanArrayBlock.this.decRef();
+        }
+
+        @Override
+        public boolean hasReferences() {
+            return BooleanArrayBlock.this.hasReferences();
+        }
+
+        @Override
+        public void close() {
+            BooleanArrayBlock.this.close();
+        }
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBlock.java
@@ -18,7 +18,9 @@ import java.io.IOException;
  * Block that stores boolean values.
  * This class is generated. Do not edit it.
  */
-public sealed interface BooleanBlock extends Block permits BooleanArrayBlock, BooleanVectorBlock, ConstantNullBlock {
+public sealed interface BooleanBlock extends Block permits BooleanArrayBlock, BooleanArrayBlock.Expanded, BooleanVectorBlock,
+    // TODO spotless hates variable type lengths.
+    ConstantNullBlock {
 
     /**
      * Retrieves the boolean value stored at the given value index.

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayBlock.java
@@ -83,6 +83,7 @@ public final class BytesRefArrayBlock extends AbstractArrayBlock implements Byte
     @Override
     public BytesRefBlock expand() {
         if (firstValueIndexes == null) {
+            incRef();
             return this;
         }
         // TODO use reference counting to share the values

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayBlock.java
@@ -86,6 +86,10 @@ public final class BytesRefArrayBlock extends AbstractArrayBlock implements Byte
             incRef();
             return this;
         }
+        if (nullsMask == null) {
+            incRef();
+            return new BytesRefArrayBlock.Expanded();
+        }
         // TODO use reference counting to share the values
         final BytesRef scratch = new BytesRef();
         try (var builder = blockFactory.newBytesRefBlockBuilder(firstValueIndexes[getPositionCount()])) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefBlock.java
@@ -19,7 +19,9 @@ import java.io.IOException;
  * Block that stores BytesRef values.
  * This class is generated. Do not edit it.
  */
-public sealed interface BytesRefBlock extends Block permits BytesRefArrayBlock, BytesRefVectorBlock, ConstantNullBlock {
+public sealed interface BytesRefBlock extends Block permits BytesRefArrayBlock, BytesRefArrayBlock.Expanded, BytesRefVectorBlock,
+    // TODO spotless hates variable type lengths.
+    ConstantNullBlock {
 
     BytesRef NULL_VALUE = new BytesRef();
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayBlock.java
@@ -83,6 +83,10 @@ public final class DoubleArrayBlock extends AbstractArrayBlock implements Double
             incRef();
             return this;
         }
+        if (nullsMask == null) {
+            incRef();
+            return new DoubleArrayBlock.Expanded();
+        }
         // TODO use reference counting to share the values
         try (var builder = blockFactory.newDoubleBlockBuilder(firstValueIndexes[getPositionCount()])) {
             for (int pos = 0; pos < getPositionCount(); pos++) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayBlock.java
@@ -80,6 +80,7 @@ public final class DoubleArrayBlock extends AbstractArrayBlock implements Double
     @Override
     public DoubleBlock expand() {
         if (firstValueIndexes == null) {
+            incRef();
             return this;
         }
         // TODO use reference counting to share the values

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayBlock.java
@@ -139,4 +139,152 @@ public final class DoubleArrayBlock extends AbstractArrayBlock implements Double
     public void closeInternal() {
         blockFactory.adjustBreaker(-ramBytesUsed(), true);
     }
+
+    final class Expanded implements DoubleBlock {
+        private Expanded() {}
+
+        @Override
+        public int getFirstValueIndex(int position) {
+            return position;
+        }
+
+        @Override
+        public int getValueCount(int position) {
+            return isNull(position) ? 0 : 1;
+        }
+
+        @Override
+        public boolean isNull(int position) {
+            // TODO: add null mask
+            return false;
+        }
+
+        @Override
+        public boolean mayHaveNulls() {
+            // TODO: add null mask
+            return false;
+        }
+
+        @Override
+        public int nullValuesCount() {
+            // TODO: add null mask
+            return 0;
+        }
+
+        @Override
+        public boolean areAllValuesNull() {
+            return nullValuesCount() == getPositionCount();
+        }
+
+        @Override
+        public BlockFactory blockFactory() {
+            return blockFactory;
+        }
+
+        @Override
+        public int getTotalValueCount() {
+            return getPositionCount();
+        }
+
+        @Override
+        public int getPositionCount() {
+            return DoubleArrayBlock.this.getTotalValueCount();
+        }
+
+        @Override
+        public boolean mayHaveMultivaluedFields() {
+            return false;
+        }
+
+        @Override
+        public MvOrdering mvOrdering() {
+            return MvOrdering.DEDUPLICATED_AND_SORTED_ASCENDING;
+        }
+
+        @Override
+        public DoubleVector asVector() {
+            return null;
+        }
+
+        @Override
+        public double getDouble(int valueIndex) {
+            return values[valueIndex];
+        }
+
+        // TODO: avoid deep copying and incRef instead.
+        @Override
+        public DoubleBlock filter(int... positions) {
+            try (var builder = blockFactory.newDoubleBlockBuilder(positions.length)) {
+                for (int pos : positions) {
+                    if (isNull(pos)) {
+                        builder.appendNull();
+                        continue;
+                    }
+                    builder.appendDouble(getDouble(getFirstValueIndex(pos)));
+                }
+                return builder.mvOrdering(mvOrdering()).build();
+            }
+        }
+
+        @Override
+        public ElementType elementType() {
+            return DoubleArrayBlock.this.elementType();
+        }
+
+        @Override
+        public DoubleBlock expand() {
+            incRef();
+            return this;
+        }
+
+        @Override
+        public long ramBytesUsed() {
+            return DoubleArrayBlock.this.ramBytesUsed();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            throw new AssertionError("TODO");
+        }
+
+        @Override
+        public int hashCode() {
+            throw new AssertionError("TODO");
+        }
+
+        @Override
+        public String toString() {
+            return getClass().getSimpleName() + "[positions=" + getPositionCount() + ", values=" + Arrays.toString(values) + ']';
+        }
+
+        @Override
+        public boolean isReleased() {
+            return hasReferences() == false;
+        }
+
+        @Override
+        public void incRef() {
+            DoubleArrayBlock.this.incRef();
+        }
+
+        @Override
+        public boolean tryIncRef() {
+            return DoubleArrayBlock.this.tryIncRef();
+        }
+
+        @Override
+        public boolean decRef() {
+            return DoubleArrayBlock.this.decRef();
+        }
+
+        @Override
+        public boolean hasReferences() {
+            return DoubleArrayBlock.this.hasReferences();
+        }
+
+        @Override
+        public void close() {
+            DoubleArrayBlock.this.close();
+        }
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBlock.java
@@ -18,7 +18,9 @@ import java.io.IOException;
  * Block that stores double values.
  * This class is generated. Do not edit it.
  */
-public sealed interface DoubleBlock extends Block permits DoubleArrayBlock, DoubleVectorBlock, ConstantNullBlock {
+public sealed interface DoubleBlock extends Block permits DoubleArrayBlock, DoubleArrayBlock.Expanded, DoubleVectorBlock,
+    // TODO spotless hates variable type lengths.
+    ConstantNullBlock {
 
     /**
      * Retrieves the double value stored at the given value index.

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayBlock.java
@@ -139,4 +139,152 @@ public final class IntArrayBlock extends AbstractArrayBlock implements IntBlock 
     public void closeInternal() {
         blockFactory.adjustBreaker(-ramBytesUsed(), true);
     }
+
+    final class Expanded implements IntBlock {
+        private Expanded() {}
+
+        @Override
+        public int getFirstValueIndex(int position) {
+            return position;
+        }
+
+        @Override
+        public int getValueCount(int position) {
+            return isNull(position) ? 0 : 1;
+        }
+
+        @Override
+        public boolean isNull(int position) {
+            // TODO: add null mask
+            return false;
+        }
+
+        @Override
+        public boolean mayHaveNulls() {
+            // TODO: add null mask
+            return false;
+        }
+
+        @Override
+        public int nullValuesCount() {
+            // TODO: add null mask
+            return 0;
+        }
+
+        @Override
+        public boolean areAllValuesNull() {
+            return nullValuesCount() == getPositionCount();
+        }
+
+        @Override
+        public BlockFactory blockFactory() {
+            return blockFactory;
+        }
+
+        @Override
+        public int getTotalValueCount() {
+            return getPositionCount();
+        }
+
+        @Override
+        public int getPositionCount() {
+            return IntArrayBlock.this.getTotalValueCount();
+        }
+
+        @Override
+        public boolean mayHaveMultivaluedFields() {
+            return false;
+        }
+
+        @Override
+        public MvOrdering mvOrdering() {
+            return MvOrdering.DEDUPLICATED_AND_SORTED_ASCENDING;
+        }
+
+        @Override
+        public IntVector asVector() {
+            return null;
+        }
+
+        @Override
+        public int getInt(int valueIndex) {
+            return values[valueIndex];
+        }
+
+        // TODO: avoid deep copying and incRef instead.
+        @Override
+        public IntBlock filter(int... positions) {
+            try (var builder = blockFactory.newIntBlockBuilder(positions.length)) {
+                for (int pos : positions) {
+                    if (isNull(pos)) {
+                        builder.appendNull();
+                        continue;
+                    }
+                    builder.appendInt(getInt(getFirstValueIndex(pos)));
+                }
+                return builder.mvOrdering(mvOrdering()).build();
+            }
+        }
+
+        @Override
+        public ElementType elementType() {
+            return IntArrayBlock.this.elementType();
+        }
+
+        @Override
+        public IntBlock expand() {
+            incRef();
+            return this;
+        }
+
+        @Override
+        public long ramBytesUsed() {
+            return IntArrayBlock.this.ramBytesUsed();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            throw new AssertionError("TODO");
+        }
+
+        @Override
+        public int hashCode() {
+            throw new AssertionError("TODO");
+        }
+
+        @Override
+        public String toString() {
+            return getClass().getSimpleName() + "[positions=" + getPositionCount() + ", values=" + Arrays.toString(values) + ']';
+        }
+
+        @Override
+        public boolean isReleased() {
+            return hasReferences() == false;
+        }
+
+        @Override
+        public void incRef() {
+            IntArrayBlock.this.incRef();
+        }
+
+        @Override
+        public boolean tryIncRef() {
+            return IntArrayBlock.this.tryIncRef();
+        }
+
+        @Override
+        public boolean decRef() {
+            return IntArrayBlock.this.decRef();
+        }
+
+        @Override
+        public boolean hasReferences() {
+            return IntArrayBlock.this.hasReferences();
+        }
+
+        @Override
+        public void close() {
+            IntArrayBlock.this.close();
+        }
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayBlock.java
@@ -83,6 +83,10 @@ public final class IntArrayBlock extends AbstractArrayBlock implements IntBlock 
             incRef();
             return this;
         }
+        if (nullsMask == null) {
+            incRef();
+            return new IntArrayBlock.Expanded();
+        }
         // TODO use reference counting to share the values
         try (var builder = blockFactory.newIntBlockBuilder(firstValueIndexes[getPositionCount()])) {
             for (int pos = 0; pos < getPositionCount(); pos++) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayBlock.java
@@ -80,6 +80,7 @@ public final class IntArrayBlock extends AbstractArrayBlock implements IntBlock 
     @Override
     public IntBlock expand() {
         if (firstValueIndexes == null) {
+            incRef();
             return this;
         }
         // TODO use reference counting to share the values

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBlock.java
@@ -18,7 +18,9 @@ import java.io.IOException;
  * Block that stores int values.
  * This class is generated. Do not edit it.
  */
-public sealed interface IntBlock extends Block permits IntArrayBlock, IntVectorBlock, ConstantNullBlock {
+public sealed interface IntBlock extends Block permits IntArrayBlock, IntArrayBlock.Expanded, IntVectorBlock,
+    // TODO spotless hates variable type lengths.
+    ConstantNullBlock {
 
     /**
      * Retrieves the int value stored at the given value index.

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayBlock.java
@@ -80,6 +80,7 @@ public final class LongArrayBlock extends AbstractArrayBlock implements LongBloc
     @Override
     public LongBlock expand() {
         if (firstValueIndexes == null) {
+            incRef();
             return this;
         }
         // TODO use reference counting to share the values

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayBlock.java
@@ -83,6 +83,10 @@ public final class LongArrayBlock extends AbstractArrayBlock implements LongBloc
             incRef();
             return this;
         }
+        if (nullsMask == null) {
+            incRef();
+            return new LongArrayBlock.Expanded();
+        }
         // TODO use reference counting to share the values
         try (var builder = blockFactory.newLongBlockBuilder(firstValueIndexes[getPositionCount()])) {
             for (int pos = 0; pos < getPositionCount(); pos++) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayBlock.java
@@ -139,4 +139,152 @@ public final class LongArrayBlock extends AbstractArrayBlock implements LongBloc
     public void closeInternal() {
         blockFactory.adjustBreaker(-ramBytesUsed(), true);
     }
+
+    final class Expanded implements LongBlock {
+        private Expanded() {}
+
+        @Override
+        public int getFirstValueIndex(int position) {
+            return position;
+        }
+
+        @Override
+        public int getValueCount(int position) {
+            return isNull(position) ? 0 : 1;
+        }
+
+        @Override
+        public boolean isNull(int position) {
+            // TODO: add null mask
+            return false;
+        }
+
+        @Override
+        public boolean mayHaveNulls() {
+            // TODO: add null mask
+            return false;
+        }
+
+        @Override
+        public int nullValuesCount() {
+            // TODO: add null mask
+            return 0;
+        }
+
+        @Override
+        public boolean areAllValuesNull() {
+            return nullValuesCount() == getPositionCount();
+        }
+
+        @Override
+        public BlockFactory blockFactory() {
+            return blockFactory;
+        }
+
+        @Override
+        public int getTotalValueCount() {
+            return getPositionCount();
+        }
+
+        @Override
+        public int getPositionCount() {
+            return LongArrayBlock.this.getTotalValueCount();
+        }
+
+        @Override
+        public boolean mayHaveMultivaluedFields() {
+            return false;
+        }
+
+        @Override
+        public MvOrdering mvOrdering() {
+            return MvOrdering.DEDUPLICATED_AND_SORTED_ASCENDING;
+        }
+
+        @Override
+        public LongVector asVector() {
+            return null;
+        }
+
+        @Override
+        public long getLong(int valueIndex) {
+            return values[valueIndex];
+        }
+
+        // TODO: avoid deep copying and incRef instead.
+        @Override
+        public LongBlock filter(int... positions) {
+            try (var builder = blockFactory.newLongBlockBuilder(positions.length)) {
+                for (int pos : positions) {
+                    if (isNull(pos)) {
+                        builder.appendNull();
+                        continue;
+                    }
+                    builder.appendLong(getLong(getFirstValueIndex(pos)));
+                }
+                return builder.mvOrdering(mvOrdering()).build();
+            }
+        }
+
+        @Override
+        public ElementType elementType() {
+            return LongArrayBlock.this.elementType();
+        }
+
+        @Override
+        public LongBlock expand() {
+            incRef();
+            return this;
+        }
+
+        @Override
+        public long ramBytesUsed() {
+            return LongArrayBlock.this.ramBytesUsed();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            throw new AssertionError("TODO");
+        }
+
+        @Override
+        public int hashCode() {
+            throw new AssertionError("TODO");
+        }
+
+        @Override
+        public String toString() {
+            return getClass().getSimpleName() + "[positions=" + getPositionCount() + ", values=" + Arrays.toString(values) + ']';
+        }
+
+        @Override
+        public boolean isReleased() {
+            return hasReferences() == false;
+        }
+
+        @Override
+        public void incRef() {
+            LongArrayBlock.this.incRef();
+        }
+
+        @Override
+        public boolean tryIncRef() {
+            return LongArrayBlock.this.tryIncRef();
+        }
+
+        @Override
+        public boolean decRef() {
+            return LongArrayBlock.this.decRef();
+        }
+
+        @Override
+        public boolean hasReferences() {
+            return LongArrayBlock.this.hasReferences();
+        }
+
+        @Override
+        public void close() {
+            LongArrayBlock.this.close();
+        }
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBlock.java
@@ -18,7 +18,9 @@ import java.io.IOException;
  * Block that stores long values.
  * This class is generated. Do not edit it.
  */
-public sealed interface LongBlock extends Block permits LongArrayBlock, LongVectorBlock, ConstantNullBlock {
+public sealed interface LongBlock extends Block permits LongArrayBlock, LongArrayBlock.Expanded, LongVectorBlock,
+    // TODO spotless hates variable type lengths.
+    ConstantNullBlock {
 
     /**
      * Retrieves the long value stored at the given value index.

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AbstractBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AbstractBlock.java
@@ -60,6 +60,7 @@ abstract class AbstractBlock implements Block {
     }
 
     /** Gets the index of the first value for the given position. */
+    @Override
     public int getFirstValueIndex(int position) {
         return firstValueIndexes == null ? position : firstValueIndexes[position];
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AbstractVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AbstractVectorBlock.java
@@ -57,6 +57,7 @@ abstract class AbstractVectorBlock extends AbstractBlock {
 
     @Override
     public final Block expand() {
+        incRef();
         return this;
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Block.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Block.java
@@ -145,8 +145,9 @@ public interface Block extends Accountable, BlockLoader.Block, NamedWriteable, R
     /**
      * Expand multivalued fields into one row per value. Returns the
      * block if there aren't any multivalued fields to expand.
+     *
+     * The returned block needs to be closed by the caller to release the block's resources.
      */
-    // TODO: We should use refcounting instead of either deep copies or returning the same identical block.
     Block expand();
 
     /**

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ConstantNullBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ConstantNullBlock.java
@@ -99,6 +99,7 @@ public final class ConstantNullBlock extends AbstractBlock implements BooleanBlo
 
     @Override
     public Block expand() {
+        incRef();
         return this;
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
@@ -101,6 +101,7 @@ $endif$
     @Override
     public $Type$Block expand() {
         if (firstValueIndexes == null) {
+            incRef();
             return this;
         }
         // TODO use reference counting to share the values

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
@@ -177,4 +177,160 @@ $endif$
         blockFactory.adjustBreaker(-ramBytesUsed(), true);
     $endif$
     }
+
+    final class Expanded implements $Type$Block {
+        private Expanded() {}
+
+        @Override
+        public int getFirstValueIndex(int position) {
+            return position;
+        }
+
+        @Override
+        public int getValueCount(int position) {
+            return isNull(position) ? 0 : 1;
+        }
+
+        @Override
+        public boolean isNull(int position) {
+            // TODO: add null mask
+            return false;
+        }
+
+        @Override
+        public boolean mayHaveNulls() {
+            // TODO: add null mask
+            return false;
+        }
+
+        @Override
+        public int nullValuesCount() {
+            // TODO: add null mask
+            return 0;
+        }
+
+        @Override
+        public boolean areAllValuesNull() {
+            return nullValuesCount() == getPositionCount();
+        }
+
+        @Override
+        public BlockFactory blockFactory() {
+            return blockFactory;
+        }
+
+        @Override
+        public int getTotalValueCount() {
+            return getPositionCount();
+        }
+
+        @Override
+        public int getPositionCount() {
+            return $Type$ArrayBlock.this.getTotalValueCount();
+        }
+
+        @Override
+        public boolean mayHaveMultivaluedFields() {
+            return false;
+        }
+
+        @Override
+        public MvOrdering mvOrdering() {
+            return MvOrdering.DEDUPLICATED_AND_SORTED_ASCENDING;
+        }
+
+        @Override
+        public $Type$Vector asVector() {
+            return null;
+        }
+
+        @Override
+    $if(BytesRef)$
+        public BytesRef getBytesRef(int valueIndex, BytesRef dest) {
+            return values.get(valueIndex, dest);
+    $else$
+        public $type$ get$Type$(int valueIndex) {
+            return values[valueIndex];
+    $endif$
+        }
+
+        // TODO: avoid deep copying and incRef instead.
+        @Override
+        public $Type$Block filter(int... positions) {
+    $if(BytesRef)$
+            final BytesRef scratch = new BytesRef();
+    $endif$
+            try (var builder = blockFactory.new$Type$BlockBuilder(positions.length)) {
+                for (int pos : positions) {
+                    if (isNull(pos)) {
+                        builder.appendNull();
+                        continue;
+                    }
+                    builder.append$Type$(get$Type$(getFirstValueIndex(pos)$if(BytesRef)$, scratch$endif$));
+                }
+                return builder.mvOrdering(mvOrdering()).build();
+            }
+        }
+
+        @Override
+        public ElementType elementType() {
+            return $Type$ArrayBlock.this.elementType();
+        }
+
+        @Override
+        public $Type$Block expand() {
+            incRef();
+            return this;
+        }
+
+        @Override
+        public long ramBytesUsed() {
+            return $Type$ArrayBlock.this.ramBytesUsed();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            throw new AssertionError("TODO");
+        }
+
+        @Override
+        public int hashCode() {
+            throw new AssertionError("TODO");
+        }
+
+        @Override
+        public String toString() {
+            return getClass().getSimpleName() + "[positions=" + getPositionCount() $if(BytesRef)$+ ", values=" + values.size()$else$+ ", values=" + Arrays.toString(values)$endif$ + ']';
+        }
+
+        @Override
+        public boolean isReleased() {
+            return hasReferences() == false;
+        }
+
+        @Override
+        public void incRef() {
+            $Type$ArrayBlock.this.incRef();
+        }
+
+        @Override
+        public boolean tryIncRef() {
+            return $Type$ArrayBlock.this.tryIncRef();
+        }
+
+        @Override
+        public boolean decRef() {
+            return $Type$ArrayBlock.this.decRef();
+        }
+
+        @Override
+        public boolean hasReferences() {
+            return $Type$ArrayBlock.this.hasReferences();
+        }
+
+        @Override
+        public void close() {
+            $Type$ArrayBlock.this.close();
+        }
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
@@ -104,6 +104,10 @@ $endif$
             incRef();
             return this;
         }
+        if (nullsMask == null) {
+            incRef();
+            return new $Type$ArrayBlock.Expanded();
+        }
         // TODO use reference counting to share the values
 $if(BytesRef)$
         final BytesRef scratch = new BytesRef();

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Block.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Block.java.st
@@ -22,7 +22,9 @@ import java.io.IOException;
  * Block that stores $type$ values.
  * This class is generated. Do not edit it.
  */
-public sealed interface $Type$Block extends Block permits $Type$ArrayBlock, $Type$VectorBlock, ConstantNullBlock {
+public sealed interface $Type$Block extends Block permits $Type$ArrayBlock, $Type$ArrayBlock.Expanded, $Type$VectorBlock,
+    // TODO spotless hates variable type lengths.
+    ConstantNullBlock {
 
 $if(BytesRef)$
     BytesRef NULL_VALUE = new BytesRef();

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockMultiValuedTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockMultiValuedTests.java
@@ -152,9 +152,7 @@ public class BlockMultiValuedTests extends ESTestCase {
     }
 
     private void assertExpanded(Block orig) {
-        Block expanded = null;
-        try (orig) {
-            expanded = orig.expand();
+        try (orig; Block expanded = orig.expand()) {
             assertThat(expanded.getPositionCount(), equalTo(orig.getTotalValueCount() + orig.nullValuesCount()));
             assertThat(expanded.getTotalValueCount(), equalTo(orig.getTotalValueCount()));
 
@@ -171,10 +169,6 @@ public class BlockMultiValuedTests extends ESTestCase {
                     assertThat(expanded.getValueCount(np), equalTo(1));
                     assertThat(BasicBlockTests.valuesAtPositions(expanded, np, ++np).get(0), equalTo(List.of(ov)));
                 }
-            }
-        } finally {
-            if (expanded != orig) {
-                Releasables.close(expanded);
             }
         }
     }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockMultiValuedTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockMultiValuedTests.java
@@ -17,7 +17,6 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.compute.operator.DriverContext;
-import org.elasticsearch.core.Releasables;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.After;
 


### PR DESCRIPTION
Avoid deep copies when calling `Block::expand`, instead `incRef()` the current block and return a special, expanded view into the Block.