### PR TITLE
Disable metrics sending only when the setting was not used explicitly

### DIFF
--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/RunTask.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/RunTask.java
@@ -205,8 +205,9 @@ public abstract class RunTask extends DefaultTestClustersTask {
                     } catch (IOException e) {
                         logger.warn("Unable to start APM server", e);
                     }
-                } else {
-                    // metrics are enabled by default, if the --with-apm-server was not used we should disable it
+                } else if (node.getSettingKeys().contains("telemetry.metrics.enabled") == false) {
+                    // in serverless metrics are enabled by default
+                    // if metrics were not enabled explicitly for gradlew run we should disable them
                     node.setting("telemetry.metrics.enabled", "false");
                 }
 


### PR DESCRIPTION
RunTaks is used by both statefull and serverless, hence we have to take into account that there could be different default values for those distributions.
when --with-apm-server is used, `telemetry.metrics.enabled` is always turned to true
and server_url is set to localhost
However when --with-apm-server is NOT used, then we should disable `telemetry.metrics.enabled`
only if that setting was not explicitly used. This explicte use is for instance when
running gradlew run and configuring ES to send to ESS cluster
a follow up from https://github.com/elastic/elasticsearch/pull/101941/files#r1388403805