### PR TITLE
Inline ActionType in RequestBuilder constructors

### DIFF
--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/SearchTemplateRequestBuilder.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/SearchTemplateRequestBuilder.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.script.mustache;
 
 import org.elasticsearch.action.ActionRequestBuilder;
-import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.client.internal.ElasticsearchClient;
 import org.elasticsearch.script.ScriptType;
@@ -18,12 +17,8 @@ import java.util.Map;
 
 public class SearchTemplateRequestBuilder extends ActionRequestBuilder<SearchTemplateRequest, SearchTemplateResponse> {
 
-    SearchTemplateRequestBuilder(ElasticsearchClient client, ActionType<SearchTemplateResponse> action) {
-        super(client, action, new SearchTemplateRequest());
-    }
-
     public SearchTemplateRequestBuilder(ElasticsearchClient client) {
-        this(client, MustachePlugin.SEARCH_TEMPLATE_ACTION);
+        super(client, MustachePlugin.SEARCH_TEMPLATE_ACTION, new SearchTemplateRequest());
     }
 
     public SearchTemplateRequestBuilder setRequest(SearchRequest searchRequest) {

--- a/modules/rank-eval/src/internalClusterTest/java/org/elasticsearch/index/rankeval/RankEvalRequestIT.java
+++ b/modules/rank-eval/src/internalClusterTest/java/org/elasticsearch/index/rankeval/RankEvalRequestIT.java
@@ -85,7 +85,7 @@ public class RankEvalRequestIT extends ESIntegTestCase {
         PrecisionAtK metric = new PrecisionAtK(1, false, 10);
         RankEvalSpec task = new RankEvalSpec(specifications, metric);
 
-        RankEvalRequestBuilder builder = new RankEvalRequestBuilder(client(), RankEvalPlugin.ACTION, new RankEvalRequest());
+        RankEvalRequestBuilder builder = new RankEvalRequestBuilder(client(), new RankEvalRequest());
         builder.setRankEvalSpec(task);
 
         String indexToUse = randomBoolean() ? TEST_INDEX : INDEX_ALIAS;
@@ -130,7 +130,7 @@ public class RankEvalRequestIT extends ESIntegTestCase {
         metric = new PrecisionAtK(1, false, 3);
         task = new RankEvalSpec(specifications, metric);
 
-        builder = new RankEvalRequestBuilder(client(), RankEvalPlugin.ACTION, new RankEvalRequest(task, new String[] { TEST_INDEX }));
+        builder = new RankEvalRequestBuilder(client(), new RankEvalRequest(task, new String[] { TEST_INDEX }));
 
         response = client().execute(RankEvalPlugin.ACTION, builder.request()).actionGet();
         // if we look only at top 3 documente, the expected P@3 for the first query is
@@ -162,11 +162,7 @@ public class RankEvalRequestIT extends ESIntegTestCase {
         DiscountedCumulativeGain metric = new DiscountedCumulativeGain(false, null, 10);
         RankEvalSpec task = new RankEvalSpec(specifications, metric);
 
-        RankEvalRequestBuilder builder = new RankEvalRequestBuilder(
-            client(),
-            RankEvalPlugin.ACTION,
-            new RankEvalRequest(task, new String[] { TEST_INDEX })
-        );
+        RankEvalRequestBuilder builder = new RankEvalRequestBuilder(client(), new RankEvalRequest(task, new String[] { TEST_INDEX }));
 
         RankEvalResponse response = client().execute(RankEvalPlugin.ACTION, builder.request()).actionGet();
         assertEquals(DiscountedCumulativeGainTests.EXPECTED_DCG, response.getMetricScore(), 10E-14);
@@ -175,7 +171,7 @@ public class RankEvalRequestIT extends ESIntegTestCase {
         metric = new DiscountedCumulativeGain(false, null, 3);
         task = new RankEvalSpec(specifications, metric);
 
-        builder = new RankEvalRequestBuilder(client(), RankEvalPlugin.ACTION, new RankEvalRequest(task, new String[] { TEST_INDEX }));
+        builder = new RankEvalRequestBuilder(client(), new RankEvalRequest(task, new String[] { TEST_INDEX }));
 
         response = client().execute(RankEvalPlugin.ACTION, builder.request()).actionGet();
         assertEquals(12.39278926071437, response.getMetricScore(), 10E-14);
@@ -193,11 +189,7 @@ public class RankEvalRequestIT extends ESIntegTestCase {
         MeanReciprocalRank metric = new MeanReciprocalRank(1, 10);
         RankEvalSpec task = new RankEvalSpec(specifications, metric);
 
-        RankEvalRequestBuilder builder = new RankEvalRequestBuilder(
-            client(),
-            RankEvalPlugin.ACTION,
-            new RankEvalRequest(task, new String[] { TEST_INDEX })
-        );
+        RankEvalRequestBuilder builder = new RankEvalRequestBuilder(client(), new RankEvalRequest(task, new String[] { TEST_INDEX }));
 
         RankEvalResponse response = client().execute(RankEvalPlugin.ACTION, builder.request()).actionGet();
         // the expected reciprocal rank for the amsterdam_query is 1/5
@@ -210,7 +202,7 @@ public class RankEvalRequestIT extends ESIntegTestCase {
         metric = new MeanReciprocalRank(1, 3);
         task = new RankEvalSpec(specifications, metric);
 
-        builder = new RankEvalRequestBuilder(client(), RankEvalPlugin.ACTION, new RankEvalRequest(task, new String[] { TEST_INDEX }));
+        builder = new RankEvalRequestBuilder(client(), new RankEvalRequest(task, new String[] { TEST_INDEX }));
 
         response = client().execute(RankEvalPlugin.ACTION, builder.request()).actionGet();
         // limiting to top 3 results, the amsterdam_query has no relevant document in it
@@ -238,11 +230,7 @@ public class RankEvalRequestIT extends ESIntegTestCase {
 
         RankEvalSpec task = new RankEvalSpec(specifications, new PrecisionAtK());
 
-        RankEvalRequestBuilder builder = new RankEvalRequestBuilder(
-            client(),
-            RankEvalPlugin.ACTION,
-            new RankEvalRequest(task, new String[] { TEST_INDEX })
-        );
+        RankEvalRequestBuilder builder = new RankEvalRequestBuilder(client(), new RankEvalRequest(task, new String[] { TEST_INDEX }));
         builder.setRankEvalSpec(task);
 
         RankEvalResponse response = client().execute(RankEvalPlugin.ACTION, builder.request()).actionGet();

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankEvalRequestBuilder.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankEvalRequestBuilder.java
@@ -9,13 +9,12 @@
 package org.elasticsearch.index.rankeval;
 
 import org.elasticsearch.action.ActionRequestBuilder;
-import org.elasticsearch.action.ActionType;
 import org.elasticsearch.client.internal.ElasticsearchClient;
 
 public class RankEvalRequestBuilder extends ActionRequestBuilder<RankEvalRequest, RankEvalResponse> {
 
-    public RankEvalRequestBuilder(ElasticsearchClient client, ActionType<RankEvalResponse> action, RankEvalRequest request) {
-        super(client, action, request);
+    public RankEvalRequestBuilder(ElasticsearchClient client, RankEvalRequest request) {
+        super(client, RankEvalPlugin.ACTION, request);
     }
 
     public void setRankEvalSpec(RankEvalSpec spec) {

--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/client/documentation/ReindexDocumentationIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/client/documentation/ReindexDocumentationIT.java
@@ -18,7 +18,6 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.reindex.AbstractBulkByScrollRequestBuilder;
 import org.elasticsearch.index.reindex.BulkByScrollResponse;
 import org.elasticsearch.index.reindex.BulkByScrollTask;
-import org.elasticsearch.index.reindex.DeleteByQueryAction;
 import org.elasticsearch.index.reindex.DeleteByQueryRequestBuilder;
 import org.elasticsearch.index.reindex.ReindexAction;
 import org.elasticsearch.index.reindex.ReindexRequestBuilder;
@@ -71,7 +70,7 @@ public class ReindexDocumentationIT extends ESIntegTestCase {
         Client client = client();
         // tag::reindex1
         BulkByScrollResponse response =
-          new ReindexRequestBuilder(client, ReindexAction.INSTANCE)
+          new ReindexRequestBuilder(client)
             .source("source_index")
             .destination("target_index")
             .filter(QueryBuilders.matchQuery("category", "xzy")) // <1>
@@ -88,7 +87,7 @@ public class ReindexDocumentationIT extends ESIntegTestCase {
         {
             // tag::update-by-query
             UpdateByQueryRequestBuilder updateByQuery =
-              new UpdateByQueryRequestBuilder(client, UpdateByQueryAction.INSTANCE);
+              new UpdateByQueryRequestBuilder(client);
             updateByQuery.source("source_index").abortOnVersionConflict(false);
             BulkByScrollResponse response = updateByQuery.get();
             // end::update-by-query
@@ -96,7 +95,7 @@ public class ReindexDocumentationIT extends ESIntegTestCase {
         {
             // tag::update-by-query-filter
             UpdateByQueryRequestBuilder updateByQuery =
-              new UpdateByQueryRequestBuilder(client, UpdateByQueryAction.INSTANCE);
+              new UpdateByQueryRequestBuilder(client);
             updateByQuery.source("source_index")
                 .filter(QueryBuilders.termQuery("level", "awesome"))
                 .maxDocs(1000)
@@ -113,7 +112,7 @@ public class ReindexDocumentationIT extends ESIntegTestCase {
         {
             // tag::update-by-query-size
             UpdateByQueryRequestBuilder updateByQuery =
-              new UpdateByQueryRequestBuilder(client, UpdateByQueryAction.INSTANCE);
+              new UpdateByQueryRequestBuilder(client);
             updateByQuery.source("source_index")
                 .source()
                 .setSize(500);
@@ -123,7 +122,7 @@ public class ReindexDocumentationIT extends ESIntegTestCase {
         {
             // tag::update-by-query-sort
             UpdateByQueryRequestBuilder updateByQuery =
-               new UpdateByQueryRequestBuilder(client, UpdateByQueryAction.INSTANCE);
+               new UpdateByQueryRequestBuilder(client);
             updateByQuery.source("source_index")
                 .maxDocs(100)
                 .source()
@@ -134,7 +133,7 @@ public class ReindexDocumentationIT extends ESIntegTestCase {
         {
             // tag::update-by-query-script
             UpdateByQueryRequestBuilder updateByQuery =
-              new UpdateByQueryRequestBuilder(client, UpdateByQueryAction.INSTANCE);
+              new UpdateByQueryRequestBuilder(client);
             updateByQuery.source("source_index")
                 .script(new Script(
                     ScriptType.INLINE,
@@ -155,7 +154,7 @@ public class ReindexDocumentationIT extends ESIntegTestCase {
         {
             // tag::update-by-query-multi-index
             UpdateByQueryRequestBuilder updateByQuery =
-              new UpdateByQueryRequestBuilder(client, UpdateByQueryAction.INSTANCE);
+              new UpdateByQueryRequestBuilder(client);
             updateByQuery.source("foo", "bar");
             BulkByScrollResponse response = updateByQuery.get();
             // end::update-by-query-multi-index
@@ -163,7 +162,7 @@ public class ReindexDocumentationIT extends ESIntegTestCase {
         {
             // tag::update-by-query-routing
             UpdateByQueryRequestBuilder updateByQuery =
-              new UpdateByQueryRequestBuilder(client, UpdateByQueryAction.INSTANCE);
+              new UpdateByQueryRequestBuilder(client);
             updateByQuery.source().setRouting("cat");
             BulkByScrollResponse response = updateByQuery.get();
             // end::update-by-query-routing
@@ -171,7 +170,7 @@ public class ReindexDocumentationIT extends ESIntegTestCase {
         {
             // tag::update-by-query-pipeline
             UpdateByQueryRequestBuilder updateByQuery =
-              new UpdateByQueryRequestBuilder(client, UpdateByQueryAction.INSTANCE);
+              new UpdateByQueryRequestBuilder(client);
             updateByQuery.setPipeline("hurray");
             BulkByScrollResponse response = updateByQuery.get();
             // end::update-by-query-pipeline
@@ -216,7 +215,7 @@ public class ReindexDocumentationIT extends ESIntegTestCase {
         }
         {
             // tag::update-by-query-rethrottle
-            new RethrottleRequestBuilder(client, ReindexPlugin.RETHROTTLE_ACTION)
+            new RethrottleRequestBuilder(client)
                 .setTargetTaskId(taskId)
                 .setRequestsPerSecond(2.0f)
                 .get();
@@ -234,7 +233,7 @@ public class ReindexDocumentationIT extends ESIntegTestCase {
 
         // tag::delete-by-query-sync
         BulkByScrollResponse response =
-          new DeleteByQueryRequestBuilder(client, DeleteByQueryAction.INSTANCE)
+          new DeleteByQueryRequestBuilder(client)
             .filter(QueryBuilders.matchQuery("gender", "male")) // <1>
             .source("persons")                                  // <2>
             .get();                                             // <3>
@@ -242,7 +241,7 @@ public class ReindexDocumentationIT extends ESIntegTestCase {
         // end::delete-by-query-sync
 
         // tag::delete-by-query-async
-        new DeleteByQueryRequestBuilder(client, DeleteByQueryAction.INSTANCE)
+        new DeleteByQueryRequestBuilder(client)
             .filter(QueryBuilders.matchQuery("gender", "male"))     // <1>
             .source("persons")                                      // <2>
             .execute(new ActionListener<BulkByScrollResponse>() {   // <3>
@@ -280,8 +279,7 @@ public class ReindexDocumentationIT extends ESIntegTestCase {
         assertHitCount(prepareSearch(INDEX_NAME).setSize(0), numDocs);
         assertThat(ALLOWED_OPERATIONS.drainPermits(), equalTo(0));
 
-        ReindexRequestBuilder builder = new ReindexRequestBuilder(client, ReindexAction.INSTANCE).source(INDEX_NAME)
-            .destination("target_index");
+        ReindexRequestBuilder builder = new ReindexRequestBuilder(client).source(INDEX_NAME).destination("target_index");
         // Scroll by 1 so that cancellation is easier to control
         builder.source().setSize(1);
 

--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/CrossClusterReindexIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/index/reindex/CrossClusterReindexIT.java
@@ -57,9 +57,7 @@ public class CrossClusterReindexIT extends AbstractMultiClustersTestCase {
         final int docsNumber = indexDocs(client(REMOTE_CLUSTER), "source-index-001");
 
         final String sourceIndexInRemote = REMOTE_CLUSTER + ":" + "source-index-001";
-        new ReindexRequestBuilder(client(LOCAL_CLUSTER), ReindexAction.INSTANCE).source(sourceIndexInRemote)
-            .destination("desc-index-001")
-            .get();
+        new ReindexRequestBuilder(client(LOCAL_CLUSTER)).source(sourceIndexInRemote).destination("desc-index-001").get();
 
         assertTrue("Number of documents in source and desc indexes does not match", waitUntil(() -> {
             SearchResponse resp = client(LOCAL_CLUSTER).prepareSearch("desc-index-001")
@@ -76,9 +74,7 @@ public class CrossClusterReindexIT extends AbstractMultiClustersTestCase {
         final int docsNumber = indexDocs(client(REMOTE_CLUSTER), "test-index-001");
 
         final String sourceIndexInRemote = REMOTE_CLUSTER + ":" + "test-index-001";
-        new ReindexRequestBuilder(client(LOCAL_CLUSTER), ReindexAction.INSTANCE).source(sourceIndexInRemote)
-            .destination("test-index-001")
-            .get();
+        new ReindexRequestBuilder(client(LOCAL_CLUSTER)).source(sourceIndexInRemote).destination("test-index-001").get();
 
         assertTrue("Number of documents in source and desc indexes does not match", waitUntil(() -> {
             SearchResponse resp = client(LOCAL_CLUSTER).prepareSearch("test-index-001")
@@ -99,9 +95,9 @@ public class CrossClusterReindexIT extends AbstractMultiClustersTestCase {
         int N = randomIntBetween(2, 10);
         for (int attempt = 0; attempt < N; attempt++) {
 
-            BulkByScrollResponse response = new ReindexRequestBuilder(client(LOCAL_CLUSTER), ReindexAction.INSTANCE).source(
-                sourceIndexInRemote
-            ).destination("test-index-001").get();
+            BulkByScrollResponse response = new ReindexRequestBuilder(client(LOCAL_CLUSTER)).source(sourceIndexInRemote)
+                .destination("test-index-001")
+                .get();
 
             if (attempt == 0) {
                 assertThat(response.getCreated(), equalTo(docsNumber));
@@ -127,9 +123,7 @@ public class CrossClusterReindexIT extends AbstractMultiClustersTestCase {
         final String sourceIndexInRemote = REMOTE_CLUSTER + ":" + "no-such-source-index-001";
         expectThrows(
             IndexNotFoundException.class,
-            () -> new ReindexRequestBuilder(client(LOCAL_CLUSTER), ReindexAction.INSTANCE).source(sourceIndexInRemote)
-                .destination("desc-index-001")
-                .get()
+            () -> new ReindexRequestBuilder(client(LOCAL_CLUSTER)).source(sourceIndexInRemote).destination("desc-index-001").get()
         );
 
         // assert that local index was not created either
@@ -145,9 +139,7 @@ public class CrossClusterReindexIT extends AbstractMultiClustersTestCase {
         final int docsNumber = indexDocs(client(REMOTE_CLUSTER), "datemath-2001-01-02");
 
         final String sourceIndexInRemote = REMOTE_CLUSTER + ":" + "<datemath-{2001-01-01||+1d{yyyy-MM-dd}}>";
-        new ReindexRequestBuilder(client(LOCAL_CLUSTER), ReindexAction.INSTANCE).source(sourceIndexInRemote)
-            .destination("desc-index-001")
-            .get();
+        new ReindexRequestBuilder(client(LOCAL_CLUSTER)).source(sourceIndexInRemote).destination("desc-index-001").get();
 
         assertTrue("Number of documents in source and desc indexes does not match", waitUntil(() -> {
             SearchResponse resp = client(LOCAL_CLUSTER).prepareSearch("desc-index-001")
@@ -165,9 +157,7 @@ public class CrossClusterReindexIT extends AbstractMultiClustersTestCase {
 
         // Remote name contains `:` symbol twice
         final String sourceIndexInRemote = REMOTE_CLUSTER + ":" + "<datemath-{2001-01-01-13||+1h/h{yyyy-MM-dd-HH|-07:00}}>";
-        new ReindexRequestBuilder(client(LOCAL_CLUSTER), ReindexAction.INSTANCE).source(sourceIndexInRemote)
-            .destination("desc-index-001")
-            .get();
+        new ReindexRequestBuilder(client(LOCAL_CLUSTER)).source(sourceIndexInRemote).destination("desc-index-001").get();
 
         assertTrue("Number of documents in source and desc indexes does not match", waitUntil(() -> {
             SearchResponse resp = client(LOCAL_CLUSTER).prepareSearch("desc-index-001")

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/RethrottleRequestBuilder.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/RethrottleRequestBuilder.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.reindex;
 
-import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksResponse;
 import org.elasticsearch.action.support.tasks.TasksRequestBuilder;
 import org.elasticsearch.client.internal.ElasticsearchClient;
@@ -17,8 +16,8 @@ import org.elasticsearch.client.internal.ElasticsearchClient;
  * Java API support for changing the throttle on reindex tasks while they are running.
  */
 public class RethrottleRequestBuilder extends TasksRequestBuilder<RethrottleRequest, ListTasksResponse, RethrottleRequestBuilder> {
-    public RethrottleRequestBuilder(ElasticsearchClient client, ActionType<ListTasksResponse> action) {
-        super(client, action, new RethrottleRequest());
+    public RethrottleRequestBuilder(ElasticsearchClient client) {
+        super(client, ReindexPlugin.RETHROTTLE_ACTION, new RethrottleRequest());
     }
 
     /**

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexFromRemoteWithAuthTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexFromRemoteWithAuthTests.java
@@ -26,7 +26,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.http.HttpInfo;
-import org.elasticsearch.index.reindex.ReindexAction;
 import org.elasticsearch.index.reindex.ReindexRequestBuilder;
 import org.elasticsearch.index.reindex.RemoteInfo;
 import org.elasticsearch.plugins.ActionPlugin;
@@ -109,14 +108,14 @@ public class ReindexFromRemoteWithAuthTests extends ESSingleNodeTestCase {
     }
 
     public void testReindexFromRemoteWithAuthentication() throws Exception {
-        ReindexRequestBuilder request = new ReindexRequestBuilder(client(), ReindexAction.INSTANCE).source("source")
+        ReindexRequestBuilder request = new ReindexRequestBuilder(client()).source("source")
             .destination("dest")
             .setRemoteInfo(newRemoteInfo("Aladdin", "open sesame", emptyMap()));
         assertThat(request.get(), matcher().created(1));
     }
 
     public void testReindexSendsHeaders() throws Exception {
-        ReindexRequestBuilder request = new ReindexRequestBuilder(client(), ReindexAction.INSTANCE).source("source")
+        ReindexRequestBuilder request = new ReindexRequestBuilder(client()).source("source")
             .destination("dest")
             .setRemoteInfo(newRemoteInfo(null, null, singletonMap(TestFilter.EXAMPLE_HEADER, "doesn't matter")));
         ElasticsearchStatusException e = expectThrows(ElasticsearchStatusException.class, () -> request.get());
@@ -125,7 +124,7 @@ public class ReindexFromRemoteWithAuthTests extends ESSingleNodeTestCase {
     }
 
     public void testReindexWithoutAuthenticationWhenRequired() throws Exception {
-        ReindexRequestBuilder request = new ReindexRequestBuilder(client(), ReindexAction.INSTANCE).source("source")
+        ReindexRequestBuilder request = new ReindexRequestBuilder(client()).source("source")
             .destination("dest")
             .setRemoteInfo(newRemoteInfo(null, null, emptyMap()));
         ElasticsearchStatusException e = expectThrows(ElasticsearchStatusException.class, () -> request.get());
@@ -135,7 +134,7 @@ public class ReindexFromRemoteWithAuthTests extends ESSingleNodeTestCase {
     }
 
     public void testReindexWithBadAuthentication() throws Exception {
-        ReindexRequestBuilder request = new ReindexRequestBuilder(client(), ReindexAction.INSTANCE).source("source")
+        ReindexRequestBuilder request = new ReindexRequestBuilder(client()).source("source")
             .destination("dest")
             .setRemoteInfo(newRemoteInfo("junk", "auth", emptyMap()));
         ElasticsearchStatusException e = expectThrows(ElasticsearchStatusException.class, () -> request.get());

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexSingleNodeTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexSingleNodeTests.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.reindex;
 
 import org.elasticsearch.index.query.RangeQueryBuilder;
-import org.elasticsearch.index.reindex.ReindexAction;
 import org.elasticsearch.index.reindex.ReindexRequestBuilder;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.sort.SortOrder;
@@ -38,9 +37,7 @@ public class ReindexSingleNodeTests extends ESSingleNodeTestCase {
 
         // Copy a subset of the docs sorted
         int subsetSize = randomIntBetween(1, max - 1);
-        ReindexRequestBuilder copy = new ReindexRequestBuilder(client(), ReindexAction.INSTANCE).source("source")
-            .destination("dest")
-            .refresh(true);
+        ReindexRequestBuilder copy = new ReindexRequestBuilder(client()).source("source").destination("dest").refresh(true);
         copy.maxDocs(subsetSize);
         copy.request().addSortField("foo", SortOrder.DESC);
         assertThat(copy.get(), matcher().created(subsetSize));

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexTestCase.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexTestCase.java
@@ -9,11 +9,8 @@
 package org.elasticsearch.reindex;
 
 import org.elasticsearch.index.reindex.AbstractBulkByScrollRequest;
-import org.elasticsearch.index.reindex.DeleteByQueryAction;
 import org.elasticsearch.index.reindex.DeleteByQueryRequestBuilder;
-import org.elasticsearch.index.reindex.ReindexAction;
 import org.elasticsearch.index.reindex.ReindexRequestBuilder;
-import org.elasticsearch.index.reindex.UpdateByQueryAction;
 import org.elasticsearch.index.reindex.UpdateByQueryRequestBuilder;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -38,19 +35,19 @@ public abstract class ReindexTestCase extends ESIntegTestCase {
     }
 
     protected ReindexRequestBuilder reindex() {
-        return new ReindexRequestBuilder(client(), ReindexAction.INSTANCE);
+        return new ReindexRequestBuilder(client());
     }
 
     protected UpdateByQueryRequestBuilder updateByQuery() {
-        return new UpdateByQueryRequestBuilder(client(), UpdateByQueryAction.INSTANCE);
+        return new UpdateByQueryRequestBuilder(client());
     }
 
     protected DeleteByQueryRequestBuilder deleteByQuery() {
-        return new DeleteByQueryRequestBuilder(client(), DeleteByQueryAction.INSTANCE);
+        return new DeleteByQueryRequestBuilder(client());
     }
 
     protected RethrottleRequestBuilder rethrottle() {
-        return new RethrottleRequestBuilder(client(), ReindexPlugin.RETHROTTLE_ACTION);
+        return new RethrottleRequestBuilder(client());
     }
 
     public static BulkIndexByScrollResponseMatcher matcher() {

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/RetryTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/RetryTests.java
@@ -97,7 +97,7 @@ public class RetryTests extends ESIntegTestCase {
     public void testReindex() throws Exception {
         testCase(
             ReindexAction.NAME,
-            client -> new ReindexRequestBuilder(client, ReindexAction.INSTANCE).source("source").destination("dest"),
+            client -> new ReindexRequestBuilder(client).source("source").destination("dest"),
             matcher().created(DOC_COUNT)
         );
     }
@@ -129,9 +129,7 @@ public class RetryTests extends ESIntegTestCase {
                 RemoteInfo.DEFAULT_SOCKET_TIMEOUT,
                 RemoteInfo.DEFAULT_CONNECT_TIMEOUT
             );
-            ReindexRequestBuilder request = new ReindexRequestBuilder(client, ReindexAction.INSTANCE).source("source")
-                .destination("dest")
-                .setRemoteInfo(remote);
+            ReindexRequestBuilder request = new ReindexRequestBuilder(client).source("source").destination("dest").setRemoteInfo(remote);
             return request;
         };
         testCase(ReindexAction.NAME, function, matcher().created(DOC_COUNT));
@@ -140,7 +138,7 @@ public class RetryTests extends ESIntegTestCase {
     public void testUpdateByQuery() throws Exception {
         testCase(
             UpdateByQueryAction.NAME,
-            client -> new UpdateByQueryRequestBuilder(client, UpdateByQueryAction.INSTANCE).source("source"),
+            client -> new UpdateByQueryRequestBuilder(client).source("source"),
             matcher().updated(DOC_COUNT)
         );
     }
@@ -148,8 +146,7 @@ public class RetryTests extends ESIntegTestCase {
     public void testDeleteByQuery() throws Exception {
         testCase(
             DeleteByQueryAction.NAME,
-            client -> new DeleteByQueryRequestBuilder(client, DeleteByQueryAction.INSTANCE).source("source")
-                .filter(QueryBuilders.matchAllQuery()),
+            client -> new DeleteByQueryRequestBuilder(client).source("source").filter(QueryBuilders.matchAllQuery()),
             matcher().deleted(DOC_COUNT)
         );
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequestBuilder.java
@@ -21,8 +21,8 @@ public class ClusterHealthRequestBuilder extends MasterNodeReadOperationRequestB
     ClusterHealthResponse,
     ClusterHealthRequestBuilder> {
 
-    public ClusterHealthRequestBuilder(ElasticsearchClient client, ClusterHealthAction action) {
-        super(client, action, new ClusterHealthRequest());
+    public ClusterHealthRequestBuilder(ElasticsearchClient client) {
+        super(client, ClusterHealthAction.INSTANCE, new ClusterHealthRequest());
     }
 
     public ClusterHealthRequestBuilder setIndices(String... indices) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/NodesHotThreadsRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/NodesHotThreadsRequestBuilder.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.action.admin.cluster.node.hotthreads;
 
-import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.nodes.NodesOperationRequestBuilder;
 import org.elasticsearch.client.internal.ElasticsearchClient;
 import org.elasticsearch.core.TimeValue;
@@ -19,8 +18,8 @@ public class NodesHotThreadsRequestBuilder extends NodesOperationRequestBuilder<
     NodesHotThreadsResponse,
     NodesHotThreadsRequestBuilder> {
 
-    public NodesHotThreadsRequestBuilder(ElasticsearchClient client, ActionType<NodesHotThreadsResponse> action) {
-        super(client, action, new NodesHotThreadsRequest());
+    public NodesHotThreadsRequestBuilder(ElasticsearchClient client) {
+        super(client, TransportNodesHotThreadsAction.TYPE, new NodesHotThreadsRequest());
     }
 
     public NodesHotThreadsRequestBuilder setThreads(int threads) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequestBuilder.java
@@ -8,15 +8,14 @@
 
 package org.elasticsearch.action.admin.cluster.node.info;
 
-import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.nodes.NodesOperationRequestBuilder;
 import org.elasticsearch.client.internal.ElasticsearchClient;
 
 // TODO: This class's interface should match that of NodesInfoRequest
 public class NodesInfoRequestBuilder extends NodesOperationRequestBuilder<NodesInfoRequest, NodesInfoResponse, NodesInfoRequestBuilder> {
 
-    public NodesInfoRequestBuilder(ElasticsearchClient client, ActionType<NodesInfoResponse> action) {
-        super(client, action, new NodesInfoRequest());
+    public NodesInfoRequestBuilder(ElasticsearchClient client) {
+        super(client, TransportNodesInfoAction.TYPE, new NodesInfoRequest());
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/reload/NodesReloadSecureSettingsRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/reload/NodesReloadSecureSettingsRequestBuilder.java
@@ -20,8 +20,8 @@ public class NodesReloadSecureSettingsRequestBuilder extends NodesOperationReque
     NodesReloadSecureSettingsResponse,
     NodesReloadSecureSettingsRequestBuilder> {
 
-    public NodesReloadSecureSettingsRequestBuilder(ElasticsearchClient client, NodesReloadSecureSettingsAction action) {
-        super(client, action, new NodesReloadSecureSettingsRequest());
+    public NodesReloadSecureSettingsRequestBuilder(ElasticsearchClient client) {
+        super(client, NodesReloadSecureSettingsAction.INSTANCE, new NodesReloadSecureSettingsRequest());
     }
 
     public NodesReloadSecureSettingsRequestBuilder setSecureStorePassword(SecureString secureStorePassword) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsRequestBuilder.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.action.admin.cluster.node.stats;
 
-import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.admin.indices.stats.CommonStatsFlags;
 import org.elasticsearch.action.support.nodes.NodesOperationRequestBuilder;
 import org.elasticsearch.client.internal.ElasticsearchClient;
@@ -18,8 +17,8 @@ public class NodesStatsRequestBuilder extends NodesOperationRequestBuilder<
     NodesStatsResponse,
     NodesStatsRequestBuilder> {
 
-    public NodesStatsRequestBuilder(ElasticsearchClient client, ActionType<NodesStatsResponse> action) {
-        super(client, action, new NodesStatsRequest());
+    public NodesStatsRequestBuilder(ElasticsearchClient client) {
+        super(client, TransportNodesStatsAction.TYPE, new NodesStatsRequest());
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/cancel/CancelTasksRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/cancel/CancelTasksRequestBuilder.java
@@ -16,8 +16,8 @@ import org.elasticsearch.client.internal.ElasticsearchClient;
  */
 public class CancelTasksRequestBuilder extends TasksRequestBuilder<CancelTasksRequest, CancelTasksResponse, CancelTasksRequestBuilder> {
 
-    public CancelTasksRequestBuilder(ElasticsearchClient client, CancelTasksAction action) {
-        super(client, action, new CancelTasksRequest());
+    public CancelTasksRequestBuilder(ElasticsearchClient client) {
+        super(client, CancelTasksAction.INSTANCE, new CancelTasksRequest());
     }
 
     public CancelTasksRequestBuilder waitForCompletion(boolean waitForCompletion) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/get/GetTaskRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/get/GetTaskRequestBuilder.java
@@ -17,8 +17,8 @@ import org.elasticsearch.tasks.TaskId;
  * Builder for the request to retrieve the list of tasks running on the specified nodes
  */
 public class GetTaskRequestBuilder extends ActionRequestBuilder<GetTaskRequest, GetTaskResponse> {
-    public GetTaskRequestBuilder(ElasticsearchClient client, GetTaskAction action) {
-        super(client, action, new GetTaskRequest());
+    public GetTaskRequestBuilder(ElasticsearchClient client) {
+        super(client, GetTaskAction.INSTANCE, new GetTaskRequest());
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/list/ListTasksRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/list/ListTasksRequestBuilder.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.action.admin.cluster.node.tasks.list;
 
-import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.tasks.TasksRequestBuilder;
 import org.elasticsearch.client.internal.ElasticsearchClient;
 
@@ -17,8 +16,8 @@ import org.elasticsearch.client.internal.ElasticsearchClient;
  */
 public class ListTasksRequestBuilder extends TasksRequestBuilder<ListTasksRequest, ListTasksResponse, ListTasksRequestBuilder> {
 
-    public ListTasksRequestBuilder(ElasticsearchClient client, ActionType<ListTasksResponse> action) {
-        super(client, action, new ListTasksRequest());
+    public ListTasksRequestBuilder(ElasticsearchClient client) {
+        super(client, TransportListTasksAction.TYPE, new ListTasksRequest());
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/cleanup/CleanupRepositoryRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/cleanup/CleanupRepositoryRequestBuilder.java
@@ -7,7 +7,6 @@
  */
 package org.elasticsearch.action.admin.cluster.repositories.cleanup;
 
-import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.master.MasterNodeOperationRequestBuilder;
 import org.elasticsearch.client.internal.ElasticsearchClient;
 
@@ -16,8 +15,8 @@ public class CleanupRepositoryRequestBuilder extends MasterNodeOperationRequestB
     CleanupRepositoryResponse,
     CleanupRepositoryRequestBuilder> {
 
-    public CleanupRepositoryRequestBuilder(ElasticsearchClient client, ActionType<CleanupRepositoryResponse> action, String repository) {
-        super(client, action, new CleanupRepositoryRequest(repository));
+    public CleanupRepositoryRequestBuilder(ElasticsearchClient client, String repository) {
+        super(client, CleanupRepositoryAction.INSTANCE, new CleanupRepositoryRequest(repository));
     }
 
     public CleanupRepositoryRequestBuilder setName(String repository) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/delete/DeleteRepositoryRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/delete/DeleteRepositoryRequestBuilder.java
@@ -23,8 +23,8 @@ public class DeleteRepositoryRequestBuilder extends AcknowledgedRequestBuilder<
     /**
      * Constructs unregister repository request builder with specified repository name
      */
-    public DeleteRepositoryRequestBuilder(ElasticsearchClient client, DeleteRepositoryAction action, String name) {
-        super(client, action, new DeleteRepositoryRequest(name));
+    public DeleteRepositoryRequestBuilder(ElasticsearchClient client, String name) {
+        super(client, DeleteRepositoryAction.INSTANCE, new DeleteRepositoryRequest(name));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/get/GetRepositoriesRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/get/GetRepositoriesRequestBuilder.java
@@ -23,8 +23,8 @@ public class GetRepositoriesRequestBuilder extends MasterNodeReadOperationReques
     /**
      * Creates new get repository request builder
      */
-    public GetRepositoriesRequestBuilder(ElasticsearchClient client, GetRepositoriesAction action, String... repositories) {
-        super(client, action, new GetRepositoriesRequest(repositories));
+    public GetRepositoriesRequestBuilder(ElasticsearchClient client, String... repositories) {
+        super(client, GetRepositoriesAction.INSTANCE, new GetRepositoriesRequest(repositories));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/put/PutRepositoryRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/put/PutRepositoryRequestBuilder.java
@@ -27,8 +27,8 @@ public class PutRepositoryRequestBuilder extends AcknowledgedRequestBuilder<
     /**
      * Constructs register repository request for the repository with a given name
      */
-    public PutRepositoryRequestBuilder(ElasticsearchClient client, PutRepositoryAction action, String name) {
-        super(client, action, new PutRepositoryRequest(name));
+    public PutRepositoryRequestBuilder(ElasticsearchClient client, String name) {
+        super(client, PutRepositoryAction.INSTANCE, new PutRepositoryRequest(name));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/verify/VerifyRepositoryRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/verify/VerifyRepositoryRequestBuilder.java
@@ -22,8 +22,8 @@ public class VerifyRepositoryRequestBuilder extends MasterNodeOperationRequestBu
     /**
      * Constructs unregister repository request builder with specified repository name
      */
-    public VerifyRepositoryRequestBuilder(ElasticsearchClient client, VerifyRepositoryAction action, String name) {
-        super(client, action, new VerifyRepositoryRequest(name));
+    public VerifyRepositoryRequestBuilder(ElasticsearchClient client, String name) {
+        super(client, VerifyRepositoryAction.INSTANCE, new VerifyRepositoryRequest(name));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteRequestBuilder.java
@@ -19,8 +19,8 @@ public class ClusterRerouteRequestBuilder extends AcknowledgedRequestBuilder<
     ClusterRerouteRequest,
     ClusterRerouteResponse,
     ClusterRerouteRequestBuilder> {
-    public ClusterRerouteRequestBuilder(ElasticsearchClient client, ClusterRerouteAction action) {
-        super(client, action, new ClusterRerouteRequest());
+    public ClusterRerouteRequestBuilder(ElasticsearchClient client) {
+        super(client, ClusterRerouteAction.INSTANCE, new ClusterRerouteRequest());
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/settings/ClusterUpdateSettingsRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/settings/ClusterUpdateSettingsRequestBuilder.java
@@ -23,8 +23,8 @@ public class ClusterUpdateSettingsRequestBuilder extends AcknowledgedRequestBuil
     ClusterUpdateSettingsResponse,
     ClusterUpdateSettingsRequestBuilder> {
 
-    public ClusterUpdateSettingsRequestBuilder(ElasticsearchClient client, ClusterUpdateSettingsAction action) {
-        super(client, action, new ClusterUpdateSettingsRequest());
+    public ClusterUpdateSettingsRequestBuilder(ElasticsearchClient client) {
+        super(client, ClusterUpdateSettingsAction.INSTANCE, new ClusterUpdateSettingsRequest());
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsRequestBuilder.java
@@ -17,8 +17,8 @@ public class ClusterSearchShardsRequestBuilder extends MasterNodeReadOperationRe
     ClusterSearchShardsResponse,
     ClusterSearchShardsRequestBuilder> {
 
-    public ClusterSearchShardsRequestBuilder(ElasticsearchClient client, ClusterSearchShardsAction action) {
-        super(client, action, new ClusterSearchShardsRequest());
+    public ClusterSearchShardsRequestBuilder(ElasticsearchClient client) {
+        super(client, ClusterSearchShardsAction.INSTANCE, new ClusterSearchShardsRequest());
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/clone/CloneSnapshotRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/clone/CloneSnapshotRequestBuilder.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.action.admin.cluster.snapshots.clone;
 
-import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.support.master.MasterNodeOperationRequestBuilder;
@@ -20,22 +19,8 @@ public class CloneSnapshotRequestBuilder extends MasterNodeOperationRequestBuild
     AcknowledgedResponse,
     CloneSnapshotRequestBuilder> {
 
-    protected CloneSnapshotRequestBuilder(
-        ElasticsearchClient client,
-        ActionType<AcknowledgedResponse> action,
-        CloneSnapshotRequest request
-    ) {
-        super(client, action, request);
-    }
-
-    public CloneSnapshotRequestBuilder(
-        ElasticsearchClient client,
-        ActionType<AcknowledgedResponse> action,
-        String repository,
-        String source,
-        String target
-    ) {
-        this(client, action, new CloneSnapshotRequest(repository, source, target, Strings.EMPTY_ARRAY));
+    public CloneSnapshotRequestBuilder(ElasticsearchClient client, String repository, String source, String target) {
+        super(client, CloneSnapshotAction.INSTANCE, new CloneSnapshotRequest(repository, source, target, Strings.EMPTY_ARRAY));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequestBuilder.java
@@ -26,8 +26,8 @@ public class CreateSnapshotRequestBuilder extends MasterNodeOperationRequestBuil
     /**
      * Constructs a new create snapshot request builder with specified repository and snapshot names
      */
-    public CreateSnapshotRequestBuilder(ElasticsearchClient client, CreateSnapshotAction action, String repository, String snapshot) {
-        super(client, action, new CreateSnapshotRequest(repository, snapshot));
+    public CreateSnapshotRequestBuilder(ElasticsearchClient client, String repository, String snapshot) {
+        super(client, CreateSnapshotAction.INSTANCE, new CreateSnapshotRequest(repository, snapshot));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/delete/DeleteSnapshotRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/delete/DeleteSnapshotRequestBuilder.java
@@ -23,8 +23,8 @@ public class DeleteSnapshotRequestBuilder extends MasterNodeOperationRequestBuil
     /**
      * Constructs delete snapshot request builder with specified repository and snapshot names
      */
-    public DeleteSnapshotRequestBuilder(ElasticsearchClient client, DeleteSnapshotAction action, String repository, String... snapshots) {
-        super(client, action, new DeleteSnapshotRequest(repository, snapshots));
+    public DeleteSnapshotRequestBuilder(ElasticsearchClient client, String repository, String... snapshots) {
+        super(client, DeleteSnapshotAction.INSTANCE, new DeleteSnapshotRequest(repository, snapshots));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsRequestBuilder.java
@@ -25,8 +25,8 @@ public class GetSnapshotsRequestBuilder extends MasterNodeOperationRequestBuilde
     /**
      * Constructs the new get snapshot request with specified repositories
      */
-    public GetSnapshotsRequestBuilder(ElasticsearchClient client, GetSnapshotsAction action, String... repositories) {
-        super(client, action, new GetSnapshotsRequest(repositories));
+    public GetSnapshotsRequestBuilder(ElasticsearchClient client, String... repositories) {
+        super(client, GetSnapshotsAction.INSTANCE, new GetSnapshotsRequest(repositories));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequestBuilder.java
@@ -28,8 +28,8 @@ public class RestoreSnapshotRequestBuilder extends MasterNodeOperationRequestBui
     /**
      * Constructs new restore snapshot request builder with specified repository and snapshot names
      */
-    public RestoreSnapshotRequestBuilder(ElasticsearchClient client, RestoreSnapshotAction action, String repository, String name) {
-        super(client, action, new RestoreSnapshotRequest(repository, name));
+    public RestoreSnapshotRequestBuilder(ElasticsearchClient client, String repository, String name) {
+        super(client, RestoreSnapshotAction.INSTANCE, new RestoreSnapshotRequest(repository, name));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotsStatusRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotsStatusRequestBuilder.java
@@ -23,15 +23,15 @@ public class SnapshotsStatusRequestBuilder extends MasterNodeOperationRequestBui
     /**
      * Constructs the new snapshot status request
      */
-    public SnapshotsStatusRequestBuilder(ElasticsearchClient client, SnapshotsStatusAction action) {
-        super(client, action, new SnapshotsStatusRequest());
+    public SnapshotsStatusRequestBuilder(ElasticsearchClient client) {
+        super(client, SnapshotsStatusAction.INSTANCE, new SnapshotsStatusRequest());
     }
 
     /**
      * Constructs the new snapshot status request with specified repository
      */
-    public SnapshotsStatusRequestBuilder(ElasticsearchClient client, SnapshotsStatusAction action, String repository) {
-        super(client, action, new SnapshotsStatusRequest(repository));
+    public SnapshotsStatusRequestBuilder(ElasticsearchClient client, String repository) {
+        super(client, SnapshotsStatusAction.INSTANCE, new SnapshotsStatusRequest(repository));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequestBuilder.java
@@ -19,8 +19,8 @@ public class ClusterStateRequestBuilder extends MasterNodeReadOperationRequestBu
     ClusterStateResponse,
     ClusterStateRequestBuilder> {
 
-    public ClusterStateRequestBuilder(ElasticsearchClient client, ClusterStateAction action) {
-        super(client, action, new ClusterStateRequest());
+    public ClusterStateRequestBuilder(ElasticsearchClient client) {
+        super(client, ClusterStateAction.INSTANCE, new ClusterStateRequest());
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsRequestBuilder.java
@@ -16,7 +16,7 @@ public class ClusterStatsRequestBuilder extends NodesOperationRequestBuilder<
     ClusterStatsResponse,
     ClusterStatsRequestBuilder> {
 
-    public ClusterStatsRequestBuilder(ElasticsearchClient client, ClusterStatsAction action) {
-        super(client, action, new ClusterStatsRequest());
+    public ClusterStatsRequestBuilder(ElasticsearchClient client) {
+        super(client, ClusterStatsAction.INSTANCE, new ClusterStatsRequest());
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/storedscripts/DeleteStoredScriptRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/storedscripts/DeleteStoredScriptRequestBuilder.java
@@ -17,8 +17,8 @@ public class DeleteStoredScriptRequestBuilder extends AcknowledgedRequestBuilder
     AcknowledgedResponse,
     DeleteStoredScriptRequestBuilder> {
 
-    public DeleteStoredScriptRequestBuilder(ElasticsearchClient client, DeleteStoredScriptAction action) {
-        super(client, action, new DeleteStoredScriptRequest());
+    public DeleteStoredScriptRequestBuilder(ElasticsearchClient client) {
+        super(client, DeleteStoredScriptAction.INSTANCE, new DeleteStoredScriptRequest());
     }
 
     public DeleteStoredScriptRequestBuilder setId(String id) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/storedscripts/GetStoredScriptRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/storedscripts/GetStoredScriptRequestBuilder.java
@@ -16,8 +16,8 @@ public class GetStoredScriptRequestBuilder extends MasterNodeReadOperationReques
     GetStoredScriptResponse,
     GetStoredScriptRequestBuilder> {
 
-    public GetStoredScriptRequestBuilder(ElasticsearchClient client, GetStoredScriptAction action) {
-        super(client, action, new GetStoredScriptRequest());
+    public GetStoredScriptRequestBuilder(ElasticsearchClient client) {
+        super(client, GetStoredScriptAction.INSTANCE, new GetStoredScriptRequest());
     }
 
     public GetStoredScriptRequestBuilder setId(String id) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/storedscripts/PutStoredScriptRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/storedscripts/PutStoredScriptRequestBuilder.java
@@ -19,8 +19,8 @@ public class PutStoredScriptRequestBuilder extends AcknowledgedRequestBuilder<
     AcknowledgedResponse,
     PutStoredScriptRequestBuilder> {
 
-    public PutStoredScriptRequestBuilder(ElasticsearchClient client, PutStoredScriptAction action) {
-        super(client, action, new PutStoredScriptRequest());
+    public PutStoredScriptRequestBuilder(ElasticsearchClient client) {
+        super(client, PutStoredScriptAction.INSTANCE, new PutStoredScriptRequest());
     }
 
     public PutStoredScriptRequestBuilder setId(String id) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/tasks/PendingClusterTasksRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/tasks/PendingClusterTasksRequestBuilder.java
@@ -16,7 +16,7 @@ public class PendingClusterTasksRequestBuilder extends MasterNodeReadOperationRe
     PendingClusterTasksResponse,
     PendingClusterTasksRequestBuilder> {
 
-    public PendingClusterTasksRequestBuilder(ElasticsearchClient client, PendingClusterTasksAction action) {
-        super(client, action, new PendingClusterTasksRequest());
+    public PendingClusterTasksRequestBuilder(ElasticsearchClient client) {
+        super(client, PendingClusterTasksAction.INSTANCE, new PendingClusterTasksRequest());
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/IndicesAliasesRequestBuilder.java
@@ -24,8 +24,8 @@ public class IndicesAliasesRequestBuilder extends AcknowledgedRequestBuilder<
     AcknowledgedResponse,
     IndicesAliasesRequestBuilder> {
 
-    public IndicesAliasesRequestBuilder(ElasticsearchClient client, IndicesAliasesAction action) {
-        super(client, action, new IndicesAliasesRequest());
+    public IndicesAliasesRequestBuilder(ElasticsearchClient client) {
+        super(client, IndicesAliasesAction.INSTANCE, new IndicesAliasesRequest());
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesRequestBuilder.java
@@ -12,7 +12,7 @@ import org.elasticsearch.client.internal.ElasticsearchClient;
 
 public class GetAliasesRequestBuilder extends BaseAliasesRequestBuilder<GetAliasesResponse, GetAliasesRequestBuilder> {
 
-    public GetAliasesRequestBuilder(ElasticsearchClient client, GetAliasesAction action, String... aliases) {
-        super(client, action, aliases);
+    public GetAliasesRequestBuilder(ElasticsearchClient client, String... aliases) {
+        super(client, GetAliasesAction.INSTANCE, aliases);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeRequestBuilder.java
@@ -17,12 +17,12 @@ public class AnalyzeRequestBuilder extends SingleShardOperationRequestBuilder<
     AnalyzeAction.Response,
     AnalyzeRequestBuilder> {
 
-    public AnalyzeRequestBuilder(ElasticsearchClient client, AnalyzeAction action) {
-        super(client, action, new AnalyzeAction.Request());
+    public AnalyzeRequestBuilder(ElasticsearchClient client) {
+        super(client, AnalyzeAction.INSTANCE, new AnalyzeAction.Request());
     }
 
-    public AnalyzeRequestBuilder(ElasticsearchClient client, AnalyzeAction action, String index, String... text) {
-        super(client, action, new AnalyzeAction.Request(index).text(text));
+    public AnalyzeRequestBuilder(ElasticsearchClient client, String index, String... text) {
+        super(client, AnalyzeAction.INSTANCE, new AnalyzeAction.Request(index).text(text));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/cache/clear/ClearIndicesCacheRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/cache/clear/ClearIndicesCacheRequestBuilder.java
@@ -16,8 +16,8 @@ public class ClearIndicesCacheRequestBuilder extends BroadcastOperationRequestBu
     ClearIndicesCacheResponse,
     ClearIndicesCacheRequestBuilder> {
 
-    public ClearIndicesCacheRequestBuilder(ElasticsearchClient client, ClearIndicesCacheAction action) {
-        super(client, action, new ClearIndicesCacheRequest());
+    public ClearIndicesCacheRequestBuilder(ElasticsearchClient client) {
+        super(client, ClearIndicesCacheAction.INSTANCE, new ClearIndicesCacheRequest());
     }
 
     public ClearIndicesCacheRequestBuilder setQueryCache(boolean queryCache) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/close/CloseIndexRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/close/CloseIndexRequestBuilder.java
@@ -18,8 +18,8 @@ import org.elasticsearch.client.internal.ElasticsearchClient;
  */
 public class CloseIndexRequestBuilder extends AcknowledgedRequestBuilder<CloseIndexRequest, CloseIndexResponse, CloseIndexRequestBuilder> {
 
-    public CloseIndexRequestBuilder(ElasticsearchClient client, CloseIndexAction action, String... indices) {
-        super(client, action, new CloseIndexRequest(indices));
+    public CloseIndexRequestBuilder(ElasticsearchClient client, String... indices) {
+        super(client, CloseIndexAction.INSTANCE, new CloseIndexRequest(indices));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequestBuilder.java
@@ -28,12 +28,12 @@ public class CreateIndexRequestBuilder extends AcknowledgedRequestBuilder<
     CreateIndexResponse,
     CreateIndexRequestBuilder> {
 
-    public CreateIndexRequestBuilder(ElasticsearchClient client, CreateIndexAction action) {
-        super(client, action, new CreateIndexRequest());
+    public CreateIndexRequestBuilder(ElasticsearchClient client) {
+        super(client, CreateIndexAction.INSTANCE, new CreateIndexRequest());
     }
 
-    public CreateIndexRequestBuilder(ElasticsearchClient client, CreateIndexAction action, String index) {
-        super(client, action, new CreateIndexRequest(index));
+    public CreateIndexRequestBuilder(ElasticsearchClient client, String index) {
+        super(client, CreateIndexAction.INSTANCE, new CreateIndexRequest(index));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/delete/DeleteIndexRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/delete/DeleteIndexRequestBuilder.java
@@ -18,8 +18,8 @@ public class DeleteIndexRequestBuilder extends AcknowledgedRequestBuilder<
     AcknowledgedResponse,
     DeleteIndexRequestBuilder> {
 
-    public DeleteIndexRequestBuilder(ElasticsearchClient client, DeleteIndexAction action, String... indices) {
-        super(client, action, new DeleteIndexRequest(indices));
+    public DeleteIndexRequestBuilder(ElasticsearchClient client, String... indices) {
+        super(client, DeleteIndexAction.INSTANCE, new DeleteIndexRequest(indices));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/flush/FlushRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/flush/FlushRequestBuilder.java
@@ -13,8 +13,8 @@ import org.elasticsearch.client.internal.ElasticsearchClient;
 
 public class FlushRequestBuilder extends BroadcastOperationRequestBuilder<FlushRequest, FlushResponse, FlushRequestBuilder> {
 
-    public FlushRequestBuilder(ElasticsearchClient client, FlushAction action) {
-        super(client, action, new FlushRequest());
+    public FlushRequestBuilder(ElasticsearchClient client) {
+        super(client, FlushAction.INSTANCE, new FlushRequest());
     }
 
     public FlushRequestBuilder setForce(boolean force) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/forcemerge/ForceMergeRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/forcemerge/ForceMergeRequestBuilder.java
@@ -23,8 +23,8 @@ public class ForceMergeRequestBuilder extends BroadcastOperationRequestBuilder<
     ForceMergeResponse,
     ForceMergeRequestBuilder> {
 
-    public ForceMergeRequestBuilder(ElasticsearchClient client, ForceMergeAction action) {
-        super(client, action, new ForceMergeRequest());
+    public ForceMergeRequestBuilder(ElasticsearchClient client) {
+        super(client, ForceMergeAction.INSTANCE, new ForceMergeRequest());
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexRequestBuilder.java
@@ -14,8 +14,8 @@ import org.elasticsearch.client.internal.ElasticsearchClient;
 
 public class GetIndexRequestBuilder extends ClusterInfoRequestBuilder<GetIndexRequest, GetIndexResponse, GetIndexRequestBuilder> {
 
-    public GetIndexRequestBuilder(ElasticsearchClient client, GetIndexAction action, String... indices) {
-        super(client, action, new GetIndexRequest().indices(indices));
+    public GetIndexRequestBuilder(ElasticsearchClient client, String... indices) {
+        super(client, GetIndexAction.INSTANCE, new GetIndexRequest().indices(indices));
     }
 
     public GetIndexRequestBuilder setFeatures(Feature... features) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetFieldMappingsRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetFieldMappingsRequestBuilder.java
@@ -16,8 +16,8 @@ import org.elasticsearch.common.util.ArrayUtils;
 /** A helper class to build {@link GetFieldMappingsRequest} objects */
 public class GetFieldMappingsRequestBuilder extends ActionRequestBuilder<GetFieldMappingsRequest, GetFieldMappingsResponse> {
 
-    public GetFieldMappingsRequestBuilder(ElasticsearchClient client, GetFieldMappingsAction action, String... indices) {
-        super(client, action, new GetFieldMappingsRequest().indices(indices));
+    public GetFieldMappingsRequestBuilder(ElasticsearchClient client, String... indices) {
+        super(client, GetFieldMappingsAction.INSTANCE, new GetFieldMappingsRequest().indices(indices));
     }
 
     public GetFieldMappingsRequestBuilder setIndices(String... indices) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetMappingsRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetMappingsRequestBuilder.java
@@ -16,7 +16,7 @@ public class GetMappingsRequestBuilder extends ClusterInfoRequestBuilder<
     GetMappingsResponse,
     GetMappingsRequestBuilder> {
 
-    public GetMappingsRequestBuilder(ElasticsearchClient client, GetMappingsAction action, String... indices) {
-        super(client, action, new GetMappingsRequest().indices(indices));
+    public GetMappingsRequestBuilder(ElasticsearchClient client, String... indices) {
+        super(client, GetMappingsAction.INSTANCE, new GetMappingsRequest().indices(indices));
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/PutMappingRequestBuilder.java
@@ -26,8 +26,8 @@ public class PutMappingRequestBuilder extends AcknowledgedRequestBuilder<
     AcknowledgedResponse,
     PutMappingRequestBuilder> {
 
-    public PutMappingRequestBuilder(ElasticsearchClient client, PutMappingAction action) {
-        super(client, action, new PutMappingRequest());
+    public PutMappingRequestBuilder(ElasticsearchClient client) {
+        super(client, PutMappingAction.INSTANCE, new PutMappingRequest());
     }
 
     public PutMappingRequestBuilder setIndices(String... indices) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/open/OpenIndexRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/open/OpenIndexRequestBuilder.java
@@ -18,8 +18,8 @@ import org.elasticsearch.client.internal.ElasticsearchClient;
  */
 public class OpenIndexRequestBuilder extends AcknowledgedRequestBuilder<OpenIndexRequest, OpenIndexResponse, OpenIndexRequestBuilder> {
 
-    public OpenIndexRequestBuilder(ElasticsearchClient client, OpenIndexAction action, String... indices) {
-        super(client, action, new OpenIndexRequest(indices));
+    public OpenIndexRequestBuilder(ElasticsearchClient client, String... indices) {
+        super(client, OpenIndexAction.INSTANCE, new OpenIndexRequest(indices));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/readonly/AddIndexBlockRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/readonly/AddIndexBlockRequestBuilder.java
@@ -21,8 +21,8 @@ public class AddIndexBlockRequestBuilder extends AcknowledgedRequestBuilder<
     AddIndexBlockResponse,
     AddIndexBlockRequestBuilder> {
 
-    public AddIndexBlockRequestBuilder(ElasticsearchClient client, AddIndexBlockAction action, APIBlock block, String... indices) {
-        super(client, action, new AddIndexBlockRequest(block, indices));
+    public AddIndexBlockRequestBuilder(ElasticsearchClient client, APIBlock block, String... indices) {
+        super(client, AddIndexBlockAction.INSTANCE, new AddIndexBlockRequest(block, indices));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/recovery/RecoveryRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/recovery/RecoveryRequestBuilder.java
@@ -19,8 +19,8 @@ public class RecoveryRequestBuilder extends BroadcastOperationRequestBuilder<Rec
     /**
      * Constructs a new recovery information request builder.
      */
-    public RecoveryRequestBuilder(ElasticsearchClient client, RecoveryAction action) {
-        super(client, action, new RecoveryRequest());
+    public RecoveryRequestBuilder(ElasticsearchClient client) {
+        super(client, RecoveryAction.INSTANCE, new RecoveryRequest());
     }
 
     public RecoveryRequestBuilder setDetailed(boolean detailed) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/refresh/RefreshRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/refresh/RefreshRequestBuilder.java
@@ -18,7 +18,7 @@ import org.elasticsearch.client.internal.ElasticsearchClient;
  */
 public class RefreshRequestBuilder extends BroadcastOperationRequestBuilder<RefreshRequest, RefreshResponse, RefreshRequestBuilder> {
 
-    public RefreshRequestBuilder(ElasticsearchClient client, RefreshAction action) {
-        super(client, action, new RefreshRequest());
+    public RefreshRequestBuilder(ElasticsearchClient client) {
+        super(client, RefreshAction.INSTANCE, new RefreshRequest());
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverRequestBuilder.java
@@ -14,8 +14,8 @@ import org.elasticsearch.client.internal.ElasticsearchClient;
 import org.elasticsearch.common.settings.Settings;
 
 public class RolloverRequestBuilder extends MasterNodeOperationRequestBuilder<RolloverRequest, RolloverResponse, RolloverRequestBuilder> {
-    public RolloverRequestBuilder(ElasticsearchClient client, RolloverAction action) {
-        super(client, action, new RolloverRequest());
+    public RolloverRequestBuilder(ElasticsearchClient client) {
+        super(client, RolloverAction.INSTANCE, new RolloverRequest());
     }
 
     public RolloverRequestBuilder setRolloverTarget(String rolloverTarget) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentsRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/segments/IndicesSegmentsRequestBuilder.java
@@ -16,7 +16,7 @@ public class IndicesSegmentsRequestBuilder extends BroadcastOperationRequestBuil
     IndicesSegmentResponse,
     IndicesSegmentsRequestBuilder> {
 
-    public IndicesSegmentsRequestBuilder(ElasticsearchClient client, IndicesSegmentsAction action) {
-        super(client, action, new IndicesSegmentsRequest());
+    public IndicesSegmentsRequestBuilder(ElasticsearchClient client) {
+        super(client, IndicesSegmentsAction.INSTANCE, new IndicesSegmentsRequest());
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsRequestBuilder.java
@@ -18,8 +18,8 @@ public class GetSettingsRequestBuilder extends MasterNodeReadOperationRequestBui
     GetSettingsResponse,
     GetSettingsRequestBuilder> {
 
-    public GetSettingsRequestBuilder(ElasticsearchClient client, GetSettingsAction action, String... indices) {
-        super(client, action, new GetSettingsRequest().indices(indices));
+    public GetSettingsRequestBuilder(ElasticsearchClient client, String... indices) {
+        super(client, GetSettingsAction.INSTANCE, new GetSettingsRequest().indices(indices));
     }
 
     public GetSettingsRequestBuilder setIndices(String... indices) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/settings/put/UpdateSettingsRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/settings/put/UpdateSettingsRequestBuilder.java
@@ -25,8 +25,8 @@ public class UpdateSettingsRequestBuilder extends AcknowledgedRequestBuilder<
     AcknowledgedResponse,
     UpdateSettingsRequestBuilder> {
 
-    public UpdateSettingsRequestBuilder(ElasticsearchClient client, UpdateSettingsAction action, String... indices) {
-        super(client, action, new UpdateSettingsRequest(indices));
+    public UpdateSettingsRequestBuilder(ElasticsearchClient client, String... indices) {
+        super(client, UpdateSettingsAction.INSTANCE, new UpdateSettingsRequest(indices));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoreRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoreRequestBuilder.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.action.admin.indices.shards;
 
-import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.MasterNodeReadOperationRequestBuilder;
 import org.elasticsearch.client.internal.ElasticsearchClient;
@@ -22,8 +21,8 @@ public class IndicesShardStoreRequestBuilder extends MasterNodeReadOperationRequ
     IndicesShardStoresResponse,
     IndicesShardStoreRequestBuilder> {
 
-    public IndicesShardStoreRequestBuilder(ElasticsearchClient client, ActionType<IndicesShardStoresResponse> action, String... indices) {
-        super(client, action, new IndicesShardStoresRequest(indices));
+    public IndicesShardStoreRequestBuilder(ElasticsearchClient client, String... indices) {
+        super(client, IndicesShardStoresAction.INSTANCE, new IndicesShardStoresRequest(indices));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/ResizeRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/ResizeRequestBuilder.java
@@ -7,7 +7,6 @@
  */
 package org.elasticsearch.action.admin.indices.shrink;
 
-import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.action.support.master.AcknowledgedRequestBuilder;
@@ -16,8 +15,8 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 
 public class ResizeRequestBuilder extends AcknowledgedRequestBuilder<ResizeRequest, ResizeResponse, ResizeRequestBuilder> {
-    public ResizeRequestBuilder(ElasticsearchClient client, ActionType<ResizeResponse> action) {
-        super(client, action, new ResizeRequest());
+    public ResizeRequestBuilder(ElasticsearchClient client) {
+        super(client, ResizeAction.INSTANCE, new ResizeRequest());
     }
 
     public ResizeRequestBuilder setTargetIndex(CreateIndexRequest request) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsRequestBuilder.java
@@ -25,8 +25,8 @@ public class IndicesStatsRequestBuilder extends BroadcastOperationRequestBuilder
     IndicesStatsResponse,
     IndicesStatsRequestBuilder> {
 
-    public IndicesStatsRequestBuilder(ElasticsearchClient client, IndicesStatsAction action) {
-        super(client, action, new IndicesStatsRequest());
+    public IndicesStatsRequestBuilder(ElasticsearchClient client) {
+        super(client, IndicesStatsAction.INSTANCE, new IndicesStatsRequest());
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/delete/DeleteIndexTemplateRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/delete/DeleteIndexTemplateRequestBuilder.java
@@ -16,8 +16,8 @@ public class DeleteIndexTemplateRequestBuilder extends MasterNodeOperationReques
     AcknowledgedResponse,
     DeleteIndexTemplateRequestBuilder> {
 
-    public DeleteIndexTemplateRequestBuilder(ElasticsearchClient client, DeleteIndexTemplateAction action, String name) {
-        super(client, action, new DeleteIndexTemplateRequest(name));
+    public DeleteIndexTemplateRequestBuilder(ElasticsearchClient client, String name) {
+        super(client, DeleteIndexTemplateAction.INSTANCE, new DeleteIndexTemplateRequest(name));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetIndexTemplatesRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetIndexTemplatesRequestBuilder.java
@@ -15,7 +15,7 @@ public class GetIndexTemplatesRequestBuilder extends MasterNodeReadOperationRequ
     GetIndexTemplatesResponse,
     GetIndexTemplatesRequestBuilder> {
 
-    public GetIndexTemplatesRequestBuilder(ElasticsearchClient client, GetIndexTemplatesAction action, String... names) {
-        super(client, action, new GetIndexTemplatesRequest(names));
+    public GetIndexTemplatesRequestBuilder(ElasticsearchClient client, String... names) {
+        super(client, GetIndexTemplatesAction.INSTANCE, new GetIndexTemplatesRequest(names));
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/PutIndexTemplateRequestBuilder.java
@@ -24,8 +24,8 @@ public class PutIndexTemplateRequestBuilder extends MasterNodeOperationRequestBu
     AcknowledgedResponse,
     PutIndexTemplateRequestBuilder> {
 
-    public PutIndexTemplateRequestBuilder(ElasticsearchClient client, PutIndexTemplateAction action, String name) {
-        super(client, action, new PutIndexTemplateRequest(name));
+    public PutIndexTemplateRequestBuilder(ElasticsearchClient client, String name) {
+        super(client, PutIndexTemplateAction.INSTANCE, new PutIndexTemplateRequest(name));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryRequestBuilder.java
@@ -17,8 +17,8 @@ public class ValidateQueryRequestBuilder extends BroadcastOperationRequestBuilde
     ValidateQueryResponse,
     ValidateQueryRequestBuilder> {
 
-    public ValidateQueryRequestBuilder(ElasticsearchClient client, ValidateQueryAction action) {
-        super(client, action, new ValidateQueryRequest());
+    public ValidateQueryRequestBuilder(ElasticsearchClient client) {
+        super(client, ValidateQueryAction.INSTANCE, new ValidateQueryRequest());
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkRequestBuilder.java
@@ -29,12 +29,12 @@ import org.elasticsearch.xcontent.XContentType;
  */
 public class BulkRequestBuilder extends ActionRequestBuilder<BulkRequest, BulkResponse> implements WriteRequestBuilder<BulkRequestBuilder> {
 
-    public BulkRequestBuilder(ElasticsearchClient client, BulkAction action, @Nullable String globalIndex) {
-        super(client, action, new BulkRequest(globalIndex));
+    public BulkRequestBuilder(ElasticsearchClient client, @Nullable String globalIndex) {
+        super(client, BulkAction.INSTANCE, new BulkRequest(globalIndex));
     }
 
-    public BulkRequestBuilder(ElasticsearchClient client, BulkAction action) {
-        super(client, action, new BulkRequest());
+    public BulkRequestBuilder(ElasticsearchClient client) {
+        super(client, BulkAction.INSTANCE, new BulkRequest());
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/delete/DeleteRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/delete/DeleteRequestBuilder.java
@@ -21,8 +21,8 @@ public class DeleteRequestBuilder extends ReplicationRequestBuilder<DeleteReques
     implements
         WriteRequestBuilder<DeleteRequestBuilder> {
 
-    public DeleteRequestBuilder(ElasticsearchClient client, DeleteAction action, @Nullable String index) {
-        super(client, action, new DeleteRequest(index));
+    public DeleteRequestBuilder(ElasticsearchClient client, @Nullable String index) {
+        super(client, DeleteAction.INSTANCE, new DeleteRequest(index));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/explain/ExplainRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/explain/ExplainRequestBuilder.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.action.explain;
 
-import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.single.shard.SingleShardOperationRequestBuilder;
 import org.elasticsearch.client.internal.ElasticsearchClient;
 import org.elasticsearch.common.Strings;
@@ -21,8 +20,8 @@ import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
  */
 public class ExplainRequestBuilder extends SingleShardOperationRequestBuilder<ExplainRequest, ExplainResponse, ExplainRequestBuilder> {
 
-    public ExplainRequestBuilder(ElasticsearchClient client, ActionType<ExplainResponse> action, String index, String id) {
-        super(client, action, new ExplainRequest().index(index).id(id));
+    public ExplainRequestBuilder(ElasticsearchClient client, String index, String id) {
+        super(client, TransportExplainAction.TYPE, new ExplainRequest().index(index).id(id));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesRequestBuilder.java
@@ -15,8 +15,8 @@ import org.elasticsearch.index.query.QueryBuilder;
 import java.util.Map;
 
 public class FieldCapabilitiesRequestBuilder extends ActionRequestBuilder<FieldCapabilitiesRequest, FieldCapabilitiesResponse> {
-    public FieldCapabilitiesRequestBuilder(ElasticsearchClient client, FieldCapabilitiesAction action, String... indices) {
-        super(client, action, new FieldCapabilitiesRequest().indices(indices));
+    public FieldCapabilitiesRequestBuilder(ElasticsearchClient client, String... indices) {
+        super(client, FieldCapabilitiesAction.INSTANCE, new FieldCapabilitiesRequest().indices(indices));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/get/GetRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/get/GetRequestBuilder.java
@@ -20,12 +20,12 @@ import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
  */
 public class GetRequestBuilder extends SingleShardOperationRequestBuilder<GetRequest, GetResponse, GetRequestBuilder> {
 
-    public GetRequestBuilder(ElasticsearchClient client, GetAction action) {
-        super(client, action, new GetRequest());
+    public GetRequestBuilder(ElasticsearchClient client) {
+        super(client, GetAction.INSTANCE, new GetRequest());
     }
 
-    public GetRequestBuilder(ElasticsearchClient client, GetAction action, @Nullable String index) {
-        super(client, action, new GetRequest(index));
+    public GetRequestBuilder(ElasticsearchClient client, @Nullable String index) {
+        super(client, GetAction.INSTANCE, new GetRequest(index));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/get/MultiGetRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/get/MultiGetRequestBuilder.java
@@ -16,8 +16,8 @@ import org.elasticsearch.client.internal.ElasticsearchClient;
  */
 public class MultiGetRequestBuilder extends ActionRequestBuilder<MultiGetRequest, MultiGetResponse> {
 
-    public MultiGetRequestBuilder(ElasticsearchClient client, MultiGetAction action) {
-        super(client, action, new MultiGetRequest());
+    public MultiGetRequestBuilder(ElasticsearchClient client) {
+        super(client, MultiGetAction.INSTANCE, new MultiGetRequest());
     }
 
     public MultiGetRequestBuilder add(String index, String id) {

--- a/server/src/main/java/org/elasticsearch/action/index/IndexRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/index/IndexRequestBuilder.java
@@ -28,12 +28,12 @@ public class IndexRequestBuilder extends ReplicationRequestBuilder<IndexRequest,
     implements
         WriteRequestBuilder<IndexRequestBuilder> {
 
-    public IndexRequestBuilder(ElasticsearchClient client, IndexAction action) {
-        super(client, action, new IndexRequest());
+    public IndexRequestBuilder(ElasticsearchClient client) {
+        super(client, IndexAction.INSTANCE, new IndexRequest());
     }
 
-    public IndexRequestBuilder(ElasticsearchClient client, IndexAction action, @Nullable String index) {
-        super(client, action, new IndexRequest(index));
+    public IndexRequestBuilder(ElasticsearchClient client, @Nullable String index) {
+        super(client, IndexAction.INSTANCE, new IndexRequest(index));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/ingest/DeletePipelineRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/DeletePipelineRequestBuilder.java
@@ -14,8 +14,8 @@ import org.elasticsearch.client.internal.ElasticsearchClient;
 
 public class DeletePipelineRequestBuilder extends ActionRequestBuilder<DeletePipelineRequest, AcknowledgedResponse> {
 
-    public DeletePipelineRequestBuilder(ElasticsearchClient client, DeletePipelineAction action, String id) {
-        super(client, action, new DeletePipelineRequest(id));
+    public DeletePipelineRequestBuilder(ElasticsearchClient client, String id) {
+        super(client, DeletePipelineAction.INSTANCE, new DeletePipelineRequest(id));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/ingest/GetPipelineRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/GetPipelineRequestBuilder.java
@@ -16,8 +16,8 @@ public class GetPipelineRequestBuilder extends MasterNodeReadOperationRequestBui
     GetPipelineResponse,
     GetPipelineRequestBuilder> {
 
-    public GetPipelineRequestBuilder(ElasticsearchClient client, GetPipelineAction action, String[] ids) {
-        super(client, action, new GetPipelineRequest(ids));
+    public GetPipelineRequestBuilder(ElasticsearchClient client, String[] ids) {
+        super(client, GetPipelineAction.INSTANCE, new GetPipelineRequest(ids));
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/action/ingest/PutPipelineRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/PutPipelineRequestBuilder.java
@@ -16,13 +16,7 @@ import org.elasticsearch.xcontent.XContentType;
 
 public class PutPipelineRequestBuilder extends ActionRequestBuilder<PutPipelineRequest, AcknowledgedResponse> {
 
-    public PutPipelineRequestBuilder(
-        ElasticsearchClient client,
-        PutPipelineAction action,
-        String id,
-        BytesReference source,
-        XContentType xContentType
-    ) {
-        super(client, action, new PutPipelineRequest(id, source, xContentType));
+    public PutPipelineRequestBuilder(ElasticsearchClient client, String id, BytesReference source, XContentType xContentType) {
+        super(client, PutPipelineAction.INSTANCE, new PutPipelineRequest(id, source, xContentType));
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/ingest/SimulatePipelineRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/SimulatePipelineRequestBuilder.java
@@ -18,13 +18,8 @@ public class SimulatePipelineRequestBuilder extends ActionRequestBuilder<Simulat
     /**
      * Create a new builder for {@link SimulatePipelineRequest}s
      */
-    public SimulatePipelineRequestBuilder(
-        ElasticsearchClient client,
-        SimulatePipelineAction action,
-        BytesReference source,
-        XContentType xContentType
-    ) {
-        super(client, action, new SimulatePipelineRequest(source, xContentType));
+    public SimulatePipelineRequestBuilder(ElasticsearchClient client, BytesReference source, XContentType xContentType) {
+        super(client, SimulatePipelineAction.INSTANCE, new SimulatePipelineRequest(source, xContentType));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/search/ClearScrollRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/search/ClearScrollRequestBuilder.java
@@ -9,15 +9,14 @@
 package org.elasticsearch.action.search;
 
 import org.elasticsearch.action.ActionRequestBuilder;
-import org.elasticsearch.action.ActionType;
 import org.elasticsearch.client.internal.ElasticsearchClient;
 
 import java.util.List;
 
 public class ClearScrollRequestBuilder extends ActionRequestBuilder<ClearScrollRequest, ClearScrollResponse> {
 
-    public ClearScrollRequestBuilder(ElasticsearchClient client, ActionType<ClearScrollResponse> action) {
-        super(client, action, new ClearScrollRequest());
+    public ClearScrollRequestBuilder(ElasticsearchClient client) {
+        super(client, TransportClearScrollAction.TYPE, new ClearScrollRequest());
     }
 
     public ClearScrollRequestBuilder setScrollIds(List<String> cursorIds) {

--- a/server/src/main/java/org/elasticsearch/action/search/MultiSearchRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/search/MultiSearchRequestBuilder.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.action.search;
 
 import org.elasticsearch.action.ActionRequestBuilder;
-import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.internal.ElasticsearchClient;
 
@@ -18,8 +17,8 @@ import org.elasticsearch.client.internal.ElasticsearchClient;
  */
 public class MultiSearchRequestBuilder extends ActionRequestBuilder<MultiSearchRequest, MultiSearchResponse> {
 
-    public MultiSearchRequestBuilder(ElasticsearchClient client, ActionType<MultiSearchResponse> action) {
-        super(client, action, new MultiSearchRequest());
+    public MultiSearchRequestBuilder(ElasticsearchClient client) {
+        super(client, TransportMultiSearchAction.TYPE, new MultiSearchRequest());
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.action.search;
 
 import org.elasticsearch.action.ActionRequestBuilder;
-import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.internal.ElasticsearchClient;
 import org.elasticsearch.core.Nullable;
@@ -42,8 +41,8 @@ import java.util.Map;
  */
 public class SearchRequestBuilder extends ActionRequestBuilder<SearchRequest, SearchResponse> {
 
-    public SearchRequestBuilder(ElasticsearchClient client, ActionType<SearchResponse> action) {
-        super(client, action, new SearchRequest());
+    public SearchRequestBuilder(ElasticsearchClient client) {
+        super(client, TransportSearchAction.TYPE, new SearchRequest());
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/search/SearchScrollRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchScrollRequestBuilder.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.action.search;
 
 import org.elasticsearch.action.ActionRequestBuilder;
-import org.elasticsearch.action.ActionType;
 import org.elasticsearch.client.internal.ElasticsearchClient;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.search.Scroll;
@@ -19,12 +18,12 @@ import org.elasticsearch.search.Scroll;
  */
 public class SearchScrollRequestBuilder extends ActionRequestBuilder<SearchScrollRequest, SearchResponse> {
 
-    public SearchScrollRequestBuilder(ElasticsearchClient client, ActionType<SearchResponse> action) {
-        super(client, action, new SearchScrollRequest());
+    public SearchScrollRequestBuilder(ElasticsearchClient client) {
+        super(client, TransportSearchScrollAction.TYPE, new SearchScrollRequest());
     }
 
-    public SearchScrollRequestBuilder(ElasticsearchClient client, ActionType<SearchResponse> action, String scrollId) {
-        super(client, action, new SearchScrollRequest(scrollId));
+    public SearchScrollRequestBuilder(ElasticsearchClient client, String scrollId) {
+        super(client, TransportSearchScrollAction.TYPE, new SearchScrollRequest(scrollId));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/termvectors/MultiTermVectorsRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/termvectors/MultiTermVectorsRequestBuilder.java
@@ -13,8 +13,8 @@ import org.elasticsearch.client.internal.ElasticsearchClient;
 
 public class MultiTermVectorsRequestBuilder extends ActionRequestBuilder<MultiTermVectorsRequest, MultiTermVectorsResponse> {
 
-    public MultiTermVectorsRequestBuilder(ElasticsearchClient client, MultiTermVectorsAction action) {
-        super(client, action, new MultiTermVectorsRequest());
+    public MultiTermVectorsRequestBuilder(ElasticsearchClient client) {
+        super(client, MultiTermVectorsAction.INSTANCE, new MultiTermVectorsRequest());
     }
 
     public MultiTermVectorsRequestBuilder add(String index, Iterable<String> ids) {

--- a/server/src/main/java/org/elasticsearch/action/termvectors/TermVectorsRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/termvectors/TermVectorsRequestBuilder.java
@@ -24,8 +24,8 @@ import java.util.Map;
  */
 public class TermVectorsRequestBuilder extends ActionRequestBuilder<TermVectorsRequest, TermVectorsResponse> {
 
-    public TermVectorsRequestBuilder(ElasticsearchClient client, TermVectorsAction action) {
-        super(client, action, new TermVectorsRequest());
+    public TermVectorsRequestBuilder(ElasticsearchClient client) {
+        super(client, TermVectorsAction.INSTANCE, new TermVectorsRequest());
     }
 
     /**
@@ -33,8 +33,8 @@ public class TermVectorsRequestBuilder extends ActionRequestBuilder<TermVectorsR
      * from the provided index. Use {@code index}, {@code type} and
      * {@code id} to specify the document to load.
      */
-    public TermVectorsRequestBuilder(ElasticsearchClient client, TermVectorsAction action, String index, String id) {
-        super(client, action, new TermVectorsRequest(index, id));
+    public TermVectorsRequestBuilder(ElasticsearchClient client, String index, String id) {
+        super(client, TermVectorsAction.INSTANCE, new TermVectorsRequest(index, id));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/update/UpdateRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/update/UpdateRequestBuilder.java
@@ -26,12 +26,12 @@ public class UpdateRequestBuilder extends InstanceShardOperationRequestBuilder<U
     implements
         WriteRequestBuilder<UpdateRequestBuilder> {
 
-    public UpdateRequestBuilder(ElasticsearchClient client, UpdateAction action) {
-        super(client, action, new UpdateRequest());
+    public UpdateRequestBuilder(ElasticsearchClient client) {
+        super(client, UpdateAction.INSTANCE, new UpdateRequest());
     }
 
-    public UpdateRequestBuilder(ElasticsearchClient client, UpdateAction action, String index, String id) {
-        super(client, action, new UpdateRequest(index, id));
+    public UpdateRequestBuilder(ElasticsearchClient client, String index, String id) {
+        super(client, UpdateAction.INSTANCE, new UpdateRequest(index, id));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/client/internal/support/AbstractClient.java
+++ b/server/src/main/java/org/elasticsearch/client/internal/support/AbstractClient.java
@@ -32,7 +32,6 @@ import org.elasticsearch.action.admin.cluster.node.info.NodesInfoRequest;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoRequestBuilder;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoResponse;
 import org.elasticsearch.action.admin.cluster.node.info.TransportNodesInfoAction;
-import org.elasticsearch.action.admin.cluster.node.reload.NodesReloadSecureSettingsAction;
 import org.elasticsearch.action.admin.cluster.node.reload.NodesReloadSecureSettingsRequestBuilder;
 import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsRequest;
 import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsRequestBuilder;
@@ -404,12 +403,12 @@ public abstract class AbstractClient implements Client {
 
     @Override
     public IndexRequestBuilder prepareIndex() {
-        return new IndexRequestBuilder(this, IndexAction.INSTANCE, null);
+        return new IndexRequestBuilder(this, null);
     }
 
     @Override
     public IndexRequestBuilder prepareIndex(String index) {
-        return new IndexRequestBuilder(this, IndexAction.INSTANCE, index);
+        return new IndexRequestBuilder(this, index);
     }
 
     @Override
@@ -424,12 +423,12 @@ public abstract class AbstractClient implements Client {
 
     @Override
     public UpdateRequestBuilder prepareUpdate() {
-        return new UpdateRequestBuilder(this, UpdateAction.INSTANCE, null, null);
+        return new UpdateRequestBuilder(this, null, null);
     }
 
     @Override
     public UpdateRequestBuilder prepareUpdate(String index, String id) {
-        return new UpdateRequestBuilder(this, UpdateAction.INSTANCE, index, id);
+        return new UpdateRequestBuilder(this, index, id);
     }
 
     @Override
@@ -444,7 +443,7 @@ public abstract class AbstractClient implements Client {
 
     @Override
     public DeleteRequestBuilder prepareDelete() {
-        return new DeleteRequestBuilder(this, DeleteAction.INSTANCE, null);
+        return new DeleteRequestBuilder(this, null);
     }
 
     @Override
@@ -464,12 +463,12 @@ public abstract class AbstractClient implements Client {
 
     @Override
     public BulkRequestBuilder prepareBulk() {
-        return new BulkRequestBuilder(this, BulkAction.INSTANCE);
+        return new BulkRequestBuilder(this);
     }
 
     @Override
     public BulkRequestBuilder prepareBulk(@Nullable String globalIndex) {
-        return new BulkRequestBuilder(this, BulkAction.INSTANCE, globalIndex);
+        return new BulkRequestBuilder(this, globalIndex);
     }
 
     @Override
@@ -484,7 +483,7 @@ public abstract class AbstractClient implements Client {
 
     @Override
     public GetRequestBuilder prepareGet() {
-        return new GetRequestBuilder(this, GetAction.INSTANCE, null);
+        return new GetRequestBuilder(this, null);
     }
 
     @Override
@@ -504,7 +503,7 @@ public abstract class AbstractClient implements Client {
 
     @Override
     public MultiGetRequestBuilder prepareMultiGet() {
-        return new MultiGetRequestBuilder(this, MultiGetAction.INSTANCE);
+        return new MultiGetRequestBuilder(this);
     }
 
     @Override
@@ -519,7 +518,7 @@ public abstract class AbstractClient implements Client {
 
     @Override
     public SearchRequestBuilder prepareSearch(String... indices) {
-        return new SearchRequestBuilder(this, TransportSearchAction.TYPE).setIndices(indices);
+        return new SearchRequestBuilder(this).setIndices(indices);
     }
 
     @Override
@@ -534,7 +533,7 @@ public abstract class AbstractClient implements Client {
 
     @Override
     public SearchScrollRequestBuilder prepareSearchScroll(String scrollId) {
-        return new SearchScrollRequestBuilder(this, TransportSearchScrollAction.TYPE, scrollId);
+        return new SearchScrollRequestBuilder(this, scrollId);
     }
 
     @Override
@@ -549,7 +548,7 @@ public abstract class AbstractClient implements Client {
 
     @Override
     public MultiSearchRequestBuilder prepareMultiSearch() {
-        return new MultiSearchRequestBuilder(this, TransportMultiSearchAction.TYPE);
+        return new MultiSearchRequestBuilder(this);
     }
 
     @Override
@@ -564,12 +563,12 @@ public abstract class AbstractClient implements Client {
 
     @Override
     public TermVectorsRequestBuilder prepareTermVectors() {
-        return new TermVectorsRequestBuilder(this, TermVectorsAction.INSTANCE);
+        return new TermVectorsRequestBuilder(this);
     }
 
     @Override
     public TermVectorsRequestBuilder prepareTermVectors(String index, String id) {
-        return new TermVectorsRequestBuilder(this, TermVectorsAction.INSTANCE, index, id);
+        return new TermVectorsRequestBuilder(this, index, id);
     }
 
     @Override
@@ -584,12 +583,12 @@ public abstract class AbstractClient implements Client {
 
     @Override
     public MultiTermVectorsRequestBuilder prepareMultiTermVectors() {
-        return new MultiTermVectorsRequestBuilder(this, MultiTermVectorsAction.INSTANCE);
+        return new MultiTermVectorsRequestBuilder(this);
     }
 
     @Override
     public ExplainRequestBuilder prepareExplain(String index, String id) {
-        return new ExplainRequestBuilder(this, TransportExplainAction.TYPE, index, id);
+        return new ExplainRequestBuilder(this, index, id);
     }
 
     @Override
@@ -614,7 +613,7 @@ public abstract class AbstractClient implements Client {
 
     @Override
     public ClearScrollRequestBuilder prepareClearScroll() {
-        return new ClearScrollRequestBuilder(this, TransportClearScrollAction.TYPE);
+        return new ClearScrollRequestBuilder(this);
     }
 
     @Override
@@ -629,7 +628,7 @@ public abstract class AbstractClient implements Client {
 
     @Override
     public FieldCapabilitiesRequestBuilder prepareFieldCaps(String... indices) {
-        return new FieldCapabilitiesRequestBuilder(this, FieldCapabilitiesAction.INSTANCE, indices);
+        return new FieldCapabilitiesRequestBuilder(this, indices);
     }
 
     static class Admin implements AdminClient {
@@ -695,7 +694,7 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public ClusterHealthRequestBuilder prepareHealth(String... indices) {
-            return new ClusterHealthRequestBuilder(this, ClusterHealthAction.INSTANCE).setIndices(indices);
+            return new ClusterHealthRequestBuilder(this).setIndices(indices);
         }
 
         @Override
@@ -710,7 +709,7 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public ClusterStateRequestBuilder prepareState() {
-            return new ClusterStateRequestBuilder(this, ClusterStateAction.INSTANCE);
+            return new ClusterStateRequestBuilder(this);
         }
 
         @Override
@@ -725,7 +724,7 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public ClusterRerouteRequestBuilder prepareReroute() {
-            return new ClusterRerouteRequestBuilder(this, ClusterRerouteAction.INSTANCE);
+            return new ClusterRerouteRequestBuilder(this);
         }
 
         @Override
@@ -743,12 +742,12 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public ClusterUpdateSettingsRequestBuilder prepareUpdateSettings() {
-            return new ClusterUpdateSettingsRequestBuilder(this, ClusterUpdateSettingsAction.INSTANCE);
+            return new ClusterUpdateSettingsRequestBuilder(this);
         }
 
         @Override
         public NodesReloadSecureSettingsRequestBuilder prepareReloadSecureSettings() {
-            return new NodesReloadSecureSettingsRequestBuilder(this, NodesReloadSecureSettingsAction.INSTANCE);
+            return new NodesReloadSecureSettingsRequestBuilder(this);
         }
 
         @Override
@@ -763,7 +762,7 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public NodesInfoRequestBuilder prepareNodesInfo(String... nodesIds) {
-            return new NodesInfoRequestBuilder(this, TransportNodesInfoAction.TYPE).setNodesIds(nodesIds);
+            return new NodesInfoRequestBuilder(this).setNodesIds(nodesIds);
         }
 
         @Override
@@ -778,7 +777,7 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public NodesStatsRequestBuilder prepareNodesStats(String... nodesIds) {
-            return new NodesStatsRequestBuilder(this, TransportNodesStatsAction.TYPE).setNodesIds(nodesIds);
+            return new NodesStatsRequestBuilder(this).setNodesIds(nodesIds);
         }
 
         @Override
@@ -793,7 +792,7 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public ClusterStatsRequestBuilder prepareClusterStats() {
-            return new ClusterStatsRequestBuilder(this, ClusterStatsAction.INSTANCE);
+            return new ClusterStatsRequestBuilder(this);
         }
 
         @Override
@@ -803,7 +802,7 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public NodesHotThreadsRequestBuilder prepareNodesHotThreads(String... nodesIds) {
-            return new NodesHotThreadsRequestBuilder(this, TransportNodesHotThreadsAction.TYPE).setNodesIds(nodesIds);
+            return new NodesHotThreadsRequestBuilder(this).setNodesIds(nodesIds);
         }
 
         @Override
@@ -818,7 +817,7 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public ListTasksRequestBuilder prepareListTasks(String... nodesIds) {
-            return new ListTasksRequestBuilder(this, TransportListTasksAction.TYPE).setNodesIds(nodesIds);
+            return new ListTasksRequestBuilder(this).setNodesIds(nodesIds);
         }
 
         @Override
@@ -838,7 +837,7 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public GetTaskRequestBuilder prepareGetTask(TaskId taskId) {
-            return new GetTaskRequestBuilder(this, GetTaskAction.INSTANCE).setTaskId(taskId);
+            return new GetTaskRequestBuilder(this).setTaskId(taskId);
         }
 
         @Override
@@ -853,7 +852,7 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public CancelTasksRequestBuilder prepareCancelTasks(String... nodesIds) {
-            return new CancelTasksRequestBuilder(this, CancelTasksAction.INSTANCE).setNodesIds(nodesIds);
+            return new CancelTasksRequestBuilder(this).setNodesIds(nodesIds);
         }
 
         @Override
@@ -863,12 +862,12 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public ClusterSearchShardsRequestBuilder prepareSearchShards(String... indices) {
-            return new ClusterSearchShardsRequestBuilder(this, ClusterSearchShardsAction.INSTANCE).setIndices(indices);
+            return new ClusterSearchShardsRequestBuilder(this).setIndices(indices);
         }
 
         @Override
         public PendingClusterTasksRequestBuilder preparePendingClusterTasks() {
-            return new PendingClusterTasksRequestBuilder(this, PendingClusterTasksAction.INSTANCE);
+            return new PendingClusterTasksRequestBuilder(this);
         }
 
         @Override
@@ -883,7 +882,7 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public PutRepositoryRequestBuilder preparePutRepository(String name) {
-            return new PutRepositoryRequestBuilder(this, PutRepositoryAction.INSTANCE, name);
+            return new PutRepositoryRequestBuilder(this, name);
         }
 
         @Override
@@ -898,12 +897,12 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public CreateSnapshotRequestBuilder prepareCreateSnapshot(String repository, String name) {
-            return new CreateSnapshotRequestBuilder(this, CreateSnapshotAction.INSTANCE, repository, name);
+            return new CreateSnapshotRequestBuilder(this, repository, name);
         }
 
         @Override
         public CloneSnapshotRequestBuilder prepareCloneSnapshot(String repository, String source, String target) {
-            return new CloneSnapshotRequestBuilder(this, CloneSnapshotAction.INSTANCE, repository, source, target);
+            return new CloneSnapshotRequestBuilder(this, repository, source, target);
         }
 
         @Override
@@ -918,7 +917,7 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public GetSnapshotsRequestBuilder prepareGetSnapshots(String... repositories) {
-            return new GetSnapshotsRequestBuilder(this, GetSnapshotsAction.INSTANCE, repositories);
+            return new GetSnapshotsRequestBuilder(this, repositories);
         }
 
         @Override
@@ -928,7 +927,7 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public DeleteSnapshotRequestBuilder prepareDeleteSnapshot(String repository, String... names) {
-            return new DeleteSnapshotRequestBuilder(this, DeleteSnapshotAction.INSTANCE, repository, names);
+            return new DeleteSnapshotRequestBuilder(this, repository, names);
         }
 
         @Override
@@ -938,7 +937,7 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public DeleteRepositoryRequestBuilder prepareDeleteRepository(String name) {
-            return new DeleteRepositoryRequestBuilder(this, DeleteRepositoryAction.INSTANCE, name);
+            return new DeleteRepositoryRequestBuilder(this, name);
         }
 
         @Override
@@ -948,7 +947,7 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public VerifyRepositoryRequestBuilder prepareVerifyRepository(String name) {
-            return new VerifyRepositoryRequestBuilder(this, VerifyRepositoryAction.INSTANCE, name);
+            return new VerifyRepositoryRequestBuilder(this, name);
         }
 
         @Override
@@ -958,12 +957,12 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public GetRepositoriesRequestBuilder prepareGetRepositories(String... name) {
-            return new GetRepositoriesRequestBuilder(this, GetRepositoriesAction.INSTANCE, name);
+            return new GetRepositoriesRequestBuilder(this, name);
         }
 
         @Override
         public CleanupRepositoryRequestBuilder prepareCleanupRepository(String repository) {
-            return new CleanupRepositoryRequestBuilder(this, CleanupRepositoryAction.INSTANCE, repository);
+            return new CleanupRepositoryRequestBuilder(this, repository);
         }
 
         @Override
@@ -983,7 +982,7 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public RestoreSnapshotRequestBuilder prepareRestoreSnapshot(String repository, String snapshot) {
-            return new RestoreSnapshotRequestBuilder(this, RestoreSnapshotAction.INSTANCE, repository, snapshot);
+            return new RestoreSnapshotRequestBuilder(this, repository, snapshot);
         }
 
         @Override
@@ -993,12 +992,12 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public SnapshotsStatusRequestBuilder prepareSnapshotStatus(String repository) {
-            return new SnapshotsStatusRequestBuilder(this, SnapshotsStatusAction.INSTANCE, repository);
+            return new SnapshotsStatusRequestBuilder(this, repository);
         }
 
         @Override
         public SnapshotsStatusRequestBuilder prepareSnapshotStatus() {
-            return new SnapshotsStatusRequestBuilder(this, SnapshotsStatusAction.INSTANCE);
+            return new SnapshotsStatusRequestBuilder(this);
         }
 
         @Override
@@ -1013,7 +1012,7 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public PutPipelineRequestBuilder preparePutPipeline(String id, BytesReference source, XContentType xContentType) {
-            return new PutPipelineRequestBuilder(this, PutPipelineAction.INSTANCE, id, source, xContentType);
+            return new PutPipelineRequestBuilder(this, id, source, xContentType);
         }
 
         @Override
@@ -1028,7 +1027,7 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public DeletePipelineRequestBuilder prepareDeletePipeline(String id) {
-            return new DeletePipelineRequestBuilder(this, DeletePipelineAction.INSTANCE, id);
+            return new DeletePipelineRequestBuilder(this, id);
         }
 
         @Override
@@ -1038,7 +1037,7 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public GetPipelineRequestBuilder prepareGetPipeline(String... ids) {
-            return new GetPipelineRequestBuilder(this, GetPipelineAction.INSTANCE, ids);
+            return new GetPipelineRequestBuilder(this, ids);
         }
 
         @Override
@@ -1053,7 +1052,7 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public SimulatePipelineRequestBuilder prepareSimulatePipeline(BytesReference source, XContentType xContentType) {
-            return new SimulatePipelineRequestBuilder(this, SimulatePipelineAction.INSTANCE, source, xContentType);
+            return new SimulatePipelineRequestBuilder(this, source, xContentType);
         }
 
         @Override
@@ -1108,12 +1107,12 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public GetStoredScriptRequestBuilder prepareGetStoredScript(String id) {
-            return new GetStoredScriptRequestBuilder(this, GetStoredScriptAction.INSTANCE).setId(id);
+            return new GetStoredScriptRequestBuilder(this).setId(id);
         }
 
         @Override
         public PutStoredScriptRequestBuilder preparePutStoredScript() {
-            return new PutStoredScriptRequestBuilder(this, PutStoredScriptAction.INSTANCE);
+            return new PutStoredScriptRequestBuilder(this);
         }
 
         @Override
@@ -1129,7 +1128,7 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public DeleteStoredScriptRequestBuilder prepareDeleteStoredScript(String id) {
-            return new DeleteStoredScriptRequestBuilder(client, DeleteStoredScriptAction.INSTANCE).setId(id);
+            return new DeleteStoredScriptRequestBuilder(client).setId(id);
         }
     }
 
@@ -1175,7 +1174,7 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public IndicesAliasesRequestBuilder prepareAliases() {
-            return new IndicesAliasesRequestBuilder(this, IndicesAliasesAction.INSTANCE);
+            return new IndicesAliasesRequestBuilder(this);
         }
 
         @Override
@@ -1190,7 +1189,7 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public GetAliasesRequestBuilder prepareGetAliases(String... aliases) {
-            return new GetAliasesRequestBuilder(this, GetAliasesAction.INSTANCE, aliases);
+            return new GetAliasesRequestBuilder(this, aliases);
         }
 
         @Override
@@ -1210,7 +1209,7 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public GetIndexRequestBuilder prepareGetIndex() {
-            return new GetIndexRequestBuilder(this, GetIndexAction.INSTANCE);
+            return new GetIndexRequestBuilder(this);
         }
 
         @Override
@@ -1220,7 +1219,7 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public ClearIndicesCacheRequestBuilder prepareClearCache(String... indices) {
-            return new ClearIndicesCacheRequestBuilder(this, ClearIndicesCacheAction.INSTANCE).setIndices(indices);
+            return new ClearIndicesCacheRequestBuilder(this).setIndices(indices);
         }
 
         @Override
@@ -1235,7 +1234,7 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public CreateIndexRequestBuilder prepareCreate(String index) {
-            return new CreateIndexRequestBuilder(this, CreateIndexAction.INSTANCE, index);
+            return new CreateIndexRequestBuilder(this, index);
         }
 
         @Override
@@ -1250,7 +1249,7 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public DeleteIndexRequestBuilder prepareDelete(String... indices) {
-            return new DeleteIndexRequestBuilder(this, DeleteIndexAction.INSTANCE, indices);
+            return new DeleteIndexRequestBuilder(this, indices);
         }
 
         @Override
@@ -1265,7 +1264,7 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public CloseIndexRequestBuilder prepareClose(String... indices) {
-            return new CloseIndexRequestBuilder(this, CloseIndexAction.INSTANCE, indices);
+            return new CloseIndexRequestBuilder(this, indices);
         }
 
         @Override
@@ -1280,7 +1279,7 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public AddIndexBlockRequestBuilder prepareAddBlock(APIBlock block, String... indices) {
-            return new AddIndexBlockRequestBuilder(this, AddIndexBlockAction.INSTANCE, block, indices);
+            return new AddIndexBlockRequestBuilder(this, block, indices);
         }
 
         @Override
@@ -1290,7 +1289,7 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public OpenIndexRequestBuilder prepareOpen(String... indices) {
-            return new OpenIndexRequestBuilder(this, OpenIndexAction.INSTANCE, indices);
+            return new OpenIndexRequestBuilder(this, indices);
         }
 
         @Override
@@ -1305,7 +1304,7 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public FlushRequestBuilder prepareFlush(String... indices) {
-            return new FlushRequestBuilder(this, FlushAction.INSTANCE).setIndices(indices);
+            return new FlushRequestBuilder(this).setIndices(indices);
         }
 
         @Override
@@ -1320,7 +1319,7 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public GetMappingsRequestBuilder prepareGetMappings(String... indices) {
-            return new GetMappingsRequestBuilder(this, GetMappingsAction.INSTANCE, indices);
+            return new GetMappingsRequestBuilder(this, indices);
         }
 
         @Override
@@ -1330,7 +1329,7 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public GetFieldMappingsRequestBuilder prepareGetFieldMappings(String... indices) {
-            return new GetFieldMappingsRequestBuilder(this, GetFieldMappingsAction.INSTANCE, indices);
+            return new GetFieldMappingsRequestBuilder(this, indices);
         }
 
         @Override
@@ -1350,7 +1349,7 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public PutMappingRequestBuilder preparePutMapping(String... indices) {
-            return new PutMappingRequestBuilder(this, PutMappingAction.INSTANCE).setIndices(indices);
+            return new PutMappingRequestBuilder(this).setIndices(indices);
         }
 
         @Override
@@ -1365,7 +1364,7 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public ForceMergeRequestBuilder prepareForceMerge(String... indices) {
-            return new ForceMergeRequestBuilder(this, ForceMergeAction.INSTANCE).setIndices(indices);
+            return new ForceMergeRequestBuilder(this).setIndices(indices);
         }
 
         @Override
@@ -1380,7 +1379,7 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public RefreshRequestBuilder prepareRefresh(String... indices) {
-            return new RefreshRequestBuilder(this, RefreshAction.INSTANCE).setIndices(indices);
+            return new RefreshRequestBuilder(this).setIndices(indices);
         }
 
         @Override
@@ -1395,7 +1394,7 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public IndicesStatsRequestBuilder prepareStats(String... indices) {
-            return new IndicesStatsRequestBuilder(this, IndicesStatsAction.INSTANCE).setIndices(indices);
+            return new IndicesStatsRequestBuilder(this).setIndices(indices);
         }
 
         @Override
@@ -1410,7 +1409,7 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public RecoveryRequestBuilder prepareRecoveries(String... indices) {
-            return new RecoveryRequestBuilder(this, RecoveryAction.INSTANCE).setIndices(indices);
+            return new RecoveryRequestBuilder(this).setIndices(indices);
         }
 
         @Override
@@ -1425,7 +1424,7 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public IndicesSegmentsRequestBuilder prepareSegments(String... indices) {
-            return new IndicesSegmentsRequestBuilder(this, IndicesSegmentsAction.INSTANCE).setIndices(indices);
+            return new IndicesSegmentsRequestBuilder(this).setIndices(indices);
         }
 
         @Override
@@ -1440,7 +1439,7 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public IndicesShardStoreRequestBuilder prepareShardStores(String... indices) {
-            return new IndicesShardStoreRequestBuilder(this, IndicesShardStoresAction.INSTANCE, indices);
+            return new IndicesShardStoreRequestBuilder(this, indices);
         }
 
         @Override
@@ -1455,7 +1454,7 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public UpdateSettingsRequestBuilder prepareUpdateSettings(String... indices) {
-            return new UpdateSettingsRequestBuilder(this, UpdateSettingsAction.INSTANCE).setIndices(indices);
+            return new UpdateSettingsRequestBuilder(this).setIndices(indices);
         }
 
         @Override
@@ -1470,17 +1469,17 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public AnalyzeRequestBuilder prepareAnalyze(@Nullable String index, String text) {
-            return new AnalyzeRequestBuilder(this, AnalyzeAction.INSTANCE, index, text);
+            return new AnalyzeRequestBuilder(this, index, text);
         }
 
         @Override
         public AnalyzeRequestBuilder prepareAnalyze(String text) {
-            return new AnalyzeRequestBuilder(this, AnalyzeAction.INSTANCE, null, text);
+            return new AnalyzeRequestBuilder(this, null, text);
         }
 
         @Override
         public AnalyzeRequestBuilder prepareAnalyze() {
-            return new AnalyzeRequestBuilder(this, AnalyzeAction.INSTANCE);
+            return new AnalyzeRequestBuilder(this);
         }
 
         @Override
@@ -1495,7 +1494,7 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public PutIndexTemplateRequestBuilder preparePutTemplate(String name) {
-            return new PutIndexTemplateRequestBuilder(this, PutIndexTemplateAction.INSTANCE, name);
+            return new PutIndexTemplateRequestBuilder(this, name);
         }
 
         @Override
@@ -1505,7 +1504,7 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public GetIndexTemplatesRequestBuilder prepareGetTemplates(String... names) {
-            return new GetIndexTemplatesRequestBuilder(this, GetIndexTemplatesAction.INSTANCE, names);
+            return new GetIndexTemplatesRequestBuilder(this, names);
         }
 
         @Override
@@ -1515,7 +1514,7 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public DeleteIndexTemplateRequestBuilder prepareDeleteTemplate(String name) {
-            return new DeleteIndexTemplateRequestBuilder(this, DeleteIndexTemplateAction.INSTANCE, name);
+            return new DeleteIndexTemplateRequestBuilder(this, name);
         }
 
         @Override
@@ -1530,18 +1529,17 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public ValidateQueryRequestBuilder prepareValidateQuery(String... indices) {
-            return new ValidateQueryRequestBuilder(this, ValidateQueryAction.INSTANCE).setIndices(indices);
+            return new ValidateQueryRequestBuilder(this).setIndices(indices);
         }
 
         @Override
         public GetSettingsRequestBuilder prepareGetSettings(String... indices) {
-            return new GetSettingsRequestBuilder(this, GetSettingsAction.INSTANCE, indices);
+            return new GetSettingsRequestBuilder(this, indices);
         }
 
         @Override
         public ResizeRequestBuilder prepareResizeIndex(String sourceIndex, String targetIndex) {
-            return new ResizeRequestBuilder(this, ResizeAction.INSTANCE).setSourceIndex(sourceIndex)
-                .setTargetIndex(new CreateIndexRequest(targetIndex));
+            return new ResizeRequestBuilder(this).setSourceIndex(sourceIndex).setTargetIndex(new CreateIndexRequest(targetIndex));
         }
 
         @Override
@@ -1551,7 +1549,7 @@ public abstract class AbstractClient implements Client {
 
         @Override
         public RolloverRequestBuilder prepareRolloverIndex(String alias) {
-            return new RolloverRequestBuilder(this, RolloverAction.INSTANCE).setRolloverTarget(alias);
+            return new RolloverRequestBuilder(this).setRolloverTarget(alias);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/reindex/DeleteByQueryRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/DeleteByQueryRequestBuilder.java
@@ -8,19 +8,17 @@
 
 package org.elasticsearch.index.reindex;
 
-import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.search.SearchRequestBuilder;
-import org.elasticsearch.action.search.TransportSearchAction;
 import org.elasticsearch.client.internal.ElasticsearchClient;
 
 public class DeleteByQueryRequestBuilder extends AbstractBulkByScrollRequestBuilder<DeleteByQueryRequest, DeleteByQueryRequestBuilder> {
 
-    public DeleteByQueryRequestBuilder(ElasticsearchClient client, ActionType<BulkByScrollResponse> action) {
-        this(client, action, new SearchRequestBuilder(client, TransportSearchAction.TYPE));
+    public DeleteByQueryRequestBuilder(ElasticsearchClient client) {
+        this(client, new SearchRequestBuilder(client));
     }
 
-    private DeleteByQueryRequestBuilder(ElasticsearchClient client, ActionType<BulkByScrollResponse> action, SearchRequestBuilder search) {
-        super(client, action, search, new DeleteByQueryRequest(search.request()));
+    private DeleteByQueryRequestBuilder(ElasticsearchClient client, SearchRequestBuilder search) {
+        super(client, DeleteByQueryAction.INSTANCE, search, new DeleteByQueryRequest(search.request()));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/reindex/ReindexRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/ReindexRequestBuilder.java
@@ -8,32 +8,19 @@
 
 package org.elasticsearch.index.reindex;
 
-import org.elasticsearch.action.ActionType;
-import org.elasticsearch.action.index.IndexAction;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchRequestBuilder;
-import org.elasticsearch.action.search.TransportSearchAction;
 import org.elasticsearch.client.internal.ElasticsearchClient;
 
 public class ReindexRequestBuilder extends AbstractBulkIndexByScrollRequestBuilder<ReindexRequest, ReindexRequestBuilder> {
     private final IndexRequestBuilder destination;
 
-    public ReindexRequestBuilder(ElasticsearchClient client, ActionType<BulkByScrollResponse> action) {
-        this(
-            client,
-            action,
-            new SearchRequestBuilder(client, TransportSearchAction.TYPE),
-            new IndexRequestBuilder(client, IndexAction.INSTANCE)
-        );
+    public ReindexRequestBuilder(ElasticsearchClient client) {
+        this(client, new SearchRequestBuilder(client), new IndexRequestBuilder(client));
     }
 
-    private ReindexRequestBuilder(
-        ElasticsearchClient client,
-        ActionType<BulkByScrollResponse> action,
-        SearchRequestBuilder search,
-        IndexRequestBuilder destination
-    ) {
-        super(client, action, search, new ReindexRequest(search.request(), destination.request()));
+    private ReindexRequestBuilder(ElasticsearchClient client, SearchRequestBuilder search, IndexRequestBuilder destination) {
+        super(client, ReindexAction.INSTANCE, search, new ReindexRequest(search.request(), destination.request()));
         this.destination = destination;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/reindex/UpdateByQueryRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/UpdateByQueryRequestBuilder.java
@@ -8,21 +8,19 @@
 
 package org.elasticsearch.index.reindex;
 
-import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.search.SearchRequestBuilder;
-import org.elasticsearch.action.search.TransportSearchAction;
 import org.elasticsearch.client.internal.ElasticsearchClient;
 
 public class UpdateByQueryRequestBuilder extends AbstractBulkIndexByScrollRequestBuilder<
     UpdateByQueryRequest,
     UpdateByQueryRequestBuilder> {
 
-    public UpdateByQueryRequestBuilder(ElasticsearchClient client, ActionType<BulkByScrollResponse> action) {
-        this(client, action, new SearchRequestBuilder(client, TransportSearchAction.TYPE));
+    public UpdateByQueryRequestBuilder(ElasticsearchClient client) {
+        this(client, new SearchRequestBuilder(client));
     }
 
-    private UpdateByQueryRequestBuilder(ElasticsearchClient client, ActionType<BulkByScrollResponse> action, SearchRequestBuilder search) {
-        super(client, action, search, new UpdateByQueryRequest(search.request()));
+    private UpdateByQueryRequestBuilder(ElasticsearchClient client, SearchRequestBuilder search) {
+        super(client, UpdateByQueryAction.INSTANCE, search, new UpdateByQueryRequest(search.request()));
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequestBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequestBuilderTests.java
@@ -51,7 +51,7 @@ public class CreateIndexRequestBuilderTests extends ESTestCase {
      * test setting the source with available setters
      */
     public void testSetSource() throws IOException {
-        CreateIndexRequestBuilder builder = new CreateIndexRequestBuilder(this.testClient, CreateIndexAction.INSTANCE);
+        CreateIndexRequestBuilder builder = new CreateIndexRequestBuilder(this.testClient);
 
         ElasticsearchParseException e = expectThrows(ElasticsearchParseException.class, () -> {
             builder.setSource(Strings.format("{ \"%s\": \"%s\" }", KEY, VALUE), XContentType.JSON);
@@ -92,7 +92,7 @@ public class CreateIndexRequestBuilderTests extends ESTestCase {
      * test setting the settings with available setters
      */
     public void testSetSettings() throws IOException {
-        CreateIndexRequestBuilder builder = new CreateIndexRequestBuilder(this.testClient, CreateIndexAction.INSTANCE);
+        CreateIndexRequestBuilder builder = new CreateIndexRequestBuilder(this.testClient);
         builder.setSettings(Settings.builder().put(KEY, VALUE));
         assertEquals(VALUE, builder.request().settings().get(KEY));
 

--- a/server/src/test/java/org/elasticsearch/action/get/TransportMultiGetActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/get/TransportMultiGetActionTests.java
@@ -188,7 +188,7 @@ public class TransportMultiGetActionTests extends ESTestCase {
     public void testTransportMultiGetAction() {
         final Task task = createTask();
         final NodeClient client = new NodeClient(Settings.EMPTY, threadPool);
-        final MultiGetRequestBuilder request = new MultiGetRequestBuilder(client, MultiGetAction.INSTANCE);
+        final MultiGetRequestBuilder request = new MultiGetRequestBuilder(client);
         request.add(new MultiGetRequest.Item("index1", "1"));
         request.add(new MultiGetRequest.Item("index1", "2"));
 
@@ -221,7 +221,7 @@ public class TransportMultiGetActionTests extends ESTestCase {
     public void testTransportMultiGetAction_withMissingRouting() {
         final Task task = createTask();
         final NodeClient client = new NodeClient(Settings.EMPTY, threadPool);
-        final MultiGetRequestBuilder request = new MultiGetRequestBuilder(client, MultiGetAction.INSTANCE);
+        final MultiGetRequestBuilder request = new MultiGetRequestBuilder(client);
         request.add(new MultiGetRequest.Item("index2", "1").routing("1"));
         request.add(new MultiGetRequest.Item("index2", "2"));
 

--- a/server/src/test/java/org/elasticsearch/action/index/IndexRequestBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/action/index/IndexRequestBuilderTests.java
@@ -47,7 +47,7 @@ public class IndexRequestBuilderTests extends ESTestCase {
      * test setting the source for the request with different available setters
      */
     public void testSetSource() throws Exception {
-        IndexRequestBuilder indexRequestBuilder = new IndexRequestBuilder(this.testClient, IndexAction.INSTANCE);
+        IndexRequestBuilder indexRequestBuilder = new IndexRequestBuilder(this.testClient);
         Map<String, String> source = new HashMap<>();
         source.put("SomeKey", "SomeValue");
         indexRequestBuilder.setSource(source);

--- a/server/src/test/java/org/elasticsearch/action/search/SearchRequestBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchRequestBuilderTests.java
@@ -20,7 +20,7 @@ public class SearchRequestBuilderTests extends ESTestCase {
 
     private SearchRequestBuilder makeBuilder() {
         ElasticsearchClient client = Mockito.mock(ElasticsearchClient.class);
-        return new SearchRequestBuilder(client, TransportSearchAction.TYPE);
+        return new SearchRequestBuilder(client);
     }
 
     public void testEmptySourceToString() {

--- a/server/src/test/java/org/elasticsearch/action/termvectors/TransportMultiTermVectorsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/termvectors/TransportMultiTermVectorsActionTests.java
@@ -190,7 +190,7 @@ public class TransportMultiTermVectorsActionTests extends ESTestCase {
     public void testTransportMultiGetAction() {
         final Task task = createTask();
         final NodeClient client = new NodeClient(Settings.EMPTY, threadPool);
-        final MultiTermVectorsRequestBuilder request = new MultiTermVectorsRequestBuilder(client, MultiTermVectorsAction.INSTANCE);
+        final MultiTermVectorsRequestBuilder request = new MultiTermVectorsRequestBuilder(client);
         request.add(new TermVectorsRequest("index1", "1"));
         request.add(new TermVectorsRequest("index2", "2"));
 
@@ -222,7 +222,7 @@ public class TransportMultiTermVectorsActionTests extends ESTestCase {
     public void testTransportMultiGetAction_withMissingRouting() {
         final Task task = createTask();
         final NodeClient client = new NodeClient(Settings.EMPTY, threadPool);
-        final MultiTermVectorsRequestBuilder request = new MultiTermVectorsRequestBuilder(client, MultiTermVectorsAction.INSTANCE);
+        final MultiTermVectorsRequestBuilder request = new MultiTermVectorsRequestBuilder(client);
         request.add(new TermVectorsRequest("index2", "1").routing("1"));
         request.add(new TermVectorsRequest("index2", "2"));
 

--- a/server/src/test/java/org/elasticsearch/search/vectors/KnnSearchRequestParserTests.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/KnnSearchRequestParserTests.java
@@ -10,7 +10,6 @@ package org.elasticsearch.search.vectors;
 
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchRequestBuilder;
-import org.elasticsearch.action.search.TransportSearchAction;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.query.QueryBuilder;
@@ -224,7 +223,7 @@ public class KnnSearchRequestParserTests extends ESTestCase {
                 .withContent(BytesReference.bytes(builder), builder.contentType())
                 .build()
         );
-        SearchRequestBuilder searchRequestBuilder = new SearchRequestBuilder(null, TransportSearchAction.TYPE);
+        SearchRequestBuilder searchRequestBuilder = new SearchRequestBuilder(null);
         knnRequestBuilder.toSearchRequest(searchRequestBuilder);
         return searchRequestBuilder;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/DeleteLicenseRequestBuilder.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/DeleteLicenseRequestBuilder.java
@@ -17,15 +17,6 @@ public class DeleteLicenseRequestBuilder extends AcknowledgedRequestBuilder<
     DeleteLicenseRequestBuilder> {
 
     public DeleteLicenseRequestBuilder(ElasticsearchClient client) {
-        this(client, DeleteLicenseAction.INSTANCE);
-    }
-
-    /**
-     * Creates new get licenses request builder
-     *
-     * @param client elasticsearch client
-     */
-    public DeleteLicenseRequestBuilder(ElasticsearchClient client, DeleteLicenseAction action) {
-        super(client, action, new DeleteLicenseRequest());
+        super(client, DeleteLicenseAction.INSTANCE, new DeleteLicenseRequest());
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/PutLicenseRequestBuilder.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/PutLicenseRequestBuilder.java
@@ -17,17 +17,13 @@ import org.elasticsearch.xcontent.XContentType;
  */
 public class PutLicenseRequestBuilder extends AcknowledgedRequestBuilder<PutLicenseRequest, PutLicenseResponse, PutLicenseRequestBuilder> {
 
-    public PutLicenseRequestBuilder(ElasticsearchClient client) {
-        this(client, PutLicenseAction.INSTANCE);
-    }
-
     /**
      * Constructs register license request
      *
      * @param client elasticsearch client
      */
-    public PutLicenseRequestBuilder(ElasticsearchClient client, PutLicenseAction action) {
-        super(client, action, new PutLicenseRequest());
+    public PutLicenseRequestBuilder(ElasticsearchClient client) {
+        super(client, PutLicenseAction.INSTANCE, new PutLicenseRequest());
     }
 
     /**

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackInfoRequestBuilder.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackInfoRequestBuilder.java
@@ -16,11 +16,7 @@ import java.util.EnumSet;
 public class XPackInfoRequestBuilder extends ActionRequestBuilder<XPackInfoRequest, XPackInfoResponse> {
 
     public XPackInfoRequestBuilder(ElasticsearchClient client) {
-        this(client, XPackInfoAction.INSTANCE);
-    }
-
-    public XPackInfoRequestBuilder(ElasticsearchClient client, XPackInfoAction action) {
-        super(client, action, new XPackInfoRequest());
+        super(client, XPackInfoAction.INSTANCE, new XPackInfoRequest());
     }
 
     public XPackInfoRequestBuilder setVerbose(boolean verbose) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/graph/action/GraphExploreRequestBuilder.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/graph/action/GraphExploreRequestBuilder.java
@@ -26,8 +26,8 @@ import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregator;
  */
 public class GraphExploreRequestBuilder extends ActionRequestBuilder<GraphExploreRequest, GraphExploreResponse> {
 
-    public GraphExploreRequestBuilder(ElasticsearchClient client, GraphExploreAction action) {
-        super(client, action, new GraphExploreRequest());
+    public GraphExploreRequestBuilder(ElasticsearchClient client) {
+        super(client, GraphExploreAction.INSTANCE, new GraphExploreRequest());
     }
 
     public GraphExploreRequestBuilder setIndices(String... indices) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/PutRoleRequestBuilder.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/PutRoleRequestBuilder.java
@@ -25,11 +25,7 @@ public class PutRoleRequestBuilder extends ActionRequestBuilder<PutRoleRequest, 
         WriteRequestBuilder<PutRoleRequestBuilder> {
 
     public PutRoleRequestBuilder(ElasticsearchClient client) {
-        this(client, PutRoleAction.INSTANCE);
-    }
-
-    public PutRoleRequestBuilder(ElasticsearchClient client, PutRoleAction action) {
-        super(client, action, new PutRoleRequest());
+        super(client, PutRoleAction.INSTANCE, new PutRoleRequest());
     }
 
     /**

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/token/CreateTokenRequestBuilder.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/token/CreateTokenRequestBuilder.java
@@ -7,7 +7,6 @@
 package org.elasticsearch.xpack.core.security.action.token;
 
 import org.elasticsearch.action.ActionRequestBuilder;
-import org.elasticsearch.action.ActionType;
 import org.elasticsearch.client.internal.ElasticsearchClient;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.core.Nullable;
@@ -17,8 +16,8 @@ import org.elasticsearch.core.Nullable;
  */
 public final class CreateTokenRequestBuilder extends ActionRequestBuilder<CreateTokenRequest, CreateTokenResponse> {
 
-    public CreateTokenRequestBuilder(ElasticsearchClient client, ActionType<CreateTokenResponse> action) {
-        super(client, action, new CreateTokenRequest());
+    public CreateTokenRequestBuilder(ElasticsearchClient client) {
+        super(client, CreateTokenAction.INSTANCE, new CreateTokenRequest());
     }
 
     /**

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/DeleteUserRequestBuilder.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/DeleteUserRequestBuilder.java
@@ -15,11 +15,7 @@ public class DeleteUserRequestBuilder extends ActionRequestBuilder<DeleteUserReq
         WriteRequestBuilder<DeleteUserRequestBuilder> {
 
     public DeleteUserRequestBuilder(ElasticsearchClient client) {
-        this(client, DeleteUserAction.INSTANCE);
-    }
-
-    public DeleteUserRequestBuilder(ElasticsearchClient client, DeleteUserAction action) {
-        super(client, action, new DeleteUserRequest());
+        super(client, DeleteUserAction.INSTANCE, new DeleteUserRequest());
     }
 
     public DeleteUserRequestBuilder username(String username) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/GetUsersRequestBuilder.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/GetUsersRequestBuilder.java
@@ -12,11 +12,7 @@ import org.elasticsearch.client.internal.ElasticsearchClient;
 public class GetUsersRequestBuilder extends ActionRequestBuilder<GetUsersRequest, GetUsersResponse> {
 
     public GetUsersRequestBuilder(ElasticsearchClient client) {
-        this(client, GetUsersAction.INSTANCE);
-    }
-
-    public GetUsersRequestBuilder(ElasticsearchClient client, GetUsersAction action) {
-        super(client, action, new GetUsersRequest());
+        super(client, GetUsersAction.INSTANCE, new GetUsersRequest());
     }
 
     public GetUsersRequestBuilder usernames(String... usernames) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/PutUserRequestBuilder.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/PutUserRequestBuilder.java
@@ -35,11 +35,7 @@ public class PutUserRequestBuilder extends ActionRequestBuilder<PutUserRequest, 
         WriteRequestBuilder<PutUserRequestBuilder> {
 
     public PutUserRequestBuilder(ElasticsearchClient client) {
-        this(client, PutUserAction.INSTANCE);
-    }
-
-    public PutUserRequestBuilder(ElasticsearchClient client, PutUserAction action) {
-        super(client, action, new PutUserRequest());
+        super(client, PutUserAction.INSTANCE, new PutUserRequest());
     }
 
     public PutUserRequestBuilder username(String username) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/action/GetCertificateInfoAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/action/GetCertificateInfoAction.java
@@ -87,13 +87,8 @@ public class GetCertificateInfoAction extends ActionType<GetCertificateInfoActio
     }
 
     public static class RequestBuilder extends ActionRequestBuilder<Request, Response> {
-
-        public RequestBuilder(ElasticsearchClient client, GetCertificateInfoAction action) {
-            super(client, action, new Request());
-        }
-
         public RequestBuilder(ElasticsearchClient client) {
-            this(client, GetCertificateInfoAction.INSTANCE);
+            super(client, GetCertificateInfoAction.INSTANCE, new Request());
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/rest/RestGetCertificateInfoAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ssl/rest/RestGetCertificateInfoAction.java
@@ -42,13 +42,11 @@ public class RestGetCertificateInfoAction extends BaseRestHandler {
 
     @Override
     protected final RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
-        return channel -> new GetCertificateInfoAction.RequestBuilder(client, GetCertificateInfoAction.INSTANCE).execute(
-            new RestBuilderListener<Response>(channel) {
-                @Override
-                public RestResponse buildResponse(Response response, XContentBuilder builder) throws Exception {
-                    return new RestResponse(RestStatus.OK, response.toXContent(builder, request));
-                }
+        return channel -> new GetCertificateInfoAction.RequestBuilder(client).execute(new RestBuilderListener<>(channel) {
+            @Override
+            public RestResponse buildResponse(Response response, XContentBuilder builder) throws Exception {
+                return new RestResponse(RestStatus.OK, response.toXContent(builder, request));
             }
-        );
+        });
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicensesTransportTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicensesTransportTests.java
@@ -76,8 +76,7 @@ public class LicensesTransportTests extends ESSingleNodeTestCase {
         License signedLicense = generateSignedLicense(TimeValue.timeValueMinutes(2));
 
         // put license
-        PutLicenseRequestBuilder putLicenseRequestBuilder = new PutLicenseRequestBuilder(clusterAdmin(), PutLicenseAction.INSTANCE)
-            .setLicense(signedLicense)
+        PutLicenseRequestBuilder putLicenseRequestBuilder = new PutLicenseRequestBuilder(clusterAdmin()).setLicense(signedLicense)
             .setAcknowledge(true);
         PutLicenseResponse putLicenseResponse = putLicenseRequestBuilder.get();
         assertThat(putLicenseResponse.isAcknowledged(), equalTo(true));
@@ -93,9 +92,10 @@ public class LicensesTransportTests extends ESSingleNodeTestCase {
         String licenseString = TestUtils.dumpLicense(signedLicense);
 
         // put license source
-        PutLicenseRequestBuilder putLicenseRequestBuilder = new PutLicenseRequestBuilder(clusterAdmin(), PutLicenseAction.INSTANCE)
-            .setLicense(new BytesArray(licenseString.getBytes(StandardCharsets.UTF_8)), XContentType.JSON)
-            .setAcknowledge(true);
+        PutLicenseRequestBuilder putLicenseRequestBuilder = new PutLicenseRequestBuilder(clusterAdmin()).setLicense(
+            new BytesArray(licenseString.getBytes(StandardCharsets.UTF_8)),
+            XContentType.JSON
+        ).setAcknowledge(true);
         PutLicenseResponse putLicenseResponse = putLicenseRequestBuilder.get();
         assertThat(putLicenseResponse.isAcknowledged(), equalTo(true));
         assertThat(putLicenseResponse.status(), equalTo(LicensesStatus.VALID));
@@ -115,7 +115,7 @@ public class LicensesTransportTests extends ESSingleNodeTestCase {
             .validate()
             .build();
 
-        PutLicenseRequestBuilder builder = new PutLicenseRequestBuilder(clusterAdmin(), PutLicenseAction.INSTANCE);
+        PutLicenseRequestBuilder builder = new PutLicenseRequestBuilder(clusterAdmin());
         builder.setLicense(tamperedLicense);
 
         // try to put license (should be invalid)
@@ -130,7 +130,7 @@ public class LicensesTransportTests extends ESSingleNodeTestCase {
     public void testPutBasicLicenseIsInvalid() throws Exception {
         License signedLicense = generateSignedLicense("basic", License.VERSION_CURRENT, -1, TimeValue.timeValueMinutes(2));
 
-        PutLicenseRequestBuilder builder = new PutLicenseRequestBuilder(clusterAdmin(), PutLicenseAction.INSTANCE);
+        PutLicenseRequestBuilder builder = new PutLicenseRequestBuilder(clusterAdmin());
         builder.setLicense(signedLicense);
 
         // try to put license (should be invalid)
@@ -144,7 +144,7 @@ public class LicensesTransportTests extends ESSingleNodeTestCase {
 
     public void testPutExpiredLicense() throws Exception {
         License expiredLicense = generateExpiredNonBasicLicense();
-        PutLicenseRequestBuilder builder = new PutLicenseRequestBuilder(clusterAdmin(), PutLicenseAction.INSTANCE);
+        PutLicenseRequestBuilder builder = new PutLicenseRequestBuilder(clusterAdmin());
         builder.setLicense(expiredLicense);
         PutLicenseResponse putLicenseResponse = builder.get();
         assertThat(putLicenseResponse.status(), equalTo(LicensesStatus.EXPIRED));
@@ -155,8 +155,7 @@ public class LicensesTransportTests extends ESSingleNodeTestCase {
 
     public void testPutLicensesSimple() throws Exception {
         License goldSignedLicense = generateSignedLicense("gold", TimeValue.timeValueMinutes(5));
-        PutLicenseRequestBuilder putLicenseRequestBuilder = new PutLicenseRequestBuilder(clusterAdmin(), PutLicenseAction.INSTANCE)
-            .setLicense(goldSignedLicense)
+        PutLicenseRequestBuilder putLicenseRequestBuilder = new PutLicenseRequestBuilder(clusterAdmin()).setLicense(goldSignedLicense)
             .setAcknowledge(true);
         PutLicenseResponse putLicenseResponse = putLicenseRequestBuilder.get();
         assertThat(putLicenseResponse.status(), equalTo(LicensesStatus.VALID));
@@ -174,8 +173,7 @@ public class LicensesTransportTests extends ESSingleNodeTestCase {
 
     public void testRemoveLicensesSimple() throws Exception {
         License goldLicense = generateSignedLicense("gold", TimeValue.timeValueMinutes(5));
-        PutLicenseRequestBuilder putLicenseRequestBuilder = new PutLicenseRequestBuilder(clusterAdmin(), PutLicenseAction.INSTANCE)
-            .setLicense(goldLicense)
+        PutLicenseRequestBuilder putLicenseRequestBuilder = new PutLicenseRequestBuilder(clusterAdmin()).setLicense(goldLicense)
             .setAcknowledge(true);
         PutLicenseResponse putLicenseResponse = putLicenseRequestBuilder.get();
         assertThat(putLicenseResponse.isAcknowledged(), equalTo(true));
@@ -183,10 +181,7 @@ public class LicensesTransportTests extends ESSingleNodeTestCase {
         GetLicenseResponse getLicenseResponse = new GetLicenseRequestBuilder(clusterAdmin(), GetLicenseAction.INSTANCE).get();
         assertThat(getLicenseResponse.license(), equalTo(goldLicense));
         // delete all licenses
-        DeleteLicenseRequestBuilder deleteLicenseRequestBuilder = new DeleteLicenseRequestBuilder(
-            clusterAdmin(),
-            DeleteLicenseAction.INSTANCE
-        );
+        DeleteLicenseRequestBuilder deleteLicenseRequestBuilder = new DeleteLicenseRequestBuilder(clusterAdmin());
         AcknowledgedResponse deleteLicenseResponse = deleteLicenseRequestBuilder.get();
         assertThat(deleteLicenseResponse.isAcknowledged(), equalTo(true));
         // get licenses (expected no licenses)
@@ -208,8 +203,7 @@ public class LicensesTransportTests extends ESSingleNodeTestCase {
             .maxNodes(5);
         License license = TestUtils.generateSignedLicense(builder);
 
-        PutLicenseRequestBuilder putLicenseRequestBuilder = new PutLicenseRequestBuilder(clusterAdmin(), PutLicenseAction.INSTANCE)
-            .setLicense(license)
+        PutLicenseRequestBuilder putLicenseRequestBuilder = new PutLicenseRequestBuilder(clusterAdmin()).setLicense(license)
             .setAcknowledge(true);
         PutLicenseResponse putLicenseResponse = putLicenseRequestBuilder.get();
         assertThat(putLicenseResponse.isAcknowledged(), equalTo(true));
@@ -230,8 +224,7 @@ public class LicensesTransportTests extends ESSingleNodeTestCase {
             .maxNodes(5);
         License license = TestUtils.generateSignedLicense(builder);
 
-        PutLicenseRequestBuilder putLicenseRequestBuilder = new PutLicenseRequestBuilder(clusterAdmin(), PutLicenseAction.INSTANCE)
-            .setLicense(license)
+        PutLicenseRequestBuilder putLicenseRequestBuilder = new PutLicenseRequestBuilder(clusterAdmin()).setLicense(license)
             .setAcknowledge(true);
         PutLicenseResponse putLicenseResponse = putLicenseRequestBuilder.get();
         assertThat(putLicenseResponse.isAcknowledged(), equalTo(true));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAliasTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAliasTests.java
@@ -10,11 +10,9 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.indices.alias.Alias;
-import org.elasticsearch.action.admin.indices.alias.IndicesAliasesAction;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest.AliasActions;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequestBuilder;
-import org.elasticsearch.action.admin.indices.create.CreateIndexAction;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequestBuilder;
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
@@ -95,10 +93,10 @@ public class MlIndexAndAliasTests extends ESTestCase {
 
         indicesAdminClient = mock(IndicesAdminClient.class);
         when(indicesAdminClient.prepareCreate(FIRST_CONCRETE_INDEX)).thenReturn(
-            new CreateIndexRequestBuilder(client, CreateIndexAction.INSTANCE, FIRST_CONCRETE_INDEX)
+            new CreateIndexRequestBuilder(client, FIRST_CONCRETE_INDEX)
         );
         doAnswer(withResponse(new CreateIndexResponse(true, true, FIRST_CONCRETE_INDEX))).when(indicesAdminClient).create(any(), any());
-        when(indicesAdminClient.prepareAliases()).thenReturn(new IndicesAliasesRequestBuilder(client, IndicesAliasesAction.INSTANCE));
+        when(indicesAdminClient.prepareAliases()).thenReturn(new IndicesAliasesRequestBuilder(client));
         doAnswer(withResponse(AcknowledgedResponse.TRUE)).when(indicesAdminClient).aliases(any(), any());
         doAnswer(withResponse(AcknowledgedResponse.TRUE)).when(indicesAdminClient).putTemplate(any(), any());
 

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/analysis/CancellationTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/analysis/CancellationTests.java
@@ -13,7 +13,6 @@ import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.action.search.TransportSearchAction;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -211,7 +210,7 @@ public class CancellationTests extends ESTestCase {
 
         // Emulation of search cancellation
         ArgumentCaptor<SearchRequest> searchRequestCaptor = ArgumentCaptor.forClass(SearchRequest.class);
-        when(client.prepareSearch(any())).thenReturn(new SearchRequestBuilder(client, TransportSearchAction.TYPE).setIndices(indices));
+        when(client.prepareSearch(any())).thenReturn(new SearchRequestBuilder(client).setIndices(indices));
         doAnswer((Answer<Void>) invocation -> {
             @SuppressWarnings("unchecked")
             SearchRequest request = (SearchRequest) invocation.getArguments()[1];

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
@@ -790,10 +790,7 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
         long to = randomBoolean() ? Long.MAX_VALUE : randomLongBetween(from, from + 1000);
         QueryBuilder filter = new RangeQueryBuilder("val").from(from, true).to(to, true);
         try (
-            EsqlQueryResponse results = new EsqlQueryRequestBuilder(client(), EsqlQueryAction.INSTANCE).query(command)
-                .filter(filter)
-                .pragmas(randomPragmas())
-                .get()
+            EsqlQueryResponse results = new EsqlQueryRequestBuilder(client()).query(command).filter(filter).pragmas(randomPragmas()).get()
         ) {
             logger.info(results);
             OptionalDouble avg = docs.values().stream().filter(v -> from <= v && v <= to).mapToLong(n -> n).average();

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionTaskIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionTaskIT.java
@@ -266,9 +266,7 @@ public class EsqlActionTaskIT extends AbstractEsqlIntegTestCase {
                 .put("status_interval", "0ms")
                 .build()
         );
-        return new EsqlQueryRequestBuilder(client(), EsqlQueryAction.INSTANCE).query("from test | stats sum(pause_me)")
-            .pragmas(pragmas)
-            .execute();
+        return new EsqlQueryRequestBuilder(client()).query("from test | stats sum(pause_me)").pragmas(pragmas).execute();
     }
 
     private void cancelTask(TaskId taskId) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlQueryRequestBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlQueryRequestBuilder.java
@@ -14,12 +14,8 @@ import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 public class EsqlQueryRequestBuilder extends ActionRequestBuilder<EsqlQueryRequest, EsqlQueryResponse> {
 
-    public EsqlQueryRequestBuilder(ElasticsearchClient client, EsqlQueryAction action, EsqlQueryRequest request) {
-        super(client, action, request);
-    }
-
-    public EsqlQueryRequestBuilder(ElasticsearchClient client, EsqlQueryAction action) {
-        this(client, action, new EsqlQueryRequest());
+    public EsqlQueryRequestBuilder(ElasticsearchClient client) {
+        super(client, EsqlQueryAction.INSTANCE, new EsqlQueryRequest());
     }
 
     public EsqlQueryRequestBuilder query(String query) {

--- a/x-pack/plugin/graph/src/internalClusterTest/java/org/elasticsearch/xpack/graph/test/GraphTests.java
+++ b/x-pack/plugin/graph/src/internalClusterTest/java/org/elasticsearch/xpack/graph/test/GraphTests.java
@@ -29,7 +29,6 @@ import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.elasticsearch.xpack.core.LocalStateCompositeXPackPlugin;
-import org.elasticsearch.xpack.core.graph.action.GraphExploreAction;
 import org.elasticsearch.xpack.core.graph.action.GraphExploreRequestBuilder;
 import org.elasticsearch.xpack.graph.Graph;
 
@@ -117,7 +116,7 @@ public class GraphTests extends ESSingleNodeTestCase {
     }
 
     public void testSignificanceQueryCrawl() {
-        GraphExploreRequestBuilder grb = new GraphExploreRequestBuilder(client(), GraphExploreAction.INSTANCE).setIndices("test");
+        GraphExploreRequestBuilder grb = new GraphExploreRequestBuilder(client()).setIndices("test");
         Hop hop1 = grb.createNextHop(QueryBuilders.termQuery("description", "beatles"));
         hop1.addVertexRequest("people").size(10).minDocCount(1); // members of beatles
         grb.createNextHop(null).addVertexRequest("people").size(100).minDocCount(1); // friends of members of beatles
@@ -145,7 +144,7 @@ public class GraphTests extends ESSingleNodeTestCase {
 
     public void testTargetedQueryCrawl() {
         // Tests use of a client-provided query to steer exploration
-        GraphExploreRequestBuilder grb = new GraphExploreRequestBuilder(client(), GraphExploreAction.INSTANCE).setIndices("test");
+        GraphExploreRequestBuilder grb = new GraphExploreRequestBuilder(client()).setIndices("test");
         Hop hop1 = grb.createNextHop(QueryBuilders.termQuery("description", "beatles"));
         hop1.addVertexRequest("people").size(10).minDocCount(1); // members of beatles
         // 70s friends of beatles
@@ -161,7 +160,7 @@ public class GraphTests extends ESSingleNodeTestCase {
     }
 
     public void testLargeNumberTermsStartCrawl() {
-        GraphExploreRequestBuilder grb = new GraphExploreRequestBuilder(client(), GraphExploreAction.INSTANCE).setIndices("test");
+        GraphExploreRequestBuilder grb = new GraphExploreRequestBuilder(client()).setIndices("test");
         Hop hop1 = grb.createNextHop(null);
         VertexRequest peopleNames = hop1.addVertexRequest("people").minDocCount(1);
         peopleNames.addInclude("john", 1);
@@ -179,7 +178,7 @@ public class GraphTests extends ESSingleNodeTestCase {
     }
 
     public void testTargetedQueryCrawlDepth2() {
-        GraphExploreRequestBuilder grb = new GraphExploreRequestBuilder(client(), GraphExploreAction.INSTANCE).setIndices("test");
+        GraphExploreRequestBuilder grb = new GraphExploreRequestBuilder(client()).setIndices("test");
         Hop hop1 = grb.createNextHop(QueryBuilders.termQuery("description", "beatles"));
         hop1.addVertexRequest("people").size(10).minDocCount(1); // members of beatles
         // 00s friends of beatles
@@ -196,7 +195,7 @@ public class GraphTests extends ESSingleNodeTestCase {
     }
 
     public void testPopularityQueryCrawl() {
-        GraphExploreRequestBuilder grb = new GraphExploreRequestBuilder(client(), GraphExploreAction.INSTANCE).setIndices("test");
+        GraphExploreRequestBuilder grb = new GraphExploreRequestBuilder(client()).setIndices("test");
         // Turning off the significance feature means we reward popularity
         grb.useSignificance(false);
         Hop hop1 = grb.createNextHop(QueryBuilders.termQuery("description", "beatles"));
@@ -213,7 +212,7 @@ public class GraphTests extends ESSingleNodeTestCase {
     }
 
     public void testTimedoutQueryCrawl() {
-        GraphExploreRequestBuilder grb = new GraphExploreRequestBuilder(client(), GraphExploreAction.INSTANCE).setIndices("test");
+        GraphExploreRequestBuilder grb = new GraphExploreRequestBuilder(client()).setIndices("test");
         grb.setTimeout(TimeValue.timeValueMillis(400));
         Hop hop1 = grb.createNextHop(QueryBuilders.termQuery("description", "beatles"));
         hop1.addVertexRequest("people").size(10).minDocCount(1); // members of beatles
@@ -237,7 +236,7 @@ public class GraphTests extends ESSingleNodeTestCase {
     }
 
     public void testNonDiversifiedCrawl() {
-        GraphExploreRequestBuilder grb = new GraphExploreRequestBuilder(client(), GraphExploreAction.INSTANCE).setIndices("test");
+        GraphExploreRequestBuilder grb = new GraphExploreRequestBuilder(client()).setIndices("test");
 
         Hop hop1 = grb.createNextHop(QueryBuilders.termsQuery("people", "dave", "other"));
         hop1.addVertexRequest("people").size(10).minDocCount(1);
@@ -249,7 +248,7 @@ public class GraphTests extends ESSingleNodeTestCase {
     }
 
     public void testDiversifiedCrawl() {
-        GraphExploreRequestBuilder grb = new GraphExploreRequestBuilder(client(), GraphExploreAction.INSTANCE).setIndices("test");
+        GraphExploreRequestBuilder grb = new GraphExploreRequestBuilder(client()).setIndices("test");
         grb.sampleDiversityField("description").maxDocsPerDiversityValue(1);
 
         Hop hop1 = grb.createNextHop(QueryBuilders.termsQuery("people", "dave", "other"));
@@ -262,7 +261,7 @@ public class GraphTests extends ESSingleNodeTestCase {
     }
 
     public void testInvalidDiversifiedCrawl() {
-        GraphExploreRequestBuilder grb = new GraphExploreRequestBuilder(client(), GraphExploreAction.INSTANCE).setIndices("test");
+        GraphExploreRequestBuilder grb = new GraphExploreRequestBuilder(client()).setIndices("test");
         grb.sampleDiversityField("description").maxDocsPerDiversityValue(1);
 
         Hop hop1 = grb.createNextHop(QueryBuilders.termsQuery("people", "roy", "other"));
@@ -283,10 +282,7 @@ public class GraphTests extends ESSingleNodeTestCase {
     }
 
     public void testMappedAndUnmappedQueryCrawl() {
-        GraphExploreRequestBuilder grb = new GraphExploreRequestBuilder(client(), GraphExploreAction.INSTANCE).setIndices(
-            "test",
-            "idx_unmapped"
-        );
+        GraphExploreRequestBuilder grb = new GraphExploreRequestBuilder(client()).setIndices("test", "idx_unmapped");
         Hop hop1 = grb.createNextHop(QueryBuilders.termQuery("description", "beatles"));
         hop1.addVertexRequest("people").size(10).minDocCount(1); // members of beatles
         grb.createNextHop(null).addVertexRequest("people").size(100).minDocCount(1); // friends of members of beatles
@@ -301,7 +297,7 @@ public class GraphTests extends ESSingleNodeTestCase {
     }
 
     public void testUnmappedQueryCrawl() {
-        GraphExploreRequestBuilder grb = new GraphExploreRequestBuilder(client(), GraphExploreAction.INSTANCE).setIndices("idx_unmapped");
+        GraphExploreRequestBuilder grb = new GraphExploreRequestBuilder(client()).setIndices("idx_unmapped");
         Hop hop1 = grb.createNextHop(QueryBuilders.termQuery("description", "beatles"));
         hop1.addVertexRequest("people").size(10).minDocCount(1);
 
@@ -312,7 +308,7 @@ public class GraphTests extends ESSingleNodeTestCase {
     }
 
     public void testRequestValidation() {
-        GraphExploreRequestBuilder grb = new GraphExploreRequestBuilder(client(), GraphExploreAction.INSTANCE).setIndices("test");
+        GraphExploreRequestBuilder grb = new GraphExploreRequestBuilder(client()).setIndices("test");
 
         try {
             grb.get();

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/registry/ModelRegistryTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/registry/ModelRegistryTests.java
@@ -12,7 +12,6 @@ import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.bulk.BulkAction;
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
@@ -231,7 +230,7 @@ public class ModelRegistryTests extends ESTestCase {
 
     private Client mockBulkClient() {
         var client = mockClient();
-        when(client.prepareBulk()).thenReturn(new BulkRequestBuilder(client, BulkAction.INSTANCE));
+        when(client.prepareBulk()).thenReturn(new BulkRequestBuilder(client));
 
         return client;
     }

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeIntegTestCase.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeIntegTestCase.java
@@ -311,9 +311,11 @@ abstract class MlNativeIntegTestCase extends ESIntegTestCase {
         RefreshResponse refreshResponse = client().execute(RefreshAction.INSTANCE, refreshRequest).actionGet();
         assertThat(refreshResponse.getStatus().getStatus(), anyOf(equalTo(200), equalTo(201)));
 
-        SearchRequest searchRequest = new SearchRequestBuilder(client(), TransportSearchAction.TYPE).setIndices(
-            NotificationsIndex.NOTIFICATIONS_INDEX
-        ).addSort("timestamp", SortOrder.ASC).setQuery(QueryBuilders.termQuery("job_id", jobId)).setSize(100).request();
+        SearchRequest searchRequest = new SearchRequestBuilder(client()).setIndices(NotificationsIndex.NOTIFICATIONS_INDEX)
+            .addSort("timestamp", SortOrder.ASC)
+            .setQuery(QueryBuilders.termQuery("job_id", jobId))
+            .setSize(100)
+            .request();
         List<String> messages = new ArrayList<>();
         assertResponse(
             client().execute(TransportSearchAction.TYPE, searchRequest),

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationDataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationDataExtractor.java
@@ -7,7 +7,6 @@
 package org.elasticsearch.xpack.ml.datafeed.extractor.aggregation;
 
 import org.elasticsearch.action.search.SearchRequestBuilder;
-import org.elasticsearch.action.search.TransportSearchAction;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.xpack.ml.datafeed.DatafeedTimingStatsReporter;
@@ -30,7 +29,7 @@ class AggregationDataExtractor extends AbstractAggregationDataExtractor<SearchRe
 
     @Override
     protected SearchRequestBuilder buildSearchRequest(SearchSourceBuilder searchSourceBuilder) {
-        return new SearchRequestBuilder(client, TransportSearchAction.TYPE).setSource(searchSourceBuilder)
+        return new SearchRequestBuilder(client).setSource(searchSourceBuilder)
             .setIndicesOptions(context.indicesOptions)
             .setAllowPartialSearchResults(false)
             .setIndices(context.indices);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationDataExtractorFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationDataExtractorFactory.java
@@ -7,7 +7,6 @@
 package org.elasticsearch.xpack.ml.datafeed.extractor.aggregation;
 
 import org.elasticsearch.action.search.SearchRequestBuilder;
-import org.elasticsearch.action.search.TransportSearchAction;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.index.query.QueryBuilder;
@@ -30,7 +29,7 @@ public record AggregationDataExtractorFactory(
 ) implements DataExtractorFactory {
 
     public static AggregatedSearchRequestBuilder requestBuilder(Client client, String[] indices, IndicesOptions indicesOptions) {
-        return (searchSourceBuilder) -> new SearchRequestBuilder(client, TransportSearchAction.TYPE).setSource(searchSourceBuilder)
+        return (searchSourceBuilder) -> new SearchRequestBuilder(client).setSource(searchSourceBuilder)
             .setIndicesOptions(indicesOptions)
             .setAllowPartialSearchResults(false)
             .setIndices(indices);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/chunked/ChunkedDataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/chunked/ChunkedDataExtractor.java
@@ -12,7 +12,6 @@ import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.action.search.TransportSearchAction;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.Aggregations;
@@ -279,7 +278,7 @@ public class ChunkedDataExtractor implements DataExtractor {
         }
 
         private SearchRequestBuilder rangeSearchRequest() {
-            return new SearchRequestBuilder(client, TransportSearchAction.TYPE).setIndices(context.indices)
+            return new SearchRequestBuilder(client).setIndices(context.indices)
                 .setIndicesOptions(context.indicesOptions)
                 .setSource(rangeSearchBuilder())
                 .setAllowPartialSearchResults(false)

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/scroll/ScrollDataExtractor.java
@@ -15,8 +15,6 @@ import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchScrollRequestBuilder;
 import org.elasticsearch.action.search.TransportClearScrollAction;
-import org.elasticsearch.action.search.TransportSearchAction;
-import org.elasticsearch.action.search.TransportSearchScrollAction;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.core.TimeValue;
@@ -154,7 +152,7 @@ class ScrollDataExtractor implements DataExtractor {
             .query(ExtractorUtils.wrapInTimeRangeQuery(context.query, context.extractedFields.timeField(), start, context.end))
             .runtimeMappings(context.runtimeMappings);
 
-        SearchRequestBuilder searchRequestBuilder = new SearchRequestBuilder(client, TransportSearchAction.TYPE).setScroll(SCROLL_TIMEOUT)
+        SearchRequestBuilder searchRequestBuilder = new SearchRequestBuilder(client).setScroll(SCROLL_TIMEOUT)
             .setIndices(context.indices)
             .setIndicesOptions(context.indicesOptions)
             .setAllowPartialSearchResults(false)
@@ -250,9 +248,7 @@ class ScrollDataExtractor implements DataExtractor {
             context.headers,
             ClientHelper.ML_ORIGIN,
             client,
-            () -> new SearchScrollRequestBuilder(client, TransportSearchScrollAction.TYPE).setScroll(SCROLL_TIMEOUT)
-                .setScrollId(scrollId)
-                .get()
+            () -> new SearchScrollRequestBuilder(client).setScroll(SCROLL_TIMEOUT).setScrollId(scrollId).get()
         );
         try {
             checkForSkippedClusters(searchResponse);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractor.java
@@ -127,7 +127,7 @@ public class DataFrameDataExtractor {
      */
     public void preview(ActionListener<List<Row>> listener) {
 
-        SearchRequestBuilder searchRequestBuilder = new SearchRequestBuilder(client, TransportSearchAction.TYPE)
+        SearchRequestBuilder searchRequestBuilder = new SearchRequestBuilder(client)
             // This ensures the search throws if there are failures and the scroll context gets cleared automatically
             .setAllowPartialSearchResults(false)
             .setIndices(context.indices)
@@ -203,7 +203,7 @@ public class DataFrameDataExtractor {
 
         LOGGER.trace(() -> format("[%s] Searching docs with [%s] in [%s, %s)", context.jobId, INCREMENTAL_ID, from, to));
 
-        SearchRequestBuilder searchRequestBuilder = new SearchRequestBuilder(client, TransportSearchAction.TYPE)
+        SearchRequestBuilder searchRequestBuilder = new SearchRequestBuilder(client)
             // This ensures the search throws if there are failures and the scroll context gets cleared automatically
             .setAllowPartialSearchResults(false)
             .addSort(DestinationIndex.INCREMENTAL_ID, SortOrder.ASC)
@@ -401,7 +401,7 @@ public class DataFrameDataExtractor {
             summaryQuery = QueryBuilders.boolQuery().filter(summaryQuery).filter(allExtractedFieldsExistQuery());
         }
 
-        return new SearchRequestBuilder(client, TransportSearchAction.TYPE).setAllowPartialSearchResults(false)
+        return new SearchRequestBuilder(client).setAllowPartialSearchResults(false)
             .setIndices(context.indices)
             .setSize(0)
             .setQuery(summaryQuery)

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportDeleteTrainedModelActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportDeleteTrainedModelActionTests.java
@@ -139,7 +139,7 @@ public class TransportDeleteTrainedModelActionTests extends ESTestCase {
 
     private static void mockCancelTask(Client client) {
         var cluster = client.admin().cluster();
-        when(cluster.prepareCancelTasks()).thenReturn(new CancelTasksRequestBuilder(client, CancelTasksAction.INSTANCE));
+        when(cluster.prepareCancelTasks()).thenReturn(new CancelTasksRequestBuilder(client));
     }
 
     private static void mockCancelTasksResponse(Client client, CancelTasksResponse response) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/CompositeAggregationDataExtractorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/CompositeAggregationDataExtractorTests.java
@@ -12,7 +12,6 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.ShardSearchFailure;
-import org.elasticsearch.action.search.TransportSearchAction;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
@@ -122,8 +121,7 @@ public class CompositeAggregationDataExtractorTests extends ESTestCase {
             .subAggregation(AggregationBuilders.avg("responsetime").field("responsetime"));
         runtimeMappings = Collections.emptyMap();
         timingStatsReporter = new DatafeedTimingStatsReporter(new DatafeedTimingStats(jobId), mock(DatafeedTimingStatsPersister.class));
-        aggregatedSearchRequestBuilder = (searchSourceBuilder) -> new SearchRequestBuilder(testClient, TransportSearchAction.TYPE)
-            .setSource(searchSourceBuilder)
+        aggregatedSearchRequestBuilder = (searchSourceBuilder) -> new SearchRequestBuilder(testClient).setSource(searchSourceBuilder)
             .setAllowPartialSearchResults(false)
             .setIndices(indices.toArray(String[]::new));
     }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProviderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProviderTests.java
@@ -16,8 +16,6 @@ import org.elasticsearch.action.search.MultiSearchResponse;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.action.search.TransportMultiSearchAction;
-import org.elasticsearch.action.search.TransportSearchAction;
 import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -757,7 +755,7 @@ public class JobResultsProviderTests extends ESTestCase {
 
         try {
             Client client = getBasicMockedClient();
-            when(client.prepareMultiSearch()).thenReturn(new MultiSearchRequestBuilder(client, TransportMultiSearchAction.TYPE));
+            when(client.prepareMultiSearch()).thenReturn(new MultiSearchRequestBuilder(client));
             doAnswer(invocationOnMock -> {
                 MultiSearchRequest multiSearchRequest = (MultiSearchRequest) invocationOnMock.getArguments()[0];
                 assertThat(multiSearchRequest.requests(), hasSize(2));
@@ -770,10 +768,10 @@ public class JobResultsProviderTests extends ESTestCase {
                 return null;
             }).when(client).multiSearch(any(), any());
             when(client.prepareSearch(AnomalyDetectorsIndex.jobResultsAliasedName("foo"))).thenReturn(
-                new SearchRequestBuilder(client, TransportSearchAction.TYPE).setIndices(AnomalyDetectorsIndex.jobResultsAliasedName("foo"))
+                new SearchRequestBuilder(client).setIndices(AnomalyDetectorsIndex.jobResultsAliasedName("foo"))
             );
             when(client.prepareSearch(AnomalyDetectorsIndex.jobResultsAliasedName("bar"))).thenReturn(
-                new SearchRequestBuilder(client, TransportSearchAction.TYPE).setIndices(AnomalyDetectorsIndex.jobResultsAliasedName("bar"))
+                new SearchRequestBuilder(client).setIndices(AnomalyDetectorsIndex.jobResultsAliasedName("bar"))
             );
 
             JobResultsProvider provider = createProvider(client);
@@ -842,9 +840,7 @@ public class JobResultsProviderTests extends ESTestCase {
         SearchResponse response = createSearchResponse(source);
         Client client = getMockedClient(queryBuilder -> assertThat(queryBuilder.getName(), equalTo("ids")), response);
 
-        when(client.prepareSearch(indexName)).thenReturn(
-            new SearchRequestBuilder(client, TransportSearchAction.TYPE).setIndices(indexName)
-        );
+        when(client.prepareSearch(indexName)).thenReturn(new SearchRequestBuilder(client).setIndices(indexName));
         JobResultsProvider provider = createProvider(client);
         ExponentialAverageCalculationContext contextFoo = new ExponentialAverageCalculationContext(
             600.0,
@@ -871,9 +867,7 @@ public class JobResultsProviderTests extends ESTestCase {
         SearchResponse response = createSearchResponse(source);
         Client client = getMockedClient(queryBuilder -> assertThat(queryBuilder.getName(), equalTo("ids")), response);
 
-        when(client.prepareSearch(indexName)).thenReturn(
-            new SearchRequestBuilder(client, TransportSearchAction.TYPE).setIndices(indexName)
-        );
+        when(client.prepareSearch(indexName)).thenReturn(new SearchRequestBuilder(client).setIndices(indexName));
         JobResultsProvider provider = createProvider(client);
         provider.datafeedTimingStats("foo", stats -> assertThat(stats, equalTo(new DatafeedTimingStats("foo"))), e -> {
             throw new AssertionError("Failure getting datafeed timing stats", e);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/utils/TaskRetrieverTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/utils/TaskRetrieverTests.java
@@ -150,7 +150,7 @@ public class TaskRetrieverTests extends ESTestCase {
     public static Client mockListTasksClient(Client client) {
         var cluster = client.admin().cluster();
 
-        when(cluster.prepareListTasks()).thenReturn(new ListTasksRequestBuilder(client, TransportListTasksAction.TYPE));
+        when(cluster.prepareListTasks()).thenReturn(new ListTasksRequestBuilder(client));
 
         return client;
     }

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexRecoveryCollectorTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexRecoveryCollectorTests.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.monitoring.collector.indices;
 
 import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.action.FailedNodeException;
-import org.elasticsearch.action.admin.indices.recovery.RecoveryAction;
 import org.elasticsearch.action.admin.indices.recovery.RecoveryRequestBuilder;
 import org.elasticsearch.action.admin.indices.recovery.RecoveryResponse;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
@@ -110,9 +109,7 @@ public class IndexRecoveryCollectorTests extends BaseCollectorTestCase {
         }
         final RecoveryResponse recoveryResponse = new RecoveryResponse(randomInt(), randomInt(), randomInt(), recoveryStates, emptyList());
 
-        final RecoveryRequestBuilder recoveryRequestBuilder = spy(
-            new RecoveryRequestBuilder(mock(ElasticsearchClient.class), RecoveryAction.INSTANCE)
-        );
+        final RecoveryRequestBuilder recoveryRequestBuilder = spy(new RecoveryRequestBuilder(mock(ElasticsearchClient.class)));
         doReturn(recoveryResponse).when(recoveryRequestBuilder).get();
 
         final IndicesAdminClient indicesAdminClient = mock(IndicesAdminClient.class);
@@ -209,9 +206,7 @@ public class IndexRecoveryCollectorTests extends BaseCollectorTestCase {
             )
         );
 
-        final RecoveryRequestBuilder recoveryRequestBuilder = spy(
-            new RecoveryRequestBuilder(mock(ElasticsearchClient.class), RecoveryAction.INSTANCE)
-        );
+        final RecoveryRequestBuilder recoveryRequestBuilder = spy(new RecoveryRequestBuilder(mock(ElasticsearchClient.class)));
         doReturn(recoveryResponse).when(recoveryRequestBuilder).get();
 
         final IndicesAdminClient indicesAdminClient = mock(IndicesAdminClient.class);

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexStatsCollectorTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexStatsCollectorTests.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.monitoring.collector.indices;
 import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.admin.indices.stats.IndexStats;
-import org.elasticsearch.action.admin.indices.stats.IndicesStatsAction;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsRequestBuilder;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
@@ -117,9 +116,7 @@ public class IndexStatsCollectorTests extends BaseCollectorTestCase {
         final String[] indexNames = indicesMetadata.keySet().toArray(new String[0]);
         when(metadata.getConcreteAllIndices()).thenReturn(indexNames);
 
-        final IndicesStatsRequestBuilder indicesStatsRequestBuilder = spy(
-            new IndicesStatsRequestBuilder(mock(ElasticsearchClient.class), IndicesStatsAction.INSTANCE)
-        );
+        final IndicesStatsRequestBuilder indicesStatsRequestBuilder = spy(new IndicesStatsRequestBuilder(mock(ElasticsearchClient.class)));
         doReturn(indicesStatsResponse).when(indicesStatsRequestBuilder).get();
 
         final IndicesAdminClient indicesAdminClient = mock(IndicesAdminClient.class);
@@ -196,9 +193,7 @@ public class IndexStatsCollectorTests extends BaseCollectorTestCase {
                 ) }
         );
 
-        final IndicesStatsRequestBuilder indicesStatsRequestBuilder = spy(
-            new IndicesStatsRequestBuilder(mock(ElasticsearchClient.class), IndicesStatsAction.INSTANCE)
-        );
+        final IndicesStatsRequestBuilder indicesStatsRequestBuilder = spy(new IndicesStatsRequestBuilder(mock(ElasticsearchClient.class)));
         doReturn(indicesStatsResponse).when(indicesStatsRequestBuilder).get();
 
         final IndicesAdminClient indicesAdminClient = mock(IndicesAdminClient.class);

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/ApiKeyIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/ApiKeyIntegTests.java
@@ -14,7 +14,6 @@ import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
 import org.elasticsearch.action.admin.indices.close.CloseIndexRequest;
 import org.elasticsearch.action.admin.indices.close.CloseIndexResponse;
-import org.elasticsearch.action.admin.indices.refresh.RefreshAction;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequestBuilder;
 import org.elasticsearch.action.admin.indices.refresh.RefreshResponse;
 import org.elasticsearch.action.get.GetAction;
@@ -75,7 +74,6 @@ import org.elasticsearch.xpack.core.security.action.role.PutRoleAction;
 import org.elasticsearch.xpack.core.security.action.role.PutRoleRequest;
 import org.elasticsearch.xpack.core.security.action.role.PutRoleResponse;
 import org.elasticsearch.xpack.core.security.action.role.RoleDescriptorRequestValidator;
-import org.elasticsearch.xpack.core.security.action.token.CreateTokenAction;
 import org.elasticsearch.xpack.core.security.action.token.CreateTokenRequestBuilder;
 import org.elasticsearch.xpack.core.security.action.token.CreateTokenResponse;
 import org.elasticsearch.xpack.core.security.action.user.PutUserAction;
@@ -1654,8 +1652,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
             clientKey1 = client().filterWithHeader(Collections.singletonMap("Authorization", "ApiKey " + base64ApiKeyKeyValue));
         } else {
             final CreateTokenResponse createTokenResponse = new CreateTokenRequestBuilder(
-                client().filterWithHeader(Collections.singletonMap("Authorization", "ApiKey " + base64ApiKeyKeyValue)),
-                CreateTokenAction.INSTANCE
+                client().filterWithHeader(Collections.singletonMap("Authorization", "ApiKey " + base64ApiKeyKeyValue))
             ).setGrantType("client_credentials").get();
             clientKey1 = client().filterWithHeader(Map.of("Authorization", "Bearer " + createTokenResponse.getTokenString()));
         }
@@ -2926,7 +2923,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
     }
 
     private void assertApiKeyNotCreated(Client client, String keyName) throws ExecutionException, InterruptedException {
-        new RefreshRequestBuilder(client, RefreshAction.INSTANCE).setIndices(SECURITY_MAIN_ALIAS).execute().get();
+        new RefreshRequestBuilder(client).setIndices(SECURITY_MAIN_ALIAS).execute().get();
         assertEquals(
             0,
             client.execute(GetApiKeyAction.INSTANCE, GetApiKeyRequest.builder().apiKeyName(keyName).ownedByAuthenticatedUser(false).build())

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/apikey/ApiKeySingleNodeTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/apikey/ApiKeySingleNodeTests.java
@@ -60,7 +60,6 @@ import org.elasticsearch.xpack.core.security.action.apikey.UpdateCrossClusterApi
 import org.elasticsearch.xpack.core.security.action.service.CreateServiceAccountTokenAction;
 import org.elasticsearch.xpack.core.security.action.service.CreateServiceAccountTokenRequest;
 import org.elasticsearch.xpack.core.security.action.service.CreateServiceAccountTokenResponse;
-import org.elasticsearch.xpack.core.security.action.token.CreateTokenAction;
 import org.elasticsearch.xpack.core.security.action.token.CreateTokenRequestBuilder;
 import org.elasticsearch.xpack.core.security.action.token.CreateTokenResponse;
 import org.elasticsearch.xpack.core.security.action.user.AuthenticateAction;
@@ -276,8 +275,7 @@ public class ApiKeySingleNodeTests extends SecuritySingleNodeTestCase {
             clientKey1 = client().filterWithHeader(Collections.singletonMap("Authorization", "ApiKey " + base64ApiKeyKeyValue));
         } else {
             final CreateTokenResponse createTokenResponse = new CreateTokenRequestBuilder(
-                client().filterWithHeader(Collections.singletonMap("Authorization", "ApiKey " + base64ApiKeyKeyValue)),
-                CreateTokenAction.INSTANCE
+                client().filterWithHeader(Collections.singletonMap("Authorization", "ApiKey " + base64ApiKeyKeyValue))
             ).setGrantType("client_credentials").get();
             clientKey1 = client().filterWithHeader(Map.of("Authorization", "Bearer " + createTokenResponse.getTokenString()));
         }
@@ -333,8 +331,7 @@ public class ApiKeySingleNodeTests extends SecuritySingleNodeTestCase {
         assertThat(
             expectThrows(
                 ElasticsearchSecurityException.class,
-                () -> new CreateTokenRequestBuilder(clientWithGrantedKey, CreateTokenAction.INSTANCE).setGrantType("client_credentials")
-                    .get()
+                () -> new CreateTokenRequestBuilder(clientWithGrantedKey).setGrantType("client_credentials").get()
             ).getMessage(),
             containsString("unauthorized")
         );

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authz/store/NativePrivilegeStoreSingleNodeTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authz/store/NativePrivilegeStoreSingleNodeTests.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.security.authz.store;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionFuture;
-import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsAction;
 import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.internal.Client;
@@ -25,12 +24,10 @@ import org.elasticsearch.xpack.core.security.action.privilege.GetPrivilegesReque
 import org.elasticsearch.xpack.core.security.action.privilege.GetPrivilegesResponse;
 import org.elasticsearch.xpack.core.security.action.privilege.PutPrivilegesAction;
 import org.elasticsearch.xpack.core.security.action.privilege.PutPrivilegesRequest;
-import org.elasticsearch.xpack.core.security.action.role.PutRoleAction;
 import org.elasticsearch.xpack.core.security.action.role.PutRoleRequestBuilder;
 import org.elasticsearch.xpack.core.security.action.user.AuthenticateAction;
 import org.elasticsearch.xpack.core.security.action.user.AuthenticateRequest;
 import org.elasticsearch.xpack.core.security.action.user.AuthenticateResponse;
-import org.elasticsearch.xpack.core.security.action.user.PutUserAction;
 import org.elasticsearch.xpack.core.security.action.user.PutUserRequestBuilder;
 import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
 import org.elasticsearch.xpack.core.security.authz.privilege.ApplicationPrivilegeDescriptor;
@@ -80,7 +77,7 @@ public class NativePrivilegeStoreSingleNodeTests extends SecuritySingleNodeTestC
 
     public void testResolvePrivilegesWorkWhenExpensiveQueriesAreDisabled() throws IOException {
         // Disable expensive query
-        new ClusterUpdateSettingsRequestBuilder(client(), ClusterUpdateSettingsAction.INSTANCE).setTransientSettings(
+        new ClusterUpdateSettingsRequestBuilder(client()).setTransientSettings(
             Settings.builder().put(ALLOW_EXPENSIVE_QUERIES.getKey(), false)
         ).get();
 
@@ -106,7 +103,7 @@ public class NativePrivilegeStoreSingleNodeTests extends SecuritySingleNodeTestC
             );
 
             // User role resolution works with wildcard application name
-            new PutRoleRequestBuilder(client(), PutRoleAction.INSTANCE).source("app_user_role", new BytesArray("""
+            new PutRoleRequestBuilder(client()).source("app_user_role", new BytesArray("""
                 {
                   "cluster": ["manage_own_api_key"],
                   "applications": [
@@ -124,7 +121,7 @@ public class NativePrivilegeStoreSingleNodeTests extends SecuritySingleNodeTestC
                 }
                 """), XContentType.JSON).get();
 
-            new PutUserRequestBuilder(client(), PutUserAction.INSTANCE).username("app_user")
+            new PutUserRequestBuilder(client()).username("app_user")
                 .password(TEST_PASSWORD_SECURE_STRING, getFastStoredHashAlgoForTests())
                 .roles("app_user_role")
                 .get();
@@ -187,7 +184,7 @@ public class NativePrivilegeStoreSingleNodeTests extends SecuritySingleNodeTestC
             assertThat(authenticateResponse.authentication().getEffectiveSubject().getUser().principal(), equalTo("app_user"));
         } finally {
             // Reset setting since test suite expects things in a clean slate
-            new ClusterUpdateSettingsRequestBuilder(client(), ClusterUpdateSettingsAction.INSTANCE).setTransientSettings(
+            new ClusterUpdateSettingsRequestBuilder(client()).setTransientSettings(
                 Settings.builder().putNull(ALLOW_EXPENSIVE_QUERIES.getKey())
             ).get();
         }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/oidc/TransportOpenIdConnectLogoutActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/oidc/TransportOpenIdConnectLogoutActionTests.java
@@ -9,12 +9,10 @@ package org.elasticsearch.xpack.security.action.oidc;
 import com.nimbusds.jwt.JWT;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.bulk.BulkAction;
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
-import org.elasticsearch.action.get.GetAction;
 import org.elasticsearch.action.get.GetRequestBuilder;
 import org.elasticsearch.action.index.IndexAction;
 import org.elasticsearch.action.index.IndexRequest;
@@ -22,7 +20,6 @@ import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.PlainActionFuture;
-import org.elasticsearch.action.update.UpdateAction;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.action.update.UpdateRequestBuilder;
 import org.elasticsearch.client.internal.Client;
@@ -118,22 +115,22 @@ public class TransportOpenIdConnectLogoutActionTests extends OpenIdConnectTestCa
         when(client.threadPool()).thenReturn(threadPool);
         when(client.settings()).thenReturn(settings);
         doAnswer(invocationOnMock -> {
-            GetRequestBuilder builder = new GetRequestBuilder(client, GetAction.INSTANCE);
+            GetRequestBuilder builder = new GetRequestBuilder(client);
             builder.setIndex((String) invocationOnMock.getArguments()[0]).setId((String) invocationOnMock.getArguments()[1]);
             return builder;
         }).when(client).prepareGet(nullable(String.class), nullable(String.class));
         doAnswer(invocationOnMock -> {
-            IndexRequestBuilder builder = new IndexRequestBuilder(client, IndexAction.INSTANCE);
+            IndexRequestBuilder builder = new IndexRequestBuilder(client);
             builder.setIndex((String) invocationOnMock.getArguments()[0]);
             return builder;
         }).when(client).prepareIndex(nullable(String.class));
         doAnswer(invocationOnMock -> {
-            UpdateRequestBuilder builder = new UpdateRequestBuilder(client, UpdateAction.INSTANCE);
+            UpdateRequestBuilder builder = new UpdateRequestBuilder(client);
             builder.setIndex((String) invocationOnMock.getArguments()[0]).setId((String) invocationOnMock.getArguments()[1]);
             return builder;
         }).when(client).prepareUpdate(nullable(String.class), anyString());
         doAnswer(invocationOnMock -> {
-            BulkRequestBuilder builder = new BulkRequestBuilder(client, BulkAction.INSTANCE);
+            BulkRequestBuilder builder = new BulkRequestBuilder(client);
             return builder;
         }).when(client).prepareBulk();
         doAnswer(invocationOnMock -> {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/saml/TransportSamlLogoutActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/saml/TransportSamlLogoutActionTests.java
@@ -7,15 +7,12 @@
 package org.elasticsearch.xpack.security.action.saml;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.bulk.BulkAction;
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
-import org.elasticsearch.action.get.GetAction;
 import org.elasticsearch.action.get.GetRequestBuilder;
 import org.elasticsearch.action.get.GetResponse;
-import org.elasticsearch.action.get.MultiGetAction;
 import org.elasticsearch.action.get.MultiGetItemResponse;
 import org.elasticsearch.action.get.MultiGetRequest;
 import org.elasticsearch.action.get.MultiGetRequestBuilder;
@@ -26,7 +23,6 @@ import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.PlainActionFuture;
-import org.elasticsearch.action.update.UpdateAction;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.action.update.UpdateRequestBuilder;
 import org.elasticsearch.client.internal.Client;
@@ -135,25 +131,25 @@ public class TransportSamlLogoutActionTests extends SamlTestCase {
         when(client.threadPool()).thenReturn(threadPool);
         when(client.settings()).thenReturn(settings);
         doAnswer(invocationOnMock -> {
-            GetRequestBuilder builder = new GetRequestBuilder(client, GetAction.INSTANCE);
+            GetRequestBuilder builder = new GetRequestBuilder(client);
             builder.setIndex((String) invocationOnMock.getArguments()[0]).setId((String) invocationOnMock.getArguments()[1]);
             return builder;
         }).when(client).prepareGet(nullable(String.class), nullable(String.class));
         doAnswer(invocationOnMock -> {
-            IndexRequestBuilder builder = new IndexRequestBuilder(client, IndexAction.INSTANCE);
+            IndexRequestBuilder builder = new IndexRequestBuilder(client);
             builder.setIndex((String) invocationOnMock.getArguments()[0]);
             return builder;
         }).when(client).prepareIndex(nullable(String.class));
         doAnswer(invocationOnMock -> {
-            UpdateRequestBuilder builder = new UpdateRequestBuilder(client, UpdateAction.INSTANCE);
+            UpdateRequestBuilder builder = new UpdateRequestBuilder(client);
             builder.setIndex((String) invocationOnMock.getArguments()[0]).setId((String) invocationOnMock.getArguments()[1]);
             return builder;
         }).when(client).prepareUpdate(nullable(String.class), nullable(String.class));
         doAnswer(invocationOnMock -> {
-            BulkRequestBuilder builder = new BulkRequestBuilder(client, BulkAction.INSTANCE);
+            BulkRequestBuilder builder = new BulkRequestBuilder(client);
             return builder;
         }).when(client).prepareBulk();
-        when(client.prepareMultiGet()).thenReturn(new MultiGetRequestBuilder(client, MultiGetAction.INSTANCE));
+        when(client.prepareMultiGet()).thenReturn(new MultiGetRequestBuilder(client));
         doAnswer(invocationOnMock -> {
             ActionListener<MultiGetResponse> listener = (ActionListener<MultiGetResponse>) invocationOnMock.getArguments()[1];
             MultiGetResponse response = mock(MultiGetResponse.class);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/token/TransportCreateTokenActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/token/TransportCreateTokenActionTests.java
@@ -10,10 +10,8 @@ package org.elasticsearch.xpack.security.action.token;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.get.GetAction;
 import org.elasticsearch.action.get.GetRequestBuilder;
 import org.elasticsearch.action.get.GetResponse;
-import org.elasticsearch.action.get.MultiGetAction;
 import org.elasticsearch.action.get.MultiGetItemResponse;
 import org.elasticsearch.action.get.MultiGetRequest;
 import org.elasticsearch.action.get.MultiGetRequestBuilder;
@@ -24,7 +22,6 @@ import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.PlainActionFuture;
-import org.elasticsearch.action.update.UpdateAction;
 import org.elasticsearch.action.update.UpdateRequestBuilder;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -107,11 +104,11 @@ public class TransportCreateTokenActionTests extends ESTestCase {
         when(client.threadPool()).thenReturn(threadPool);
         when(client.settings()).thenReturn(SETTINGS);
         doAnswer(invocationOnMock -> {
-            GetRequestBuilder builder = new GetRequestBuilder(client, GetAction.INSTANCE);
+            GetRequestBuilder builder = new GetRequestBuilder(client);
             builder.setIndex((String) invocationOnMock.getArguments()[0]).setId((String) invocationOnMock.getArguments()[1]);
             return builder;
         }).when(client).prepareGet(anyString(), anyString());
-        when(client.prepareMultiGet()).thenReturn(new MultiGetRequestBuilder(client, MultiGetAction.INSTANCE));
+        when(client.prepareMultiGet()).thenReturn(new MultiGetRequestBuilder(client));
         doAnswer(invocationOnMock -> {
             @SuppressWarnings("unchecked")
             ActionListener<MultiGetResponse> listener = (ActionListener<MultiGetResponse>) invocationOnMock.getArguments()[1];
@@ -129,10 +126,8 @@ public class TransportCreateTokenActionTests extends ESTestCase {
             listener.onResponse(response);
             return Void.TYPE;
         }).when(client).multiGet(any(MultiGetRequest.class), anyActionListener());
-        when(client.prepareIndex(nullable(String.class))).thenReturn(new IndexRequestBuilder(client, IndexAction.INSTANCE));
-        when(client.prepareUpdate(any(String.class), any(String.class))).thenReturn(
-            new UpdateRequestBuilder(client, UpdateAction.INSTANCE)
-        );
+        when(client.prepareIndex(nullable(String.class))).thenReturn(new IndexRequestBuilder(client));
+        when(client.prepareUpdate(any(String.class), any(String.class))).thenReturn(new UpdateRequestBuilder(client));
         doAnswer(invocationOnMock -> {
             idxReqReference.set((IndexRequest) invocationOnMock.getArguments()[1]);
             @SuppressWarnings("unchecked")

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
@@ -24,16 +24,13 @@ import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.get.GetRequest;
-import org.elasticsearch.action.index.IndexAction;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.action.search.TransportSearchAction;
 import org.elasticsearch.action.support.PlainActionFuture;
-import org.elasticsearch.action.update.UpdateAction;
 import org.elasticsearch.action.update.UpdateRequestBuilder;
 import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.client.internal.Client;
@@ -245,8 +242,8 @@ public class ApiKeyServiceTests extends ESTestCase {
             .realmRef(new RealmRef("file", "file", "node-1"))
             .build(false);
         final CreateApiKeyRequest createApiKeyRequest = new CreateApiKeyRequest("key-1", null, null);
-        when(client.prepareIndex(anyString())).thenReturn(new IndexRequestBuilder(client, IndexAction.INSTANCE));
-        when(client.prepareBulk()).thenReturn(new BulkRequestBuilder(client, BulkAction.INSTANCE));
+        when(client.prepareIndex(anyString())).thenReturn(new IndexRequestBuilder(client));
+        when(client.prepareBulk()).thenReturn(new BulkRequestBuilder(client));
         when(client.threadPool()).thenReturn(threadPool);
         final AtomicBoolean bulkActionInvoked = new AtomicBoolean(false);
         doAnswer(inv -> {
@@ -271,7 +268,7 @@ public class ApiKeyServiceTests extends ESTestCase {
         when(clock.instant()).thenReturn(Instant.ofEpochMilli(now));
         final Settings settings = Settings.builder().put(XPackSettings.API_KEY_SERVICE_ENABLED_SETTING.getKey(), true).build();
         when(client.threadPool()).thenReturn(threadPool);
-        SearchRequestBuilder searchRequestBuilder = Mockito.spy(new SearchRequestBuilder(client, TransportSearchAction.TYPE));
+        SearchRequestBuilder searchRequestBuilder = Mockito.spy(new SearchRequestBuilder(client));
         when(client.prepareSearch(eq(SECURITY_MAIN_ALIAS))).thenReturn(searchRequestBuilder);
         final ApiKeyService service = createApiKeyService(settings);
         final AtomicReference<SearchRequest> searchRequest = new AtomicReference<>();
@@ -332,7 +329,7 @@ public class ApiKeyServiceTests extends ESTestCase {
     public void testInvalidateApiKeys() throws Exception {
         final Settings settings = Settings.builder().put(XPackSettings.API_KEY_SERVICE_ENABLED_SETTING.getKey(), true).build();
         when(client.threadPool()).thenReturn(threadPool);
-        SearchRequestBuilder searchRequestBuilder = Mockito.spy(new SearchRequestBuilder(client, TransportSearchAction.TYPE));
+        SearchRequestBuilder searchRequestBuilder = Mockito.spy(new SearchRequestBuilder(client));
         when(client.prepareSearch(eq(SECURITY_MAIN_ALIAS))).thenReturn(searchRequestBuilder);
         final ApiKeyService service = createApiKeyService(settings);
         final AtomicReference<SearchRequest> searchRequest = new AtomicReference<>();
@@ -406,7 +403,7 @@ public class ApiKeyServiceTests extends ESTestCase {
 
         // Mock the search request for keys to invalidate
         when(client.threadPool()).thenReturn(threadPool);
-        when(client.prepareSearch(eq(SECURITY_MAIN_ALIAS))).thenReturn(new SearchRequestBuilder(client, TransportSearchAction.TYPE));
+        when(client.prepareSearch(eq(SECURITY_MAIN_ALIAS))).thenReturn(new SearchRequestBuilder(client));
         doAnswer(invocation -> {
             final var listener = (ActionListener<SearchResponse>) invocation.getArguments()[1];
             final var searchHit = new SearchHit(docId, apiKeyId);
@@ -445,8 +442,8 @@ public class ApiKeyServiceTests extends ESTestCase {
         }).when(client).search(any(SearchRequest.class), anyActionListener());
 
         // Capture the Update request so that we can verify it is configured as expected
-        when(client.prepareBulk()).thenReturn(new BulkRequestBuilder(client, BulkAction.INSTANCE));
-        final var updateRequestBuilder = Mockito.spy(new UpdateRequestBuilder(client, UpdateAction.INSTANCE));
+        when(client.prepareBulk()).thenReturn(new BulkRequestBuilder(client));
+        final var updateRequestBuilder = Mockito.spy(new UpdateRequestBuilder(client));
         when(client.prepareUpdate(eq(SECURITY_MAIN_ALIAS), eq(apiKeyId))).thenReturn(updateRequestBuilder);
 
         // Stub bulk and cache clearing calls so that the entire action flow can complete (not strictly necessary but nice to have)
@@ -502,8 +499,8 @@ public class ApiKeyServiceTests extends ESTestCase {
             .realmRef(new RealmRef(randomAlphaOfLengthBetween(3, 8), randomAlphaOfLengthBetween(3, 8), randomAlphaOfLengthBetween(3, 8)))
             .build(false);
         final CreateApiKeyRequest createApiKeyRequest = new CreateApiKeyRequest(randomAlphaOfLengthBetween(3, 8), null, null);
-        when(client.prepareIndex(anyString())).thenReturn(new IndexRequestBuilder(client, IndexAction.INSTANCE));
-        when(client.prepareBulk()).thenReturn(new BulkRequestBuilder(client, BulkAction.INSTANCE));
+        when(client.prepareIndex(anyString())).thenReturn(new IndexRequestBuilder(client));
+        when(client.prepareBulk()).thenReturn(new BulkRequestBuilder(client));
         when(client.threadPool()).thenReturn(threadPool);
         doAnswer(inv -> {
             final Object[] args = inv.getArguments();
@@ -739,7 +736,7 @@ public class ApiKeyServiceTests extends ESTestCase {
         final Instant now = Instant.now();
         when(clock.instant()).thenReturn(now);
         when(client.threadPool()).thenReturn(threadPool);
-        SearchRequestBuilder searchRequestBuilder = Mockito.spy(new SearchRequestBuilder(client, TransportSearchAction.TYPE));
+        SearchRequestBuilder searchRequestBuilder = Mockito.spy(new SearchRequestBuilder(client));
         when(client.prepareSearch(eq(SECURITY_MAIN_ALIAS))).thenReturn(searchRequestBuilder);
 
         final List<SearchHit> searchHits = new ArrayList<>();

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
@@ -14,18 +14,15 @@ import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.get.GetAction;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.get.GetRequestBuilder;
 import org.elasticsearch.action.get.GetResponse;
-import org.elasticsearch.action.get.MultiGetAction;
 import org.elasticsearch.action.get.MultiGetRequestBuilder;
 import org.elasticsearch.action.index.IndexAction;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.support.PlainActionFuture;
-import org.elasticsearch.action.update.UpdateAction;
 import org.elasticsearch.action.update.UpdateRequestBuilder;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
@@ -287,10 +284,8 @@ public class AuthenticationServiceTests extends ESTestCase {
         threadContext = threadPool.getThreadContext();
         when(client.threadPool()).thenReturn(threadPool);
         when(client.settings()).thenReturn(settings);
-        when(client.prepareIndex(nullable(String.class))).thenReturn(new IndexRequestBuilder(client, IndexAction.INSTANCE));
-        when(client.prepareUpdate(nullable(String.class), nullable(String.class))).thenReturn(
-            new UpdateRequestBuilder(client, UpdateAction.INSTANCE)
-        );
+        when(client.prepareIndex(nullable(String.class))).thenReturn(new IndexRequestBuilder(client));
+        when(client.prepareUpdate(nullable(String.class), nullable(String.class))).thenReturn(new UpdateRequestBuilder(client));
         doAnswer(invocationOnMock -> {
             @SuppressWarnings("unchecked")
             ActionListener<IndexResponse> responseActionListener = (ActionListener<IndexResponse>) invocationOnMock.getArguments()[2];
@@ -307,7 +302,7 @@ public class AuthenticationServiceTests extends ESTestCase {
             return null;
         }).when(client).execute(eq(IndexAction.INSTANCE), any(IndexRequest.class), anyActionListener());
         doAnswer(invocationOnMock -> {
-            GetRequestBuilder builder = new GetRequestBuilder(client, GetAction.INSTANCE);
+            GetRequestBuilder builder = new GetRequestBuilder(client);
             builder.setIndex((String) invocationOnMock.getArguments()[0]).setId((String) invocationOnMock.getArguments()[1]);
             return builder;
         }).when(client).prepareGet(nullable(String.class), nullable(String.class));
@@ -1910,7 +1905,7 @@ public class AuthenticationServiceTests extends ESTestCase {
             );
         }
         String token = tokenFuture.get().getAccessToken();
-        when(client.prepareMultiGet()).thenReturn(new MultiGetRequestBuilder(client, MultiGetAction.INSTANCE));
+        when(client.prepareMultiGet()).thenReturn(new MultiGetRequestBuilder(client));
         mockGetTokenFromAccessTokenBytes(tokenService, newTokenBytes.v1(), expected, Map.of(), false, null, client);
         when(securityIndex.defensiveCopy()).thenReturn(securityIndex);
         when(securityIndex.isAvailable(SecurityIndexManager.Availability.PRIMARY_SHARDS)).thenReturn(true);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/TokenServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/TokenServiceTests.java
@@ -16,12 +16,10 @@ import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.NoShardAvailableActionException;
 import org.elasticsearch.action.UnavailableShardsException;
-import org.elasticsearch.action.bulk.BulkAction;
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
-import org.elasticsearch.action.get.GetAction;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.get.GetRequestBuilder;
 import org.elasticsearch.action.get.GetResponse;
@@ -32,9 +30,7 @@ import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.action.search.TransportSearchAction;
 import org.elasticsearch.action.support.PlainActionFuture;
-import org.elasticsearch.action.update.UpdateAction;
 import org.elasticsearch.action.update.UpdateRequestBuilder;
 import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.client.internal.Client;
@@ -163,18 +159,18 @@ public class TokenServiceTests extends ESTestCase {
         when(client.threadPool()).thenReturn(threadPool);
         when(client.settings()).thenReturn(settings);
         doAnswer(invocationOnMock -> {
-            GetRequestBuilder builder = new GetRequestBuilder(client, GetAction.INSTANCE);
+            GetRequestBuilder builder = new GetRequestBuilder(client);
             builder.setIndex((String) invocationOnMock.getArguments()[0]).setId((String) invocationOnMock.getArguments()[1]);
             return builder;
         }).when(client).prepareGet(anyString(), anyString());
-        when(client.prepareIndex(any(String.class))).thenReturn(new IndexRequestBuilder(client, IndexAction.INSTANCE));
-        when(client.prepareBulk()).thenReturn(new BulkRequestBuilder(client, BulkAction.INSTANCE));
+        when(client.prepareIndex(any(String.class))).thenReturn(new IndexRequestBuilder(client));
+        when(client.prepareBulk()).thenReturn(new BulkRequestBuilder(client));
         when(client.prepareUpdate(any(String.class), any(String.class))).thenAnswer(inv -> {
             final String index = (String) inv.getArguments()[0];
             final String id = (String) inv.getArguments()[1];
-            return new UpdateRequestBuilder(client, UpdateAction.INSTANCE).setIndex(index).setId(id);
+            return new UpdateRequestBuilder(client).setIndex(index).setId(id);
         });
-        when(client.prepareSearch(any(String.class))).thenReturn(new SearchRequestBuilder(client, TransportSearchAction.TYPE));
+        when(client.prepareSearch(any(String.class))).thenReturn(new SearchRequestBuilder(client));
         doAnswer(invocationOnMock -> {
             @SuppressWarnings("unchecked")
             ActionListener<IndexResponse> responseActionListener = (ActionListener<IndexResponse>) invocationOnMock.getArguments()[2];

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/mapper/NativeRoleMappingStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/mapper/NativeRoleMappingStoreTests.java
@@ -11,7 +11,6 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.action.search.TransportSearchAction;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterName;
@@ -194,9 +193,7 @@ public class NativeRoleMappingStoreTests extends ESTestCase {
         final ThreadPool mockThreadPool = mock(ThreadPool.class);
         when(mockThreadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
         when(client.threadPool()).thenReturn(mockThreadPool);
-        when(client.prepareSearch(eq(SECURITY_MAIN_ALIAS))).thenReturn(
-            Mockito.spy(new SearchRequestBuilder(client, TransportSearchAction.TYPE))
-        );
+        when(client.prepareSearch(eq(SECURITY_MAIN_ALIAS))).thenReturn(Mockito.spy(new SearchRequestBuilder(client)));
         final ExpressionRoleMapping mapping = new ExpressionRoleMapping(
             "mapping",
             new FieldExpression("dn", Collections.singletonList(new FieldValue("*"))),
@@ -238,9 +235,7 @@ public class NativeRoleMappingStoreTests extends ESTestCase {
         final ThreadPool mockThreadPool = mock(ThreadPool.class);
         when(mockThreadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
         when(client.threadPool()).thenReturn(mockThreadPool);
-        when(client.prepareSearch(eq(SECURITY_MAIN_ALIAS))).thenReturn(
-            Mockito.spy(new SearchRequestBuilder(client, TransportSearchAction.TYPE))
-        );
+        when(client.prepareSearch(eq(SECURITY_MAIN_ALIAS))).thenReturn(Mockito.spy(new SearchRequestBuilder(client)));
         final ExpressionRoleMapping mapping = new ExpressionRoleMapping(
             "mapping",
             new FieldExpression("dn", Collections.singletonList(new FieldValue("*"))),
@@ -302,9 +297,7 @@ public class NativeRoleMappingStoreTests extends ESTestCase {
         final ThreadPool mockThreadPool = mock(ThreadPool.class);
         when(mockThreadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
         when(client.threadPool()).thenReturn(mockThreadPool);
-        when(client.prepareSearch(eq(SECURITY_MAIN_ALIAS))).thenReturn(
-            Mockito.spy(new SearchRequestBuilder(client, TransportSearchAction.TYPE))
-        );
+        when(client.prepareSearch(eq(SECURITY_MAIN_ALIAS))).thenReturn(Mockito.spy(new SearchRequestBuilder(client)));
         final ExpressionRoleMapping mapping = new ExpressionRoleMapping(
             "mapping",
             new FieldExpression("dn", Collections.singletonList(new FieldValue("*"))),

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/profile/ProfileServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/profile/ProfileServiceTests.java
@@ -20,7 +20,6 @@ import org.elasticsearch.action.get.MultiGetAction;
 import org.elasticsearch.action.get.MultiGetItemResponse;
 import org.elasticsearch.action.get.MultiGetRequest;
 import org.elasticsearch.action.get.MultiGetResponse;
-import org.elasticsearch.action.index.IndexAction;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.MultiSearchRequest;
 import org.elasticsearch.action.search.MultiSearchRequestBuilder;
@@ -196,9 +195,7 @@ public class ProfileServiceTests extends ESTestCase {
         );
         this.client = mock(Client.class);
         when(client.threadPool()).thenReturn(threadPool);
-        when(client.prepareSearch(SECURITY_PROFILE_ALIAS)).thenReturn(
-            new SearchRequestBuilder(client, TransportSearchAction.TYPE).setIndices(SECURITY_PROFILE_ALIAS)
-        );
+        when(client.prepareSearch(SECURITY_PROFILE_ALIAS)).thenReturn(new SearchRequestBuilder(client).setIndices(SECURITY_PROFILE_ALIAS));
         this.profileIndex = SecurityMocks.mockSecurityIndexManager(SECURITY_PROFILE_ALIAS);
         final ClusterService clusterService = mock(ClusterService.class);
         final ClusterState clusterState = mock(ClusterState.class);
@@ -598,9 +595,7 @@ public class ProfileServiceTests extends ESTestCase {
             return null;
         }).when(client).execute(eq(TransportMultiSearchAction.TYPE), any(MultiSearchRequest.class), anyActionListener());
 
-        when(client.prepareIndex(SECURITY_PROFILE_ALIAS)).thenReturn(
-            new IndexRequestBuilder(client, IndexAction.INSTANCE, SECURITY_PROFILE_ALIAS)
-        );
+        when(client.prepareIndex(SECURITY_PROFILE_ALIAS)).thenReturn(new IndexRequestBuilder(client, SECURITY_PROFILE_ALIAS));
 
         final RuntimeException expectedException = new RuntimeException("expected");
         doAnswer(invocation -> {
@@ -895,14 +890,8 @@ public class ProfileServiceTests extends ESTestCase {
     public void testActivateWhenShouldSkipUpdateForActivateReturnsTrue() throws IOException {
         final ProfileService service = spy(profileService);
 
-        doAnswer(
-            invocation -> new UpdateRequestBuilder(
-                client,
-                UpdateAction.INSTANCE,
-                SECURITY_PROFILE_ALIAS,
-                (String) invocation.getArguments()[1]
-            )
-        ).when(client).prepareUpdate(eq(SECURITY_PROFILE_ALIAS), anyString());
+        doAnswer(invocation -> new UpdateRequestBuilder(client, SECURITY_PROFILE_ALIAS, (String) invocation.getArguments()[1])).when(client)
+            .prepareUpdate(eq(SECURITY_PROFILE_ALIAS), anyString());
 
         final UpdateResponse updateResponse = mock(UpdateResponse.class);
         when(updateResponse.getPrimaryTerm()).thenReturn(randomNonNegativeLong());
@@ -931,14 +920,8 @@ public class ProfileServiceTests extends ESTestCase {
 
     public void testActivateWhenShouldSkipUpdateForActivateReturnsFalseFirst() throws IOException {
         final ProfileService service = spy(profileService);
-        doAnswer(
-            invocation -> new UpdateRequestBuilder(
-                client,
-                UpdateAction.INSTANCE,
-                SECURITY_PROFILE_ALIAS,
-                (String) invocation.getArguments()[1]
-            )
-        ).when(client).prepareUpdate(eq(SECURITY_PROFILE_ALIAS), anyString());
+        doAnswer(invocation -> new UpdateRequestBuilder(client, SECURITY_PROFILE_ALIAS, (String) invocation.getArguments()[1])).when(client)
+            .prepareUpdate(eq(SECURITY_PROFILE_ALIAS), anyString());
 
         // Throw version conflict on update to force GET document
         final Exception updateException;
@@ -993,14 +976,8 @@ public class ProfileServiceTests extends ESTestCase {
 
     public void testActivateWhenGetRequestErrors() throws IOException {
         final ProfileService service = spy(profileService);
-        doAnswer(
-            invocation -> new UpdateRequestBuilder(
-                client,
-                UpdateAction.INSTANCE,
-                SECURITY_PROFILE_ALIAS,
-                (String) invocation.getArguments()[1]
-            )
-        ).when(client).prepareUpdate(eq(SECURITY_PROFILE_ALIAS), anyString());
+        doAnswer(invocation -> new UpdateRequestBuilder(client, SECURITY_PROFILE_ALIAS, (String) invocation.getArguments()[1])).when(client)
+            .prepareUpdate(eq(SECURITY_PROFILE_ALIAS), anyString());
 
         // Throw version conflict on update to force GET document
         final var versionConflictEngineException = new VersionConflictEngineException(mock(ShardId.class), "", "");
@@ -1069,7 +1046,7 @@ public class ProfileServiceTests extends ESTestCase {
                 return null;
             }).when(client).execute(eq(TransportMultiSearchAction.TYPE), any(MultiSearchRequest.class), anyActionListener());
 
-            when(client.prepareMultiSearch()).thenReturn(new MultiSearchRequestBuilder(client, TransportMultiSearchAction.TYPE));
+            when(client.prepareMultiSearch()).thenReturn(new MultiSearchRequestBuilder(client));
             final PlainActionFuture<Map<String, Object>> future = new PlainActionFuture<>();
             profileService.usageStats(future);
             assertThat(future.actionGet(), equalTo(metrics));

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/test/SecurityMocks.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/test/SecurityMocks.java
@@ -10,7 +10,6 @@ package org.elasticsearch.xpack.security.test;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionType;
-import org.elasticsearch.action.get.GetAction;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.get.GetRequestBuilder;
 import org.elasticsearch.action.get.GetResponse;
@@ -103,7 +102,7 @@ public final class SecurityMocks {
     }
 
     public static void mockGetRequest(Client client, String indexAliasName, String documentId, GetResult result) {
-        final GetRequestBuilder requestBuilder = new GetRequestBuilder(client, GetAction.INSTANCE);
+        final GetRequestBuilder requestBuilder = new GetRequestBuilder(client);
         requestBuilder.setIndex(indexAliasName);
         requestBuilder.setId(documentId);
         when(client.prepareGet(indexAliasName, documentId)).thenReturn(requestBuilder);
@@ -125,7 +124,7 @@ public final class SecurityMocks {
     }
 
     public static void mockGetRequestException(Client client, Exception e) {
-        when(client.prepareGet(anyString(), anyString())).thenReturn(new GetRequestBuilder(client, GetAction.INSTANCE));
+        when(client.prepareGet(anyString(), anyString())).thenReturn(new GetRequestBuilder(client));
         doAnswer(inv -> {
             @SuppressWarnings("unchecked")
             ActionListener<GetResponse> listener = (ActionListener<GetResponse>) inv.getArguments()[1];
@@ -207,7 +206,7 @@ public final class SecurityMocks {
             Assert.assertThat(inv.getArguments(), arrayWithSize(1));
             final Object requestIndex = inv.getArguments()[0];
             Assert.assertThat(requestIndex, instanceOf(String.class));
-            return new IndexRequestBuilder(client, IndexAction.INSTANCE).setIndex((String) requestIndex);
+            return new IndexRequestBuilder(client).setIndex((String) requestIndex);
         }).when(client).prepareIndex(anyString());
         doAnswer(inv -> {
             Assert.assertThat(inv.getArguments(), arrayWithSize(3));

--- a/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/SqlClearCursorRequestBuilder.java
+++ b/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/SqlClearCursorRequestBuilder.java
@@ -11,8 +11,8 @@ import org.elasticsearch.client.internal.ElasticsearchClient;
 
 public class SqlClearCursorRequestBuilder extends ActionRequestBuilder<SqlClearCursorRequest, SqlClearCursorResponse> {
 
-    public SqlClearCursorRequestBuilder(ElasticsearchClient client, SqlClearCursorAction action) {
-        super(client, action, new SqlClearCursorRequest());
+    public SqlClearCursorRequestBuilder(ElasticsearchClient client) {
+        super(client, SqlClearCursorAction.INSTANCE, new SqlClearCursorRequest());
     }
 
     public SqlClearCursorRequestBuilder cursor(String cursor) {

--- a/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/SqlQueryRequestBuilder.java
+++ b/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/SqlQueryRequestBuilder.java
@@ -26,10 +26,9 @@ import static java.util.Collections.emptyMap;
  */
 public class SqlQueryRequestBuilder extends ActionRequestBuilder<SqlQueryRequest, SqlQueryResponse> {
 
-    public SqlQueryRequestBuilder(ElasticsearchClient client, SqlQueryAction action) {
+    public SqlQueryRequestBuilder(ElasticsearchClient client) {
         this(
             client,
-            action,
             "",
             emptyList(),
             null,
@@ -53,7 +52,6 @@ public class SqlQueryRequestBuilder extends ActionRequestBuilder<SqlQueryRequest
 
     public SqlQueryRequestBuilder(
         ElasticsearchClient client,
-        SqlQueryAction action,
         String query,
         List<SqlTypedParamValue> params,
         QueryBuilder filter,
@@ -75,7 +73,7 @@ public class SqlQueryRequestBuilder extends ActionRequestBuilder<SqlQueryRequest
     ) {
         super(
             client,
-            action,
+            SqlQueryAction.INSTANCE,
             new SqlQueryRequest(
                 query,
                 params,

--- a/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/SqlTranslateRequestBuilder.java
+++ b/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/SqlTranslateRequestBuilder.java
@@ -25,10 +25,9 @@ import static java.util.Collections.emptyMap;
  * Builder for the request for the sql action for translating SQL queries into ES requests
  */
 public class SqlTranslateRequestBuilder extends ActionRequestBuilder<SqlTranslateRequest, SqlTranslateResponse> {
-    public SqlTranslateRequestBuilder(ElasticsearchClient client, SqlTranslateAction action) {
+    public SqlTranslateRequestBuilder(ElasticsearchClient client) {
         this(
             client,
-            action,
             null,
             null,
             emptyMap(),
@@ -43,7 +42,6 @@ public class SqlTranslateRequestBuilder extends ActionRequestBuilder<SqlTranslat
 
     public SqlTranslateRequestBuilder(
         ElasticsearchClient client,
-        SqlTranslateAction action,
         String query,
         QueryBuilder filter,
         Map<String, Object> runtimeMappings,
@@ -56,7 +54,7 @@ public class SqlTranslateRequestBuilder extends ActionRequestBuilder<SqlTranslat
     ) {
         super(
             client,
-            action,
+            SqlTranslateAction.INSTANCE,
             new SqlTranslateRequest(query, params, filter, runtimeMappings, zoneId, fetchSize, requestTimeout, pageTimeout, requestInfo)
         );
     }

--- a/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/AsyncSqlSearchActionIT.java
+++ b/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/AsyncSqlSearchActionIT.java
@@ -109,7 +109,7 @@ public class AsyncSqlSearchActionIT extends AbstractSqlBlockingIntegTestCase {
 
         boolean success = randomBoolean();
         String query = "SELECT event_type FROM test WHERE " + (success ? "i=1" : "10/i=1");
-        SqlQueryRequestBuilder builder = new SqlQueryRequestBuilder(client(), SqlQueryAction.INSTANCE).query(query)
+        SqlQueryRequestBuilder builder = new SqlQueryRequestBuilder(client()).query(query)
             .waitForCompletionTimeout(TimeValue.timeValueMillis(1));
 
         List<SearchBlockPlugin> plugins = initBlockFactory(true, false);
@@ -159,7 +159,7 @@ public class AsyncSqlSearchActionIT extends AbstractSqlBlockingIntegTestCase {
 
         boolean success = randomBoolean();
         String query = "SELECT event_type FROM test WHERE " + (success ? "i=1" : "10/i=1");
-        SqlQueryRequestBuilder builder = new SqlQueryRequestBuilder(client(), SqlQueryAction.INSTANCE).query(query)
+        SqlQueryRequestBuilder builder = new SqlQueryRequestBuilder(client()).query(query)
             .waitForCompletionTimeout(TimeValue.timeValueMillis(1));
 
         boolean customKeepAlive = randomBoolean();
@@ -215,7 +215,7 @@ public class AsyncSqlSearchActionIT extends AbstractSqlBlockingIntegTestCase {
 
         boolean success = randomBoolean();
         String query = "SELECT event_type FROM test WHERE " + (success ? "i=1" : "10/i=1");
-        SqlQueryRequestBuilder builder = new SqlQueryRequestBuilder(client(), SqlQueryAction.INSTANCE).query(query)
+        SqlQueryRequestBuilder builder = new SqlQueryRequestBuilder(client()).query(query)
             .waitForCompletionTimeout(TimeValue.timeValueMillis(1));
 
         boolean customKeepAlive = randomBoolean();
@@ -257,7 +257,7 @@ public class AsyncSqlSearchActionIT extends AbstractSqlBlockingIntegTestCase {
         boolean success = randomBoolean();
         boolean keepOnCompletion = randomBoolean();
         String query = "SELECT event_type FROM test WHERE " + (success ? "i=1" : "10/i=1");
-        SqlQueryRequestBuilder builder = new SqlQueryRequestBuilder(client(), SqlQueryAction.INSTANCE).query(query)
+        SqlQueryRequestBuilder builder = new SqlQueryRequestBuilder(client()).query(query)
             .waitForCompletionTimeout(TimeValue.timeValueSeconds(10));
         if (keepOnCompletion || randomBoolean()) {
             builder.keepOnCompletion(keepOnCompletion);

--- a/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/SqlActionIT.java
+++ b/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/SqlActionIT.java
@@ -30,9 +30,10 @@ public class SqlActionIT extends AbstractSqlIntegTestCase {
 
         boolean dataBeforeCount = randomBoolean();
         String columns = dataBeforeCount ? "data, count" : "count, data";
-        SqlQueryResponse response = new SqlQueryRequestBuilder(client(), SqlQueryAction.INSTANCE).query(
-            "SELECT " + columns + " FROM test ORDER BY count"
-        ).mode(Mode.JDBC).version(Version.CURRENT.toString()).get();
+        SqlQueryResponse response = new SqlQueryRequestBuilder(client()).query("SELECT " + columns + " FROM test ORDER BY count")
+            .mode(Mode.JDBC)
+            .version(Version.CURRENT.toString())
+            .get();
         assertThat(response.size(), equalTo(2L));
         assertThat(response.columns(), hasSize(2));
         int dataIndex = dataBeforeCount ? 0 : 1;
@@ -48,7 +49,7 @@ public class SqlActionIT extends AbstractSqlIntegTestCase {
     }
 
     public void testSqlActionCurrentVersion() {
-        SqlQueryResponse response = new SqlQueryRequestBuilder(client(), SqlQueryAction.INSTANCE).query("SELECT true")
+        SqlQueryResponse response = new SqlQueryRequestBuilder(client()).query("SELECT true")
             .mode(randomFrom(Mode.CLI, Mode.JDBC))
             .version(Version.CURRENT.toString())
             .get();
@@ -57,7 +58,7 @@ public class SqlActionIT extends AbstractSqlIntegTestCase {
     }
 
     public void testSqlActionOutdatedVersion() {
-        SqlQueryRequestBuilder request = new SqlQueryRequestBuilder(client(), SqlQueryAction.INSTANCE).query("SELECT true")
+        SqlQueryRequestBuilder request = new SqlQueryRequestBuilder(client()).query("SELECT true")
             .mode(randomFrom(Mode.CLI, Mode.JDBC))
             .version("1.2.3");
         assertRequestBuilderThrows(request, org.elasticsearch.action.ActionRequestValidationException.class);

--- a/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/SqlCancellationIT.java
+++ b/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/SqlCancellationIT.java
@@ -63,9 +63,7 @@ public class SqlCancellationIT extends AbstractSqlBlockingIntegTestCase {
         indexRandom(true, builders);
         boolean cancelDuringSearch = randomBoolean();
         List<SearchBlockPlugin> plugins = initBlockFactory(cancelDuringSearch, cancelDuringSearch == false);
-        SqlQueryRequest request = new SqlQueryRequestBuilder(client(), SqlQueryAction.INSTANCE).query(
-            "SELECT event_type FROM test WHERE val=1"
-        ).request();
+        SqlQueryRequest request = new SqlQueryRequestBuilder(client()).query("SELECT event_type FROM test WHERE val=1").request();
         String id = randomAlphaOfLength(10);
         logger.trace("Preparing search");
         // We might perform field caps on the same thread if it is local client, so we cannot use the standard mechanism

--- a/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/SqlClearCursorActionIT.java
+++ b/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/SqlClearCursorActionIT.java
@@ -34,18 +34,14 @@ public class SqlClearCursorActionIT extends AbstractSqlIntegTestCase {
 
         int fetchSize = randomIntBetween(5, 20);
         logger.info("Fetching {} records at a time", fetchSize);
-        SqlQueryResponse sqlQueryResponse = new SqlQueryRequestBuilder(client(), SqlQueryAction.INSTANCE).query("SELECT * FROM test")
-            .fetchSize(fetchSize)
-            .get();
+        SqlQueryResponse sqlQueryResponse = new SqlQueryRequestBuilder(client()).query("SELECT * FROM test").fetchSize(fetchSize).get();
         assertEquals(fetchSize, sqlQueryResponse.size());
 
         assertThat(getNumberOfSearchContexts(), greaterThan(0L));
         assertThat(sqlQueryResponse.cursor(), notNullValue());
         assertThat(sqlQueryResponse.cursor(), not(equalTo(Cursor.EMPTY)));
 
-        SqlClearCursorResponse cleanCursorResponse = new SqlClearCursorRequestBuilder(client(), SqlClearCursorAction.INSTANCE).cursor(
-            sqlQueryResponse.cursor()
-        ).get();
+        SqlClearCursorResponse cleanCursorResponse = new SqlClearCursorRequestBuilder(client()).cursor(sqlQueryResponse.cursor()).get();
         assertTrue(cleanCursorResponse.isSucceeded());
 
         assertEquals(0, getNumberOfSearchContexts());
@@ -66,9 +62,7 @@ public class SqlClearCursorActionIT extends AbstractSqlIntegTestCase {
 
         int fetchSize = randomIntBetween(5, 20);
         logger.info("Fetching {} records at a time", fetchSize);
-        SqlQueryResponse sqlQueryResponse = new SqlQueryRequestBuilder(client(), SqlQueryAction.INSTANCE).query("SELECT * FROM test")
-            .fetchSize(fetchSize)
-            .get();
+        SqlQueryResponse sqlQueryResponse = new SqlQueryRequestBuilder(client()).query("SELECT * FROM test").fetchSize(fetchSize).get();
         assertEquals(fetchSize, sqlQueryResponse.size());
 
         assertThat(getNumberOfSearchContexts(), greaterThan(0L));
@@ -77,14 +71,12 @@ public class SqlClearCursorActionIT extends AbstractSqlIntegTestCase {
 
         long fetched = sqlQueryResponse.size();
         do {
-            sqlQueryResponse = new SqlQueryRequestBuilder(client(), SqlQueryAction.INSTANCE).cursor(sqlQueryResponse.cursor()).get();
+            sqlQueryResponse = new SqlQueryRequestBuilder(client()).cursor(sqlQueryResponse.cursor()).get();
             fetched += sqlQueryResponse.size();
         } while (sqlQueryResponse.cursor().isEmpty() == false);
         assertEquals(indexSize, fetched);
 
-        SqlClearCursorResponse cleanCursorResponse = new SqlClearCursorRequestBuilder(client(), SqlClearCursorAction.INSTANCE).cursor(
-            sqlQueryResponse.cursor()
-        ).get();
+        SqlClearCursorResponse cleanCursorResponse = new SqlClearCursorRequestBuilder(client()).cursor(sqlQueryResponse.cursor()).get();
         assertFalse(cleanCursorResponse.isSucceeded());
 
         assertEquals(0, getNumberOfSearchContexts());

--- a/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/SqlLicenseIT.java
+++ b/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/SqlLicenseIT.java
@@ -111,12 +111,12 @@ public class SqlLicenseIT extends AbstractLicensesIntegrationTestCase {
 
         ElasticsearchSecurityException e = expectThrows(
             ElasticsearchSecurityException.class,
-            () -> new SqlQueryRequestBuilder(client(), SqlQueryAction.INSTANCE).query("SELECT * FROM test").get()
+            () -> new SqlQueryRequestBuilder(client()).query("SELECT * FROM test").get()
         );
         assertThat(e.getMessage(), equalTo("current license is non-compliant for [sql]"));
         enableSqlLicensing();
 
-        SqlQueryResponse response = new SqlQueryRequestBuilder(client(), SqlQueryAction.INSTANCE).query("SELECT * FROM test").get();
+        SqlQueryResponse response = new SqlQueryRequestBuilder(client()).query("SELECT * FROM test").get();
         assertThat(response.size(), Matchers.equalTo(2L));
     }
 
@@ -126,14 +126,12 @@ public class SqlLicenseIT extends AbstractLicensesIntegrationTestCase {
 
         ElasticsearchSecurityException e = expectThrows(
             ElasticsearchSecurityException.class,
-            () -> new SqlQueryRequestBuilder(client(), SqlQueryAction.INSTANCE).query("SELECT * FROM test").mode("jdbc").get()
+            () -> new SqlQueryRequestBuilder(client()).query("SELECT * FROM test").mode("jdbc").get()
         );
         assertThat(e.getMessage(), equalTo("current license is non-compliant for [jdbc]"));
         enableJdbcLicensing();
 
-        SqlQueryResponse response = new SqlQueryRequestBuilder(client(), SqlQueryAction.INSTANCE).query("SELECT * FROM test")
-            .mode("jdbc")
-            .get();
+        SqlQueryResponse response = new SqlQueryRequestBuilder(client()).query("SELECT * FROM test").mode("jdbc").get();
         assertThat(response.size(), Matchers.equalTo(2L));
     }
 
@@ -143,13 +141,12 @@ public class SqlLicenseIT extends AbstractLicensesIntegrationTestCase {
 
         ElasticsearchSecurityException e = expectThrows(
             ElasticsearchSecurityException.class,
-            () -> new SqlTranslateRequestBuilder(client(), SqlTranslateAction.INSTANCE).query("SELECT * FROM test").get()
+            () -> new SqlTranslateRequestBuilder(client()).query("SELECT * FROM test").get()
         );
         assertThat(e.getMessage(), equalTo("current license is non-compliant for [sql]"));
         enableSqlLicensing();
 
-        SqlTranslateResponse response = new SqlTranslateRequestBuilder(client(), SqlTranslateAction.INSTANCE).query("SELECT * FROM test")
-            .get();
+        SqlTranslateResponse response = new SqlTranslateRequestBuilder(client()).query("SELECT * FROM test").get();
         SearchSourceBuilder source = response.source();
         assertThat(source.docValueFields(), Matchers.contains(new FieldAndFormat("count", null)));
         FetchSourceContext fetchSource = source.fetchSource();

--- a/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/SqlSearchPageTimeoutIT.java
+++ b/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/SqlSearchPageTimeoutIT.java
@@ -42,7 +42,7 @@ public class SqlSearchPageTimeoutIT extends AbstractSqlIntegTestCase {
     public void testSearchContextIsCleanedUpAfterPageTimeout(String query) throws Exception {
         setupTestIndex();
 
-        SqlQueryResponse response = new SqlQueryRequestBuilder(client(), SqlQueryAction.INSTANCE).query(query)
+        SqlQueryResponse response = new SqlQueryRequestBuilder(client()).query(query)
             .fetchSize(1)
             .pageTimeout(TimeValue.timeValueMillis(500))
             .get();
@@ -54,7 +54,7 @@ public class SqlSearchPageTimeoutIT extends AbstractSqlIntegTestCase {
 
         SearchPhaseExecutionException exception = expectThrows(
             SearchPhaseExecutionException.class,
-            () -> new SqlQueryRequestBuilder(client(), SqlQueryAction.INSTANCE).cursor(response.cursor()).get()
+            () -> new SqlQueryRequestBuilder(client()).cursor(response.cursor()).get()
         );
 
         assertThat(Arrays.asList(exception.guessRootCauses()), contains(instanceOf(SearchContextMissingException.class)));

--- a/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/SqlTranslateActionIT.java
+++ b/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/SqlTranslateActionIT.java
@@ -31,9 +31,8 @@ public class SqlTranslateActionIT extends AbstractSqlIntegTestCase {
 
         boolean columnOrder = randomBoolean();
         String columns = columnOrder ? "data, count, date" : "date, data, count";
-        SqlTranslateResponse response = new SqlTranslateRequestBuilder(client(), SqlTranslateAction.INSTANCE).query(
-            "SELECT " + columns + " FROM test ORDER BY count"
-        ).get();
+        SqlTranslateResponse response = new SqlTranslateRequestBuilder(client()).query("SELECT " + columns + " FROM test ORDER BY count")
+            .get();
         SearchSourceBuilder source = response.source();
         List<FieldAndFormat> actualFields = source.fetchFields();
         List<FieldAndFormat> expectedFields = new ArrayList<>(3);

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/CancellationTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/CancellationTests.java
@@ -31,7 +31,6 @@ import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.ql.index.IndexResolver;
 import org.elasticsearch.xpack.ql.type.DefaultDataTypeRegistry;
 import org.elasticsearch.xpack.sql.SqlTestUtils;
-import org.elasticsearch.xpack.sql.action.SqlQueryAction;
 import org.elasticsearch.xpack.sql.action.SqlQueryRequest;
 import org.elasticsearch.xpack.sql.action.SqlQueryRequestBuilder;
 import org.elasticsearch.xpack.sql.action.SqlQueryResponse;
@@ -72,7 +71,7 @@ public class CancellationTests extends ESTestCase {
         IndexResolver indexResolver = indexResolver(client);
         PlanExecutor planExecutor = new PlanExecutor(client, indexResolver, new NamedWriteableRegistry(Collections.emptyList()));
         CountDownLatch countDownLatch = new CountDownLatch(1);
-        SqlQueryRequest request = new SqlQueryRequestBuilder(client, SqlQueryAction.INSTANCE).query("SELECT foo FROM bar").request();
+        SqlQueryRequest request = new SqlQueryRequestBuilder(client).query("SELECT foo FROM bar").request();
         TransportSqlQueryAction.operation(planExecutor, task, request, new ActionListener<>() {
             @Override
             public void onResponse(SqlQueryResponse sqlSearchResponse) {
@@ -135,8 +134,7 @@ public class CancellationTests extends ESTestCase {
         IndexResolver indexResolver = indexResolver(client);
         PlanExecutor planExecutor = new PlanExecutor(client, indexResolver, new NamedWriteableRegistry(Collections.emptyList()));
         CountDownLatch countDownLatch = new CountDownLatch(1);
-        SqlQueryRequest request = new SqlQueryRequestBuilder(client, SqlQueryAction.INSTANCE).query("SELECT foo FROM " + indices[0])
-            .request();
+        SqlQueryRequest request = new SqlQueryRequestBuilder(client).query("SELECT foo FROM " + indices[0]).request();
         TransportSqlQueryAction.operation(planExecutor, task, request, new ActionListener<>() {
             @Override
             public void onResponse(SqlQueryResponse sqlSearchResponse) {
@@ -196,7 +194,7 @@ public class CancellationTests extends ESTestCase {
 
         // Emulation of search cancellation
         ArgumentCaptor<SearchRequest> searchRequestCaptor = ArgumentCaptor.forClass(SearchRequest.class);
-        when(client.prepareSearch(any())).thenReturn(new SearchRequestBuilder(client, TransportSearchAction.TYPE).setIndices(indices));
+        when(client.prepareSearch(any())).thenReturn(new SearchRequestBuilder(client).setIndices(indices));
         doAnswer((Answer<Void>) invocation -> {
             @SuppressWarnings("unchecked")
             SearchRequest request = (SearchRequest) invocation.getArguments()[1];
@@ -224,7 +222,7 @@ public class CancellationTests extends ESTestCase {
 
         IndexResolver indexResolver = indexResolver(client);
         PlanExecutor planExecutor = new PlanExecutor(client, indexResolver, new NamedWriteableRegistry(Collections.emptyList()));
-        SqlQueryRequest request = new SqlQueryRequestBuilder(client, SqlQueryAction.INSTANCE).query(query).request();
+        SqlQueryRequest request = new SqlQueryRequestBuilder(client).query(query).request();
         CountDownLatch countDownLatch = new CountDownLatch(1);
         TransportSqlQueryAction.operation(planExecutor, task, request, new ActionListener<>() {
             @Override


### PR DESCRIPTION
These are always constant values. We can inline them everywhere to save code and easy removing the subclasses of ActionType going forward.
