### PR TITLE
[Enterprise Search] Add POST connector sync job

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector_sync_job.post.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector_sync_job.post.json
@@ -1,0 +1,33 @@
+{
+  "connector_sync_job.post": {
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/enterprise-search/current/connectors.html",
+      "description": "Creates a connector sync job."
+    },
+    "stability": "experimental",
+    "visibility": "feature_flag",
+    "feature_flag": "es.connector_api_feature_flag_enabled",
+    "headers": {
+      "accept": [
+        "application/json"
+      ],
+      "content_type": [
+        "application/json"
+      ]
+    },
+    "url": {
+      "paths": [
+        {
+          "path": "/_connector/_sync_job",
+          "methods": [
+            "POST"
+          ]
+        }
+      ]
+    },
+    "body": {
+      "description": "The connector sync job data.",
+      "required": true
+    }
+  }
+}

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -144,6 +144,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.security.Provider;
 import java.security.SecureRandom;
+import java.time.Instant;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -783,6 +784,16 @@ public abstract class ESTestCase extends LuceneTestCase {
      */
     public static long randomLongBetween(long min, long max) {
         return RandomNumbers.randomLongBetween(random(), min, max);
+    }
+
+    /**
+     * @return a random instant between a min and a max value with a random nanosecond precision
+     */
+    public static Instant randomInstantBetween(Instant minInstant, Instant maxInstant) {
+        return Instant.ofEpochSecond(
+            randomLongBetween(minInstant.getEpochSecond(), maxInstant.getEpochSecond()),
+            randomLongBetween(0, 999999999)
+        );
     }
 
     /**

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/400_connector_sync_job_post.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/400_connector_sync_job_post.yml
@@ -1,0 +1,74 @@
+setup:
+  - skip:
+      version: " - 8.11.99"
+      reason: Introduced in 8.12.0
+  - do:
+      connector.put:
+        connector_id: test-connector
+        body:
+          index_name: search-test
+          name: my-connector
+          language: de
+          is_native: false
+          service_type: super-connector
+
+---
+'Create connector sync job':
+  - do:
+      connector_sync_job.post:
+        body:
+          id: test-connector
+          job_type: full
+          trigger_method: on_demand
+  - set:  { id: id }
+  - match: { id: $id }
+
+---
+'Create connector sync job with missing job type':
+  - do:
+      connector_sync_job.post:
+        body:
+          id: test-connector
+          trigger_method: on_demand
+  - set:  { id: id }
+  - match: { id: $id }
+
+---
+'Create connector sync job with missing trigger method':
+  - do:
+      connector_sync_job.post:
+        body:
+          id: test-connector
+          job_type: full
+  - set:  { id: id }
+  - match: { id: $id }
+
+---
+'Create connector sync job with non-existing connector id':
+  - do:
+      connector_sync_job.post:
+        body:
+          id: non-existing-id
+          job_type: full
+          trigger_method: on_demand
+      catch: missing
+
+---
+'Create connector sync job with invalid job type':
+  - do:
+      connector_sync_job.post:
+        body:
+          id: test-connector
+          job_type: invalid_job_type
+          trigger_method: on_demand
+      catch: bad_request
+
+---
+'Create connector sync job with invalid trigger method':
+  - do:
+      connector_sync_job.post:
+        body:
+          id: test-connector
+          job_type: full
+          trigger_method: invalid_trigger_method
+      catch: bad_request

--- a/x-pack/plugin/ent-search/src/main/java/module-info.java
+++ b/x-pack/plugin/ent-search/src/main/java/module-info.java
@@ -35,6 +35,8 @@ module org.elasticsearch.application {
     exports org.elasticsearch.xpack.application.rules.action;
     exports org.elasticsearch.xpack.application.connector;
     exports org.elasticsearch.xpack.application.connector.action;
+    exports org.elasticsearch.xpack.application.connector.syncjob;
+    exports org.elasticsearch.xpack.application.connector.syncjob.action;
 
     provides org.elasticsearch.features.FeatureSpecification with org.elasticsearch.xpack.application.EnterpriseSearchFeatures;
 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearch.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearch.java
@@ -54,6 +54,9 @@ import org.elasticsearch.xpack.application.connector.action.TransportDeleteConne
 import org.elasticsearch.xpack.application.connector.action.TransportGetConnectorAction;
 import org.elasticsearch.xpack.application.connector.action.TransportListConnectorAction;
 import org.elasticsearch.xpack.application.connector.action.TransportPutConnectorAction;
+import org.elasticsearch.xpack.application.connector.syncjob.action.PostConnectorSyncJobAction;
+import org.elasticsearch.xpack.application.connector.syncjob.action.RestPostConnectorSyncJobAction;
+import org.elasticsearch.xpack.application.connector.syncjob.action.TransportPostConnectorSyncJobAction;
 import org.elasticsearch.xpack.application.rules.QueryRulesConfig;
 import org.elasticsearch.xpack.application.rules.QueryRulesIndexService;
 import org.elasticsearch.xpack.application.rules.RuleQueryBuilder;
@@ -173,6 +176,7 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
                     new ActionHandler<>(PutConnectorAction.INSTANCE, TransportPutConnectorAction.class)
                 )
             );
+            actionHandlers.add(new ActionHandler<>(PostConnectorSyncJobAction.INSTANCE, TransportPostConnectorSyncJobAction.class));
         }
 
         return Collections.unmodifiableList(actionHandlers);
@@ -227,6 +231,7 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
                     new RestPutConnectorAction()
                 )
             );
+            restHandlers.add(new RestPostConnectorSyncJobAction());
         }
 
         return Collections.unmodifiableList(restHandlers);

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/Connector.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/Connector.java
@@ -9,9 +9,9 @@ package org.elasticsearch.xpack.application.connector;
 
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
@@ -28,6 +28,7 @@ import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
@@ -60,7 +61,9 @@ import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstr
  *     <li>A boolean flag 'syncNow', which, when set, triggers an immediate synchronization operation.</li>
  * </ul>
  */
-public class Connector implements Writeable, ToXContentObject {
+public class Connector implements NamedWriteable, ToXContentObject {
+
+    public static final String NAME = Connector.class.getName().toUpperCase(Locale.ROOT);
 
     private final String connectorId;
     @Nullable
@@ -185,21 +188,21 @@ public class Connector implements Writeable, ToXContentObject {
         this.syncNow = in.readBoolean();
     }
 
-    static final ParseField ID_FIELD = new ParseField("connector_id");
+    public static final ParseField ID_FIELD = new ParseField("connector_id");
     static final ParseField API_KEY_ID_FIELD = new ParseField("api_key_id");
-    static final ParseField CONFIGURATION_FIELD = new ParseField("configuration");
+    public static final ParseField CONFIGURATION_FIELD = new ParseField("configuration");
     static final ParseField CUSTOM_SCHEDULING_FIELD = new ParseField("custom_scheduling");
     static final ParseField DESCRIPTION_FIELD = new ParseField("description");
     static final ParseField ERROR_FIELD = new ParseField("error");
     static final ParseField FEATURES_FIELD = new ParseField("features");
-    static final ParseField FILTERING_FIELD = new ParseField("filtering");
-    static final ParseField INDEX_NAME_FIELD = new ParseField("index_name");
+    public static final ParseField FILTERING_FIELD = new ParseField("filtering");
+    public static final ParseField INDEX_NAME_FIELD = new ParseField("index_name");
     static final ParseField IS_NATIVE_FIELD = new ParseField("is_native");
-    static final ParseField LANGUAGE_FIELD = new ParseField("language");
+    public static final ParseField LANGUAGE_FIELD = new ParseField("language");
     static final ParseField NAME_FIELD = new ParseField("name");
-    static final ParseField PIPELINE_FIELD = new ParseField("pipeline");
+    public static final ParseField PIPELINE_FIELD = new ParseField("pipeline");
     static final ParseField SCHEDULING_FIELD = new ParseField("scheduling");
-    static final ParseField SERVICE_TYPE_FIELD = new ParseField("service_type");
+    public static final ParseField SERVICE_TYPE_FIELD = new ParseField("service_type");
     static final ParseField STATUS_FIELD = new ParseField("status");
     static final ParseField SYNC_CURSOR_FIELD = new ParseField("sync_cursor");
     static final ParseField SYNC_NOW_FIELD = new ParseField("sync_now");
@@ -444,6 +447,30 @@ public class Connector implements Writeable, ToXContentObject {
         return connectorId;
     }
 
+    public List<ConnectorFiltering> getFiltering() {
+        return filtering;
+    }
+
+    public String getIndexName() {
+        return indexName;
+    }
+
+    public String getLanguage() {
+        return language;
+    }
+
+    public ConnectorIngestPipeline getPipeline() {
+        return pipeline;
+    }
+
+    public String getServiceType() {
+        return serviceType;
+    }
+
+    public Map<String, Object> getConfiguration() {
+        return configuration;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -493,6 +520,11 @@ public class Connector implements Writeable, ToXContentObject {
             syncCursor,
             syncNow
         );
+    }
+
+    @Override
+    public String getWriteableName() {
+        return NAME;
     }
 
     public static class Builder {

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorSyncStatus.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorSyncStatus.java
@@ -30,6 +30,16 @@ public enum ConnectorSyncStatus {
     PENDING,
     SUSPENDED;
 
+    public static ConnectorSyncStatus fromString(String syncStatusString) {
+        for (ConnectorSyncStatus syncStatus : ConnectorSyncStatus.values()) {
+            if (syncStatus.toString().equalsIgnoreCase(syncStatusString)) {
+                return syncStatus;
+            }
+        }
+
+        throw new IllegalArgumentException("Unknown sync status '" + syncStatusString + "'.");
+    }
+
     @Override
     public String toString() {
         return name().toLowerCase(Locale.ROOT);

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJob.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJob.java
@@ -1,0 +1,485 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.connector.syncjob;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.xcontent.ParseField;
+import org.elasticsearch.xcontent.ToXContentObject;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.application.connector.Connector;
+import org.elasticsearch.xpack.application.connector.ConnectorSyncStatus;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Represents a sync job in the Elasticsearch ecosystem. Sync jobs refer to a unit of work, which syncs data from a 3rd party
+ * data source into an Elasticsearch index using the Connectors service. A ConnectorSyncJob always refers
+ * to a corresponding {@link Connector}. Each ConnectorSyncJob instance encapsulates various settings and state information, including:
+ * <ul>
+ *     <li>A timestamp, when the sync job cancellation was requested.</li>
+ *     <li>A timestamp, when the sync job was cancelled.</li>
+ *     <li>A timestamp, when the sync job was completed.</li>
+ *     <li>A subset of the {@link Connector} fields the sync job is referring to.</li>
+ *     <li>A timestamp, when the sync job was created.</li>
+ *     <li>The number of documents deleted by the sync job.</li>
+ *     <li>An error, which might have appeared during the sync job execution.</li>
+ *     <li>A unique identifier for distinguishing different connectors.</li>
+ *     <li>The number of documents indexed by the sync job.</li>
+ *     <li>The volume of the indexed documents.</li>
+ *     <li>The {@link ConnectorSyncJobType} of the sync job.</li>
+ *     <li>A timestamp, when the sync job was last seen by the Connectors service.</li>
+ *     <li>A {@link Map} containing metadata of the sync job.</li>
+ *     <li>A timestamp, when the sync job was started.</li>
+ *     <li>The {@link ConnectorSyncStatus} of the connector.</li>
+ *     <li>The total number of documents present in the index after the sync job completes.</li>
+ *     <li>The {@link ConnectorSyncJobTriggerMethod} of the sync job.</li>
+ *     <li>The hostname of the worker to run the sync job.</li>
+ * </ul>
+ */
+public class ConnectorSyncJob implements Writeable, ToXContentObject {
+
+    static final ParseField CANCELATION_REQUESTED_AT_FIELD = new ParseField("cancelation_requested_at");
+
+    static final ParseField CANCELED_AT_FIELD = new ParseField("canceled_at");
+
+    static final ParseField COMPLETED_AT_FIELD = new ParseField("completed_at");
+
+    static final ParseField CONNECTOR_FIELD = new ParseField("connector");
+
+    static final ParseField CREATED_AT_FIELD = new ParseField("created_at");
+
+    static final ParseField DELETED_DOCUMENT_COUNT = new ParseField("deleted_document_count");
+
+    static final ParseField ERROR_FIELD = new ParseField("error");
+
+    public static final ParseField ID_FIELD = new ParseField("id");
+
+    static final ParseField INDEXED_DOCUMENT_COUNT_FIELD = new ParseField("indexed_document_count");
+
+    static final ParseField INDEXED_DOCUMENT_VOLUME_FIELD = new ParseField("indexed_document_volume");
+
+    public static final ParseField JOB_TYPE_FIELD = new ParseField("job_type");
+
+    static final ParseField LAST_SEEN_FIELD = new ParseField("last_seen");
+
+    static final ParseField METADATA_FIELD = new ParseField("metadata");
+
+    static final ParseField STARTED_AT_FIELD = new ParseField("started_at");
+
+    static final ParseField STATUS_FIELD = new ParseField("status");
+
+    static final ParseField TOTAL_DOCUMENT_COUNT_FIELD = new ParseField("total_document_count");
+
+    public static final ParseField TRIGGER_METHOD_FIELD = new ParseField("trigger_method");
+
+    static final ParseField WORKER_HOSTNAME_FIELD = new ParseField("worker_hostname");
+
+    static final ConnectorSyncStatus DEFAULT_INITIAL_STATUS = ConnectorSyncStatus.PENDING;
+
+    static final ConnectorSyncJobType DEFAULT_JOB_TYPE = ConnectorSyncJobType.FULL;
+
+    static final ConnectorSyncJobTriggerMethod DEFAULT_TRIGGER_METHOD = ConnectorSyncJobTriggerMethod.ON_DEMAND;
+
+    private final Instant cancelationRequestedAt;
+
+    @Nullable
+    private final Instant canceledAt;
+
+    @Nullable
+    private final Instant completedAt;
+
+    private final Connector connector;
+
+    private final Instant createdAt;
+
+    private final long deletedDocumentCount;
+
+    @Nullable
+    private final String error;
+
+    private final String id;
+
+    private final long indexedDocumentCount;
+
+    private final long indexedDocumentVolume;
+
+    private final ConnectorSyncJobType jobType;
+
+    @Nullable
+    private final Instant lastSeen;
+
+    private final Map<String, Object> metadata;
+
+    @Nullable
+    private final Instant startedAt;
+
+    private final ConnectorSyncStatus status;
+
+    @Nullable
+    private final long totalDocumentCount;
+
+    private final ConnectorSyncJobTriggerMethod triggerMethod;
+
+    @Nullable
+    private final String workerHostname;
+
+    /**
+     *
+     * @param cancelationRequestedAt    Timestamp when the sync job cancellation was requested.
+     * @param canceledAt                Timestamp, when the sync job was cancelled.
+     * @param completedAt               Timestamp, when the sync job was completed.
+     * @param connector                 Subset of connector fields the sync job is referring to.
+     * @param createdAt                 Timestamp, when the sync job was created.
+     * @param deletedDocumentCount      Number of documents deleted by the sync job.
+     * @param error                     Error, which might have appeared during the sync job execution.
+     * @param id                        Unique identifier for distinguishing different connectors.
+     * @param indexedDocumentCount      Number of documents indexed by the sync job.
+     * @param indexedDocumentVolume     Volume of the indexed documents.
+     * @param jobType                   Job type of the sync job.
+     * @param lastSeen                  Timestamp, when the sync was last seen by the Connectors service.
+     * @param metadata                  Map containing metadata of the sync job.
+     * @param startedAt                 Timestamp, when the sync job was started.
+     * @param status                    Sync status of the connector.
+     * @param totalDocumentCount        Total number of documents present in the index after the sync job completes.
+     * @param triggerMethod             Trigger method of the sync job.
+     * @param workerHostname            Hostname of the worker to run the sync job.
+     */
+    private ConnectorSyncJob(
+        Instant cancelationRequestedAt,
+        Instant canceledAt,
+        Instant completedAt,
+        Connector connector,
+        Instant createdAt,
+        long deletedDocumentCount,
+        String error,
+        String id,
+        long indexedDocumentCount,
+        long indexedDocumentVolume,
+        ConnectorSyncJobType jobType,
+        Instant lastSeen,
+        Map<String, Object> metadata,
+        Instant startedAt,
+        ConnectorSyncStatus status,
+        long totalDocumentCount,
+        ConnectorSyncJobTriggerMethod triggerMethod,
+        String workerHostname
+    ) {
+        this.cancelationRequestedAt = cancelationRequestedAt;
+        this.canceledAt = canceledAt;
+        this.completedAt = completedAt;
+        this.connector = connector;
+        this.createdAt = createdAt;
+        this.deletedDocumentCount = deletedDocumentCount;
+        this.error = error;
+        this.id = Objects.requireNonNull(id, "[id] cannot be null");
+        this.indexedDocumentCount = indexedDocumentCount;
+        this.indexedDocumentVolume = indexedDocumentVolume;
+        this.jobType = Objects.requireNonNullElse(jobType, ConnectorSyncJobType.FULL);
+        this.lastSeen = lastSeen;
+        this.metadata = Objects.requireNonNullElse(metadata, Collections.emptyMap());
+        this.startedAt = startedAt;
+        this.status = status;
+        this.totalDocumentCount = totalDocumentCount;
+        this.triggerMethod = Objects.requireNonNullElse(triggerMethod, ConnectorSyncJobTriggerMethod.ON_DEMAND);
+        this.workerHostname = workerHostname;
+    }
+
+    public ConnectorSyncJob(StreamInput in) throws IOException {
+        this.cancelationRequestedAt = in.readOptionalInstant();
+        this.canceledAt = in.readOptionalInstant();
+        this.completedAt = in.readOptionalInstant();
+        this.connector = in.readNamedWriteable(Connector.class);
+        this.createdAt = in.readInstant();
+        this.deletedDocumentCount = in.readLong();
+        this.error = in.readOptionalString();
+        this.id = in.readString();
+        this.indexedDocumentCount = in.readLong();
+        this.indexedDocumentVolume = in.readLong();
+        this.jobType = in.readEnum(ConnectorSyncJobType.class);
+        this.lastSeen = in.readOptionalInstant();
+        this.metadata = in.readMap(StreamInput::readString, StreamInput::readGenericValue);
+        this.startedAt = in.readOptionalInstant();
+        this.status = in.readEnum(ConnectorSyncStatus.class);
+        this.totalDocumentCount = in.readOptionalLong();
+        this.triggerMethod = in.readEnum(ConnectorSyncJobTriggerMethod.class);
+        this.workerHostname = in.readOptionalString();
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        {
+            builder.field(CANCELATION_REQUESTED_AT_FIELD.getPreferredName(), cancelationRequestedAt);
+            builder.field(CANCELED_AT_FIELD.getPreferredName(), canceledAt);
+            builder.field(COMPLETED_AT_FIELD.getPreferredName(), completedAt);
+
+            builder.startObject(CONNECTOR_FIELD.getPreferredName());
+            {
+                builder.field(Connector.ID_FIELD.getPreferredName(), connector.getConnectorId());
+                builder.field(Connector.FILTERING_FIELD.getPreferredName(), connector.getFiltering());
+                builder.field(Connector.INDEX_NAME_FIELD.getPreferredName(), connector.getIndexName());
+                builder.field(Connector.LANGUAGE_FIELD.getPreferredName(), connector.getLanguage());
+                builder.field(Connector.PIPELINE_FIELD.getPreferredName(), connector.getPipeline());
+                builder.field(Connector.SERVICE_TYPE_FIELD.getPreferredName(), connector.getServiceType());
+                builder.field(Connector.CONFIGURATION_FIELD.getPreferredName(), connector.getConfiguration());
+            }
+            builder.endObject();
+
+            builder.field(CREATED_AT_FIELD.getPreferredName(), createdAt);
+            builder.field(DELETED_DOCUMENT_COUNT.getPreferredName(), deletedDocumentCount);
+            builder.field(ERROR_FIELD.getPreferredName(), error);
+            builder.field(ID_FIELD.getPreferredName(), id);
+            builder.field(INDEXED_DOCUMENT_COUNT_FIELD.getPreferredName(), indexedDocumentCount);
+            builder.field(INDEXED_DOCUMENT_VOLUME_FIELD.getPreferredName(), indexedDocumentVolume);
+            builder.field(JOB_TYPE_FIELD.getPreferredName(), jobType);
+            builder.field(LAST_SEEN_FIELD.getPreferredName(), lastSeen);
+            builder.field(METADATA_FIELD.getPreferredName(), metadata);
+            builder.field(STARTED_AT_FIELD.getPreferredName(), startedAt);
+            builder.field(STATUS_FIELD.getPreferredName(), status);
+            builder.field(TOTAL_DOCUMENT_COUNT_FIELD.getPreferredName(), totalDocumentCount);
+            builder.field(TRIGGER_METHOD_FIELD.getPreferredName(), triggerMethod);
+            builder.field(WORKER_HOSTNAME_FIELD.getPreferredName(), workerHostname);
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeOptionalInstant(cancelationRequestedAt);
+        out.writeOptionalInstant(canceledAt);
+        out.writeOptionalInstant(completedAt);
+        out.writeNamedWriteable(connector);
+        out.writeInstant(createdAt);
+        out.writeLong(deletedDocumentCount);
+        out.writeOptionalString(error);
+        out.writeString(id);
+        out.writeLong(indexedDocumentCount);
+        out.writeLong(indexedDocumentVolume);
+        out.writeEnum(jobType);
+        out.writeOptionalInstant(lastSeen);
+        out.writeMap(metadata, StreamOutput::writeString, StreamOutput::writeGenericValue);
+        out.writeOptionalInstant(startedAt);
+        out.writeEnum(status);
+        out.writeOptionalLong(totalDocumentCount);
+        out.writeEnum(triggerMethod);
+        out.writeOptionalString(workerHostname);
+    }
+
+    public boolean equals(Object other) {
+        if (this == other) return true;
+        if (other == null || getClass() != other.getClass()) return false;
+
+        ConnectorSyncJob connectorSyncJob = (ConnectorSyncJob) other;
+
+        return Objects.equals(cancelationRequestedAt, connectorSyncJob.cancelationRequestedAt)
+            && Objects.equals(canceledAt, connectorSyncJob.canceledAt)
+            && Objects.equals(completedAt, connectorSyncJob.completedAt)
+            && Objects.equals(connector, connectorSyncJob.connector)
+            && Objects.equals(createdAt, connectorSyncJob.createdAt)
+            && Objects.equals(deletedDocumentCount, connectorSyncJob.deletedDocumentCount)
+            && Objects.equals(error, connectorSyncJob.error)
+            && Objects.equals(id, connectorSyncJob.id)
+            && Objects.equals(indexedDocumentCount, connectorSyncJob.indexedDocumentCount)
+            && Objects.equals(indexedDocumentVolume, connectorSyncJob.indexedDocumentVolume)
+            && Objects.equals(jobType, connectorSyncJob.jobType)
+            && Objects.equals(lastSeen, connectorSyncJob.lastSeen)
+            && Objects.equals(metadata, connectorSyncJob.metadata)
+            && Objects.equals(startedAt, connectorSyncJob.startedAt)
+            && Objects.equals(status, connectorSyncJob.status)
+            && Objects.equals(totalDocumentCount, connectorSyncJob.totalDocumentCount)
+            && Objects.equals(triggerMethod, connectorSyncJob.triggerMethod)
+            && Objects.equals(workerHostname, connectorSyncJob.workerHostname);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+            cancelationRequestedAt,
+            canceledAt,
+            completedAt,
+            connector,
+            createdAt,
+            deletedDocumentCount,
+            error,
+            id,
+            indexedDocumentCount,
+            indexedDocumentVolume,
+            jobType,
+            lastSeen,
+            metadata,
+            startedAt,
+            status,
+            totalDocumentCount,
+            triggerMethod,
+            workerHostname
+        );
+    }
+
+    public static class Builder {
+        private Instant cancellationRequestedAt;
+
+        private Instant canceledAt;
+
+        private Instant completedAt;
+
+        private Connector connector;
+
+        private Instant createdAt;
+
+        private long deletedDocumentCount;
+
+        private String error;
+
+        private String id;
+
+        private long indexedDocumentCount;
+
+        private long indexedDocumentVolume;
+
+        private ConnectorSyncJobType jobType;
+
+        private Instant lastSeen;
+
+        private Map<String, Object> metadata;
+
+        private Instant startedAt;
+
+        private ConnectorSyncStatus status;
+
+        private long totalDocumentCount;
+
+        private ConnectorSyncJobTriggerMethod triggerMethod;
+
+        private String workerHostname;
+
+        public Builder setCancellationRequestedAt(Instant cancellationRequestedAt) {
+            this.cancellationRequestedAt = cancellationRequestedAt;
+            return this;
+        }
+
+        public Builder setCanceledAt(Instant canceledAt) {
+            this.canceledAt = canceledAt;
+            return this;
+        }
+
+        public Builder setCompletedAt(Instant completedAt) {
+            this.completedAt = completedAt;
+            return this;
+        }
+
+        public Builder setConnector(Connector connector) {
+            this.connector = connector;
+            return this;
+        }
+
+        public Builder setCreatedAt(Instant createdAt) {
+            this.createdAt = createdAt;
+            return this;
+        }
+
+        public Builder setDeletedDocumentCount(long deletedDocumentCount) {
+            this.deletedDocumentCount = deletedDocumentCount;
+            return this;
+        }
+
+        public Builder setError(String error) {
+            this.error = error;
+            return this;
+        }
+
+        public Builder setId(String id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder setIndexedDocumentCount(long indexedDocumentCount) {
+            this.indexedDocumentCount = indexedDocumentCount;
+            return this;
+        }
+
+        public Builder setIndexedDocumentVolume(long indexedDocumentVolume) {
+            this.indexedDocumentVolume = indexedDocumentVolume;
+            return this;
+        }
+
+        public Builder setJobType(ConnectorSyncJobType jobType) {
+            this.jobType = jobType;
+            return this;
+        }
+
+        public Builder setLastSeen(Instant lastSeen) {
+            this.lastSeen = lastSeen;
+            return this;
+        }
+
+        public Builder setMetadata(Map<String, Object> metadata) {
+            this.metadata = metadata;
+            return this;
+        }
+
+        public Builder setStartedAt(Instant startedAt) {
+            this.startedAt = startedAt;
+            return this;
+        }
+
+        public Builder setStatus(ConnectorSyncStatus status) {
+            this.status = status;
+            return this;
+        }
+
+        public Builder setTotalDocumentCount(long totalDocumentCount) {
+            this.totalDocumentCount = totalDocumentCount;
+            return this;
+        }
+
+        public Builder setTriggerMethod(ConnectorSyncJobTriggerMethod triggerMethod) {
+            this.triggerMethod = triggerMethod;
+            return this;
+        }
+
+        public Builder setWorkerHostname(String workerHostname) {
+            this.workerHostname = workerHostname;
+            return this;
+        }
+
+        public ConnectorSyncJob build() {
+            return new ConnectorSyncJob(
+                cancellationRequestedAt,
+                canceledAt,
+                completedAt,
+                connector,
+                createdAt,
+                deletedDocumentCount,
+                error,
+                id,
+                indexedDocumentCount,
+                indexedDocumentVolume,
+                jobType,
+                lastSeen,
+                metadata,
+                startedAt,
+                status,
+                totalDocumentCount,
+                triggerMethod,
+                workerHostname
+            );
+        }
+    }
+}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobIndexService.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.connector.syncjob;
+
+import org.elasticsearch.ResourceNotFoundException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.DocWriteRequest;
+import org.elasticsearch.action.get.GetRequest;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.client.internal.OriginSettingClient;
+import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xpack.application.connector.Connector;
+import org.elasticsearch.xpack.application.connector.ConnectorFiltering;
+import org.elasticsearch.xpack.application.connector.ConnectorIndexService;
+import org.elasticsearch.xpack.application.connector.ConnectorIngestPipeline;
+import org.elasticsearch.xpack.application.connector.ConnectorTemplateRegistry;
+import org.elasticsearch.xpack.application.connector.syncjob.action.PostConnectorSyncJobAction;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.xpack.core.ClientHelper.CONNECTORS_ORIGIN;
+
+/**
+ * A service that manages persistent {@link ConnectorSyncJob} configurations.
+ */
+public class ConnectorSyncJobIndexService {
+
+    private static final Long ZERO = 0L;
+
+    private final Client clientWithOrigin;
+
+    public static final String CONNECTOR_SYNC_JOB_INDEX_NAME = ConnectorTemplateRegistry.CONNECTOR_SYNC_JOBS_INDEX_NAME_PATTERN;
+
+    /**
+     * @param client A client for executing actions on the connectors sync jobs index.
+     */
+    public ConnectorSyncJobIndexService(Client client) {
+        this.clientWithOrigin = new OriginSettingClient(client, CONNECTORS_ORIGIN);
+    }
+
+    /**
+     * @param request   Request for creating a connector sync job.
+     * @param listener  Listener to respond to a successful response or an error.
+     */
+    public void createConnectorSyncJob(
+        PostConnectorSyncJobAction.Request request,
+        ActionListener<PostConnectorSyncJobAction.Response> listener
+    ) {
+        try {
+            getSyncJobConnectorInfo(request.getId(), listener.delegateFailure((l, connector) -> {
+                Instant now = Instant.now();
+                ConnectorSyncJobType jobType = Objects.requireNonNullElse(request.getJobType(), ConnectorSyncJob.DEFAULT_JOB_TYPE);
+                ConnectorSyncJobTriggerMethod triggerMethod = Objects.requireNonNullElse(
+                    request.getTriggerMethod(),
+                    ConnectorSyncJob.DEFAULT_TRIGGER_METHOD
+                );
+
+                try {
+                    String syncJobId = generateId();
+
+                    final IndexRequest indexRequest = new IndexRequest(CONNECTOR_SYNC_JOB_INDEX_NAME).id(syncJobId)
+                        .opType(DocWriteRequest.OpType.INDEX)
+                        .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+
+                    ConnectorSyncJob syncJob = new ConnectorSyncJob.Builder().setId(syncJobId)
+                        .setJobType(jobType)
+                        .setTriggerMethod(triggerMethod)
+                        .setStatus(ConnectorSyncJob.DEFAULT_INITIAL_STATUS)
+                        .setConnector(connector)
+                        .setCreatedAt(now)
+                        .setLastSeen(now)
+                        .setTotalDocumentCount(ZERO)
+                        .setIndexedDocumentCount(ZERO)
+                        .setIndexedDocumentVolume(ZERO)
+                        .setDeletedDocumentCount(ZERO)
+                        .build();
+
+                    indexRequest.source(syncJob.toXContent(jsonBuilder(), ToXContent.EMPTY_PARAMS));
+
+                    clientWithOrigin.index(
+                        indexRequest,
+                        ActionListener.wrap(
+                            indexResponse -> listener.onResponse(new PostConnectorSyncJobAction.Response(indexResponse.getId())),
+                            listener::onFailure
+                        )
+                    );
+                } catch (IOException e) {
+                    listener.onFailure(e);
+                }
+            }));
+        } catch (Exception e) {
+            listener.onFailure(e);
+        }
+    }
+
+    private String generateId() {
+        /* Workaround: only needed for generating an id upfront, autoGenerateId() has a side effect generating a timestamp,
+         * which would raise an error on the response layer later ("autoGeneratedTimestamp should not be set externally").
+         * TODO: do we even need to copy the "_id" and set it as "id"?
+         */
+        return UUIDs.base64UUID();
+    }
+
+    private void getSyncJobConnectorInfo(String connectorId, ActionListener<Connector> listener) {
+        try {
+
+            final GetRequest request = new GetRequest(ConnectorIndexService.CONNECTOR_INDEX_NAME, connectorId);
+
+            clientWithOrigin.get(request, new ActionListener<>() {
+                @Override
+                public void onResponse(GetResponse response) {
+                    final boolean connectorDoesNotExist = response.isExists() == false;
+
+                    if (connectorDoesNotExist) {
+                        onFailure(new ResourceNotFoundException("Connector with id '" + connectorId + "' does not exist."));
+                        return;
+                    }
+
+                    Map<String, Object> source = response.getSource();
+
+                    @SuppressWarnings("unchecked")
+                    final Connector syncJobConnectorInfo = new Connector.Builder().setConnectorId(
+                        (String) source.get(Connector.ID_FIELD.getPreferredName())
+                    )
+                        .setFiltering((List<ConnectorFiltering>) source.get(Connector.FILTERING_FIELD.getPreferredName()))
+                        .setIndexName((String) source.get(Connector.INDEX_NAME_FIELD.getPreferredName()))
+                        .setLanguage((String) source.get(Connector.LANGUAGE_FIELD.getPreferredName()))
+                        .setPipeline((ConnectorIngestPipeline) source.get(Connector.PIPELINE_FIELD.getPreferredName()))
+                        .setServiceType((String) source.get(Connector.SERVICE_TYPE_FIELD.getPreferredName()))
+                        .setConfiguration((Map<String, Object>) source.get(Connector.CONFIGURATION_FIELD.getPreferredName()))
+                        .build();
+
+                    listener.onResponse(syncJobConnectorInfo);
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    listener.onFailure(e);
+                }
+            });
+        } catch (Exception e) {
+            listener.onFailure(e);
+        }
+    }
+}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobTriggerMethod.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobTriggerMethod.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.connector.syncjob;
+
+import java.util.Locale;
+
+public enum ConnectorSyncJobTriggerMethod {
+    ON_DEMAND,
+    SCHEDULED;
+
+    public static ConnectorSyncJobTriggerMethod fromString(String triggerMethodString) {
+        for (ConnectorSyncJobTriggerMethod triggerMethod : ConnectorSyncJobTriggerMethod.values()) {
+            if (triggerMethod.name().equalsIgnoreCase(triggerMethodString)) {
+                return triggerMethod;
+            }
+        }
+
+        throw new IllegalArgumentException("Unknown trigger method '" + triggerMethodString + "'.");
+    }
+
+    @Override
+    public String toString() {
+        return name().toLowerCase(Locale.ROOT);
+    }
+}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobType.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobType.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.connector.syncjob;
+
+import java.util.Locale;
+
+public enum ConnectorSyncJobType {
+    FULL,
+    INCREMENTAL,
+    ACCESS_CONTROL;
+
+    public static ConnectorSyncJobType fromString(String syncJobTypeString) {
+        for (ConnectorSyncJobType syncJobType : ConnectorSyncJobType.values()) {
+            if (syncJobType.name().equalsIgnoreCase(syncJobTypeString)) {
+                return syncJobType;
+            }
+        }
+
+        throw new IllegalArgumentException("Unknown sync job type '" + syncJobTypeString + "'.");
+    }
+
+    @Override
+    public String toString() {
+        return name().toLowerCase(Locale.ROOT);
+    }
+}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/PostConnectorSyncJobAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/PostConnectorSyncJobAction.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.connector.syncjob.action;
+
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.xcontent.ConstructingObjectParser;
+import org.elasticsearch.xcontent.ToXContentObject;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
+import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.application.connector.syncjob.ConnectorSyncJob;
+import org.elasticsearch.xpack.application.connector.syncjob.ConnectorSyncJobTriggerMethod;
+import org.elasticsearch.xpack.application.connector.syncjob.ConnectorSyncJobType;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import static org.elasticsearch.action.ValidateActions.addValidationError;
+import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
+import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
+import static org.elasticsearch.xpack.application.EnterpriseSearch.CONNECTOR_API_ENDPOINT;
+
+public class PostConnectorSyncJobAction extends ActionType<PostConnectorSyncJobAction.Response> {
+
+    public static final PostConnectorSyncJobAction INSTANCE = new PostConnectorSyncJobAction();
+
+    public static final String NAME = "cluster:admin/xpack/connector/sync_job/post";
+
+    public static final String CONNECTOR_SYNC_JOB_API_ENDPOINT = CONNECTOR_API_ENDPOINT + "/_sync_job";
+
+    private PostConnectorSyncJobAction() {
+        super(NAME, PostConnectorSyncJobAction.Response::new);
+    }
+
+    public static class Request extends ActionRequest implements ToXContentObject {
+        public static final String EMPTY_CONNECTOR_ID_ERROR_MESSAGE = "[id] of the connector cannot be null or empty";
+        private final String id;
+        private final ConnectorSyncJobType jobType;
+        private final ConnectorSyncJobTriggerMethod triggerMethod;
+
+        public Request(String id, ConnectorSyncJobType jobType, ConnectorSyncJobTriggerMethod triggerMethod) {
+            this.id = id;
+            this.jobType = jobType;
+            this.triggerMethod = triggerMethod;
+        }
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            this.id = in.readString();
+            this.jobType = in.readOptionalEnum(ConnectorSyncJobType.class);
+            this.triggerMethod = in.readOptionalEnum(ConnectorSyncJobTriggerMethod.class);
+        }
+
+        private static final ConstructingObjectParser<Request, Void> PARSER = new ConstructingObjectParser<>(
+            "connector_sync_job_post_request",
+            false,
+            ((args) -> {
+                String connectorId = (String) args[0];
+                String syncJobTypeString = (String) args[1];
+                String triggerMethodString = (String) args[2];
+
+                boolean syncJobTypeSpecified = syncJobTypeString != null;
+                boolean triggerMethodSpecified = triggerMethodString != null;
+
+                return new Request(
+                    connectorId,
+                    syncJobTypeSpecified ? ConnectorSyncJobType.fromString(syncJobTypeString) : null,
+                    triggerMethodSpecified ? ConnectorSyncJobTriggerMethod.fromString(triggerMethodString) : null
+                );
+            })
+        );
+
+        static {
+            PARSER.declareString(constructorArg(), ConnectorSyncJob.ID_FIELD);
+            PARSER.declareString(optionalConstructorArg(), ConnectorSyncJob.JOB_TYPE_FIELD);
+            PARSER.declareString(optionalConstructorArg(), ConnectorSyncJob.TRIGGER_METHOD_FIELD);
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public ConnectorSyncJobType getJobType() {
+            return jobType;
+        }
+
+        public ConnectorSyncJobTriggerMethod getTriggerMethod() {
+            return triggerMethod;
+        }
+
+        public static Request fromXContentBytes(BytesReference source, XContentType xContentType) {
+            try (XContentParser parser = XContentHelper.createParser(XContentParserConfiguration.EMPTY, source, xContentType)) {
+                return Request.fromXContent(parser);
+            } catch (IOException e) {
+                throw new ElasticsearchParseException("Failed to parse: " + source.utf8ToString(), e);
+            }
+        }
+
+        public static Request fromXContent(XContentParser parser) throws IOException {
+            return PARSER.parse(parser, null);
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            {
+                builder.field("id", id);
+                builder.field("job_type", jobType);
+                builder.field("trigger_method", triggerMethod);
+            }
+            builder.endObject();
+            return builder;
+        }
+
+        @Override
+        public ActionRequestValidationException validate() {
+            ActionRequestValidationException validationException = null;
+
+            if (Strings.isNullOrEmpty(getId())) {
+                validationException = addValidationError(EMPTY_CONNECTOR_ID_ERROR_MESSAGE, validationException);
+            }
+
+            return validationException;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeString(id);
+            out.writeOptionalEnum(jobType);
+            out.writeOptionalEnum(triggerMethod);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Request request = (Request) o;
+            return Objects.equals(id, request.id) && jobType == request.jobType && triggerMethod == request.triggerMethod;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(id, jobType, triggerMethod);
+        }
+    }
+
+    public static class Response extends ActionResponse implements ToXContentObject {
+
+        private final String id;
+
+        public Response(StreamInput in) throws IOException {
+            super(in);
+            this.id = in.readString();
+        }
+
+        public Response(String id) {
+            this.id = id;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeString(id);
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            builder.field("id", id);
+            builder.endObject();
+            return builder;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Response response = (Response) o;
+            return Objects.equals(id, response.id);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(id);
+        }
+    }
+}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/RestPostConnectorSyncJobAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/RestPostConnectorSyncJobAction.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.connector.syncjob.action;
+
+import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.rest.action.RestToXContentListener;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.elasticsearch.rest.RestRequest.Method.POST;
+
+public class RestPostConnectorSyncJobAction extends BaseRestHandler {
+
+    @Override
+    public String getName() {
+        return "connector_sync_job_post_action";
+    }
+
+    @Override
+    public List<Route> routes() {
+        return List.of(new Route(POST, "/" + PostConnectorSyncJobAction.CONNECTOR_SYNC_JOB_API_ENDPOINT));
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
+        PostConnectorSyncJobAction.Request request = PostConnectorSyncJobAction.Request.fromXContentBytes(
+            restRequest.content(),
+            restRequest.getXContentType()
+        );
+
+        return channel -> client.execute(
+            PostConnectorSyncJobAction.INSTANCE,
+            request,
+            new RestToXContentListener<>(channel, r -> RestStatus.CREATED, r -> null)
+        );
+    }
+}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/TransportPostConnectorSyncJobAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/TransportPostConnectorSyncJobAction.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.connector.syncjob.action;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.application.connector.syncjob.ConnectorSyncJobIndexService;
+
+public class TransportPostConnectorSyncJobAction extends HandledTransportAction<
+    PostConnectorSyncJobAction.Request,
+    PostConnectorSyncJobAction.Response> {
+
+    protected final ConnectorSyncJobIndexService syncJobIndexService;
+
+    @Inject
+    public TransportPostConnectorSyncJobAction(
+        TransportService transportService,
+        ClusterService clusterService,
+        ActionFilters actionFilters,
+        Client client
+    ) {
+        super(
+            PostConnectorSyncJobAction.NAME,
+            transportService,
+            actionFilters,
+            PostConnectorSyncJobAction.Request::new,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE
+        );
+        this.syncJobIndexService = new ConnectorSyncJobIndexService(client);
+    }
+
+    @Override
+    protected void doExecute(
+        Task task,
+        PostConnectorSyncJobAction.Request request,
+        ActionListener<PostConnectorSyncJobAction.Response> listener
+    ) {
+        syncJobIndexService.createConnectorSyncJob(request, listener);
+    }
+}

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorTestUtils.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorTestUtils.java
@@ -168,6 +168,16 @@ public final class ConnectorTestUtils {
             .build();
     }
 
+    public static Connector getRandomSyncJobConnectorInfo() {
+        return new Connector.Builder().setConnectorId(randomAlphaOfLength(10))
+            .setFiltering(List.of(getRandomConnectorFiltering()))
+            .setIndexName(randomAlphaOfLength(10))
+            .setLanguage(randomAlphaOfLength(10))
+            .setServiceType(randomAlphaOfLength(10))
+            .setConfiguration(Collections.emptyMap())
+            .build();
+    }
+
     public static Connector getRandomConnector() {
         return new Connector.Builder().setConnectorId(randomAlphaOfLength(10))
             .setApiKeyId(randomFrom(new String[] { null, randomAlphaOfLength(10) }))
@@ -217,7 +227,7 @@ public final class ConnectorTestUtils {
         );
     }
 
-    private static ConnectorSyncStatus getRandomSyncStatus() {
+    public static ConnectorSyncStatus getRandomSyncStatus() {
         ConnectorSyncStatus[] values = ConnectorSyncStatus.values();
         return values[randomInt(values.length - 1)];
     }

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobIndexServiceTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobIndexServiceTests.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.connector.syncjob;
+
+import org.elasticsearch.action.ActionFuture;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.DocWriteRequest;
+import org.elasticsearch.action.DocWriteResponse;
+import org.elasticsearch.action.get.GetRequest;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xpack.application.connector.Connector;
+import org.elasticsearch.xpack.application.connector.ConnectorIndexService;
+import org.elasticsearch.xpack.application.connector.ConnectorSyncStatus;
+import org.elasticsearch.xpack.application.connector.ConnectorTestUtils;
+import org.elasticsearch.xpack.application.connector.syncjob.action.PostConnectorSyncJobAction;
+import org.junit.Before;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class ConnectorSyncJobIndexServiceTests extends ESSingleNodeTestCase {
+
+    private static final String NON_EXISTING_CONNECTOR_ID = "non-existing-connector-id";
+    private static final int TIMEOUT_SECONDS = 10;
+
+    private ConnectorSyncJobIndexService connectorSyncJobIndexService;
+    private Connector connector;
+
+    @Before
+    public void setup() throws Exception {
+        connector = ConnectorTestUtils.getRandomSyncJobConnectorInfo();
+
+        final IndexRequest indexRequest = new IndexRequest(ConnectorIndexService.CONNECTOR_INDEX_NAME).opType(DocWriteRequest.OpType.INDEX)
+            .id(connector.getConnectorId())
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+            .source(connector.toXContent(jsonBuilder(), ToXContent.EMPTY_PARAMS));
+        ActionFuture<DocWriteResponse> index = client().index(indexRequest);
+
+        // wait 10 seconds for connector creation
+        index.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+        this.connectorSyncJobIndexService = new ConnectorSyncJobIndexService(client());
+    }
+
+    public void testCreateConnectorSyncJob() throws Exception {
+        PostConnectorSyncJobAction.Request syncJobRequest = ConnectorSyncJobTestUtils.getRandomPostConnectorSyncJobActionRequest(
+            connector.getConnectorId()
+        );
+        PostConnectorSyncJobAction.Response response = awaitPutConnectorSyncJob(syncJobRequest);
+        Map<String, Object> connectorSyncJobSource = getConnectorSyncJobSourceById(response.getId());
+
+        String id = (String) connectorSyncJobSource.get(ConnectorSyncJob.ID_FIELD.getPreferredName());
+
+        ConnectorSyncJobType requestJobType = syncJobRequest.getJobType();
+        ConnectorSyncJobType jobType = ConnectorSyncJobType.fromString(
+            (String) connectorSyncJobSource.get(ConnectorSyncJob.JOB_TYPE_FIELD.getPreferredName())
+        );
+
+        ConnectorSyncJobTriggerMethod requestTriggerMethod = syncJobRequest.getTriggerMethod();
+        ConnectorSyncJobTriggerMethod triggerMethod = ConnectorSyncJobTriggerMethod.fromString(
+            (String) connectorSyncJobSource.get(ConnectorSyncJob.TRIGGER_METHOD_FIELD.getPreferredName())
+        );
+
+        ConnectorSyncStatus initialStatus = ConnectorSyncStatus.fromString(
+            (String) connectorSyncJobSource.get(ConnectorSyncJob.STATUS_FIELD.getPreferredName())
+        );
+
+        Instant createdNow = Instant.parse((String) connectorSyncJobSource.get(ConnectorSyncJob.CREATED_AT_FIELD.getPreferredName()));
+        Instant lastSeen = Instant.parse((String) connectorSyncJobSource.get(ConnectorSyncJob.LAST_SEEN_FIELD.getPreferredName()));
+
+        Integer totalDocumentCount = (Integer) connectorSyncJobSource.get(ConnectorSyncJob.TOTAL_DOCUMENT_COUNT_FIELD.getPreferredName());
+        Integer indexedDocumentCount = (Integer) connectorSyncJobSource.get(
+            ConnectorSyncJob.INDEXED_DOCUMENT_COUNT_FIELD.getPreferredName()
+        );
+        Integer indexedDocumentVolume = (Integer) connectorSyncJobSource.get(
+            ConnectorSyncJob.INDEXED_DOCUMENT_VOLUME_FIELD.getPreferredName()
+        );
+        Integer deletedDocumentCount = (Integer) connectorSyncJobSource.get(ConnectorSyncJob.DELETED_DOCUMENT_COUNT.getPreferredName());
+
+        assertThat(id, notNullValue());
+        assertThat(jobType, equalTo(requestJobType));
+        assertThat(triggerMethod, equalTo(requestTriggerMethod));
+        assertThat(initialStatus, equalTo(ConnectorSyncJob.DEFAULT_INITIAL_STATUS));
+        assertThat(createdNow, equalTo(lastSeen));
+        assertThat(totalDocumentCount, equalTo(0));
+        assertThat(indexedDocumentCount, equalTo(0));
+        assertThat(indexedDocumentVolume, equalTo(0));
+        assertThat(deletedDocumentCount, equalTo(0));
+    }
+
+    public void testCreateConnectorSyncJob_WithMissingJobType_ExpectDefaultJobTypeToBeSet() throws Exception {
+        PostConnectorSyncJobAction.Request syncJobRequest = new PostConnectorSyncJobAction.Request(
+            connector.getConnectorId(),
+            null,
+            ConnectorSyncJobTriggerMethod.ON_DEMAND
+        );
+        PostConnectorSyncJobAction.Response response = awaitPutConnectorSyncJob(syncJobRequest);
+
+        Map<String, Object> connectorSyncJobSource = getConnectorSyncJobSourceById(response.getId());
+        ConnectorSyncJobType jobType = ConnectorSyncJobType.fromString(
+            (String) connectorSyncJobSource.get(ConnectorSyncJob.JOB_TYPE_FIELD.getPreferredName())
+        );
+
+        assertThat(jobType, equalTo(ConnectorSyncJob.DEFAULT_JOB_TYPE));
+    }
+
+    public void testCreateConnectorSyncJob_WithMissingTriggerMethod_ExpectDefaultTriggerMethodToBeSet() throws Exception {
+        PostConnectorSyncJobAction.Request syncJobRequest = new PostConnectorSyncJobAction.Request(
+            connector.getConnectorId(),
+            ConnectorSyncJobType.FULL,
+            null
+        );
+        PostConnectorSyncJobAction.Response response = awaitPutConnectorSyncJob(syncJobRequest);
+
+        Map<String, Object> connectorSyncJobSource = getConnectorSyncJobSourceById(response.getId());
+        ConnectorSyncJobTriggerMethod triggerMethod = ConnectorSyncJobTriggerMethod.fromString(
+            (String) connectorSyncJobSource.get(ConnectorSyncJob.TRIGGER_METHOD_FIELD.getPreferredName())
+        );
+
+        assertThat(triggerMethod, equalTo(ConnectorSyncJob.DEFAULT_TRIGGER_METHOD));
+    }
+
+    public void testCreateConnectorSyncJob_WithMissingConnectorId_ExpectException() throws Exception {
+        PostConnectorSyncJobAction.Request syncJobRequest = new PostConnectorSyncJobAction.Request(
+            NON_EXISTING_CONNECTOR_ID,
+            ConnectorSyncJobType.FULL,
+            ConnectorSyncJobTriggerMethod.ON_DEMAND
+        );
+        awaitPutConnectorSyncJobExpectingException(
+            syncJobRequest,
+            ActionListener.wrap(response -> {}, exception -> assertThat(exception.getMessage(), containsString(NON_EXISTING_CONNECTOR_ID)))
+        );
+    }
+
+    private Map<String, Object> getConnectorSyncJobSourceById(String syncJobId) throws ExecutionException, InterruptedException,
+        TimeoutException {
+        GetRequest getRequest = new GetRequest(ConnectorSyncJobIndexService.CONNECTOR_SYNC_JOB_INDEX_NAME, syncJobId);
+        ActionFuture<GetResponse> getResponseActionFuture = client().get(getRequest);
+
+        return getResponseActionFuture.get(TIMEOUT_SECONDS, TimeUnit.SECONDS).getSource();
+    }
+
+    private void awaitPutConnectorSyncJobExpectingException(
+        PostConnectorSyncJobAction.Request syncJobRequest,
+        ActionListener<PostConnectorSyncJobAction.Response> listener
+    ) throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
+
+        connectorSyncJobIndexService.createConnectorSyncJob(syncJobRequest, new ActionListener<>() {
+            @Override
+            public void onResponse(PostConnectorSyncJobAction.Response putConnectorSyncJobResponse) {
+                fail("Expected an exception and not a successful response");
+                latch.countDown();
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                listener.onFailure(e);
+                latch.countDown();
+            }
+        });
+
+        boolean requestTimedOut = latch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        assertTrue("Timeout waiting for put request", requestTimedOut);
+    }
+
+    private PostConnectorSyncJobAction.Response awaitPutConnectorSyncJob(PostConnectorSyncJobAction.Request syncJobRequest)
+        throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
+
+        final AtomicReference<PostConnectorSyncJobAction.Response> responseRef = new AtomicReference<>(null);
+        final AtomicReference<Exception> exception = new AtomicReference<>(null);
+
+        connectorSyncJobIndexService.createConnectorSyncJob(syncJobRequest, new ActionListener<>() {
+            @Override
+            public void onResponse(PostConnectorSyncJobAction.Response putConnectorSyncJobResponse) {
+                responseRef.set(putConnectorSyncJobResponse);
+                latch.countDown();
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                exception.set(e);
+                latch.countDown();
+            }
+        });
+
+        if (exception.get() != null) {
+            throw exception.get();
+        }
+
+        boolean requestTimedOut = latch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        PostConnectorSyncJobAction.Response response = responseRef.get();
+
+        assertTrue("Timeout waiting for post request", requestTimedOut);
+        assertNotNull("Received null response from post request", response);
+
+        return response;
+    }
+
+}

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobTestUtils.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobTestUtils.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.connector.syncjob;
+
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.xpack.application.connector.ConnectorTestUtils;
+import org.elasticsearch.xpack.application.connector.syncjob.action.PostConnectorSyncJobAction;
+
+import java.time.Instant;
+
+import static org.elasticsearch.test.ESTestCase.randomAlphaOfLength;
+import static org.elasticsearch.test.ESTestCase.randomAlphaOfLengthBetween;
+import static org.elasticsearch.test.ESTestCase.randomFrom;
+import static org.elasticsearch.test.ESTestCase.randomInstantBetween;
+import static org.elasticsearch.test.ESTestCase.randomInt;
+import static org.elasticsearch.test.ESTestCase.randomLong;
+import static org.elasticsearch.test.ESTestCase.randomMap;
+
+public class ConnectorSyncJobTestUtils {
+
+    public static ConnectorSyncJob getRandomConnectorSyncJob() {
+        Instant lowerBoundInstant = Instant.ofEpochSecond(0L);
+        Instant upperBoundInstant = Instant.ofEpochSecond(3000000000L);
+
+        return new ConnectorSyncJob.Builder().setCancellationRequestedAt(
+            randomFrom(new Instant[] { null, randomInstantBetween(lowerBoundInstant, upperBoundInstant) })
+        )
+            .setCanceledAt(randomFrom(new Instant[] { null, randomInstantBetween(lowerBoundInstant, upperBoundInstant) }))
+            .setCompletedAt(randomFrom(new Instant[] { null, randomInstantBetween(lowerBoundInstant, upperBoundInstant) }))
+            .setConnector(ConnectorTestUtils.getRandomSyncJobConnectorInfo())
+            .setCreatedAt(randomInstantBetween(lowerBoundInstant, upperBoundInstant))
+            .setDeletedDocumentCount(randomLong())
+            .setError(randomFrom(new String[] { null, randomAlphaOfLength(10) }))
+            .setId(randomAlphaOfLength(10))
+            .setIndexedDocumentCount(randomLong())
+            .setIndexedDocumentVolume(randomLong())
+            .setJobType(getRandomConnectorJobType())
+            .setLastSeen(randomFrom(new Instant[] { null, randomInstantBetween(lowerBoundInstant, upperBoundInstant) }))
+            .setMetadata(
+                randomMap(
+                    0,
+                    10,
+                    () -> new Tuple<>(randomAlphaOfLength(10), randomFrom(new Object[] { null, randomAlphaOfLength(10), randomLong() }))
+                )
+            )
+            .setStartedAt(randomFrom(new Instant[] { null, randomInstantBetween(lowerBoundInstant, upperBoundInstant) }))
+            .setStatus(ConnectorTestUtils.getRandomSyncStatus())
+            .setTotalDocumentCount(randomLong())
+            .setTriggerMethod(getRandomConnectorSyncJobTriggerMethod())
+            .setWorkerHostname(randomAlphaOfLength(10))
+            .build();
+    }
+
+    public static ConnectorSyncJobTriggerMethod getRandomConnectorSyncJobTriggerMethod() {
+        ConnectorSyncJobTriggerMethod[] values = ConnectorSyncJobTriggerMethod.values();
+        return values[randomInt(values.length - 1)];
+    }
+
+    public static ConnectorSyncJobType getRandomConnectorJobType() {
+        ConnectorSyncJobType[] values = ConnectorSyncJobType.values();
+        return values[randomInt(values.length - 1)];
+    }
+
+    public static PostConnectorSyncJobAction.Request getRandomPostConnectorSyncJobActionRequest() {
+        return new PostConnectorSyncJobAction.Request(
+            randomAlphaOfLengthBetween(5, 15),
+            randomFrom(ConnectorSyncJobType.values()),
+            randomFrom(ConnectorSyncJobTriggerMethod.values())
+        );
+    }
+
+    public static PostConnectorSyncJobAction.Request getRandomPostConnectorSyncJobActionRequest(String connectorId) {
+        return new PostConnectorSyncJobAction.Request(
+            connectorId,
+            randomFrom(ConnectorSyncJobType.values()),
+            randomFrom(ConnectorSyncJobTriggerMethod.values())
+        );
+    }
+
+    public static PostConnectorSyncJobAction.Response getRandomPostConnectorSyncJobActionResponse() {
+        return new PostConnectorSyncJobAction.Response(randomAlphaOfLength(10));
+    }
+}

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobTests.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.connector.syncjob;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.application.connector.Connector;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class ConnectorSyncJobTests extends ESTestCase {
+
+    private NamedWriteableRegistry namedWriteableRegistry;
+
+    @Before
+    public void registerNamedObjects() {
+        namedWriteableRegistry = new NamedWriteableRegistry(
+            List.of(new NamedWriteableRegistry.Entry(Connector.class, Connector.NAME, Connector::new))
+        );
+    }
+
+    public final void testRandomSerialization() throws IOException {
+        for (int run = 0; run < 10; run++) {
+            ConnectorSyncJob syncJob = ConnectorSyncJobTestUtils.getRandomConnectorSyncJob();
+            assertTransportSerialization(syncJob);
+        }
+    }
+
+    private void assertTransportSerialization(ConnectorSyncJob testInstance) throws IOException {
+        ConnectorSyncJob deserializedInstance = copyInstance(testInstance);
+        assertNotSame(testInstance, deserializedInstance);
+        assertThat(testInstance, equalTo(deserializedInstance));
+    }
+
+    private ConnectorSyncJob copyInstance(ConnectorSyncJob instance) throws IOException {
+        return copyWriteable(instance, namedWriteableRegistry, ConnectorSyncJob::new);
+    }
+}

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobTriggerMethodTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobTriggerMethodTests.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.connector.syncjob;
+
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class ConnectorSyncJobTriggerMethodTests extends ESTestCase {
+
+    public void testFromString_WithValidTriggerMethodString() {
+        ConnectorSyncJobTriggerMethod triggerMethod = ConnectorSyncJobTestUtils.getRandomConnectorSyncJobTriggerMethod();
+
+        assertThat(ConnectorSyncJobTriggerMethod.fromString(triggerMethod.toString()), equalTo(triggerMethod));
+    }
+
+    public void testFromString_WithInvalidTriggerMethodString_ExpectException() {
+        expectThrows(IllegalArgumentException.class, () -> ConnectorSyncJobTriggerMethod.fromString("invalid string"));
+    }
+
+}

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobTypeTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobTypeTests.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.connector.syncjob;
+
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class ConnectorSyncJobTypeTests extends ESTestCase {
+
+    public void testFromString_WithValidSyncJobTypeString() {
+        ConnectorSyncJobType syncJobType = ConnectorSyncJobTestUtils.getRandomConnectorJobType();
+
+        assertThat(ConnectorSyncJobType.fromString(syncJobType.toString()), equalTo(syncJobType));
+    }
+
+    public void testFromString_WithInvalidSyncJobTypeString_ExpectException() {
+        expectThrows(IllegalArgumentException.class, () -> ConnectorSyncJobType.fromString("invalid sync job type"));
+    }
+}

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/action/PostConnectorSyncJobActionRequestBWCSerializingTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/action/PostConnectorSyncJobActionRequestBWCSerializingTests.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.connector.syncjob.action;
+
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xpack.application.connector.syncjob.ConnectorSyncJobTestUtils;
+import org.elasticsearch.xpack.core.ml.AbstractBWCSerializationTestCase;
+
+import java.io.IOException;
+
+public class PostConnectorSyncJobActionRequestBWCSerializingTests extends AbstractBWCSerializationTestCase<
+    PostConnectorSyncJobAction.Request> {
+
+    @Override
+    protected Writeable.Reader<PostConnectorSyncJobAction.Request> instanceReader() {
+        return PostConnectorSyncJobAction.Request::new;
+    }
+
+    @Override
+    protected PostConnectorSyncJobAction.Request createTestInstance() {
+        return ConnectorSyncJobTestUtils.getRandomPostConnectorSyncJobActionRequest();
+    }
+
+    @Override
+    protected PostConnectorSyncJobAction.Request mutateInstance(PostConnectorSyncJobAction.Request instance) throws IOException {
+        return randomValueOtherThan(instance, this::createTestInstance);
+    }
+
+    @Override
+    protected PostConnectorSyncJobAction.Request doParseInstance(XContentParser parser) throws IOException {
+        return PostConnectorSyncJobAction.Request.fromXContent(parser);
+    }
+
+    @Override
+    protected PostConnectorSyncJobAction.Request mutateInstanceForVersion(
+        PostConnectorSyncJobAction.Request instance,
+        TransportVersion version
+    ) {
+        return instance;
+    }
+}

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/action/PostConnectorSyncJobActionResponseBWCSerializingTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/action/PostConnectorSyncJobActionResponseBWCSerializingTests.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.connector.syncjob.action;
+
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.xpack.application.connector.syncjob.ConnectorSyncJobTestUtils;
+import org.elasticsearch.xpack.core.ml.AbstractBWCWireSerializationTestCase;
+
+import java.io.IOException;
+
+public class PostConnectorSyncJobActionResponseBWCSerializingTests extends AbstractBWCWireSerializationTestCase<
+    PostConnectorSyncJobAction.Response> {
+
+    @Override
+    protected Writeable.Reader<PostConnectorSyncJobAction.Response> instanceReader() {
+        return PostConnectorSyncJobAction.Response::new;
+    }
+
+    @Override
+    protected PostConnectorSyncJobAction.Response createTestInstance() {
+        return ConnectorSyncJobTestUtils.getRandomPostConnectorSyncJobActionResponse();
+    }
+
+    @Override
+    protected PostConnectorSyncJobAction.Response mutateInstance(PostConnectorSyncJobAction.Response instance) throws IOException {
+        return randomValueOtherThan(instance, this::createTestInstance);
+    }
+
+    @Override
+    protected PostConnectorSyncJobAction.Response mutateInstanceForVersion(
+        PostConnectorSyncJobAction.Response instance,
+        TransportVersion version
+    ) {
+        return instance;
+    }
+
+}

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/action/PostConnectorSyncJobActionTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/action/PostConnectorSyncJobActionTests.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.connector.syncjob.action;
+
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.application.connector.syncjob.ConnectorSyncJobTestUtils;
+import org.elasticsearch.xpack.application.connector.syncjob.ConnectorSyncJobTriggerMethod;
+import org.elasticsearch.xpack.application.connector.syncjob.ConnectorSyncJobType;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+public class PostConnectorSyncJobActionTests extends ESTestCase {
+
+    public void testValidate_WhenConnectorIdIsPresent_ExpectNoValidationError() {
+        PostConnectorSyncJobAction.Request request = ConnectorSyncJobTestUtils.getRandomPostConnectorSyncJobActionRequest();
+        ActionRequestValidationException exception = request.validate();
+
+        assertThat(exception, nullValue());
+    }
+
+    public void testValidate_WhenConnectorIdIsNull_ExpectValidationError() {
+        PostConnectorSyncJobAction.Request requestWithMissingConnectorId = new PostConnectorSyncJobAction.Request(
+            null,
+            ConnectorSyncJobType.FULL,
+            ConnectorSyncJobTriggerMethod.ON_DEMAND
+        );
+        ActionRequestValidationException exception = requestWithMissingConnectorId.validate();
+
+        assertThat(exception, notNullValue());
+        assertThat(exception.getMessage(), containsString(PostConnectorSyncJobAction.Request.EMPTY_CONNECTOR_ID_ERROR_MESSAGE));
+    }
+
+}

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/action/TransportPostConnectorSyncJobActionTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/action/TransportPostConnectorSyncJobActionTests.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.connector.syncjob.action;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.Transport;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.application.connector.syncjob.ConnectorSyncJobTestUtils;
+import org.junit.Before;
+
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.Mockito.mock;
+
+public class TransportPostConnectorSyncJobActionTests extends ESSingleNodeTestCase {
+
+    private static final Long TIMEOUT_SECONDS = 10L;
+
+    private final ThreadPool threadPool = new TestThreadPool(getClass().getName());
+    private TransportPostConnectorSyncJobAction action;
+
+    @Before
+    public void setup() {
+        ClusterService clusterService = getInstanceFromNode(ClusterService.class);
+
+        TransportService transportService = new TransportService(
+            Settings.EMPTY,
+            mock(Transport.class),
+            threadPool,
+            TransportService.NOOP_TRANSPORT_INTERCEPTOR,
+            x -> null,
+            null,
+            Collections.emptySet()
+        );
+
+        action = new TransportPostConnectorSyncJobAction(transportService, clusterService, mock(ActionFilters.class), client());
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        ThreadPool.terminate(threadPool, TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    }
+
+    public void testPostConnectorSyncJob_ExpectNoWarnings() throws InterruptedException {
+        PostConnectorSyncJobAction.Request request = ConnectorSyncJobTestUtils.getRandomPostConnectorSyncJobActionRequest();
+
+        executeRequest(request);
+
+        ensureNoWarnings();
+    }
+
+    private void executeRequest(PostConnectorSyncJobAction.Request request) throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(1);
+        action.doExecute(mock(Task.class), request, ActionListener.wrap(response -> latch.countDown(), exception -> latch.countDown()));
+
+        boolean requestTimedOut = latch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+        assertTrue("Timeout waiting for post request", requestTimedOut);
+    }
+}

--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
@@ -127,6 +127,7 @@ public class Constants {
         "cluster:admin/xpack/connector/get",
         "cluster:admin/xpack/connector/list",
         "cluster:admin/xpack/connector/put",
+        "cluster:admin/xpack/connector/sync_job/post",
         "cluster:admin/xpack/deprecation/info",
         "cluster:admin/xpack/deprecation/nodes/info",
         "cluster:admin/xpack/enrich/delete",


### PR DESCRIPTION
(My IDE blew up while rebasing and I've continued rebasing from a wrong point and screwed up my local history without noticing, therefore reopened again. For review reference: https://github.com/elastic/elasticsearch/pull/102714)

This PR adds the ConnectorSyncJob model and a corresponding POST endpoint for creating a new sync job.

As the current API spec expects an id field inside a connector sync job, which is the same value as the internal _id I needed to use a workaround for generating an id to avoid doing the following: Index sync job without id -> fetch this sync job again -> set the id -> index again. I've added a comment that this could be mitigated, if we remove the id field as it's also not specified in the [Connectors Protocol](https://github.com/elastic/connectors/blob/main/docs/CONNECTOR_PROTOCOL.md), but nothing blocking right now, just to raise the awareness. Or maybe there's a more obvious/ES way of achieving, what I want to do with this workaround?

I've also added getSyncJobConnectorInfo intentionally to ConnectorSyncJobIndexService for now as I don't want interfere with Jedr's work. I guess that's fine for now and can be addressed later, but happy to discuss that (moving that to ConnectorIndexService or using something Jedr probably builds down the line for another endpoint).