### PR TITLE
Adjust the maximum resolution used in GeoHexVisitorTests

### DIFF
--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoHexVisitorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoHexVisitorTests.java
@@ -51,7 +51,7 @@ public class GeoHexVisitorTests extends ESTestCase {
         // we ignore polar cells are they are problematic and do not keep the relationships
         long h3 = randomValueOtherThanMany(
             l -> l == H3.geoToH3(90, 0, H3.getResolution(l)) || l == H3.geoToH3(-90, 0, H3.getResolution(l)),
-            () -> H3.geoToH3(GeoTestUtil.nextLatitude(), GeoTestUtil.nextLongitude(), randomIntBetween(2, 14))
+            () -> H3.geoToH3(GeoTestUtil.nextLatitude(), GeoTestUtil.nextLongitude(), randomIntBetween(2, 13))
         );
         long centerChild = H3.childPosToH3(h3, 0);
         // children position 3 is chosen so we never use a polar polygon


### PR DESCRIPTION
At resolution 14 the test can fail due to numerical errors when computing line intersections. This are not an issue per se but it makes unpredictable to predict the relationships in case of QUERY_INSIDE as sometimes are reported as QUERY_CROSSES, therefore we skip them.

closes https://github.com/elastic/elasticsearch/issues/102773