### PR TITLE
Active shards message corrected for search shards

### DIFF
--- a/docs/changelog/102808.yaml
+++ b/docs/changelog/102808.yaml
@@ -1,0 +1,6 @@
+pr: 102808
+summary: Active shards message corrected for search shards
+area: Distributed
+type: bug
+issues:
+ - 101896

--- a/server/src/main/java/org/elasticsearch/action/support/ActiveShardCount.java
+++ b/server/src/main/java/org/elasticsearch/action/support/ActiveShardCount.java
@@ -176,19 +176,24 @@ public record ActiveShardCount(int value) implements Writeable {
      */
     public EnoughShards enoughShardsActive(final IndexShardRoutingTable shardRoutingTable) {
         final int activeShardCount = shardRoutingTable.activeShards().size();
+        boolean enoughShards = false;
+        int currentActiveShards = activeShardCount;
         if (this == ActiveShardCount.ALL) {
-            return new EnoughShards(activeShardCount == shardRoutingTable.size(), activeShardCount);
+            enoughShards = activeShardCount == shardRoutingTable.size();
         } else if (value == 0) {
-            return new EnoughShards(true, activeShardCount);
+            enoughShards = true;
         } else if (value == 1) {
             if (shardRoutingTable.hasSearchShards()) {
-                return new EnoughShards(shardRoutingTable.getActiveSearchShardCount() >= 1, shardRoutingTable.getActiveSearchShardCount());
+                enoughShards = shardRoutingTable.getActiveSearchShardCount() >= 1;
+                currentActiveShards = shardRoutingTable.getActiveSearchShardCount();
             } else {
-                return new EnoughShards(activeShardCount >= 1, activeShardCount);
+                enoughShards = activeShardCount >= 1;
             }
         } else {
-            return new EnoughShards(shardRoutingTable.getActiveSearchShardCount() >= value, shardRoutingTable.getActiveSearchShardCount());
+            enoughShards = shardRoutingTable.getActiveSearchShardCount() >= value;
+            currentActiveShards = shardRoutingTable.getActiveSearchShardCount();
         }
+        return new EnoughShards(enoughShards, currentActiveShards);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationOperation.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationOperation.java
@@ -26,7 +26,6 @@ import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.seqno.SequenceNumbers;
 import org.elasticsearch.index.shard.ReplicationGroup;
 import org.elasticsearch.index.shard.ShardId;
@@ -431,8 +430,8 @@ public class ReplicationOperation<
             return null;  // not waiting for any shards
         }
         final IndexShardRoutingTable shardRoutingTable = primary.getReplicationGroup().getRoutingTable();
-        Tuple<Boolean, Integer> enoughShardsActive = waitForActiveShards.enoughShardsActive(shardRoutingTable);
-        if (enoughShardsActive.v1()) {
+        ActiveShardCount.EnoughShards enoughShardsActive = waitForActiveShards.enoughShardsActive(shardRoutingTable);
+        if (enoughShardsActive.enoughShards()) {
             return null;
         } else {
             final String resolvedShards = waitForActiveShards == ActiveShardCount.ALL
@@ -443,7 +442,7 @@ public class ReplicationOperation<
                     + "request [{}]",
                 shardId,
                 waitForActiveShards,
-                enoughShardsActive.v2(),
+                enoughShardsActive.currentActiveShards(),
                 resolvedShards,
                 opType,
                 request
@@ -451,7 +450,7 @@ public class ReplicationOperation<
             return "Not enough active copies to meet shard count of ["
                 + waitForActiveShards
                 + "] (have "
-                + enoughShardsActive.v2()
+                + enoughShardsActive.currentActiveShards()
                 + ", needed "
                 + resolvedShards
                 + ").";

--- a/server/src/test/java/org/elasticsearch/action/support/replication/ReplicationOperationTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/replication/ReplicationOperationTests.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.shard.IndexShardNotStartedException;
 import org.elasticsearch.index.shard.IndexShardState;
 import org.elasticsearch.index.shard.ReplicationGroup;
@@ -45,6 +46,7 @@ import org.elasticsearch.transport.SendRequestTransportException;
 
 import java.net.InetAddress;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -65,7 +67,6 @@ import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
 public class ReplicationOperationTests extends ESTestCase {
@@ -439,10 +440,15 @@ public class ReplicationOperationTests extends ESTestCase {
         final int unassignedReplicas = randomInt(2);
         final int totalShards = 1 + assignedReplicas + unassignedReplicas;
         final int activeShardCount = randomIntBetween(0, totalShards);
+        final boolean stateless = randomBoolean();
         Request request = new Request(shardId).waitForActiveShards(
             activeShardCount == totalShards ? ActiveShardCount.ALL : ActiveShardCount.from(activeShardCount)
         );
-        final boolean passesActiveShardCheck = activeShardCount <= assignedReplicas + 1;
+        // In the case of stateless, only the search/replica assigned shards are calculated as active shards. But in other cases, or when
+        // the wait is for ALL active shards, ReplicationOperation#checkActiveShardCount() takes into account the primary shard as well,
+        // and that is why we need to increment the assigned replicas by 1 when calculating the actual active shards.
+        final int actualActiveShards = assignedReplicas + ((stateless && request.waitForActiveShards() != ActiveShardCount.ALL) ? 0 : 1);
+        final boolean passesActiveShardCheck = activeShardCount <= actualActiveShards;
 
         ShardRoutingState[] replicaStates = new ShardRoutingState[assignedReplicas + unassignedReplicas];
         for (int i = 0; i < assignedReplicas; i++) {
@@ -452,12 +458,26 @@ public class ReplicationOperationTests extends ESTestCase {
             replicaStates[i] = ShardRoutingState.UNASSIGNED;
         }
 
-        final ClusterState state = state(index, true, ShardRoutingState.STARTED, replicaStates);
+        final ClusterState state = state(
+            index,
+            true,
+            ShardRoutingState.STARTED,
+            stateless ? ShardRouting.Role.INDEX_ONLY : ShardRouting.Role.DEFAULT,
+            Arrays.stream(replicaStates)
+                .map(
+                    shardRoutingState -> new Tuple<>(
+                        shardRoutingState,
+                        stateless ? ShardRouting.Role.SEARCH_ONLY : ShardRouting.Role.DEFAULT
+                    )
+                )
+                .toList()
+        );
         logger.debug(
-            "using active shard count of [{}], assigned shards [{}], total shards [{}]." + " expecting op to [{}]. using state: \n{}",
+            "using active shards [{}], assigned shards [{}], total shards [{}]. stateless [{}]. expecting op to [{}]. using state: \n{}",
             request.waitForActiveShards(),
             1 + assignedReplicas,
             1 + assignedReplicas + unassignedReplicas,
+            stateless,
             passesActiveShardCheck ? "succeed" : "retry",
             state
         );
@@ -487,7 +507,18 @@ public class ReplicationOperationTests extends ESTestCase {
             op.execute();
             assertTrue("operations should have been performed, active shard count is met", request.processedOnPrimary.get());
         } else {
-            assertThat(op.checkActiveShardCount(), notNullValue());
+            assertThat(
+                op.checkActiveShardCount(),
+                equalTo(
+                    "Not enough active copies to meet shard count of ["
+                        + request.waitForActiveShards()
+                        + "] (have "
+                        + actualActiveShards
+                        + ", needed "
+                        + activeShardCount
+                        + ")."
+                )
+            );
             op.execute();
             assertFalse("operations should not have been perform, active shard count is *NOT* met", request.processedOnPrimary.get());
             assertListenerThrows("should throw exception to trigger retry", listener, UnavailableShardsException.class);

--- a/server/src/test/java/org/elasticsearch/action/support/replication/ReplicationOperationTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/replication/ReplicationOperationTests.java
@@ -475,7 +475,7 @@ public class ReplicationOperationTests extends ESTestCase {
                 .toList()
         );
         logger.debug(
-            "using active shards [{}], assigned shards [{}], total shards [{}]. unpromotable replicas [{}]. expecting op to [{}]. using state: \n{}",
+            "using active shards [{}], assigned shards [{}], total shards [{}]. unpromotable [{}]. expecting op to [{}]. state: \n{}",
             request.waitForActiveShards(),
             1 + assignedReplicas,
             1 + assignedReplicas + unassignedReplicas,

--- a/test/framework/src/main/java/org/elasticsearch/action/support/replication/ClusterStateCreationUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/action/support/replication/ClusterStateCreationUtils.java
@@ -89,6 +89,25 @@ public class ClusterStateCreationUtils {
         ShardRoutingState primaryState,
         List<Tuple<ShardRoutingState, ShardRouting.Role>> replicaStates
     ) {
+        return state(index, activePrimaryLocal, primaryState, ShardRouting.Role.DEFAULT, replicaStates);
+    }
+
+    /**
+     * Creates cluster state with and index that has one shard and #(replicaStates) replicas with given roles
+     *
+     * @param index              name of the index
+     * @param activePrimaryLocal if active primary should coincide with the local node in the cluster state
+     * @param primaryState       state of primary
+     * @param primaryRole        role of primary
+     * @param replicaStates      states and roles of the replicas. length of this collection determines also the number of replicas
+     */
+    public static ClusterState state(
+        String index,
+        boolean activePrimaryLocal,
+        ShardRoutingState primaryState,
+        ShardRouting.Role primaryRole,
+        List<Tuple<ShardRoutingState, ShardRouting.Role>> replicaStates
+    ) {
         assert primaryState == ShardRoutingState.STARTED
             || primaryState == ShardRoutingState.RELOCATING
             || replicaStates.stream().allMatch(s -> s.v1() == ShardRoutingState.UNASSIGNED)
@@ -155,7 +174,7 @@ public class ClusterStateCreationUtils {
             unassignedInfo = new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, null);
         }
         indexShardRoutingBuilder.addShard(
-            TestShardRouting.newShardRouting(index, 0, primaryNode, relocatingNode, true, primaryState, unassignedInfo)
+            TestShardRouting.newShardRouting(index, 0, primaryNode, relocatingNode, true, primaryState, unassignedInfo, primaryRole)
         );
 
         for (var replicaState : replicaStates) {


### PR DESCRIPTION
Note that the broader topic of waiting for active shards in the context of stateless is handled in ES-7302. This only fixes the message returned to mention the search shards (that the logic considers when calculating the boolean to return).

For example, if no search shard is active, the message was previously returning "(have 1, need 1)" because it was considering the primary shard. However it is now corrected to say "have 0" since the logic considers only search shards.

Fixes #101896