### PR TITLE
Add memory utilization Kibana metric to the monitoring index templates

### DIFF
--- a/docs/changelog/102810.yaml
+++ b/docs/changelog/102810.yaml
@@ -1,0 +1,5 @@
+pr: 102810
+summary: Add memory utilization Kibana metric to the monitoring index templates
+area: Monitoring
+type: enhancement
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/monitoring/exporter/MonitoringTemplateUtils.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/monitoring/exporter/MonitoringTemplateUtils.java
@@ -18,7 +18,7 @@ public final class MonitoringTemplateUtils {
      * <p>
      * It may be possible for this to diverge between templates and pipelines, but for now they're the same.
      */
-    public static final int LAST_UPDATED_VERSION = 8_08_00_99;
+    public static final int LAST_UPDATED_VERSION = 8_12_00_99;
 
     /**
      * Current version of templates used in their name to differentiate from breaking changes (separate from product version).

--- a/x-pack/plugin/core/template-resources/src/main/resources/monitoring-kibana-mb.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/monitoring-kibana-mb.json
@@ -80,6 +80,20 @@
                             }
                           }
                         },
+                        "array_buffers": {
+                          "properties": {
+                            "bytes": {
+                              "type": "long"
+                            }
+                          }
+                        },
+                        "external": {
+                          "properties": {
+                            "bytes": {
+                              "type": "long"
+                            }
+                          }
+                        },
                         "heap": {
                           "properties": {
                             "total": {
@@ -190,6 +204,26 @@
                     "platform": {
                       "ignore_above": 1024,
                       "type": "keyword"
+                    },
+                    "cpuacct": {
+                      "properties": {
+                        "control_group": {
+                          "type": "keyword"
+                        },
+                        "usage_nanos": {
+                          "type": "long"
+                        }
+                      }
+                    },
+                    "cgroup_memory": {
+                      "properties": {
+                        "current_in_bytes": {
+                          "type": "long"
+                        },
+                        "swap_current_in_bytes": {
+                          "type": "long"
+                        }
+                      }
                     }
                   }
                 },

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java
@@ -49,7 +49,7 @@ public class MonitoringTemplateRegistry extends IndexTemplateRegistry {
      * continue to use the release version number in this registry, even though this is not standard practice for template
      * registries.
      */
-    public static final int REGISTRY_VERSION = 8_08_00_99;
+    public static final int REGISTRY_VERSION = 8_12_00_99;
     private static final String REGISTRY_VERSION_VARIABLE = "xpack.monitoring.template.release.version";
 
     /**
@@ -77,7 +77,7 @@ public class MonitoringTemplateRegistry extends IndexTemplateRegistry {
      * writes monitoring data in ECS format as of 8.0. These templates define the ECS schema as well as alias fields for the old monitoring
      * mappings that point to the corresponding ECS fields.
      */
-    public static final int STACK_MONITORING_REGISTRY_VERSION = 8_00_00_99 + 11;
+    public static final int STACK_MONITORING_REGISTRY_VERSION = 8_00_00_99 + 12;
     private static final String STACK_MONITORING_REGISTRY_VERSION_VARIABLE = "xpack.stack.monitoring.template.release.version";
     private static final String STACK_TEMPLATE_VERSION = "8";
     private static final String STACK_TEMPLATE_VERSION_VARIABLE = "xpack.stack.monitoring.template.version";


### PR DESCRIPTION
Adds mappings for new Kibana memory fields added in https://github.com/elastic/kibana/pull/172146 to the monitoring templates.

Corresponding Beats PR: https://github.com/elastic/beats/pull/37232