### PR TITLE
[Transform] Split comma-separated source index strings into separate indices

### DIFF
--- a/docs/changelog/102811.yaml
+++ b/docs/changelog/102811.yaml
@@ -1,0 +1,6 @@
+pr: 102811
+summary: Split comma-separated source index strings into separate indices
+area: Transform
+type: bug
+issues:
+ - 99564

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/SourceConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/SourceConfig.java
@@ -82,18 +82,30 @@ public class SourceConfig implements Writeable, ToXContentObject {
      * @param runtimeMappings Search-time runtime fields that can be used by the transform
      */
     public SourceConfig(String[] index, QueryConfig queryConfig, Map<String, Object> runtimeMappings) {
-        ExceptionsHelper.requireNonNull(index, INDEX.getPreferredName());
+        this.index = extractIndices(ExceptionsHelper.requireNonNull(index, INDEX.getPreferredName()));
+        this.queryConfig = ExceptionsHelper.requireNonNull(queryConfig, QUERY.getPreferredName());
+        this.runtimeMappings = Collections.unmodifiableMap(
+            ExceptionsHelper.requireNonNull(runtimeMappings, SearchSourceBuilder.RUNTIME_MAPPINGS_FIELD.getPreferredName())
+        );
+    }
+
+    /**
+     * Extracts all index names or index patterns from the given array of strings.
+     *
+     * @param index array of indices (may contain comma-separated index names or index patterns)
+     * @return array of indices without comma-separated index names or index patterns
+     */
+    private static String[] extractIndices(String[] index) {
         if (index.length == 0) {
             throw new IllegalArgumentException("must specify at least one index");
         }
         if (Arrays.stream(index).anyMatch(Strings::isNullOrEmpty)) {
             throw new IllegalArgumentException("all indices need to be non-null and non-empty");
         }
-        this.index = index;
-        this.queryConfig = ExceptionsHelper.requireNonNull(queryConfig, QUERY.getPreferredName());
-        this.runtimeMappings = Collections.unmodifiableMap(
-            ExceptionsHelper.requireNonNull(runtimeMappings, SearchSourceBuilder.RUNTIME_MAPPINGS_FIELD.getPreferredName())
-        );
+        return Arrays.stream(index)
+            .map(commaSeparatedIndices -> commaSeparatedIndices.split(","))
+            .flatMap(Arrays::stream)
+            .toArray(String[]::new);
     }
 
     public SourceConfig(final StreamInput in) throws IOException {

--- a/x-pack/plugin/transform/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/multi_cluster/80_transform.yml
+++ b/x-pack/plugin/transform/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/multi_cluster/80_transform.yml
@@ -244,7 +244,7 @@ teardown:
         transform_id: "simple-local-remote-transform"
         body: >
           {
-            "source": { "index": ["test_index", "my_remote_cluster:remote_test_index"] },
+            "source": { "index": "test_index,my_remote_cluster:remote_test_index" },
             "dest": { "index": "simple-local-remote-transform" },
             "pivot": {
               "group_by": { "user": {"terms": {"field": "user"}}},


### PR DESCRIPTION
There were a few cases where user-provided comma-separated source index strings (e.g.: `"index1,remote2:index2"`) did not work properly in transforms. The transform would then fail in an non-obvious manner (especially when remote clusters are involved).

One example code snippet where they were problematic:
```
            resolvedSource = new TreeSet<>(Arrays.asList(source));
            resolvedRemoteSource = new TreeSet<>(RemoteClusterLicenseChecker.remoteIndices(resolvedSource));
            resolvedSource.removeAll(resolvedRemoteSource);
```
('source' could contain comma-separated indices but `RemoteClusterLicenseChecker.remoteIndices` does not expect that)

This PR ensures that when `SourceConfig` object is created, all the strings provided in the `source` array are split using comma delimiter (`,`). Hence, all the calls using `SourceConfig.getIndex` method will return source index array **without** problematic comma-separated strings.

Closes https://github.com/elastic/elasticsearch/issues/99564