### PR TITLE
Make SearchResponse effectively ref-counted and use pooled buffers for its source field

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/SearchServiceCleanupOnLostMasterIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/SearchServiceCleanupOnLostMasterIT.java
@@ -21,6 +21,7 @@ import org.hamcrest.Matchers;
 import java.util.Collection;
 import java.util.List;
 
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 
@@ -69,8 +70,7 @@ public class SearchServiceCleanupOnLostMasterIT extends ESIntegTestCase {
 
         index("test", "test", "{}");
 
-        assertThat(prepareSearch("test").setScroll("30m").get().getScrollId(), is(notNullValue()));
-
+        assertResponse(prepareSearch("test").setScroll("30m"), response -> assertThat(response.getScrollId(), is(notNullValue())));
         loseMaster.accept(master, dataNode);
         // in the past, this failed because the search context for the scroll would prevent the shard lock from being released.
         ensureYellow();

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/SearchWithRejectionsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/SearchWithRejectionsIT.java
@@ -52,7 +52,7 @@ public class SearchWithRejectionsIT extends ESIntegTestCase {
         }
         for (int i = 0; i < numSearches; i++) {
             try {
-                responses[i].get();
+                responses[i].get().decRef();
             } catch (Exception t) {}
         }
         assertBusy(

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/SignificantTermsSignificanceScoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/SignificantTermsSignificanceScoreIT.java
@@ -237,8 +237,7 @@ public class SignificantTermsSignificanceScoreIT extends ESIntegTestCase {
             );
         }
 
-        request.get();
-
+        request.get().decRef();
     }
 
     @Override

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/CardinalityWithRequestBreakerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/CardinalityWithRequestBreakerIT.java
@@ -53,7 +53,7 @@ public class CardinalityWithRequestBreakerIT extends ESIntegTestCase {
                     .collectMode(randomFrom(Aggregator.SubAggCollectionMode.values()))
                     .order(BucketOrder.aggregation("cardinality", randomBoolean()))
                     .subAggregation(cardinality("cardinality").precisionThreshold(randomLongBetween(1, 40000)).field("field1.keyword"))
-            ).get();
+            ).get().decRef();
         } catch (ElasticsearchException e) {
             if (ExceptionsHelper.unwrap(e, CircuitBreakingException.class) == null) {
                 throw e;

--- a/server/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
@@ -700,7 +700,12 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
                     searchContextId = null;
                 }
             }
-            listener.onResponse(buildSearchResponse(internalSearchResponse, failures, scrollId, searchContextId));
+            var resp = buildSearchResponse(internalSearchResponse, failures, scrollId, searchContextId);
+            try {
+                listener.onResponse(resp);
+            } finally {
+                resp.decRef();
+            }
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/action/search/FetchSearchPhase.java
+++ b/server/src/main/java/org/elasticsearch/action/search/FetchSearchPhase.java
@@ -235,6 +235,10 @@ final class FetchSearchPhase extends SearchPhase {
             reducedQueryPhase,
             fetchResultsArr
         );
-        context.executeNextPhase(this, nextPhaseFactory.apply(internalResponse, queryResults));
+        try {
+            context.executeNextPhase(this, nextPhaseFactory.apply(internalResponse, queryResults));
+        } finally {
+            internalResponse.decRef();
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/search/SearchScrollAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchScrollAsyncAction.java
@@ -241,14 +241,14 @@ abstract class SearchScrollAsyncAction<T extends SearchPhaseResult> implements R
     ) {
         try {
             final InternalSearchResponse internalResponse = SearchPhaseController.merge(true, queryPhase, fetchResults);
-            // the scroll ID never changes we always return the same ID. This ID contains all the shards and their context ids
-            // such that we can talk to them again in the next roundtrip.
-            String scrollId = null;
-            if (request.scroll() != null) {
-                scrollId = request.scrollId();
-            }
-            listener.onResponse(
-                new SearchResponse(
+            try {
+                // the scroll ID never changes we always return the same ID. This ID contains all the shards and their context ids
+                // such that we can talk to them again in the next roundtrip.
+                String scrollId = null;
+                if (request.scroll() != null) {
+                    scrollId = request.scrollId();
+                }
+                var response = new SearchResponse(
                     internalResponse,
                     scrollId,
                     this.scrollId.getContext().length,
@@ -258,8 +258,15 @@ abstract class SearchScrollAsyncAction<T extends SearchPhaseResult> implements R
                     buildShardFailures(),
                     SearchResponse.Clusters.EMPTY,
                     null
-                )
-            );
+                );
+                try {
+                    listener.onResponse(response);
+                } finally {
+                    response.decRef();
+                }
+            } finally {
+                internalResponse.decRef();
+            }
         } catch (Exception e) {
             listener.onFailure(new ReduceSearchPhaseException("fetch", "inner finish failed", e, buildShardFailures()));
         }

--- a/server/src/main/java/org/elasticsearch/search/SearchHits.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchHits.java
@@ -18,8 +18,11 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.xcontent.ChunkedToXContent;
 import org.elasticsearch.common.xcontent.ChunkedToXContentHelper;
+import org.elasticsearch.core.AbstractRefCounted;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.RefCounted;
 import org.elasticsearch.rest.action.search.RestSearchAction;
+import org.elasticsearch.transport.LeakTracker;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentParser;
 
@@ -32,11 +35,9 @@ import java.util.Objects;
 
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 
-public final class SearchHits implements Writeable, ChunkedToXContent, Iterable<SearchHit> {
+public final class SearchHits implements Writeable, ChunkedToXContent, Iterable<SearchHit>, RefCounted {
 
     public static final SearchHit[] EMPTY = new SearchHit[0];
-    public static final SearchHits EMPTY_WITH_TOTAL_HITS = new SearchHits(EMPTY, new TotalHits(0, Relation.EQUAL_TO), 0);
-    public static final SearchHits EMPTY_WITHOUT_TOTAL_HITS = new SearchHits(EMPTY, null, 0);
 
     private final SearchHit[] hits;
     private final TotalHits totalHits;
@@ -47,6 +48,16 @@ public final class SearchHits implements Writeable, ChunkedToXContent, Iterable<
     private final String collapseField;
     @Nullable
     private final Object[] collapseValues;
+
+    private final RefCounted refCounted = LeakTracker.wrap(new AbstractRefCounted() {
+        @Override
+        protected void closeInternal() {
+            for (int i = 0; i < hits.length; i++) {
+                hits[i].decRef();
+                hits[i] = null;
+            }
+        }
+    });
 
     public SearchHits(SearchHit[] hits, @Nullable TotalHits totalHits, float maxScore) {
         this(hits, totalHits, maxScore, null, null, null);
@@ -92,6 +103,7 @@ public final class SearchHits implements Writeable, ChunkedToXContent, Iterable<
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
+        assert hasReferences();
         final boolean hasTotalHits = totalHits != null;
         out.writeBoolean(hasTotalHits);
         if (hasTotalHits) {
@@ -162,6 +174,26 @@ public final class SearchHits implements Writeable, ChunkedToXContent, Iterable<
     @Override
     public Iterator<SearchHit> iterator() {
         return Iterators.forArray(getHits());
+    }
+
+    @Override
+    public void incRef() {
+        refCounted.incRef();
+    }
+
+    @Override
+    public boolean tryIncRef() {
+        return refCounted.tryIncRef();
+    }
+
+    @Override
+    public boolean decRef() {
+        return refCounted.decRef();
+    }
+
+    @Override
+    public boolean hasReferences() {
+        return refCounted.hasReferences();
     }
 
     public static final class Fields {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalTopHits.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalTopHits.java
@@ -53,6 +53,7 @@ public class InternalTopHits extends InternalAggregation implements TopHits {
         this.size = size;
         this.topDocs = topDocs;
         this.searchHits = searchHits;
+        searchHits.incRef();
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregator.java
@@ -233,7 +233,7 @@ class TopHitsAggregator extends MetricsAggregator {
             subSearchContext.from(),
             subSearchContext.size(),
             new TopDocsAndMaxScore(topDocs, Float.NaN),
-            SearchHits.EMPTY_WITH_TOTAL_HITS,
+            new SearchHits(SearchHits.EMPTY, new TotalHits(0, TotalHits.Relation.EQUAL_TO), 0),
             metadata()
         );
     }

--- a/server/src/main/java/org/elasticsearch/search/internal/InternalSearchResponse.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/InternalSearchResponse.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.search.internal;
 
+import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.action.search.SearchResponseSections;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -24,7 +25,7 @@ import java.io.IOException;
  */
 public class InternalSearchResponse extends SearchResponseSections implements Writeable {
     public static final InternalSearchResponse EMPTY_WITH_TOTAL_HITS = new InternalSearchResponse(
-        SearchHits.EMPTY_WITH_TOTAL_HITS,
+        new SearchHits(SearchHits.EMPTY, new TotalHits(0, TotalHits.Relation.EQUAL_TO), 0),
         null,
         null,
         null,
@@ -34,7 +35,7 @@ public class InternalSearchResponse extends SearchResponseSections implements Wr
     );
 
     public static final InternalSearchResponse EMPTY_WITHOUT_TOTAL_HITS = new InternalSearchResponse(
-        SearchHits.EMPTY_WITHOUT_TOTAL_HITS,
+        new SearchHits(SearchHits.EMPTY, null, 0),
         null,
         null,
         null,
@@ -65,6 +66,7 @@ public class InternalSearchResponse extends SearchResponseSections implements Wr
             in.readOptionalWriteable(SearchProfileResults::new),
             in.readVInt()
         );
+        hits.decRef(); // TODO: meh
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/ShardSizeTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/ShardSizeTestCase.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.search.aggregations.bucket;
 
 import org.elasticsearch.action.index.IndexRequestBuilder;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.test.ESIntegTestCase;
 
 import java.util.ArrayList;
@@ -19,6 +18,7 @@ import java.util.List;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.is;
 
@@ -78,14 +78,15 @@ public abstract class ShardSizeTestCase extends ESIntegTestCase {
 
         indexRandom(true, docs);
 
-        SearchResponse resp = prepareSearch("idx").setRouting(routing1).setQuery(matchAllQuery()).get();
-        assertNoFailures(resp);
-        long totalOnOne = resp.getHits().getTotalHits().value;
-        assertThat(totalOnOne, is(15L));
-        resp = prepareSearch("idx").setRouting(routing2).setQuery(matchAllQuery()).get();
-        assertNoFailures(resp);
-        long totalOnTwo = resp.getHits().getTotalHits().value;
-        assertThat(totalOnTwo, is(12L));
+        assertNoFailuresAndResponse(prepareSearch("idx").setRouting(routing1).setQuery(matchAllQuery()), resp -> {
+            long totalOnOne = resp.getHits().getTotalHits().value;
+            assertThat(totalOnOne, is(15L));
+        });
+        assertNoFailuresAndResponse(prepareSearch("idx").setRouting(routing2).setQuery(matchAllQuery()), resp -> {
+            assertNoFailures(resp);
+            long totalOnTwo = resp.getHits().getTotalHits().value;
+            assertThat(totalOnTwo, is(12L));
+        });
     }
 
     protected List<IndexRequestBuilder> indexDoc(String shard, String key, int times) throws Exception {

--- a/server/src/test/java/org/elasticsearch/search/profile/SearchProfileResultsBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/profile/SearchProfileResultsBuilderTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.search.profile;
 
+import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.search.SearchHits;
@@ -96,7 +97,7 @@ public class SearchProfileResultsBuilderTests extends ESTestCase {
 
     private static FetchSearchResult fetchResult(SearchShardTarget target, ProfileResult profileResult) {
         FetchSearchResult fetchResult = new FetchSearchResult();
-        fetchResult.shardResult(SearchHits.EMPTY_WITH_TOTAL_HITS, profileResult);
+        fetchResult.shardResult(new SearchHits(SearchHits.EMPTY, new TotalHits(0, TotalHits.Relation.EQUAL_TO), 0), profileResult);
         fetchResult.setSearchShardTarget(target);
         return fetchResult;
     }

--- a/server/src/test/java/org/elasticsearch/test/search/aggregations/bucket/SharedSignificantTermsTestMethods.java
+++ b/server/src/test/java/org/elasticsearch/test/search/aggregations/bucket/SharedSignificantTermsTestMethods.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.test.search.aggregations.bucket;
 
 import org.elasticsearch.action.index.IndexRequestBuilder;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.bucket.terms.SignificantTerms;
 import org.elasticsearch.search.aggregations.bucket.terms.StringTerms;
@@ -29,7 +28,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.terms;
 import static org.elasticsearch.test.ESIntegTestCase.client;
 import static org.elasticsearch.test.ESIntegTestCase.prepareSearch;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
 import static org.hamcrest.Matchers.equalTo;
 
 public class SharedSignificantTermsTestMethods {
@@ -48,22 +47,25 @@ public class SharedSignificantTermsTestMethods {
     }
 
     private static void checkSignificantTermsAggregationCorrect(ESIntegTestCase testCase) {
-        SearchResponse response = prepareSearch(INDEX_NAME).addAggregation(
-            terms("class").field(CLASS_FIELD).subAggregation(significantTerms("sig_terms").field(TEXT_FIELD))
-        ).get();
-        assertNoFailures(response);
-        StringTerms classes = response.getAggregations().get("class");
-        Assert.assertThat(classes.getBuckets().size(), equalTo(2));
-        for (Terms.Bucket classBucket : classes.getBuckets()) {
-            Map<String, Aggregation> aggs = classBucket.getAggregations().asMap();
-            Assert.assertTrue(aggs.containsKey("sig_terms"));
-            SignificantTerms agg = (SignificantTerms) aggs.get("sig_terms");
-            Assert.assertThat(agg.getBuckets().size(), equalTo(1));
-            SignificantTerms.Bucket sigBucket = agg.iterator().next();
-            String term = sigBucket.getKeyAsString();
-            String classTerm = classBucket.getKeyAsString();
-            Assert.assertTrue(term.equals(classTerm));
-        }
+        assertNoFailuresAndResponse(
+            prepareSearch(INDEX_NAME).addAggregation(
+                terms("class").field(CLASS_FIELD).subAggregation(significantTerms("sig_terms").field(TEXT_FIELD))
+            ),
+            response -> {
+                StringTerms classes = response.getAggregations().get("class");
+                Assert.assertThat(classes.getBuckets().size(), equalTo(2));
+                for (Terms.Bucket classBucket : classes.getBuckets()) {
+                    Map<String, Aggregation> aggs = classBucket.getAggregations().asMap();
+                    Assert.assertTrue(aggs.containsKey("sig_terms"));
+                    SignificantTerms agg = (SignificantTerms) aggs.get("sig_terms");
+                    Assert.assertThat(agg.getBuckets().size(), equalTo(1));
+                    SignificantTerms.Bucket sigBucket = agg.iterator().next();
+                    String term = sigBucket.getKeyAsString();
+                    String classTerm = classBucket.getKeyAsString();
+                    Assert.assertTrue(term.equals(classTerm));
+                }
+            }
+        );
     }
 
     public static void index01Docs(String type, String settings, ESIntegTestCase testCase) throws ExecutionException, InterruptedException {

--- a/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncSearchResponseTests.java
+++ b/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncSearchResponseTests.java
@@ -210,7 +210,7 @@ public class AsyncSearchResponseTests extends ESTestCase {
         long took = 22968L;
         long expectedCompletionTime = startTimeMillis + took;
 
-        SearchHits hits = SearchHits.EMPTY_WITHOUT_TOTAL_HITS;
+        SearchHits hits = new SearchHits(SearchHits.EMPTY, null, 0);
         SearchResponseSections sections = new SearchResponseSections(hits, null, null, false, null, null, 2);
         SearchResponse searchResponse = new SearchResponse(
             sections,
@@ -315,7 +315,7 @@ public class AsyncSearchResponseTests extends ESTestCase {
         long expirationTimeMillis = 1689784924517L;
         long took = 22968L;
 
-        SearchHits hits = SearchHits.EMPTY_WITHOUT_TOTAL_HITS;
+        SearchHits hits = new SearchHits(SearchHits.EMPTY, null, 0);
         SearchResponseSections sections = new SearchResponseSections(hits, null, null, false, null, null, 2);
 
         SearchResponse.Clusters clusters = createCCSClusterObjects(3, 3, true);
@@ -461,7 +461,7 @@ public class AsyncSearchResponseTests extends ESTestCase {
         long took = 22968L;
         long expectedCompletionTime = startTimeMillis + took;
 
-        SearchHits hits = SearchHits.EMPTY_WITHOUT_TOTAL_HITS;
+        SearchHits hits = new SearchHits(SearchHits.EMPTY, null, 0);
         SearchResponseSections sections = new SearchResponseSections(hits, null, null, true, null, null, 2);
         SearchResponse.Clusters clusters = createCCSClusterObjects(4, 3, true);
 
@@ -658,7 +658,7 @@ public class AsyncSearchResponseTests extends ESTestCase {
         long expirationTimeMillis = 1689784924517L;
         long took = 22968L;
 
-        SearchHits hits = SearchHits.EMPTY_WITHOUT_TOTAL_HITS;
+        SearchHits hits = new SearchHits(SearchHits.EMPTY, null, 0);
         SearchResponseSections sections = new SearchResponseSections(hits, null, null, false, null, null, 2);
         SearchResponse searchResponse = new SearchResponse(
             sections,

--- a/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncSearchTaskTests.java
+++ b/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncSearchTaskTests.java
@@ -406,7 +406,7 @@ public class AsyncSearchTaskTests extends ESTestCase {
         ShardSearchFailure... failures
     ) {
         InternalSearchResponse response = new InternalSearchResponse(
-            SearchHits.EMPTY_WITH_TOTAL_HITS,
+            new SearchHits(SearchHits.EMPTY, new TotalHits(0, TotalHits.Relation.EQUAL_TO), 0),
             InternalAggregations.EMPTY,
             null,
             null,

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsTaskTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsTaskTests.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.ml.dataframe;
 
+import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.index.IndexAction;
 import org.elasticsearch.action.index.IndexRequest;
@@ -239,7 +240,7 @@ public class DataFrameAnalyticsTaskTests extends ESTestCase {
     }
 
     public void testPersistProgress_ProgressDocumentCreated() throws IOException {
-        testPersistProgress(SearchHits.EMPTY_WITH_TOTAL_HITS, ".ml-state-write");
+        testPersistProgress(new SearchHits(SearchHits.EMPTY, new TotalHits(0, TotalHits.Relation.EQUAL_TO), 0), ".ml-state-write");
     }
 
     public void testPersistProgress_ProgressDocumentUpdated() throws IOException {
@@ -283,7 +284,7 @@ public class DataFrameAnalyticsTaskTests extends ESTestCase {
         );
 
         SearchResponse searchResponse = mock(SearchResponse.class);
-        when(searchResponse.getHits()).thenReturn(SearchHits.EMPTY_WITH_TOTAL_HITS);
+        when(searchResponse.getHits()).thenReturn(new SearchHits(SearchHits.EMPTY, new TotalHits(0, TotalHits.Relation.EQUAL_TO), 0));
         doAnswer(withResponse(searchResponse)).when(client).execute(eq(TransportSearchAction.TYPE), any(), any());
 
         IndexResponse indexResponse = mock(IndexResponse.class);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersisterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersisterTests.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.ml.job.persistence;
 
+import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.bulk.BulkAction;
@@ -354,7 +355,7 @@ public class JobResultsPersisterTests extends ESTestCase {
     }
 
     public void testPersistQuantilesSync_QuantilesDocumentCreated() {
-        testPersistQuantilesSync(SearchHits.EMPTY_WITH_TOTAL_HITS, ".ml-state-write");
+        testPersistQuantilesSync(new SearchHits(SearchHits.EMPTY, new TotalHits(0, TotalHits.Relation.EQUAL_TO), 0), ".ml-state-write");
     }
 
     public void testPersistQuantilesSync_QuantilesDocumentUpdated() {
@@ -393,7 +394,7 @@ public class JobResultsPersisterTests extends ESTestCase {
     }
 
     public void testPersistQuantilesAsync_QuantilesDocumentCreated() {
-        testPersistQuantilesAsync(SearchHits.EMPTY_WITH_TOTAL_HITS, ".ml-state-write");
+        testPersistQuantilesAsync(new SearchHits(SearchHits.EMPTY, new TotalHits(0, TotalHits.Relation.EQUAL_TO), 0), ".ml-state-write");
     }
 
     public void testPersistQuantilesAsync_QuantilesDocumentUpdated() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/process/IndexingStateProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/process/IndexingStateProcessorTests.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.ml.process;
 
 import com.carrotsearch.randomizedtesting.annotations.Timeout;
 
+import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
@@ -119,7 +120,7 @@ public class IndexingStateProcessorTests extends ESTestCase {
     }
 
     public void testStateRead_StateDocumentCreated() throws IOException {
-        testStateRead(SearchHits.EMPTY_WITH_TOTAL_HITS, ".ml-state-write");
+        testStateRead(new SearchHits(SearchHits.EMPTY, new TotalHits(0, TotalHits.Relation.EQUAL_TO), 0), ".ml-state-write");
     }
 
     public void testStateRead_StateDocumentUpdated() throws IOException {
@@ -181,7 +182,7 @@ public class IndexingStateProcessorTests extends ESTestCase {
      */
     @Timeout(millis = 10 * 1000)
     public void testLargeStateRead() throws Exception {
-        when(searchResponse.getHits()).thenReturn(SearchHits.EMPTY_WITH_TOTAL_HITS);
+        when(searchResponse.getHits()).thenReturn(new SearchHits(SearchHits.EMPTY, new TotalHits(0, TotalHits.Relation.EQUAL_TO), 0));
 
         StringBuilder builder = new StringBuilder(NUM_LARGE_DOCS * (LARGE_DOC_SIZE + 10)); // 10 for header and separators
         for (int docNum = 1; docNum <= NUM_LARGE_DOCS; ++docNum) {

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/RollupResponseTranslator.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/RollupResponseTranslator.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.rollup;
 
+import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.search.MultiSearchResponse;
@@ -342,7 +343,7 @@ public class RollupResponseTranslator {
         }
 
         InternalSearchResponse combinedInternal = new InternalSearchResponse(
-            SearchHits.EMPTY_WITH_TOTAL_HITS,
+            new SearchHits(SearchHits.EMPTY, new TotalHits(0, TotalHits.Relation.EQUAL_TO), 0),
             aggs,
             null,
             null,

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/FrozenSearchableSnapshotsIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/FrozenSearchableSnapshotsIntegTests.java
@@ -20,7 +20,6 @@ import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest
 import org.elasticsearch.action.admin.indices.shrink.ResizeType;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
 import org.elasticsearch.action.admin.indices.stats.ShardStats;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -70,7 +69,7 @@ import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
 import static org.elasticsearch.search.aggregations.AggregationBuilders.dateHistogram;
 import static org.elasticsearch.snapshots.SearchableSnapshotsSettings.SEARCHABLE_SNAPSHOT_STORE_TYPE;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshots.SNAPSHOT_RECOVERY_STATE_FACTORY_KEY;
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.containsString;
@@ -110,19 +109,25 @@ public class FrozenSearchableSnapshotsIntegTests extends BaseFrozenSearchableSna
 
         populateIndex(indexName, 10_000);
 
-        final TotalHits originalAllHits = internalCluster().client()
-            .prepareSearch(indexName)
-            .setTrackTotalHits(true)
-            .get()
-            .getHits()
-            .getTotalHits();
-        final TotalHits originalBarHits = internalCluster().client()
+        final TotalHits originalAllHits;
+        var originalResponse = internalCluster().client().prepareSearch(indexName).setTrackTotalHits(true).get();
+        try {
+            originalAllHits = originalResponse.getHits().getTotalHits();
+        } finally {
+            originalResponse.decRef();
+        }
+        final TotalHits originalBarHits;
+        var barResponse = internalCluster().client()
             .prepareSearch(indexName)
             .setTrackTotalHits(true)
             .setQuery(matchQuery("foo", "bar"))
-            .get()
-            .getHits()
-            .getTotalHits();
+            .get();
+        try {
+            originalBarHits = barResponse.getHits().getTotalHits();
+        } finally {
+            barResponse.decRef();
+        }
+
         logger.info("--> [{}] in total, of which [{}] match the query", originalAllHits, originalBarHits);
 
         expectThrows(
@@ -462,25 +467,8 @@ public class FrozenSearchableSnapshotsIntegTests extends BaseFrozenSearchableSna
         // use a fixed client for the searches, as clients randomize timeouts, which leads to different cache entries
         Client client = client();
 
-        final SearchResponse r1 = client.prepareSearch("test-index")
-            .setSize(0)
-            .setSearchType(SearchType.QUERY_THEN_FETCH)
-            .addAggregation(
-                dateHistogram("histo").field("f").timeZone(ZoneId.of("+01:00")).minDocCount(0).calendarInterval(DateHistogramInterval.MONTH)
-            )
-            .get();
-        assertNoFailures(r1);
-
-        assertRequestCacheState(client(), "test-index", 0, 1);
-
-        // The cached is actually used
-        assertThat(
-            indicesAdmin().prepareStats("test-index").setRequestCache(true).get().getTotal().getRequestCache().getMemorySizeInBytes(),
-            greaterThan(0L)
-        );
-
-        for (int i = 0; i < 10; ++i) {
-            final SearchResponse r2 = client.prepareSearch("test-index")
+        assertNoFailuresAndResponse(
+            client.prepareSearch("test-index")
                 .setSize(0)
                 .setSearchType(SearchType.QUERY_THEN_FETCH)
                 .addAggregation(
@@ -488,22 +476,51 @@ public class FrozenSearchableSnapshotsIntegTests extends BaseFrozenSearchableSna
                         .timeZone(ZoneId.of("+01:00"))
                         .minDocCount(0)
                         .calendarInterval(DateHistogramInterval.MONTH)
-                )
-                .get();
-            assertNoFailures(r2);
-            assertRequestCacheState(client(), "test-index", i + 1, 1);
-            Histogram h1 = r1.getAggregations().get("histo");
-            Histogram h2 = r2.getAggregations().get("histo");
-            final List<? extends Histogram.Bucket> buckets1 = h1.getBuckets();
-            final List<? extends Histogram.Bucket> buckets2 = h2.getBuckets();
-            assertEquals(buckets1.size(), buckets2.size());
-            for (int j = 0; j < buckets1.size(); ++j) {
-                final Histogram.Bucket b1 = buckets1.get(j);
-                final Histogram.Bucket b2 = buckets2.get(j);
-                assertEquals(b1.getKey(), b2.getKey());
-                assertEquals(b1.getDocCount(), b2.getDocCount());
+                ),
+            r1 -> {
+                assertRequestCacheState(client(), "test-index", 0, 1);
+
+                // The cached is actually used
+                assertThat(
+                    indicesAdmin().prepareStats("test-index")
+                        .setRequestCache(true)
+                        .get()
+                        .getTotal()
+                        .getRequestCache()
+                        .getMemorySizeInBytes(),
+                    greaterThan(0L)
+                );
+
+                for (int i = 0; i < 10; ++i) {
+                    final int idx = i;
+                    assertNoFailuresAndResponse(
+                        client.prepareSearch("test-index")
+                            .setSize(0)
+                            .setSearchType(SearchType.QUERY_THEN_FETCH)
+                            .addAggregation(
+                                dateHistogram("histo").field("f")
+                                    .timeZone(ZoneId.of("+01:00"))
+                                    .minDocCount(0)
+                                    .calendarInterval(DateHistogramInterval.MONTH)
+                            ),
+                        r2 -> {
+                            assertRequestCacheState(client(), "test-index", idx + 1, 1);
+                            Histogram h1 = r1.getAggregations().get("histo");
+                            Histogram h2 = r2.getAggregations().get("histo");
+                            final List<? extends Histogram.Bucket> buckets1 = h1.getBuckets();
+                            final List<? extends Histogram.Bucket> buckets2 = h2.getBuckets();
+                            assertEquals(buckets1.size(), buckets2.size());
+                            for (int j = 0; j < buckets1.size(); ++j) {
+                                final Histogram.Bucket b1 = buckets1.get(j);
+                                final Histogram.Bucket b2 = buckets2.get(j);
+                                assertEquals(b1.getKey(), b2.getKey());
+                                assertEquals(b1.getDocCount(), b2.getDocCount());
+                            }
+                        }
+                    );
+                }
             }
-        }
+        );
 
         // shut down shard and check that cache entries are actually removed
         indicesAdmin().prepareClose("test-index").get();

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/SearchableSnapshotsBlobStoreCacheMaintenanceIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/SearchableSnapshotsBlobStoreCacheMaintenanceIntegTests.java
@@ -56,6 +56,7 @@ import java.util.stream.Collectors;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshots.SNAPSHOT_BLOB_CACHE_INDEX;
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshots.SNAPSHOT_INDEX_ID_SETTING;
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshots.SNAPSHOT_INDEX_NAME_SETTING;
@@ -166,28 +167,29 @@ public class SearchableSnapshotsBlobStoreCacheMaintenanceIntegTests extends Base
                 for (String mountedIndex : mountedIndices.keySet()) {
                     final Settings indexSettings = mountedIndices.get(mountedIndex).v1();
 
-                    final long remainingEntriesInCache = systemClient().prepareSearch(SNAPSHOT_BLOB_CACHE_INDEX)
-                        .setQuery(
-                            BlobStoreCacheMaintenanceService.buildDeleteByQuery(
-                                INDEX_NUMBER_OF_SHARDS_SETTING.get(indexSettings),
-                                SNAPSHOT_SNAPSHOT_ID_SETTING.get(indexSettings),
-                                SNAPSHOT_INDEX_ID_SETTING.get(indexSettings)
+                    assertResponse(
+                        systemClient().prepareSearch(SNAPSHOT_BLOB_CACHE_INDEX)
+                            .setQuery(
+                                BlobStoreCacheMaintenanceService.buildDeleteByQuery(
+                                    INDEX_NUMBER_OF_SHARDS_SETTING.get(indexSettings),
+                                    SNAPSHOT_SNAPSHOT_ID_SETTING.get(indexSettings),
+                                    SNAPSHOT_INDEX_ID_SETTING.get(indexSettings)
+                                )
                             )
-                        )
-                        .setSize(0)
-                        .get()
-                        .getHits()
-                        .getTotalHits().value;
-
-                    if (indicesToDelete.contains(mountedIndex)) {
-                        assertThat(remainingEntriesInCache, equalTo(0L));
-                    } else if (snapshotId.equals(SNAPSHOT_SNAPSHOT_ID_SETTING.get(indexSettings))) {
-                        assertThat(remainingEntriesInCache, greaterThanOrEqualTo(mountedIndices.get(randomMountedIndex).v2()));
-                    } else if (moreIndicesToDelete.contains(mountedIndex)) {
-                        assertThat(remainingEntriesInCache, equalTo(0L));
-                    } else {
-                        assertThat(remainingEntriesInCache, equalTo(mountedIndices.get(mountedIndex).v2()));
-                    }
+                            .setSize(0),
+                        res -> {
+                            final long remainingEntriesInCache = res.getHits().getTotalHits().value;
+                            if (indicesToDelete.contains(mountedIndex)) {
+                                assertThat(remainingEntriesInCache, equalTo(0L));
+                            } else if (snapshotId.equals(SNAPSHOT_SNAPSHOT_ID_SETTING.get(indexSettings))) {
+                                assertThat(remainingEntriesInCache, greaterThanOrEqualTo(mountedIndices.get(randomMountedIndex).v2()));
+                            } else if (moreIndicesToDelete.contains(mountedIndex)) {
+                                assertThat(remainingEntriesInCache, equalTo(0L));
+                            } else {
+                                assertThat(remainingEntriesInCache, equalTo(mountedIndices.get(mountedIndex).v2()));
+                            }
+                        }
+                    );
                 }
             });
         }
@@ -316,13 +318,16 @@ public class SearchableSnapshotsBlobStoreCacheMaintenanceIntegTests extends Base
     }
 
     private long numberOfEntriesInCache() {
-        return systemClient().prepareSearch(SNAPSHOT_BLOB_CACHE_INDEX)
+        var res = systemClient().prepareSearch(SNAPSHOT_BLOB_CACHE_INDEX)
             .setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN)
             .setTrackTotalHits(true)
             .setSize(0)
-            .get()
-            .getHits()
-            .getTotalHits().value;
+            .get();
+        try {
+            return res.getHits().getTotalHits().value;
+        } finally {
+            res.decRef();
+        }
     }
 
     private void refreshSystemIndex(boolean failIfNotExist) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/TokenServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/TokenServiceTests.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.security.authc;
 
+import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.TransportVersion;
@@ -1243,7 +1244,7 @@ public class TokenServiceTests extends ESTestCase {
                     hit.sourceRef(docSource);
                     hits = new SearchHits(new SearchHit[] { hit }, null, 1);
                 } else {
-                    hits = SearchHits.EMPTY_WITH_TOTAL_HITS;
+                    hits = new SearchHits(SearchHits.EMPTY, new TotalHits(0, TotalHits.Relation.EQUAL_TO), 0);
                 }
                 when(response.getHits()).thenReturn(hits);
                 listener.onResponse(response);

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherServiceTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherServiceTests.java
@@ -174,7 +174,7 @@ public class WatcherServiceTests extends ESTestCase {
 
         // empty scroll response, no further scrolling needed
         SearchResponseSections scrollSearchSections = new SearchResponseSections(
-            SearchHits.EMPTY_WITH_TOTAL_HITS,
+            new SearchHits(SearchHits.EMPTY, new TotalHits(0, TotalHits.Relation.EQUAL_TO), 0),
             null,
             null,
             false,


### PR DESCRIPTION
WIP, there's an issue with aggs here but it's very close. 

relates #102030 