### PR TITLE
Bring back dependency on the `org.opensaml.security` module

### DIFF
--- a/x-pack/plugin/security/src/main/java/module-info.java
+++ b/x-pack/plugin/security/src/main/java/module-info.java
@@ -34,6 +34,7 @@ module org.elasticsearch.security {
     requires org.opensaml.saml;
     requires org.opensaml.saml.impl;
     requires org.opensaml.security.impl;
+    requires org.opensaml.security;
     requires org.opensaml.xmlsec.impl;
     requires org.opensaml.xmlsec;
 


### PR DESCRIPTION
Otherwise, the build fails in Intellij with

```
java: package org.opensaml.security.credential is not visible
  (package org.opensaml.security.credential is declared in the unnamed module, but module org.elasticsearch.security does not read it)
```

Note: Maybe Intellij can't properly analyse shaded dependencies.

See #101904