### PR TITLE
Disable concurrency for sampler and diversified sampler

### DIFF
--- a/docs/changelog/102832.yaml
+++ b/docs/changelog/102832.yaml
@@ -1,0 +1,5 @@
+pr: 102832
+summary: Disable concurrency for sampler and diversified sampler
+area: Aggregations
+type: enhancement
+issues: []

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/DiversifiedSamplerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/DiversifiedSamplerIT.java
@@ -40,7 +40,7 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 @ESIntegTestCase.SuiteScopeTestCase
 public class DiversifiedSamplerIT extends ESIntegTestCase {
 
-    public static final int NUM_SHARDS = 2;
+    public static final int NUM_SHARDS = 1;
 
     public String randomExecutionHint() {
         return randomBoolean() ? null : randomFrom(SamplerAggregator.ExecutionMode.values()).toString();
@@ -83,8 +83,9 @@ public class DiversifiedSamplerIT extends ESIntegTestCase {
             prepareIndex("idx_unmapped_author").setId("" + i)
                 .setSource("name", parts[2], "genre", parts[8], "price", Float.parseFloat(parts[3]))
                 .get();
+            // frequent refresh makes it more likely that more segments are created, hence we may parallelize the search across slices
+            indicesAdmin().refresh(new RefreshRequest()).get();
         }
-        indicesAdmin().refresh(new RefreshRequest("test")).get();
     }
 
     public void testIssue10719() throws Exception {

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/DiversifiedSamplerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/DiversifiedSamplerIT.java
@@ -40,7 +40,7 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 @ESIntegTestCase.SuiteScopeTestCase
 public class DiversifiedSamplerIT extends ESIntegTestCase {
 
-    public static final int NUM_SHARDS = 1;
+    private static final int NUM_SHARDS = 1;
 
     public String randomExecutionHint() {
         return randomBoolean() ? null : randomFrom(SamplerAggregator.ExecutionMode.values()).toString();

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/SamplerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/SamplerIT.java
@@ -81,8 +81,9 @@ public class SamplerIT extends ESIntegTestCase {
             prepareIndex("idx_unmapped_author").setId("" + i)
                 .setSource("name", parts[2], "genre", parts[8], "price", Float.parseFloat(parts[3]))
                 .get();
+            // frequent refresh makes it more likely that more segments are created, hence we may parallelize the search across slices
+            indicesAdmin().refresh(new RefreshRequest()).get();
         }
-        indicesAdmin().refresh(new RefreshRequest("test")).get();
     }
 
     public void testIssue10719() throws Exception {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedAggregationBuilder.java
@@ -28,6 +28,7 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.ToLongFunction;
 
 public class DiversifiedAggregationBuilder extends ValuesSourceAggregationBuilder<DiversifiedAggregationBuilder> {
     public static final String NAME = "diversified_sampler";
@@ -188,5 +189,10 @@ public class DiversifiedAggregationBuilder extends ValuesSourceAggregationBuilde
     @Override
     public TransportVersion getMinimalSupportedVersion() {
         return TransportVersions.ZERO;
+    }
+
+    @Override
+    public boolean supportsParallelCollection(ToLongFunction<String> fieldCardinalityResolver) {
+        return false;
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/SamplerAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/SamplerAggregationBuilder.java
@@ -24,6 +24,7 @@ import org.elasticsearch.xcontent.XContentParser;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.ToLongFunction;
 
 public class SamplerAggregationBuilder extends AbstractAggregationBuilder<SamplerAggregationBuilder> {
     public static final String NAME = "sampler";
@@ -140,5 +141,10 @@ public class SamplerAggregationBuilder extends AbstractAggregationBuilder<Sample
     @Override
     public TransportVersion getMinimalSupportedVersion() {
         return TransportVersions.ZERO;
+    }
+
+    @Override
+    public boolean supportsParallelCollection(ToLongFunction<String> fieldCardinalityResolver) {
+        return false;
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedSamplerTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/sampler/DiversifiedSamplerTests.java
@@ -199,4 +199,21 @@ public class DiversifiedSamplerTests extends AggregatorTestCase {
         indexReader.close();
         directory.close();
     }
+
+    public void testSupportsParallelCollection() {
+        DiversifiedAggregationBuilder sampler = new DiversifiedAggregationBuilder("name");
+        if (randomBoolean()) {
+            sampler.field("field");
+        }
+        if (randomBoolean()) {
+            sampler.maxDocsPerValue(randomIntBetween(1, 1000));
+        }
+        if (randomBoolean()) {
+            sampler.subAggregation(new TermsAggregationBuilder("name").field("field"));
+        }
+        if (randomBoolean()) {
+            sampler.shardSize(randomIntBetween(1, 1000));
+        }
+        assertFalse(sampler.supportsParallelCollection(null));
+    }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/sampler/SamplerAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/sampler/SamplerAggregatorTests.java
@@ -132,4 +132,14 @@ public class SamplerAggregatorTests extends AggregatorTestCase {
         }
     }
 
+    public void testSupportsParallelCollection() {
+        SamplerAggregationBuilder sampler = new SamplerAggregationBuilder("name");
+        if (randomBoolean()) {
+            sampler.subAggregation(new TermsAggregationBuilder("name").field("field"));
+        }
+        if (randomBoolean()) {
+            sampler.shardSize(randomIntBetween(1, 1000));
+        }
+        assertFalse(sampler.supportsParallelCollection(null));
+    }
 }


### PR DESCRIPTION
Sampler and Diversified sampler aggs are subject to precision errors when executed in parallel across slices. The problematic bits are the shard_size and max_docs_per_value. These are harder to work around compared to e.g. terms aggs where we can simply look at the cardinality of the field, and perhaps less important.

For now, we just disable concurrency to stay on the safe side.