### PR TITLE
[7.17] Update IronBank BASE_IMAGE with ironbank prefix (#102720)

### DIFF
--- a/distribution/docker/src/docker/Dockerfile
+++ b/distribution/docker/src/docker/Dockerfile
@@ -26,7 +26,7 @@
 ################################################################################
 
 ARG BASE_REGISTRY=registry1.dso.mil
-ARG BASE_IMAGE=redhat/ubi/ubi9
+ARG BASE_IMAGE=ironbank/redhat/ubi/ubi9
 ARG BASE_TAG=9.2
 
 FROM ${base_image} AS builder


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Update IronBank BASE_IMAGE with ironbank prefix (#102720)