### PR TITLE
Make test fixture plugin not break configuration cache basic compatibility

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/testfixtures/TestFixtureTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/testfixtures/TestFixtureTask.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+package org.elasticsearch.gradle.internal.testfixtures;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.tasks.Internal;
+
+public abstract class TestFixtureTask extends DefaultTask {
+
+    @Internal
+    abstract DirectoryProperty getFixturesDir();
+}

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/testfixtures/TestFixturesPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/testfixtures/TestFixturesPlugin.java
@@ -81,37 +81,36 @@ public class TestFixturesPlugin implements Plugin<Project> {
         );
 
         ExtraPropertiesExtension ext = project.getExtensions().getByType(ExtraPropertiesExtension.class);
-        File testfixturesDir = project.file("testfixtures_shared");
-        ext.set("testFixturesDir", testfixturesDir);
+        File testFixturesDir = project.file("testfixtures_shared");
+        ext.set("testFixturesDir", testFixturesDir);
 
         if (project.file(DOCKER_COMPOSE_YML).exists()) {
             project.getPluginManager().apply(BasePlugin.class);
             project.getPluginManager().apply(DockerComposePlugin.class);
-
-            TaskProvider<Task> preProcessFixture = project.getTasks().register("preProcessFixture", t -> {
-                t.doFirst(new Action<Task>() {
-                    @Override
-                    public void execute(Task task) {
-                        try {
-                            Files.createDirectories(testfixturesDir.toPath());
-                        } catch (IOException e) {
-                            throw new UncheckedIOException(e);
-                        }
+            TaskProvider<TestFixtureTask> preProcessFixture = project.getTasks().register("preProcessFixture", TestFixtureTask.class, t -> {
+                t.getFixturesDir().set(testFixturesDir);
+                t.doFirst(task -> {
+                    try {
+                        Files.createDirectories(testFixturesDir.toPath());
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
                     }
                 });
             });
             TaskProvider<Task> buildFixture = project.getTasks()
                 .register("buildFixture", t -> t.dependsOn(preProcessFixture, tasks.named("composeUp")));
 
-            TaskProvider<Task> postProcessFixture = project.getTasks().register("postProcessFixture", task -> {
-                task.dependsOn(buildFixture);
-                configureServiceInfoForTask(
-                    task,
-                    project,
-                    false,
-                    (name, port) -> task.getExtensions().getByType(ExtraPropertiesExtension.class).set(name, port)
-                );
-            });
+            TaskProvider<TestFixtureTask> postProcessFixture = project.getTasks()
+                .register("postProcessFixture", TestFixtureTask.class, task -> {
+                    task.getFixturesDir().set(testFixturesDir);
+                    task.dependsOn(buildFixture);
+                    configureServiceInfoForTask(
+                        task,
+                        project,
+                        false,
+                        (name, port) -> task.getExtensions().getByType(ExtraPropertiesExtension.class).set(name, port)
+                    );
+                });
 
             maybeSkipTask(dockerSupport, preProcessFixture);
             maybeSkipTask(dockerSupport, postProcessFixture);
@@ -138,7 +137,7 @@ public class TestFixturesPlugin implements Plugin<Project> {
                 t.mustRunAfter(preProcessFixture);
             });
             tasks.named("composePull").configure(t -> t.mustRunAfter(preProcessFixture));
-            tasks.named("composeDown").configure(t -> t.doLast(t2 -> getFileSystemOperations().delete(d -> d.delete(testfixturesDir))));
+            tasks.named("composeDown").configure(t -> t.doLast(t2 -> getFileSystemOperations().delete(d -> d.delete(testFixturesDir))));
         } else {
             project.afterEvaluate(spec -> {
                 if (extension.fixtures.isEmpty()) {
@@ -179,7 +178,7 @@ public class TestFixturesPlugin implements Plugin<Project> {
         tasks.withType(taskClass).configureEach(t -> maybeSkipTask(dockerSupport, t));
     }
 
-    private void maybeSkipTask(Provider<DockerSupportService> dockerSupport, TaskProvider<Task> task) {
+    private void maybeSkipTask(Provider<DockerSupportService> dockerSupport, TaskProvider<? extends Task> task) {
         task.configure(t -> maybeSkipTask(dockerSupport, t));
     }
 

--- a/modules/repository-url/build.gradle
+++ b/modules/repository-url/build.gradle
@@ -44,14 +44,3 @@ tasks.named("thirdPartyAudit").configure {
   )
 }
 
-//File repositoryDir = fixture.fsRepositoryDir as File
-
-testClusters.configureEach {
-  // repositoryDir is used by a FS repository to create snapshots
-  setting 'path.repo', "${repositoryDir.absolutePath}", PropertyNormalization.IGNORE_VALUE
-  // repositoryDir is used by two URL repositories to restore snapshots
-  setting 'repositories.url.allowed_urls', {
-    "http://snapshot.test*,${fixtureAddress('url-fixture')}"
-  }, PropertyNormalization.IGNORE_VALUE
-}
-

--- a/test/fixtures/krb5kdc-fixture/build.gradle
+++ b/test/fixtures/krb5kdc-fixture/build.gradle
@@ -1,3 +1,6 @@
+import org.gradle.api.services.internal.BuildServiceProvider
+import org.gradle.api.services.internal.BuildServiceRegistryInternal
+
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
@@ -13,15 +16,15 @@ tasks.named("preProcessFixture").configure {
   doLast {
     // We need to create these up-front because if docker creates them they will be owned by root and we won't be
     // able to clean them up
-    services.each { file("${testFixturesDir}/shared/${it}").mkdirs() }
+    services.each { fixturesDir.dir("shared/${it}").get().getAsFile().mkdirs() }
   }
 }
 
-tasks.named("postProcessFixture").configure {
-  inputs.dir("${testFixturesDir}/shared")
+tasks.named("postProcessFixture").configure { task ->
+  inputs.dir(fixturesDir.dir('shared').get().getAsFile())
   services.each { service ->
-    File confTemplate = file("${testFixturesDir}/shared/${service}/krb5.conf.template")
-    File confFile = file("${testFixturesDir}/shared/${service}/krb5.conf")
+    File confTemplate = fixturesDir.file("shared/${service}/krb5.conf.template").get().asFile
+    File confFile = fixturesDir.file("shared/${service}/krb5.conf").get().asFile
     outputs.file(confFile)
     doLast {
       assert confTemplate.exists()
@@ -32,9 +35,8 @@ tasks.named("postProcessFixture").configure {
   }
 }
 
-
-project.ext.krb5Conf = { service -> file("$testFixturesDir/shared/${service}/krb5.conf") }
-project.ext.krb5Keytabs = { service, fileName -> file("$testFixturesDir/shared/${service}/keytabs/${fileName}") }
+project.ext.krb5Conf = { s -> file("$testFixturesDir/shared/${s}/krb5.conf") }
+project.ext.krb5Keytabs = { s, fileName -> file("$testFixturesDir/shared/${s}/keytabs/${fileName}") }
 
 configurations {
   krb5ConfHdfsFile {


### PR DESCRIPTION
Make just the basic configuration of a project using test fixture plugin not break configuration cache. 
This is just for not breaking caching of the gradle configuration. Running tests task relying on 
test fixture plugin and its wiring is still configuration cache in complete. This is just for unblocking
other configuration cache related work. 

In the long run we are going to remove this plugin