### PR TITLE
Skip global ordinals loading if query does not match after rewrite

### DIFF
--- a/docs/changelog/102844.yaml
+++ b/docs/changelog/102844.yaml
@@ -1,0 +1,5 @@
+pr: 102844
+summary: Skip global ordinals loading if query does not match after rewrite
+area: Aggregations
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -540,6 +540,8 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                     return;
                 }
             }
+            // TODO: in think it makes sense to always do a canMatch here and
+            // return an empty response (not null response) in case canMatch is false?
             ensureAfterSeqNoRefreshed(shard, orig, () -> executeQueryPhase(orig, task), l);
         }));
     }

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -540,7 +540,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                     return;
                 }
             }
-            // TODO: in think it makes sense to always do a canMatch here and
+            // TODO: i think it makes sense to always do a canMatch here and
             // return an empty response (not null response) in case canMatch is false?
             ensureAfterSeqNoRefreshed(shard, orig, () -> executeQueryPhase(orig, task), l);
         }));

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTermsAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTermsAggregatorFactory.java
@@ -130,16 +130,11 @@ public class SignificantTermsAggregatorFactory extends ValuesSourceAggregatorFac
      * Note that if {@link org.elasticsearch.search.SearchService#executeQueryPhase(ShardSearchRequest, SearchShardTask, ActionListener)}
      * always do a can match then we don't need this code here.
      */
-    public static boolean matchNoDocs(AggregationContext context, Aggregator parent) {
+    static boolean matchNoDocs(AggregationContext context, Aggregator parent) {
         if (context.query() instanceof MatchNoDocsQuery) {
             while (parent != null) {
                 if (parent instanceof GlobalAggregator) {
                     return false;
-                }
-                if (parent instanceof TermsAggregator termsAggregator) {
-                    if (termsAggregator.bucketCountThresholds.getMinDocCount() == 0) {
-                        return false;
-                    }
                 }
                 parent = parent.parent();
             }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTermsAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTermsAggregatorFactory.java
@@ -15,7 +15,6 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.SearchShardTask;
 import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
-import org.elasticsearch.index.query.MatchNoneQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.DocValueFormat;
@@ -37,7 +36,6 @@ import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.aggregations.support.ValuesSourceRegistry;
-import org.elasticsearch.search.internal.InternalScrollSearchRequest;
 import org.elasticsearch.search.internal.ShardSearchRequest;
 import org.elasticsearch.xcontent.ParseField;
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTermsAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTermsAggregatorFactory.java
@@ -9,9 +9,13 @@
 package org.elasticsearch.search.aggregations.bucket.terms;
 
 import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.search.MatchNoDocsQuery;
 import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.search.SearchShardTask;
 import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.index.query.MatchNoneQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.DocValueFormat;
@@ -23,6 +27,7 @@ import org.elasticsearch.search.aggregations.CardinalityUpperBound;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.NonCollectingAggregator;
 import org.elasticsearch.search.aggregations.bucket.BucketUtils;
+import org.elasticsearch.search.aggregations.bucket.global.GlobalAggregator;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregator.BucketCountThresholds;
 import org.elasticsearch.search.aggregations.bucket.terms.heuristic.SignificanceHeuristic;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
@@ -32,6 +37,8 @@ import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.aggregations.support.ValuesSourceRegistry;
+import org.elasticsearch.search.internal.InternalScrollSearchRequest;
+import org.elasticsearch.search.internal.ShardSearchRequest;
 import org.elasticsearch.xcontent.ParseField;
 
 import java.io.IOException;
@@ -81,7 +88,7 @@ public class SignificantTermsAggregatorFactory extends ValuesSourceAggregatorFac
             if (executionHint != null) {
                 execution = ExecutionMode.fromString(executionHint, deprecationLogger);
             }
-            if (valuesSourceConfig.hasOrdinals() == false) {
+            if (valuesSourceConfig.hasOrdinals() == false || matchNoDocs(context, parent)) {
                 execution = ExecutionMode.MAP;
             }
             if (execution == null) {
@@ -113,6 +120,35 @@ public class SignificantTermsAggregatorFactory extends ValuesSourceAggregatorFac
                 metadata
             );
         };
+    }
+
+    /**
+     * Whether the aggregation will execute. If the main query matches no documents and parent aggregation isn't a global or terms
+     * aggregation with min_doc_count = 0, the the aggregator will not really execute. In those cases it doesn't make sense to load
+     * global ordinals.
+     * <p>
+     * Some searches that will never match can still fall through and we endup running query that will produce no results.
+     * However even in that case we sometimes do expensive things like loading global ordinals. This method should prevent this.
+     * Note that if {@link org.elasticsearch.search.SearchService#executeQueryPhase(ShardSearchRequest, SearchShardTask, ActionListener)}
+     * always do a can match then we don't need this code here.
+     */
+    public static boolean matchNoDocs(AggregationContext context, Aggregator parent) {
+        if (context.query() instanceof MatchNoDocsQuery) {
+            while (parent != null) {
+                if (parent instanceof GlobalAggregator) {
+                    return false;
+                }
+                if (parent instanceof TermsAggregator termsAggregator) {
+                    if (termsAggregator.bucketCountThresholds.getMinDocCount() == 0) {
+                        return false;
+                    }
+                }
+                parent = parent.parent();
+            }
+            return true;
+        } else {
+            return false;
+        }
     }
 
     /**
@@ -296,7 +332,6 @@ public class SignificantTermsAggregatorFactory extends ValuesSourceAggregatorFac
     public enum ExecutionMode {
 
         MAP(new ParseField("map")) {
-
             @Override
             Aggregator create(
                 String name,
@@ -335,7 +370,6 @@ public class SignificantTermsAggregatorFactory extends ValuesSourceAggregatorFac
 
         },
         GLOBAL_ORDINALS(new ParseField("global_ordinals")) {
-
             @Override
             Aggregator create(
                 String name,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorFactory.java
@@ -109,7 +109,7 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
                 execution = ExecutionMode.fromString(executionHint);
             }
             // In some cases, using ordinals is just not supported: override it
-            if (valuesSource.hasOrdinals() == false && matchNoDocs(context, parent)) {
+            if (valuesSource.hasOrdinals() == false || matchNoDocs(context, parent)) {
                 execution = ExecutionMode.MAP;
             }
             if (execution == null) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregatorFactory.java
@@ -45,6 +45,8 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.function.LongPredicate;
 
+import static org.elasticsearch.search.aggregations.bucket.terms.SignificantTermsAggregatorFactory.matchNoDocs;
+
 public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
     static Boolean REMAP_GLOBAL_ORDS, COLLECT_SEGMENT_ORDS;
 
@@ -107,7 +109,7 @@ public class TermsAggregatorFactory extends ValuesSourceAggregatorFactory {
                 execution = ExecutionMode.fromString(executionHint);
             }
             // In some cases, using ordinals is just not supported: override it
-            if (valuesSource.hasOrdinals() == false) {
+            if (valuesSource.hasOrdinals() == false && matchNoDocs(context, parent)) {
                 execution = ExecutionMode.MAP;
             }
             if (execution == null) {

--- a/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
@@ -43,12 +43,10 @@ import org.elasticsearch.search.sort.SortAndFormats;
 import org.elasticsearch.search.suggest.SuggestPhase;
 import org.elasticsearch.threadpool.ThreadPool;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 
-import static org.elasticsearch.search.SearchService.queryStillMatchesAfterRewrite;
 import static org.elasticsearch.search.internal.SearchContext.TRACK_TOTAL_HITS_DISABLED;
 
 /**
@@ -61,25 +59,6 @@ public class QueryPhase {
     private QueryPhase() {}
 
     public static void execute(SearchContext searchContext) throws QueryPhaseExecutionException {
-        try {
-            // Some searches that will never match can still fall through and we endup running query that will produce no results.
-            // However even in that case we sometimes do expensive things like loading global ordinals. This rewrite should prevent this.
-            // Note that if SearchService#executeQueryPhase(...) always do a can match then we don't need this code here.
-            if (queryStillMatchesAfterRewrite(searchContext.request(), searchContext.getSearchExecutionContext()) == false) {
-                searchContext.queryResult()
-                    .topDocs(
-                        new TopDocsAndMaxScore(
-                            new TopDocs(new TotalHits(0, TotalHits.Relation.EQUAL_TO), Lucene.EMPTY_SCORE_DOCS),
-                            Float.NaN
-                        ),
-                        new DocValueFormat[0]
-                    );
-                return;
-            }
-        } catch (IOException e) {
-            throw new QueryPhaseExecutionException(searchContext.shardTarget(), "query phase rewrite failed", e);
-        }
-
         if (searchContext.rankShardContext() == null) {
             executeQuery(searchContext);
         } else {

--- a/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
@@ -66,6 +66,14 @@ public class QueryPhase {
             // However even in that case we sometimes do expensive things like loading global ordinals. This rewrite should prevent this.
             // Note that if SearchService#executeQueryPhase(...) always do a can match then we don't need this code here.
             if (queryStillMatchesAfterRewrite(searchContext.request(), searchContext.getSearchExecutionContext()) == false) {
+                searchContext.queryResult()
+                    .topDocs(
+                        new TopDocsAndMaxScore(
+                            new TopDocs(new TotalHits(0, TotalHits.Relation.EQUAL_TO), Lucene.EMPTY_SCORE_DOCS),
+                            Float.NaN
+                        ),
+                        new DocValueFormat[0]
+                    );
                 return;
             }
         } catch (IOException e) {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTermsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTermsAggregatorTests.java
@@ -42,7 +42,6 @@ import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
-import org.elasticsearch.search.aggregations.BucketOrder;
 import org.elasticsearch.search.aggregations.bucket.sampler.random.InternalRandomSampler;
 import org.elasticsearch.search.aggregations.bucket.sampler.random.RandomSamplerAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.terms.SignificantTermsAggregatorFactory.ExecutionMode;

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTermsAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTermsAggregatorTests.java
@@ -20,12 +20,15 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.index.mapper.BinaryFieldMapper;
+import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.LuceneDocument;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
@@ -39,6 +42,7 @@ import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
+import org.elasticsearch.search.aggregations.BucketOrder;
 import org.elasticsearch.search.aggregations.bucket.sampler.random.InternalRandomSampler;
 import org.elasticsearch.search.aggregations.bucket.sampler.random.RandomSamplerAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.terms.SignificantTermsAggregatorFactory.ExecutionMode;
@@ -60,6 +64,7 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 
 import static org.elasticsearch.search.aggregations.AggregationBuilders.significantTerms;
+import static org.elasticsearch.search.aggregations.bucket.terms.TermsAggregatorTests.doc;
 import static org.hamcrest.Matchers.equalTo;
 
 public class SignificantTermsAggregatorTests extends AggregatorTestCase {
@@ -666,6 +671,26 @@ public class SignificantTermsAggregatorTests extends AggregatorTestCase {
                 }
             }
         }
+    }
+
+    public void testMatchNoDocsQuery() throws Exception {
+        MappedFieldType fieldType = new KeywordFieldMapper.KeywordFieldType("string", randomBoolean(), true, Collections.emptyMap());
+        SignificantTermsAggregationBuilder aggregationBuilder = new SignificantTermsAggregationBuilder("_name").field("string");
+        CheckedConsumer<RandomIndexWriter, IOException> createIndex = iw -> {
+            iw.addDocument(doc(fieldType, "a", "b"));
+            iw.addDocument(doc(fieldType, "", "c", "a"));
+            iw.addDocument(doc(fieldType, "b", "d"));
+            iw.addDocument(doc(fieldType, ""));
+        };
+        testCase(
+            createIndex,
+            (SignificantStringTerms result) -> { assertEquals(0, result.getBuckets().size()); },
+            new AggTestConfig(aggregationBuilder, fieldType).withQuery(new MatchNoDocsQuery())
+        );
+
+        debugTestCase(aggregationBuilder, new MatchNoDocsQuery(), createIndex, (result, impl, debug) -> {
+            assertEquals(impl, MapStringTermsAggregator.class);
+        }, fieldType);
     }
 
     private void addMixedTextDocs(IndexWriter w) throws IOException {


### PR DESCRIPTION
This avoids these stacktraces in case the main query has been rewritten to `MatchNoneQueryBuilder`:

```
org.apache.lucene.util.packed.PackedInts.getMutable(PackedInts.java)
org.apache.lucene.util.packed.PackedInts.getMutable(PackedInts.java:706)
org.apache.lucene.util.packed.PackedLongValues$Builder.pack(PackedLongValues.java:283)
org.apache.lucene.util.packed.PackedLongValues$Builder.pack(PackedLongValues.java:260)
org.apache.lucene.util.packed.PackedLongValues$Builder.add(PackedLongValues.java:243)
org.apache.lucene.index.OrdinalMap.<init>(OrdinalMap.java:295)
org.apache.lucene.index.OrdinalMap.build(OrdinalMap.java:182)
org.apache.lucene.index.OrdinalMap.build(OrdinalMap.java:160)
org.elasticsearch.index.fielddata.ordinals.GlobalOrdinalsBuilder.build(GlobalOrdinalsBuilder.java:53)
org.elasticsearch.index.fielddata.plain.AbstractIndexOrdinalsFieldData.loadGlobalDirect(AbstractIndexOrdinalsFieldData.java:139)
org.elasticsearch.index.fielddata.plain.AbstractIndexOrdinalsFieldData.loadGlobalDirect(AbstractIndexOrdinalsFieldData.java:32)
org.elasticsearch.indices.fielddata.cache.IndicesFieldDataCache$IndexFieldCache.lambda$load$1(IndicesFieldDataCache.java:164)
org.elasticsearch.indices.fielddata.cache.IndicesFieldDataCache$IndexFieldCache$$Lambda+0x000000f002931690.load()
org.elasticsearch.common.cache.Cache.computeIfAbsent(Cache.java:418)
org.elasticsearch.indices.fielddata.cache.IndicesFieldDataCache$IndexFieldCache.load(IndicesFieldDataCache.java:161)
org.elasticsearch.index.fielddata.plain.AbstractIndexOrdinalsFieldData.loadGlobalInternal(AbstractIndexOrdinalsFieldData.java:127)
org.elasticsearch.index.fielddata.plain.AbstractIndexOrdinalsFieldData.loadGlobal(AbstractIndexOrdinalsFieldData.java:93)
org.elasticsearch.search.aggregations.support.ValuesSource$Bytes$WithOrdinals$FieldData.globalOrdinalsValues(ValuesSource.java:283)
org.elasticsearch.search.aggregations.bucket.terms.TermsAggregatorFactory.globalOrdsValues(TermsAggregatorFactory.java:590)
org.elasticsearch.search.aggregations.bucket.terms.SignificantTermsAggregatorFactory$ExecutionMode$2.create(SignificantTermsAggregatorFactory.java:368)
org.elasticsearch.search.aggregations.bucket.terms.SignificantTermsAggregatorFactory.lambda$bytesSupplier$0(SignificantTermsAggregatorFactory.java:101)
org.elasticsearch.search.aggregations.bucket.terms.SignificantTermsAggregatorFactory$$Lambda+0x000000f001a7e878.build()
org.elasticsearch.search.aggregations.bucket.terms.SignificantTermsAggregatorFactory.doCreateInternal(SignificantTermsAggregatorFactory.java:279)
org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory.createInternal(ValuesSourceAggregatorFactory.java:41)
org.elasticsearch.search.aggregations.AggregatorFactory.create(AggregatorFactory.java:80)
org.elasticsearch.search.aggregations.AggregatorFactories.createSubAggregators(AggregatorFactories.java:233)
org.elasticsearch.search.aggregations.AggregatorFactories.createTopLevelAggregators(AggregatorFactories.java:243)
org.elasticsearch.search.aggregations.AggregationPhase.newAggregatorCollector(AggregationPhase.java:51)
org.elasticsearch.search.aggregations.AggregationPhase.lambda$preProcess$1(AggregationPhase.java:37)
org.elasticsearch.search.aggregations.AggregationPhase$$Lambda+0x000000f00292eeb0.get()
org.elasticsearch.search.aggregations.AggregatorCollectorManager.newCollector(AggregatorCollectorManager.java:39)
org.elasticsearch.search.aggregations.AggregatorCollectorManager.newCollector(AggregatorCollectorManager.java:21)
org.elasticsearch.search.query.QueryPhaseCollectorManager.newCollector(QueryPhaseCollectorManager.java:139)
org.elasticsearch.search.internal.ContextIndexSearcher.search(ContextIndexSearcher.java:311)
org.elasticsearch.search.query.QueryPhase.addCollectorsAndSearch(QueryPhase.java:205)
org.elasticsearch.search.query.QueryPhase.executeQuery(QueryPhase.java:135)
org.elasticsearch.search.query.QueryPhase.execute(QueryPhase.java:63)
org.elasticsearch.indices.IndicesService.lambda$loadIntoContext$31(IndicesService.java:1563)
org.elasticsearch.indices.IndicesService$$Lambda+0x000000f0028f8ac8.accept()
org.elasticsearch.indices.IndicesService.lambda$cacheShardLevelResult$32(IndicesService.java:1629)
org.elasticsearch.indices.IndicesService$$Lambda+0x000000f0028f9210.get()
org.elasticsearch.indices.IndicesRequestCache$Loader.load(IndicesRequestCache.java:174)
org.elasticsearch.indices.IndicesRequestCache$Loader.load(IndicesRequestCache.java:157)
org.elasticsearch.common.cache.Cache.computeIfAbsent(Cache.java:418)
org.elasticsearch.indices.IndicesRequestCache.getOrCompute(IndicesRequestCache.java:120)
org.elasticsearch.indices.IndicesService.cacheShardLevelResult(IndicesService.java:1635)
org.elasticsearch.indices.IndicesService.loadIntoContext(IndicesService.java:1557)
org.elasticsearch.search.SearchService.loadOrExecuteQueryPhase(SearchService.java:516)
org.elasticsearch.search.SearchService.executeQueryPhase(SearchService.java:671)
org.elasticsearch.search.SearchService.lambda$executeQueryPhase$2(SearchService.java:543)
org.elasticsearch.search.SearchService$$Lambda+0x000000f0028f6410.get()
org.elasticsearch.action.ActionRunnable$2.accept(ActionRunnable.java:51)
org.elasticsearch.action.ActionRunnable$2.accept(ActionRunnable.java:48)
org.elasticsearch.action.ActionRunnable$3.doRun(ActionRunnable.java:73)
org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:26)
org.elasticsearch.common.util.concurrent.TimedRunnable.doRun(TimedRunnable.java:33)
org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:983)
org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:26)
java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
java.lang.Thread.runWith(Thread.java:1596)
java.lang.Thread.run(Thread.java:1583)
```