### PR TITLE
Decref CacheFileRegion after read is done not before

### DIFF
--- a/docs/changelog/102848.yaml
+++ b/docs/changelog/102848.yaml
@@ -1,0 +1,5 @@
+pr: 102848
+summary: Decref `SharedBytes.IO` after read is done not before
+area: Snapshot/Restore
+type: bug
+issues: []

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
@@ -681,7 +681,7 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
                 final List<SparseFileTracker.Gap> gaps = tracker.waitForRange(
                     rangeToWrite,
                     rangeToRead,
-                    ActionListener.runBefore(listener, resource::close).delegateFailureAndWrap((l, success) -> {
+                    ActionListener.runAfter(listener, resource::close).delegateFailureAndWrap((l, success) -> {
                         var ioRef = io;
                         assert regionOwners.get(ioRef) == this;
                         final int start = Math.toIntExact(rangeToRead.start());


### PR DESCRIPTION
The CacheFileRegion instance is decref before the read operation is executed, meaning that the SharedBytes.IO instance can return to the pool of free regions, being polled and written for another cache file region by another thread, before the first read is effectively completed (and will return incorrect bytes).