### PR TITLE
[Profiling] Remove superfluous flamegraph response fields

### DIFF
--- a/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/GetFlameGraphActionIT.java
+++ b/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/GetFlameGraphActionIT.java
@@ -16,8 +16,6 @@ public class GetFlameGraphActionIT extends ProfilingTestCase {
         assertEquals(1.0d, response.getSamplingRate(), 0.001d);
         assertEquals(44, response.getSelfCPU());
         assertEquals(1865, response.getTotalCPU());
-        assertEquals(1.3651d, response.getSelfAnnualCostsUSD(), 0.0001d);
-        assertEquals(0.000144890d, response.getSelfAnnualCO2Tons(), 0.000000001d);
         assertEquals(44, response.getTotalSamples());
     }
 }

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetFlamegraphResponse.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetFlamegraphResponse.java
@@ -25,10 +25,6 @@ public class GetFlamegraphResponse extends ActionResponse implements ChunkedToXC
     private final double samplingRate;
     private final long selfCPU;
     private final long totalCPU;
-    private final double selfAnnualCO2Tons;
-    private final double totalAnnualCO2Tons;
-    private final double selfAnnualCostsUSD;
-    private final double totalAnnualCostsUSD;
     private final long totalSamples;
     private final List<Map<String, Integer>> edges;
     private final List<String> fileIds;
@@ -68,10 +64,6 @@ public class GetFlamegraphResponse extends ActionResponse implements ChunkedToXC
         this.annualCostsUSDExclusive = in.readCollectionAsList(StreamInput::readDouble);
         this.selfCPU = in.readLong();
         this.totalCPU = in.readLong();
-        this.selfAnnualCO2Tons = in.readDouble();
-        this.totalAnnualCO2Tons = in.readDouble();
-        this.selfAnnualCostsUSD = in.readDouble();
-        this.totalAnnualCostsUSD = in.readDouble();
         this.totalSamples = in.readLong();
     }
 
@@ -96,10 +88,6 @@ public class GetFlamegraphResponse extends ActionResponse implements ChunkedToXC
         List<Double> annualCostsUSDExclusive,
         long selfCPU,
         long totalCPU,
-        double selfAnnualCO2Tons,
-        double totalAnnualCO2Tons,
-        double selfAnnualCostsUSD,
-        double totalAnnualCostsUSD,
         long totalSamples
     ) {
         this.size = size;
@@ -122,10 +110,6 @@ public class GetFlamegraphResponse extends ActionResponse implements ChunkedToXC
         this.annualCostsUSDExclusive = annualCostsUSDExclusive;
         this.selfCPU = selfCPU;
         this.totalCPU = totalCPU;
-        this.selfAnnualCO2Tons = selfAnnualCO2Tons;
-        this.totalAnnualCO2Tons = totalAnnualCO2Tons;
-        this.selfAnnualCostsUSD = selfAnnualCostsUSD;
-        this.totalAnnualCostsUSD = totalAnnualCostsUSD;
         this.totalSamples = totalSamples;
     }
 
@@ -151,10 +135,6 @@ public class GetFlamegraphResponse extends ActionResponse implements ChunkedToXC
         out.writeCollection(this.annualCostsUSDExclusive, StreamOutput::writeDouble);
         out.writeLong(this.selfCPU);
         out.writeLong(this.totalCPU);
-        out.writeDouble(this.selfAnnualCO2Tons);
-        out.writeDouble(this.totalAnnualCO2Tons);
-        out.writeDouble(this.selfAnnualCostsUSD);
-        out.writeDouble(this.totalAnnualCostsUSD);
         out.writeLong(this.totalSamples);
     }
 
@@ -288,10 +268,6 @@ public class GetFlamegraphResponse extends ActionResponse implements ChunkedToXC
             Iterators.single((b, p) -> b.field("SamplingRate", samplingRate)),
             Iterators.single((b, p) -> b.field("SelfCPU", selfCPU)),
             Iterators.single((b, p) -> b.field("TotalCPU", totalCPU)),
-            Iterators.single((b, p) -> b.field("SelfAnnualCO2Tons", selfAnnualCO2Tons)),
-            Iterators.single((b, p) -> b.field("TotalAnnualCO2Tons", totalAnnualCO2Tons)),
-            Iterators.single((b, p) -> b.field("SelfAnnualCostsUSD", selfAnnualCostsUSD)),
-            Iterators.single((b, p) -> b.field("TotalAnnualCostsUSD", totalAnnualCostsUSD)),
             Iterators.single((b, p) -> b.field("TotalSamples", totalSamples)),
             ChunkedToXContentHelper.endObject()
         );

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetFlamegraphResponse.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetFlamegraphResponse.java
@@ -202,22 +202,6 @@ public class GetFlamegraphResponse extends ActionResponse implements ChunkedToXC
         return totalCPU;
     }
 
-    public double getSelfAnnualCostsUSD() {
-        return selfAnnualCostsUSD;
-    }
-
-    public double getTotalAnnualCostsUSD() {
-        return totalAnnualCostsUSD;
-    }
-
-    public double getSelfAnnualCO2Tons() {
-        return selfAnnualCO2Tons;
-    }
-
-    public double getTotalAnnualCO2Tons() {
-        return totalAnnualCO2Tons;
-    }
-
     public long getTotalSamples() {
         return totalSamples;
     }

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetFlamegraphAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetFlamegraphAction.java
@@ -147,10 +147,6 @@ public class TransportGetFlamegraphAction extends HandledTransportAction<GetStac
         private int size = 0;
         private long selfCPU;
         private long totalCPU;
-        private double selfAnnualCO2Tons;
-        private double totalAnnualCO2Tons;
-        private double selfAnnualCostsUSD;
-        private double totalAnnualCostsUSD;
         // totalSamples is the total number of samples in the stacktraces
         private final long totalSamples;
         // Map: FrameGroupId -> NodeId
@@ -229,10 +225,8 @@ public class TransportGetFlamegraphAction extends HandledTransportAction<GetStac
             this.totalCPU += samples;
             this.countExclusive.add(0L);
             this.annualCO2TonsInclusive.add(annualCO2Tons);
-            this.totalAnnualCO2Tons += annualCO2Tons;
             this.annualCO2TonsExclusive.add(0.0);
             this.annualCostsUSDInclusive.add(annualCostsUSD);
-            this.totalAnnualCostsUSD += annualCostsUSD;
             this.annualCostsUSDExclusive.add(0.0);
             if (frameGroupId != null) {
                 this.edges.get(currentNode).put(frameGroupId, node);
@@ -268,25 +262,21 @@ public class TransportGetFlamegraphAction extends HandledTransportAction<GetStac
         public void addAnnualCO2TonsInclusive(int nodeId, double annualCO2Tons) {
             Double priorAnnualCO2Tons = this.annualCO2TonsInclusive.get(nodeId);
             this.annualCO2TonsInclusive.set(nodeId, priorAnnualCO2Tons + annualCO2Tons);
-            this.totalAnnualCO2Tons += annualCO2Tons;
         }
 
         public void addAnnualCO2TonsExclusive(int nodeId, double annualCO2Tons) {
             Double priorAnnualCO2Tons = this.annualCO2TonsExclusive.get(nodeId);
             this.annualCO2TonsExclusive.set(nodeId, priorAnnualCO2Tons + annualCO2Tons);
-            this.selfAnnualCO2Tons += annualCO2Tons;
         }
 
         public void addAnnualCostsUSDInclusive(int nodeId, double annualCostsUSD) {
             Double priorAnnualCostsUSD = this.annualCostsUSDInclusive.get(nodeId);
             this.annualCostsUSDInclusive.set(nodeId, priorAnnualCostsUSD + annualCostsUSD);
-            this.totalAnnualCostsUSD += annualCostsUSD;
         }
 
         public void addAnnualCostsUSDExclusive(int nodeId, double annualCostsUSD) {
             Double priorAnnualCostsUSD = this.annualCostsUSDExclusive.get(nodeId);
             this.annualCostsUSDExclusive.set(nodeId, priorAnnualCostsUSD + annualCostsUSD);
-            this.selfAnnualCostsUSD += annualCostsUSD;
         }
 
         public GetFlamegraphResponse build() {
@@ -311,10 +301,6 @@ public class TransportGetFlamegraphAction extends HandledTransportAction<GetStac
                 annualCostsUSDExclusive,
                 selfCPU,
                 totalCPU,
-                selfAnnualCO2Tons,
-                totalAnnualCO2Tons,
-                selfAnnualCostsUSD,
-                totalAnnualCostsUSD,
                 totalSamples
             );
         }


### PR DESCRIPTION
The removed fields are redundant, have not yet been released and the Kibana side does not use these values.
