### PR TITLE
[LTR] Missing param handling improvements

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/LearnToRankConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/LearnToRankConfig.java
@@ -22,7 +22,9 @@ import org.elasticsearch.xpack.core.ml.utils.NamedXContentObjectHelper;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -33,7 +35,9 @@ public class LearnToRankConfig extends RegressionConfig implements Rewriteable<L
     static final TransportVersion MIN_SUPPORTED_TRANSPORT_VERSION = TransportVersion.current();
     public static final ParseField NUM_TOP_FEATURE_IMPORTANCE_VALUES = new ParseField("num_top_feature_importance_values");
     public static final ParseField FEATURE_EXTRACTORS = new ParseField("feature_extractors");
-    public static LearnToRankConfig EMPTY_PARAMS = new LearnToRankConfig(null, null);
+    public static final ParseField DEFAULT_PARAMS = new ParseField("default_params");
+
+    public static LearnToRankConfig EMPTY_PARAMS = new LearnToRankConfig(null, null, null);
 
     private static final ObjectParser<LearnToRankConfig.Builder, Boolean> LENIENT_PARSER = createParser(true);
     private static final ObjectParser<LearnToRankConfig.Builder, Boolean> STRICT_PARSER = createParser(false);
@@ -51,6 +55,7 @@ public class LearnToRankConfig extends RegressionConfig implements Rewriteable<L
             b -> {},
             FEATURE_EXTRACTORS
         );
+        parser.declareObject(Builder::setParamsDefaults, (p, c) -> p.map(), DEFAULT_PARAMS);
         return parser;
     }
 
@@ -67,8 +72,13 @@ public class LearnToRankConfig extends RegressionConfig implements Rewriteable<L
     }
 
     private final List<LearnToRankFeatureExtractorBuilder> featureExtractorBuilders;
+    private final Map<String, Object> paramsDefaults;
 
-    public LearnToRankConfig(Integer numTopFeatureImportanceValues, List<LearnToRankFeatureExtractorBuilder> featureExtractorBuilders) {
+    public LearnToRankConfig(
+        Integer numTopFeatureImportanceValues,
+        List<LearnToRankFeatureExtractorBuilder> featureExtractorBuilders,
+        Map<String, Object> paramsDefaults
+    ) {
         super(DEFAULT_RESULTS_FIELD, numTopFeatureImportanceValues);
         if (featureExtractorBuilders != null) {
             Set<String> featureNames = featureExtractorBuilders.stream()
@@ -80,12 +90,14 @@ public class LearnToRankConfig extends RegressionConfig implements Rewriteable<L
                 );
             }
         }
-        this.featureExtractorBuilders = featureExtractorBuilders == null ? List.of() : featureExtractorBuilders;
+        this.featureExtractorBuilders = Collections.unmodifiableList(Objects.requireNonNullElse(featureExtractorBuilders, List.of()));
+        this.paramsDefaults = Collections.unmodifiableMap(Objects.requireNonNullElse(paramsDefaults, Map.of()));
     }
 
     public LearnToRankConfig(StreamInput in) throws IOException {
         super(in);
         this.featureExtractorBuilders = in.readNamedWriteableCollectionAsList(LearnToRankFeatureExtractorBuilder.class);
+        this.paramsDefaults = in.readMap();
     }
 
     public List<LearnToRankFeatureExtractorBuilder> getFeatureExtractorBuilders() {
@@ -95,6 +107,10 @@ public class LearnToRankConfig extends RegressionConfig implements Rewriteable<L
     @Override
     public String getResultsField() {
         return DEFAULT_RESULTS_FIELD;
+    }
+
+    public Map<String, Object> getParamsDefaults() {
+        return paramsDefaults;
     }
 
     @Override
@@ -126,6 +142,7 @@ public class LearnToRankConfig extends RegressionConfig implements Rewriteable<L
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeNamedWriteableCollection(featureExtractorBuilders);
+        out.writeGenericMap(paramsDefaults);
     }
 
     @Override
@@ -146,6 +163,11 @@ public class LearnToRankConfig extends RegressionConfig implements Rewriteable<L
                 featureExtractorBuilders
             );
         }
+
+        if (paramsDefaults.isEmpty() == false) {
+            builder.field(DEFAULT_PARAMS.getPreferredName(), paramsDefaults);
+        }
+
         builder.endObject();
         return builder;
     }
@@ -156,12 +178,13 @@ public class LearnToRankConfig extends RegressionConfig implements Rewriteable<L
         if (o == null || getClass() != o.getClass()) return false;
         if (super.equals(o) == false) return false;
         LearnToRankConfig that = (LearnToRankConfig) o;
-        return Objects.equals(featureExtractorBuilders, that.featureExtractorBuilders);
+        return Objects.equals(featureExtractorBuilders, that.featureExtractorBuilders)
+            && Objects.equals(paramsDefaults, that.paramsDefaults);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), featureExtractorBuilders);
+        return Objects.hash(super.hashCode(), featureExtractorBuilders, paramsDefaults);
     }
 
     @Override
@@ -197,7 +220,7 @@ public class LearnToRankConfig extends RegressionConfig implements Rewriteable<L
             rewritten |= (rewrittenExtractor != extractorBuilder);
         }
         if (rewritten) {
-            return new LearnToRankConfig(getNumTopFeatureImportanceValues(), rewrittenExtractors);
+            return new LearnToRankConfig(getNumTopFeatureImportanceValues(), rewrittenExtractors, paramsDefaults);
         }
         return this;
     }
@@ -205,12 +228,14 @@ public class LearnToRankConfig extends RegressionConfig implements Rewriteable<L
     public static class Builder {
         private Integer numTopFeatureImportanceValues;
         private List<LearnToRankFeatureExtractorBuilder> learnToRankFeatureExtractorBuilders;
+        private Map<String, Object> paramsDefaults = Map.of();
 
         Builder() {}
 
         Builder(LearnToRankConfig config) {
             this.numTopFeatureImportanceValues = config.getNumTopFeatureImportanceValues();
             this.learnToRankFeatureExtractorBuilders = config.featureExtractorBuilders;
+            this.paramsDefaults = config.getParamsDefaults();
         }
 
         public Builder setNumTopFeatureImportanceValues(Integer numTopFeatureImportanceValues) {
@@ -225,8 +250,13 @@ public class LearnToRankConfig extends RegressionConfig implements Rewriteable<L
             return this;
         }
 
+        public Builder setParamsDefaults(Map<String, Object> paramsDefaults) {
+            this.paramsDefaults = paramsDefaults;
+            return this;
+        }
+
         public LearnToRankConfig build() {
-            return new LearnToRankConfig(numTopFeatureImportanceValues, learnToRankFeatureExtractorBuilders);
+            return new LearnToRankConfig(numTopFeatureImportanceValues, learnToRankFeatureExtractorBuilders, paramsDefaults);
         }
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/LearnToRankConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/LearnToRankConfig.java
@@ -18,6 +18,7 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.ml.MlConfigVersion;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ltr.LearnToRankFeatureExtractorBuilder;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ltr.QueryExtractorBuilder;
 import org.elasticsearch.xpack.core.ml.utils.NamedXContentObjectHelper;
 
 import java.io.IOException;
@@ -102,6 +103,17 @@ public class LearnToRankConfig extends RegressionConfig implements Rewriteable<L
 
     public List<LearnToRankFeatureExtractorBuilder> getFeatureExtractorBuilders() {
         return featureExtractorBuilders;
+    }
+
+    public List<QueryExtractorBuilder> getQueryFeatureExtractorBuilders() {
+        List<QueryExtractorBuilder> queryExtractorBuilders = new ArrayList<>();
+        for (LearnToRankFeatureExtractorBuilder featureExtractorBuilder : featureExtractorBuilders) {
+            if (featureExtractorBuilder instanceof QueryExtractorBuilder queryExtractorBuilder) {
+                queryExtractorBuilders.add(queryExtractorBuilder);
+            }
+        }
+
+        return queryExtractorBuilders;
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ltr/QueryExtractorBuilder.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ltr/QueryExtractorBuilder.java
@@ -70,6 +70,9 @@ public record QueryExtractorBuilder(String featureName, QueryProvider query, flo
     public QueryExtractorBuilder(String featureName, QueryProvider query, float defaultScore) {
         this.featureName = requireNonNull(featureName, FEATURE_NAME);
         this.query = requireNonNull(query, QUERY);
+        if (defaultScore < 0f) {
+            throw new IllegalArgumentException("[" + NAME + "] requires defaultScore to be positive.");
+        }
         this.defaultScore = defaultScore;
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ltr/QueryExtractorBuilder.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ltr/QueryExtractorBuilder.java
@@ -84,7 +84,9 @@ public record QueryExtractorBuilder(String featureName, QueryProvider query, flo
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         builder.field(FEATURE_NAME.getPreferredName(), featureName);
-        builder.field(DEFAULT_SCORE.getPreferredName(), defaultScore);
+        if (defaultScore > 0f) {
+            builder.field(DEFAULT_SCORE.getPreferredName(), defaultScore);
+        }
         builder.field(QUERY.getPreferredName(), query.getQuery());
         builder.endObject();
         return builder;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ltr/QueryExtractorBuilder.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ltr/QueryExtractorBuilder.java
@@ -34,14 +34,16 @@ public record QueryExtractorBuilder(String featureName, QueryProvider query, flo
     public static final ParseField QUERY = new ParseField("query");
     public static final ParseField DEFAULT_SCORE = new ParseField("default_score");
 
+    public static float DEFAULT_SCORE_DEFAULT = 0f;
+
     private static final ConstructingObjectParser<QueryExtractorBuilder, Void> PARSER = new ConstructingObjectParser<>(
         NAME.getPreferredName(),
-        a -> new QueryExtractorBuilder((String) a[0], (QueryProvider) a[1], Objects.requireNonNullElse((Float) a[2], 0f))
+        a -> new QueryExtractorBuilder((String) a[0], (QueryProvider) a[1], Objects.requireNonNullElse((Float) a[2], DEFAULT_SCORE_DEFAULT))
     );
     private static final ConstructingObjectParser<QueryExtractorBuilder, Void> LENIENT_PARSER = new ConstructingObjectParser<>(
         NAME.getPreferredName(),
         true,
-        a -> new QueryExtractorBuilder((String) a[0], (QueryProvider) a[1], Objects.requireNonNullElse((Float) a[2], 0f))
+        a -> new QueryExtractorBuilder((String) a[0], (QueryProvider) a[1], Objects.requireNonNullElse((Float) a[2], DEFAULT_SCORE_DEFAULT))
     );
     static {
         PARSER.declareString(constructorArg(), FEATURE_NAME);
@@ -62,7 +64,7 @@ public record QueryExtractorBuilder(String featureName, QueryProvider query, flo
     }
 
     public QueryExtractorBuilder(String featureName, QueryProvider query) {
-        this(featureName, query, 0);
+        this(featureName, query, DEFAULT_SCORE_DEFAULT);
     }
 
     public QueryExtractorBuilder(String featureName, QueryProvider query, float defaultScore) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ltr/QueryExtractorBuilder.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ltr/QueryExtractorBuilder.java
@@ -61,6 +61,10 @@ public record QueryExtractorBuilder(String featureName, QueryProvider query, flo
         return lenient ? LENIENT_PARSER.apply(parser, null) : PARSER.apply(parser, null);
     }
 
+    public QueryExtractorBuilder(String featureName, QueryProvider query) {
+        this(featureName, query, 0);
+    }
+
     public QueryExtractorBuilder(String featureName, QueryProvider query, float defaultScore) {
         this.featureName = requireNonNull(featureName, FEATURE_NAME);
         this.query = requireNonNull(query, QUERY);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ltr/QueryExtractorBuilder.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ltr/QueryExtractorBuilder.java
@@ -18,35 +18,42 @@ import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.ml.utils.QueryProvider;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
+import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
 import static org.elasticsearch.xpack.core.ml.job.messages.Messages.INFERENCE_CONFIG_QUERY_BAD_FORMAT;
 import static org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper.requireNonNull;
 
-public record QueryExtractorBuilder(String featureName, QueryProvider query) implements LearnToRankFeatureExtractorBuilder {
+public record QueryExtractorBuilder(String featureName, QueryProvider query, float defaultScore)
+    implements
+        LearnToRankFeatureExtractorBuilder {
 
     public static final ParseField NAME = new ParseField("query_extractor");
     public static final ParseField FEATURE_NAME = new ParseField("feature_name");
     public static final ParseField QUERY = new ParseField("query");
+    public static final ParseField DEFAULT_SCORE = new ParseField("default_score");
 
     private static final ConstructingObjectParser<QueryExtractorBuilder, Void> PARSER = new ConstructingObjectParser<>(
         NAME.getPreferredName(),
-        a -> new QueryExtractorBuilder((String) a[0], (QueryProvider) a[1])
+        a -> new QueryExtractorBuilder((String) a[0], (QueryProvider) a[1], Objects.requireNonNullElse((Float) a[2], 0f))
     );
     private static final ConstructingObjectParser<QueryExtractorBuilder, Void> LENIENT_PARSER = new ConstructingObjectParser<>(
         NAME.getPreferredName(),
         true,
-        a -> new QueryExtractorBuilder((String) a[0], (QueryProvider) a[1])
+        a -> new QueryExtractorBuilder((String) a[0], (QueryProvider) a[1], Objects.requireNonNullElse((Float) a[2], 0f))
     );
     static {
         PARSER.declareString(constructorArg(), FEATURE_NAME);
         PARSER.declareObject(constructorArg(), (p, c) -> QueryProvider.fromXContent(p, false, INFERENCE_CONFIG_QUERY_BAD_FORMAT), QUERY);
+        PARSER.declareFloat(optionalConstructorArg(), DEFAULT_SCORE);
         LENIENT_PARSER.declareString(constructorArg(), FEATURE_NAME);
         LENIENT_PARSER.declareObject(
             constructorArg(),
             (p, c) -> QueryProvider.fromXContent(p, true, INFERENCE_CONFIG_QUERY_BAD_FORMAT),
             QUERY
         );
+        LENIENT_PARSER.declareFloat(optionalConstructorArg(), DEFAULT_SCORE);
     }
 
     public static QueryExtractorBuilder fromXContent(XContentParser parser, Object context) {
@@ -54,19 +61,21 @@ public record QueryExtractorBuilder(String featureName, QueryProvider query) imp
         return lenient ? LENIENT_PARSER.apply(parser, null) : PARSER.apply(parser, null);
     }
 
-    public QueryExtractorBuilder(String featureName, QueryProvider query) {
+    public QueryExtractorBuilder(String featureName, QueryProvider query, float defaultScore) {
         this.featureName = requireNonNull(featureName, FEATURE_NAME);
         this.query = requireNonNull(query, QUERY);
+        this.defaultScore = defaultScore;
     }
 
     public QueryExtractorBuilder(StreamInput input) throws IOException {
-        this(input.readString(), QueryProvider.fromStream(input));
+        this(input.readString(), QueryProvider.fromStream(input), input.readFloat());
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         builder.field(FEATURE_NAME.getPreferredName(), featureName);
+        builder.field(DEFAULT_SCORE.getPreferredName(), defaultScore);
         builder.field(QUERY.getPreferredName(), query.getQuery());
         builder.endObject();
         return builder;
@@ -81,6 +90,7 @@ public record QueryExtractorBuilder(String featureName, QueryProvider query) imp
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(featureName);
         query.writeTo(out);
+        out.writeFloat(defaultScore);
     }
 
     @Override
@@ -106,6 +116,6 @@ public record QueryExtractorBuilder(String featureName, QueryProvider query) imp
         if (rewritten == query) {
             return this;
         }
-        return new QueryExtractorBuilder(featureName, rewritten);
+        return new QueryExtractorBuilder(featureName, rewritten, defaultScore);
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfigBuilderTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfigBuilderTests.java
@@ -30,7 +30,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import static org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfigTests.randomStringList;
-import static org.elasticsearch.xpack.core.ml.utils.QueryProviderTests.createRandomValidQueryProvider;
+import static org.elasticsearch.xpack.core.ml.utils.QueryProviderTests.createTestQueryProvider;
 
 public class DatafeedConfigBuilderTests extends AbstractWireSerializingTestCase<DatafeedConfig.Builder> {
 
@@ -44,7 +44,7 @@ public class DatafeedConfigBuilderTests extends AbstractWireSerializingTestCase<
         }
         builder.setIndices(randomStringList(1, 10));
         if (randomBoolean()) {
-            builder.setQueryProvider(createRandomValidQueryProvider(randomAlphaOfLengthBetween(1, 10), randomAlphaOfLengthBetween(1, 10)));
+            builder.setQueryProvider(createTestQueryProvider(randomAlphaOfLengthBetween(1, 10), randomAlphaOfLengthBetween(1, 10)));
         }
         boolean addScriptFields = randomBoolean();
         if (addScriptFields) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfigTests.java
@@ -70,7 +70,7 @@ import java.util.Map;
 
 import static org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfigBuilderTests.createRandomizedDatafeedConfigBuilder;
 import static org.elasticsearch.xpack.core.ml.job.messages.Messages.DATAFEED_AGGREGATIONS_INTERVAL_MUST_BE_GREATER_THAN_ZERO;
-import static org.elasticsearch.xpack.core.ml.utils.QueryProviderTests.createRandomValidQueryProvider;
+import static org.elasticsearch.xpack.core.ml.utils.QueryProviderTests.createTestQueryProvider;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -794,7 +794,7 @@ public class DatafeedConfigTests extends AbstractXContentSerializingTestCase<Dat
             .subAggregation(bucketScriptPipelineAggregationBuilder);
         DatafeedConfig.Builder datafeedConfigBuilder = createDatafeedBuilderWithDateHistogram(dateHistogram);
         datafeedConfigBuilder.setQueryProvider(
-            createRandomValidQueryProvider(randomAlphaOfLengthBetween(1, 10), randomAlphaOfLengthBetween(1, 10))
+            createTestQueryProvider(randomAlphaOfLengthBetween(1, 10), randomAlphaOfLengthBetween(1, 10))
         );
         DatafeedConfig datafeedConfig = datafeedConfigBuilder.build();
         AggregatorFactories.Builder aggBuilder = new AggregatorFactories.Builder().addAggregator(dateHistogram);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedUpdateTests.java
@@ -60,7 +60,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import static org.elasticsearch.xpack.core.ml.datafeed.AggProviderTests.createRandomValidAggProvider;
-import static org.elasticsearch.xpack.core.ml.utils.QueryProviderTests.createRandomValidQueryProvider;
+import static org.elasticsearch.xpack.core.ml.utils.QueryProviderTests.createTestQueryProvider;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
@@ -97,7 +97,7 @@ public class DatafeedUpdateTests extends AbstractXContentSerializingTestCase<Dat
             builder.setIndices(DatafeedConfigTests.randomStringList(1, 10));
         }
         if (randomBoolean()) {
-            builder.setQuery(createRandomValidQueryProvider(randomAlphaOfLengthBetween(1, 10), randomAlphaOfLengthBetween(1, 10)));
+            builder.setQuery(createTestQueryProvider(randomAlphaOfLengthBetween(1, 10), randomAlphaOfLengthBetween(1, 10)));
         }
         if (randomBoolean()) {
             int scriptsSize = randomInt(3);
@@ -264,7 +264,7 @@ public class DatafeedUpdateTests extends AbstractXContentSerializingTestCase<Dat
         DatafeedConfig.Builder datafeedBuilder = new DatafeedConfig.Builder("foo", "foo-feed");
         datafeedBuilder.setIndices(Collections.singletonList("i_1"));
         DatafeedConfig datafeed = datafeedBuilder.build();
-        QueryProvider queryProvider = createRandomValidQueryProvider("a", "b");
+        QueryProvider queryProvider = createTestQueryProvider("a", "b");
         DatafeedUpdate.Builder update = new DatafeedUpdate.Builder(datafeed.getId());
         update.setIndices(Collections.singletonList("i_2"));
         update.setQueryDelay(TimeValue.timeValueSeconds(42));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/LearnToRankConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/LearnToRankConfigTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.query.QueryRewriteContext;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
@@ -28,7 +29,6 @@ import org.junit.Before;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Predicate;
@@ -45,7 +45,8 @@ public class LearnToRankConfigTests extends InferenceConfigItemTestCase<LearnToR
             randomBoolean() ? null : randomIntBetween(0, 10),
             randomBoolean()
                 ? null
-                : Stream.generate(QueryExtractorBuilderTests::randomInstance).limit(randomInt(5)).collect(Collectors.toList())
+                : Stream.generate(QueryExtractorBuilderTests::randomInstance).limit(randomInt(5)).collect(Collectors.toList()),
+            randomBoolean() ? null : randomMap(0, 10, () -> Tuple.tuple(randomIdentifier(), randomIdentifier()))
         );
     }
 
@@ -61,7 +62,45 @@ public class LearnToRankConfigTests extends InferenceConfigItemTestCase<LearnToR
 
     @Override
     protected LearnToRankConfig mutateInstance(LearnToRankConfig instance) {
-        return null;// TODO implement https://github.com/elastic/elasticsearch/issues/25929
+        int i = randomInt(2);
+
+        LearnToRankConfig.Builder builder = LearnToRankConfig.builder(instance);
+
+        switch (i) {
+            case 0 -> {
+                builder.setNumTopFeatureImportanceValues(
+                    randomValueOtherThan(
+                        instance.getNumTopFeatureImportanceValues(),
+                        () -> randomBoolean() && instance.getNumTopFeatureImportanceValues() != 0 ? null : randomIntBetween(0, 10)
+                    )
+                );
+            }
+            case 1 -> {
+                builder.setLearnToRankFeatureExtractorBuilders(
+                    randomValueOtherThan(
+                        instance.getFeatureExtractorBuilders(),
+                        () -> randomBoolean() || instance.getFeatureExtractorBuilders().isEmpty()
+                            ? Stream.generate(QueryExtractorBuilderTests::randomInstance)
+                                .limit(randomIntBetween(1, 5))
+                                .collect(Collectors.toList())
+                            : null
+                    )
+                );
+            }
+            case 2 -> {
+                builder.setParamsDefaults(
+                    randomValueOtherThan(
+                        instance.getParamsDefaults(),
+                        () -> randomBoolean() || instance.getParamsDefaults().isEmpty()
+                            ? randomMap(1, 10, () -> Tuple.tuple(randomIdentifier(), randomIdentifier()))
+                            : null
+                    )
+                );
+            }
+            default -> throw new AssertionError("Unexpected random test case");
+        }
+
+        return builder.build();
     }
 
     @Override
@@ -94,10 +133,11 @@ public class LearnToRankConfigTests extends InferenceConfigItemTestCase<LearnToR
             new TestValueExtractor("foo"),
             new TestValueExtractor("foo")
         );
-        expectThrows(
-            IllegalArgumentException.class,
-            () -> new LearnToRankConfig(randomBoolean() ? null : randomIntBetween(0, 10), featureExtractorBuilderList)
-        );
+
+        LearnToRankConfig.Builder builder = LearnToRankConfig.builder(randomLearnToRankConfig())
+            .setLearnToRankFeatureExtractorBuilders(featureExtractorBuilderList);
+
+        expectThrows(IllegalArgumentException.class, () -> builder.build());
     }
 
     @Override
@@ -105,7 +145,7 @@ public class LearnToRankConfigTests extends InferenceConfigItemTestCase<LearnToR
         List<NamedXContentRegistry.Entry> namedXContent = new ArrayList<>();
         namedXContent.addAll(new MlInferenceNamedXContentProvider().getNamedXContentParsers());
         namedXContent.addAll(new MlLTRNamedXContentProvider().getNamedXContentParsers());
-        namedXContent.addAll(new SearchModule(Settings.EMPTY, Collections.emptyList()).getNamedXContents());
+        namedXContent.addAll(new SearchModule(Settings.EMPTY, List.of()).getNamedXContents());
         namedXContent.add(
             new NamedXContentRegistry.Entry(
                 LearnToRankFeatureExtractorBuilder.class,
@@ -119,7 +159,7 @@ public class LearnToRankConfigTests extends InferenceConfigItemTestCase<LearnToR
     @Override
     protected NamedWriteableRegistry getNamedWriteableRegistry() {
         List<NamedWriteableRegistry.Entry> namedWriteables = new ArrayList<>(new MlInferenceNamedXContentProvider().getNamedWriteables());
-        namedWriteables.addAll(new SearchModule(Settings.EMPTY, Collections.emptyList()).getNamedWriteables());
+        namedWriteables.addAll(new SearchModule(Settings.EMPTY, List.of()).getNamedWriteables());
         namedWriteables.addAll(new MlLTRNamedXContentProvider().getNamedWriteables());
         namedWriteables.add(
             new NamedWriteableRegistry.Entry(

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ltr/QueryExtractorBuilderTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ltr/QueryExtractorBuilderTests.java
@@ -26,7 +26,11 @@ public class QueryExtractorBuilderTests extends AbstractXContentSerializingTestC
     protected boolean lenient;
 
     public static QueryExtractorBuilder randomInstance() {
-        return new QueryExtractorBuilder(randomAlphaOfLength(10), QueryProviderTests.createRandomValidQueryProvider(), randomFloat());
+        return new QueryExtractorBuilder(
+            randomAlphaOfLength(10),
+            QueryProviderTests.createRandomValidQueryProvider(),
+            randomFrom(0f, randomFloat())
+        );
     }
 
     @Before
@@ -67,7 +71,7 @@ public class QueryExtractorBuilderTests extends AbstractXContentSerializingTestC
             case 2 -> new QueryExtractorBuilder(
                 instance.featureName(),
                 instance.query(),
-                randomValueOtherThan(instance.defaultScore(), () -> randomFloat())
+                randomValueOtherThan(instance.defaultScore(), () -> randomFrom(0f, randomFloat()))
             );
             default -> throw new AssertionError("unknown random case for instance mutation");
         };

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ltr/QueryExtractorBuilderTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ltr/QueryExtractorBuilderTests.java
@@ -26,7 +26,7 @@ public class QueryExtractorBuilderTests extends AbstractXContentSerializingTestC
     protected boolean lenient;
 
     public static QueryExtractorBuilder randomInstance() {
-        return new QueryExtractorBuilder(randomAlphaOfLength(10), QueryProviderTests.createRandomValidQueryProvider());
+        return new QueryExtractorBuilder(randomAlphaOfLength(10), QueryProviderTests.createRandomValidQueryProvider(), randomFloat());
     }
 
     @Before
@@ -56,10 +56,19 @@ public class QueryExtractorBuilderTests extends AbstractXContentSerializingTestC
 
     @Override
     protected QueryExtractorBuilder mutateInstance(QueryExtractorBuilder instance) throws IOException {
-        int i = randomInt(1);
+        int i = randomInt(2);
         return switch (i) {
-            case 0 -> new QueryExtractorBuilder(randomAlphaOfLength(10), instance.query());
-            case 1 -> new QueryExtractorBuilder(instance.featureName(), QueryProviderTests.createRandomValidQueryProvider());
+            case 0 -> new QueryExtractorBuilder(randomAlphaOfLength(10), instance.query(), instance.defaultScore());
+            case 1 -> new QueryExtractorBuilder(
+                instance.featureName(),
+                QueryProviderTests.createRandomValidQueryProvider(),
+                instance.defaultScore()
+            );
+            case 2 -> new QueryExtractorBuilder(
+                instance.featureName(),
+                instance.query(),
+                randomValueOtherThan(instance.defaultScore(), () -> randomFloat())
+            );
             default -> throw new AssertionError("unknown random case for instance mutation");
         };
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/utils/QueryProviderTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/utils/QueryProviderTests.java
@@ -65,10 +65,10 @@ public class QueryProviderTests extends AbstractXContentSerializingTestCase<Quer
     }
 
     public static QueryProvider createRandomValidQueryProvider() {
-        return createRandomValidQueryProvider(randomAlphaOfLengthBetween(1, 10), randomAlphaOfLengthBetween(1, 10));
+        return createTestQueryProvider(randomAlphaOfLengthBetween(1, 10), randomAlphaOfLengthBetween(1, 10));
     }
 
-    public static QueryProvider createRandomValidQueryProvider(String field, String value) {
+    public static QueryProvider createTestQueryProvider(String field, String value) {
         Map<String, Object> terms = Collections.singletonMap(
             BoolQueryBuilder.NAME,
             Collections.singletonMap(

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ltr/LearnToRankServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ltr/LearnToRankServiceTests.java
@@ -35,7 +35,6 @@ import org.elasticsearch.xpack.ml.inference.loadingservice.ModelLoadingService;
 import org.elasticsearch.xpack.ml.inference.persistence.TrainedModelProvider;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -74,7 +73,8 @@ public class LearnToRankServiceTests extends ESTestCase {
                         QueryProviderTests.createRandomValidQueryProvider("field_2", "bar"),
                         DEFAULT_SCORES.get("feature_2")
                     )
-                )
+                ),
+                Map.of()
             )
         )
         .build();
@@ -104,7 +104,8 @@ public class LearnToRankServiceTests extends ESTestCase {
                         QueryProviderTests.createRandomValidQueryProvider("field_2", "{{bar_param}}"),
                         DEFAULT_SCORES.get("feature_2")
                     )
-                )
+                ),
+                Map.of()
             )
         )
         .build();
@@ -118,7 +119,7 @@ public class LearnToRankServiceTests extends ESTestCase {
             xContentRegistry()
         );
         ActionListener<LearnToRankConfig> listener = mock(ActionListener.class);
-        learnToRankService.loadLearnToRankConfig(GOOD_MODEL, Collections.emptyMap(), listener);
+        learnToRankService.loadLearnToRankConfig(GOOD_MODEL, Map.of(), listener);
 
         verify(listener).onResponse(eq((LearnToRankConfig) GOOD_MODEL_CONFIG.getInferenceConfig()));
     }
@@ -132,7 +133,7 @@ public class LearnToRankServiceTests extends ESTestCase {
             xContentRegistry()
         );
         ActionListener<LearnToRankConfig> listener = mock(ActionListener.class);
-        learnToRankService.loadLearnToRankConfig("non-existing-model", Collections.emptyMap(), listener);
+        learnToRankService.loadLearnToRankConfig("non-existing-model", Map.of(), listener);
 
         verify(listener).onFailure(isA(ResourceNotFoundException.class));
     }
@@ -146,7 +147,7 @@ public class LearnToRankServiceTests extends ESTestCase {
             xContentRegistry()
         );
         ActionListener<LearnToRankConfig> listener = mock(ActionListener.class);
-        learnToRankService.loadLearnToRankConfig(BAD_MODEL, Collections.emptyMap(), listener);
+        learnToRankService.loadLearnToRankConfig(BAD_MODEL, Map.of(), listener);
 
         verify(listener).onFailure(isA(ElasticsearchStatusException.class));
     }
@@ -213,7 +214,7 @@ public class LearnToRankServiceTests extends ESTestCase {
         List<NamedXContentRegistry.Entry> namedXContent = new ArrayList<>();
         namedXContent.addAll(new MlInferenceNamedXContentProvider().getNamedXContentParsers());
         namedXContent.addAll(new MlLTRNamedXContentProvider().getNamedXContentParsers());
-        namedXContent.addAll(new SearchModule(Settings.EMPTY, Collections.emptyList()).getNamedXContents());
+        namedXContent.addAll(new SearchModule(Settings.EMPTY, List.of()).getNamedXContents());
         return new NamedXContentRegistry(namedXContent);
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ltr/QueryFeatureExtractorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ltr/QueryFeatureExtractorTests.java
@@ -70,19 +70,25 @@ public class QueryFeatureExtractorTests extends AbstractBuilderTestCase {
         );
         QueryRewriteContext ctx = createQueryRewriteContext();
         List<QueryExtractorBuilder> queryExtractorBuilders = List.of(
-            new QueryExtractorBuilder("text_score", QueryProvider.fromParsedQuery(QueryBuilders.matchQuery(TEXT_FIELD_NAME, "quick fox")))
-                .rewrite(ctx),
+            new QueryExtractorBuilder(
+                "text_score",
+                QueryProvider.fromParsedQuery(QueryBuilders.matchQuery(TEXT_FIELD_NAME, "quick fox")),
+                randomFloat()
+            ).rewrite(ctx),
             new QueryExtractorBuilder(
                 "number_score",
-                QueryProvider.fromParsedQuery(QueryBuilders.rangeQuery(INT_FIELD_NAME).from(12).to(12))
+                QueryProvider.fromParsedQuery(QueryBuilders.rangeQuery(INT_FIELD_NAME).from(12).to(12)),
+                randomFloat()
             ).rewrite(ctx),
             new QueryExtractorBuilder(
                 "matching_none",
-                QueryProvider.fromParsedQuery(QueryBuilders.termQuery(TEXT_FIELD_NAME, "never found term"))
+                QueryProvider.fromParsedQuery(QueryBuilders.termQuery(TEXT_FIELD_NAME, "never found term")),
+                randomFloat()
             ).rewrite(ctx),
             new QueryExtractorBuilder(
                 "matching_missing_field",
-                QueryProvider.fromParsedQuery(QueryBuilders.termQuery("missing_text", "quick fox"))
+                QueryProvider.fromParsedQuery(QueryBuilders.termQuery("missing_text", "quick fox")),
+                randomFloat()
             ).rewrite(ctx)
         );
         SearchExecutionContext dummySEC = createSearchExecutionContext();

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ltr/QueryFeatureExtractorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ltr/QueryFeatureExtractorTests.java
@@ -70,25 +70,19 @@ public class QueryFeatureExtractorTests extends AbstractBuilderTestCase {
         );
         QueryRewriteContext ctx = createQueryRewriteContext();
         List<QueryExtractorBuilder> queryExtractorBuilders = List.of(
-            new QueryExtractorBuilder(
-                "text_score",
-                QueryProvider.fromParsedQuery(QueryBuilders.matchQuery(TEXT_FIELD_NAME, "quick fox")),
-                randomFloat()
-            ).rewrite(ctx),
+            new QueryExtractorBuilder("text_score", QueryProvider.fromParsedQuery(QueryBuilders.matchQuery(TEXT_FIELD_NAME, "quick fox")))
+                .rewrite(ctx),
             new QueryExtractorBuilder(
                 "number_score",
-                QueryProvider.fromParsedQuery(QueryBuilders.rangeQuery(INT_FIELD_NAME).from(12).to(12)),
-                randomFloat()
+                QueryProvider.fromParsedQuery(QueryBuilders.rangeQuery(INT_FIELD_NAME).from(12).to(12))
             ).rewrite(ctx),
             new QueryExtractorBuilder(
                 "matching_none",
-                QueryProvider.fromParsedQuery(QueryBuilders.termQuery(TEXT_FIELD_NAME, "never found term")),
-                randomFloat()
+                QueryProvider.fromParsedQuery(QueryBuilders.termQuery(TEXT_FIELD_NAME, "never found term"))
             ).rewrite(ctx),
             new QueryExtractorBuilder(
                 "matching_missing_field",
-                QueryProvider.fromParsedQuery(QueryBuilders.termQuery("missing_text", "quick fox")),
-                randomFloat()
+                QueryProvider.fromParsedQuery(QueryBuilders.termQuery("missing_text", "quick fox"))
             ).rewrite(ctx)
         );
         SearchExecutionContext dummySEC = createSearchExecutionContext();


### PR DESCRIPTION
Following up on: https://github.com/elastic/elasticsearch/pull/102601

This PR implements add the following to the learn to rank config stored within the model:
- default param values at the global level 
- default score for each query extractor


The following config: 

```
"learn_to_rank": {
  "default_params": {
    "category_id": 12
  },
  "feature_extractors": [
    { "query_extractor": { "default_score": 2, "feature_name": "product_match", "query": {  "match": { "title" : "{{fulltext_search}}" } } } },
    { "query_extractor": { "feature_name": "category_match", "query": {  "term": { "category" : "{{category_id}}" } } } },
    { "query_extractor": { "feature_name": "brand_match", "query": {  "match": { "brand" : "{{fulltext_search}}" } } } }
  ]
}
```

```
  "feature_extractors": [
     { "query_extractor": { "feature_name": "product_match", "query": {  "match_all": { "boost": 2 } } } } },
     { "query_extractor": { "feature_name": "category_match", "query": {  "term": { "category" : "12" } } } }
     { "query_extractor": { "feature_name": "brand_match", "query": {  "match_none: {} } } } }
  ]
```

Explanation:
- `category_match` feature will be using the default param for the missing {{category_id}} param
- `product_match` feature will be using a query that is returning a score of 2 (default_score) for each document (boosted match_all query) as a replacement the query with the {{fulltext_search}} missing param
- `brand_match` will be using a match_none query (feature extracted equal to 0) as a replacement as a replacement the query with the {{fulltext_search}} missing param 