### PR TITLE
[8.11] Increase timeout in MixedClusterClientYamlTestSuiteIT (#100585)

### DIFF
--- a/qa/mixed-cluster/src/test/java/org/elasticsearch/backwards/MixedClusterClientYamlTestSuiteIT.java
+++ b/qa/mixed-cluster/src/test/java/org/elasticsearch/backwards/MixedClusterClientYamlTestSuiteIT.java
@@ -15,7 +15,7 @@ import org.apache.lucene.tests.util.TimeUnits;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
 import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
 
-@TimeoutSuite(millis = 40 * TimeUnits.MINUTE) // some of the windows test VMs are slow as hell
+@TimeoutSuite(millis = 60 * TimeUnits.MINUTE) // some of the windows test VMs are slow as hell
 public class MixedClusterClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
 
     public MixedClusterClientYamlTestSuiteIT(ClientYamlTestCandidate testCandidate) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.11`:
 - [Increase timeout in MixedClusterClientYamlTestSuiteIT (#100585)](https://github.com/elastic/elasticsearch/pull/100585)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)