### PR TITLE
[Docs] Move coordinate note for geojson/wkt up to the beginning of the geo_shape page

### DIFF
--- a/docs/reference/mapping/types/geo-shape.asciidoc
+++ b/docs/reference/mapping/types/geo-shape.asciidoc
@@ -32,9 +32,10 @@ type.
 
 [NOTE]
 =============================================
-In GeoJSON and WKT, and therefore Elasticsearch, the correct *coordinate
-order is longitude, latitude (X, Y)* within coordinate arrays. This
-differs from many Geospatial APIs (e.g., Google Maps) that generally
+In https://datatracker.ietf.org/doc/html/rfc7946[GeoJSON]
+and https://www.ogc.org/standard/sfa/[WKT], and therefore Elasticsearch,
+the correct *coordinate order is longitude, latitude (X, Y)* within coordinate
+arrays. This differs from many Geospatial APIs (e.g., Google Maps) that generally
 use the colloquial latitude, longitude (Y, X).
 =============================================
 

--- a/docs/reference/mapping/types/geo-shape.asciidoc
+++ b/docs/reference/mapping/types/geo-shape.asciidoc
@@ -30,6 +30,14 @@ The `geo_shape` mapping maps GeoJSON or WKT geometry objects to the `geo_shape`
 type. To enable it, users must explicitly map fields to the `geo_shape`
 type.
 
+[NOTE]
+=============================================
+In GeoJSON and WKT, and therefore Elasticsearch, the correct *coordinate
+order is longitude, latitude (X, Y)* within coordinate arrays. This
+differs from many Geospatial APIs (e.g., Google Maps) that generally
+use the colloquial latitude, longitude (Y, X).
+=============================================
+
 [cols="<,<,<",options="header",]
 |=======================================================================
 |Option |Description| Default
@@ -142,11 +150,6 @@ specifying only the top left and bottom right points.
 =============================================
 For all types, both the inner `type` and `coordinates` fields are
 required.
-
-In GeoJSON and WKT, and therefore Elasticsearch, the correct *coordinate
-order is longitude, latitude (X, Y)* within coordinate arrays. This
-differs from many Geospatial APIs (e.g., Google Maps) that generally
-use the colloquial latitude, longitude (Y, X).
 =============================================
 
 [[geo-point-type]]


### PR DESCRIPTION
Following up on this comment from @iverase on a [discussion post](https://discuss.elastic.co/t/can-not-create-a-document-has-mutlipolygon-having-hole/348177/3?u=jsanz), I'm proposing to move the coordinate reference note up closer to the header of the article for better awareness of this pretty common misconception and linking the specification pages for GeoJSON and WKT.
