### PR TITLE
[CI] fix for leak in SearchCancellationIT

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/SearchCancellationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/SearchCancellationIT.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.search;
 
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.search.MultiSearchResponse;
@@ -51,7 +50,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST)
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/102257")
 public class SearchCancellationIT extends AbstractSearchCancellationTestCase {
 
     @Override

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractSearchCancellationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractSearchCancellationTestCase.java
@@ -123,8 +123,9 @@ public class AbstractSearchCancellationTestCase extends ESIntegTestCase {
     }
 
     protected SearchResponse ensureSearchWasCancelled(ActionFuture<SearchResponse> searchResponse) {
+        SearchResponse response = null;
         try {
-            SearchResponse response = searchResponse.actionGet();
+            response = searchResponse.actionGet();
             logger.info("Search response {}", response);
             assertNotEquals("At least one shard should have failed", 0, response.getFailedShards());
             for (ShardSearchFailure failure : response.getShardFailures()) {
@@ -137,6 +138,8 @@ public class AbstractSearchCancellationTestCase extends ESIntegTestCase {
             assertThat(ExceptionsHelper.status(ex), equalTo(RestStatus.BAD_REQUEST));
             logger.info("All shards failed with", ex);
             return null;
+        } finally {
+            if (response != null) response.decRef();
         }
     }
 


### PR DESCRIPTION
Fix for the error described below in `SearchCancellationIT`
```
java.lang.AssertionError: 	
Expected: an empty collection	
     but: <[LEAK: resource was not cleaned up before it was garbage-collected.	
Recent access records: 
#1:	
	org.elasticsearch.action.search.TransportMultiSearchAction$1.finish(TransportMultiSearchAction.java:196)	
	org.elasticsearch.action.search.TransportMultiSearchAction$1.handleResponse(TransportMultiSearchAction.java:175)	
	org.elasticsearch.action.search.TransportMultiSearchAction$1.onResponse(TransportMultiSearchAction.java:160)	
	org.elasticsearch.action.search.TransportMultiSearchAction$1.onResponse(TransportMultiSearchAction.java:157)
```