### PR TITLE
Fix #102864 - cast long to int if value is Integer.MIN_VALUE

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/mapper/GeoPointFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/GeoPointFieldMapperTests.java
@@ -705,7 +705,7 @@ public class GeoPointFieldMapperTests extends MapperTestCase {
 
     protected static Object asJacksonNumberOutput(long l) {
         // Cast to int to mimic jackson-core behaviour in NumberOutput.outputLong()
-        if (l < 0 && l > Integer.MIN_VALUE || l >= 0 && l <= Integer.MAX_VALUE) {
+        if (l < 0 && l >= Integer.MIN_VALUE || l >= 0 && l <= Integer.MAX_VALUE) {
             return (int) l;
         } else {
             return l;


### PR DESCRIPTION
The test failed if the value matched exactly -Integer.MIN_VALUE, in which case Jackson was casting it from long to int, but the test code was not doing the same.

Fixes #102864
