### PR TITLE
[ML] Fix text embedding response format for TransportCoordinatedInferenceAction

### DIFF
--- a/server/src/main/java/org/elasticsearch/inference/InferenceServiceResults.java
+++ b/server/src/main/java/org/elasticsearch/inference/InferenceServiceResults.java
@@ -17,6 +17,17 @@ import java.util.Map;
 public interface InferenceServiceResults extends NamedWriteable, ToXContentFragment {
 
     /**
+     * Transform the result to match the format required for the TransportCoordinatedInferenceAction.
+     * For the inference plugin TextEmbeddingResults, the {@link #transformToLegacyFormat()} transforms the
+     * results into an intermediate format only used by the plugin's return value. It doesn't align with what the
+     * TransportCoordinatedInferenceAction expects. TransportCoordinatedInferenceAction expects an ml plugin
+     * TextEmbeddingResults.
+     *
+     * For other results like SparseEmbeddingResults, this method can be a pass through to the transformToLegacyFormat.
+     */
+    List<? extends InferenceResults> transformToCoordinationFormat();
+
+    /**
      * Transform the result to match the format required for versions prior to
      * {@link org.elasticsearch.TransportVersions#INFERENCE_SERVICE_RESULTS_ADDED}
      */

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/results/SparseEmbeddingResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/results/SparseEmbeddingResults.java
@@ -82,6 +82,11 @@ public record SparseEmbeddingResults(List<Embedding> embeddings) implements Infe
     }
 
     @Override
+    public List<? extends InferenceResults> transformToCoordinationFormat() {
+        return transformToLegacyFormat();
+    }
+
+    @Override
     public List<? extends InferenceResults> transformToLegacyFormat() {
         return embeddings.stream()
             .map(

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/results/TextEmbeddingResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/results/TextEmbeddingResults.java
@@ -79,6 +79,14 @@ public record TextEmbeddingResults(List<Embedding> embeddings) implements Infere
     }
 
     @Override
+    public List<? extends InferenceResults> transformToCoordinationFormat() {
+        return embeddings.stream()
+            .map(embedding -> embedding.values.stream().mapToDouble(value -> value).toArray())
+            .map(values -> new org.elasticsearch.xpack.core.ml.inference.results.TextEmbeddingResults(TEXT_EMBEDDING, values, false))
+            .toList();
+    }
+
+    @Override
     @SuppressWarnings("deprecation")
     public List<? extends InferenceResults> transformToLegacyFormat() {
         var legacyEmbedding = new LegacyTextEmbeddingResults(

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/results/SparseEmbeddingResultsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/results/SparseEmbeddingResultsTests.java
@@ -11,12 +11,14 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.inference.results.SparseEmbeddingResults;
+import org.elasticsearch.xpack.core.ml.inference.results.TextExpansionResults;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfig.DEFAULT_RESULTS_FIELD;
 import static org.hamcrest.Matchers.is;
 
 public class SparseEmbeddingResultsTests extends AbstractWireSerializingTestCase<SparseEmbeddingResults> {
@@ -149,6 +151,25 @@ public class SparseEmbeddingResultsTests extends AbstractWireSerializingTestCase
                 }
               ]
             }"""));
+    }
+
+    public void testTransformToCoordinationFormat() {
+        var results = createSparseResult(
+            List.of(
+                createEmbedding(List.of(new SparseEmbeddingResults.WeightedToken("token", 0.1F)), false),
+                createEmbedding(List.of(new SparseEmbeddingResults.WeightedToken("token2", 0.2F)), true)
+            )
+        ).transformToCoordinationFormat();
+
+        assertThat(
+            results,
+            is(
+                List.of(
+                    new TextExpansionResults(DEFAULT_RESULTS_FIELD, List.of(new TextExpansionResults.WeightedToken("token", 0.1F)), false),
+                    new TextExpansionResults(DEFAULT_RESULTS_FIELD, List.of(new TextExpansionResults.WeightedToken("token2", 0.2F)), true)
+                )
+            )
+        );
     }
 
     public record EmbeddingExpectation(Map<String, Float> tokens, boolean isTruncated) {}

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/results/TextEmbeddingResultsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/results/TextEmbeddingResultsTests.java
@@ -100,6 +100,30 @@ public class TextEmbeddingResultsTests extends AbstractWireSerializingTestCase<T
             }"""));
     }
 
+    public void testTransformToCoordinationFormat() {
+        var results = new TextEmbeddingResults(
+            List.of(new TextEmbeddingResults.Embedding(List.of(0.1F, 0.2F)), new TextEmbeddingResults.Embedding(List.of(0.3F, 0.4F)))
+        ).transformToCoordinationFormat();
+
+        assertThat(
+            results,
+            is(
+                List.of(
+                    new org.elasticsearch.xpack.core.ml.inference.results.TextEmbeddingResults(
+                        TextEmbeddingResults.TEXT_EMBEDDING,
+                        new double[] { 0.1F, 0.2F },
+                        false
+                    ),
+                    new org.elasticsearch.xpack.core.ml.inference.results.TextEmbeddingResults(
+                        TextEmbeddingResults.TEXT_EMBEDDING,
+                        new double[] { 0.3F, 0.4F },
+                        false
+                    )
+                )
+            )
+        );
+    }
+
     @Override
     protected Writeable.Reader<TextEmbeddingResults> instanceReader() {
         return TextEmbeddingResults::new;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportCoordinatedInferenceAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportCoordinatedInferenceAction.java
@@ -182,7 +182,7 @@ public class TransportCoordinatedInferenceAction extends HandledTransportAction<
     }
 
     static InferModelAction.Response translateInferenceServiceResponse(InferenceServiceResults inferenceResults) {
-        var legacyResults = new ArrayList<InferenceResults>(inferenceResults.transformToLegacyFormat());
+        var legacyResults = new ArrayList<InferenceResults>(inferenceResults.transformToCoordinationFormat());
         return new InferModelAction.Response(legacyResults, null, false);
     }
 }


### PR DESCRIPTION
This PR fixes an issue where the response format of the inference plugin does not match what the `TextEmbeddingQueryVectorBuilder` expects. The builder expects [this](https://github.com/elastic/elasticsearch/blob/main/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/vectors/TextEmbeddingQueryVectorBuilder.java#L113-L127). An ml plugin `TextEmbeddingResults`.

This PR adds a new method to the `InferenceServiceResults` to enforce that all implementations will correctly translate the value. Another option would be to have `TransportCoordinatedInferenceAction` do an `instanceof` check because only `TextEmbeddingResults` is the issue.