### PR TITLE
Switch InstallPluginActionTests to non-blocking SecureRandom seed generator

### DIFF
--- a/distribution/tools/plugin-cli/build.gradle
+++ b/distribution/tools/plugin-cli/build.gradle
@@ -44,8 +44,7 @@ tasks.named("test").configure {
   // its entropy is quite limited, to the point that it's known to hang: https://bugs.openjdk.org/browse/JDK-6521844
   // We force the seed to be initialized from /dev/urandom, which is less secure, but in case of unit tests is not important.
   if (OS.current() == OS.LINUX) {
-    // The extra /./ is to work around https://bugs.openjdk.org/browse/JDK-4705093. See https://bugs.openjdk.org/browse/JDK-6202721.
-    systemProperty 'java.security.egd', 'file:/dev/./urandom'
+    systemProperty 'java.security.egd', 'file:/dev/urandom'
   }
 }
 

--- a/distribution/tools/plugin-cli/build.gradle
+++ b/distribution/tools/plugin-cli/build.gradle
@@ -6,6 +6,8 @@
  * Side Public License, v 1.
  */
 
+import org.elasticsearch.gradle.OS
+
 apply plugin: 'elasticsearch.build'
 
 base {
@@ -38,6 +40,13 @@ tasks.named("dependencyLicenses").configure {
 tasks.named("test").configure {
   // TODO: find a way to add permissions for the tests in this module
   systemProperty 'tests.security.manager', 'false'
+  // These tests are "heavy" on the secure number generator. On Linux, the NativePRNG defaults to /dev/random for the seeds, and
+  // its entropy is quite limited, to the point that it's known to hang: https://bugs.openjdk.org/browse/JDK-6521844
+  // We force the seed to be initialized from /dev/urandom, which is less secure, but in case of unit tests is not important.
+  if (OS.current() == OS.LINUX) {
+    // The extra /./ is to work around https://bugs.openjdk.org/browse/JDK-4705093. See https://bugs.openjdk.org/browse/JDK-6202721.
+    systemProperty 'java.security.egd', 'file:/dev/./urandom'
+  }
 }
 
 /*

--- a/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/InstallPluginActionTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/InstallPluginActionTests.java
@@ -118,7 +118,6 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 
 @LuceneTestCase.SuppressFileSystems("*")
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/102783")
 public class InstallPluginActionTests extends ESTestCase {
 
     private InstallPluginAction skipJarHellAction;


### PR DESCRIPTION
On Linux, the NativePRNG uses by default /dev/random as a source of randomness for seeds; according to comments on the [class itself](https://github.com/openjdk/jdk/blob/master/src/java.base/unix/classes/sun/security/provider/NativePRNG.java)

>     On some Unix platforms, /dev/random may block until enough entropy is
>     available, but that may negatively impact the perceived startup
>     on some versions of Linux entropy can be exhausted very quickly and could thus impact
>     startup time.

This PR makes SecureRandom use the NONBLOCKING approach by forcing to use `/dev/urandom`.
It may be less secure than using `/dev/random`, but this should be not too important in tests.

Closes https://github.com/elastic/elasticsearch/issues/102711