### PR TITLE
Add `glacier_ir` and `outposts` S3 storage classes

### DIFF
--- a/docs/changelog/102894.yaml
+++ b/docs/changelog/102894.yaml
@@ -1,0 +1,6 @@
+pr: 102894
+summary: Add `glacier_ir` and `outposts` S3 storage classes
+area: Snapshot/Restore
+type: enhancement
+issues:
+ - 81351

--- a/docs/reference/snapshot-restore/repository-s3.asciidoc
+++ b/docs/reference/snapshot-restore/repository-s3.asciidoc
@@ -295,17 +295,17 @@ include::repository-shared-settings.asciidoc[]
 `storage_class`::
 
     Sets the S3 storage class for objects stored in the snapshot repository.
-    Values may be `standard`, `reduced_redundancy`, `standard_ia`, `onezone_ia`
-    and `intelligent_tiering`. Defaults to `standard`. Changing this setting on
-    an existing repository only affects the storage class for newly created
-    objects, resulting in a mixed usage of storage classes. You may use an S3
-    Lifecycle Policy to adjust the storage class of existing objects in your
-    repository, but you must not transition objects to Glacier classes and you
-    must not expire objects. If you use Glacier storage classes or object
-    expiry then you may permanently lose access to your repository contents.
-    For more information about S3 storage classes, see
-    https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html[AWS
-    Storage Classes Guide]
+    May be `standard`, `reduced_redundancy`, `standard_ia`, `onezone_ia`,
+    `intelligent_tiering`, `glacier_ir` or `outposts`. Defaults to `standard`.
+    Changing this setting on an existing repository only affects the storage
+    class for newly created objects, resulting in a mixed usage of storage
+    classes. You may use an S3 Lifecycle Policy to adjust the storage class of
+    existing objects in your repository, but you must not transition objects to
+    Glacier, Deep Archive, or other unsupported storage classes, and you must
+    not expire objects. If you use Glacier, Deep Archive, or other unsupported
+    storage classes, or object expiry then you may permanently lose access to
+    your repository contents. For more information about S3 storage classes,
+    see https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html[AWS Storage Classes Guide].
 
 NOTE: The option of defining client settings in the repository settings as
 documented below is considered deprecated, and will be removed in a future


### PR DESCRIPTION
Today we support a subset of all the S3 storage classes, rejecting the
`glacier` class since it needs a different access pattern from the
instant-access storage classes. We list the supported classes in the
reference documentation.

However, as we've upgraded to newer SDK versions we've inadvertently
added the ability to choose other storage classes that aren't in the
supported list. In particular today we do not reject `glacier_ir`,
`deep_archive`, or `outposts`, but nor do we claim to support them.

This commit changes the validation so that it now checks against an
explicit list of supported classes, mirroring the list in the reference
documentation, to protect against the same problem in future SDK
upgrades. However to avoid a breaking change it maintains today's
behaviour of accepting `glacier_ir` and `outposts` as valid. Thus in
effect this change adds support for the `glacier_ir` and `outposts`
storage classes even though it was technically possible to use them in
earlier versions too.

In contrast, with this commit we start to explicitly reject
`deep_archive`. This storage class definitely does not work, so it's not
a breaking change to reject it sooner.

Closes #81351