### PR TITLE
Fix remaining leaked SearchResponse issues in :server:integTests

### DIFF
--- a/modules/parent-join/src/internalClusterTest/java/org/elasticsearch/join/query/ChildQuerySearchIT.java
+++ b/modules/parent-join/src/internalClusterTest/java/org/elasticsearch/join/query/ChildQuerySearchIT.java
@@ -305,7 +305,6 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
                     constantScoreQuery(hasParentQuery("parent", termQuery("p_field", parentToChildrenEntry.getKey()), false))
                 ).setSize(numChildDocsPerParent),
                 response -> {
-                    assertNoFailures(response);
                     Set<String> childIds = parentToChildrenEntry.getValue();
                     assertThat(response.getHits().getTotalHits().value, equalTo((long) childIds.size()));
                     for (int i = 0; i < response.getHits().getTotalHits().value; i++) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/search/LookupRuntimeFieldIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/search/LookupRuntimeFieldIT.java
@@ -24,6 +24,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.hamcrest.Matchers.equalTo;
 
 public class LookupRuntimeFieldIT extends ESIntegTestCase {
@@ -132,90 +134,92 @@ public class LookupRuntimeFieldIT extends ESIntegTestCase {
     }
 
     public void testBasic() {
-        SearchResponse searchResponse = prepareSearch("books").addFetchField("author")
-            .addFetchField("title")
-            .addSort("published_date", SortOrder.DESC)
-            .setSize(3)
-            .get();
-        ElasticsearchAssertions.assertNoFailures(searchResponse);
-        ElasticsearchAssertions.assertHitCount(searchResponse, 5);
+        assertNoFailuresAndResponse(
+            prepareSearch("books").addFetchField("author").addFetchField("title").addSort("published_date", SortOrder.DESC).setSize(3),
+            searchResponse -> {
+                ElasticsearchAssertions.assertHitCount(searchResponse, 5);
 
-        SearchHit hit0 = searchResponse.getHits().getHits()[0];
-        assertThat(hit0.field("title").getValues(), equalTo(List.of("the fifth book")));
-        assertThat(
-            hit0.field("author").getValues(),
-            equalTo(List.of(Map.of("first_name", List.of("Mike"), "last_name", List.of("Boston"))))
-        );
+                SearchHit hit0 = searchResponse.getHits().getHits()[0];
+                assertThat(hit0.field("title").getValues(), equalTo(List.of("the fifth book")));
+                assertThat(
+                    hit0.field("author").getValues(),
+                    equalTo(List.of(Map.of("first_name", List.of("Mike"), "last_name", List.of("Boston"))))
+                );
 
-        SearchHit hit1 = searchResponse.getHits().getHits()[1];
-        assertThat(hit1.field("title").getValues(), equalTo(List.of("the forth book")));
-        assertThat(
-            hit1.field("author").getValues(),
-            equalTo(
-                List.of(
-                    Map.of("first_name", List.of("Mike"), "last_name", List.of("Boston")),
-                    Map.of("first_name", List.of("Jack"), "last_name", List.of("Austin"))
-                )
-            )
-        );
+                SearchHit hit1 = searchResponse.getHits().getHits()[1];
+                assertThat(hit1.field("title").getValues(), equalTo(List.of("the forth book")));
+                assertThat(
+                    hit1.field("author").getValues(),
+                    equalTo(
+                        List.of(
+                            Map.of("first_name", List.of("Mike"), "last_name", List.of("Boston")),
+                            Map.of("first_name", List.of("Jack"), "last_name", List.of("Austin"))
+                        )
+                    )
+                );
 
-        SearchHit hit2 = searchResponse.getHits().getHits()[2];
-        assertThat(hit2.field("title").getValues(), equalTo(List.of("the third book")));
-        assertThat(
-            hit2.field("author").getValues(),
-            equalTo(List.of(Map.of("first_name", List.of("Mike"), "last_name", List.of("Boston"))))
+                SearchHit hit2 = searchResponse.getHits().getHits()[2];
+                assertThat(hit2.field("title").getValues(), equalTo(List.of("the third book")));
+                assertThat(
+                    hit2.field("author").getValues(),
+                    equalTo(List.of(Map.of("first_name", List.of("Mike"), "last_name", List.of("Boston"))))
+                );
+            }
         );
     }
 
     public void testLookupMultipleIndices() throws IOException {
-        SearchResponse searchResponse = prepareSearch("books").setRuntimeMappings(parseMapping("""
-            {
-                "publisher": {
-                    "type": "lookup",
-                    "target_index": "publishers",
-                    "input_field": "publisher_id",
-                    "target_field": "_id",
-                    "fetch_fields": ["name", "city"]
+        assertResponse(
+            prepareSearch("books").setRuntimeMappings(parseMapping("""
+                {
+                    "publisher": {
+                        "type": "lookup",
+                        "target_index": "publishers",
+                        "input_field": "publisher_id",
+                        "target_field": "_id",
+                        "fetch_fields": ["name", "city"]
+                    }
                 }
-            }
-            """))
-            .setFetchSource(false)
-            .addFetchField("title")
-            .addFetchField("author")
-            .addFetchField("publisher")
-            .addSort("published_date", SortOrder.DESC)
-            .setSize(2)
-            .get();
-        SearchHit hit0 = searchResponse.getHits().getHits()[0];
-        assertThat(hit0.field("title").getValues(), equalTo(List.of("the fifth book")));
-        assertThat(
-            hit0.field("author").getValues(),
-            equalTo(List.of(Map.of("first_name", List.of("Mike"), "last_name", List.of("Boston"))))
-        );
-        assertThat(
-            hit0.field("publisher").getValues(),
-            equalTo(List.of(Map.of("name", List.of("The second publisher"), "city", List.of("Toronto"))))
-        );
+                """))
+                .setFetchSource(false)
+                .addFetchField("title")
+                .addFetchField("author")
+                .addFetchField("publisher")
+                .addSort("published_date", SortOrder.DESC)
+                .setSize(2),
+            searchResponse -> {
+                SearchHit hit0 = searchResponse.getHits().getHits()[0];
+                assertThat(hit0.field("title").getValues(), equalTo(List.of("the fifth book")));
+                assertThat(
+                    hit0.field("author").getValues(),
+                    equalTo(List.of(Map.of("first_name", List.of("Mike"), "last_name", List.of("Boston"))))
+                );
+                assertThat(
+                    hit0.field("publisher").getValues(),
+                    equalTo(List.of(Map.of("name", List.of("The second publisher"), "city", List.of("Toronto"))))
+                );
 
-        SearchHit hit1 = searchResponse.getHits().getHits()[1];
-        assertThat(hit1.field("title").getValues(), equalTo(List.of("the forth book")));
-        assertThat(
-            hit1.field("author").getValues(),
-            equalTo(
-                List.of(
-                    Map.of("first_name", List.of("Mike"), "last_name", List.of("Boston")),
-                    Map.of("first_name", List.of("Jack"), "last_name", List.of("Austin"))
-                )
-            )
-        );
-        assertThat(
-            hit1.field("publisher").getValues(),
-            equalTo(List.of(Map.of("name", List.of("The first publisher"), "city", List.of("Montreal", "Vancouver"))))
+                SearchHit hit1 = searchResponse.getHits().getHits()[1];
+                assertThat(hit1.field("title").getValues(), equalTo(List.of("the forth book")));
+                assertThat(
+                    hit1.field("author").getValues(),
+                    equalTo(
+                        List.of(
+                            Map.of("first_name", List.of("Mike"), "last_name", List.of("Boston")),
+                            Map.of("first_name", List.of("Jack"), "last_name", List.of("Austin"))
+                        )
+                    )
+                );
+                assertThat(
+                    hit1.field("publisher").getValues(),
+                    equalTo(List.of(Map.of("name", List.of("The first publisher"), "city", List.of("Montreal", "Vancouver"))))
+                );
+            }
         );
     }
 
     public void testFetchField() throws Exception {
-        SearchResponse searchResponse = prepareSearch("books").setRuntimeMappings(parseMapping("""
+        assertNoFailuresAndResponse(prepareSearch("books").setRuntimeMappings(parseMapping("""
             {
                 "author": {
                     "type": "lookup",
@@ -225,12 +229,15 @@ public class LookupRuntimeFieldIT extends ESIntegTestCase {
                     "fetch_fields": ["first_name", {"field": "joined", "format": "MM/yyyy"}]
                 }
             }
-            """)).addFetchField("author").addFetchField("title").addSort("published_date", SortOrder.ASC).setSize(1).get();
-        ElasticsearchAssertions.assertNoFailures(searchResponse);
-        SearchHit hit0 = searchResponse.getHits().getHits()[0];
-        // "author", "john", "first_name", "John", "last_name", "New York", "joined", "2020-03-01"
-        assertThat(hit0.field("title").getValues(), equalTo(List.of("the first book")));
-        assertThat(hit0.field("author").getValues(), equalTo(List.of(Map.of("first_name", List.of("John"), "joined", List.of("03/2020")))));
+            """)).addFetchField("author").addFetchField("title").addSort("published_date", SortOrder.ASC).setSize(1), searchResponse -> {
+            SearchHit hit0 = searchResponse.getHits().getHits()[0];
+            // "author", "john", "first_name", "John", "last_name", "New York", "joined", "2020-03-01"
+            assertThat(hit0.field("title").getValues(), equalTo(List.of("the first book")));
+            assertThat(
+                hit0.field("author").getValues(),
+                equalTo(List.of(Map.of("first_name", List.of("John"), "joined", List.of("03/2020"))))
+            );
+        });
     }
 
     private Map<String, Object> parseMapping(String mapping) throws IOException {

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/search/PointInTimeIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/search/PointInTimeIT.java
@@ -49,7 +49,7 @@ import java.util.stream.Collectors;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.empty;
@@ -83,9 +83,10 @@ public class PointInTimeIT extends ESIntegTestCase {
         }
         refresh("test");
         String pitId = openPointInTime(new String[] { "test" }, TimeValue.timeValueMinutes(2));
-        SearchResponse resp1 = prepareSearch().setPreference(null).setPointInTime(new PointInTimeBuilder(pitId)).get();
-        assertThat(resp1.pointInTimeId(), equalTo(pitId));
-        assertHitCount(resp1, numDocs);
+        assertResponse(prepareSearch().setPreference(null).setPointInTime(new PointInTimeBuilder(pitId)), resp1 -> {
+            assertThat(resp1.pointInTimeId(), equalTo(pitId));
+            assertHitCount(resp1, numDocs);
+        });
         int deletedDocs = 0;
         for (int i = 0; i < numDocs; i++) {
             if (randomBoolean()) {
@@ -96,18 +97,20 @@ public class PointInTimeIT extends ESIntegTestCase {
         }
         refresh("test");
         if (randomBoolean()) {
-            SearchResponse resp2 = prepareSearch("test").setPreference(null).setQuery(new MatchAllQueryBuilder()).get();
-            assertNoFailures(resp2);
-            assertHitCount(resp2, numDocs - deletedDocs);
+            final int delDocCount = deletedDocs;
+            assertNoFailuresAndResponse(
+                prepareSearch("test").setPreference(null).setQuery(new MatchAllQueryBuilder()),
+                resp2 -> assertHitCount(resp2, numDocs - delDocCount)
+            );
         }
         try {
-            SearchResponse resp3 = prepareSearch().setPreference(null)
-                .setQuery(new MatchAllQueryBuilder())
-                .setPointInTime(new PointInTimeBuilder(pitId))
-                .get();
-            assertNoFailures(resp3);
-            assertHitCount(resp3, numDocs);
-            assertThat(resp3.pointInTimeId(), equalTo(pitId));
+            assertNoFailuresAndResponse(
+                prepareSearch().setPreference(null).setQuery(new MatchAllQueryBuilder()).setPointInTime(new PointInTimeBuilder(pitId)),
+                resp3 -> {
+                    assertHitCount(resp3, numDocs);
+                    assertThat(resp3.pointInTimeId(), equalTo(pitId));
+                }
+            );
         } finally {
             closePointInTime(pitId);
         }
@@ -127,27 +130,24 @@ public class PointInTimeIT extends ESIntegTestCase {
         refresh();
         String pitId = openPointInTime(new String[] { "*" }, TimeValue.timeValueMinutes(2));
         try {
-            SearchResponse resp = prepareSearch().setPreference(null).setPointInTime(new PointInTimeBuilder(pitId)).get();
-            assertNoFailures(resp);
-            assertHitCount(resp, numDocs);
-            assertNotNull(resp.pointInTimeId());
-            assertThat(resp.pointInTimeId(), equalTo(pitId));
             int moreDocs = randomIntBetween(10, 50);
-            for (int i = 0; i < moreDocs; i++) {
-                String id = "more-" + i;
-                String index = "index-" + randomIntBetween(1, numIndices);
-                prepareIndex(index).setId(id).setSource("value", i).get();
-            }
-            refresh();
-            resp = prepareSearch().get();
-            assertNoFailures(resp);
-            assertHitCount(resp, numDocs + moreDocs);
-
-            resp = prepareSearch().setPreference(null).setPointInTime(new PointInTimeBuilder(pitId)).get();
-            assertNoFailures(resp);
-            assertHitCount(resp, numDocs);
-            assertNotNull(resp.pointInTimeId());
-            assertThat(resp.pointInTimeId(), equalTo(pitId));
+            assertNoFailuresAndResponse(prepareSearch().setPreference(null).setPointInTime(new PointInTimeBuilder(pitId)), resp -> {
+                assertHitCount(resp, numDocs);
+                assertNotNull(resp.pointInTimeId());
+                assertThat(resp.pointInTimeId(), equalTo(pitId));
+                for (int i = 0; i < moreDocs; i++) {
+                    String id = "more-" + i;
+                    String index = "index-" + randomIntBetween(1, numIndices);
+                    prepareIndex(index).setId(id).setSource("value", i).get();
+                }
+                refresh();
+            });
+            assertNoFailuresAndResponse(prepareSearch(), resp -> assertHitCount(resp, numDocs + moreDocs));
+            assertNoFailuresAndResponse(prepareSearch().setPreference(null).setPointInTime(new PointInTimeBuilder(pitId)), resp -> {
+                assertHitCount(resp, numDocs);
+                assertNotNull(resp.pointInTimeId());
+                assertThat(resp.pointInTimeId(), equalTo(pitId));
+            });
         } finally {
             closePointInTime(pitId);
         }
@@ -187,8 +187,7 @@ public class PointInTimeIT extends ESIntegTestCase {
                 String[] actualIndices = searchContextId.getActualIndices();
                 assertEquals(1, actualIndices.length);
                 assertEquals("index-3", actualIndices[0]);
-                assertResponse(prepareSearch().setPointInTime(new PointInTimeBuilder(pitId)).setSize(50), resp -> {
-                    assertNoFailures(resp);
+                assertNoFailuresAndResponse(prepareSearch().setPointInTime(new PointInTimeBuilder(pitId)).setSize(50), resp -> {
                     assertHitCount(resp, numDocs);
                     assertNotNull(resp.pointInTimeId());
                     assertThat(resp.pointInTimeId(), equalTo(pitId));
@@ -213,10 +212,10 @@ public class PointInTimeIT extends ESIntegTestCase {
         refresh();
         String pitId = openPointInTime(new String[] { "test" }, TimeValue.timeValueMinutes(2));
         try {
-            SearchResponse resp = prepareSearch().setPreference(null).setPointInTime(new PointInTimeBuilder(pitId)).get();
-            assertNoFailures(resp);
-            assertHitCount(resp, numDocs);
-            assertThat(resp.pointInTimeId(), equalTo(pitId));
+            assertNoFailuresAndResponse(prepareSearch().setPreference(null).setPointInTime(new PointInTimeBuilder(pitId)), resp -> {
+                assertHitCount(resp, numDocs);
+                assertThat(resp.pointInTimeId(), equalTo(pitId));
+            });
             final Set<String> dataNodes = clusterService().state()
                 .nodes()
                 .getDataNodes()
@@ -233,10 +232,10 @@ public class PointInTimeIT extends ESIntegTestCase {
                 }
                 refresh();
             }
-            resp = prepareSearch().setPreference(null).setPointInTime(new PointInTimeBuilder(pitId)).get();
-            assertNoFailures(resp);
-            assertHitCount(resp, numDocs);
-            assertThat(resp.pointInTimeId(), equalTo(pitId));
+            assertNoFailuresAndResponse(prepareSearch().setPreference(null).setPointInTime(new PointInTimeBuilder(pitId)), resp -> {
+                assertHitCount(resp, numDocs);
+                assertThat(resp.pointInTimeId(), equalTo(pitId));
+            });
             assertBusy(() -> {
                 final Set<String> assignedNodes = clusterService().state()
                     .routingTable()
@@ -246,10 +245,10 @@ public class PointInTimeIT extends ESIntegTestCase {
                     .collect(Collectors.toSet());
                 assertThat(assignedNodes, everyItem(not(in(excludedNodes))));
             }, 30, TimeUnit.SECONDS);
-            resp = prepareSearch().setPreference(null).setPointInTime(new PointInTimeBuilder(pitId)).get();
-            assertNoFailures(resp);
-            assertHitCount(resp, numDocs);
-            assertThat(resp.pointInTimeId(), equalTo(pitId));
+            assertNoFailuresAndResponse(prepareSearch().setPreference(null).setPointInTime(new PointInTimeBuilder(pitId)), resp -> {
+                assertHitCount(resp, numDocs);
+                assertThat(resp.pointInTimeId(), equalTo(pitId));
+            });
         } finally {
             closePointInTime(pitId);
         }
@@ -264,17 +263,21 @@ public class PointInTimeIT extends ESIntegTestCase {
         }
         refresh();
         String pit = openPointInTime(new String[] { "index" }, TimeValue.timeValueSeconds(5));
-        SearchResponse resp1 = prepareSearch().setPreference(null).setPointInTime(new PointInTimeBuilder(pit)).get();
-        assertNoFailures(resp1);
-        assertHitCount(resp1, index1);
-        if (rarely()) {
-            assertBusy(() -> {
-                final CommonStats stats = indicesAdmin().prepareStats().setSearch(true).get().getTotal();
-                assertThat(stats.search.getOpenContexts(), equalTo(0L));
-            }, 60, TimeUnit.SECONDS);
-        } else {
-            closePointInTime(resp1.pointInTimeId());
-        }
+        assertNoFailuresAndResponse(prepareSearch().setPreference(null).setPointInTime(new PointInTimeBuilder(pit)), resp1 -> {
+            assertHitCount(resp1, index1);
+            if (rarely()) {
+                try {
+                    assertBusy(() -> {
+                        final CommonStats stats = indicesAdmin().prepareStats().setSearch(true).get().getTotal();
+                        assertThat(stats.search.getOpenContexts(), equalTo(0L));
+                    }, 60, TimeUnit.SECONDS);
+                } catch (Exception e) {
+                    throw new AssertionError(e);
+                }
+            } else {
+                closePointInTime(resp1.pointInTimeId());
+            }
+        });
         SearchPhaseExecutionException e = expectThrows(
             SearchPhaseExecutionException.class,
             () -> prepareSearch().setPreference(null).setPointInTime(new PointInTimeBuilder(pit)).get()
@@ -302,20 +305,23 @@ public class PointInTimeIT extends ESIntegTestCase {
         refresh();
         String pit = openPointInTime(new String[] { "index-*" }, TimeValue.timeValueMinutes(2));
         try {
-            SearchResponse resp = prepareSearch().setPreference(null).setPointInTime(new PointInTimeBuilder(pit)).get();
-            assertNoFailures(resp);
-            assertHitCount(resp, index1 + index2);
+            assertNoFailuresAndResponse(
+                prepareSearch().setPreference(null).setPointInTime(new PointInTimeBuilder(pit)),
+                resp -> assertHitCount(resp, index1 + index2)
+            );
             indicesAdmin().prepareDelete("index-1").get();
             if (randomBoolean()) {
-                resp = prepareSearch("index-*").get();
-                assertNoFailures(resp);
-                assertHitCount(resp, index2);
+                assertNoFailuresAndResponse(prepareSearch("index-*"), resp -> assertHitCount(resp, index2));
             }
 
             // Allow partial search result
-            resp = prepareSearch().setPreference(null).setAllowPartialSearchResults(true).setPointInTime(new PointInTimeBuilder(pit)).get();
-            assertFailures(resp);
-            assertHitCount(resp, index2);
+            assertResponse(
+                prepareSearch().setPreference(null).setAllowPartialSearchResults(true).setPointInTime(new PointInTimeBuilder(pit)),
+                resp -> {
+                    assertFailures(resp);
+                    assertHitCount(resp, index2);
+                }
+            );
 
             // Do not allow partial search result
             expectThrows(
@@ -356,14 +362,15 @@ public class PointInTimeIT extends ESIntegTestCase {
                 }
             }
             prepareIndex("test").setId("1").setSource("created_date", "2020-01-01").get();
-            SearchResponse resp = prepareSearch().setQuery(new RangeQueryBuilder("created_date").gte("2020-01-02").lte("2020-01-03"))
-                .setSearchType(SearchType.QUERY_THEN_FETCH)
-                .setPreference(null)
-                .setPreFilterShardSize(randomIntBetween(2, 3))
-                .setMaxConcurrentShardRequests(randomIntBetween(1, 2))
-                .setPointInTime(new PointInTimeBuilder(pitId))
-                .get();
-            assertThat(resp.getHits().getHits(), arrayWithSize(0));
+            assertResponse(
+                prepareSearch().setQuery(new RangeQueryBuilder("created_date").gte("2020-01-02").lte("2020-01-03"))
+                    .setSearchType(SearchType.QUERY_THEN_FETCH)
+                    .setPreference(null)
+                    .setPreFilterShardSize(randomIntBetween(2, 3))
+                    .setMaxConcurrentShardRequests(randomIntBetween(1, 2))
+                    .setPointInTime(new PointInTimeBuilder(pitId)),
+                resp -> assertThat(resp.getHits().getHits(), arrayWithSize(0))
+            );
             for (String node : internalCluster().nodesInclude("test")) {
                 for (IndexService indexService : internalCluster().getInstance(IndicesService.class, node)) {
                     for (IndexShard indexShard : indexService) {
@@ -415,19 +422,20 @@ public class PointInTimeIT extends ESIntegTestCase {
         refresh();
         String pitId = openPointInTime(new String[] { "test-*" }, TimeValue.timeValueMinutes(2));
         try {
-            SearchResponse resp = prepareSearch().setPreference(null).setPointInTime(new PointInTimeBuilder(pitId)).get();
-            assertNoFailures(resp);
-            assertHitCount(resp, numDocs1 + numDocs2);
-            assertThat(resp.pointInTimeId(), equalTo(pitId));
+            assertNoFailuresAndResponse(prepareSearch().setPreference(null).setPointInTime(new PointInTimeBuilder(pitId)), resp -> {
+                assertHitCount(resp, numDocs1 + numDocs2);
+                assertThat(resp.pointInTimeId(), equalTo(pitId));
+            });
 
             internalCluster().restartNode(assignedNodeForIndex1);
-            resp = prepareSearch().setPreference(null)
-                .setAllowPartialSearchResults(true)
-                .setPointInTime(new PointInTimeBuilder(pitId))
-                .get();
-            assertFailures(resp);
-            assertThat(resp.pointInTimeId(), equalTo(pitId));
-            assertHitCount(resp, numDocs2);
+            assertResponse(
+                prepareSearch().setPreference(null).setAllowPartialSearchResults(true).setPointInTime(new PointInTimeBuilder(pitId)),
+                resp -> {
+                    assertFailures(resp);
+                    assertThat(resp.pointInTimeId(), equalTo(pitId));
+                    assertHitCount(resp, numDocs2);
+                }
+            );
         } finally {
             closePointInTime(pitId);
         }
@@ -547,40 +555,45 @@ public class PointInTimeIT extends ESIntegTestCase {
             reverseMuls[i] = expectedSorts.get(i).order() == SortOrder.ASC ? 1 : -1;
         }
         SearchResponse response = client().search(searchRequest).get();
-        Object[] lastSortValues = null;
-        while (response.getHits().getHits().length > 0) {
-            Object[] lastHitSortValues = null;
-            for (SearchHit hit : response.getHits().getHits()) {
-                assertTrue(seen.add(hit.getIndex() + hit.getId()));
+        try {
+            Object[] lastSortValues = null;
+            while (response.getHits().getHits().length > 0) {
+                Object[] lastHitSortValues = null;
+                for (SearchHit hit : response.getHits().getHits()) {
+                    assertTrue(seen.add(hit.getIndex() + hit.getId()));
 
-                if (lastHitSortValues != null) {
+                    if (lastHitSortValues != null) {
+                        for (int i = 0; i < expectedSorts.size(); i++) {
+                            Comparable value = (Comparable) hit.getRawSortValues()[i];
+                            int cmp = value.compareTo(lastHitSortValues[i]) * reverseMuls[i];
+                            if (cmp != 0) {
+                                assertThat(cmp, equalTo(1));
+                                break;
+                            }
+                        }
+                    }
+                    lastHitSortValues = hit.getRawSortValues();
+                }
+                int len = response.getHits().getHits().length;
+                SearchHit last = response.getHits().getHits()[len - 1];
+                if (lastSortValues != null) {
                     for (int i = 0; i < expectedSorts.size(); i++) {
-                        Comparable value = (Comparable) hit.getRawSortValues()[i];
-                        int cmp = value.compareTo(lastHitSortValues[i]) * reverseMuls[i];
+                        Comparable value = (Comparable) last.getSortValues()[i];
+                        int cmp = value.compareTo(lastSortValues[i]) * reverseMuls[i];
                         if (cmp != 0) {
                             assertThat(cmp, equalTo(1));
                             break;
                         }
                     }
                 }
-                lastHitSortValues = hit.getRawSortValues();
+                assertThat(last.getSortValues().length, equalTo(expectedSorts.size()));
+                lastSortValues = last.getSortValues();
+                searchRequest.source().searchAfter(last.getSortValues());
+                response.decRef();
+                response = client().search(searchRequest).get();
             }
-            int len = response.getHits().getHits().length;
-            SearchHit last = response.getHits().getHits()[len - 1];
-            if (lastSortValues != null) {
-                for (int i = 0; i < expectedSorts.size(); i++) {
-                    Comparable value = (Comparable) last.getSortValues()[i];
-                    int cmp = value.compareTo(lastSortValues[i]) * reverseMuls[i];
-                    if (cmp != 0) {
-                        assertThat(cmp, equalTo(1));
-                        break;
-                    }
-                }
-            }
-            assertThat(last.getSortValues().length, equalTo(expectedSorts.size()));
-            lastSortValues = last.getSortValues();
-            searchRequest.source().searchAfter(last.getSortValues());
-            response = client().search(searchRequest).get();
+        } finally {
+            response.decRef();
         }
         assertThat(seen.size(), equalTo(expectedNumDocs));
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/search/TransportSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/search/TransportSearchIT.java
@@ -74,6 +74,7 @@ import java.util.concurrent.ExecutionException;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -121,7 +122,7 @@ public class TransportSearchIT extends ESIntegTestCase {
         return Collections.singletonList(TestPlugin.class);
     }
 
-    public void testLocalClusterAlias() {
+    public void testLocalClusterAlias() throws ExecutionException, InterruptedException {
         long nowInMillis = randomLongBetween(0, Long.MAX_VALUE);
         IndexRequest indexRequest = new IndexRequest("test");
         indexRequest.id("1");
@@ -140,14 +141,15 @@ public class TransportSearchIT extends ESIntegTestCase {
                 nowInMillis,
                 randomBoolean()
             );
-            SearchResponse searchResponse = client().search(searchRequest).actionGet();
-            assertEquals(1, searchResponse.getHits().getTotalHits().value);
-            SearchHit[] hits = searchResponse.getHits().getHits();
-            assertEquals(1, hits.length);
-            SearchHit hit = hits[0];
-            assertEquals("local", hit.getClusterAlias());
-            assertEquals("test", hit.getIndex());
-            assertEquals("1", hit.getId());
+            assertResponse(client().search(searchRequest), searchResponse -> {
+                assertEquals(1, searchResponse.getHits().getTotalHits().value);
+                SearchHit[] hits = searchResponse.getHits().getHits();
+                assertEquals(1, hits.length);
+                SearchHit hit = hits[0];
+                assertEquals("local", hit.getClusterAlias());
+                assertEquals("test", hit.getIndex());
+                assertEquals("1", hit.getId());
+            });
         }
         {
             SearchRequest searchRequest = SearchRequest.subSearchRequest(
@@ -158,14 +160,15 @@ public class TransportSearchIT extends ESIntegTestCase {
                 nowInMillis,
                 randomBoolean()
             );
-            SearchResponse searchResponse = client().search(searchRequest).actionGet();
-            assertEquals(1, searchResponse.getHits().getTotalHits().value);
-            SearchHit[] hits = searchResponse.getHits().getHits();
-            assertEquals(1, hits.length);
-            SearchHit hit = hits[0];
-            assertEquals("", hit.getClusterAlias());
-            assertEquals("test", hit.getIndex());
-            assertEquals("1", hit.getId());
+            assertResponse(client().search(searchRequest), searchResponse -> {
+                assertEquals(1, searchResponse.getHits().getTotalHits().value);
+                SearchHit[] hits = searchResponse.getHits().getHits();
+                assertEquals(1, hits.length);
+                SearchHit hit = hits[0];
+                assertEquals("", hit.getClusterAlias());
+                assertEquals("test", hit.getIndex());
+                assertEquals("1", hit.getId());
+            });
         }
     }
 
@@ -193,8 +196,7 @@ public class TransportSearchIT extends ESIntegTestCase {
         {
             SearchRequest searchRequest = new SearchRequest("<test-{now/d}>");
             searchRequest.indicesOptions(IndicesOptions.fromOptions(true, true, true, true));
-            SearchResponse searchResponse = client().search(searchRequest).actionGet();
-            assertEquals(0, searchResponse.getTotalShards());
+            assertResponse(client().search(searchRequest), searchResponse -> assertEquals(0, searchResponse.getTotalShards()));
         }
         {
             SearchRequest searchRequest = SearchRequest.subSearchRequest(
@@ -217,9 +219,10 @@ public class TransportSearchIT extends ESIntegTestCase {
                 randomBoolean()
             );
             searchRequest.indices("<test-{now/d}>");
-            SearchResponse searchResponse = client().search(searchRequest).actionGet();
-            assertEquals(1, searchResponse.getHits().getTotalHits().value);
-            assertEquals("test-1970.01.01", searchResponse.getHits().getHits()[0].getIndex());
+            assertResponse(client().search(searchRequest), searchResponse -> {
+                assertEquals(1, searchResponse.getHits().getTotalHits().value);
+                assertEquals("test-1970.01.01", searchResponse.getHits().getHits()[0].getIndex());
+            });
         }
         {
             SearchRequest searchRequest = SearchRequest.subSearchRequest(
@@ -236,13 +239,14 @@ public class TransportSearchIT extends ESIntegTestCase {
             rangeQuery.lt("1982-01-01");
             sourceBuilder.query(rangeQuery);
             searchRequest.source(sourceBuilder);
-            SearchResponse searchResponse = client().search(searchRequest).actionGet();
-            assertEquals(1, searchResponse.getHits().getTotalHits().value);
-            assertEquals("test-1970.01.01", searchResponse.getHits().getHits()[0].getIndex());
+            assertResponse(client().search(searchRequest), searchResponse -> {
+                assertEquals(1, searchResponse.getHits().getTotalHits().value);
+                assertEquals("test-1970.01.01", searchResponse.getHits().getHits()[0].getIndex());
+            });
         }
     }
 
-    public void testFinalReduce() {
+    public void testFinalReduce() throws ExecutionException, InterruptedException {
         long nowInMillis = randomLongBetween(0, Long.MAX_VALUE);
         TaskId taskId = new TaskId("node", randomNonNegativeLong());
         {
@@ -274,11 +278,12 @@ public class TransportSearchIT extends ESIntegTestCase {
             SearchRequest searchRequest = randomBoolean()
                 ? originalRequest
                 : SearchRequest.subSearchRequest(taskId, originalRequest, Strings.EMPTY_ARRAY, "remote", nowInMillis, true);
-            SearchResponse searchResponse = client().search(searchRequest).actionGet();
-            assertEquals(2, searchResponse.getHits().getTotalHits().value);
-            Aggregations aggregations = searchResponse.getAggregations();
-            LongTerms longTerms = aggregations.get("terms");
-            assertEquals(1, longTerms.getBuckets().size());
+            assertResponse(client().search(searchRequest), searchResponse -> {
+                assertEquals(2, searchResponse.getHits().getTotalHits().value);
+                Aggregations aggregations = searchResponse.getAggregations();
+                LongTerms longTerms = aggregations.get("terms");
+                assertEquals(1, longTerms.getBuckets().size());
+            });
         }
         {
             SearchRequest searchRequest = SearchRequest.subSearchRequest(
@@ -289,11 +294,12 @@ public class TransportSearchIT extends ESIntegTestCase {
                 nowInMillis,
                 false
             );
-            SearchResponse searchResponse = client().search(searchRequest).actionGet();
-            assertEquals(2, searchResponse.getHits().getTotalHits().value);
-            Aggregations aggregations = searchResponse.getAggregations();
-            LongTerms longTerms = aggregations.get("terms");
-            assertEquals(2, longTerms.getBuckets().size());
+            assertResponse(client().search(searchRequest), searchResponse -> {
+                assertEquals(2, searchResponse.getHits().getTotalHits().value);
+                Aggregations aggregations = searchResponse.getAggregations();
+                LongTerms longTerms = aggregations.get("terms");
+                assertEquals(2, longTerms.getBuckets().size());
+            });
         }
     }
 
@@ -309,7 +315,7 @@ public class TransportSearchIT extends ESIntegTestCase {
         Arrays.fill(validCheckpoints, SequenceNumbers.UNASSIGNED_SEQ_NO);
 
         // no exception
-        prepareSearch("testAlias").setWaitForCheckpoints(Collections.singletonMap("testAlias", validCheckpoints)).get();
+        prepareSearch("testAlias").setWaitForCheckpoints(Collections.singletonMap("testAlias", validCheckpoints)).get().decRef();
 
         IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
@@ -373,7 +379,7 @@ public class TransportSearchIT extends ESIntegTestCase {
             assertAcked(prepareCreate("test2").setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, numPrimaries2)));
 
             // no exception
-            prepareSearch("test1").get();
+            prepareSearch("test1").get().decRef();
 
             updateClusterSettings(Settings.builder().put(TransportSearchAction.SHARD_COUNT_LIMIT_SETTING.getKey(), numPrimaries1 - 1));
 
@@ -386,7 +392,7 @@ public class TransportSearchIT extends ESIntegTestCase {
             updateClusterSettings(Settings.builder().put(TransportSearchAction.SHARD_COUNT_LIMIT_SETTING.getKey(), numPrimaries1));
 
             // no exception
-            prepareSearch("test1").get();
+            prepareSearch("test1").get().decRef();
 
             e = expectThrows(IllegalArgumentException.class, () -> prepareSearch("test1", "test2").get());
             assertThat(
@@ -422,12 +428,13 @@ public class TransportSearchIT extends ESIntegTestCase {
         prepareIndex("test").setId("1").setSource("created_date", "2020-01-01").get();
         prepareIndex("test").setId("2").setSource("created_date", "2020-01-02").get();
         prepareIndex("test").setId("3").setSource("created_date", "2020-01-03").get();
-        assertBusy(() -> {
-            SearchResponse resp = prepareSearch("test").setQuery(new RangeQueryBuilder("created_date").gte("2020-01-02").lte("2020-01-03"))
-                .setPreFilterShardSize(randomIntBetween(1, 3))
-                .get();
-            assertThat(resp.getHits().getTotalHits().value, equalTo(2L));
-        });
+        assertBusy(
+            () -> assertResponse(
+                prepareSearch("test").setQuery(new RangeQueryBuilder("created_date").gte("2020-01-02").lte("2020-01-03"))
+                    .setPreFilterShardSize(randomIntBetween(1, 3)),
+                resp -> assertThat(resp.getHits().getTotalHits().value, equalTo(2L))
+            )
+        );
     }
 
     public void testCircuitBreakerReduceFail() throws Exception {
@@ -471,7 +478,7 @@ public class TransportSearchIT extends ESIntegTestCase {
             assertBusy(() -> {
                 Exception exc = expectThrows(
                     Exception.class,
-                    () -> client.prepareSearch("test").addAggregation(new TestAggregationBuilder("test")).get()
+                    () -> client.prepareSearch("test").addAggregation(new TestAggregationBuilder("test")).get().decRef()
                 );
                 assertThat(exc.getCause().getMessage(), containsString("<reduce_aggs>"));
             });

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/support/master/IndexingMasterFailoverIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/support/master/IndexingMasterFailoverIT.java
@@ -20,7 +20,7 @@ import java.util.HashSet;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
 
-import static org.hamcrest.Matchers.equalTo;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0, autoManageMasterNodes = false)
 public class IndexingMasterFailoverIT extends ESIntegTestCase {
@@ -97,7 +97,7 @@ public class IndexingMasterFailoverIT extends ESIntegTestCase {
 
         ensureGreen("myindex");
         refresh();
-        assertThat(prepareSearch("myindex").get().getHits().getTotalHits().value, equalTo(10L));
+        assertHitCount(prepareSearch("myindex"), 10);
     }
 
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/MinimumMasterNodesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/MinimumMasterNodesIT.java
@@ -105,10 +105,7 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
 
         logger.info("--> verify we get the data back");
         for (int i = 0; i < 10; i++) {
-            assertThat(
-                prepareSearch().setSize(0).setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value,
-                equalTo(100L)
-            );
+            assertHitCount(prepareSearch().setSize(0).setQuery(QueryBuilders.matchAllQuery()), 100);
         }
 
         String masterNode = internalCluster().getMasterName();

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/allocation/FilteringAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/allocation/FilteringAllocationIT.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.hamcrest.Matchers.equalTo;
 
 @ClusterScope(scope = Scope.TEST, numDataNodes = 0)
@@ -51,7 +52,7 @@ public class FilteringAllocationIT extends ESIntegTestCase {
             prepareIndex("test").setId(Integer.toString(i)).setSource("field", "value" + i).get();
         }
         indicesAdmin().prepareRefresh().get();
-        assertThat(prepareSearch().setSize(0).setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value, equalTo(100L));
+        assertHitCount(prepareSearch().setSize(0).setQuery(QueryBuilders.matchAllQuery()), 100);
 
         final boolean closed = randomBoolean();
         if (closed) {
@@ -79,7 +80,7 @@ public class FilteringAllocationIT extends ESIntegTestCase {
         }
 
         indicesAdmin().prepareRefresh().get();
-        assertThat(prepareSearch().setSize(0).setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value, equalTo(100L));
+        assertHitCount(prepareSearch().setSize(0).setQuery(QueryBuilders.matchAllQuery()), 100);
     }
 
     public void testAutoExpandReplicasToFilteredNodes() {
@@ -132,7 +133,7 @@ public class FilteringAllocationIT extends ESIntegTestCase {
             prepareIndex("test").setId(Integer.toString(i)).setSource("field", "value" + i).get();
         }
         indicesAdmin().prepareRefresh().get();
-        assertThat(prepareSearch().setSize(0).setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value, equalTo(100L));
+        assertHitCount(prepareSearch().setSize(0).setQuery(QueryBuilders.matchAllQuery()), 100);
 
         final boolean closed = randomBoolean();
         if (closed) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/discovery/ClusterDisruptionCleanSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/discovery/ClusterDisruptionCleanSettingsIT.java
@@ -23,7 +23,7 @@ import java.util.Collection;
 import java.util.List;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
-import static org.hamcrest.Matchers.equalTo;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0)
 public class ClusterDisruptionCleanSettingsIT extends ESIntegTestCase {
@@ -63,6 +63,6 @@ public class ClusterDisruptionCleanSettingsIT extends ESIntegTestCase {
 
         IndicesStoreIntegrationIT.relocateAndBlockCompletion(logger, "test", 0, node_1, node_2);
         // now search for the documents and see if we get a reply
-        assertThat(prepareSearch().setSize(0).get().getHits().getTotalHits().value, equalTo(100L));
+        assertHitCount(prepareSearch().setSize(0), 100);
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/shard/SearchIdleIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/shard/SearchIdleIT.java
@@ -48,7 +48,14 @@ import static org.hamcrest.Matchers.equalTo;
 public class SearchIdleIT extends ESSingleNodeTestCase {
 
     public void testAutomaticRefreshSearch() throws InterruptedException {
-        runTestAutomaticRefresh(numDocs -> client().prepareSearch("test").get().getHits().getTotalHits().value);
+        runTestAutomaticRefresh(numDocs -> {
+            var resp = client().prepareSearch("test").get();
+            try {
+                return resp.getHits().getTotalHits().value;
+            } finally {
+                resp.decRef();
+            }
+        });
     }
 
     public void testAutomaticRefreshGet() throws InterruptedException {

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/IndicesOptionsIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/IndicesOptionsIntegrationIT.java
@@ -408,7 +408,7 @@ public class IndicesOptionsIntegrationIT extends ESIntegTestCase {
         expectThrows(IndexNotFoundException.class, () -> prepareSearch("test2", "test3").setQuery(matchAllQuery()).get());
 
         // you should still be able to run empty searches without things blowing up
-        prepareSearch().setQuery(matchAllQuery()).get();
+        prepareSearch().setQuery(matchAllQuery()).get().decRef();
     }
 
     // For now don't handle closed indices
@@ -681,7 +681,7 @@ public class IndicesOptionsIntegrationIT extends ESIntegTestCase {
                 });
             } else {
                 try {
-                    requestBuilder.get();
+                    requestBuilder.get().decRef();
                     fail("IndexNotFoundException or IndexClosedException was expected");
                 } catch (IndexNotFoundException | IndexClosedException e) {}
             }
@@ -694,7 +694,7 @@ public class IndicesOptionsIntegrationIT extends ESIntegTestCase {
                     assertThat(response.getResponses()[0].getResponse(), notNullValue());
                 });
             } else {
-                requestBuilder.get();
+                requestBuilder.get().decRef();
             }
         }
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/memory/breaker/CircuitBreakerNoopIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/memory/breaker/CircuitBreakerNoopIT.java
@@ -51,7 +51,7 @@ public class CircuitBreakerNoopIT extends ESIntegTestCase {
         indexRandom(true, reqs);
 
         // A cardinality aggregation uses BigArrays and thus the REQUEST breaker
-        client.prepareSearch("cb-test").setQuery(matchAllQuery()).addAggregation(cardinality("card").field("test")).get();
+        client.prepareSearch("cb-test").setQuery(matchAllQuery()).addAggregation(cardinality("card").field("test")).get().decRef();
         // no exception because the breaker is a noop
     }
 
@@ -68,7 +68,7 @@ public class CircuitBreakerNoopIT extends ESIntegTestCase {
         indexRandom(true, reqs);
 
         // Sorting using fielddata and thus the FIELDDATA breaker
-        client.prepareSearch("cb-test").setQuery(matchAllQuery()).addSort("test", SortOrder.DESC).get();
+        client.prepareSearch("cb-test").setQuery(matchAllQuery()).addSort("test", SortOrder.DESC).get().decRef();
         // no exception because the breaker is a noop
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/memory/breaker/CircuitBreakerServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/memory/breaker/CircuitBreakerServiceIT.java
@@ -193,7 +193,7 @@ public class CircuitBreakerServiceIT extends ESIntegTestCase {
         indexRandom(true, false, true, reqs);
 
         // execute a search that loads field data (sorting on the "test" field)
-        client.prepareSearch("ramtest").setQuery(matchAllQuery()).addSort("test", SortOrder.DESC).get();
+        client.prepareSearch("ramtest").setQuery(matchAllQuery()).addSort("test", SortOrder.DESC).get().decRef();
 
         // clear field data cache (thus setting the loaded field data back to 0)
         clearFieldData();

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/memory/breaker/RandomExceptionCircuitBreakerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/memory/breaker/RandomExceptionCircuitBreakerIT.java
@@ -159,7 +159,7 @@ public class RandomExceptionCircuitBreakerIT extends ESIntegTestCase {
             boolean success = false;
             try {
                 // Sort by the string and numeric fields, to load them into field data
-                searchRequestBuilder.get();
+                searchRequestBuilder.get().decRef();
                 success = true;
             } catch (SearchPhaseExecutionException ex) {
                 logger.info("expected SearchPhaseException: [{}]", ex.getMessage());

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
@@ -933,7 +933,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
 
         indexRandom(true, docs);
         flush();
-        assertThat(prepareSearch(name).setSize(0).get().getHits().getTotalHits().value, equalTo((long) numDocs));
+        assertHitCount(prepareSearch(name).setSize(0), numDocs);
         return indicesAdmin().prepareStats(name).get();
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/state/CloseWhileRelocatingShardsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/state/CloseWhileRelocatingShardsIT.java
@@ -48,6 +48,7 @@ import static org.elasticsearch.indices.state.CloseIndexIT.assertException;
 import static org.elasticsearch.indices.state.CloseIndexIT.assertIndexIsClosed;
 import static org.elasticsearch.indices.state.CloseIndexIT.assertIndexIsOpened;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
 
@@ -241,20 +242,22 @@ public class CloseWhileRelocatingShardsIT extends ESIntegTestCase {
             ensureGreen(indices);
 
             for (String index : acknowledgedCloses) {
-                long docsCount = prepareSearch(index).setSize(0).setTrackTotalHits(true).get().getHits().getTotalHits().value;
-                assertEquals(
-                    "Expected "
-                        + docsPerIndex.get(index)
-                        + " docs in index "
-                        + index
-                        + " but got "
-                        + docsCount
-                        + " (close acknowledged="
-                        + acknowledgedCloses.contains(index)
-                        + ")",
-                    (long) docsPerIndex.get(index),
-                    docsCount
-                );
+                assertResponse(prepareSearch(index).setSize(0).setTrackTotalHits(true), response -> {
+                    long docsCount = response.getHits().getTotalHits().value;
+                    assertEquals(
+                        "Expected "
+                            + docsPerIndex.get(index)
+                            + " docs in index "
+                            + index
+                            + " but got "
+                            + docsCount
+                            + " (close acknowledged="
+                            + acknowledgedCloses.contains(index)
+                            + ")",
+                        (long) docsPerIndex.get(index),
+                        docsCount
+                    );
+                });
             }
         } finally {
             updateClusterSettings(Settings.builder().putNull(EnableAllocationDecider.CLUSTER_ROUTING_REBALANCE_ENABLE_SETTING.getKey()));

--- a/server/src/internalClusterTest/java/org/elasticsearch/recovery/RelocationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/recovery/RelocationIT.java
@@ -43,7 +43,6 @@ import org.elasticsearch.indices.recovery.PeerRecoveryTargetService;
 import org.elasticsearch.indices.recovery.RecoveryFileChunkRequest;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.SearchHit;
-import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.test.BackgroundIndexer;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
@@ -80,6 +79,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHitsWithoutFailures;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.everyItem;
@@ -133,7 +133,7 @@ public class RelocationIT extends ESIntegTestCase {
 
         logger.info("--> verifying count");
         indicesAdmin().prepareRefresh().get();
-        assertThat(prepareSearch("test").setSize(0).get().getHits().getTotalHits().value, equalTo(20L));
+        assertHitCount(prepareSearch("test").setSize(0), 20L);
 
         logger.info("--> start another node");
         final String node_2 = internalCluster().startNode();
@@ -155,7 +155,7 @@ public class RelocationIT extends ESIntegTestCase {
 
         logger.info("--> verifying count again...");
         indicesAdmin().prepareRefresh().get();
-        assertThat(prepareSearch("test").setSize(0).get().getHits().getTotalHits().value, equalTo(20L));
+        assertHitCount(prepareSearch("test").setSize(0), 20);
     }
 
     public void testRelocationWhileIndexingRandom() throws Exception {
@@ -229,35 +229,31 @@ public class RelocationIT extends ESIntegTestCase {
             logger.info("--> refreshing the index");
             indicesAdmin().prepareRefresh("test").get();
             logger.info("--> searching the index");
-            boolean ranOnce = false;
             for (int i = 0; i < 10; i++) {
+                final int idx = i;
                 logger.info("--> START search test round {}", i + 1);
-                SearchHits hits = prepareSearch("test").setQuery(matchAllQuery())
-                    .setSize((int) indexer.totalIndexedDocs())
-                    .storedFields()
-                    .get()
-                    .getHits();
-                ranOnce = true;
-                if (hits.getTotalHits().value != indexer.totalIndexedDocs()) {
-                    int[] hitIds = new int[(int) indexer.totalIndexedDocs()];
-                    for (int hit = 0; hit < indexer.totalIndexedDocs(); hit++) {
-                        hitIds[hit] = hit + 1;
-                    }
-                    Set<Integer> set = Arrays.stream(hitIds).boxed().collect(Collectors.toSet());
-                    for (SearchHit hit : hits.getHits()) {
-                        int id = Integer.parseInt(hit.getId());
-                        if (set.remove(id) == false) {
-                            logger.error("Extra id [{}]", id);
+                assertResponse(
+                    prepareSearch("test").setQuery(matchAllQuery()).setSize((int) indexer.totalIndexedDocs()).storedFields(),
+                    response -> {
+                        var hits = response.getHits();
+                        if (hits.getTotalHits().value != indexer.totalIndexedDocs()) {
+                            int[] hitIds = new int[(int) indexer.totalIndexedDocs()];
+                            for (int hit = 0; hit < indexer.totalIndexedDocs(); hit++) {
+                                hitIds[hit] = hit + 1;
+                            }
+                            Set<Integer> set = Arrays.stream(hitIds).boxed().collect(Collectors.toSet());
+                            for (SearchHit hit : hits.getHits()) {
+                                int id = Integer.parseInt(hit.getId());
+                                if (set.remove(id) == false) {
+                                    logger.error("Extra id [{}]", id);
+                                }
+                            }
+                            set.forEach(value -> logger.error("Missing id [{}]", value));
                         }
+                        assertThat(hits.getTotalHits().value, equalTo(indexer.totalIndexedDocs()));
+                        logger.info("--> DONE search test round {}", idx + 1);
                     }
-                    set.forEach(value -> logger.error("Missing id [{}]", value));
-                }
-                assertThat(hits.getTotalHits().value, equalTo(indexer.totalIndexedDocs()));
-                logger.info("--> DONE search test round {}", i + 1);
-
-            }
-            if (ranOnce == false) {
-                fail();
+                );
             }
         }
     }
@@ -570,7 +566,7 @@ public class RelocationIT extends ESIntegTestCase {
 
         logger.info("--> verifying count");
         indicesAdmin().prepareRefresh().get();
-        assertThat(prepareSearch("test").setSize(0).get().getHits().getTotalHits().value, equalTo(20L));
+        assertHitCount(prepareSearch("test").setSize(0), 20);
     }
 
     public void testRelocateWhileContinuouslyIndexingAndWaitingForRefresh() throws Exception {
@@ -636,7 +632,7 @@ public class RelocationIT extends ESIntegTestCase {
             assertTrue(pendingIndexResponses.stream().allMatch(ActionFuture::isDone));
         }, 1, TimeUnit.MINUTES);
 
-        assertThat(prepareSearch("test").setSize(0).get().getHits().getTotalHits().value, equalTo(120L));
+        assertHitCount(prepareSearch("test").setSize(0), 120);
     }
 
     public void testRelocationEstablishedPeerRecoveryRetentionLeases() throws Exception {

--- a/server/src/internalClusterTest/java/org/elasticsearch/routing/AliasRoutingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/routing/AliasRoutingIT.java
@@ -19,6 +19,7 @@ import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.xcontent.XContentFactory;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -116,45 +117,24 @@ public class AliasRoutingIT extends ESIntegTestCase {
 
         logger.info("--> search with no routing, should fine one");
         for (int i = 0; i < 5; i++) {
-            assertThat(prepareSearch().setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value, equalTo(1L));
+            assertHitCount(prepareSearch().setQuery(QueryBuilders.matchAllQuery()), 1);
         }
 
         logger.info("--> search with wrong routing, should not find");
         for (int i = 0; i < 5; i++) {
-            assertThat(
-                prepareSearch().setRouting("1").setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value,
-                equalTo(0L)
-            );
-
-            assertThat(
-                prepareSearch().setSize(0).setRouting("1").setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value,
-                equalTo(0L)
-            );
-
-            assertThat(prepareSearch("alias1").setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value, equalTo(0L));
-
-            assertThat(
-                prepareSearch("alias1").setSize(0).setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value,
-                equalTo(0L)
-            );
+            assertHitCount(prepareSearch().setRouting("1").setQuery(QueryBuilders.matchAllQuery()), 0);
+            assertHitCount(prepareSearch().setSize(0).setRouting("1").setQuery(QueryBuilders.matchAllQuery()), 0);
+            assertHitCount(prepareSearch("alias1").setQuery(QueryBuilders.matchAllQuery()), 0);
+            assertHitCount(prepareSearch("alias1").setSize(0).setQuery(QueryBuilders.matchAllQuery()), 0);
         }
 
         logger.info("--> search with correct routing, should find");
         for (int i = 0; i < 5; i++) {
 
-            assertThat(
-                prepareSearch().setRouting("0").setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value,
-                equalTo(1L)
-            );
-            assertThat(
-                prepareSearch().setSize(0).setRouting("0").setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value,
-                equalTo(1L)
-            );
-            assertThat(prepareSearch("alias0").setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value, equalTo(1L));
-            assertThat(
-                prepareSearch("alias0").setSize(0).setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value,
-                equalTo(1L)
-            );
+            assertHitCount(prepareSearch().setRouting("0").setQuery(QueryBuilders.matchAllQuery()), 1);
+            assertHitCount(prepareSearch().setSize(0).setRouting("0").setQuery(QueryBuilders.matchAllQuery()), 1);
+            assertHitCount(prepareSearch("alias0").setQuery(QueryBuilders.matchAllQuery()), 1);
+            assertHitCount(prepareSearch("alias0").setSize(0).setQuery(QueryBuilders.matchAllQuery()), 1);
         }
 
         logger.info("--> indexing with id [2], and routing [1] using alias");
@@ -162,111 +142,50 @@ public class AliasRoutingIT extends ESIntegTestCase {
 
         logger.info("--> search with no routing, should fine two");
         for (int i = 0; i < 5; i++) {
-            assertThat(prepareSearch().setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value, equalTo(2L));
-            assertThat(
-                prepareSearch().setSize(0).setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value,
-                equalTo(2L)
-            );
+            assertHitCount(prepareSearch().setQuery(QueryBuilders.matchAllQuery()), 2);
+            assertHitCount(prepareSearch().setSize(0).setQuery(QueryBuilders.matchAllQuery()), 2);
         }
 
         logger.info("--> search with 0 routing, should find one");
         for (int i = 0; i < 5; i++) {
-            assertThat(
-                prepareSearch().setRouting("0").setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value,
-                equalTo(1L)
-            );
-            assertThat(
-                prepareSearch().setSize(0).setRouting("0").setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value,
-                equalTo(1L)
-            );
-            assertThat(prepareSearch("alias0").setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value, equalTo(1L));
-            assertThat(
-                prepareSearch("alias0").setSize(0).setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value,
-                equalTo(1L)
-            );
+            assertHitCount(prepareSearch().setRouting("0").setQuery(QueryBuilders.matchAllQuery()), 1);
+            assertHitCount(prepareSearch().setSize(0).setRouting("0").setQuery(QueryBuilders.matchAllQuery()), 1);
+            assertHitCount(prepareSearch("alias0").setQuery(QueryBuilders.matchAllQuery()), 1);
+            assertHitCount(prepareSearch("alias0").setSize(0).setQuery(QueryBuilders.matchAllQuery()), 1);
         }
 
         logger.info("--> search with 1 routing, should find one");
         for (int i = 0; i < 5; i++) {
-            assertThat(
-                prepareSearch().setRouting("1").setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value,
-                equalTo(1L)
-            );
-            assertThat(
-                prepareSearch().setSize(0).setRouting("1").setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value,
-                equalTo(1L)
-            );
-            assertThat(prepareSearch("alias1").setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value, equalTo(1L));
-            assertThat(
-                prepareSearch("alias1").setSize(0).setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value,
-                equalTo(1L)
-            );
+            assertHitCount(prepareSearch().setRouting("1").setQuery(QueryBuilders.matchAllQuery()), 1);
+            assertHitCount(prepareSearch().setSize(0).setRouting("1").setQuery(QueryBuilders.matchAllQuery()), 1);
+            assertHitCount(prepareSearch("alias1").setQuery(QueryBuilders.matchAllQuery()), 1);
+            assertHitCount(prepareSearch("alias1").setSize(0).setQuery(QueryBuilders.matchAllQuery()), 1);
         }
 
         logger.info("--> search with 0,1 indexRoutings , should find two");
         for (int i = 0; i < 5; i++) {
-            assertThat(
-                prepareSearch().setRouting("0", "1").setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value,
-                equalTo(2L)
-            );
-            assertThat(
-                prepareSearch().setSize(0)
-                    .setRouting("0", "1")
-                    .setQuery(QueryBuilders.matchAllQuery())
-                    .get()
-                    .getHits()
-                    .getTotalHits().value,
-                equalTo(2L)
-            );
-            assertThat(prepareSearch("alias01").setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value, equalTo(2L));
-            assertThat(
-                prepareSearch("alias01").setSize(0).setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value,
-                equalTo(2L)
-            );
+            assertHitCount(prepareSearch().setRouting("0", "1").setQuery(QueryBuilders.matchAllQuery()), 2);
+            assertHitCount(prepareSearch().setSize(0).setRouting("0", "1").setQuery(QueryBuilders.matchAllQuery()), 2);
+            assertHitCount(prepareSearch("alias01").setQuery(QueryBuilders.matchAllQuery()), 2);
+            assertHitCount(prepareSearch("alias01").setSize(0).setQuery(QueryBuilders.matchAllQuery()), 2);
         }
 
         logger.info("--> search with two routing aliases , should find two");
         for (int i = 0; i < 5; i++) {
-            assertThat(
-                prepareSearch("alias0", "alias1").setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value,
-                equalTo(2L)
-            );
-            assertThat(
-                prepareSearch("alias0", "alias1").setSize(0).setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value,
-                equalTo(2L)
-            );
+            assertHitCount(prepareSearch("alias0", "alias1").setQuery(QueryBuilders.matchAllQuery()), 2);
+            assertHitCount(prepareSearch("alias0", "alias1").setSize(0).setQuery(QueryBuilders.matchAllQuery()), 2);
         }
 
         logger.info("--> search with alias0, alias1 and alias01, should find two");
         for (int i = 0; i < 5; i++) {
-            assertThat(
-                prepareSearch("alias0", "alias1", "alias01").setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value,
-                equalTo(2L)
-            );
-            assertThat(
-                prepareSearch("alias0", "alias1", "alias01").setSize(0)
-                    .setQuery(QueryBuilders.matchAllQuery())
-                    .get()
-                    .getHits()
-                    .getTotalHits().value,
-                equalTo(2L)
-            );
+            assertHitCount(prepareSearch("alias0", "alias1", "alias01").setQuery(QueryBuilders.matchAllQuery()), 2);
+            assertHitCount(prepareSearch("alias0", "alias1", "alias01").setSize(0).setQuery(QueryBuilders.matchAllQuery()), 2);
         }
 
         logger.info("--> search with test, alias0 and alias1, should find two");
         for (int i = 0; i < 5; i++) {
-            assertThat(
-                prepareSearch("test", "alias0", "alias1").setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value,
-                equalTo(2L)
-            );
-            assertThat(
-                prepareSearch("test", "alias0", "alias1").setSize(0)
-                    .setQuery(QueryBuilders.matchAllQuery())
-                    .get()
-                    .getHits()
-                    .getTotalHits().value,
-                equalTo(2L)
-            );
+            assertHitCount(prepareSearch("test", "alias0", "alias1").setQuery(QueryBuilders.matchAllQuery()), 2);
+            assertHitCount(prepareSearch("test", "alias0", "alias1").setSize(0).setQuery(QueryBuilders.matchAllQuery()), 2);
         }
 
     }
@@ -316,43 +235,20 @@ public class AliasRoutingIT extends ESIntegTestCase {
 
         logger.info("--> search with alias-a1,alias-b0, should not find");
         for (int i = 0; i < 5; i++) {
-            assertThat(
-                prepareSearch("alias-a1", "alias-b0").setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value,
-                equalTo(0L)
-            );
-            assertThat(
-                prepareSearch("alias-a1", "alias-b0").setSize(0)
-                    .setQuery(QueryBuilders.matchAllQuery())
-                    .get()
-                    .getHits()
-                    .getTotalHits().value,
-                equalTo(0L)
-            );
+            assertHitCount(prepareSearch("alias-a1", "alias-b0").setQuery(QueryBuilders.matchAllQuery()), 0);
+            assertHitCount(prepareSearch("alias-a1", "alias-b0").setSize(0).setQuery(QueryBuilders.matchAllQuery()), 0);
         }
 
         logger.info("--> search with alias-ab, should find two");
         for (int i = 0; i < 5; i++) {
-            assertThat(prepareSearch("alias-ab").setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value, equalTo(2L));
-            assertThat(
-                prepareSearch("alias-ab").setSize(0).setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value,
-                equalTo(2L)
-            );
+            assertHitCount(prepareSearch("alias-ab").setQuery(QueryBuilders.matchAllQuery()), 2);
+            assertHitCount(prepareSearch("alias-ab").setSize(0).setQuery(QueryBuilders.matchAllQuery()), 2);
         }
 
         logger.info("--> search with alias-a0,alias-b1 should find two");
         for (int i = 0; i < 5; i++) {
-            assertThat(
-                prepareSearch("alias-a0", "alias-b1").setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value,
-                equalTo(2L)
-            );
-            assertThat(
-                prepareSearch("alias-a0", "alias-b1").setSize(0)
-                    .setQuery(QueryBuilders.matchAllQuery())
-                    .get()
-                    .getHits()
-                    .getTotalHits().value,
-                equalTo(2L)
-            );
+            assertHitCount(prepareSearch("alias-a0", "alias-b1").setQuery(QueryBuilders.matchAllQuery()), 2);
+            assertHitCount(prepareSearch("alias-a0", "alias-b1").setSize(0).setQuery(QueryBuilders.matchAllQuery()), 2);
         }
     }
 
@@ -374,7 +270,7 @@ public class AliasRoutingIT extends ESIntegTestCase {
 
         logger.info("--> search all on index_* should find two");
         for (int i = 0; i < 5; i++) {
-            assertThat(prepareSearch("index_*").setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value, equalTo(2L));
+            assertHitCount(prepareSearch("index_*").setQuery(QueryBuilders.matchAllQuery()), 2);
         }
     }
 
@@ -420,11 +316,8 @@ public class AliasRoutingIT extends ESIntegTestCase {
         logger.info("--> verifying get and search with routing, should find");
         for (int i = 0; i < 5; i++) {
             assertThat(client().prepareGet("test", "0").setRouting("3").get().isExists(), equalTo(true));
-            assertThat(prepareSearch("alias").setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value, equalTo(1L));
-            assertThat(
-                prepareSearch("alias").setSize(0).setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value,
-                equalTo(1L)
-            );
+            assertHitCount(prepareSearch("alias").setQuery(QueryBuilders.matchAllQuery()), 1);
+            assertHitCount(prepareSearch("alias").setSize(0).setQuery(QueryBuilders.matchAllQuery()), 1);
         }
 
         logger.info("--> creating alias with routing [4]");
@@ -432,11 +325,8 @@ public class AliasRoutingIT extends ESIntegTestCase {
 
         logger.info("--> verifying search with wrong routing should not find");
         for (int i = 0; i < 5; i++) {
-            assertThat(prepareSearch("alias").setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value, equalTo(0L));
-            assertThat(
-                prepareSearch("alias").setSize(0).setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value,
-                equalTo(0L)
-            );
+            assertHitCount(prepareSearch("alias").setQuery(QueryBuilders.matchAllQuery()), 0);
+            assertHitCount(prepareSearch("alias").setSize(0).setQuery(QueryBuilders.matchAllQuery()), 0);
         }
 
         logger.info("--> creating alias with search routing [3,4] and index routing 4");
@@ -453,11 +343,8 @@ public class AliasRoutingIT extends ESIntegTestCase {
         for (int i = 0; i < 5; i++) {
             assertThat(client().prepareGet("test", "0").setRouting("3").get().isExists(), equalTo(true));
             assertThat(client().prepareGet("test", "1").setRouting("4").get().isExists(), equalTo(true));
-            assertThat(prepareSearch("alias").setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value, equalTo(2L));
-            assertThat(
-                prepareSearch("alias").setSize(0).setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value,
-                equalTo(2L)
-            );
+            assertHitCount(prepareSearch("alias").setQuery(QueryBuilders.matchAllQuery()), 2);
+            assertHitCount(prepareSearch("alias").setSize(0).setQuery(QueryBuilders.matchAllQuery()), 2);
         }
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/routing/SimpleRoutingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/routing/SimpleRoutingIT.java
@@ -35,6 +35,7 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.xcontent.XContentFactory;
 
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
@@ -134,36 +135,19 @@ public class SimpleRoutingIT extends ESIntegTestCase {
 
         logger.info("--> search with no routing, should fine one");
         for (int i = 0; i < 5; i++) {
-            assertThat(prepareSearch().setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value, equalTo(1L));
+            assertHitCount(prepareSearch().setQuery(QueryBuilders.matchAllQuery()), 1L);
         }
 
         logger.info("--> search with wrong routing, should not find");
         for (int i = 0; i < 5; i++) {
-            assertThat(
-                prepareSearch().setRouting("1").setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value,
-                equalTo(0L)
-            );
-            assertThat(
-                prepareSearch().setSize(0).setRouting("1").setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value,
-                equalTo(0L)
-            );
+            assertHitCount(prepareSearch().setRouting("1").setQuery(QueryBuilders.matchAllQuery()), 0);
+            assertHitCount(prepareSearch().setSize(0).setRouting("1").setQuery(QueryBuilders.matchAllQuery()), 0);
         }
 
         logger.info("--> search with correct routing, should find");
         for (int i = 0; i < 5; i++) {
-            assertThat(
-                prepareSearch().setRouting(routingValue).setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value,
-                equalTo(1L)
-            );
-            assertThat(
-                prepareSearch().setSize(0)
-                    .setRouting(routingValue)
-                    .setQuery(QueryBuilders.matchAllQuery())
-                    .get()
-                    .getHits()
-                    .getTotalHits().value,
-                equalTo(1L)
-            );
+            assertHitCount(prepareSearch().setRouting(routingValue).setQuery(QueryBuilders.matchAllQuery()), 1);
+            assertHitCount(prepareSearch().setSize(0).setRouting(routingValue).setQuery(QueryBuilders.matchAllQuery()), 1);
         }
 
         String secondRoutingValue = "1";
@@ -176,86 +160,42 @@ public class SimpleRoutingIT extends ESIntegTestCase {
 
         logger.info("--> search with no routing, should fine two");
         for (int i = 0; i < 5; i++) {
-            assertThat(prepareSearch().setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value, equalTo(2L));
-            assertThat(
-                prepareSearch().setSize(0).setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value,
-                equalTo(2L)
-            );
+            assertHitCount(prepareSearch().setQuery(QueryBuilders.matchAllQuery()), 2);
+            assertHitCount(prepareSearch().setSize(0).setQuery(QueryBuilders.matchAllQuery()), 2);
         }
 
         logger.info("--> search with {} routing, should find one", routingValue);
         for (int i = 0; i < 5; i++) {
-            assertThat(
-                prepareSearch().setRouting(routingValue).setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value,
-                equalTo(1L)
-            );
-            assertThat(
-                prepareSearch().setSize(0)
-                    .setRouting(routingValue)
-                    .setQuery(QueryBuilders.matchAllQuery())
-                    .get()
-                    .getHits()
-                    .getTotalHits().value,
-                equalTo(1L)
-            );
+            assertHitCount(prepareSearch().setRouting(routingValue).setQuery(QueryBuilders.matchAllQuery()), 1);
+            assertHitCount(prepareSearch().setSize(0).setRouting(routingValue).setQuery(QueryBuilders.matchAllQuery()), 1);
         }
 
         logger.info("--> search with {} routing, should find one", secondRoutingValue);
         for (int i = 0; i < 5; i++) {
-            assertThat(
-                prepareSearch().setRouting("1").setQuery(QueryBuilders.matchAllQuery()).get().getHits().getTotalHits().value,
-                equalTo(1L)
-            );
-            assertThat(
-                prepareSearch().setSize(0)
-                    .setRouting(secondRoutingValue)
-                    .setQuery(QueryBuilders.matchAllQuery())
-                    .get()
-                    .getHits()
-                    .getTotalHits().value,
-                equalTo(1L)
-            );
+            assertHitCount(prepareSearch().setRouting("1").setQuery(QueryBuilders.matchAllQuery()), 1);
+            assertHitCount(prepareSearch().setSize(0).setRouting(secondRoutingValue).setQuery(QueryBuilders.matchAllQuery()), 1);
         }
 
         logger.info("--> search with {},{} indexRoutings , should find two", routingValue, "1");
         for (int i = 0; i < 5; i++) {
-            assertThat(
-                prepareSearch().setRouting(routingValue, secondRoutingValue)
-                    .setQuery(QueryBuilders.matchAllQuery())
-                    .get()
-                    .getHits()
-                    .getTotalHits().value,
-                equalTo(2L)
-            );
-            assertThat(
-                prepareSearch().setSize(0)
-                    .setRouting(routingValue, secondRoutingValue)
-                    .setQuery(QueryBuilders.matchAllQuery())
-                    .get()
-                    .getHits()
-                    .getTotalHits().value,
-                equalTo(2L)
+            assertHitCount(prepareSearch().setRouting(routingValue, secondRoutingValue).setQuery(QueryBuilders.matchAllQuery()), 2);
+            assertHitCount(
+                prepareSearch().setSize(0).setRouting(routingValue, secondRoutingValue).setQuery(QueryBuilders.matchAllQuery()),
+                2
             );
         }
 
         logger.info("--> search with {},{},{} indexRoutings , should find two", routingValue, secondRoutingValue, routingValue);
         for (int i = 0; i < 5; i++) {
-            assertThat(
-                prepareSearch().setRouting(routingValue, secondRoutingValue, routingValue)
-                    .setQuery(QueryBuilders.matchAllQuery())
-                    .get()
-                    .getHits()
-                    .getTotalHits().value,
-                equalTo(2L)
+            assertHitCount(
+                prepareSearch().setRouting(routingValue, secondRoutingValue, routingValue).setQuery(QueryBuilders.matchAllQuery()),
+                2
             );
-            assertThat(
+            assertHitCount(
                 prepareSearch().setSize(0)
                     .setRouting(routingValue, secondRoutingValue, routingValue)
-                    .setQuery(QueryBuilders.matchAllQuery())
-                    .get()
-                    .getHits()
-                    .getTotalHits().value,
-                equalTo(2L)
+                    .setQuery(QueryBuilders.matchAllQuery()),
+                2
             );
         }
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CrossClusterSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CrossClusterSearchIT.java
@@ -372,7 +372,10 @@ public class CrossClusterSearchIT extends AbstractMultiClustersTestCase {
 
         boolean minimizeRoundtrips = TransportSearchAction.shouldMinimizeRoundtrips(searchRequest);
 
-        client(LOCAL_CLUSTER).search(searchRequest, queryFuture);
+        client(LOCAL_CLUSTER).search(searchRequest, queryFuture.delegateFailure((l, r) -> {
+            r.incRef();
+            l.onResponse(r);
+        }));
         assertBusy(() -> assertTrue(queryFuture.isDone()));
 
         // dfs=true overrides the minimize_roundtrips=true setting and does not minimize roundtrips
@@ -612,7 +615,10 @@ public class CrossClusterSearchIT extends AbstractMultiClustersTestCase {
 
         boolean minimizeRoundtrips = TransportSearchAction.shouldMinimizeRoundtrips(searchRequest);
 
-        client(LOCAL_CLUSTER).search(searchRequest, queryFuture);
+        client(LOCAL_CLUSTER).search(searchRequest, queryFuture.delegateFailure((l, r) -> {
+            r.incRef();
+            l.onResponse(r);
+        }));
         assertBusy(() -> assertTrue(queryFuture.isDone()));
 
         if (skipUnavailable == false || minimizeRoundtrips == false) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/subphase/highlight/HighlighterSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/subphase/highlight/HighlighterSearchIT.java
@@ -378,8 +378,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
 
         assertNotHighlighted(
             prepareSearch().setQuery(matchPhraseQuery("no_long_term", "test foo highlighed").slop(3))
-                .highlighter(new HighlightBuilder().field("no_long_term", 18, 1).highlighterType("fvh").postTags("</b>").preTags("<b>"))
-                .get(),
+                .highlighter(new HighlightBuilder().field("no_long_term", 18, 1).highlighterType("fvh").postTags("</b>").preTags("<b>")),
             0,
             "no_long_term"
         );

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/functionscore/QueryRescorerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/functionscore/QueryRescorerIT.java
@@ -803,7 +803,7 @@ public class QueryRescorerIT extends ESIntegTestCase {
         request.setSize(4);
         request.addRescorer(new QueryRescorerBuilder(matchAllQuery()), 50);
 
-        assertEquals(4, request.get().getHits().getHits().length);
+        assertResponse(request, response -> assertEquals(4, response.getHits().getHits().length));
     }
 
     public void testRescorePhaseWithInvalidSort() throws Exception {

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/query/MultiMatchQueryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/query/MultiMatchQueryIT.java
@@ -447,8 +447,13 @@ public class MultiMatchQueryIT extends ESIntegTestCase {
     }
 
     public void testEquivalence() {
-
-        final int numDocs = (int) prepareSearch("test").setSize(0).setQuery(matchAllQuery()).get().getHits().getTotalHits().value;
+        var response = prepareSearch("test").setSize(0).setQuery(matchAllQuery()).get();
+        final int numDocs;
+        try {
+            numDocs = (int) response.getHits().getTotalHits().value;
+        } finally {
+            response.decRef();
+        }
         int numIters = scaledRandomIntBetween(5, 10);
         for (int i = 0; i < numIters; i++) {
             {

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/routing/SearchPreferenceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/routing/SearchPreferenceIT.java
@@ -232,13 +232,13 @@ public class SearchPreferenceIT extends ESIntegTestCase {
 
         final String customPreference = randomAlphaOfLength(10);
 
-        final String nodeId = prepareSearch("test").setQuery(matchAllQuery())
-            .setPreference(customPreference)
-            .get()
-            .getHits()
-            .getAt(0)
-            .getShard()
-            .getNodeId();
+        final String nodeId;
+        var response = prepareSearch("test").setQuery(matchAllQuery()).setPreference(customPreference).get();
+        try {
+            nodeId = response.getHits().getAt(0).getShard().getNodeId();
+        } finally {
+            response.decRef();
+        }
 
         assertSearchesSpecificNode("test", customPreference, nodeId);
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/routing/SearchReplicaSelectionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/routing/SearchReplicaSelectionIT.java
@@ -65,7 +65,7 @@ public class SearchReplicaSelectionIT extends ESIntegTestCase {
 
         // Now after more searches, we should select a node with the lowest ARS rank.
         for (int i = 0; i < 5; i++) {
-            client.prepareSearch().setQuery(matchAllQuery()).get();
+            client.prepareSearch().setQuery(matchAllQuery()).get().decRef();
         }
 
         ClusterStateResponse clusterStateResponse = client.admin().cluster().prepareState().get();

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/scroll/DuelScrollIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/scroll/DuelScrollIT.java
@@ -30,6 +30,7 @@ import java.util.Set;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -37,56 +38,61 @@ public class DuelScrollIT extends ESIntegTestCase {
     public void testDuelQueryThenFetch() throws Exception {
         TestContext context = create(SearchType.DFS_QUERY_THEN_FETCH, SearchType.QUERY_THEN_FETCH);
 
-        SearchResponse control = prepareSearch("index").setSearchType(context.searchType)
-            .addSort(context.sort)
-            .setSize(context.numDocs)
-            .get();
-        assertNoFailures(control);
-        SearchHits sh = control.getHits();
-        assertThat(sh.getTotalHits().value, equalTo((long) context.numDocs));
-        assertThat(sh.getHits().length, equalTo(context.numDocs));
+        assertNoFailuresAndResponse(
+            prepareSearch("index").setSearchType(context.searchType).addSort(context.sort).setSize(context.numDocs),
+            control -> {
+                SearchHits sh = control.getHits();
+                assertThat(sh.getTotalHits().value, equalTo((long) context.numDocs));
+                assertThat(sh.getHits().length, equalTo(context.numDocs));
 
-        SearchResponse searchScrollResponse = prepareSearch("index").setSearchType(context.searchType)
-            .addSort(context.sort)
-            .setSize(context.scrollRequestSize)
-            .setScroll("10m")
-            .get();
+                SearchResponse searchScrollResponse = prepareSearch("index").setSearchType(context.searchType)
+                    .addSort(context.sort)
+                    .setSize(context.scrollRequestSize)
+                    .setScroll("10m")
+                    .get();
+                try {
 
-        assertNoFailures(searchScrollResponse);
-        assertThat(searchScrollResponse.getHits().getTotalHits().value, equalTo((long) context.numDocs));
-        assertThat(searchScrollResponse.getHits().getHits().length, equalTo(context.scrollRequestSize));
+                    assertNoFailures(searchScrollResponse);
+                    assertThat(searchScrollResponse.getHits().getTotalHits().value, equalTo((long) context.numDocs));
+                    assertThat(searchScrollResponse.getHits().getHits().length, equalTo(context.scrollRequestSize));
 
-        int counter = 0;
-        for (SearchHit hit : searchScrollResponse.getHits()) {
-            assertThat(hit.getSortValues()[0], equalTo(sh.getAt(counter++).getSortValues()[0]));
-        }
+                    int counter = 0;
+                    for (SearchHit hit : searchScrollResponse.getHits()) {
+                        assertThat(hit.getSortValues()[0], equalTo(sh.getAt(counter++).getSortValues()[0]));
+                    }
 
-        int iter = 1;
-        String scrollId = searchScrollResponse.getScrollId();
-        while (true) {
-            searchScrollResponse = client().prepareSearchScroll(scrollId).setScroll("10m").get();
-            assertNoFailures(searchScrollResponse);
-            assertThat(searchScrollResponse.getHits().getTotalHits().value, equalTo((long) context.numDocs));
-            if (searchScrollResponse.getHits().getHits().length == 0) {
-                break;
+                    int iter = 1;
+                    String scrollId = searchScrollResponse.getScrollId();
+                    while (true) {
+                        searchScrollResponse.decRef();
+                        searchScrollResponse = client().prepareSearchScroll(scrollId).setScroll("10m").get();
+                        assertNoFailures(searchScrollResponse);
+                        assertThat(searchScrollResponse.getHits().getTotalHits().value, equalTo((long) context.numDocs));
+                        if (searchScrollResponse.getHits().getHits().length == 0) {
+                            break;
+                        }
+
+                        int expectedLength;
+                        int scrollSlice = ++iter * context.scrollRequestSize;
+                        if (scrollSlice <= context.numDocs) {
+                            expectedLength = context.scrollRequestSize;
+                        } else {
+                            expectedLength = context.scrollRequestSize - (scrollSlice - context.numDocs);
+                        }
+                        assertThat(searchScrollResponse.getHits().getHits().length, equalTo(expectedLength));
+                        for (SearchHit hit : searchScrollResponse.getHits()) {
+                            assertThat(hit.getSortValues()[0], equalTo(sh.getAt(counter++).getSortValues()[0]));
+                        }
+                        scrollId = searchScrollResponse.getScrollId();
+                    }
+
+                    assertThat(counter, equalTo(context.numDocs));
+                    clearScroll(scrollId);
+                } finally {
+                    searchScrollResponse.decRef();
+                }
             }
-
-            int expectedLength;
-            int scrollSlice = ++iter * context.scrollRequestSize;
-            if (scrollSlice <= context.numDocs) {
-                expectedLength = context.scrollRequestSize;
-            } else {
-                expectedLength = context.scrollRequestSize - (scrollSlice - context.numDocs);
-            }
-            assertThat(searchScrollResponse.getHits().getHits().length, equalTo(expectedLength));
-            for (SearchHit hit : searchScrollResponse.getHits()) {
-                assertThat(hit.getSortValues()[0], equalTo(sh.getAt(counter++).getSortValues()[0]));
-            }
-            scrollId = searchScrollResponse.getScrollId();
-        }
-
-        assertThat(counter, equalTo(context.numDocs));
-        clearScroll(scrollId);
+        );
     }
 
     private TestContext create(SearchType... searchTypes) throws Exception {
@@ -213,47 +219,51 @@ public class DuelScrollIT extends ESIntegTestCase {
 
     private void testDuelIndexOrder(SearchType searchType, boolean trackScores, int numDocs) throws Exception {
         final int size = scaledRandomIntBetween(5, numDocs + 5);
-        final SearchResponse control = prepareSearch("test").setSearchType(searchType)
-            .setSize(numDocs)
-            .setQuery(QueryBuilders.matchQuery("foo", "true"))
-            .addSort(SortBuilders.fieldSort("_doc"))
-            .setTrackScores(trackScores)
-            .get();
-        assertNoFailures(control);
+        assertNoFailuresAndResponse(
+            prepareSearch("test").setSearchType(searchType)
+                .setSize(numDocs)
+                .setQuery(QueryBuilders.matchQuery("foo", "true"))
+                .addSort(SortBuilders.fieldSort("_doc"))
+                .setTrackScores(trackScores),
+            control -> {
 
-        SearchResponse scroll = prepareSearch("test").setSearchType(searchType)
-            .setSize(size)
-            .setQuery(QueryBuilders.matchQuery("foo", "true"))
-            .addSort(SortBuilders.fieldSort("_doc"))
-            .setTrackScores(trackScores)
-            .setScroll("10m")
-            .get();
+                SearchResponse scroll = prepareSearch("test").setSearchType(searchType)
+                    .setSize(size)
+                    .setQuery(QueryBuilders.matchQuery("foo", "true"))
+                    .addSort(SortBuilders.fieldSort("_doc"))
+                    .setTrackScores(trackScores)
+                    .setScroll("10m")
+                    .get();
 
-        int scrollDocs = 0;
-        try {
-            while (true) {
-                assertNoFailures(scroll);
-                assertEquals(control.getHits().getTotalHits().value, scroll.getHits().getTotalHits().value);
-                assertEquals(control.getHits().getMaxScore(), scroll.getHits().getMaxScore(), 0.01f);
-                if (scroll.getHits().getHits().length == 0) {
-                    break;
+                int scrollDocs = 0;
+                try {
+                    while (true) {
+                        assertNoFailures(scroll);
+                        assertEquals(control.getHits().getTotalHits().value, scroll.getHits().getTotalHits().value);
+                        assertEquals(control.getHits().getMaxScore(), scroll.getHits().getMaxScore(), 0.01f);
+                        if (scroll.getHits().getHits().length == 0) {
+                            break;
+                        }
+                        for (int i = 0; i < scroll.getHits().getHits().length; ++i) {
+                            SearchHit controlHit = control.getHits().getAt(scrollDocs + i);
+                            SearchHit scrollHit = scroll.getHits().getAt(i);
+                            assertEquals(controlHit.getId(), scrollHit.getId());
+                        }
+                        scrollDocs += scroll.getHits().getHits().length;
+                        scroll.decRef();
+                        scroll = client().prepareSearchScroll(scroll.getScrollId()).setScroll("10m").get();
+                    }
+                    assertEquals(control.getHits().getTotalHits().value, scrollDocs);
+                } catch (AssertionError e) {
+                    logger.info("Control:\n{}", control);
+                    logger.info("Scroll size={}, from={}:\n{}", size, scrollDocs, scroll);
+                    throw e;
+                } finally {
+                    clearScroll(scroll.getScrollId());
+                    scroll.decRef();
                 }
-                for (int i = 0; i < scroll.getHits().getHits().length; ++i) {
-                    SearchHit controlHit = control.getHits().getAt(scrollDocs + i);
-                    SearchHit scrollHit = scroll.getHits().getAt(i);
-                    assertEquals(controlHit.getId(), scrollHit.getId());
-                }
-                scrollDocs += scroll.getHits().getHits().length;
-                scroll = client().prepareSearchScroll(scroll.getScrollId()).setScroll("10m").get();
             }
-            assertEquals(control.getHits().getTotalHits().value, scrollDocs);
-        } catch (AssertionError e) {
-            logger.info("Control:\n{}", control);
-            logger.info("Scroll size={}, from={}:\n{}", size, scrollDocs, scroll);
-            throw e;
-        } finally {
-            clearScroll(scroll.getScrollId());
-        }
+        );
     }
 
     public void testDuelIndexOrderQueryThenFetch() throws Exception {

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/scroll/SearchScrollWithFailingNodesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/scroll/SearchScrollWithFailingNodesIT.java
@@ -62,30 +62,37 @@ public class SearchScrollWithFailingNodesIT extends ESIntegTestCase {
             .setSize(10)
             .setScroll(TimeValue.timeValueMinutes(1))
             .get();
-        assertAllSuccessful(searchResponse);
-        long numHits = 0;
-        do {
-            numHits += searchResponse.getHits().getHits().length;
-            searchResponse = client().prepareSearchScroll(searchResponse.getScrollId()).setScroll(TimeValue.timeValueMinutes(1)).get();
+        try {
             assertAllSuccessful(searchResponse);
-        } while (searchResponse.getHits().getHits().length > 0);
-        assertThat(numHits, equalTo(100L));
-        clearScroll("_all");
+            long numHits = 0;
+            do {
+                numHits += searchResponse.getHits().getHits().length;
+                searchResponse.decRef();
+                searchResponse = client().prepareSearchScroll(searchResponse.getScrollId()).setScroll(TimeValue.timeValueMinutes(1)).get();
+                assertAllSuccessful(searchResponse);
+            } while (searchResponse.getHits().getHits().length > 0);
+            assertThat(numHits, equalTo(100L));
+            clearScroll("_all");
 
-        internalCluster().stopRandomNonMasterNode();
+            internalCluster().stopRandomNonMasterNode();
 
-        searchResponse = prepareSearch().setQuery(matchAllQuery()).setSize(10).setScroll(TimeValue.timeValueMinutes(1)).get();
-        assertThat(searchResponse.getSuccessfulShards(), lessThan(searchResponse.getTotalShards()));
-        numHits = 0;
-        int numberOfSuccessfulShards = searchResponse.getSuccessfulShards();
-        do {
-            numHits += searchResponse.getHits().getHits().length;
-            searchResponse = client().prepareSearchScroll(searchResponse.getScrollId()).setScroll(TimeValue.timeValueMinutes(1)).get();
-            assertThat(searchResponse.getSuccessfulShards(), equalTo(numberOfSuccessfulShards));
-        } while (searchResponse.getHits().getHits().length > 0);
-        assertThat(numHits, greaterThan(0L));
+            searchResponse.decRef();
+            searchResponse = prepareSearch().setQuery(matchAllQuery()).setSize(10).setScroll(TimeValue.timeValueMinutes(1)).get();
+            assertThat(searchResponse.getSuccessfulShards(), lessThan(searchResponse.getTotalShards()));
+            numHits = 0;
+            int numberOfSuccessfulShards = searchResponse.getSuccessfulShards();
+            do {
+                numHits += searchResponse.getHits().getHits().length;
+                searchResponse.decRef();
+                searchResponse = client().prepareSearchScroll(searchResponse.getScrollId()).setScroll(TimeValue.timeValueMinutes(1)).get();
+                assertThat(searchResponse.getSuccessfulShards(), equalTo(numberOfSuccessfulShards));
+            } while (searchResponse.getHits().getHits().length > 0);
+            assertThat(numHits, greaterThan(0L));
 
-        clearScroll(searchResponse.getScrollId());
+            clearScroll(searchResponse.getScrollId());
+        } finally {
+            searchResponse.decRef();
+        }
     }
 
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/searchafter/SearchAfterIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/searchafter/SearchAfterIT.java
@@ -50,6 +50,8 @@ import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailuresAndResponse;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.arrayWithSize;
@@ -157,15 +159,18 @@ public class SearchAfterIT extends ESIntegTestCase {
             prepareIndex("test").setId("0").setSource("field1", 0),
             prepareIndex("test").setId("1").setSource("field1", 100, "field2", "toto")
         );
-        SearchResponse searchResponse = prepareSearch("test").addSort("field1", SortOrder.ASC)
-            .addSort("field2", SortOrder.ASC)
-            .setQuery(matchAllQuery())
-            .searchAfter(new Object[] { 0, null })
-            .get();
-        assertThat(searchResponse.getHits().getTotalHits().value, Matchers.equalTo(2L));
-        assertThat(searchResponse.getHits().getHits().length, Matchers.equalTo(1));
-        assertThat(searchResponse.getHits().getHits()[0].getSourceAsMap().get("field1"), Matchers.equalTo(100));
-        assertThat(searchResponse.getHits().getHits()[0].getSourceAsMap().get("field2"), Matchers.equalTo("toto"));
+        assertResponse(
+            prepareSearch("test").addSort("field1", SortOrder.ASC)
+                .addSort("field2", SortOrder.ASC)
+                .setQuery(matchAllQuery())
+                .searchAfter(new Object[] { 0, null }),
+            searchResponse -> {
+                assertThat(searchResponse.getHits().getTotalHits().value, Matchers.equalTo(2L));
+                assertThat(searchResponse.getHits().getHits().length, Matchers.equalTo(1));
+                assertThat(searchResponse.getHits().getHits()[0].getSourceAsMap().get("field1"), Matchers.equalTo(100));
+                assertThat(searchResponse.getHits().getHits()[0].getSourceAsMap().get("field2"), Matchers.equalTo("toto"));
+            }
+        );
     }
 
     public void testWithSimpleTypes() throws Exception {
@@ -229,31 +234,36 @@ public class SearchAfterIT extends ESIntegTestCase {
             .add(new IndexRequest("test").id("5").source("start_date", "2017-01-20", "end_date", "2025-05-28"))
             .get();
 
-        SearchResponse resp = prepareSearch("test").addSort(SortBuilders.fieldSort("start_date").setFormat("dd/MM/yyyy"))
-            .addSort(SortBuilders.fieldSort("end_date").setFormat("yyyy-MM-dd"))
-            .setSize(2)
-            .get();
-        assertNoFailures(resp);
-        assertThat(resp.getHits().getHits()[0].getSortValues(), arrayContaining("22/01/2015", "2022-07-23"));
-        assertThat(resp.getHits().getHits()[1].getSortValues(), arrayContaining("21/02/2016", "2024-03-24"));
+        assertNoFailuresAndResponse(
+            prepareSearch("test").addSort(SortBuilders.fieldSort("start_date").setFormat("dd/MM/yyyy"))
+                .addSort(SortBuilders.fieldSort("end_date").setFormat("yyyy-MM-dd"))
+                .setSize(2),
+            resp -> {
+                assertThat(resp.getHits().getHits()[0].getSortValues(), arrayContaining("22/01/2015", "2022-07-23"));
+                assertThat(resp.getHits().getHits()[1].getSortValues(), arrayContaining("21/02/2016", "2024-03-24"));
+            }
+        );
 
-        resp = prepareSearch("test").addSort(SortBuilders.fieldSort("start_date").setFormat("dd/MM/yyyy"))
-            .addSort(SortBuilders.fieldSort("end_date").setFormat("yyyy-MM-dd"))
-            .searchAfter(new String[] { "21/02/2016", "2024-03-24" })
-            .setSize(2)
-            .get();
-        assertNoFailures(resp);
-        assertThat(resp.getHits().getHits()[0].getSortValues(), arrayContaining("20/01/2017", "2025-05-28"));
-        assertThat(resp.getHits().getHits()[1].getSortValues(), arrayContaining("23/04/2018", "2021-02-22"));
-
-        resp = prepareSearch("test").addSort(SortBuilders.fieldSort("start_date").setFormat("dd/MM/yyyy"))
-            .addSort(SortBuilders.fieldSort("end_date")) // it's okay because end_date has the format "yyyy-MM-dd"
-            .searchAfter(new String[] { "21/02/2016", "2024-03-24" })
-            .setSize(2)
-            .get();
-        assertNoFailures(resp);
-        assertThat(resp.getHits().getHits()[0].getSortValues(), arrayContaining("20/01/2017", 1748390400000L));
-        assertThat(resp.getHits().getHits()[1].getSortValues(), arrayContaining("23/04/2018", 1613952000000L));
+        assertNoFailuresAndResponse(
+            prepareSearch("test").addSort(SortBuilders.fieldSort("start_date").setFormat("dd/MM/yyyy"))
+                .addSort(SortBuilders.fieldSort("end_date").setFormat("yyyy-MM-dd"))
+                .searchAfter(new String[] { "21/02/2016", "2024-03-24" })
+                .setSize(2),
+            resp -> {
+                assertThat(resp.getHits().getHits()[0].getSortValues(), arrayContaining("20/01/2017", "2025-05-28"));
+                assertThat(resp.getHits().getHits()[1].getSortValues(), arrayContaining("23/04/2018", "2021-02-22"));
+            }
+        );
+        assertNoFailuresAndResponse(
+            prepareSearch("test").addSort(SortBuilders.fieldSort("start_date").setFormat("dd/MM/yyyy"))
+                .addSort(SortBuilders.fieldSort("end_date")) // it's okay because end_date has the format "yyyy-MM-dd"
+                .searchAfter(new String[] { "21/02/2016", "2024-03-24" })
+                .setSize(2),
+            resp -> {
+                assertThat(resp.getHits().getHits()[0].getSortValues(), arrayContaining("20/01/2017", 1748390400000L));
+                assertThat(resp.getHits().getHits()[1].getSortValues(), arrayContaining("23/04/2018", 1613952000000L));
+            }
+        );
 
         SearchRequestBuilder searchRequest = prepareSearch("test").addSort(SortBuilders.fieldSort("start_date").setFormat("dd/MM/yyyy"))
             .addSort(SortBuilders.fieldSort("end_date").setFormat("epoch_millis"))
@@ -332,11 +342,15 @@ public class SearchAfterIT extends ESIntegTestCase {
                 req.searchAfter(sortValues);
             }
             SearchResponse searchResponse = req.get();
-            for (SearchHit hit : searchResponse.getHits()) {
-                List<Object> toCompare = convertSortValues(documents.get(offset++));
-                assertThat(LST_COMPARATOR.compare(toCompare, Arrays.asList(hit.getSortValues())), equalTo(0));
+            try {
+                for (SearchHit hit : searchResponse.getHits()) {
+                    List<Object> toCompare = convertSortValues(documents.get(offset++));
+                    assertThat(LST_COMPARATOR.compare(toCompare, Arrays.asList(hit.getSortValues())), equalTo(0));
+                }
+                sortValues = searchResponse.getHits().getHits()[searchResponse.getHits().getHits().length - 1].getSortValues();
+            } finally {
+                searchResponse.decRef();
             }
-            sortValues = searchResponse.getHits().getHits()[searchResponse.getHits().getHits().length - 1].getSortValues();
         }
     }
 
@@ -445,11 +459,13 @@ public class SearchAfterIT extends ESIntegTestCase {
                         assertThat(((Number) timestamp).longValue(), equalTo(timestamps.get(foundHits)));
                         foundHits++;
                     }
+                    resp.decRef();
                     resp = client().prepareSearchScroll(resp.getScrollId()).setScroll(TimeValue.timeValueMinutes(5)).get();
                 } while (resp.getHits().getHits().length > 0);
                 assertThat(foundHits, equalTo(timestamps.size()));
             } finally {
                 client().prepareClearScroll().addScrollId(resp.getScrollId()).get();
+                resp.decRef();
             }
         }
         // search_after with sort with point in time
@@ -479,11 +495,13 @@ public class SearchAfterIT extends ESIntegTestCase {
                     assertNotNull(after);
                     assertThat("Sorted by timestamp and pit tier breaker", after, arrayWithSize(2));
                     searchRequest.source().searchAfter(after);
+                    resp.decRef();
                     resp = client().search(searchRequest).actionGet();
                 } while (resp.getHits().getHits().length > 0);
                 assertThat(foundHits, equalTo(timestamps.size()));
             } finally {
                 client().execute(TransportClosePointInTimeAction.TYPE, new ClosePointInTimeRequest(pitID)).actionGet();
+                resp.decRef();
             }
         }
 
@@ -512,12 +530,14 @@ public class SearchAfterIT extends ESIntegTestCase {
                     assertNotNull(after);
                     assertThat("sorted by pit tie breaker", after, arrayWithSize(1));
                     searchRequest.source().searchAfter(after);
+                    resp.decRef();
                     resp = client().search(searchRequest).actionGet();
                 } while (resp.getHits().getHits().length > 0);
                 Collections.sort(foundSeqNos);
                 assertThat(foundSeqNos, equalTo(timestamps));
             } finally {
                 client().execute(TransportClosePointInTimeAction.TYPE, new ClosePointInTimeRequest(pitID)).actionGet();
+                resp.decRef();
             }
         }
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/slice/SearchSliceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/slice/SearchSliceIT.java
@@ -39,6 +39,7 @@ import java.util.concurrent.ExecutionException;
 
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.startsWith;
@@ -111,8 +112,8 @@ public class SearchSliceIT extends ESIntegTestCase {
         int numShards = 10;
         int totalDocs = randomIntBetween(100, 1000);
         setupIndex(totalDocs, numShards);
-        {
-            SearchResponse sr = prepareSearch("test").setQuery(matchAllQuery()).setPreference("_shards:1,4").setSize(0).get();
+
+        assertResponse(prepareSearch("test").setQuery(matchAllQuery()).setPreference("_shards:1,4").setSize(0), sr -> {
             int numDocs = (int) sr.getHits().getTotalHits().value;
             int max = randomIntBetween(2, numShards * 3);
             int fetchSize = randomIntBetween(10, 100);
@@ -122,9 +123,9 @@ public class SearchSliceIT extends ESIntegTestCase {
                 .setPreference("_shards:1,4")
                 .addSort(SortBuilders.fieldSort("_doc"));
             assertSearchSlicesWithScroll(request, "_id", max, numDocs);
-        }
-        {
-            SearchResponse sr = prepareSearch("test").setQuery(matchAllQuery()).setRouting("foo", "bar").setSize(0).get();
+        });
+
+        assertResponse(prepareSearch("test").setQuery(matchAllQuery()).setRouting("foo", "bar").setSize(0), sr -> {
             int numDocs = (int) sr.getHits().getTotalHits().value;
             int max = randomIntBetween(2, numShards * 3);
             int fetchSize = randomIntBetween(10, 100);
@@ -134,15 +135,15 @@ public class SearchSliceIT extends ESIntegTestCase {
                 .setRouting("foo", "bar")
                 .addSort(SortBuilders.fieldSort("_doc"));
             assertSearchSlicesWithScroll(request, "_id", max, numDocs);
-        }
-        {
-            assertAcked(
-                indicesAdmin().prepareAliases()
-                    .addAliasAction(IndicesAliasesRequest.AliasActions.add().index("test").alias("alias1").routing("foo"))
-                    .addAliasAction(IndicesAliasesRequest.AliasActions.add().index("test").alias("alias2").routing("bar"))
-                    .addAliasAction(IndicesAliasesRequest.AliasActions.add().index("test").alias("alias3").routing("baz"))
-            );
-            SearchResponse sr = prepareSearch("alias1", "alias3").setQuery(matchAllQuery()).setSize(0).get();
+        });
+
+        assertAcked(
+            indicesAdmin().prepareAliases()
+                .addAliasAction(IndicesAliasesRequest.AliasActions.add().index("test").alias("alias1").routing("foo"))
+                .addAliasAction(IndicesAliasesRequest.AliasActions.add().index("test").alias("alias2").routing("bar"))
+                .addAliasAction(IndicesAliasesRequest.AliasActions.add().index("test").alias("alias3").routing("baz"))
+        );
+        assertResponse(prepareSearch("alias1", "alias3").setQuery(matchAllQuery()).setSize(0), sr -> {
             int numDocs = (int) sr.getHits().getTotalHits().value;
             int max = randomIntBetween(2, numShards * 3);
             int fetchSize = randomIntBetween(10, 100);
@@ -151,7 +152,7 @@ public class SearchSliceIT extends ESIntegTestCase {
                 .setSize(fetchSize)
                 .addSort(SortBuilders.fieldSort("_doc"));
             assertSearchSlicesWithScroll(request, "_id", max, numDocs);
-        }
+        });
     }
 
     private void assertSearchSlicesWithScroll(SearchRequestBuilder request, String field, int numSlice, int numDocs) {
@@ -160,27 +161,32 @@ public class SearchSliceIT extends ESIntegTestCase {
         for (int id = 0; id < numSlice; id++) {
             SliceBuilder sliceBuilder = new SliceBuilder(field, id, numSlice);
             SearchResponse searchResponse = request.slice(sliceBuilder).get();
-            totalResults += searchResponse.getHits().getHits().length;
-            int expectedSliceResults = (int) searchResponse.getHits().getTotalHits().value;
-            int numSliceResults = searchResponse.getHits().getHits().length;
-            String scrollId = searchResponse.getScrollId();
-            for (SearchHit hit : searchResponse.getHits().getHits()) {
-                assertTrue(keys.add(hit.getId()));
-            }
-            while (searchResponse.getHits().getHits().length > 0) {
-                searchResponse = client().prepareSearchScroll("test")
-                    .setScrollId(scrollId)
-                    .setScroll(new Scroll(TimeValue.timeValueSeconds(10)))
-                    .get();
-                scrollId = searchResponse.getScrollId();
+            try {
                 totalResults += searchResponse.getHits().getHits().length;
-                numSliceResults += searchResponse.getHits().getHits().length;
+                int expectedSliceResults = (int) searchResponse.getHits().getTotalHits().value;
+                int numSliceResults = searchResponse.getHits().getHits().length;
+                String scrollId = searchResponse.getScrollId();
                 for (SearchHit hit : searchResponse.getHits().getHits()) {
                     assertTrue(keys.add(hit.getId()));
                 }
+                while (searchResponse.getHits().getHits().length > 0) {
+                    searchResponse.decRef();
+                    searchResponse = client().prepareSearchScroll("test")
+                        .setScrollId(scrollId)
+                        .setScroll(new Scroll(TimeValue.timeValueSeconds(10)))
+                        .get();
+                    scrollId = searchResponse.getScrollId();
+                    totalResults += searchResponse.getHits().getHits().length;
+                    numSliceResults += searchResponse.getHits().getHits().length;
+                    for (SearchHit hit : searchResponse.getHits().getHits()) {
+                        assertTrue(keys.add(hit.getId()));
+                    }
+                }
+                assertThat(numSliceResults, equalTo(expectedSliceResults));
+                clearScroll(scrollId);
+            } finally {
+                searchResponse.decRef();
             }
-            assertThat(numSliceResults, equalTo(expectedSliceResults));
-            clearScroll(scrollId);
         }
         assertThat(totalResults, equalTo(numDocs));
         assertThat(keys.size(), equalTo(numDocs));
@@ -222,24 +228,29 @@ public class SearchSliceIT extends ESIntegTestCase {
                 .setSize(randomIntBetween(10, 100));
 
             SearchResponse searchResponse = request.get();
-            int expectedSliceResults = (int) searchResponse.getHits().getTotalHits().value;
+            try {
+                int expectedSliceResults = (int) searchResponse.getHits().getTotalHits().value;
 
-            while (true) {
-                int numHits = searchResponse.getHits().getHits().length;
-                if (numHits == 0) {
-                    break;
+                while (true) {
+                    int numHits = searchResponse.getHits().getHits().length;
+                    if (numHits == 0) {
+                        break;
+                    }
+
+                    totalResults += numHits;
+                    numSliceResults += numHits;
+                    for (SearchHit hit : searchResponse.getHits().getHits()) {
+                        assertTrue(keys.add(hit.getId()));
+                    }
+
+                    Object[] sortValues = searchResponse.getHits().getHits()[numHits - 1].getSortValues();
+                    searchResponse.decRef();
+                    searchResponse = request.searchAfter(sortValues).get();
                 }
-
-                totalResults += numHits;
-                numSliceResults += numHits;
-                for (SearchHit hit : searchResponse.getHits().getHits()) {
-                    assertTrue(keys.add(hit.getId()));
-                }
-
-                Object[] sortValues = searchResponse.getHits().getHits()[numHits - 1].getSortValues();
-                searchResponse = request.searchAfter(sortValues).get();
+                assertThat(numSliceResults, equalTo(expectedSliceResults));
+            } finally {
+                searchResponse.decRef();
             }
-            assertThat(numSliceResults, equalTo(expectedSliceResults));
         }
         assertThat(totalResults, equalTo(numDocs));
         assertThat(keys.size(), equalTo(numDocs));

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/source/MetadataFetchingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/source/MetadataFetchingIT.java
@@ -86,8 +86,8 @@ public class MetadataFetchingIT extends ESIntegTestCase {
             assertThat(response.getHits().getAt(0).getId(), nullValue());
             assertThat(response.getHits().getAt(0).field("_routing"), nullValue());
             assertThat(response.getHits().getAt(0).getSourceAsString(), nullValue());
-
-            response = prepareSearch("test").storedFields("_none_").get();
+        });
+        assertResponse(prepareSearch("test").storedFields("_none_"), response -> {
             assertThat(response.getHits().getAt(0).getId(), nullValue());
             assertThat(response.getHits().getAt(0).getSourceAsString(), nullValue());
         });

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/stats/FieldUsageStatsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/stats/FieldUsageStatsIT.java
@@ -119,7 +119,8 @@ public class FieldUsageStatsIT extends ESIntegTestCase {
             .addAggregation(AggregationBuilders.terms("agg1").field("field.keyword"))
             .setSize(0)
             .setPreference("fixed")
-            .get();
+            .get()
+            .decRef();
 
         stats = aggregated(client().execute(FieldUsageStatsAction.INSTANCE, new FieldUsageStatsRequest()).get().getStats().get("test"));
         logger.info("Stats after second query: {}", stats);
@@ -148,7 +149,8 @@ public class FieldUsageStatsIT extends ESIntegTestCase {
             .setQuery(QueryBuilders.rangeQuery("date_field").from("2016/01/01"))
             .setSize(100)
             .setPreference("fixed")
-            .get();
+            .get()
+            .decRef();
 
         stats = aggregated(client().execute(FieldUsageStatsAction.INSTANCE, new FieldUsageStatsRequest()).get().getStats().get("test"));
         logger.info("Stats after third query: {}", stats);

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
@@ -55,6 +55,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertFileExists;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
@@ -953,7 +954,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
             indexDoc(testIndex, Integer.toString(i), "foo", "bar" + i);
         }
         refresh();
-        assertThat(prepareSearch(testIndex).setSize(0).get().getHits().getTotalHits().value, equalTo(100L));
+        assertHitCount(prepareSearch(testIndex).setSize(0), 100);
 
         logger.info("--> start relocations");
         allowNodes(testIndex, 1);

--- a/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESBlobStoreRepositoryIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/ESBlobStoreRepositoryIntegTestCase.java
@@ -331,7 +331,13 @@ public abstract class ESBlobStoreRepositoryIntegTestCase extends ESIntegTestCase
                     logger.info("--> add random documents to {}", index);
                     addRandomDocuments(index, randomIntBetween(10, 1000));
                 } else {
-                    int docCount = (int) prepareSearch(index).setSize(0).get().getHits().getTotalHits().value;
+                    var resp = prepareSearch(index).setSize(0).get();
+                    final int docCount;
+                    try {
+                        docCount = (int) resp.getHits().getTotalHits().value;
+                    } finally {
+                        resp.decRef();
+                    }
                     int deleteCount = randomIntBetween(1, docCount);
                     logger.info("--> delete {} random documents from {}", deleteCount, index);
                     for (int i = 0; i < deleteCount; i++) {
@@ -401,7 +407,12 @@ public abstract class ESBlobStoreRepositoryIntegTestCase extends ESIntegTestCase
                 addRandomDocuments(indexName, docCount);
             }
             // Check number of documents in this iteration
-            docCounts[i] = (int) prepareSearch(indexName).setSize(0).get().getHits().getTotalHits().value;
+            var resp = prepareSearch(indexName).setSize(0).get();
+            try {
+                docCounts[i] = (int) resp.getHits().getTotalHits().value;
+            } finally {
+                resp.decRef();
+            }
             logger.info("-->  create snapshot {}:{} with {} documents", repoName, snapshotName + "-" + i, docCounts[i]);
             assertSuccessfulSnapshot(
                 clusterAdmin().prepareCreateSnapshot(repoName, snapshotName + "-" + i).setWaitForCompletion(true).setIndices(indexName)

--- a/test/framework/src/main/java/org/elasticsearch/search/geo/BaseShapeIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/geo/BaseShapeIntegTestCase.java
@@ -262,7 +262,7 @@ public abstract class BaseShapeIntegTestCase<T extends AbstractGeometryQueryBuil
 
             // Set search.allow_expensive_queries to "null"
             updateClusterSettings(Settings.builder().put("search.allow_expensive_queries", (String) null));
-            assertThat(builder.get().getHits().getTotalHits().value, equalTo(1L));
+            assertHitCount(builder, 1);
 
             // Set search.allow_expensive_queries to "true"
             updateClusterSettings(Settings.builder().put("search.allow_expensive_queries", true));

--- a/test/framework/src/main/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
@@ -502,9 +502,14 @@ public abstract class AbstractSnapshotIntegTestCase extends ESIntegTestCase {
     }
 
     protected long getCountForIndex(String indexName) {
-        return client().search(
+        var resp = client().search(
             new SearchRequest(new SearchRequest(indexName).source(new SearchSourceBuilder().size(0).trackTotalHits(true)))
-        ).actionGet().getHits().getTotalHits().value;
+        ).actionGet();
+        try {
+            return resp.getHits().getTotalHits().value;
+        } finally {
+            resp.decRef();
+        }
     }
 
     protected void assertDocCount(String index, long count) {


### PR DESCRIPTION
This should be the last round for this module, found these using a prototype that has `SearchResponse` ref-counted already.

Tried to keep it as simple as possible, using `assertResponse` where possible. When it wasn't reasonable to use it or otherwise not the best option:
* try-finally in case variables got assigned
* shortened lots of hit-count assertions
* used dec-ref before reassigning variables in a couple tests that reused the same var for the search response in a loop, not the nicest but definitely the easiest to review option

