### PR TITLE
Fix failing to release ref-count after resolving ActionListener

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/ActionListener.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionListener.java
@@ -16,6 +16,7 @@ import org.elasticsearch.core.Assertions;
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.core.CheckedFunction;
 import org.elasticsearch.core.CheckedRunnable;
+import org.elasticsearch.core.RefCounted;
 import org.elasticsearch.core.Releasable;
 
 import java.util.ArrayList;
@@ -306,6 +307,18 @@ public interface ActionListener<Response> {
         } catch (RuntimeException ex) {
             assert false : ex;
             throw ex;
+        }
+    }
+
+    /**
+     * Shorthand for resolving given {@code listener} with given {@code response} and decrementing the response's ref count by one
+     * afterwards.
+     */
+    static <R extends RefCounted> void respondAndRelease(ActionListener<R> listener, R response) {
+        try {
+            listener.onResponse(response);
+        } finally {
+            response.decRef();
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/action/ActionRunnable.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionRunnable.java
@@ -70,12 +70,7 @@ public abstract class ActionRunnable<Response> extends AbstractRunnable {
         return wrap(listener, new CheckedConsumer<>() {
             @Override
             public void accept(ActionListener<T> l) throws Exception {
-                var res = supplier.get();
-                try {
-                    l.onResponse(res);
-                } finally {
-                    res.decRef();
-                }
+                ActionListener.respondAndRelease(l, supplier.get());
             }
 
             @Override

--- a/server/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
@@ -700,7 +700,7 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
                     searchContextId = null;
                 }
             }
-            listener.onResponse(buildSearchResponse(internalSearchResponse, failures, scrollId, searchContextId));
+            ActionListener.respondAndRelease(listener, buildSearchResponse(internalSearchResponse, failures, scrollId, searchContextId));
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/action/search/SearchScrollAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchScrollAsyncAction.java
@@ -247,7 +247,8 @@ abstract class SearchScrollAsyncAction<T extends SearchPhaseResult> implements R
             if (request.scroll() != null) {
                 scrollId = request.scrollId();
             }
-            listener.onResponse(
+            ActionListener.respondAndRelease(
+                listener,
                 new SearchResponse(
                     internalResponse,
                     scrollId,

--- a/server/src/main/java/org/elasticsearch/action/search/TransportMultiSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportMultiSearchAction.java
@@ -186,15 +186,10 @@ public class TransportMultiSearchAction extends HandledTransportAction<MultiSear
             }
 
             private void finish() {
-                final var response = new MultiSearchResponse(
-                    responses.toArray(new MultiSearchResponse.Item[responses.length()]),
-                    buildTookInMillis()
+                ActionListener.respondAndRelease(
+                    listener,
+                    new MultiSearchResponse(responses.toArray(new MultiSearchResponse.Item[responses.length()]), buildTookInMillis())
                 );
-                try {
-                    listener.onResponse(response);
-                } finally {
-                    response.decRef();
-                }
             }
 
             /**

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -549,8 +549,8 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                         searchResponse.isTerminatedEarly(),
                         searchResponse.getNumReducePhases()
                     );
-
-                    listener.onResponse(
+                    ActionListener.respondAndRelease(
+                        listener,
                         new SearchResponse(
                             internalSearchResponse,
                             searchResponse.getScrollId(),
@@ -571,7 +571,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                     logCCSError(failure, clusterAlias, skipUnavailable);
                     ccsClusterInfoUpdate(failure, clusters, clusterAlias, skipUnavailable);
                     if (skipUnavailable) {
-                        listener.onResponse(SearchResponse.empty(timeProvider::buildTookInMillis, clusters));
+                        ActionListener.respondAndRelease(listener, SearchResponse.empty(timeProvider::buildTookInMillis, clusters));
                     } else {
                         listener.onFailure(wrapRemoteClusterFailure(clusterAlias, e));
                     }

--- a/server/src/test/java/org/elasticsearch/action/search/ExpandSearchPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/ExpandSearchPhaseTests.java
@@ -102,15 +102,10 @@ public class ExpandSearchPhaseTests extends ESTestCase {
                         mSearchResponses.add(new MultiSearchResponse.Item(mockSearchPhaseContext.searchResponse.get(), null));
                     }
 
-                    var response = new MultiSearchResponse(
-                        mSearchResponses.toArray(new MultiSearchResponse.Item[0]),
-                        randomIntBetween(1, 10000)
+                    ActionListener.respondAndRelease(
+                        listener,
+                        new MultiSearchResponse(mSearchResponses.toArray(new MultiSearchResponse.Item[0]), randomIntBetween(1, 10000))
                     );
-                    try {
-                        listener.onResponse(response);
-                    } finally {
-                        response.decRef();
-                    }
                 }
             };
 
@@ -170,17 +165,15 @@ public class ExpandSearchPhaseTests extends ESTestCase {
                     ShardSearchFailure.EMPTY_ARRAY,
                     SearchResponse.Clusters.EMPTY
                 );
-                var response = new MultiSearchResponse(
-                    new MultiSearchResponse.Item[] {
-                        new MultiSearchResponse.Item(null, new RuntimeException("boom")),
-                        new MultiSearchResponse.Item(searchResponse, null) },
-                    randomIntBetween(1, 10000)
+                ActionListener.respondAndRelease(
+                    listener,
+                    new MultiSearchResponse(
+                        new MultiSearchResponse.Item[] {
+                            new MultiSearchResponse.Item(null, new RuntimeException("boom")),
+                            new MultiSearchResponse.Item(searchResponse, null) },
+                        randomIntBetween(1, 10000)
+                    )
                 );
-                try {
-                    listener.onResponse(response);
-                } finally {
-                    response.decRef();
-                }
             }
         };
 

--- a/server/src/test/java/org/elasticsearch/action/search/FetchLookupFieldsPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/FetchLookupFieldsPhaseTests.java
@@ -119,12 +119,7 @@ public class FetchLookupFieldsPhaseTests extends ESTestCase {
                         null
                     );
                 }
-                var response = new MultiSearchResponse(responses, randomNonNegativeLong());
-                try {
-                    listener.onResponse(response);
-                } finally {
-                    response.decRef();
-                }
+                ActionListener.respondAndRelease(listener, new MultiSearchResponse(responses, randomNonNegativeLong()));
             }
         };
 

--- a/server/src/test/java/org/elasticsearch/action/search/MultiSearchActionTookTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/MultiSearchActionTookTests.java
@@ -147,21 +147,19 @@ public class MultiSearchActionTookTests extends ESTestCase {
                 requests.add(request);
                 commonExecutor.execute(() -> {
                     counter.decrementAndGet();
-                    var resp = new SearchResponse(
-                        InternalSearchResponse.EMPTY_WITH_TOTAL_HITS,
-                        null,
-                        0,
-                        0,
-                        0,
-                        0L,
-                        ShardSearchFailure.EMPTY_ARRAY,
-                        SearchResponse.Clusters.EMPTY
+                    ActionListener.respondAndRelease(
+                        listener,
+                        new SearchResponse(
+                            InternalSearchResponse.EMPTY_WITH_TOTAL_HITS,
+                            null,
+                            0,
+                            0,
+                            0,
+                            0L,
+                            ShardSearchFailure.EMPTY_ARRAY,
+                            SearchResponse.Clusters.EMPTY
+                        )
                     );
-                    try {
-                        listener.onResponse(resp);
-                    } finally {
-                        resp.decRef();
-                    }
                 });
             }
 

--- a/server/src/test/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncActionTests.java
@@ -157,13 +157,7 @@ public class SearchQueryThenFetchAsyncActionTests extends ESTestCase {
                     queryResult.size(1);
                     successfulOps.incrementAndGet();
                     queryResult.incRef();
-                    new Thread(() -> {
-                        try {
-                            listener.onResponse(queryResult);
-                        } finally {
-                            queryResult.decRef();
-                        }
-                    }).start();
+                    new Thread(() -> ActionListener.respondAndRelease(listener, queryResult)).start();
                 } finally {
                     queryResult.decRef();
                 }

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/AsyncSearchTask.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/AsyncSearchTask.java
@@ -201,7 +201,7 @@ final class AsyncSearchTask extends SearchTask implements AsyncTask {
             }
         }
         if (executeImmediately) {
-            listener.onResponse(getResponseWithHeaders());
+            ActionListener.respondAndRelease(listener, getResponseWithHeaders());
         }
     }
 
@@ -238,7 +238,7 @@ final class AsyncSearchTask extends SearchTask implements AsyncTask {
                         if (hasRun.compareAndSet(false, true)) {
                             // timeout occurred before completion
                             removeCompletionListener(id);
-                            listener.onResponse(getResponseWithHeaders());
+                            ActionListener.respondAndRelease(listener, getResponseWithHeaders());
                         }
                     }, waitForCompletion, threadPool.generic());
                 } catch (Exception exc) {
@@ -255,7 +255,7 @@ final class AsyncSearchTask extends SearchTask implements AsyncTask {
             }
         }
         if (executeImmediately) {
-            listener.onResponse(getResponseWithHeaders());
+            ActionListener.respondAndRelease(listener, getResponseWithHeaders());
         }
     }
 

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/repositories/GetCcrRestoreFileChunkAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/repositories/GetCcrRestoreFileChunkAction.java
@@ -85,12 +85,7 @@ public class GetCcrRestoreFileChunkAction extends ActionType<GetCcrRestoreFileCh
                 try (CcrRestoreSourceService.SessionReader sessionReader = restoreSourceService.getSessionReader(sessionUUID)) {
                     long offsetAfterRead = sessionReader.readFileBytes(fileName, reference);
                     long offsetBeforeRead = offsetAfterRead - reference.length();
-                    var chunk = new GetCcrRestoreFileChunkResponse(offsetBeforeRead, reference);
-                    try {
-                        listener.onResponse(chunk);
-                    } finally {
-                        chunk.decRef();
-                    }
+                    ActionListener.respondAndRelease(listener, new GetCcrRestoreFileChunkResponse(offsetBeforeRead, reference));
                 }
             } catch (IOException e) {
                 listener.onFailure(e);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/OwningChannelActionListener.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/OwningChannelActionListener.java
@@ -28,11 +28,7 @@ public final class OwningChannelActionListener<Response extends TransportRespons
 
     @Override
     public void onResponse(Response response) {
-        try {
-            listener.onResponse(response);
-        } finally {
-            response.decRef();
-        }
+        ActionListener.respondAndRelease(listener, response);
     }
 
     @Override

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProviderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProviderTests.java
@@ -948,15 +948,13 @@ public class JobResultsProviderTests extends ESTestCase {
             queryBuilderConsumer.accept(multiSearchRequest.requests().get(0).source().query());
             @SuppressWarnings("unchecked")
             ActionListener<MultiSearchResponse> actionListener = (ActionListener<MultiSearchResponse>) invocationOnMock.getArguments()[1];
-            MultiSearchResponse mresponse = new MultiSearchResponse(
-                new MultiSearchResponse.Item[] { new MultiSearchResponse.Item(response, null) },
-                randomNonNegativeLong()
+            ActionListener.respondAndRelease(
+                actionListener,
+                new MultiSearchResponse(
+                    new MultiSearchResponse.Item[] { new MultiSearchResponse.Item(response, null) },
+                    randomNonNegativeLong()
+                )
             );
-            try {
-                actionListener.onResponse(mresponse);
-            } finally {
-                mresponse.decRef();
-            }
             return null;
         }).when(client).multiSearch(any(), any());
         doAnswer(invocationOnMock -> {

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportRollupSearchAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportRollupSearchAction.java
@@ -143,7 +143,7 @@ public class TransportRollupSearchAction extends TransportAction<SearchRequest, 
                     );
                 }
             };
-            listener.onResponse(processResponses(rollupSearchContext, msearchResponse, reduceContextBuilder));
+            ActionListener.respondAndRelease(listener, processResponses(rollupSearchContext, msearchResponse, reduceContextBuilder));
         }, listener::onFailure));
     }
 


### PR DESCRIPTION
Fixing a couple of spots that I found by making `SearchResponse` actually ref-counted, where we missed decrementing a ref-count after passing a just constructed object to a listener.
Added short-cut utility for this to `ActionListener` because this pattern is already all over the place and will become even more common shortly as the search response ref-counting work is progressing.

non-issue for now since this wasn't actually causing any bugs