### PR TITLE
Introduce local block factory

### DIFF
--- a/docs/changelog/102901.yaml
+++ b/docs/changelog/102901.yaml
@@ -1,0 +1,5 @@
+pr: 102901
+summary: Introduce local block factory
+area: ES|QL
+type: enhancement
+issues: []

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayBlock.java
@@ -50,7 +50,7 @@ public final class BooleanArrayBlock extends AbstractArrayBlock implements Boole
 
     @Override
     public BooleanBlock filter(int... positions) {
-        try (var builder = blockFactory.newBooleanBlockBuilder(positions.length)) {
+        try (var builder = blockFactory().newBooleanBlockBuilder(positions.length)) {
             for (int pos : positions) {
                 if (isNull(pos)) {
                     builder.appendNull();
@@ -84,7 +84,7 @@ public final class BooleanArrayBlock extends AbstractArrayBlock implements Boole
             return this;
         }
         // TODO use reference counting to share the values
-        try (var builder = blockFactory.newBooleanBlockBuilder(firstValueIndexes[getPositionCount()])) {
+        try (var builder = blockFactory().newBooleanBlockBuilder(firstValueIndexes[getPositionCount()])) {
             for (int pos = 0; pos < getPositionCount(); pos++) {
                 if (isNull(pos)) {
                     builder.appendNull();
@@ -137,6 +137,6 @@ public final class BooleanArrayBlock extends AbstractArrayBlock implements Boole
 
     @Override
     public void closeInternal() {
-        blockFactory.adjustBreaker(-ramBytesUsed(), true);
+        blockFactory().adjustBreaker(-ramBytesUsed(), true);
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayVector.java
@@ -55,7 +55,7 @@ public final class BooleanArrayVector extends AbstractVector implements BooleanV
 
     @Override
     public BooleanVector filter(int... positions) {
-        try (BooleanVector.Builder builder = blockFactory.newBooleanVectorBuilder(positions.length)) {
+        try (BooleanVector.Builder builder = blockFactory().newBooleanVectorBuilder(positions.length)) {
             for (int pos : positions) {
                 builder.appendBoolean(values[pos]);
             }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBigArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBigArrayVector.java
@@ -60,6 +60,7 @@ public final class BooleanBigArrayVector extends AbstractVector implements Boole
 
     @Override
     public BooleanVector filter(int... positions) {
+        var blockFactory = blockFactory();
         final BitArray filtered = new BitArray(positions.length, blockFactory.bigArrays());
         for (int i = 0; i < positions.length; i++) {
             if (values.get(positions[i])) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVectorBlock.java
@@ -83,4 +83,9 @@ public final class BooleanVectorBlock extends AbstractVectorBlock implements Boo
         assert (vector.isReleased() == false) : "can't release block [" + this + "] containing already released vector";
         Releasables.closeExpectNoException(vector);
     }
+
+    @Override
+    public void allowPassingToDifferentDriver() {
+        vector.allowPassingToDifferentDriver();
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayBlock.java
@@ -53,7 +53,7 @@ public final class BytesRefArrayBlock extends AbstractArrayBlock implements Byte
     @Override
     public BytesRefBlock filter(int... positions) {
         final BytesRef scratch = new BytesRef();
-        try (var builder = blockFactory.newBytesRefBlockBuilder(positions.length)) {
+        try (var builder = blockFactory().newBytesRefBlockBuilder(positions.length)) {
             for (int pos : positions) {
                 if (isNull(pos)) {
                     builder.appendNull();
@@ -88,7 +88,7 @@ public final class BytesRefArrayBlock extends AbstractArrayBlock implements Byte
         }
         // TODO use reference counting to share the values
         final BytesRef scratch = new BytesRef();
-        try (var builder = blockFactory.newBytesRefBlockBuilder(firstValueIndexes[getPositionCount()])) {
+        try (var builder = blockFactory().newBytesRefBlockBuilder(firstValueIndexes[getPositionCount()])) {
             for (int pos = 0; pos < getPositionCount(); pos++) {
                 if (isNull(pos)) {
                     builder.appendNull();
@@ -141,7 +141,7 @@ public final class BytesRefArrayBlock extends AbstractArrayBlock implements Byte
 
     @Override
     public void closeInternal() {
-        blockFactory.adjustBreaker(-ramBytesUsed() + values.bigArraysRamBytesUsed(), true);
+        blockFactory().adjustBreaker(-ramBytesUsed() + values.bigArraysRamBytesUsed(), true);
         Releasables.closeExpectNoException(values);
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayVector.java
@@ -57,7 +57,7 @@ public final class BytesRefArrayVector extends AbstractVector implements BytesRe
     @Override
     public BytesRefVector filter(int... positions) {
         final var scratch = new BytesRef();
-        try (BytesRefVector.Builder builder = blockFactory.newBytesRefVectorBuilder(positions.length)) {
+        try (BytesRefVector.Builder builder = blockFactory().newBytesRefVectorBuilder(positions.length)) {
             for (int pos : positions) {
                 builder.appendBytesRef(values.get(pos, scratch));
             }
@@ -98,7 +98,7 @@ public final class BytesRefArrayVector extends AbstractVector implements BytesRe
             throw new IllegalStateException("can't release already released vector [" + this + "]");
         }
         released = true;
-        blockFactory.adjustBreaker(-ramBytesUsed() + values.bigArraysRamBytesUsed(), true);
+        blockFactory().adjustBreaker(-ramBytesUsed() + values.bigArraysRamBytesUsed(), true);
         Releasables.closeExpectNoException(values);
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVectorBlock.java
@@ -84,4 +84,9 @@ public final class BytesRefVectorBlock extends AbstractVectorBlock implements By
         assert (vector.isReleased() == false) : "can't release block [" + this + "] containing already released vector";
         Releasables.closeExpectNoException(vector);
     }
+
+    @Override
+    public void allowPassingToDifferentDriver() {
+        vector.allowPassingToDifferentDriver();
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantBooleanVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantBooleanVector.java
@@ -84,6 +84,6 @@ public final class ConstantBooleanVector extends AbstractVector implements Boole
             throw new IllegalStateException("can't release already released vector [" + this + "]");
         }
         released = true;
-        blockFactory.adjustBreaker(-ramBytesUsed(), true);
+        blockFactory().adjustBreaker(-ramBytesUsed(), true);
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantBytesRefVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantBytesRefVector.java
@@ -89,6 +89,6 @@ public final class ConstantBytesRefVector extends AbstractVector implements Byte
             throw new IllegalStateException("can't release already released vector [" + this + "]");
         }
         released = true;
-        blockFactory.adjustBreaker(-ramBytesUsed(), true);
+        blockFactory().adjustBreaker(-ramBytesUsed(), true);
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantDoubleVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantDoubleVector.java
@@ -84,6 +84,6 @@ public final class ConstantDoubleVector extends AbstractVector implements Double
             throw new IllegalStateException("can't release already released vector [" + this + "]");
         }
         released = true;
-        blockFactory.adjustBreaker(-ramBytesUsed(), true);
+        blockFactory().adjustBreaker(-ramBytesUsed(), true);
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantIntVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantIntVector.java
@@ -84,6 +84,6 @@ public final class ConstantIntVector extends AbstractVector implements IntVector
             throw new IllegalStateException("can't release already released vector [" + this + "]");
         }
         released = true;
-        blockFactory.adjustBreaker(-ramBytesUsed(), true);
+        blockFactory().adjustBreaker(-ramBytesUsed(), true);
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantLongVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantLongVector.java
@@ -84,6 +84,6 @@ public final class ConstantLongVector extends AbstractVector implements LongVect
             throw new IllegalStateException("can't release already released vector [" + this + "]");
         }
         released = true;
-        blockFactory.adjustBreaker(-ramBytesUsed(), true);
+        blockFactory().adjustBreaker(-ramBytesUsed(), true);
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayBlock.java
@@ -50,7 +50,7 @@ public final class DoubleArrayBlock extends AbstractArrayBlock implements Double
 
     @Override
     public DoubleBlock filter(int... positions) {
-        try (var builder = blockFactory.newDoubleBlockBuilder(positions.length)) {
+        try (var builder = blockFactory().newDoubleBlockBuilder(positions.length)) {
             for (int pos : positions) {
                 if (isNull(pos)) {
                     builder.appendNull();
@@ -84,7 +84,7 @@ public final class DoubleArrayBlock extends AbstractArrayBlock implements Double
             return this;
         }
         // TODO use reference counting to share the values
-        try (var builder = blockFactory.newDoubleBlockBuilder(firstValueIndexes[getPositionCount()])) {
+        try (var builder = blockFactory().newDoubleBlockBuilder(firstValueIndexes[getPositionCount()])) {
             for (int pos = 0; pos < getPositionCount(); pos++) {
                 if (isNull(pos)) {
                     builder.appendNull();
@@ -137,6 +137,6 @@ public final class DoubleArrayBlock extends AbstractArrayBlock implements Double
 
     @Override
     public void closeInternal() {
-        blockFactory.adjustBreaker(-ramBytesUsed(), true);
+        blockFactory().adjustBreaker(-ramBytesUsed(), true);
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayVector.java
@@ -55,7 +55,7 @@ public final class DoubleArrayVector extends AbstractVector implements DoubleVec
 
     @Override
     public DoubleVector filter(int... positions) {
-        try (DoubleVector.Builder builder = blockFactory.newDoubleVectorBuilder(positions.length)) {
+        try (DoubleVector.Builder builder = blockFactory().newDoubleVectorBuilder(positions.length)) {
             for (int pos : positions) {
                 builder.appendDouble(values[pos]);
             }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBigArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBigArrayVector.java
@@ -60,6 +60,7 @@ public final class DoubleBigArrayVector extends AbstractVector implements Double
 
     @Override
     public DoubleVector filter(int... positions) {
+        var blockFactory = blockFactory();
         final DoubleArray filtered = blockFactory.bigArrays().newDoubleArray(positions.length, true);
         for (int i = 0; i < positions.length; i++) {
             filtered.set(i, values.get(positions[i]));

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleVectorBlock.java
@@ -83,4 +83,9 @@ public final class DoubleVectorBlock extends AbstractVectorBlock implements Doub
         assert (vector.isReleased() == false) : "can't release block [" + this + "] containing already released vector";
         Releasables.closeExpectNoException(vector);
     }
+
+    @Override
+    public void allowPassingToDifferentDriver() {
+        vector.allowPassingToDifferentDriver();
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayBlock.java
@@ -50,7 +50,7 @@ public final class IntArrayBlock extends AbstractArrayBlock implements IntBlock 
 
     @Override
     public IntBlock filter(int... positions) {
-        try (var builder = blockFactory.newIntBlockBuilder(positions.length)) {
+        try (var builder = blockFactory().newIntBlockBuilder(positions.length)) {
             for (int pos : positions) {
                 if (isNull(pos)) {
                     builder.appendNull();
@@ -84,7 +84,7 @@ public final class IntArrayBlock extends AbstractArrayBlock implements IntBlock 
             return this;
         }
         // TODO use reference counting to share the values
-        try (var builder = blockFactory.newIntBlockBuilder(firstValueIndexes[getPositionCount()])) {
+        try (var builder = blockFactory().newIntBlockBuilder(firstValueIndexes[getPositionCount()])) {
             for (int pos = 0; pos < getPositionCount(); pos++) {
                 if (isNull(pos)) {
                     builder.appendNull();
@@ -137,6 +137,6 @@ public final class IntArrayBlock extends AbstractArrayBlock implements IntBlock 
 
     @Override
     public void closeInternal() {
-        blockFactory.adjustBreaker(-ramBytesUsed(), true);
+        blockFactory().adjustBreaker(-ramBytesUsed(), true);
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayVector.java
@@ -55,7 +55,7 @@ public final class IntArrayVector extends AbstractVector implements IntVector {
 
     @Override
     public IntVector filter(int... positions) {
-        try (IntVector.Builder builder = blockFactory.newIntVectorBuilder(positions.length)) {
+        try (IntVector.Builder builder = blockFactory().newIntVectorBuilder(positions.length)) {
             for (int pos : positions) {
                 builder.appendInt(values[pos]);
             }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBigArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBigArrayVector.java
@@ -60,6 +60,7 @@ public final class IntBigArrayVector extends AbstractVector implements IntVector
 
     @Override
     public IntVector filter(int... positions) {
+        var blockFactory = blockFactory();
         final IntArray filtered = blockFactory.bigArrays().newIntArray(positions.length, true);
         for (int i = 0; i < positions.length; i++) {
             filtered.set(i, values.get(positions[i]));

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVectorBlock.java
@@ -83,4 +83,9 @@ public final class IntVectorBlock extends AbstractVectorBlock implements IntBloc
         assert (vector.isReleased() == false) : "can't release block [" + this + "] containing already released vector";
         Releasables.closeExpectNoException(vector);
     }
+
+    @Override
+    public void allowPassingToDifferentDriver() {
+        vector.allowPassingToDifferentDriver();
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayBlock.java
@@ -50,7 +50,7 @@ public final class LongArrayBlock extends AbstractArrayBlock implements LongBloc
 
     @Override
     public LongBlock filter(int... positions) {
-        try (var builder = blockFactory.newLongBlockBuilder(positions.length)) {
+        try (var builder = blockFactory().newLongBlockBuilder(positions.length)) {
             for (int pos : positions) {
                 if (isNull(pos)) {
                     builder.appendNull();
@@ -84,7 +84,7 @@ public final class LongArrayBlock extends AbstractArrayBlock implements LongBloc
             return this;
         }
         // TODO use reference counting to share the values
-        try (var builder = blockFactory.newLongBlockBuilder(firstValueIndexes[getPositionCount()])) {
+        try (var builder = blockFactory().newLongBlockBuilder(firstValueIndexes[getPositionCount()])) {
             for (int pos = 0; pos < getPositionCount(); pos++) {
                 if (isNull(pos)) {
                     builder.appendNull();
@@ -137,6 +137,6 @@ public final class LongArrayBlock extends AbstractArrayBlock implements LongBloc
 
     @Override
     public void closeInternal() {
-        blockFactory.adjustBreaker(-ramBytesUsed(), true);
+        blockFactory().adjustBreaker(-ramBytesUsed(), true);
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayVector.java
@@ -55,7 +55,7 @@ public final class LongArrayVector extends AbstractVector implements LongVector 
 
     @Override
     public LongVector filter(int... positions) {
-        try (LongVector.Builder builder = blockFactory.newLongVectorBuilder(positions.length)) {
+        try (LongVector.Builder builder = blockFactory().newLongVectorBuilder(positions.length)) {
             for (int pos : positions) {
                 builder.appendLong(values[pos]);
             }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBigArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBigArrayVector.java
@@ -60,6 +60,7 @@ public final class LongBigArrayVector extends AbstractVector implements LongVect
 
     @Override
     public LongVector filter(int... positions) {
+        var blockFactory = blockFactory();
         final LongArray filtered = blockFactory.bigArrays().newLongArray(positions.length, true);
         for (int i = 0; i < positions.length; i++) {
             filtered.set(i, values.get(positions[i]));

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVectorBlock.java
@@ -83,4 +83,9 @@ public final class LongVectorBlock extends AbstractVectorBlock implements LongBl
         assert (vector.isReleased() == false) : "can't release block [" + this + "] containing already released vector";
         Releasables.closeExpectNoException(vector);
     }
+
+    @Override
+    public void allowPassingToDifferentDriver() {
+        vector.allowPassingToDifferentDriver();
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AbstractBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AbstractBlock.java
@@ -21,7 +21,7 @@ abstract class AbstractBlock implements Block {
     @Nullable
     protected final BitSet nullsMask;
 
-    protected final BlockFactory blockFactory;
+    private BlockFactory blockFactory;
 
     /**
      * @param positionCount the number of values in this block
@@ -93,6 +93,11 @@ abstract class AbstractBlock implements Block {
     @Override
     public BlockFactory blockFactory() {
         return blockFactory;
+    }
+
+    @Override
+    public void allowPassingToDifferentDriver() {
+        blockFactory = blockFactory.parent();
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AbstractVector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AbstractVector.java
@@ -13,7 +13,7 @@ package org.elasticsearch.compute.data;
 abstract class AbstractVector implements Vector {
 
     private final int positionCount;
-    protected final BlockFactory blockFactory;
+    private BlockFactory blockFactory;
     protected boolean released;
 
     protected AbstractVector(int positionCount, BlockFactory blockFactory) {
@@ -33,6 +33,11 @@ abstract class AbstractVector implements Vector {
     @Override
     public BlockFactory blockFactory() {
         return blockFactory;
+    }
+
+    @Override
+    public void allowPassingToDifferentDriver() {
+        blockFactory = blockFactory.parent();
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Block.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Block.java
@@ -66,10 +66,10 @@ public interface Block extends Accountable, BlockLoader.Block, NamedWriteable, R
     BlockFactory blockFactory();
 
     /**
-     * This method must be called before passing this Block to another Driver. Internally, we change the owning block factory
-     * of this Block to its parent block factory. This ensures that when another driver releases this Block, it returns memory
-     * directly to the parent block factory instead of the local block factory of this Block. This is necessary because the local
-     * block factory doesn't support simultaneous access by more than one thread.
+     * Before passing a Block to another Driver, it is necessary to switch the owning block factory to its parent, which is associated
+     * with the global circuit breaker. This ensures that when the new driver releases this Block, it returns memory directly to the
+     * parent block factory instead of the local block factory of this Block. This is important because the local block factory is
+     * not thread safe and doesn't support simultaneous access by more than one thread.
      */
     void allowPassingToDifferentDriver();
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Block.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Block.java
@@ -62,7 +62,16 @@ public interface Block extends Accountable, BlockLoader.Block, NamedWriteable, R
     ElementType elementType();
 
     /** The block factory associated with this block. */
+    // TODO: renaming this to owning blockFactory once we pass blockFactory for filter and expand
     BlockFactory blockFactory();
+
+    /**
+     * This method must be called before passing this Block to another Driver. Internally, we change the owning block factory
+     * of this Block to its parent block factory. This ensures that when another driver releases this Block, it returns memory
+     * directly to the parent block factory instead of the local block factory of this Block. This is necessary because the local
+     * block factory doesn't support simultaneous access by more than one thread.
+     */
+    void allowPassingToDifferentDriver();
 
     /**
      * Tells if this block has been released. A block is released by calling its {@link Block#close()} or {@link Block#decRef()} methods.
@@ -105,11 +114,6 @@ public interface Block extends Accountable, BlockLoader.Block, NamedWriteable, R
      * TODO: pass BlockFactory
      */
     Block filter(int... positions);
-
-    /**
-     * This method must be called before passing this Block to another Driver.
-     */
-    void allowPassingToDifferentDriver();
 
     /**
      * How are multivalued fields ordered?

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Block.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Block.java
@@ -102,8 +102,14 @@ public interface Block extends Accountable, BlockLoader.Block, NamedWriteable, R
      * The new block may hold a reference to this block, increasing this block's reference count.
      * @param positions the positions to retain
      * @return a filtered block
+     * TODO: pass BlockFactory
      */
     Block filter(int... positions);
+
+    /**
+     * This method must be called before passing this Block to another Driver.
+     */
+    void allowPassingToDifferentDriver();
 
     /**
      * How are multivalued fields ordered?
@@ -145,6 +151,7 @@ public interface Block extends Accountable, BlockLoader.Block, NamedWriteable, R
     /**
      * Expand multivalued fields into one row per value. Returns the same block if there aren't any multivalued
      * fields to expand. The returned block needs to be closed by the caller to release the block's resources.
+     * TODO: pass BlockFactory
      */
     Block expand();
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ConstantNullBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ConstantNullBlock.java
@@ -69,7 +69,7 @@ public final class ConstantNullBlock extends AbstractBlock implements BooleanBlo
 
     @Override
     public ConstantNullBlock filter(int... positions) {
-        return (ConstantNullBlock) blockFactory.newConstantNullBlock(positions.length);
+        return (ConstantNullBlock) blockFactory().newConstantNullBlock(positions.length);
     }
 
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
@@ -128,7 +128,7 @@ public final class ConstantNullBlock extends AbstractBlock implements BooleanBlo
 
     @Override
     public void closeInternal() {
-        blockFactory.adjustBreaker(-ramBytesUsed(), true);
+        blockFactory().adjustBreaker(-ramBytesUsed(), true);
     }
 
     static class Builder implements Block.Builder {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocBlock.java
@@ -167,4 +167,9 @@ public class DocBlock extends AbstractVectorBlock implements Block {
             Releasables.closeExpectNoException(shards, segments, docs);
         }
     }
+
+    @Override
+    public void allowPassingToDifferentDriver() {
+        vector.allowPassingToDifferentDriver();
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocVector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocVector.java
@@ -224,6 +224,13 @@ public final class DocVector extends AbstractVector implements Vector {
     }
 
     @Override
+    public void allowPassingToDifferentDriver() {
+        shards.allowPassingToDifferentDriver();
+        segments.allowPassingToDifferentDriver();
+        docs.allowPassingToDifferentDriver();
+    }
+
+    @Override
     public void close() {
         released = true;
         Releasables.closeExpectNoException(shards.asBlock(), segments.asBlock(), docs.asBlock()); // Ugh! we always close blocks

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/LocalCircuitBreaker.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/LocalCircuitBreaker.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data;
+
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.Releasable;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Requesting and returning memory from a {@link CircuitBreaker} can be costly due to the involvement of read/write
+ * on one or several atomic longs. To address this issue, the local breaker adopts a strategy of over-requesting memory,
+ * utilizing the reserved amount for subsequent memory requests without direct access to the actual breaker.
+ *
+ * @see BlockFactory#newChildFactory(LocalCircuitBreaker)
+ * @see Block#allowPassingToDifferentDriver()
+ */
+public final class LocalCircuitBreaker implements CircuitBreaker, Releasable {
+    private final CircuitBreaker breaker;
+    private final long overReservedBytes;
+    private final long maxOverReservedBytes;
+    private long reservedBytes;
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    public LocalCircuitBreaker(CircuitBreaker breaker, Settings settings) {
+        this(
+            breaker,
+            settings.getAsBytesSize(
+                BlockFactory.LOCAL_BREAKER_OVER_RESERVED_SIZE_SETTING,
+                BlockFactory.LOCAL_BREAKER_OVER_RESERVED_DEFAULT_SIZE
+            ).getBytes(),
+            settings.getAsBytesSize(
+                BlockFactory.LOCAL_BREAKER_OVER_RESERVED_MAX_SIZE_SETTING,
+                BlockFactory.LOCAL_BREAKER_OVER_RESERVED_DEFAULT_MAX_SIZE
+            ).getBytes()
+        );
+    }
+
+    public LocalCircuitBreaker(CircuitBreaker breaker, long overReservedBytes, long maxOverReservedBytes) {
+        this.breaker = breaker;
+        this.maxOverReservedBytes = maxOverReservedBytes;
+        this.overReservedBytes = Math.min(overReservedBytes, maxOverReservedBytes);
+    }
+
+    @Override
+    public void circuitBreak(String fieldName, long bytesNeeded) {
+        breaker.circuitBreak(fieldName, bytesNeeded);
+    }
+
+    @Override
+    public void addEstimateBytesAndMaybeBreak(long bytes, String label) throws CircuitBreakingException {
+        if (bytes <= reservedBytes) {
+            reservedBytes -= bytes;
+            maybeReduceReservedBytes();
+        } else {
+            breaker.addEstimateBytesAndMaybeBreak(bytes - reservedBytes + overReservedBytes, label);
+            reservedBytes = overReservedBytes;
+        }
+    }
+
+    @Override
+    public void addWithoutBreaking(long bytes) {
+        if (bytes <= reservedBytes) {
+            reservedBytes -= bytes;
+            maybeReduceReservedBytes();
+        } else {
+            // leave the reserve untouched as we are making a call anyway
+            breaker.addWithoutBreaking(bytes);
+        }
+    }
+
+    private void maybeReduceReservedBytes() {
+        if (reservedBytes > maxOverReservedBytes) {
+            breaker.addWithoutBreaking(maxOverReservedBytes - reservedBytes);
+            reservedBytes = maxOverReservedBytes;
+        }
+    }
+
+    public CircuitBreaker parentBreaker() {
+        return breaker;
+    }
+
+    @Override
+    public long getUsed() {
+        return breaker.getUsed();
+    }
+
+    // for testings
+    long getReservedBytes() {
+        return reservedBytes;
+    }
+
+    @Override
+    public long getLimit() {
+        return breaker.getLimit();
+    }
+
+    @Override
+    public double getOverhead() {
+        return breaker.getOverhead();
+    }
+
+    @Override
+    public long getTrippedCount() {
+        return breaker.getTrippedCount();
+    }
+
+    @Override
+    public String getName() {
+        return breaker.getName();
+    }
+
+    @Override
+    public Durability getDurability() {
+        return breaker.getDurability();
+    }
+
+    @Override
+    public void setLimitAndOverhead(long limit, double overhead) {
+        breaker.setLimitAndOverhead(limit, overhead);
+    }
+
+    @Override
+    public void close() {
+        if (closed.compareAndSet(false, true)) {
+            breaker.addWithoutBreaking(-reservedBytes);
+        }
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/LocalCircuitBreaker.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/LocalCircuitBreaker.java
@@ -29,18 +29,19 @@ public final class LocalCircuitBreaker implements CircuitBreaker, Releasable {
     private long reservedBytes;
     private final AtomicBoolean closed = new AtomicBoolean(false);
 
-    public LocalCircuitBreaker(CircuitBreaker breaker, Settings settings) {
-        this(
-            breaker,
-            settings.getAsBytesSize(
-                BlockFactory.LOCAL_BREAKER_OVER_RESERVED_SIZE_SETTING,
-                BlockFactory.LOCAL_BREAKER_OVER_RESERVED_DEFAULT_SIZE
-            ).getBytes(),
-            settings.getAsBytesSize(
-                BlockFactory.LOCAL_BREAKER_OVER_RESERVED_MAX_SIZE_SETTING,
-                BlockFactory.LOCAL_BREAKER_OVER_RESERVED_DEFAULT_MAX_SIZE
-            ).getBytes()
-        );
+    public record SizeSettings(long overReservedBytes, long maxOverReservedBytes) {
+        public SizeSettings(Settings settings) {
+            this(
+                settings.getAsBytesSize(
+                    BlockFactory.LOCAL_BREAKER_OVER_RESERVED_SIZE_SETTING,
+                    BlockFactory.LOCAL_BREAKER_OVER_RESERVED_DEFAULT_SIZE
+                ).getBytes(),
+                settings.getAsBytesSize(
+                    BlockFactory.LOCAL_BREAKER_OVER_RESERVED_MAX_SIZE_SETTING,
+                    BlockFactory.LOCAL_BREAKER_OVER_RESERVED_DEFAULT_MAX_SIZE
+                ).getBytes()
+            );
+        }
     }
 
     public LocalCircuitBreaker(CircuitBreaker breaker, long overReservedBytes, long maxOverReservedBytes) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Page.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Page.java
@@ -236,7 +236,13 @@ public final class Page implements Writeable {
         Releasables.closeExpectNoException(blocks);
     }
 
-    static int mapSize(int expectedSize) {
-        return expectedSize < 2 ? expectedSize + 1 : (int) (expectedSize / 0.75 + 1.0);
+    /**
+     * Must call this method before passing this Page to another Driver.
+     * @see org.elasticsearch.compute.operator.SinkOperator#addInput(Page)
+     */
+    public void allowPassingPagesToDifferentContext() {
+        for (Block block : blocks) {
+            block.allowPassingToDifferentDriver();
+        }
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Page.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Page.java
@@ -237,8 +237,10 @@ public final class Page implements Writeable {
     }
 
     /**
-     * Must call this method before passing this Page to another Driver.
-     * @see org.elasticsearch.compute.operator.SinkOperator#addInput(Page)
+     * This method must be called before passing this Page to another Driver. Internally, we change the owning block factory of the blocks
+     * on this Page to their parent block factory. This ensures that when another driver releases this Page, we return memory directly
+     * to the parent block factory instead of the local block factory of the blocks on this Page. This is necessary because the local
+     * block factory doesn't support simultaneous access by more than one thread.
      */
     public void allowPassingToDifferentDriver() {
         for (Block block : blocks) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Page.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Page.java
@@ -237,10 +237,10 @@ public final class Page implements Writeable {
     }
 
     /**
-     * This method must be called before passing this Page to another Driver. Internally, we change the owning block factory of the blocks
-     * on this Page to their parent block factory. This ensures that when another driver releases this Page, we return memory directly
-     * to the parent block factory instead of the local block factory of the blocks on this Page. This is necessary because the local
-     * block factory doesn't support simultaneous access by more than one thread.
+     * Before passing a Page to another Driver, it is necessary to switch the owning block factories of its Blocks to their parents,
+     * which are associated with the global circuit breaker. This ensures that when the new driver releases this Page, it returns
+     * memory directly to the parent block factory instead of the local block factory. This is important because the local block
+     * factory is not thread safe and doesn't support simultaneous access by more than one thread.
      */
     public void allowPassingToDifferentDriver() {
         for (Block block : blocks) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Page.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Page.java
@@ -240,7 +240,7 @@ public final class Page implements Writeable {
      * Must call this method before passing this Page to another Driver.
      * @see org.elasticsearch.compute.operator.SinkOperator#addInput(Page)
      */
-    public void allowPassingPagesToDifferentContext() {
+    public void allowPassingToDifferentDriver() {
         for (Block block : blocks) {
             block.allowPassingToDifferentDriver();
         }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Vector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Vector.java
@@ -51,6 +51,11 @@ public interface Vector extends Accountable, Releasable {
     BlockFactory blockFactory();
 
     /**
+     * This method must be called before passing this Vector to another Driver.
+     */
+    void allowPassingToDifferentDriver();
+
+    /**
      * Builds {@link Vector}s. Typically, you use one of it's direct supinterfaces like {@link IntVector.Builder}.
      * This is {@link Releasable} and should be released after building the vector or if building the vector fails.
      */

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Vector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Vector.java
@@ -48,13 +48,14 @@ public interface Vector extends Accountable, Releasable {
     boolean isConstant();
 
     /** The block factory associated with this vector. */
+    // TODO: Renaming this to owningBlockFactory
     BlockFactory blockFactory();
 
     /**
-     * This method must be called before passing this Vector to another Driver. Internally, we change the owning block factory
-     * of this Vector to its parent block factory. This ensures that when another driver releases this Vector, it returns memory
-     * directly to the parent block factory instead of the local block factory of this Block. This is necessary because the local
-     * block factory doesn't support simultaneous access by more than one thread.
+     * Before passing a Vector to another Driver, it is necessary to switch the owning block factory to its parent, which is associated
+     * with the global circuit breaker. This ensures that when the new driver releases this Vector, it returns memory directly to the
+     * parent block factory instead of the local block factory of this Block. This is important because the local block factory is
+     * not thread safe and doesn't support simultaneous access by more than one thread.
      */
     void allowPassingToDifferentDriver();
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Vector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Vector.java
@@ -51,7 +51,10 @@ public interface Vector extends Accountable, Releasable {
     BlockFactory blockFactory();
 
     /**
-     * This method must be called before passing this Vector to another Driver.
+     * This method must be called before passing this Vector to another Driver. Internally, we change the owning block factory
+     * of this Vector to its parent block factory. This ensures that when another driver releases this Vector, it returns memory
+     * directly to the parent block factory instead of the local block factory of this Block. This is necessary because the local
+     * block factory doesn't support simultaneous access by more than one thread.
      */
     void allowPassingToDifferentDriver();
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
@@ -71,7 +71,7 @@ $endif$
 $if(BytesRef)$
         final BytesRef scratch = new BytesRef();
 $endif$
-        try (var builder = blockFactory.new$Type$BlockBuilder(positions.length)) {
+        try (var builder = blockFactory().new$Type$BlockBuilder(positions.length)) {
             for (int pos : positions) {
                 if (isNull(pos)) {
                     builder.appendNull();
@@ -108,7 +108,7 @@ $endif$
 $if(BytesRef)$
         final BytesRef scratch = new BytesRef();
 $endif$
-        try (var builder = blockFactory.new$Type$BlockBuilder(firstValueIndexes[getPositionCount()])) {
+        try (var builder = blockFactory().new$Type$BlockBuilder(firstValueIndexes[getPositionCount()])) {
             for (int pos = 0; pos < getPositionCount(); pos++) {
                 if (isNull(pos)) {
                     builder.appendNull();
@@ -171,10 +171,10 @@ $endif$
     @Override
     public void closeInternal() {
     $if(BytesRef)$
-        blockFactory.adjustBreaker(-ramBytesUsed() + values.bigArraysRamBytesUsed(), true);
+        blockFactory().adjustBreaker(-ramBytesUsed() + values.bigArraysRamBytesUsed(), true);
         Releasables.closeExpectNoException(values);
     $else$
-        blockFactory.adjustBreaker(-ramBytesUsed(), true);
+        blockFactory().adjustBreaker(-ramBytesUsed(), true);
     $endif$
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayVector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayVector.java.st
@@ -79,7 +79,7 @@ $endif$
     $if(BytesRef)$
         final var scratch = new BytesRef();
     $endif$
-        try ($Type$Vector.Builder builder = blockFactory.new$Type$VectorBuilder(positions.length)) {
+        try ($Type$Vector.Builder builder = blockFactory().new$Type$VectorBuilder(positions.length)) {
             for (int pos : positions) {
             $if(BytesRef)$
                 builder.append$Type$(values.get(pos, scratch));
@@ -129,7 +129,7 @@ $if(BytesRef)$
             throw new IllegalStateException("can't release already released vector [" + this + "]");
         }
         released = true;
-        blockFactory.adjustBreaker(-ramBytesUsed() + values.bigArraysRamBytesUsed(), true);
+        blockFactory().adjustBreaker(-ramBytesUsed() + values.bigArraysRamBytesUsed(), true);
         Releasables.closeExpectNoException(values);
     }
 $endif$

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BigArrayVector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BigArrayVector.java.st
@@ -60,6 +60,7 @@ public final class $Type$BigArrayVector extends AbstractVector implements $Type$
 
     @Override
     public $Type$Vector filter(int... positions) {
+        var blockFactory = blockFactory();
    $if(boolean)$
         final BitArray filtered = new BitArray(positions.length, blockFactory.bigArrays());
         for (int i = 0; i < positions.length; i++) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ConstantVector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ConstantVector.java.st
@@ -108,6 +108,6 @@ $endif$
             throw new IllegalStateException("can't release already released vector [" + this + "]");
         }
         released = true;
-        blockFactory.adjustBreaker(-ramBytesUsed(), true);
+        blockFactory().adjustBreaker(-ramBytesUsed(), true);
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorBlock.java.st
@@ -91,4 +91,9 @@ $endif$
         assert (vector.isReleased() == false) : "can't release block [" + this + "] containing already released vector";
         Releasables.closeExpectNoException(vector);
     }
+
+    @Override
+    public void allowPassingToDifferentDriver() {
+        vector.allowPassingToDifferentDriver();
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/AsyncOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/AsyncOperator.java
@@ -12,7 +12,6 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.compute.data.Page;
-import org.elasticsearch.core.Releasables;
 import org.elasticsearch.index.seqno.LocalCheckpointTracker;
 import org.elasticsearch.index.seqno.SequenceNumbers;
 import org.elasticsearch.tasks.TaskCancelledException;
@@ -78,7 +77,7 @@ public abstract class AsyncOperator implements Operator {
                 buffers.put(seqNo, output);
                 onSeqNoCompleted(seqNo);
             }, e -> {
-                input.releaseBlocks();
+                releasePageOnAnyThread(input);
                 onFailure(e);
                 onSeqNoCompleted(seqNo);
             });
@@ -89,6 +88,11 @@ public abstract class AsyncOperator implements Operator {
                 driverContext.removeAsyncAction();
             }
         }
+    }
+
+    private void releasePageOnAnyThread(Page page) {
+        page.allowPassingPagesToDifferentContext();
+        page.releaseBlocks();
     }
 
     /**
@@ -157,7 +161,7 @@ public abstract class AsyncOperator implements Operator {
             Page page = buffers.remove(nextCheckpoint);
             checkpoint.markSeqNoAsPersisted(nextCheckpoint);
             if (page != null) {
-                Releasables.closeExpectNoException(page::releaseBlocks);
+                releasePageOnAnyThread(page);
             }
         }
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/AsyncOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/AsyncOperator.java
@@ -91,7 +91,7 @@ public abstract class AsyncOperator implements Operator {
     }
 
     private void releasePageOnAnyThread(Page page) {
-        page.allowPassingPagesToDifferentContext();
+        page.allowPassingToDifferentDriver();
         page.releaseBlocks();
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/OutputOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/OutputOperator.java
@@ -62,7 +62,7 @@ public class OutputOperator extends SinkOperator {
     }
 
     @Override
-    public void addInput(Page page) {
+    protected void doAddInput(Page page) {
         pageConsumer.accept(mapper.apply(page));
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/PageConsumerOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/PageConsumerOperator.java
@@ -40,7 +40,7 @@ public class PageConsumerOperator extends SinkOperator {
     }
 
     @Override
-    public void addInput(Page page) {
+    protected void doAddInput(Page page) {
         pageConsumer.accept(page);
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/SinkOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/SinkOperator.java
@@ -28,7 +28,7 @@ public abstract class SinkOperator implements Operator {
     @Override
     public final void addInput(Page page) {
         // We need to change the ownership of the blocks of the input page before passing them to another driver.
-        page.allowPassingPagesToDifferentContext();
+        page.allowPassingToDifferentDriver();
         doAddInput(page);
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/SinkOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/SinkOperator.java
@@ -23,6 +23,15 @@ public abstract class SinkOperator implements Operator {
         throw new UnsupportedOperationException();
     }
 
+    protected abstract void doAddInput(Page page);
+
+    @Override
+    public final void addInput(Page page) {
+        // We need to change the ownership of the blocks of the input page before passing them to another driver.
+        page.allowPassingPagesToDifferentContext();
+        doAddInput(page);
+    }
+
     /**
      * A factory for creating sink operators.
      */

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/ExchangeSinkOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/ExchangeSinkOperator.java
@@ -73,10 +73,9 @@ public class ExchangeSinkOperator extends SinkOperator {
     }
 
     @Override
-    public void addInput(Page page) {
+    protected void doAddInput(Page page) {
         pagesAccepted++;
-        var newPage = transformer.apply(page);
-        sink.addPage(newPage);
+        sink.addPage(transformer.apply(page));
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockFactoryTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockFactoryTests.java
@@ -27,12 +27,16 @@ import org.junit.Before;
 
 import java.util.BitSet;
 import java.util.List;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -566,6 +570,82 @@ public class BlockFactoryTests extends ESTestCase {
         assertTrue(vector.isReleased());
         assertTrue(vector.asBlock().isReleased());
         assertThat(breaker.getUsed(), equalTo(0L));
+    }
+
+    public void testParent() {
+        long overLimit = between(1, 10);
+        long maxOverLimit = randomLongBetween(overLimit, 1000);
+        LocalCircuitBreaker localBreaker = new LocalCircuitBreaker(blockFactory.breaker(), overLimit, maxOverLimit);
+        BlockFactory childFactory = blockFactory.newChildFactory(localBreaker);
+        assertThat(childFactory.parent(), sameInstance(blockFactory));
+        assertThat(blockFactory.parent(), sameInstance(blockFactory));
+        localBreaker.close();
+    }
+
+    private Block randomBlock(BlockFactory blockFactory, int positionCount) {
+        return BasicBlockTests.randomBlock(
+            blockFactory,
+            randomFrom(ElementType.BYTES_REF, ElementType.LONG, ElementType.BOOLEAN),
+            positionCount,
+            randomBoolean(),
+            between(0, 1),
+            between(1, 3),
+            between(0, 1),
+            between(1, 3)
+        ).block();
+    }
+
+    public void testAllowPassingBlockToDifferentContext() throws Exception {
+        long overLimit1 = between(0, 10);
+        long maxOverLimit1 = randomLongBetween(overLimit1, 1000);
+        LocalCircuitBreaker localBreaker1 = new LocalCircuitBreaker(blockFactory.breaker(), overLimit1, maxOverLimit1);
+        long overLimit2 = between(0, 10);
+        long maxOverLimit2 = randomLongBetween(overLimit2, 1000);
+        LocalCircuitBreaker localBreaker2 = new LocalCircuitBreaker(blockFactory.breaker(), overLimit2, maxOverLimit2);
+        BlockFactory childFactory1 = blockFactory.newChildFactory(localBreaker1);
+        BlockFactory childFactory2 = blockFactory.newChildFactory(localBreaker2);
+        Thread[] releasingThreads = new Thread[between(1, 4)];
+        Page[] passedPages = new Page[releasingThreads.length];
+        for (int i = 0; i < passedPages.length; i++) {
+            int positionCount = between(1, 100);
+            Block[] blocks = new Block[between(1, 10)];
+            for (int b = 0; b < blocks.length; b++) {
+                blocks[b] = randomBlock(randomFrom(childFactory1, childFactory2), positionCount);
+                blocks[b].allowPassingToDifferentDriver();
+                assertThat(blocks[b].blockFactory(), equalTo(blockFactory));
+            }
+            passedPages[i] = new Page(blocks);
+        }
+        Block[] localBlocks = new Block[between(1, 100)];
+        for (int i = 0; i < localBlocks.length; i++) {
+            BlockFactory childFactory = randomFrom(childFactory1, childFactory2);
+            localBlocks[i] = randomBlock(childFactory, between(1, 100));
+            assertThat(localBlocks[i].blockFactory(), equalTo(childFactory));
+        }
+        CyclicBarrier barrier = new CyclicBarrier(releasingThreads.length + 1);
+        for (int i = 0; i < releasingThreads.length; i++) {
+            int threadIndex = i;
+            releasingThreads[threadIndex] = new Thread(() -> {
+                try {
+                    barrier.await(30, TimeUnit.SECONDS);
+                    passedPages[threadIndex].releaseBlocks();
+                } catch (Exception e) {
+                    throw new AssertionError(e);
+                }
+            });
+            releasingThreads[threadIndex].start();
+        }
+        barrier.await(30, TimeUnit.SECONDS);
+        for (Block block : localBlocks) {
+            block.close();
+        }
+        for (Thread releasingThread : releasingThreads) {
+            releasingThread.join();
+        }
+        assertThat(localBreaker1.getReservedBytes(), lessThanOrEqualTo(maxOverLimit1));
+        assertThat(localBreaker2.getReservedBytes(), lessThanOrEqualTo(maxOverLimit2));
+        localBreaker1.close();
+        localBreaker2.close();
     }
 
     static BytesRef randomBytesRef() {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockFactoryTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockFactoryTests.java
@@ -596,11 +596,11 @@ public class BlockFactoryTests extends ESTestCase {
     }
 
     public void testAllowPassingBlockToDifferentContext() throws Exception {
-        long overLimit1 = between(0, 10);
-        long maxOverLimit1 = randomLongBetween(overLimit1, 1000);
+        long overLimit1 = between(0, 10 * 1024);
+        long maxOverLimit1 = randomLongBetween(overLimit1, 100 * 1024);
         LocalCircuitBreaker localBreaker1 = new LocalCircuitBreaker(blockFactory.breaker(), overLimit1, maxOverLimit1);
-        long overLimit2 = between(0, 10);
-        long maxOverLimit2 = randomLongBetween(overLimit2, 1000);
+        long overLimit2 = between(0, 10 * 1024);
+        long maxOverLimit2 = randomLongBetween(overLimit1, 100 * 1024);
         LocalCircuitBreaker localBreaker2 = new LocalCircuitBreaker(blockFactory.breaker(), overLimit2, maxOverLimit2);
         BlockFactory childFactory1 = blockFactory.newChildFactory(localBreaker1);
         BlockFactory childFactory2 = blockFactory.newChildFactory(localBreaker2);

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/LocalCircuitBreakerTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/LocalCircuitBreakerTests.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data;
+
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.MockBigArrays;
+import org.elasticsearch.common.util.PageCacheRecycler;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class LocalCircuitBreakerTests extends ESTestCase {
+
+    static class TrackingCircuitBreaker implements CircuitBreaker {
+        private final CircuitBreaker breaker;
+        private final AtomicInteger called = new AtomicInteger();
+
+        TrackingCircuitBreaker(CircuitBreaker breaker) {
+            this.breaker = breaker;
+        }
+
+        @Override
+        public void circuitBreak(String fieldName, long bytesNeeded) {
+
+        }
+
+        @Override
+        public void addEstimateBytesAndMaybeBreak(long bytes, String label) throws CircuitBreakingException {
+            called.incrementAndGet();
+            breaker.addEstimateBytesAndMaybeBreak(bytes, label);
+        }
+
+        @Override
+        public void addWithoutBreaking(long bytes) {
+            called.incrementAndGet();
+            breaker.addWithoutBreaking(bytes);
+        }
+
+        @Override
+        public long getUsed() {
+            return breaker.getUsed();
+        }
+
+        @Override
+        public long getLimit() {
+            return breaker.getLimit();
+        }
+
+        @Override
+        public double getOverhead() {
+            return breaker.getOverhead();
+        }
+
+        @Override
+        public long getTrippedCount() {
+            return breaker.getTrippedCount();
+        }
+
+        @Override
+        public String getName() {
+            return breaker.getName();
+        }
+
+        @Override
+        public Durability getDurability() {
+            return breaker.getDurability();
+        }
+
+        @Override
+        public void setLimitAndOverhead(long limit, double overhead) {
+            breaker.setLimitAndOverhead(limit, overhead);
+        }
+
+        int callTimes() {
+            return called.get();
+        }
+    }
+
+    private TrackingCircuitBreaker newTestBreaker(long limit) {
+        var bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, ByteSizeValue.ofBytes(limit)).withCircuitBreaking();
+        return new TrackingCircuitBreaker(bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST));
+    }
+
+    public void testBasic() {
+        TrackingCircuitBreaker breaker = newTestBreaker(120);
+        LocalCircuitBreaker localBreaker = new LocalCircuitBreaker(breaker, 30, 50);
+        localBreaker.addEstimateBytesAndMaybeBreak(20, "test");
+        assertThat(localBreaker.getReservedBytes(), equalTo(30L));
+        assertThat(breaker.callTimes(), equalTo(1));
+        assertThat(breaker.getUsed(), equalTo(50L));
+        localBreaker.addWithoutBreaking(-5);
+        assertThat(breaker.getUsed(), equalTo(50L));
+        assertThat(localBreaker.getReservedBytes(), equalTo(35L));
+        localBreaker.addEstimateBytesAndMaybeBreak(25, "test");
+        assertThat(breaker.getUsed(), equalTo(50L));
+        assertThat(breaker.callTimes(), equalTo(1));
+        assertThat(localBreaker.getReservedBytes(), equalTo(10L));
+        var error = expectThrows(CircuitBreakingException.class, () -> localBreaker.addEstimateBytesAndMaybeBreak(60, "test"));
+        assertThat(error.getBytesWanted(), equalTo(80L));
+        assertThat(breaker.callTimes(), equalTo(2));
+        localBreaker.addEstimateBytesAndMaybeBreak(30, "test");
+        assertThat(breaker.getUsed(), equalTo(100L));
+        assertThat(localBreaker.getReservedBytes(), equalTo(30L));
+        assertThat(breaker.callTimes(), equalTo(3));
+        localBreaker.addWithoutBreaking(-40L);
+        assertThat(breaker.getUsed(), equalTo(80L));
+        assertThat(localBreaker.getReservedBytes(), equalTo(50L));
+        assertThat(breaker.callTimes(), equalTo(4));
+        localBreaker.close();
+        assertThat(breaker.getUsed(), equalTo(30L));
+    }
+}

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/MockBlockFactory.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/MockBlockFactory.java
@@ -63,7 +63,19 @@ public class MockBlockFactory extends BlockFactory {
     }
 
     public MockBlockFactory(CircuitBreaker breaker, BigArrays bigArrays) {
-        super(breaker, bigArrays);
+        this(breaker, bigArrays, null);
+    }
+
+    protected MockBlockFactory(CircuitBreaker breaker, BigArrays bigArrays, BlockFactory parent) {
+        super(breaker, bigArrays, parent);
+    }
+
+    @Override
+    public BlockFactory newChildFactory(LocalCircuitBreaker childBreaker) {
+        if (childBreaker.parentBreaker() != breaker()) {
+            throw new IllegalStateException("Different parent breaker");
+        }
+        return new MockBlockFactory(childBreaker, bigArrays(), this);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/AsyncOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/AsyncOperatorTests.java
@@ -23,11 +23,13 @@ import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.LocalCircuitBreaker;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.MockBlockFactory;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.FixedExecutorBuilder;
@@ -69,7 +71,16 @@ public class AsyncOperatorTests extends ESTestCase {
     }
 
     public void testBasic() {
-        DriverContext driverContext = driverContext();
+        BlockFactory globalBlockFactory = blockFactory();
+        LocalCircuitBreaker localBreaker = null;
+        final DriverContext driverContext;
+        if (randomBoolean()) {
+            localBreaker = new LocalCircuitBreaker(globalBlockFactory.breaker(), between(0, 1024), between(0, 4096));
+            BlockFactory localFactory = new BlockFactory(localBreaker, globalBlockFactory.bigArrays());
+            driverContext = new DriverContext(globalBlockFactory.bigArrays(), localFactory);
+        } else {
+            driverContext = new DriverContext(globalBlockFactory.bigArrays(), globalBlockFactory);
+        }
         int positions = randomIntBetween(0, 10_000);
         List<Long> ids = new ArrayList<>(positions);
         Map<Long, String> dict = new HashMap<>();
@@ -98,7 +109,7 @@ public class AsyncOperatorTests extends ESTestCase {
         };
         int maxConcurrentRequests = randomIntBetween(1, 10);
         AsyncOperator asyncOperator = new AsyncOperator(driverContext, maxConcurrentRequests) {
-            final LookupService lookupService = new LookupService(threadPool, driverContext.blockFactory(), dict, maxConcurrentRequests);
+            final LookupService lookupService = new LookupService(threadPool, globalBlockFactory, dict, maxConcurrentRequests);
 
             @Override
             protected void performAsync(Page inputPage, ActionListener<Page> listener) {
@@ -143,10 +154,12 @@ public class AsyncOperatorTests extends ESTestCase {
         Driver driver = new Driver(driverContext, sourceOperator, intermediateOperators, outputOperator, () -> assertFalse(it.hasNext()));
         Driver.start(threadPool.getThreadContext(), threadPool.executor(ESQL_TEST_EXECUTOR), driver, between(1, 10000), future);
         future.actionGet();
+        Releasables.close(localBreaker);
     }
 
     public void testStatus() {
-        DriverContext driverContext = driverContext();
+        BlockFactory blockFactory = blockFactory();
+        DriverContext driverContext = new DriverContext(blockFactory.bigArrays(), blockFactory);
         Map<Page, ActionListener<Page>> handlers = new HashMap<>();
         AsyncOperator operator = new AsyncOperator(driverContext, 2) {
             @Override
@@ -195,7 +208,16 @@ public class AsyncOperatorTests extends ESTestCase {
     }
 
     public void testFailure() throws Exception {
-        DriverContext driverContext = driverContext();
+        BlockFactory globalBlockFactory = blockFactory();
+        LocalCircuitBreaker localBreaker = null;
+        final DriverContext driverContext;
+        if (randomBoolean()) {
+            localBreaker = new LocalCircuitBreaker(globalBlockFactory.breaker(), between(0, 1024), between(0, 4096));
+            BlockFactory localFactory = new BlockFactory(localBreaker, globalBlockFactory.bigArrays());
+            driverContext = new DriverContext(globalBlockFactory.bigArrays(), localFactory);
+        } else {
+            driverContext = new DriverContext(globalBlockFactory.bigArrays(), globalBlockFactory);
+        }
         final SequenceLongBlockSourceOperator sourceOperator = new SequenceLongBlockSourceOperator(
             driverContext.blockFactory(),
             LongStream.range(0, 100 * 1024)
@@ -213,7 +235,7 @@ public class AsyncOperatorTests extends ESTestCase {
                             throw new ElasticsearchException("simulated");
                         }
                         int positionCount = inputPage.getBlock(0).getPositionCount();
-                        IntBlock block = driverContext.blockFactory().newConstantIntBlockWith(between(1, 100), positionCount);
+                        IntBlock block = globalBlockFactory.newConstantIntBlockWith(between(1, 100), positionCount);
                         listener.onResponse(inputPage.appendPage(new Page(block)));
                     }
                 };
@@ -232,7 +254,7 @@ public class AsyncOperatorTests extends ESTestCase {
         };
         SinkOperator outputOperator = new PageConsumerOperator(Page::releaseBlocks);
         PlainActionFuture<Void> future = new PlainActionFuture<>();
-        Driver driver = new Driver(driverContext, sourceOperator, List.of(asyncOperator), outputOperator, () -> {});
+        Driver driver = new Driver(driverContext, sourceOperator, List.of(asyncOperator), outputOperator, localBreaker);
         Driver.start(threadPool.getThreadContext(), threadPool.executor(ESQL_TEST_EXECUTOR), driver, between(1, 1000), future);
         assertBusy(() -> assertTrue(future.isDone()));
         if (failed.get()) {
@@ -290,13 +312,13 @@ public class AsyncOperatorTests extends ESTestCase {
         }
     }
 
-    protected DriverContext driverContext() {
+    protected BlockFactory blockFactory() {
         BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, ByteSizeValue.ofGb(1)).withCircuitBreaking();
         CircuitBreaker breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
         breakers.add(breaker);
         BlockFactory factory = new MockBlockFactory(breaker, bigArrays);
         blockFactories.add(factory);
-        return new DriverContext(bigArrays, factory);
+        return factory;
     }
 
     private final List<CircuitBreaker> breakers = new ArrayList<>();

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/exchange/ExchangeServiceTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/exchange/ExchangeServiceTests.java
@@ -225,7 +225,7 @@ public class ExchangeServiceTests extends ESTestCase {
                 }
 
                 @Override
-                public void addInput(Page page) {
+                protected void doAddInput(Page page) {
                     try {
                         assertFalse("already finished", finished);
                         IntBlock block = page.getBlock(0);

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractEsqlIntegTestCase.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/AbstractEsqlIntegTestCase.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.operator.exchange.ExchangeService;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.QueryBuilder;
@@ -68,6 +69,16 @@ public abstract class AbstractEsqlIntegTestCase extends ESIntegTestCase {
                 Setting.timeSetting(
                     ExchangeService.INACTIVE_SINKS_INTERVAL_SETTING,
                     TimeValue.timeValueSeconds(5),
+                    Setting.Property.NodeScope
+                ),
+                Setting.byteSizeSetting(
+                    BlockFactory.LOCAL_BREAKER_OVER_RESERVED_SIZE_SETTING,
+                    ByteSizeValue.ofBytes(randomIntBetween(0, 4096)),
+                    Setting.Property.NodeScope
+                ),
+                Setting.byteSizeSetting(
+                    BlockFactory.LOCAL_BREAKER_OVER_RESERVED_MAX_SIZE_SETTING,
+                    ByteSizeValue.ofBytes(randomIntBetween(0, 16 * 1024)),
                     Setting.Property.NodeScope
                 )
             );

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EnrichIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EnrichIT.java
@@ -16,6 +16,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.operator.exchange.ExchangeService;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
@@ -100,6 +101,8 @@ public class EnrichIT extends AbstractEsqlIntegTestCase {
                 HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_TYPE_SETTING.getDefault(Settings.EMPTY)
             )
             .put(ExchangeService.INACTIVE_SINKS_INTERVAL_SETTING, TimeValue.timeValueMillis(between(500, 2000)))
+            .put(BlockFactory.LOCAL_BREAKER_OVER_RESERVED_SIZE_SETTING, ByteSizeValue.ofBytes(between(0, 128)))
+            .put(BlockFactory.LOCAL_BREAKER_OVER_RESERVED_MAX_SIZE_SETTING, ByteSizeValue.ofBytes(between(0, 512)))
             // allow reading pages from network can trip the circuit breaker
             .put(IGNORE_DESERIALIZATION_ERRORS_SETTING.getKey(), true)
             .build();

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EnrichIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EnrichIT.java
@@ -101,8 +101,8 @@ public class EnrichIT extends AbstractEsqlIntegTestCase {
                 HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_TYPE_SETTING.getDefault(Settings.EMPTY)
             )
             .put(ExchangeService.INACTIVE_SINKS_INTERVAL_SETTING, TimeValue.timeValueMillis(between(500, 2000)))
-            .put(BlockFactory.LOCAL_BREAKER_OVER_RESERVED_SIZE_SETTING, ByteSizeValue.ofBytes(between(0, 128)))
-            .put(BlockFactory.LOCAL_BREAKER_OVER_RESERVED_MAX_SIZE_SETTING, ByteSizeValue.ofBytes(between(0, 512)))
+            .put(BlockFactory.LOCAL_BREAKER_OVER_RESERVED_SIZE_SETTING, ByteSizeValue.ofBytes(between(0, 256)))
+            .put(BlockFactory.LOCAL_BREAKER_OVER_RESERVED_MAX_SIZE_SETTING, ByteSizeValue.ofBytes(between(0, 1024)))
             // allow reading pages from network can trip the circuit breaker
             .put(IGNORE_DESERIALIZATION_ERRORS_SETTING.getKey(), true)
             .build();

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionBreakerIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionBreakerIT.java
@@ -69,8 +69,8 @@ public class EsqlActionBreakerIT extends EsqlActionIT {
                 HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_TYPE_SETTING.getDefault(Settings.EMPTY)
             )
             .put(ExchangeService.INACTIVE_SINKS_INTERVAL_SETTING, TimeValue.timeValueMillis(between(500, 2000)))
-            .put(BlockFactory.LOCAL_BREAKER_OVER_RESERVED_SIZE_SETTING, ByteSizeValue.ofBytes(between(0, 64)))
-            .put(BlockFactory.LOCAL_BREAKER_OVER_RESERVED_MAX_SIZE_SETTING, ByteSizeValue.ofBytes(between(0, 256)))
+            .put(BlockFactory.LOCAL_BREAKER_OVER_RESERVED_SIZE_SETTING, ByteSizeValue.ofBytes(between(0, 256)))
+            .put(BlockFactory.LOCAL_BREAKER_OVER_RESERVED_MAX_SIZE_SETTING, ByteSizeValue.ofBytes(between(0, 1024)))
             // allow reading pages from network can trip the circuit breaker
             .put(IGNORE_DESERIALIZATION_ERRORS_SETTING.getKey(), true)
             .build();

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionBreakerIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionBreakerIT.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.operator.exchange.ExchangeService;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
@@ -68,6 +69,8 @@ public class EsqlActionBreakerIT extends EsqlActionIT {
                 HierarchyCircuitBreakerService.REQUEST_CIRCUIT_BREAKER_TYPE_SETTING.getDefault(Settings.EMPTY)
             )
             .put(ExchangeService.INACTIVE_SINKS_INTERVAL_SETTING, TimeValue.timeValueMillis(between(500, 2000)))
+            .put(BlockFactory.LOCAL_BREAKER_OVER_RESERVED_SIZE_SETTING, ByteSizeValue.ofBytes(between(0, 64)))
+            .put(BlockFactory.LOCAL_BREAKER_OVER_RESERVED_MAX_SIZE_SETTING, ByteSizeValue.ofBytes(between(0, 256)))
             // allow reading pages from network can trip the circuit breaker
             .put(IGNORE_DESERIALIZATION_ERRORS_SETTING.getKey(), true)
             .build();

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/EnrichLookupService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/EnrichLookupService.java
@@ -29,6 +29,7 @@ import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BlockStreamInput;
 import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.LocalCircuitBreaker;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.lucene.BlockReaderFactories;
 import org.elasticsearch.compute.lucene.ValuesSourceReaderOperator;
@@ -238,6 +239,7 @@ public class EnrichLookupService {
         ActionListener<Page> listener
     ) {
         Block inputBlock = inputPage.getBlock(0);
+        LocalCircuitBreaker localBreaker = null;
         try {
             if (inputBlock.areAllValuesNull()) {
                 listener.onResponse(createNullResponse(inputPage.getPositionCount(), extractFields));
@@ -246,18 +248,19 @@ public class EnrichLookupService {
             ShardSearchRequest shardSearchRequest = new ShardSearchRequest(shardId, 0, AliasFilter.EMPTY);
             SearchContext searchContext = searchService.createSearchContext(shardSearchRequest, SearchService.NO_TIMEOUT);
             listener = ActionListener.runBefore(listener, searchContext::close);
+            localBreaker = new LocalCircuitBreaker(blockFactory.breaker(), clusterService.getSettings());
+            DriverContext driverContext = new DriverContext(bigArrays, blockFactory.newChildFactory(localBreaker));
             SearchExecutionContext searchExecutionContext = searchContext.getSearchExecutionContext();
             MappedFieldType fieldType = searchExecutionContext.getFieldType(matchField);
             final SourceOperator queryOperator = switch (matchType) {
                 case "match", "range" -> {
                     QueryList queryList = QueryList.termQueryList(fieldType, searchExecutionContext, inputBlock);
-                    yield new EnrichQuerySourceOperator(blockFactory, queryList, searchExecutionContext.getIndexReader());
+                    yield new EnrichQuerySourceOperator(driverContext.blockFactory(), queryList, searchExecutionContext.getIndexReader());
                 }
                 default -> throw new EsqlIllegalArgumentException("illegal match type " + matchType);
             };
             List<Operator> intermediateOperators = new ArrayList<>(extractFields.size() + 2);
             final ElementType[] mergingTypes = new ElementType[extractFields.size()];
-
             // load the fields
             List<ValuesSourceReaderOperator.FieldInfo> fields = new ArrayList<>(extractFields.size());
             for (int i = 0; i < extractFields.size(); i++) {
@@ -273,7 +276,7 @@ public class EnrichLookupService {
             }
             intermediateOperators.add(
                 new ValuesSourceReaderOperator(
-                    blockFactory,
+                    driverContext.blockFactory(),
                     fields,
                     List.of(new ValuesSourceReaderOperator.ShardContext(searchContext.searcher().getIndexReader(), () -> {
                         throw new UnsupportedOperationException("can't load _source as part of enrich");
@@ -289,19 +292,26 @@ public class EnrichLookupService {
             // merging field-values by position
             final int[] mergingChannels = IntStream.range(0, extractFields.size()).map(i -> i + 1).toArray();
             intermediateOperators.add(
-                new MergePositionsOperator(singleLeaf, inputPage.getPositionCount(), 0, mergingChannels, mergingTypes, blockFactory)
+                new MergePositionsOperator(
+                    singleLeaf,
+                    inputPage.getPositionCount(),
+                    0,
+                    mergingChannels,
+                    mergingTypes,
+                    driverContext.blockFactory()
+                )
             );
             AtomicReference<Page> result = new AtomicReference<>();
             OutputOperator outputOperator = new OutputOperator(List.of(), Function.identity(), result::set);
             Driver driver = new Driver(
                 "enrich-lookup:" + sessionId,
-                new DriverContext(bigArrays, blockFactory),
+                driverContext,
                 () -> lookupDescription(sessionId, shardId, matchType, matchField, extractFields, inputPage.getPositionCount()),
                 queryOperator,
                 intermediateOperators,
                 outputOperator,
                 Driver.DEFAULT_STATUS_INTERVAL,
-                searchContext
+                localBreaker
             );
             task.addListener(() -> {
                 String reason = Objects.requireNonNullElse(task.getReasonCancelled(), "task was cancelled");
@@ -309,6 +319,7 @@ public class EnrichLookupService {
             });
 
             var threadContext = transportService.getThreadPool().getThreadContext();
+            localBreaker = null;
             Driver.start(threadContext, executor, driver, Driver.DEFAULT_MAX_ITERATIONS, listener.map(ignored -> {
                 Page out = result.get();
                 if (out == null) {
@@ -318,6 +329,8 @@ public class EnrichLookupService {
             }));
         } catch (Exception e) {
             listener.onFailure(e);
+        } finally {
+            Releasables.close(localBreaker);
         }
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -747,7 +747,12 @@ public class LocalExecutionPlanner {
             List<Operator> operators = new ArrayList<>();
             SinkOperator sink = null;
             boolean success = false;
-            final var localBreaker = new LocalCircuitBreaker(blockFactory.breaker(), settings);
+            var localBreakerSettings = new LocalCircuitBreaker.SizeSettings(settings);
+            final var localBreaker = new LocalCircuitBreaker(
+                blockFactory.breaker(),
+                localBreakerSettings.overReservedBytes(),
+                localBreakerSettings.maxOverReservedBytes()
+            );
             var driverContext = new DriverContext(bigArrays, blockFactory.newChildFactory(localBreaker));
             try {
                 source = physicalOperation.source(driverContext);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
@@ -20,6 +20,7 @@ import org.elasticsearch.action.support.RefCountingListener;
 import org.elasticsearch.action.support.RefCountingRunnable;
 import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.util.BigArrays;
@@ -100,12 +101,14 @@ public class ComputeService {
     private final DriverTaskRunner driverRunner;
     private final ExchangeService exchangeService;
     private final EnrichLookupService enrichLookupService;
+    private final ClusterService clusterService;
 
     public ComputeService(
         SearchService searchService,
         TransportService transportService,
         ExchangeService exchangeService,
         EnrichLookupService enrichLookupService,
+        ClusterService clusterService,
         ThreadPool threadPool,
         BigArrays bigArrays,
         BlockFactory blockFactory
@@ -119,6 +122,7 @@ public class ComputeService {
         this.driverRunner = new DriverTaskRunner(transportService, this.esqlExecutor);
         this.exchangeService = exchangeService;
         this.enrichLookupService = enrichLookupService;
+        this.clusterService = clusterService;
     }
 
     public void execute(
@@ -278,6 +282,7 @@ public class ComputeService {
                 task,
                 bigArrays,
                 blockFactory,
+                clusterService.getSettings(),
                 context.configuration,
                 context.exchangeSource(),
                 context.exchangeSink(),

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
@@ -74,6 +74,7 @@ public class TransportEsqlQueryAction extends HandledTransportAction<EsqlQueryRe
             transportService,
             exchangeService,
             enrichLookupService,
+            clusterService,
             threadPool,
             bigArrays,
             blockFactory

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
@@ -329,11 +329,14 @@ public class CsvTests extends ESTestCase {
         String sessionId = "csv-test";
         ExchangeSourceHandler exchangeSource = new ExchangeSourceHandler(between(1, 64), threadPool.executor(ESQL_THREAD_POOL_NAME));
         ExchangeSinkHandler exchangeSink = new ExchangeSinkHandler(between(1, 64), threadPool::relativeTimeInMillis);
+        Settings.Builder settings = Settings.builder();
+
         LocalExecutionPlanner executionPlanner = new LocalExecutionPlanner(
             sessionId,
             new CancellableTask(1, "transport", "esql", null, TaskId.EMPTY_TASK_ID, Map.of()),
             bigArrays,
             new BlockFactory(bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST), bigArrays),
+            randomNodeSettings(),
             configuration,
             exchangeSource,
             exchangeSink,
@@ -406,6 +409,15 @@ public class CsvTests extends ESTestCase {
         } finally {
             Releasables.close(() -> Releasables.close(drivers), exchangeSource::decRef);
         }
+    }
+
+    private Settings randomNodeSettings() {
+        Settings.Builder builder = Settings.builder();
+        if (randomBoolean()) {
+            builder.put(BlockFactory.LOCAL_BREAKER_OVER_RESERVED_SIZE_SETTING, ByteSizeValue.ofBytes(randomIntBetween(0, 4096)));
+            builder.put(BlockFactory.LOCAL_BREAKER_OVER_RESERVED_MAX_SIZE_SETTING, ByteSizeValue.ofBytes(randomIntBetween(0, 16 * 1024)));
+        }
+        return builder.build();
     }
 
     private Throwable reworkException(Throwable th) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlannerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlannerTests.java
@@ -125,6 +125,7 @@ public class LocalExecutionPlannerTests extends MapperServiceTestCase {
             null,
             BigArrays.NON_RECYCLING_INSTANCE,
             BlockFactory.getNonBreakingInstance(),
+            Settings.EMPTY,
             config(),
             null,
             null,


### PR DESCRIPTION
Requesting and returning memory from a CircuitBreaker can be costly due to the involvement of read/write on one or several atomic longs. To address this issue, the local breaker adopts a strategy of over-requesting memory, utilizing the reserved amount for subsequent memory requests without direct access to the actual breaker.

Before passing a Block to another Driver, it is necessary to switch the owning block factory to its parent, which is associated with the global breaker. This is done to bypass the local breaker when releasing memory, as the releasing thread can be any thread, not necessarily the one executing the Driver.

There are two specific operators that need to change the owning block factory: SinkOperator (superset of ExchangeSinkOperator), which is the last operator of a Driver, and AsyncOperator, which can be responded by any thread in response.

The optimization reduces the latency of the enrich operation in the nyc_taxis benchmark from 100ms to 50ms. When combined with #102902, it further reduces the latency to below 40ms, better than the previous performance before the regression.

Relates #102625