### PR TITLE
Fast path for reading single doc with ordinals

### DIFF
--- a/docs/changelog/102902.yaml
+++ b/docs/changelog/102902.yaml
@@ -1,0 +1,5 @@
+pr: 102902
+summary: Fast path for reading single doc with ordinals
+area: ES|QL
+type: enhancement
+issues: []


### PR DESCRIPTION
This optimization is added for enrich lookups, which are likely to match a single document. The change decreases the latency of the enrich operation in the nyc_taxis benchmark from 100ms to 70ms. When combined with #102901, it further reduces the latency to below 40ms, better than the previous performance before the regression.

Relates #102625