### PR TITLE
[7.17] Suppress gradle welcome messages (#102898)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
+org.gradle.welcome=never
 org.gradle.warning.mode=none
 org.gradle.parallel=true
 # We need to declare --add-exports to make spotless working seamlessly with jdk16


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Suppress gradle welcome messages (#102898)](https://github.com/elastic/elasticsearch/pull/102898)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)