### PR TITLE
Fix layout for MV_EXPAND

### DIFF
--- a/docs/changelog/102916.yaml
+++ b/docs/changelog/102916.yaml
@@ -1,0 +1,6 @@
+pr: 102916
+summary: Fix layout for MV_EXPAND
+area: ES|QL
+type: bug
+issues:
+ - 102912

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/mv_expand.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/mv_expand.csv-spec
@@ -306,3 +306,13 @@ a:long      | b:long      | c:long      | gender:keyword | str:keyword   | x:key
 57          |57           |57           |M               |"57,M"         |M              
 0           |10           |10           |null            |null         |null           
 ;
+
+
+//see https://github.com/elastic/elasticsearch/issues/102912
+statsDissectThatOverwritesAndMvExpand#[skip:-8.11.99]
+row  a = "a", b = 1 | stats  e = min(b) by a | dissect a "%{e}" | mv_expand e;
+
+a:keyword | e:keyword
+a         | a
+;
+

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/Layout.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/Layout.java
@@ -119,5 +119,14 @@ public interface Layout {
             }
             return new DefaultLayout(Collections.unmodifiableMap(layout), numberOfChannels);
         }
+
+        public void replace(NameId id, NameId id1) {
+            for (ChannelSet channel : this.channels) {
+                if (channel != null && channel.nameIds.contains(id)) {
+                    channel.nameIds.remove(id);
+                    channel.nameIds.add(id1);
+                }
+            }
+        }
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -582,7 +582,6 @@ public class LocalExecutionPlanner {
     private PhysicalOperation planMvExpand(MvExpandExec mvExpandExec, LocalExecutionPlannerContext context) {
         PhysicalOperation source = plan(mvExpandExec.child(), context);
         int blockSize = 5000;// TODO estimate row size and use context.pageSize()
-        // Layout outputLayout = outputLayout(source, mvExpandExec);
         Layout.Builder layout = source.layout.builder();
         layout.replace(mvExpandExec.target().id(), mvExpandExec.expanded().id());
         return source.with(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -581,20 +581,10 @@ public class LocalExecutionPlanner {
 
     private PhysicalOperation planMvExpand(MvExpandExec mvExpandExec, LocalExecutionPlannerContext context) {
         PhysicalOperation source = plan(mvExpandExec.child(), context);
-        List<Attribute> childOutput = mvExpandExec.child().output();
         int blockSize = 5000;// TODO estimate row size and use context.pageSize()
-
-        Layout.Builder layout = new Layout.Builder();
-        List<Layout.ChannelSet> inverse = source.layout.inverse();
-        var expandedName = mvExpandExec.expanded().name();
-        for (int index = 0; index < inverse.size(); index++) {
-            if (childOutput.get(index).name().equals(expandedName)) {
-                layout.append(mvExpandExec.expanded());
-            } else {
-                layout.append(inverse.get(index));
-            }
-        }
-
+        // Layout outputLayout = outputLayout(source, mvExpandExec);
+        Layout.Builder layout = source.layout.builder();
+        layout.replace(mvExpandExec.target().id(), mvExpandExec.expanded().id());
         return source.with(
             new MvExpandOperator.Factory(source.layout.get(mvExpandExec.target().id()).channel(), blockSize),
             layout.build()


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/102912

Fixing MV_EXPAND layout by manually replacing the input attribute with the output one (that is what practically the operator does).
