### PR TITLE
Add ldap user metadata mappings for full name and email

### DIFF
--- a/docs/changelog/102925.yaml
+++ b/docs/changelog/102925.yaml
@@ -1,0 +1,5 @@
+pr: 102925
+summary: Add ldap user metadata mappings for full name and email
+area: Authentication
+type: enhancement
+issues: []

--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -431,6 +431,16 @@ Specifies the attribute to examine on the user for group membership.
 If any `group_search` settings are specified, this setting is ignored. Defaults
 to `memberOf`.
 
+`user_full_name_attribute`::
+(<<static-cluster-setting,Static>>)
+Specifies the attribute to examine on the user for the full name of the user.
+Defaults to `cn`.
+
+`user_email_attribute`::
+(<<static-cluster-setting,Static>>)
+Specifies the attribute to examine on the user for the email address of the user.
+Defaults to `mail`.
+
 `user_search.base_dn`::
 (<<static-cluster-setting,Static>>)
 Specifies a container DN to search for users. Required

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/ldap/support/LdapMetadataResolverSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/ldap/support/LdapMetadataResolverSettings.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.core.security.authc.ldap.support;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.xpack.core.security.authc.RealmSettings;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 
@@ -19,9 +18,19 @@ public final class LdapMetadataResolverSettings {
         key -> Setting.stringListSetting(key, Setting.Property.NodeScope)
     );
 
+    public static final Function<String, Setting.AffixSetting<String>> FULL_NAME_SETTING = RealmSettings.affixSetting(
+        "user_full_name_attribute",
+        key -> Setting.simpleString(key, "cn", Setting.Property.NodeScope)
+    );
+
+    public static final Function<String, Setting.AffixSetting<String>> EMAIL_SETTING = RealmSettings.affixSetting(
+        "user_email_attribute",
+        key -> Setting.simpleString(key, "mail", Setting.Property.NodeScope)
+    );
+
     private LdapMetadataResolverSettings() {}
 
     public static List<Setting.AffixSetting<?>> getSettings(String type) {
-        return Collections.singletonList(ADDITIONAL_METADATA_SETTING.apply(type));
+        return List.of(ADDITIONAL_METADATA_SETTING.apply(type), EMAIL_SETTING.apply(type), FULL_NAME_SETTING.apply(type));
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/LdapRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/LdapRealm.java
@@ -261,10 +261,13 @@ public final class LdapRealm extends CachingUsernamePasswordRealm {
                 metadata.put("ldap_groups", ldapData.groups);
                 metadata.putAll(ldapData.metadata);
                 final UserData user = new UserData(username, session.userDn(), ldapData.groups, metadata, session.realm());
+
                 roleMapper.resolveRoles(user, ActionListener.wrap(roles -> {
                     IOUtils.close(session);
                     String[] rolesArray = roles.toArray(new String[roles.size()]);
-                    listener.onResponse(AuthenticationResult.success(new User(username, rolesArray, null, null, metadata, true)));
+                    listener.onResponse(
+                        AuthenticationResult.success(new User(username, rolesArray, ldapData.fullName, ldapData.email, metadata, true))
+                    );
                 }, onFailure));
             }, onFailure));
             loadingGroups = true;

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/support/LdapMetadataResolver.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/support/LdapMetadataResolver.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.elasticsearch.xpack.security.authc.ldap.ActiveDirectorySIDUtil.TOKEN_GROUPS;
 import static org.elasticsearch.xpack.security.authc.ldap.ActiveDirectorySIDUtil.convertToString;
@@ -31,12 +32,20 @@ import static org.elasticsearch.xpack.security.authc.ldap.support.LdapUtils.OBJE
 import static org.elasticsearch.xpack.security.authc.ldap.support.LdapUtils.searchForEntry;
 
 public class LdapMetadataResolver {
-
     private final String[] attributeNames;
     private final boolean ignoreReferralErrors;
 
     public LdapMetadataResolver(RealmConfig realmConfig, boolean ignoreReferralErrors) {
-        this(realmConfig.getSetting(LdapMetadataResolverSettings.ADDITIONAL_METADATA_SETTING), ignoreReferralErrors);
+        this(
+            Stream.concat(
+                realmConfig.getSetting(LdapMetadataResolverSettings.ADDITIONAL_METADATA_SETTING).stream(),
+                Stream.of(
+                    realmConfig.getSetting(LdapMetadataResolverSettings.FULL_NAME_SETTING),
+                    realmConfig.getSetting(LdapMetadataResolverSettings.EMAIL_SETTING)
+                )
+            ).collect(Collectors.toSet()),
+            ignoreReferralErrors
+        );
     }
 
     LdapMetadataResolver(Collection<String> attributeNames, boolean ignoreReferralErrors) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/support/LdapSession.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/support/LdapSession.java
@@ -111,7 +111,14 @@ public class LdapSession implements Releasable {
         groups(ActionListener.wrap(groups -> {
             logger.debug("Resolved {} LDAP groups [{}] for user [{}]", groups.size(), groups, userDn);
             metadata(ActionListener.wrap(meta -> {
-                logger.debug("Resolved {} meta-data fields [{}] for user [{}]", meta.getMetaData().size(), meta, userDn);
+                logger.debug(
+                    "Resolved full name [{}], email [{}] and {} meta-data [{}] for user [{}]",
+                    meta.getFullName(),
+                    meta.getEmail(),
+                    meta.getMetaData().size(),
+                    meta,
+                    userDn
+                );
                 listener.onResponse(new LdapUserData(meta.getFullName(), meta.getEmail(), groups, meta.getMetaData()));
             }, listener::onFailure));
         }, listener::onFailure));

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/support/LdapMetadataResolverTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/support/LdapMetadataResolverTests.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.aMapWithSize;
-import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/support/LdapMetadataResolverTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/support/LdapMetadataResolverTests.java
@@ -27,6 +27,7 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
@@ -54,7 +55,7 @@ public class LdapMetadataResolverTests extends ESTestCase {
             .build();
         RealmConfig config = new RealmConfig(realmId, settings, TestEnvironment.newEnvironment(settings), new ThreadContext(settings));
         resolver = new LdapMetadataResolver(config, false);
-        assertThat(resolver.attributeNames(), arrayContaining("cn", "uid"));
+        assertThat(resolver.attributeNames(), arrayContainingInAnyOrder("cn", "uid", "mail"));
     }
 
     public void testResolveSingleValuedAttributeFromCachedAttributes() throws Exception {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/support/LdapMetadataResolverTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/support/LdapMetadataResolverTests.java
@@ -54,11 +54,11 @@ public class LdapMetadataResolverTests extends ESTestCase {
             .build();
         RealmConfig config = new RealmConfig(realmId, settings, TestEnvironment.newEnvironment(settings), new ThreadContext(settings));
         resolver = new LdapMetadataResolver(config, false);
-        assertThat(resolver.attributeNames(), arrayContainingInAnyOrder("cn", "uid", "mail"));
+        assertThat(resolver.attributeNames(), arrayContainingInAnyOrder("cn", "uid"));
     }
 
     public void testResolveSingleValuedAttributeFromCachedAttributes() throws Exception {
-        resolver = new LdapMetadataResolver(Arrays.asList("cn", "uid"), true);
+        resolver = new LdapMetadataResolver(null, null, Arrays.asList("cn", "uid"), true);
         final Collection<Attribute> attributes = Arrays.asList(
             new Attribute("cn", "Clint Barton"),
             new Attribute("uid", "hawkeye"),
@@ -72,7 +72,7 @@ public class LdapMetadataResolverTests extends ESTestCase {
     }
 
     public void testResolveMultiValuedAttributeFromCachedAttributes() throws Exception {
-        resolver = new LdapMetadataResolver(Arrays.asList("cn", "uid"), true);
+        resolver = new LdapMetadataResolver(null, null, Arrays.asList("cn", "uid"), true);
         final Collection<Attribute> attributes = Arrays.asList(
             new Attribute("cn", "Clint Barton", "hawkeye"),
             new Attribute("uid", "hawkeye")
@@ -85,7 +85,7 @@ public class LdapMetadataResolverTests extends ESTestCase {
     }
 
     public void testResolveMissingAttributeFromCachedAttributes() throws Exception {
-        resolver = new LdapMetadataResolver(Arrays.asList("cn", "uid"), true);
+        resolver = new LdapMetadataResolver(null, null, Arrays.asList("cn", "uid"), true);
         final Collection<Attribute> attributes = Collections.singletonList(new Attribute("uid", "hawkeye"));
         final Map<String, Object> map = resolve(attributes);
         assertThat(map, aMapWithSize(1));
@@ -94,8 +94,8 @@ public class LdapMetadataResolverTests extends ESTestCase {
     }
 
     private Map<String, Object> resolve(Collection<Attribute> attributes) throws Exception {
-        final PlainActionFuture<Map<String, Object>> future = new PlainActionFuture<>();
+        final PlainActionFuture<LdapMetadataResolver.LdapMetadataResult> future = new PlainActionFuture<>();
         resolver.resolve(null, HAWKEYE_DN, TimeValue.timeValueSeconds(1), logger, attributes, future);
-        return future.get();
+        return future.get().getMetaData();
     }
 }

--- a/x-pack/plugin/security/src/test/resources/org/elasticsearch/xpack/security/authc/ldap/support/seven-seas.ldif
+++ b/x-pack/plugin/security/src/test/resources/org/elasticsearch/xpack/security/authc/ldap/support/seven-seas.ldif
@@ -206,6 +206,32 @@ uid: jhallett
 mail: jhallett@royalnavy.mod.uk
 userpassword: pass
 
+dn: cn=John Samuel,ou=people,o=sevenSeas
+objectclass: person
+objectclass: organizationalPerson
+objectclass: inetOrgPerson
+objectclass: top
+cn: John Samuel
+description: Clerk John Samuel
+givenname: John
+manager: cn=William Bligh,ou=people,o=sevenSeas
+sn: Samuel
+uid: jsamuel
+userpassword: pass
+
+dn: cn=William Cole,ou=people,o=sevenSeas
+objectclass: person
+objectclass: organizationalPerson
+objectclass: inetOrgPerson
+objectclass: top
+cn: William Cole
+description: William Mark Cole
+givenname: William
+manager: cn=William Bligh,ou=people,o=sevenSeas
+sn: Cole
+uid: wcole@royalnavy.mod.uk
+userpassword: pass
+
 dn: cn=HMS Bounty,ou=crews,ou=groups,o=sevenSeas
 objectclass: groupOfUniqueNames
 objectclass: top

--- a/x-pack/plugin/security/src/test/resources/org/elasticsearch/xpack/security/authc/ldap/support/seven-seas.ldif
+++ b/x-pack/plugin/security/src/test/resources/org/elasticsearch/xpack/security/authc/ldap/support/seven-seas.ldif
@@ -216,20 +216,7 @@ description: Clerk John Samuel
 givenname: John
 manager: cn=William Bligh,ou=people,o=sevenSeas
 sn: Samuel
-uid: jsamuel
-userpassword: pass
-
-dn: cn=William Cole,ou=people,o=sevenSeas
-objectclass: person
-objectclass: organizationalPerson
-objectclass: inetOrgPerson
-objectclass: top
-cn: William Cole
-description: William Mark Cole
-givenname: William
-manager: cn=William Bligh,ou=people,o=sevenSeas
-sn: Cole
-uid: wcole@royalnavy.mod.uk
+uid: jsamuel@royalnavy.mod.uk
 userpassword: pass
 
 dn: cn=HMS Bounty,ou=crews,ou=groups,o=sevenSeas

--- a/x-pack/qa/openldap-tests/src/test/java/org/elasticsearch/test/OpenLdapTests.java
+++ b/x-pack/qa/openldap-tests/src/test/java/org/elasticsearch/test/OpenLdapTests.java
@@ -244,7 +244,8 @@ public class OpenLdapTests extends ESTestCase {
             .putList(
                 getFullSettingKey(realmId.getName(), LdapMetadataResolverSettings.ADDITIONAL_METADATA_SETTING.apply("ldap")),
                 "cn",
-                "sn"
+                "sn",
+                "mail"
             )
             .put(getFullSettingKey(realmId, RealmSettings.ORDER_SETTING), 0)
             .build();
@@ -282,7 +283,7 @@ public class OpenLdapTests extends ESTestCase {
         LdapMetadataResolver resolver = new LdapMetadataResolver(config, true);
         try (LDAPConnection ldapConnection = setupOpenLdapConnection()) {
             final Map<String, Object> map = resolve(ldapConnection, resolver);
-            assertThat(map.size(), equalTo(3));
+            assertThat(map.size(), equalTo(1));
             assertThat(map.get("objectClass"), instanceOf(List.class));
             assertThat((List<?>) map.get("objectClass"), contains("top", "posixAccount", "inetOrgPerson"));
         }
@@ -303,7 +304,7 @@ public class OpenLdapTests extends ESTestCase {
         LdapMetadataResolver resolver = new LdapMetadataResolver(config, true);
         try (LDAPConnection ldapConnection = setupOpenLdapConnection()) {
             final Map<String, Object> map = resolve(ldapConnection, resolver);
-            assertThat(map.size(), equalTo(2));
+            assertThat(map.size(), equalTo(0));
         }
     }
 
@@ -344,9 +345,9 @@ public class OpenLdapTests extends ESTestCase {
     }
 
     private Map<String, Object> resolve(LDAPConnection connection, LdapMetadataResolver resolver) throws Exception {
-        final PlainActionFuture<Map<String, Object>> future = new PlainActionFuture<>();
+        final PlainActionFuture<LdapMetadataResolver.LdapMetadataResult> future = new PlainActionFuture<>();
         resolver.resolve(connection, HAWKEYE_DN, TimeValue.timeValueSeconds(1), logger, null, future);
-        return future.get();
+        return future.get().getMetaData();
     }
 
     private static String getFromProperty(String port) {

--- a/x-pack/qa/openldap-tests/src/test/java/org/elasticsearch/test/OpenLdapTests.java
+++ b/x-pack/qa/openldap-tests/src/test/java/org/elasticsearch/test/OpenLdapTests.java
@@ -257,9 +257,10 @@ public class OpenLdapTests extends ESTestCase {
         LdapMetadataResolver resolver = new LdapMetadataResolver(config, true);
         try (LDAPConnection ldapConnection = setupOpenLdapConnection()) {
             final Map<String, Object> map = resolve(ldapConnection, resolver);
-            assertThat(map.size(), equalTo(2));
+            assertThat(map.size(), equalTo(3));
             assertThat(map.get("cn"), equalTo("Clint Barton"));
             assertThat(map.get("sn"), equalTo("Clint Barton"));
+            assertThat(map.get("mail"), equalTo("hawkeye@oldap.test.elasticsearch.com"));
         }
     }
 
@@ -281,7 +282,7 @@ public class OpenLdapTests extends ESTestCase {
         LdapMetadataResolver resolver = new LdapMetadataResolver(config, true);
         try (LDAPConnection ldapConnection = setupOpenLdapConnection()) {
             final Map<String, Object> map = resolve(ldapConnection, resolver);
-            assertThat(map.size(), equalTo(1));
+            assertThat(map.size(), equalTo(3));
             assertThat(map.get("objectClass"), instanceOf(List.class));
             assertThat((List<?>) map.get("objectClass"), contains("top", "posixAccount", "inetOrgPerson"));
         }
@@ -302,7 +303,7 @@ public class OpenLdapTests extends ESTestCase {
         LdapMetadataResolver resolver = new LdapMetadataResolver(config, true);
         try (LDAPConnection ldapConnection = setupOpenLdapConnection()) {
             final Map<String, Object> map = resolve(ldapConnection, resolver);
-            assertThat(map.size(), equalTo(0));
+            assertThat(map.size(), equalTo(2));
         }
     }
 

--- a/x-pack/qa/third-party/active-directory/src/test/java/org/elasticsearch/xpack/security/authc/ldap/ActiveDirectorySessionFactoryTests.java
+++ b/x-pack/qa/third-party/active-directory/src/test/java/org/elasticsearch/xpack/security/authc/ldap/ActiveDirectorySessionFactoryTests.java
@@ -511,15 +511,15 @@ public class ActiveDirectorySessionFactoryTests extends AbstractActiveDirectoryT
             .put(getFullSettingKey(REALM_ID, LdapMetadataResolverSettings.ADDITIONAL_METADATA_SETTING), "tokenGroups")
             .build();
         RealmConfig config = configureRealm("ad-test", LdapRealmSettings.AD_TYPE, settings);
-        final PlainActionFuture<Map<String, Object>> future = new PlainActionFuture<>();
+        final PlainActionFuture<LdapMetadataResolver.LdapMetadataResult> future = new PlainActionFuture<>();
         LdapMetadataResolver resolver = new LdapMetadataResolver(config, true);
         try (ActiveDirectorySessionFactory sessionFactory = getActiveDirectorySessionFactory(config, sslService, threadPool)) {
             String userName = "hulk";
             try (LdapSession ldap = session(sessionFactory, userName, SECURED_PASSWORD)) {
                 assertConnectionCanReconnect(ldap.getConnection());
                 resolver.resolve(ldap.getConnection(), BRUCE_BANNER_DN, TimeValue.timeValueSeconds(1), logger, null, future);
-                Map<String, Object> metadataGroupSIDs = future.get();
-                assertThat(metadataGroupSIDs.size(), equalTo(2));
+                Map<String, Object> metadataGroupSIDs = future.get().getMetaData();
+                assertThat(metadataGroupSIDs.size(), equalTo(1));
                 assertNotNull(metadataGroupSIDs.get("tokenGroups"));
                 List<String> SIDs = ((List<String>) metadataGroupSIDs.get("tokenGroups"));
                 assertThat(SIDs.size(), equalTo(7));

--- a/x-pack/qa/third-party/active-directory/src/test/java/org/elasticsearch/xpack/security/authc/ldap/ActiveDirectorySessionFactoryTests.java
+++ b/x-pack/qa/third-party/active-directory/src/test/java/org/elasticsearch/xpack/security/authc/ldap/ActiveDirectorySessionFactoryTests.java
@@ -519,7 +519,7 @@ public class ActiveDirectorySessionFactoryTests extends AbstractActiveDirectoryT
                 assertConnectionCanReconnect(ldap.getConnection());
                 resolver.resolve(ldap.getConnection(), BRUCE_BANNER_DN, TimeValue.timeValueSeconds(1), logger, null, future);
                 Map<String, Object> metadataGroupSIDs = future.get();
-                assertThat(metadataGroupSIDs.size(), equalTo(1));
+                assertThat(metadataGroupSIDs.size(), equalTo(2));
                 assertNotNull(metadataGroupSIDs.get("tokenGroups"));
                 List<String> SIDs = ((List<String>) metadataGroupSIDs.get("tokenGroups"));
                 assertThat(SIDs.size(), equalTo(7));


### PR DESCRIPTION
This PR adds two new configurations to the LDAP realm: 
1. `user_full_name_attribute` - the attribute in the user metadata that contains the full name of the user. Defaults to `cn` (common name). 
2. `user_email_attribute` - the attribute in the user metadata that contains the email address of the user. Defaults to `mail`. 

This changes the current behaviour of the ldap authentication flow by instead of setting `fullName` and `email` to `null`,  default to mapping `cn` and `mail` in the user metadata to those attributes. 

Fixes: https://github.com/elastic/elasticsearch/issues/102860