### PR TITLE
[Transform] Ensure transform updates only modify the expected transform task

### DIFF
--- a/docs/changelog/102934.yaml
+++ b/docs/changelog/102934.yaml
@@ -1,5 +1,5 @@
 pr: 102934
-summary: Filter persistent transform tasks that match the update request
+summary: Ensure transform updates only modify the expected transform task
 area: Transform
 type: bug
 issues:

--- a/docs/changelog/102934.yaml
+++ b/docs/changelog/102934.yaml
@@ -1,0 +1,6 @@
+pr: 102934
+summary: Filter persistent transform tasks that match the update request
+area: Transform
+type: bug
+issues:
+ - 102933

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/UpdateTransformAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/UpdateTransformAction.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.support.tasks.BaseTasksResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.tasks.Task;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
@@ -185,6 +186,15 @@ public class UpdateTransformAction extends ActionType<UpdateTransformAction.Resp
                 && Objects.equals(config, other.config)
                 && Objects.equals(authState, other.authState)
                 && getTimeout().equals(other.getTimeout());
+        }
+
+        @Override
+        public boolean match(Task task) {
+            if (task.getDescription().startsWith(TransformField.PERSISTENT_TASK_DESCRIPTION_PREFIX)) {
+                String taskId = task.getDescription().substring(TransformField.PERSISTENT_TASK_DESCRIPTION_PREFIX.length());
+                return taskId.equals(this.id);
+            }
+            return false;
         }
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/action/UpdateTransformActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/action/UpdateTransformActionRequestTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.core.transform.action;
 
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.persistent.AllocatedPersistentTask;
 import org.elasticsearch.xpack.core.transform.action.UpdateTransformAction.Request;
 import org.elasticsearch.xpack.core.transform.transforms.AuthorizationStateTests;
 import org.elasticsearch.xpack.core.transform.transforms.TransformConfigTests;
@@ -73,5 +74,13 @@ public class UpdateTransformActionRequestTests extends AbstractWireSerializingTr
         }
 
         return new Request(update, id, deferValidation, timeout);
+    }
+
+    public void testMatch() {
+        Request request = new Request(randomTransformConfigUpdate(), "my-transform-7", false, null);
+        assertTrue(request.match(new AllocatedPersistentTask(123, "", "", "data_frame_my-transform-7", null, null)));
+        assertFalse(request.match(new AllocatedPersistentTask(123, "", "", "data_frame_my-transform-", null, null)));
+        assertFalse(request.match(new AllocatedPersistentTask(123, "", "", "data_frame_my-transform-77", null, null)));
+        assertFalse(request.match(new AllocatedPersistentTask(123, "", "", "my-transform-7", null, null)));
     }
 }


### PR DESCRIPTION
`TransportUpdateTransformAction` is a `TransportTasksAction` which means that it fans out to individual tasks running on the nodes.
In order to find the appropriate tasks the `match` method must be implemented properly. For the `_update` action request the `match` implementation was missing which caused the action to fan out to **all** the transform persistent tasks causing unexpected changes in live (held in memory) transform settings.
This PR implements the `match` method so that the problem is fixed.

Closes https://github.com/elastic/elasticsearch/issues/102933