### PR TITLE
[8.11] [Transform] Ensure transform updates only modify the expected transform task (#102934)

### DIFF
--- a/docs/changelog/102934.yaml
+++ b/docs/changelog/102934.yaml
@@ -1,0 +1,6 @@
+pr: 102934
+summary: Ensure transform updates only modify the expected transform task
+area: Transform
+type: bug
+issues:
+ - 102933

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/UpdateTransformAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/UpdateTransformAction.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.support.tasks.BaseTasksResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.tasks.Task;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
@@ -186,6 +187,15 @@ public class UpdateTransformAction extends ActionType<UpdateTransformAction.Resp
                 && Objects.equals(config, other.config)
                 && Objects.equals(authState, other.authState)
                 && getTimeout().equals(other.getTimeout());
+        }
+
+        @Override
+        public boolean match(Task task) {
+            if (task.getDescription().startsWith(TransformField.PERSISTENT_TASK_DESCRIPTION_PREFIX)) {
+                String taskId = task.getDescription().substring(TransformField.PERSISTENT_TASK_DESCRIPTION_PREFIX.length());
+                return taskId.equals(this.id);
+            }
+            return false;
         }
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/action/UpdateTransformActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/action/UpdateTransformActionRequestTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.core.transform.action;
 
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.persistent.AllocatedPersistentTask;
 import org.elasticsearch.xpack.core.transform.action.UpdateTransformAction.Request;
 import org.elasticsearch.xpack.core.transform.transforms.AuthorizationStateTests;
 import org.elasticsearch.xpack.core.transform.transforms.TransformConfigTests;
@@ -73,5 +74,13 @@ public class UpdateTransformActionRequestTests extends AbstractWireSerializingTr
         }
 
         return new Request(update, id, deferValidation, timeout);
+    }
+
+    public void testMatch() {
+        Request request = new Request(randomTransformConfigUpdate(), "my-transform-7", false, null);
+        assertTrue(request.match(new AllocatedPersistentTask(123, "", "", "data_frame_my-transform-7", null, null)));
+        assertFalse(request.match(new AllocatedPersistentTask(123, "", "", "data_frame_my-transform-", null, null)));
+        assertFalse(request.match(new AllocatedPersistentTask(123, "", "", "data_frame_my-transform-77", null, null)));
+        assertFalse(request.match(new AllocatedPersistentTask(123, "", "", "my-transform-7", null, null)));
     }
 }


### PR DESCRIPTION
Backports the following commits to 8.11:
 - [Transform] Ensure transform updates only modify the expected transform task (#102934)