### PR TITLE
[7.17] [Transform] Ensure transform updates only modify the expected transform task (#102934)

### DIFF
--- a/docs/changelog/102934.yaml
+++ b/docs/changelog/102934.yaml
@@ -1,0 +1,6 @@
+pr: 102934
+summary: Ensure transform updates only modify the expected transform task
+area: Transform
+type: bug
+issues:
+ - 102933

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/UpdateTransformAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/UpdateTransformAction.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.support.tasks.BaseTasksResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.tasks.Task;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
@@ -177,6 +178,15 @@ public class UpdateTransformAction extends ActionType<UpdateTransformAction.Resp
                 && this.id.equals(other.id)
                 && Objects.equals(config, other.config)
                 && getTimeout().equals(other.getTimeout());
+        }
+
+        @Override
+        public boolean match(Task task) {
+            if (task.getDescription().startsWith(TransformField.PERSISTENT_TASK_DESCRIPTION_PREFIX)) {
+                String taskId = task.getDescription().substring(TransformField.PERSISTENT_TASK_DESCRIPTION_PREFIX.length());
+                return taskId.equals(this.id);
+            }
+            return false;
         }
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/action/UpdateTransformActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/action/UpdateTransformActionRequestTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.core.transform.action;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.persistent.AllocatedPersistentTask;
 import org.elasticsearch.xpack.core.transform.action.UpdateTransformAction.Request;
 import org.elasticsearch.xpack.core.transform.action.compat.UpdateTransformActionPre78;
 import org.elasticsearch.xpack.core.transform.transforms.TransformConfigTests;
@@ -85,6 +86,14 @@ public class UpdateTransformActionRequestTests extends AbstractWireSerializingTr
         return new Request(update, id, deferValidation, timeout);
     }
 
+    public void testMatch() {
+        Request request = new Request(randomTransformConfigUpdate(), "my-transform-7", false, null);
+        assertTrue(request.match(new AllocatedPersistentTask(123, "", "", "data_frame_my-transform-7", null, null)));
+        assertFalse(request.match(new AllocatedPersistentTask(123, "", "", "data_frame_my-transform-", null, null)));
+        assertFalse(request.match(new AllocatedPersistentTask(123, "", "", "data_frame_my-transform-77", null, null)));
+        assertFalse(request.match(new AllocatedPersistentTask(123, "", "", "my-transform-7", null, null)));
+    }
+
     public void testBWCPre78() throws IOException {
         Request newRequest = createTestInstance();
         UpdateTransformActionPre78.Request oldRequest = writeAndReadBWCObject(
@@ -134,5 +143,4 @@ public class UpdateTransformActionRequestTests extends AbstractWireSerializingTr
         assertEquals(newRequest.getUpdate().getSyncConfig(), newRequestFromOld.getUpdate().getSyncConfig());
         assertEquals(newRequest.isDeferValidation(), newRequestFromOld.isDeferValidation());
     }
-
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[Transform] Ensure transform updates only modify the expected transform task (#102934)](https://github.com/elastic/elasticsearch/pull/102934)

<!--- Backport version: 8.8.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)