### PR TITLE
Re-enable HeapAttack tests

### DIFF
--- a/x-pack/plugin/esql/qa/server/heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/heap_attack/HeapAttackIT.java
+++ b/x-pack/plugin/esql/qa/server/heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/heap_attack/HeapAttackIT.java
@@ -113,7 +113,6 @@ public class HeapAttackIT extends ESRestTestCase {
     /**
      * This groups on 5000 columns which used to throw a {@link StackOverflowError}.
      */
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/100640")
     public void testGroupOnManyLongs() throws IOException {
         initManyLongs();
         Map<?, ?> map = XContentHelper.convertToMap(
@@ -182,7 +181,6 @@ public class HeapAttackIT extends ESRestTestCase {
     /**
      * Returns many moderately long strings.
      */
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/100678")
     public void testManyConcat() throws IOException {
         initManyLongs();
         Map<?, ?> map = XContentHelper.convertToMap(JsonXContent.jsonXContent, EntityUtils.toString(manyConcat(300).getEntity()), false);


### PR DESCRIPTION
This PR re-enables two more heap attack tests. I have run more than 100 iterations with these tests without hitting any failures.