### PR TITLE
[ML] If trained model download task is in progress, wait for it to finish before executing start trained model deployment

### DIFF
--- a/docs/changelog/102944.yaml
+++ b/docs/changelog/102944.yaml
@@ -1,0 +1,6 @@
+pr: 102944
+summary: "If trained model download task is in progress, wait for it to finish before\
+  \ executing start trained model deployment"
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
@@ -123,6 +123,8 @@ public final class Messages {
         "Unable to delete model [{0}] as it is required by machine learning";
     public static final String MODEL_DEFINITION_TRUNCATED =
         "Model definition truncated. Unable to deserialize trained model definition [{0}]";
+    public static final String MODEL_DOWNLOAD_IN_PROGRESS =
+        "Model download task is currently running. Wait for trained model [{0}] download task to complete then try again";
     public static final String UNABLE_TO_DEPLOY_MODEL_BAD_PARTS = "Unable to deploy model, please delete and recreate the model definition";
     public static final String INFERENCE_FAILED_TO_DESERIALIZE = "Could not deserialize trained model [{0}]";
     public static final String INFERENCE_TOO_MANY_DEFINITIONS_REQUESTED =

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetTrainedModelsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetTrainedModelsAction.java
@@ -89,6 +89,7 @@ public class TransportGetTrainedModelsAction extends HandledTransportAction<Requ
                 new OriginSettingClient(client, ML_ORIGIN),
                 configs.get(0),
                 false,  // missing docs are not an error
+                null,   // if download is in progress, don't wait for it to complete
                 ActionListener.wrap(modelIdAndLength -> {
                     configs.get(0).setFullDefinition(modelIdAndLength.v2() > 0);
                     listener.onResponse(responseBuilder.setModels(configs).build());

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
@@ -551,7 +551,7 @@ public class TransportStartTrainedModelDeploymentAction extends TransportMasterN
     /*
     @param timeout null value indicates that the request should not wait for the download to complete before returning
      */
-    static void step1CheckForDownloadTask(
+    private static void step1CheckForDownloadTask(
         OriginSettingClient mlOriginClient,
         boolean errorIfDefinitionIsMissing,
         TimeValue timeout,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
@@ -3,6 +3,8 @@
  * or more contributor license agreements. Licensed under the Elastic License
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
+ *
+ * this file was contributed to by a generative AI
  */
 
 package org.elasticsearch.xpack.ml.action;
@@ -13,6 +15,7 @@ import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.client.internal.Client;
@@ -64,6 +67,7 @@ import org.elasticsearch.xpack.ml.inference.assignment.TrainedModelAssignmentSer
 import org.elasticsearch.xpack.ml.inference.persistence.TrainedModelDefinitionDoc;
 import org.elasticsearch.xpack.ml.notifications.InferenceAuditor;
 import org.elasticsearch.xpack.ml.process.MlMemoryTracker;
+import org.elasticsearch.xpack.ml.utils.TaskRetriever;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -269,7 +273,13 @@ public class TransportStartTrainedModelDeploymentAction extends TransportMasterN
                         error -> {
                             if (ExceptionsHelper.unwrapCause(error) instanceof ResourceNotFoundException) {
                                 // no name clash, continue with the deployment
-                                checkFullModelDefinitionIsPresent(client, trainedModelConfig, true, modelSizeListener);
+                                checkFullModelDefinitionIsPresent(
+                                    client,
+                                    trainedModelConfig,
+                                    true,
+                                    request.getTimeout(),
+                                    modelSizeListener
+                                );
                             } else {
                                 listener.onFailure(error);
                             }
@@ -277,7 +287,7 @@ public class TransportStartTrainedModelDeploymentAction extends TransportMasterN
                     )
                 );
             } else {
-                checkFullModelDefinitionIsPresent(client, trainedModelConfig, true, modelSizeListener);
+                checkFullModelDefinitionIsPresent(client, trainedModelConfig, true, request.getTimeout(), modelSizeListener);
             }
 
         }, listener::onFailure);
@@ -342,27 +352,30 @@ public class TransportStartTrainedModelDeploymentAction extends TransportMasterN
      * individual per-document definition lengths and checking
      * the total is equal to the total definition length as
      * stored in the docs.
-     *
+     * <p>
      * On success the response is a tuple
      * {@code <String, Long> (model id, total definition length)}
-     *
+     * <p>
      * If {@code errorIfDefinitionIsMissing == false} and some
      * definition docs are missing then {@code listener::onResponse}
      * is called with the total definition length == 0.
      * This usage is to answer yes/no questions if the full model
      * definition is present.
      *
-     * @param mlOriginClient A client using ML_ORIGIN
-     * @param config trained model config
+     * @param mlOriginClient             A client using ML_ORIGIN
+     * @param config                     trained model config
      * @param errorIfDefinitionIsMissing If true missing definition parts cause errors.
      *                                   If false and some parts are missing the total
      *                                   definition length in the response is set to 0.
-     * @param listener response listener
+     * @param timeout                    The timeout value in seconds that the request should fail if it does not complete.
+     *                                   If null, then this will not wait for the download to complete before returning.
+     * @param listener                   response listener
      */
     static void checkFullModelDefinitionIsPresent(
         OriginSettingClient mlOriginClient,
         TrainedModelConfig config,
         boolean errorIfDefinitionIsMissing,
+        TimeValue timeout,
         ActionListener<Tuple<String, Long>> listener
     ) {
         if (config.getLocation() instanceof IndexLocation == false) {
@@ -373,27 +386,86 @@ public class TransportStartTrainedModelDeploymentAction extends TransportMasterN
         final String modelId = config.getModelId();
 
         String index = ((IndexLocation) config.getLocation()).getIndexName();
-        mlOriginClient.prepareSearch(index)
-            .setQuery(
-                QueryBuilders.constantScoreQuery(
-                    QueryBuilders.boolQuery()
-                        .filter(QueryBuilders.termQuery(TrainedModelConfig.MODEL_ID.getPreferredName(), modelId))
-                        .filter(
-                            QueryBuilders.termQuery(InferenceIndexConstants.DOC_TYPE.getPreferredName(), TrainedModelDefinitionDoc.NAME)
-                        )
-                )
-            )
-            .setFetchSource(false)
-            .addDocValueField(TrainedModelDefinitionDoc.DEFINITION_LENGTH.getPreferredName())
-            .addDocValueField(TrainedModelDefinitionDoc.TOTAL_DEFINITION_LENGTH.getPreferredName())
-            .setSize(MAX_NUM_NATIVE_DEFINITION_PARTS)
-            .setTrackTotalHits(true)
-            .addSort(SortBuilders.fieldSort(TrainedModelDefinitionDoc.DOC_NUM.getPreferredName()).order(SortOrder.ASC).unmappedType("long"))
-            .execute(ActionListener.wrap(response -> {
-                SearchHit[] hits = response.getHits().getHits();
-                if (hits.length == 0) {
+
+        // Step 3
+        // Verify the model definition parts are all present
+        ActionListener<SearchResponse> step3SearchResultsVerificationListener = step3VerifyModelPartsArePresent(
+            errorIfDefinitionIsMissing,
+            listener,
+            modelId
+        );
+
+        // Step 2
+        // Search for the model definition parts to ensure they are all present
+        ActionListener<Runnable> step2DocsSearchListener = step2SearchForModelParts(
+            mlOriginClient,
+            listener,
+            index,
+            modelId,
+            step3SearchResultsVerificationListener
+        );
+
+        // Step 1 (there is no step zero)
+        // Check if there is a download task for this model, and wait for it to complete or timeout
+        step1CheckForDownloadTask(mlOriginClient, errorIfDefinitionIsMissing, timeout, listener, modelId, step2DocsSearchListener);
+    }
+
+    private static ActionListener<SearchResponse> step3VerifyModelPartsArePresent(
+        boolean errorIfDefinitionIsMissing,
+        ActionListener<Tuple<String, Long>> listener,
+        String modelId
+    ) {
+        return ActionListener.wrap(response -> {
+            SearchHit[] hits = response.getHits().getHits();
+            if (hits.length == 0) {
+                failOrRespondWith0(
+                    () -> new ResourceNotFoundException(Messages.getMessage(Messages.MODEL_DEFINITION_NOT_FOUND, modelId)),
+                    errorIfDefinitionIsMissing,
+                    modelId,
+                    listener
+                );
+                return;
+            }
+
+            long firstTotalLength;
+            DocumentField firstTotalLengthField = hits[0].field(TrainedModelDefinitionDoc.TOTAL_DEFINITION_LENGTH.getPreferredName());
+            if (firstTotalLengthField != null && firstTotalLengthField.getValue() instanceof Long firstTotalDefinitionLength) {
+                firstTotalLength = firstTotalDefinitionLength;
+            } else {
+                failOrRespondWith0(
+                    () -> missingFieldsError(
+                        modelId,
+                        hits[0].getId(),
+                        List.of(TrainedModelDefinitionDoc.TOTAL_DEFINITION_LENGTH.getPreferredName())
+                    ),
+                    errorIfDefinitionIsMissing,
+                    modelId,
+                    listener
+                );
+                return;
+            }
+
+            Set<String> missingFields = new HashSet<>();
+            long summedLengths = 0;
+            for (SearchHit hit : hits) {
+                long totalLength = -1;
+                DocumentField totalLengthField = hit.field(TrainedModelDefinitionDoc.TOTAL_DEFINITION_LENGTH.getPreferredName());
+                if (totalLengthField != null && totalLengthField.getValue() instanceof Long totalDefinitionLength) {
+                    totalLength = totalDefinitionLength;
+                } else {
+                    missingFields.add(TrainedModelDefinitionDoc.TOTAL_DEFINITION_LENGTH.getPreferredName());
+                }
+
+                DocumentField definitionLengthField = hit.field(TrainedModelDefinitionDoc.DEFINITION_LENGTH.getPreferredName());
+                if (definitionLengthField != null && definitionLengthField.getValue() instanceof Long definitionLength) {
+                    summedLengths += definitionLength;
+                } else {
+                    missingFields.add(TrainedModelDefinitionDoc.DEFINITION_LENGTH.getPreferredName());
+                }
+
+                if (missingFields.isEmpty() == false) {
                     failOrRespondWith0(
-                        () -> new ResourceNotFoundException(Messages.getMessage(Messages.MODEL_DEFINITION_NOT_FOUND, modelId)),
+                        () -> missingFieldsError(modelId, hit.getId(), missingFields),
                         errorIfDefinitionIsMissing,
                         modelId,
                         listener
@@ -401,16 +473,18 @@ public class TransportStartTrainedModelDeploymentAction extends TransportMasterN
                     return;
                 }
 
-                long firstTotalLength;
-                DocumentField firstTotalLengthField = hits[0].field(TrainedModelDefinitionDoc.TOTAL_DEFINITION_LENGTH.getPreferredName());
-                if (firstTotalLengthField != null && firstTotalLengthField.getValue() instanceof Long firstTotalDefinitionLength) {
-                    firstTotalLength = firstTotalDefinitionLength;
-                } else {
+                if (totalLength != firstTotalLength) {
+                    final long finalTotalLength = totalLength;
                     failOrRespondWith0(
-                        () -> missingFieldsError(
+                        () -> ExceptionsHelper.badRequestException(
+                            "[{}] [total_definition_length] must be the same in all model definition parts. "
+                                + "The value [{}] in model definition part [{}] does not match the value [{}] in part [{}]. "
+                                + Messages.UNABLE_TO_DEPLOY_MODEL_BAD_PARTS,
                             modelId,
-                            hits[0].getId(),
-                            List.of(TrainedModelDefinitionDoc.TOTAL_DEFINITION_LENGTH.getPreferredName())
+                            finalTotalLength,
+                            TrainedModelDefinitionDoc.docNum(modelId, Objects.requireNonNull(hit.getId())),
+                            firstTotalLength,
+                            TrainedModelDefinitionDoc.docNum(modelId, Objects.requireNonNull(hits[0].getId()))
                         ),
                         errorIfDefinitionIsMissing,
                         modelId,
@@ -419,76 +493,87 @@ public class TransportStartTrainedModelDeploymentAction extends TransportMasterN
                     return;
                 }
 
-                Set<String> missingFields = new HashSet<>();
-                long summedLengths = 0;
-                for (SearchHit hit : hits) {
-                    long totalLength = -1;
-                    DocumentField totalLengthField = hit.field(TrainedModelDefinitionDoc.TOTAL_DEFINITION_LENGTH.getPreferredName());
-                    if (totalLengthField != null && totalLengthField.getValue() instanceof Long totalDefinitionLength) {
-                        totalLength = totalDefinitionLength;
-                    } else {
-                        missingFields.add(TrainedModelDefinitionDoc.TOTAL_DEFINITION_LENGTH.getPreferredName());
-                    }
+            }
+            if (summedLengths != firstTotalLength) {
+                failOrRespondWith0(
+                    () -> ExceptionsHelper.badRequestException(Messages.getMessage(Messages.MODEL_DEFINITION_TRUNCATED, modelId)),
+                    errorIfDefinitionIsMissing,
+                    modelId,
+                    listener
+                );
+                return;
+            }
+            listener.onResponse(new Tuple<>(modelId, summedLengths));
+        }, e -> {
+            if (ExceptionsHelper.unwrapCause(e) instanceof ResourceNotFoundException) {
+                failOrRespondWith0(() -> {
+                    Exception ex = new ResourceNotFoundException(Messages.getMessage(Messages.MODEL_DEFINITION_NOT_FOUND, modelId));
+                    ex.addSuppressed(e);
+                    return ex;
+                }, errorIfDefinitionIsMissing, modelId, listener);
+            } else {
+                listener.onFailure(e);
+            }
+        });
+    }
 
-                    DocumentField definitionLengthField = hit.field(TrainedModelDefinitionDoc.DEFINITION_LENGTH.getPreferredName());
-                    if (definitionLengthField != null && definitionLengthField.getValue() instanceof Long definitionLength) {
-                        summedLengths += definitionLength;
-                    } else {
-                        missingFields.add(TrainedModelDefinitionDoc.DEFINITION_LENGTH.getPreferredName());
-                    }
+    private static ActionListener<Runnable> step2SearchForModelParts(
+        OriginSettingClient mlOriginClient,
+        ActionListener<Tuple<String, Long>> listener,
+        String index,
+        String modelId,
+        ActionListener<SearchResponse> nextStepListener
+    ) {
+        return ActionListener.wrap(r -> {
+            mlOriginClient.prepareSearch(index)
+                .setQuery(
+                    QueryBuilders.constantScoreQuery(
+                        QueryBuilders.boolQuery()
+                            .filter(QueryBuilders.termQuery(TrainedModelConfig.MODEL_ID.getPreferredName(), modelId))
+                            .filter(
+                                QueryBuilders.termQuery(InferenceIndexConstants.DOC_TYPE.getPreferredName(), TrainedModelDefinitionDoc.NAME)
+                            )
+                    )
+                )
+                .setFetchSource(false)
+                .addDocValueField(TrainedModelDefinitionDoc.DEFINITION_LENGTH.getPreferredName())
+                .addDocValueField(TrainedModelDefinitionDoc.TOTAL_DEFINITION_LENGTH.getPreferredName())
+                .setSize(MAX_NUM_NATIVE_DEFINITION_PARTS)
+                .setTrackTotalHits(true)
+                .addSort(
+                    SortBuilders.fieldSort(TrainedModelDefinitionDoc.DOC_NUM.getPreferredName()).order(SortOrder.ASC).unmappedType("long")
+                )
+                .execute(nextStepListener);
 
-                    if (missingFields.isEmpty() == false) {
-                        failOrRespondWith0(
-                            () -> missingFieldsError(modelId, hit.getId(), missingFields),
-                            errorIfDefinitionIsMissing,
-                            modelId,
-                            listener
-                        );
-                        return;
-                    }
+        }, listener::onFailure);
+    }
 
-                    if (totalLength != firstTotalLength) {
-                        final long finalTotalLength = totalLength;
-                        failOrRespondWith0(
-                            () -> ExceptionsHelper.badRequestException(
-                                "[{}] [total_definition_length] must be the same in all model definition parts. "
-                                    + "The value [{}] in model definition part [{}] does not match the value [{}] in part [{}]. "
-                                    + Messages.UNABLE_TO_DEPLOY_MODEL_BAD_PARTS,
-                                modelId,
-                                finalTotalLength,
-                                TrainedModelDefinitionDoc.docNum(modelId, Objects.requireNonNull(hit.getId())),
-                                firstTotalLength,
-                                TrainedModelDefinitionDoc.docNum(modelId, Objects.requireNonNull(hits[0].getId()))
-                            ),
-                            errorIfDefinitionIsMissing,
-                            modelId,
-                            listener
-                        );
-                        return;
-                    }
-
-                }
-                if (summedLengths != firstTotalLength) {
-                    failOrRespondWith0(
-                        () -> ExceptionsHelper.badRequestException(Messages.getMessage(Messages.MODEL_DEFINITION_TRUNCATED, modelId)),
-                        errorIfDefinitionIsMissing,
-                        modelId,
-                        listener
-                    );
-                    return;
-                }
-                listener.onResponse(new Tuple<>(modelId, summedLengths));
-            }, e -> {
-                if (ExceptionsHelper.unwrapCause(e) instanceof ResourceNotFoundException) {
-                    failOrRespondWith0(() -> {
-                        Exception ex = new ResourceNotFoundException(Messages.getMessage(Messages.MODEL_DEFINITION_NOT_FOUND, modelId));
-                        ex.addSuppressed(e);
-                        return ex;
-                    }, errorIfDefinitionIsMissing, modelId, listener);
-                } else {
-                    listener.onFailure(e);
-                }
-            }));
+    /*
+    @param timeout null value indicates that the request should not wait for the download to complete before returning
+     */
+    static void step1CheckForDownloadTask(
+        OriginSettingClient mlOriginClient,
+        boolean errorIfDefinitionIsMissing,
+        TimeValue timeout,
+        ActionListener<Tuple<String, Long>> failureListener,
+        String modelId,
+        ActionListener<Runnable> nextStepListener
+    ) {
+        TaskRetriever.getDownloadTaskInfo(mlOriginClient, modelId, timeout != null, ActionListener.wrap(taskInfo -> {
+            if (taskInfo == null) {
+                nextStepListener.onResponse(null);
+            } else {
+                failOrRespondWith0(
+                    () -> new ElasticsearchStatusException(
+                        Messages.getMessage(Messages.MODEL_DOWNLOAD_IN_PROGRESS, modelId),
+                        RestStatus.REQUEST_TIMEOUT
+                    ),
+                    errorIfDefinitionIsMissing,
+                    modelId,
+                    failureListener
+                );
+            }
+        }, failureListener::onFailure), timeout);
     }
 
     private static void failOrRespondWith0(

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/3rd_party_deployment.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/3rd_party_deployment.yml
@@ -228,9 +228,15 @@ setup:
           	"field_names": ["text_field"]
             }
           }
-
   - do:
       catch: /Model download task is currently running\. Wait for trained model \[.elser_model_2\] download task to complete then try again/
+      ml.start_trained_model_deployment:
+        model_id: .elser_model_2
+  - do:
+      ml.delete_trained_model:
+        model_id: .elser_model_2
+  - do:
+      catch: /No known trained model with model_id \[.elser_model_2\]/
       ml.start_trained_model_deployment:
         model_id: .elser_model_2
 ---

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/3rd_party_deployment.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/3rd_party_deployment.yml
@@ -153,11 +153,11 @@ setup:
   - do:
       ml.get_trained_models:
         model_id: "bert_fill_mask_model"
-  - match: {trained_model_configs.0.inference_config.fill_mask.mask_token: "[MASK]"}
+  - match: { trained_model_configs.0.inference_config.fill_mask.mask_token: "[MASK]" }
   - do:
       ml.get_trained_models:
         model_id: "roberta_fill_mask_model"
-  - match: {trained_model_configs.0.inference_config.fill_mask.mask_token: "<mask>"}
+  - match: { trained_model_configs.0.inference_config.fill_mask.mask_token: "<mask>" }
   - do:
       catch: /IllegalArgumentException. Mask token requested was \[<mask>\] but must be \[\[MASK\]\] for this model/
       ml.put_trained_model:
@@ -215,6 +215,24 @@ setup:
       catch: /Could not find trained model definition \[distilbert-finetuned-sst\]/
       ml.start_trained_model_deployment:
         model_id: distilbert-finetuned-sst
+
+---
+"Test start deployment fails while model download in progress":
+
+  - do:
+      ml.put_trained_model:
+        model_id: .elser_model_2
+        body: >
+          {
+            "input": {
+          	"field_names": ["text_field"]
+            }
+          }
+
+  - do:
+      catch: /Model download task is currently running\. Wait for trained model \[.elser_model_2\] download task to complete then try again/
+      ml.start_trained_model_deployment:
+        model_id: .elser_model_2
 ---
 "Test start and stop deployment with no cache":
   - do:
@@ -222,9 +240,9 @@ setup:
         model_id: test_model
         cache_size: 0
         wait_for: started
-  - match: {assignment.assignment_state: started}
-  - match: {assignment.task_parameters.model_id: test_model}
-  - match: {assignment.task_parameters.cache_size: "0"}
+  - match: { assignment.assignment_state: started }
+  - match: { assignment.task_parameters.model_id: test_model }
+  - match: { assignment.task_parameters.cache_size: "0" }
 
   - do:
       ml.stop_trained_model_deployment:
@@ -240,9 +258,9 @@ setup:
         model_id: test_model
         cache_size: 10kb
         wait_for: started
-  - match: {assignment.assignment_state: started}
-  - match: {assignment.task_parameters.model_id: test_model}
-  - match: {assignment.task_parameters.cache_size: 10kb}
+  - match: { assignment.assignment_state: started }
+  - match: { assignment.task_parameters.model_id: test_model }
+  - match: { assignment.task_parameters.cache_size: 10kb }
 
   - do:
       allowed_warnings:
@@ -380,9 +398,9 @@ setup:
         deployment_id: test_model_deployment_cache_test
         cache_size: 10kb
         wait_for: started
-  - match: {assignment.assignment_state: started}
-  - match: {assignment.task_parameters.model_id: test_model}
-  - match: {assignment.task_parameters.cache_size: 10kb}
+  - match: { assignment.assignment_state: started }
+  - match: { assignment.task_parameters.model_id: test_model }
+  - match: { assignment.task_parameters.cache_size: 10kb }
 
   - do:
       allowed_warnings:
@@ -535,7 +553,7 @@ setup:
         model_id: test_model
         deployment_id: test_model_for_search
         wait_for: started
-  - match: {assignment.assignment_state: started}
+  - match: { assignment.assignment_state: started }
 
   - do:
       ml.stop_trained_model_deployment:
@@ -565,9 +583,9 @@ setup:
         deployment_id: test_model_for_search
         priority: low
         wait_for: started
-  - match: {assignment.assignment_state: started}
-  - match: {assignment.task_parameters.model_id: test_model}
-  - match: {assignment.task_parameters.deployment_id: test_model_for_search}
+  - match: { assignment.assignment_state: started }
+  - match: { assignment.task_parameters.model_id: test_model }
+  - match: { assignment.task_parameters.deployment_id: test_model_for_search }
   - do:
       allowed_warnings:
         - '[POST /_ml/trained_models/{model_id}/deployment/_infer] is deprecated! Use [POST /_ml/trained_models/{model_id}/_infer] instead.'
@@ -586,9 +604,9 @@ setup:
         deployment_id: test_model_for_ingest
         priority: low
         wait_for: started
-  - match: {assignment.assignment_state: started}
-  - match: {assignment.task_parameters.model_id: test_model}
-  - match: {assignment.task_parameters.deployment_id: test_model_for_ingest}
+  - match: { assignment.assignment_state: started }
+  - match: { assignment.task_parameters.model_id: test_model }
+  - match: { assignment.task_parameters.deployment_id: test_model_for_ingest }
   - do:
       allowed_warnings:
         - '[POST /_ml/trained_models/{model_id}/deployment/_infer] is deprecated! Use [POST /_ml/trained_models/{model_id}/_infer] instead.'
@@ -625,7 +643,7 @@ setup:
         model_id: test_model
         deployment_id: test_model_deployment
         wait_for: started
-  - match: {assignment.assignment_state: started}
+  - match: { assignment.assignment_state: started }
 
   - do:
       catch: /Could not start model deployment because an existing deployment with the same id \[test_model_deployment\] exist/
@@ -648,9 +666,9 @@ setup:
       ml.start_trained_model_deployment:
         model_id: test_model
         wait_for: started
-  - match: {assignment.assignment_state: started}
-  - match: {assignment.task_parameters.model_id: test_model}
-  - match: {assignment.task_parameters.deployment_id: test_model}
+  - match: { assignment.assignment_state: started }
+  - match: { assignment.task_parameters.model_id: test_model }
+  - match: { assignment.task_parameters.deployment_id: test_model }
 
 ---
 "Test cannot create model with a deployment Id":
@@ -659,7 +677,7 @@ setup:
         model_id: test_model
         wait_for: started
         deployment_id: test_model_deployment
-  - match: {assignment.assignment_state: started}
+  - match: { assignment.assignment_state: started }
 
   - do:
       catch: /Cannot create model \[test_model_deployment\] the id is the same as an current model deployment/


### PR DESCRIPTION
Fixes https://github.com/elastic/ml-team/issues/1043

If a model download task is in progress, we cannot start the model deployment. Previously, an incorrect error message was returned. This change adds a new error message for the case, as well as a new integration test case.

Furthermore, I refactored the masterOperation of [TransportGetTrainedModelsAction.java](https://github.com/elastic/elasticsearch/compare/mlCheckModelDownloadTask?expand=1#diff-971ebdde42a96b2e5dd5df418f1fd3daa053b39e3638cc4e9a84fd889d90ab1d) to be a bit more readable, although I tried to perform a minimal refactoring. 

I performed manual testing by running elasticsearch and kibana locally and sending commands from dev console, which had failed previously. 