### PR TITLE
Remove redundant character in mlt-query.asciidoc 

### DIFF
--- a/docs/reference/query-dsl/mlt-query.asciidoc
+++ b/docs/reference/query-dsl/mlt-query.asciidoc
@@ -107,7 +107,7 @@ analyzes it, usually using the same analyzer at the field, then selects the
 top K terms with highest tf-idf to form a disjunctive query of these terms.
 
 IMPORTANT: The fields on which to perform MLT must be indexed and of type
-`text` or `keyword``. Additionally, when using `like` with documents, either
+`text` or `keyword`. Additionally, when using `like` with documents, either
 `_source` must be enabled or the fields must be `stored` or store
 `term_vector`. In order to speed up analysis, it could help to store term
 vectors at index time.


### PR DESCRIPTION
I was reading documentation of MLT query and found this typo. Just tried to fix it. Feel free to ignore or close this PR if it seems unnecessary.