### PR TITLE
[DOCS] Change ES|QL getting started guide for updated dataset

### DIFF
--- a/docs/reference/esql/esql-get-started.asciidoc
+++ b/docs/reference/esql/esql-get-started.asciidoc
@@ -158,8 +158,8 @@ is different than this example, where the sorting comes before the limit.
 
 Use the <<esql-eval>> command to append columns to a table, with calculated
 values. For example, the following query appends a `duration_ms` column. The
-values in the column are computed by dividing `event.duration` by 1,000,000. In
-other words: `event.duration` converted from nanoseconds to milliseconds.
+values in the column are computed by dividing `event_duration` by 1,000,000. In
+other words: `event_duration` converted from nanoseconds to milliseconds.
 
 [source,esql]
 ----

--- a/docs/reference/tab-widgets/esql/esql-getting-started-sample-data.asciidoc
+++ b/docs/reference/tab-widgets/esql/esql-getting-started-sample-data.asciidoc
@@ -1,7 +1,7 @@
 // tag::own-deployment[]
 
 First ingest some sample data. In {kib}, open the main menu and select *Dev
-Tools*. Run the the following two requests:
+Tools*. Run the following two requests:
 
 [source,console]
 ----
@@ -9,7 +9,7 @@ PUT sample_data
 {
   "mappings": {
     "properties": {
-      "client.ip": {
+      "client_ip": {
         "type": "ip"
       },
       "message": {
@@ -21,19 +21,19 @@ PUT sample_data
 
 PUT sample_data/_bulk
 {"index": {}}
-{"@timestamp": "2023-10-23T12:15:03.360Z", "client.ip": "172.21.2.162", "message": "Connected to 10.1.0.3", "event.duration": 3450233}
+{"@timestamp": "2023-10-23T12:15:03.360Z", "client_ip": "172.21.2.162", "message": "Connected to 10.1.0.3", "event_duration": 3450233}
 {"index": {}}
-{"@timestamp": "2023-10-23T12:27:28.948Z", "client.ip": "172.21.2.113", "message": "Connected to 10.1.0.2", "event.duration": 2764889}
+{"@timestamp": "2023-10-23T12:27:28.948Z", "client_ip": "172.21.2.113", "message": "Connected to 10.1.0.2", "event_duration": 2764889}
 {"index": {}}
-{"@timestamp": "2023-10-23T13:33:34.937Z", "client.ip": "172.21.0.5", "message": "Disconnected", "event.duration": 1232382}
+{"@timestamp": "2023-10-23T13:33:34.937Z", "client_ip": "172.21.0.5", "message": "Disconnected", "event_duration": 1232382}
 {"index": {}}
-{"@timestamp": "2023-10-23T13:51:54.732Z", "client.ip": "172.21.3.15", "message": "Connection error", "event.duration": 725448}
+{"@timestamp": "2023-10-23T13:51:54.732Z", "client_ip": "172.21.3.15", "message": "Connection error", "event_duration": 725448}
 {"index": {}}
-{"@timestamp": "2023-10-23T13:52:55.015Z", "client.ip": "172.21.3.15", "message": "Connection error", "event.duration": 8268153}
+{"@timestamp": "2023-10-23T13:52:55.015Z", "client_ip": "172.21.3.15", "message": "Connection error", "event_duration": 8268153}
 {"index": {}}
-{"@timestamp": "2023-10-23T13:53:55.832Z", "client.ip": "172.21.3.15", "message": "Connection error", "event.duration": 5033755}
+{"@timestamp": "2023-10-23T13:53:55.832Z", "client_ip": "172.21.3.15", "message": "Connection error", "event_duration": 5033755}
 {"index": {}}
-{"@timestamp": "2023-10-23T13:55:01.543Z", "client.ip": "172.21.3.15", "message": "Connected to 10.1.0.1", "event.duration": 1756467}
+{"@timestamp": "2023-10-23T13:55:01.543Z", "client_ip": "172.21.3.15", "message": "Connected to 10.1.0.1", "event_duration": 1756467}
 ----
 
 // end::own-deployment[]


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/102653 made some changes to the ES|QL getting started dataset (`client.ip` became `client_ip` and `event.duration` became `event_duration`). I forgot to update all occurrences of these fields in the actual getting started guide. This PR fixes that.