### PR TITLE
Add RefCountAwareThreadedActionListener and use it for transport messages

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportSnapshotsStatusAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/TransportSnapshotsStatusAction.java
@@ -12,7 +12,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.ThreadedActionListener;
+import org.elasticsearch.action.support.RefCountAwareThreadedActionListener;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.cluster.ClusterState;
@@ -144,7 +144,7 @@ public class TransportSnapshotsStatusAction extends TransportMasterNodeAction<Sn
                 new TransportNodesSnapshotsStatus.Request(nodesIds.toArray(Strings.EMPTY_ARRAY)).snapshots(snapshots)
                     .timeout(request.masterNodeTimeout()),
                 // fork to snapshot meta since building the response is expensive for large snapshots
-                new ThreadedActionListener<>(
+                new RefCountAwareThreadedActionListener<>(
                     threadPool.executor(ThreadPool.Names.SNAPSHOT_META),
                     listener.delegateFailureAndWrap(
                         (l, nodeSnapshotStatuses) -> buildResponse(

--- a/server/src/main/java/org/elasticsearch/action/support/AbstractThreadedActionListener.java
+++ b/server/src/main/java/org/elasticsearch/action/support/AbstractThreadedActionListener.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.support;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+
+import java.util.concurrent.Executor;
+
+/**
+ * Base class for action listeners that wrap another action listener and dispatch its completion to an executor.
+ */
+public abstract class AbstractThreadedActionListener<Response> implements ActionListener<Response> {
+
+    private static final Logger logger = LogManager.getLogger(AbstractThreadedActionListener.class);
+
+    protected final Executor executor;
+    protected final ActionListener<Response> delegate;
+    protected final boolean forceExecution;
+
+    protected AbstractThreadedActionListener(Executor executor, boolean forceExecution, ActionListener<Response> delegate) {
+        this.forceExecution = forceExecution;
+        this.executor = executor;
+        this.delegate = delegate;
+    }
+
+    @Override
+    public final void onFailure(final Exception e) {
+        executor.execute(new AbstractRunnable() {
+            @Override
+            public boolean isForceExecution() {
+                return forceExecution;
+            }
+
+            @Override
+            protected void doRun() {
+                delegate.onFailure(e);
+            }
+
+            @Override
+            public void onRejection(Exception rejectionException) {
+                rejectionException.addSuppressed(e);
+                try {
+                    delegate.onFailure(rejectionException);
+                } catch (Exception doubleFailure) {
+                    rejectionException.addSuppressed(doubleFailure);
+                    onFailure(rejectionException);
+                }
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                logger.error(() -> "failed to execute failure callback on [" + AbstractThreadedActionListener.this + "]", e);
+                assert false : e;
+            }
+
+            @Override
+            public String toString() {
+                return AbstractThreadedActionListener.this + "/onFailure";
+            }
+        });
+    }
+
+    @Override
+    public final String toString() {
+        return getClass().getSimpleName() + "[" + executor + "/" + delegate + "]";
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/support/RefCountAwareThreadedActionListener.java
+++ b/server/src/main/java/org/elasticsearch/action/support/RefCountAwareThreadedActionListener.java
@@ -10,24 +10,23 @@ package org.elasticsearch.action.support;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRunnable;
+import org.elasticsearch.core.RefCounted;
 
 import java.util.concurrent.Executor;
 
 /**
- * An action listener that wraps another action listener and dispatches its completion to an executor.
+ * Same as {@link ThreadedActionListener} but for {@link RefCounted} types. Makes sure to increment ref-count by one before forking
+ * to another thread and decrementing after the forked task completes.
  */
-public final class ThreadedActionListener<Response> extends AbstractThreadedActionListener<Response> {
+public final class RefCountAwareThreadedActionListener<Response extends RefCounted> extends AbstractThreadedActionListener<Response> {
 
-    public ThreadedActionListener(Executor executor, ActionListener<Response> delegate) {
-        this(executor, false, delegate);
-    }
-
-    public ThreadedActionListener(Executor executor, boolean forceExecution, ActionListener<Response> delegate) {
-        super(executor, forceExecution, delegate);
+    public RefCountAwareThreadedActionListener(Executor executor, ActionListener<Response> delegate) {
+        super(executor, false, delegate);
     }
 
     @Override
     public void onResponse(final Response response) {
+        response.incRef();
         executor.execute(new ActionRunnable<>(delegate) {
             @Override
             public boolean isForceExecution() {
@@ -41,7 +40,12 @@ public final class ThreadedActionListener<Response> extends AbstractThreadedActi
 
             @Override
             public String toString() {
-                return ThreadedActionListener.this + "/onResponse";
+                return RefCountAwareThreadedActionListener.this + "/onResponse";
+            }
+
+            @Override
+            public void onAfter() {
+                response.decRef();
             }
         });
     }

--- a/server/src/main/java/org/elasticsearch/action/support/RefCountAwareThreadedActionListener.java
+++ b/server/src/main/java/org/elasticsearch/action/support/RefCountAwareThreadedActionListener.java
@@ -26,7 +26,7 @@ public final class RefCountAwareThreadedActionListener<Response extends RefCount
 
     @Override
     public void onResponse(final Response response) {
-        response.incRef();
+        response.mustIncRef();
         executor.execute(new ActionRunnable<>(delegate) {
             @Override
             public boolean isForceExecution() {

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -27,7 +27,7 @@ import org.elasticsearch.action.admin.indices.stats.CommonStatsFlags.Flag;
 import org.elasticsearch.action.admin.indices.stats.IndexShardStats;
 import org.elasticsearch.action.admin.indices.stats.ShardStats;
 import org.elasticsearch.action.search.SearchType;
-import org.elasticsearch.action.support.ThreadedActionListener;
+import org.elasticsearch.action.support.RefCountAwareThreadedActionListener;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.DataStream;
@@ -890,7 +890,7 @@ public class IndicesService extends AbstractLifecycleComponent
                     .source(mapping.source().string(), XContentType.JSON)
                     .timeout(TimeValue.MAX_VALUE)
                     .masterNodeTimeout(TimeValue.MAX_VALUE),
-                new ThreadedActionListener<>(threadPool.generic(), listener.map(ignored -> null))
+                new RefCountAwareThreadedActionListener<>(threadPool.generic(), listener.map(ignored -> null))
             );
         }, this, clusterStateVersion);
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/ExpiredForecastsRemover.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/ExpiredForecastsRemover.java
@@ -14,7 +14,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.TransportSearchAction;
-import org.elasticsearch.action.support.ThreadedActionListener;
+import org.elasticsearch.action.support.RefCountAwareThreadedActionListener;
 import org.elasticsearch.client.internal.OriginSettingClient;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
@@ -110,7 +110,7 @@ public class ExpiredForecastsRemover implements MlDataRemover {
         client.execute(
             TransportSearchAction.TYPE,
             searchRequest,
-            new ThreadedActionListener<>(threadPool.executor(MachineLearning.UTILITY_THREAD_POOL_NAME), forecastStatsHandler)
+            new RefCountAwareThreadedActionListener<>(threadPool.executor(MachineLearning.UTILITY_THREAD_POOL_NAME), forecastStatsHandler)
         );
     }
 

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStackTracesAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStackTracesAction.java
@@ -14,7 +14,7 @@ import org.elasticsearch.action.get.MultiGetResponse;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
-import org.elasticsearch.action.support.ThreadedActionListener;
+import org.elasticsearch.action.support.RefCountAwareThreadedActionListener;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.ParentTaskAssigningClient;
 import org.elasticsearch.client.internal.node.NodeClient;
@@ -764,7 +764,7 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
             client.prepareMultiGet()
                 .addIds(index.getName(), slice)
                 .setRealtime(realtime)
-                .execute(new ThreadedActionListener<>(responseExecutor, listener));
+                .execute(new RefCountAwareThreadedActionListener<>(responseExecutor, listener));
         }
     }
 


### PR DESCRIPTION
The current ThreadedActionListener is not compatible with ref-counted response types. I created a version of it that correclty handles ref-couting and is otherwise a drop-in replacement for the ThreadedActionListener.
Made use of this new listener in all spots where a ref-counted value is used (obviously all noop for now, but soon at least the search response won't be).

part of #102030 