### PR TITLE
Mute NestedAggregatorTests suite

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregatorTests.java
@@ -25,6 +25,7 @@ import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.settings.Settings;
@@ -105,6 +106,7 @@ import static org.hamcrest.Matchers.equalTo;
  *     prefixed with the nested path: nestedPath + "." + fieldName</li>
  * </ul>
  */
+@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/102974")
 public class NestedAggregatorTests extends AggregatorTestCase {
 
     private static final String VALUE_FIELD_NAME = "number";
@@ -502,7 +504,6 @@ public class NestedAggregatorTests extends AggregatorTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/102974")
     public void testNestedOrdering_random() throws IOException {
         int numBooks = randomIntBetween(32, 512);
         List<Tuple<String, int[]>> books = new ArrayList<>();
@@ -563,7 +564,6 @@ public class NestedAggregatorTests extends AggregatorTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/102974")
     public void testPreGetChildLeafCollectors() throws IOException {
         try (Directory directory = newDirectory()) {
             try (RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {


### PR DESCRIPTION
This suite can potentially fail in most of the tests after the lucene upgrade to lucene 9.9. It is just a test failure and we will providing a fix soon but in the meanwhile lets mute it.

relates https://github.com/elastic/elasticsearch/issues/102974