### PR TITLE
[ML] Disable concurrency for frequent items aggregation

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/FrequentItemSetsAggregationBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/FrequentItemSetsAggregationBuilder.java
@@ -33,6 +33,7 @@ import org.elasticsearch.xpack.ml.aggs.frequentitemsets.mr.ItemSetMapReduceValue
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.function.ToLongFunction;
 
 import static org.elasticsearch.common.Strings.format;
 
@@ -264,4 +265,8 @@ public final class FrequentItemSetsAggregationBuilder extends AbstractAggregatio
         return TransportVersions.V_8_4_0;
     }
 
+    @Override
+    public boolean supportsParallelCollection(ToLongFunction<String> fieldCardinalityResolver) {
+        return false;
+    }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/FrequentItemSetsAggregationBuilderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/FrequentItemSetsAggregationBuilderTests.java
@@ -248,4 +248,9 @@ public class FrequentItemSetsAggregationBuilderTests extends AbstractXContentSer
                 return new IncludeExclude(null, null, null, new TreeSet<>(Set.of(newBytesRef("exclude"))));
         }
     }
+
+    public void testSupportsParallelCollection() {
+        FrequentItemSetsAggregationBuilder frequentItemSetsAggregationBuilder = randomFrequentItemsSetsAggregationBuilder();
+        assertFalse(frequentItemSetsAggregationBuilder.supportsParallelCollection(null));
+    }
 }


### PR DESCRIPTION
The frequent items aggregation suffers from a significant increase in garbage collection activity when executed in parallel across slices.

It does not run much faster when parallelised, so the simplest fix is to disable parallelisation.