### PR TITLE
Fix SearchResponse reference count leaks in ML module

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/search/SearchResponseUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/SearchResponseUtils.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+package org.elasticsearch.search;
+
+import org.elasticsearch.action.search.SearchRequestBuilder;
+
+public enum SearchResponseUtils {
+    ;
+
+    public static long getTotalHitsValue(SearchRequestBuilder request) {
+        var resp = request.get();
+        try {
+            return resp.getHits().getTotalHits().value;
+        } finally {
+            resp.decRef();
+        }
+    }
+}

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ClientHelperTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ClientHelperTests.java
@@ -340,7 +340,7 @@ public class ClientHelperTests extends ESTestCase {
             assertThat(headers, not(hasEntry(AuthenticationServiceField.RUN_AS_USER_HEADER, "anything")));
 
             return client.search(new SearchRequest()).actionGet();
-        });
+        }).decRef();
     }
 
     /**
@@ -356,7 +356,7 @@ public class ClientHelperTests extends ESTestCase {
 
             consumer.accept(client.threadPool().getThreadContext().getHeaders());
             return client.search(new SearchRequest()).actionGet();
-        });
+        }).decRef();
     }
 
     public void testFilterSecurityHeaders() {

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ClassificationHousePricingIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ClassificationHousePricingIT.java
@@ -1567,36 +1567,38 @@ public class ClassificationHousePricingIT extends MlNativeDataFrameAnalyticsInte
 
         client().admin().indices().refresh(new RefreshRequest(destIndex));
         SearchResponse sourceData = prepareSearch(sourceIndex).setTrackTotalHits(true).setSize(1000).get();
-
-        // obtain addition information for investigation of #90599
-        String modelId = getModelId(jobId);
-        TrainedModelMetadata modelMetadata = getModelMetadata(modelId);
-        assertThat(modelMetadata.getHyperparameters().size(), greaterThan(0));
-        StringBuilder hyperparameters = new StringBuilder(); // used to investigate #90019
-        for (Hyperparameters hyperparameter : modelMetadata.getHyperparameters()) {
-            hyperparameters.append(hyperparameter.hyperparameterName).append(": ").append(hyperparameter.value).append("\n");
+        try {
+            // obtain addition information for investigation of #90599
+            String modelId = getModelId(jobId);
+            TrainedModelMetadata modelMetadata = getModelMetadata(modelId);
+            assertThat(modelMetadata.getHyperparameters().size(), greaterThan(0));
+            StringBuilder hyperparameters = new StringBuilder(); // used to investigate #90019
+            for (Hyperparameters hyperparameter : modelMetadata.getHyperparameters()) {
+                hyperparameters.append(hyperparameter.hyperparameterName).append(": ").append(hyperparameter.value).append("\n");
+            }
+            TrainedModelDefinition modelDefinition = getModelDefinition(modelId);
+            Ensemble ensemble = (Ensemble) modelDefinition.getTrainedModel();
+            int numberTrees = ensemble.getModels().size();
+            String str = "Failure: failed for modelId %s numberTrees %d\n";
+            for (SearchHit hit : sourceData.getHits()) {
+                Map<String, Object> destDoc = getDestDoc(config, hit);
+                assertNotNull(destDoc);
+                Map<String, Object> resultsObject = getFieldValue(destDoc, "ml");
+                assertThat(resultsObject.containsKey(predictionField), is(true));
+                String predictionValue = (String) resultsObject.get(predictionField);
+                assertNotNull(predictionValue);
+                assertThat(resultsObject.containsKey("feature_importance"), is(true));
+                @SuppressWarnings("unchecked")
+                List<Map<String, Object>> importanceArray = (List<Map<String, Object>>) resultsObject.get("feature_importance");
+                assertThat(
+                    Strings.format(str, modelId, numberTrees) + predictionValue + hyperparameters + modelDefinition,
+                    importanceArray,
+                    hasSize(greaterThan(0))
+                );
+            }
+        } finally {
+            sourceData.decRef();
         }
-        TrainedModelDefinition modelDefinition = getModelDefinition(modelId);
-        Ensemble ensemble = (Ensemble) modelDefinition.getTrainedModel();
-        int numberTrees = ensemble.getModels().size();
-        String str = "Failure: failed for modelId %s numberTrees %d\n";
-        for (SearchHit hit : sourceData.getHits()) {
-            Map<String, Object> destDoc = getDestDoc(config, hit);
-            assertNotNull(destDoc);
-            Map<String, Object> resultsObject = getFieldValue(destDoc, "ml");
-            assertThat(resultsObject.containsKey(predictionField), is(true));
-            String predictionValue = (String) resultsObject.get(predictionField);
-            assertNotNull(predictionValue);
-            assertThat(resultsObject.containsKey("feature_importance"), is(true));
-            @SuppressWarnings("unchecked")
-            List<Map<String, Object>> importanceArray = (List<Map<String, Object>>) resultsObject.get("feature_importance");
-            assertThat(
-                Strings.format(str, modelId, numberTrees) + predictionValue + hyperparameters + modelDefinition,
-                importanceArray,
-                hasSize(greaterThan(0))
-            );
-        }
-
     }
 
     static void indexData(String sourceIndex) {

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DatafeedWithAggsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DatafeedWithAggsIT.java
@@ -35,6 +35,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -163,7 +164,7 @@ public class DatafeedWithAggsIT extends MlNativeAutodetectIntegTestCase {
                 bucket.getEventCount()
             );
             // Confirm that it's possible to search for the same buckets by @timestamp - proves that @timestamp works as a field alias
-            assertThat(
+            assertHitCount(
                 prepareSearch(AnomalyDetectorsIndex.jobResultsAliasedName(jobId)).setQuery(
                     QueryBuilders.boolQuery()
                         .filter(QueryBuilders.termQuery("job_id", jobId))
@@ -171,8 +172,8 @@ public class DatafeedWithAggsIT extends MlNativeAutodetectIntegTestCase {
                         .filter(
                             QueryBuilders.rangeQuery("@timestamp").gte(bucket.getTimestamp().getTime()).lte(bucket.getTimestamp().getTime())
                         )
-                ).setTrackTotalHits(true).get().getHits().getTotalHits().value,
-                equalTo(1L)
+                ).setTrackTotalHits(true),
+                1
             );
         }
     }

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DeleteExpiredDataIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/DeleteExpiredDataIT.java
@@ -20,6 +20,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchResponseUtils;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
@@ -268,14 +269,13 @@ public class DeleteExpiredDataIT extends MlNativeAutodetectIntegTestCase {
 
         retainAllSnapshots("snapshots-retention-with-retain");
 
-        long totalModelSizeStatsBeforeDelete = prepareSearch("*").setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN_CLOSED_HIDDEN)
-            .setQuery(QueryBuilders.termQuery("result_type", "model_size_stats"))
-            .get()
-            .getHits()
-            .getTotalHits().value;
-        long totalNotificationsCountBeforeDelete = prepareSearch(NotificationsIndex.NOTIFICATIONS_INDEX).get()
-            .getHits()
-            .getTotalHits().value;
+        long totalModelSizeStatsBeforeDelete = SearchResponseUtils.getTotalHitsValue(
+            prepareSearch("*").setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN_CLOSED_HIDDEN)
+                .setQuery(QueryBuilders.termQuery("result_type", "model_size_stats"))
+        );
+        long totalNotificationsCountBeforeDelete = SearchResponseUtils.getTotalHitsValue(
+            prepareSearch(NotificationsIndex.NOTIFICATIONS_INDEX)
+        );
         assertThat(totalModelSizeStatsBeforeDelete, greaterThan(0L));
         assertThat(totalNotificationsCountBeforeDelete, greaterThan(0L));
 
@@ -319,14 +319,13 @@ public class DeleteExpiredDataIT extends MlNativeAutodetectIntegTestCase {
         assertThat(getRecords("results-and-snapshots-retention").size(), equalTo(0));
         assertThat(getModelSnapshots("results-and-snapshots-retention").size(), equalTo(1));
 
-        long totalModelSizeStatsAfterDelete = prepareSearch("*").setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN_CLOSED_HIDDEN)
-            .setQuery(QueryBuilders.termQuery("result_type", "model_size_stats"))
-            .get()
-            .getHits()
-            .getTotalHits().value;
-        long totalNotificationsCountAfterDelete = prepareSearch(NotificationsIndex.NOTIFICATIONS_INDEX).get()
-            .getHits()
-            .getTotalHits().value;
+        long totalModelSizeStatsAfterDelete = SearchResponseUtils.getTotalHitsValue(
+            prepareSearch("*").setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN_CLOSED_HIDDEN)
+                .setQuery(QueryBuilders.termQuery("result_type", "model_size_stats"))
+        );
+        long totalNotificationsCountAfterDelete = SearchResponseUtils.getTotalHitsValue(
+            prepareSearch(NotificationsIndex.NOTIFICATIONS_INDEX)
+        );
         assertThat(totalModelSizeStatsAfterDelete, equalTo(totalModelSizeStatsBeforeDelete));
         assertThat(totalNotificationsCountAfterDelete, greaterThanOrEqualTo(totalNotificationsCountBeforeDelete));
 

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RunDataFrameAnalyticsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RunDataFrameAnalyticsIT.java
@@ -20,6 +20,7 @@ import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchResponseUtils;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.ml.action.GetDataFrameAnalyticsStatsAction;
 import org.elasticsearch.xpack.core.ml.action.NodeAcknowledgedResponse;
@@ -396,11 +397,12 @@ public class RunDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsIntegTest
 
         assertResponse(prepareSearch(config.getDest().getIndex()).setTrackTotalHits(true), searchResponse -> {
             if (searchResponse.getHits().getTotalHits().value == docCount) {
-                searchResponse = prepareSearch(config.getDest().getIndex()).setTrackTotalHits(true)
-                    .setQuery(QueryBuilders.existsQuery("custom_ml.outlier_score"))
-                    .get();
-                logger.debug("We stopped during analysis: [{}] < [{}]", searchResponse.getHits().getTotalHits().value, docCount);
-                assertThat(searchResponse.getHits().getTotalHits().value, lessThan((long) docCount));
+                long seenCount = SearchResponseUtils.getTotalHitsValue(
+                    prepareSearch(config.getDest().getIndex()).setTrackTotalHits(true)
+                        .setQuery(QueryBuilders.existsQuery("custom_ml.outlier_score"))
+                );
+                logger.debug("We stopped during analysis: [{}] < [{}]", seenCount, docCount);
+                assertThat(seenCount, lessThan((long) docCount));
             } else {
                 logger.debug("We stopped during reindexing: [{}] < [{}]", searchResponse.getHits().getTotalHits().value, docCount);
             }

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/license/MachineLearningLicensingIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/license/MachineLearningLicensingIT.java
@@ -756,7 +756,7 @@ public class MachineLearningLicensingIT extends BaseMlIntegTestCase {
 
         SearchRequest search = new SearchRequest(index);
         search.source().aggregation(termsAgg);
-        client().search(search).actionGet();
+        client().search(search).actionGet().decRef();
 
         // Pick a license that does not allow machine learning
         License.OperationMode mode = randomInvalidLicenseType();

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/BucketCorrelationAggregationIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/BucketCorrelationAggregationIT.java
@@ -12,7 +12,6 @@ import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.index.IndexRequest;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
@@ -31,6 +30,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.hamcrest.Matchers.closeTo;
 
 public class BucketCorrelationAggregationIT extends MlSingleNodeTestCase {
@@ -71,34 +71,42 @@ public class BucketCorrelationAggregationIT extends MlSingleNodeTestCase {
 
         AtomicLong counter = new AtomicLong();
         double[] steps = Stream.generate(() -> counter.getAndAdd(2L)).limit(50).mapToDouble(l -> (double) l).toArray();
-        SearchResponse percentilesSearch = client().prepareSearch("data")
-            .addAggregation(AggregationBuilders.percentiles("percentiles").field("metric").percentiles(steps))
-            .setSize(0)
-            .setTrackTotalHits(true)
-            .get();
-        long totalHits = percentilesSearch.getHits().getTotalHits().value;
-        Percentiles percentiles = percentilesSearch.getAggregations().get("percentiles");
-        Tuple<RangeAggregationBuilder, BucketCorrelationAggregationBuilder> aggs = buildRangeAggAndSetExpectations(
-            percentiles,
-            steps,
-            totalHits,
-            "metric"
+        assertResponse(
+            client().prepareSearch("data")
+                .addAggregation(AggregationBuilders.percentiles("percentiles").field("metric").percentiles(steps))
+                .setSize(0)
+                .setTrackTotalHits(true),
+            percentilesSearch -> {
+                long totalHits = percentilesSearch.getHits().getTotalHits().value;
+                Percentiles percentiles = percentilesSearch.getAggregations().get("percentiles");
+                Tuple<RangeAggregationBuilder, BucketCorrelationAggregationBuilder> aggs = buildRangeAggAndSetExpectations(
+                    percentiles,
+                    steps,
+                    totalHits,
+                    "metric"
+                );
+
+                assertResponse(
+                    client().prepareSearch("data")
+                        .setSize(0)
+                        .setTrackTotalHits(false)
+                        .addAggregation(
+                            AggregationBuilders.terms("buckets").field("term").subAggregation(aggs.v1()).subAggregation(aggs.v2())
+                        ),
+                    countCorrelations -> {
+
+                        Terms terms = countCorrelations.getAggregations().get("buckets");
+                        Terms.Bucket catBucket = terms.getBucketByKey("cat");
+                        Terms.Bucket dogBucket = terms.getBucketByKey("dog");
+                        NumericMetricsAggregation.SingleValue approxCatCorrelation = catBucket.getAggregations().get("correlates");
+                        NumericMetricsAggregation.SingleValue approxDogCorrelation = dogBucket.getAggregations().get("correlates");
+
+                        assertThat(approxCatCorrelation.value(), closeTo(catCorrelation, 0.1));
+                        assertThat(approxDogCorrelation.value(), closeTo(dogCorrelation, 0.1));
+                    }
+                );
+            }
         );
-
-        SearchResponse countCorrelations = client().prepareSearch("data")
-            .setSize(0)
-            .setTrackTotalHits(false)
-            .addAggregation(AggregationBuilders.terms("buckets").field("term").subAggregation(aggs.v1()).subAggregation(aggs.v2()))
-            .get();
-
-        Terms terms = countCorrelations.getAggregations().get("buckets");
-        Terms.Bucket catBucket = terms.getBucketByKey("cat");
-        Terms.Bucket dogBucket = terms.getBucketByKey("dog");
-        NumericMetricsAggregation.SingleValue approxCatCorrelation = catBucket.getAggregations().get("correlates");
-        NumericMetricsAggregation.SingleValue approxDogCorrelation = dogBucket.getAggregations().get("correlates");
-
-        assertThat(approxCatCorrelation.value(), closeTo(catCorrelation, 0.1));
-        assertThat(approxDogCorrelation.value(), closeTo(dogCorrelation, 0.1));
     }
 
     private static Tuple<RangeAggregationBuilder, BucketCorrelationAggregationBuilder> buildRangeAggAndSetExpectations(

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/CategorizeTextAggregationIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/CategorizeTextAggregationIT.java
@@ -10,7 +10,6 @@ package org.elasticsearch.xpack.ml.integration;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.index.IndexRequest;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
@@ -21,6 +20,7 @@ import org.elasticsearch.xpack.ml.aggs.categorization.InternalCategorizationAggr
 import org.elasticsearch.xpack.ml.support.BaseMlIntegTestCase;
 import org.junit.Before;
 
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
@@ -39,53 +39,69 @@ public class CategorizeTextAggregationIT extends BaseMlIntegTestCase {
     }
 
     public void testAggregation() {
-        SearchResponse response = prepareSearch(DATA_INDEX).setSize(0)
-            .setTrackTotalHits(false)
-            .addAggregation(
-                new CategorizeTextAggregationBuilder("categorize", "msg").subAggregation(AggregationBuilders.max("max").field("time"))
-                    .subAggregation(AggregationBuilders.min("min").field("time"))
-            )
-            .get();
+        assertResponse(
+            prepareSearch(DATA_INDEX).setSize(0)
+                .setTrackTotalHits(false)
+                .addAggregation(
+                    new CategorizeTextAggregationBuilder("categorize", "msg").subAggregation(AggregationBuilders.max("max").field("time"))
+                        .subAggregation(AggregationBuilders.min("min").field("time"))
+                ),
+            response -> {
 
-        InternalCategorizationAggregation agg = response.getAggregations().get("categorize");
-        assertThat(agg.getBuckets(), hasSize(3));
+                InternalCategorizationAggregation agg = response.getAggregations().get("categorize");
+                assertThat(agg.getBuckets(), hasSize(3));
 
-        assertCategorizationBucket(agg.getBuckets().get(0), "Node started", 3);
-        assertCategorizationBucket(agg.getBuckets().get(1), "Failed to shutdown error org.aaaa.bbbb.Cccc line caused by foo exception", 2);
-        assertCategorizationBucket(agg.getBuckets().get(2), "Node stopped", 1);
+                assertCategorizationBucket(agg.getBuckets().get(0), "Node started", 3);
+                assertCategorizationBucket(
+                    agg.getBuckets().get(1),
+                    "Failed to shutdown error org.aaaa.bbbb.Cccc line caused by foo exception",
+                    2
+                );
+                assertCategorizationBucket(agg.getBuckets().get(2), "Node stopped", 1);
+            }
+        );
     }
 
     public void testAggregationWithOnlyOneBucket() {
-        SearchResponse response = prepareSearch(DATA_INDEX).setSize(0)
-            .setTrackTotalHits(false)
-            .addAggregation(
-                new CategorizeTextAggregationBuilder("categorize", "msg").size(1)
-                    .subAggregation(AggregationBuilders.max("max").field("time"))
-                    .subAggregation(AggregationBuilders.min("min").field("time"))
-            )
-            .get();
-        InternalCategorizationAggregation agg = response.getAggregations().get("categorize");
-        assertThat(agg.getBuckets(), hasSize(1));
-
-        assertCategorizationBucket(agg.getBuckets().get(0), "Node started", 3);
+        assertResponse(
+            prepareSearch(DATA_INDEX).setSize(0)
+                .setTrackTotalHits(false)
+                .addAggregation(
+                    new CategorizeTextAggregationBuilder("categorize", "msg").size(1)
+                        .subAggregation(AggregationBuilders.max("max").field("time"))
+                        .subAggregation(AggregationBuilders.min("min").field("time"))
+                ),
+            response -> {
+                InternalCategorizationAggregation agg = response.getAggregations().get("categorize");
+                assertThat(agg.getBuckets(), hasSize(1));
+                assertCategorizationBucket(agg.getBuckets().get(0), "Node started", 3);
+            }
+        );
     }
 
     public void testAggregationWithBroadCategories() {
-        SearchResponse response = prepareSearch(DATA_INDEX).setSize(0)
-            .setTrackTotalHits(false)
-            .addAggregation(
-                // Overriding the similarity threshold to just 11% (default is 70%) results in the
-                // "Node started" and "Node stopped" messages being grouped in the same category
-                new CategorizeTextAggregationBuilder("categorize", "msg").setSimilarityThreshold(11)
-                    .subAggregation(AggregationBuilders.max("max").field("time"))
-                    .subAggregation(AggregationBuilders.min("min").field("time"))
-            )
-            .get();
-        InternalCategorizationAggregation agg = response.getAggregations().get("categorize");
-        assertThat(agg.getBuckets(), hasSize(2));
+        assertResponse(
+            prepareSearch(DATA_INDEX).setSize(0)
+                .setTrackTotalHits(false)
+                .addAggregation(
+                    // Overriding the similarity threshold to just 11% (default is 70%) results in the
+                    // "Node started" and "Node stopped" messages being grouped in the same category
+                    new CategorizeTextAggregationBuilder("categorize", "msg").setSimilarityThreshold(11)
+                        .subAggregation(AggregationBuilders.max("max").field("time"))
+                        .subAggregation(AggregationBuilders.min("min").field("time"))
+                ),
+            response -> {
+                InternalCategorizationAggregation agg = response.getAggregations().get("categorize");
+                assertThat(agg.getBuckets(), hasSize(2));
 
-        assertCategorizationBucket(agg.getBuckets().get(0), "Node", 4);
-        assertCategorizationBucket(agg.getBuckets().get(1), "Failed to shutdown error org.aaaa.bbbb.Cccc line caused by foo exception", 2);
+                assertCategorizationBucket(agg.getBuckets().get(0), "Node", 4);
+                assertCategorizationBucket(
+                    agg.getBuckets().get(1),
+                    "Failed to shutdown error org.aaaa.bbbb.Cccc line caused by foo exception",
+                    2
+                );
+            }
+        );
     }
 
     private void assertCategorizationBucket(InternalCategorizationAggregation.Bucket bucket, String key, long docCount) {

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DataFrameAnalyticsCRUDIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DataFrameAnalyticsCRUDIT.java
@@ -25,6 +25,7 @@ import org.junit.Before;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Collections.emptyMap;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -96,7 +97,7 @@ public class DataFrameAnalyticsCRUDIT extends MlSingleNodeTestCase {
 
         client().execute(DeleteDataFrameAnalyticsAction.INSTANCE, new DeleteDataFrameAnalyticsAction.Request(configId)).actionGet();
 
-        assertThat(
+        assertHitCount(
             originSettingClient.prepareSearch(".ml-state-*")
                 .setQuery(
                     QueryBuilders.idsQuery()
@@ -105,21 +106,15 @@ public class DataFrameAnalyticsCRUDIT extends MlSingleNodeTestCase {
                             "data_frame_analytics-delete-config-with-state-and-stats-progress"
                         )
                 )
-                .setTrackTotalHits(true)
-                .get()
-                .getHits()
-                .getTotalHits().value,
-            equalTo(0L)
+                .setTrackTotalHits(true),
+            0
         );
 
-        assertThat(
+        assertHitCount(
             originSettingClient.prepareSearch(".ml-stats-*")
                 .setQuery(QueryBuilders.idsQuery().addIds("delete-config-with-state-and-stats_1", "delete-config-with-state-and-stats_2"))
-                .setTrackTotalHits(true)
-                .get()
-                .getHits()
-                .getTotalHits().value,
-            equalTo(0L)
+                .setTrackTotalHits(true),
+            0
         );
     }
 

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DatafeedCcsIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DatafeedCcsIT.java
@@ -191,7 +191,11 @@ public class DatafeedCcsIT extends AbstractMultiClustersTestCase {
             SearchResponse response = client(LOCAL_CLUSTER).prepareSearch(".ml-notifications*")
                 .setQuery(new MatchPhraseQueryBuilder("message", message))
                 .get();
-            return response.getHits().getTotalHits().value > 0;
+            try {
+                return response.getHits().getTotalHits().value > 0;
+            } finally {
+                response.decRef();
+            }
         } catch (ElasticsearchException e) {
             return false;
         }

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/IndexLayoutIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/IndexLayoutIT.java
@@ -26,6 +26,7 @@ import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.equalTo;
@@ -140,10 +141,7 @@ public class IndexLayoutIT extends BaseMlIntegTestCase {
             arrayContaining(".ml-state-000001")
         );
 
-        assertThat(
-            client.prepareSearch(AnomalyDetectorsIndex.jobStateIndexPattern()).setTrackTotalHits(true).get().getHits().getTotalHits().value,
-            equalTo(0L)
-        );
+        assertHitCount(client.prepareSearch(AnomalyDetectorsIndex.jobStateIndexPattern()).setTrackTotalHits(true), 0);
     }
 
 }

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/JobStorageDeletionTaskIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/JobStorageDeletionTaskIT.java
@@ -43,6 +43,7 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
@@ -202,7 +203,7 @@ public class JobStorageDeletionTaskIT extends BaseMlIntegTestCase {
         );
 
         // Make sure all results referencing the dedicated job are gone
-        assertThat(
+        assertHitCount(
             prepareSearch().setIndices(AnomalyDetectorsIndex.jobResultsIndexPrefix() + "*")
                 .setIndicesOptions(IndicesOptions.lenientExpandOpenHidden())
                 .setTrackTotalHits(true)
@@ -210,11 +211,8 @@ public class JobStorageDeletionTaskIT extends BaseMlIntegTestCase {
                 .setSource(
                     SearchSourceBuilder.searchSource()
                         .query(QueryBuilders.boolQuery().filter(QueryBuilders.termQuery(Job.ID.getPreferredName(), jobIdDedicated)))
-                )
-                .get()
-                .getHits()
-                .getTotalHits().value,
-            equalTo(0L)
+                ),
+            0
         );
     }
 

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/TrainedModelCRUDIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/TrainedModelCRUDIT.java
@@ -23,6 +23,7 @@ import org.junit.Before;
 
 import java.util.Base64;
 
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.isA;
 
@@ -102,15 +103,7 @@ public class TrainedModelCRUDIT extends MlSingleNodeTestCase {
 
         client().execute(DeleteTrainedModelAction.INSTANCE, new DeleteTrainedModelAction.Request(modelId)).actionGet();
 
-        assertThat(
-            client().prepareSearch(InferenceIndexConstants.nativeDefinitionStore())
-                .setTrackTotalHitsUpTo(1)
-                .setSize(0)
-                .get()
-                .getHits()
-                .getTotalHits().value,
-            equalTo(0L)
-        );
+        assertHitCount(client().prepareSearch(InferenceIndexConstants.nativeDefinitionStore()).setTrackTotalHitsUpTo(1).setSize(0), 0);
     }
 
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/delayeddatacheck/DatafeedDelayedDataDetector.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/delayeddatacheck/DatafeedDelayedDataDetector.java
@@ -135,16 +135,20 @@ public class DatafeedDelayedDataDetector implements DelayedDataDetector {
         SearchRequest searchRequest = new SearchRequest(datafeedIndices).source(searchSourceBuilder).indicesOptions(indicesOptions);
         try (ThreadContext.StoredContext ignore = client.threadPool().getThreadContext().stashWithOrigin(ML_ORIGIN)) {
             SearchResponse response = client.execute(TransportSearchAction.TYPE, searchRequest).actionGet();
-            List<? extends Histogram.Bucket> buckets = ((Histogram) response.getAggregations().get(DATE_BUCKETS)).getBuckets();
-            Map<Long, Long> hashMap = Maps.newMapWithExpectedSize(buckets.size());
-            for (Histogram.Bucket bucket : buckets) {
-                long bucketTime = toHistogramKeyToEpoch(bucket.getKey());
-                if (bucketTime < 0) {
-                    throw new IllegalStateException("Histogram key [" + bucket.getKey() + "] cannot be converted to a timestamp");
+            try {
+                List<? extends Histogram.Bucket> buckets = ((Histogram) response.getAggregations().get(DATE_BUCKETS)).getBuckets();
+                Map<Long, Long> hashMap = Maps.newMapWithExpectedSize(buckets.size());
+                for (Histogram.Bucket bucket : buckets) {
+                    long bucketTime = toHistogramKeyToEpoch(bucket.getKey());
+                    if (bucketTime < 0) {
+                        throw new IllegalStateException("Histogram key [" + bucket.getKey() + "] cannot be converted to a timestamp");
+                    }
+                    hashMap.put(bucketTime, bucket.getDocCount());
                 }
-                hashMap.put(bucketTime, bucket.getDocCount());
+                return hashMap;
+            } finally {
+                response.decRef();
             }
-            return hashMap;
         }
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AbstractAggregationDataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AbstractAggregationDataExtractor.java
@@ -122,10 +122,14 @@ abstract class AbstractAggregationDataExtractor<T extends ActionRequestBuilder<S
         T searchRequest = buildSearchRequest(buildBaseSearchSource());
         assert searchRequest.request().allowPartialSearchResults() == false;
         SearchResponse searchResponse = executeSearchRequest(searchRequest);
-        checkForSkippedClusters(searchResponse);
-        LOGGER.debug("[{}] Search response was obtained", context.jobId);
-        timingStatsReporter.reportSearchDuration(searchResponse.getTook());
-        return validateAggs(searchResponse.getAggregations());
+        try {
+            checkForSkippedClusters(searchResponse);
+            LOGGER.debug("[{}] Search response was obtained", context.jobId);
+            timingStatsReporter.reportSearchDuration(searchResponse.getTook());
+            return validateAggs(searchResponse.getAggregations());
+        } finally {
+            searchResponse.decRef();
+        }
     }
 
     private void initAggregationProcessor(Aggregations aggs) throws IOException {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/CompositeAggregationDataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/CompositeAggregationDataExtractor.java
@@ -138,17 +138,21 @@ class CompositeAggregationDataExtractor implements DataExtractor {
         searchSourceBuilder.aggregation(compositeAggregationBuilder);
         ActionRequestBuilder<SearchRequest, SearchResponse> searchRequest = requestBuilder.build(searchSourceBuilder);
         SearchResponse searchResponse = executeSearchRequest(searchRequest);
-        LOGGER.trace(() -> "[" + context.jobId + "] Search composite response was obtained");
-        timingStatsReporter.reportSearchDuration(searchResponse.getTook());
-        Aggregations aggregations = searchResponse.getAggregations();
-        if (aggregations == null) {
-            return null;
+        try {
+            LOGGER.trace(() -> "[" + context.jobId + "] Search composite response was obtained");
+            timingStatsReporter.reportSearchDuration(searchResponse.getTook());
+            Aggregations aggregations = searchResponse.getAggregations();
+            if (aggregations == null) {
+                return null;
+            }
+            CompositeAggregation compositeAgg = aggregations.get(compositeAggregationBuilder.getName());
+            if (compositeAgg == null || compositeAgg.getBuckets().isEmpty()) {
+                return null;
+            }
+            return aggregations;
+        } finally {
+            searchResponse.decRef();
         }
-        CompositeAggregation compositeAgg = aggregations.get(compositeAggregationBuilder.getName());
-        if (compositeAgg == null || compositeAgg.getBuckets().isEmpty()) {
-            return null;
-        }
-        return aggregations;
     }
 
     protected SearchResponse executeSearchRequest(ActionRequestBuilder<SearchRequest, SearchResponse> searchRequestBuilder) {
@@ -158,7 +162,15 @@ class CompositeAggregationDataExtractor implements DataExtractor {
             client,
             searchRequestBuilder::get
         );
-        checkForSkippedClusters(searchResponse);
+        boolean success = false;
+        try {
+            checkForSkippedClusters(searchResponse);
+            success = true;
+        } finally {
+            if (success == false) {
+                searchResponse.decRef();
+            }
+        }
         return searchResponse;
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsProcessManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/AnalyticsProcessManager.java
@@ -170,7 +170,11 @@ public class AnalyticsProcessManager {
                 .setFetchSource(false)
                 .setQuery(QueryBuilders.idsQuery().addIds(config.getAnalysis().getStateDocIdPrefix(config.getId()) + "1"))
                 .get();
-            return searchResponse.getHits().getHits().length == 1;
+            try {
+                return searchResponse.getHits().getHits().length == 1;
+            } finally {
+                searchResponse.decRef();
+            }
         }
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/NativeAnalyticsProcess.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/process/NativeAnalyticsProcess.java
@@ -85,12 +85,16 @@ public class NativeAnalyticsProcess extends AbstractNativeAnalyticsProcess<Analy
                     .setSize(1)
                     .setQuery(QueryBuilders.idsQuery().addIds(stateDocIdPrefix + ++docNum))
                     .get();
-                if (stateResponse.getHits().getHits().length == 0) {
-                    break;
+                try {
+                    if (stateResponse.getHits().getHits().length == 0) {
+                        break;
+                    }
+                    SearchHit stateDoc = stateResponse.getHits().getAt(0);
+                    logger.debug(() -> format("[%s] Restoring state document [%s]", config.jobId(), stateDoc.getId()));
+                    StateToProcessWriterHelper.writeStateToStream(stateDoc.getSourceRef(), restoreStream);
+                } finally {
+                    stateResponse.decRef();
                 }
-                SearchHit stateDoc = stateResponse.getHits().getAt(0);
-                logger.debug(() -> format("[%s] Restoring state document [%s]", config.jobId(), stateDoc.getId()));
-                StateToProcessWriterHelper.writeStateToStream(stateDoc.getSourceRef(), restoreStream);
             }
         }
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersister.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersister.java
@@ -328,12 +328,16 @@ public class JobResultsPersister {
             shouldRetry,
             retryMessage -> logger.debug("[{}] {} {}", jobId, quantilesDocId, retryMessage)
         );
-        String indexOrAlias = searchResponse.getHits().getHits().length > 0
-            ? searchResponse.getHits().getHits()[0].getIndex()
-            : AnomalyDetectorsIndex.jobStateIndexWriteAlias();
+        try {
+            String indexOrAlias = searchResponse.getHits().getHits().length > 0
+                ? searchResponse.getHits().getHits()[0].getIndex()
+                : AnomalyDetectorsIndex.jobStateIndexWriteAlias();
 
-        Persistable persistable = new Persistable(indexOrAlias, quantiles.getJobId(), quantiles, quantilesDocId);
-        persistable.persist(shouldRetry, AnomalyDetectorsIndex.jobStateIndexWriteAlias().equals(indexOrAlias));
+            Persistable persistable = new Persistable(indexOrAlias, quantiles.getJobId(), quantiles, quantilesDocId);
+            persistable.persist(shouldRetry, AnomalyDetectorsIndex.jobStateIndexWriteAlias().equals(indexOrAlias));
+        } finally {
+            searchResponse.decRef();
+        }
     }
 
     /**

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersister.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersister.java
@@ -328,16 +328,16 @@ public class JobResultsPersister {
             shouldRetry,
             retryMessage -> logger.debug("[{}] {} {}", jobId, quantilesDocId, retryMessage)
         );
+        final String indexOrAlias;
         try {
-            String indexOrAlias = searchResponse.getHits().getHits().length > 0
+            indexOrAlias = searchResponse.getHits().getHits().length > 0
                 ? searchResponse.getHits().getHits()[0].getIndex()
                 : AnomalyDetectorsIndex.jobStateIndexWriteAlias();
-
-            Persistable persistable = new Persistable(indexOrAlias, quantiles.getJobId(), quantiles, quantilesDocId);
-            persistable.persist(shouldRetry, AnomalyDetectorsIndex.jobStateIndexWriteAlias().equals(indexOrAlias));
         } finally {
             searchResponse.decRef();
         }
+        Persistable persistable = new Persistable(indexOrAlias, quantiles.getJobId(), quantiles, quantilesDocId);
+        persistable.persist(shouldRetry, AnomalyDetectorsIndex.jobStateIndexWriteAlias().equals(indexOrAlias));
     }
 
     /**

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProvider.java
@@ -1422,24 +1422,27 @@ public class JobResultsProvider {
                 .setTrackTotalHits(true)
                 .get();
         }
+        try {
+            List<ModelPlot> results = new ArrayList<>();
 
-        List<ModelPlot> results = new ArrayList<>();
-
-        for (SearchHit hit : searchResponse.getHits().getHits()) {
-            BytesReference source = hit.getSourceRef();
-            try (
-                InputStream stream = source.streamInput();
-                XContentParser parser = XContentFactory.xContent(XContentType.JSON)
-                    .createParser(XContentParserConfiguration.EMPTY.withDeprecationHandler(LoggingDeprecationHandler.INSTANCE), stream)
-            ) {
-                ModelPlot modelPlot = ModelPlot.LENIENT_PARSER.apply(parser, null);
-                results.add(modelPlot);
-            } catch (IOException e) {
-                throw new ElasticsearchParseException("failed to parse modelPlot", e);
+            for (SearchHit hit : searchResponse.getHits().getHits()) {
+                BytesReference source = hit.getSourceRef();
+                try (
+                    InputStream stream = source.streamInput();
+                    XContentParser parser = XContentFactory.xContent(XContentType.JSON)
+                        .createParser(XContentParserConfiguration.EMPTY.withDeprecationHandler(LoggingDeprecationHandler.INSTANCE), stream)
+                ) {
+                    ModelPlot modelPlot = ModelPlot.LENIENT_PARSER.apply(parser, null);
+                    results.add(modelPlot);
+                } catch (IOException e) {
+                    throw new ElasticsearchParseException("failed to parse modelPlot", e);
+                }
             }
-        }
 
-        return new QueryPage<>(results, searchResponse.getHits().getTotalHits().value, ModelPlot.RESULTS_FIELD);
+            return new QueryPage<>(results, searchResponse.getHits().getTotalHits().value, ModelPlot.RESULTS_FIELD);
+        } finally {
+            searchResponse.decRef();
+        }
     }
 
     public QueryPage<CategorizerStats> categorizerStats(String jobId, int from, int size) {
@@ -1456,24 +1459,27 @@ public class JobResultsProvider {
                 .setTrackTotalHits(true)
                 .get();
         }
+        try {
+            List<CategorizerStats> results = new ArrayList<>();
 
-        List<CategorizerStats> results = new ArrayList<>();
-
-        for (SearchHit hit : searchResponse.getHits().getHits()) {
-            BytesReference source = hit.getSourceRef();
-            try (
-                InputStream stream = source.streamInput();
-                XContentParser parser = XContentFactory.xContent(XContentType.JSON)
-                    .createParser(XContentParserConfiguration.EMPTY.withDeprecationHandler(LoggingDeprecationHandler.INSTANCE), stream)
-            ) {
-                CategorizerStats categorizerStats = CategorizerStats.LENIENT_PARSER.apply(parser, null).build();
-                results.add(categorizerStats);
-            } catch (IOException e) {
-                throw new ElasticsearchParseException("failed to parse categorizerStats", e);
+            for (SearchHit hit : searchResponse.getHits().getHits()) {
+                BytesReference source = hit.getSourceRef();
+                try (
+                    InputStream stream = source.streamInput();
+                    XContentParser parser = XContentFactory.xContent(XContentType.JSON)
+                        .createParser(XContentParserConfiguration.EMPTY.withDeprecationHandler(LoggingDeprecationHandler.INSTANCE), stream)
+                ) {
+                    CategorizerStats categorizerStats = CategorizerStats.LENIENT_PARSER.apply(parser, null).build();
+                    results.add(categorizerStats);
+                } catch (IOException e) {
+                    throw new ElasticsearchParseException("failed to parse categorizerStats", e);
+                }
             }
-        }
 
-        return new QueryPage<>(results, searchResponse.getHits().getTotalHits().value, ModelPlot.RESULTS_FIELD);
+            return new QueryPage<>(results, searchResponse.getHits().getTotalHits().value, ModelPlot.RESULTS_FIELD);
+        } finally {
+            searchResponse.decRef();
+        }
     }
 
     /**

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/StateStreamer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/StateStreamer.java
@@ -76,17 +76,21 @@ public class StateStreamer {
                     .setSize(1)
                     .setQuery(QueryBuilders.idsQuery().addIds(stateDocId))
                     .get();
-                if (stateResponse.getHits().getHits().length == 0) {
-                    LOGGER.error(
-                        "Expected {} documents for model state for {} snapshot {} but failed to find {}",
-                        modelSnapshot.getSnapshotDocCount(),
-                        jobId,
-                        modelSnapshot.getSnapshotId(),
-                        stateDocId
-                    );
-                    break;
+                try {
+                    if (stateResponse.getHits().getHits().length == 0) {
+                        LOGGER.error(
+                            "Expected {} documents for model state for {} snapshot {} but failed to find {}",
+                            modelSnapshot.getSnapshotDocCount(),
+                            jobId,
+                            modelSnapshot.getSnapshotId(),
+                            stateDocId
+                        );
+                        break;
+                    }
+                    writeStateToStream(stateResponse.getHits().getAt(0).getSourceRef(), restoreStream);
+                } finally {
+                    stateResponse.decRef();
                 }
-                writeStateToStream(stateResponse.getHits().getAt(0).getSourceRef(), restoreStream);
             }
         }
 
@@ -108,10 +112,14 @@ public class StateStreamer {
                     .setSize(1)
                     .setQuery(QueryBuilders.idsQuery().addIds(docId))
                     .get();
-                if (stateResponse.getHits().getHits().length == 0) {
-                    break;
+                try {
+                    if (stateResponse.getHits().getHits().length == 0) {
+                        break;
+                    }
+                    writeStateToStream(stateResponse.getHits().getAt(0).getSourceRef(), restoreStream);
+                } finally {
+                    stateResponse.decRef();
                 }
-                writeStateToStream(stateResponse.getHits().getAt(0).getSourceRef(), restoreStream);
             }
         }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/IndexingStateProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/IndexingStateProcessor.java
@@ -228,8 +228,12 @@ public class IndexingStateProcessor implements StateProcessor {
             () -> true,
             retryMessage -> LOGGER.debug("[{}] {} {}", jobId, documentId, retryMessage)
         );
-        return searchResponse.getHits().getHits().length > 0
-            ? searchResponse.getHits().getHits()[0].getIndex()
-            : AnomalyDetectorsIndex.jobStateIndexWriteAlias();
+        try {
+            return searchResponse.getHits().getHits().length > 0
+                ? searchResponse.getHits().getHits()[0].getIndex()
+                : AnomalyDetectorsIndex.jobStateIndexWriteAlias();
+        } finally {
+            searchResponse.decRef();
+        }
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/persistence/BatchedDocumentsIterator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/persistence/BatchedDocumentsIterator.java
@@ -85,8 +85,12 @@ public abstract class BatchedDocumentsIterator<T> implements BatchedIterator<T> 
             SearchScrollRequest searchScrollRequest = new SearchScrollRequest(scrollId).scroll(CONTEXT_ALIVE_DURATION);
             searchResponse = client.searchScroll(searchScrollRequest).actionGet();
         }
-        scrollId = searchResponse.getScrollId();
-        return mapHits(searchResponse);
+        try {
+            scrollId = searchResponse.getScrollId();
+            return mapHits(searchResponse);
+        } finally {
+            searchResponse.decRef();
+        }
     }
 
     private SearchResponse initScroll() {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/persistence/ResultsPersisterService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/persistence/ResultsPersisterService.java
@@ -294,7 +294,10 @@ public class ResultsPersisterService {
             client,
             () -> (isShutdown == false) && shouldRetry.get(),
             retryMsgHandler,
-            removeListener
+            removeListener.delegateFailure((l, r) -> {
+                r.mustIncRef();
+                l.onResponse(r);
+            })
         );
         onGoingRetryableSearchActions.put(key, mlRetryableAction);
         mlRetryableAction.run();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/persistence/SearchAfterDocumentsIterator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/persistence/SearchAfterDocumentsIterator.java
@@ -108,10 +108,14 @@ public abstract class SearchAfterDocumentsIterator<T> implements BatchedIterator
         }
 
         SearchResponse searchResponse = doSearch(searchAfterFields());
-        if (trackTotalHits && totalHits.get() == 0) {
-            totalHits.set(searchResponse.getHits().getTotalHits().value);
+        try {
+            if (trackTotalHits && totalHits.get() == 0) {
+                totalHits.set(searchResponse.getHits().getTotalHits().value);
+            }
+            return mapHits(searchResponse);
+        } finally {
+            searchResponse.decRef();
         }
-        return mapHits(searchResponse);
     }
 
     private SearchResponse doSearch(Object[] searchAfterValues) {

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transform/search/ExecutableSearchTransform.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transform/search/ExecutableSearchTransform.java
@@ -62,13 +62,17 @@ public class ExecutableSearchTransform extends ExecutableTransform<SearchTransfo
                 client,
                 () -> client.search(searchRequest).actionGet(timeout)
             );
-            final Params params;
-            if (request.isRestTotalHitsAsint()) {
-                params = new MapParams(Collections.singletonMap("rest_total_hits_as_int", "true"));
-            } else {
-                params = EMPTY_PARAMS;
+            try {
+                final Params params;
+                if (request.isRestTotalHitsAsint()) {
+                    params = new MapParams(Collections.singletonMap("rest_total_hits_as_int", "true"));
+                } else {
+                    params = EMPTY_PARAMS;
+                }
+                return new SearchTransform.Result(request, new Payload.XContent(resp, params));
+            } finally {
+                resp.decRef();
             }
-            return new SearchTransform.Result(request, new Payload.XContent(resp, params));
         } catch (Exception e) {
             logger.error(() -> format("failed to execute [%s] transform for [%s]", TYPE, ctx.id()), e);
             return new SearchTransform.Result(request, e);


### PR DESCRIPTION
Fixing all kinds of leaks in both ml prod and test code. Added a new utility for a very common operation in tests that I'm planning on replacing other use sites with in a follow up.

part of #102030 