### PR TITLE
[Profiling] Fix flamegraph aggregation

### DIFF
--- a/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/GetFlameGraphActionIT.java
+++ b/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/GetFlameGraphActionIT.java
@@ -9,13 +9,15 @@ package org.elasticsearch.xpack.profiling;
 
 public class GetFlameGraphActionIT extends ProfilingTestCase {
     public void testGetStackTracesUnfiltered() throws Exception {
-        GetStackTracesRequest request = new GetStackTracesRequest(10, 1.0d, 1.0d, null, null, null, null, null, null, null, null);
+        GetStackTracesRequest request = new GetStackTracesRequest(1000, 600.0d, 1.0d, null, null, null, null, null, null, null, null);
         GetFlamegraphResponse response = client().execute(GetFlamegraphAction.INSTANCE, request).get();
         // only spot-check top level properties - detailed tests are done in unit tests
-        assertEquals(297, response.getSize());
+        assertEquals(994, response.getSize());
         assertEquals(1.0d, response.getSamplingRate(), 0.001d);
-        assertEquals(60, response.getSelfCPU());
-        assertEquals(1956, response.getTotalCPU());
-        assertEquals(40, response.getTotalSamples());
+        assertEquals(44, response.getSelfCPU());
+        assertEquals(1865, response.getTotalCPU());
+        assertEquals(1.3651d, response.getSelfAnnualCostsUSD(), 0.0001d);
+        assertEquals(0.000144890d, response.getSelfAnnualCO2Tons(), 0.000000001d);
+        assertEquals(44, response.getTotalSamples());
     }
 }

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/Frame.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/Frame.java
@@ -7,4 +7,4 @@
 
 package org.elasticsearch.xpack.profiling;
 
-public record Frame(String fileName, String functionName, int functionOffset, int lineNumber, boolean inline) {}
+public record Frame(String fileName, String functionName, int functionOffset, int lineNumber, boolean inline, boolean last) {}

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetFlamegraphResponse.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetFlamegraphResponse.java
@@ -222,6 +222,22 @@ public class GetFlamegraphResponse extends ActionResponse implements ChunkedToXC
         return totalCPU;
     }
 
+    public double getSelfAnnualCostsUSD() {
+        return selfAnnualCostsUSD;
+    }
+
+    public double getTotalAnnualCostsUSD() {
+        return totalAnnualCostsUSD;
+    }
+
+    public double getSelfAnnualCO2Tons() {
+        return selfAnnualCO2Tons;
+    }
+
+    public double getTotalAnnualCO2Tons() {
+        return totalAnnualCO2Tons;
+    }
+
     public long getTotalSamples() {
         return totalSamples;
     }

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/StackFrame.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/StackFrame.java
@@ -15,35 +15,35 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Consumer;
 
 final class StackFrame implements ToXContentObject {
     List<String> fileName;
     List<String> functionName;
     List<Integer> functionOffset;
     List<Integer> lineNumber;
-    private final int size;
 
     StackFrame(Object fileName, Object functionName, Object functionOffset, Object lineNumber) {
         this.fileName = listOf(fileName);
         this.functionName = listOf(functionName);
         this.functionOffset = listOf(functionOffset);
         this.lineNumber = listOf(lineNumber);
-        this.size = this.functionName.size(); // functionName is the only array that is always set
     }
 
-    public int size() {
-        return size;
-    }
-
-    public Frame get(int index) {
-        // Array lengths might not be consistent, so we need to do checks here.
-        return new Frame(
-            fileName.size() > index ? fileName.get(index) : "",
-            functionName.get(index),
-            functionOffset.size() > index ? functionOffset.get(index) : 0,
-            lineNumber.size() > index ? lineNumber.get(index) : 0,
-            index > 0
-        );
+    public void forEach(Consumer<Frame> action) {
+        int size = this.functionName.size(); // functionName is the only array that is always set
+        for (int i = 0; i < size; i++) {
+            action.accept(
+                new Frame(
+                    fileName.size() > i ? fileName.get(i) : "",
+                    functionName.get(i),
+                    functionOffset.size() > i ? functionOffset.get(i) : 0,
+                    lineNumber.size() > i ? lineNumber.get(i) : 0,
+                    i > 0,
+                    i == size - 1
+                )
+            );
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetFlamegraphAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetFlamegraphAction.java
@@ -100,9 +100,9 @@ public class TransportGetFlamegraphAction extends HandledTransportAction<GetStac
                 Integer addressOrLine = stackTrace.addressOrLines.get(i);
                 StackFrame stackFrame = response.getStackFrames().getOrDefault(frameId, EMPTY_STACKFRAME);
                 String executable = response.getExecutables().getOrDefault(fileId, "");
+                final boolean isLeafFrame = i == frameCount - 1;
 
-                for (int j = 0; j < stackFrame.size(); j++) {
-                    Frame frame = stackFrame.get(j);
+                stackFrame.forEach(frame -> {
                     String frameGroupId = FrameGroupID.create(fileId, addressOrLine, executable, frame.fileName(), frame.functionName());
 
                     int nodeId;
@@ -128,14 +128,14 @@ public class TransportGetFlamegraphAction extends HandledTransportAction<GetStac
                             frameGroupId
                         );
                     }
-                    if (i == frameCount - 1 && j == stackFrame.size() - 1) {
+                    if (isLeafFrame && frame.last()) {
                         // Leaf frame: sum up counts for exclusive CPU.
                         builder.addSamplesExclusive(nodeId, samples);
                         builder.addAnnualCO2TonsExclusive(nodeId, annualCO2Tons);
                         builder.addAnnualCostsUSDExclusive(nodeId, annualCostsUSD);
                     }
                     builder.setCurrentNode(nodeId);
-                }
+                });
             }
         }
         return builder.build();

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetFlamegraphAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetFlamegraphAction.java
@@ -101,7 +101,8 @@ public class TransportGetFlamegraphAction extends HandledTransportAction<GetStac
                 StackFrame stackFrame = response.getStackFrames().getOrDefault(frameId, EMPTY_STACKFRAME);
                 String executable = response.getExecutables().getOrDefault(fileId, "");
 
-                for (Frame frame : stackFrame.frames()) {
+                for (int j = 0; j < stackFrame.size(); j++) {
+                    Frame frame = stackFrame.get(j);
                     String frameGroupId = FrameGroupID.create(fileId, addressOrLine, executable, frame.fileName(), frame.functionName());
 
                     int nodeId;
@@ -127,7 +128,7 @@ public class TransportGetFlamegraphAction extends HandledTransportAction<GetStac
                             frameGroupId
                         );
                     }
-                    if (i == frameCount - 1) {
+                    if (i == frameCount - 1 && j == stackFrame.size() - 1) {
                         // Leaf frame: sum up counts for exclusive CPU.
                         builder.addSamplesExclusive(nodeId, samples);
                         builder.addAnnualCO2TonsExclusive(nodeId, annualCO2Tons);
@@ -142,6 +143,7 @@ public class TransportGetFlamegraphAction extends HandledTransportAction<GetStac
 
     private static class FlamegraphBuilder {
         private int currentNode = 0;
+        // size is the number of nodes in the flamegraph
         private int size = 0;
         private long selfCPU;
         private long totalCPU;
@@ -149,6 +151,7 @@ public class TransportGetFlamegraphAction extends HandledTransportAction<GetStac
         private double totalAnnualCO2Tons;
         private double selfAnnualCostsUSD;
         private double totalAnnualCostsUSD;
+        // totalSamples is the total number of samples in the stacktraces
         private final long totalSamples;
         // Map: FrameGroupId -> NodeId
         private final List<Map<String, Integer>> edges;


### PR DESCRIPTION
This fixes two issues which are coupled.
1. The frames weren't accounted for correctly. This could lead 0 nodes accounted for a frame (including the inline frames).
2. `addSamplesExclusive()` and other aggregations were called for each inline frame belonging to a leaf frame. Instead, we only want to call this once per leaf frame.
