### PR TITLE
Deprecate the unused elasticsearch_version field of enrich policy json

### DIFF
--- a/docs/changelog/103013.yaml
+++ b/docs/changelog/103013.yaml
@@ -1,0 +1,5 @@
+pr: 103013
+summary: Deprecate the unused `elasticsearch_version` field of enrich policy json
+area: Ingest Node
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -190,6 +190,7 @@ public class TransportVersions {
     public static final TransportVersion SOURCE_IN_SINGLE_VALUE_QUERY_ADDED = def(8_557_00_0);
     public static final TransportVersion MISSED_INDICES_UPDATE_EXCEPTION_ADDED = def(8_558_00_0);
     public static final TransportVersion INFERENCE_SERVICE_EMBEDDING_SIZE_ADDED = def(8_559_00_0);
+    public static final TransportVersion ENRICH_ELASTICSEARCH_VERSION_REMOVED = def(8_560_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/EnrichPolicy.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/EnrichPolicy.java
@@ -222,9 +222,6 @@ public final class EnrichPolicy implements Writeable, ToXContentFragment {
         builder.array(INDICES.getPreferredName(), indices.toArray(new String[0]));
         builder.field(MATCH_FIELD.getPreferredName(), matchField);
         builder.array(ENRICH_FIELDS.getPreferredName(), enrichFields.toArray(new String[0]));
-        if (params.paramAsBoolean("include_version", false) && elasticsearchVersion != null) {
-            builder.field(ELASTICSEARCH_VERSION.getPreferredName(), elasticsearchVersion.toString());
-        }
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/EnrichPolicy.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/EnrichPolicy.java
@@ -14,6 +14,8 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.logging.DeprecationCategory;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
@@ -32,6 +34,11 @@ import java.util.Objects;
  * Represents an enrich policy including its configuration.
  */
 public final class EnrichPolicy implements Writeable, ToXContentFragment {
+
+    private static final String ELASTICEARCH_VERSION_DEPRECATION_MESSAGE =
+        "the [elasticsearch_version] field of an enrich policy has no effect and will be removed in Elasticsearch 9.0";
+
+    private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(EnrichPolicy.class);
 
     public static final String ENRICH_INDEX_NAME_BASE = ".enrich-";
     public static final String ENRICH_INDEX_PATTERN = ENRICH_INDEX_NAME_BASE + "*";
@@ -132,9 +139,16 @@ public final class EnrichPolicy implements Writeable, ToXContentFragment {
         List<String> enrichFields,
         String elasticsearchVersion
     ) {
-        // for backwards compatibility reasons, it is possible to pass in an elasticsearchVersion -- that version is
-        // completely ignored and does nothing.
         this(type, query, indices, matchField, enrichFields);
+        // for backwards compatibility reasons, it is possible to pass in an elasticsearchVersion -- that version is
+        // completely ignored and does nothing. we'll fix that in a future version, so send a deprecation warning.
+        if (elasticsearchVersion != null) {
+            deprecationLogger.warn(
+                DeprecationCategory.OTHER,
+                "enrich_policy_with_elasticsearch_version",
+                ELASTICEARCH_VERSION_DEPRECATION_MESSAGE
+            );
+        }
     }
 
     public String getType() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/EnrichPolicy.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/EnrichPolicy.java
@@ -108,7 +108,6 @@ public final class EnrichPolicy implements Writeable, ToXContentFragment {
     private final List<String> indices;
     private final String matchField;
     private final List<String> enrichFields;
-    private final Version elasticsearchVersion;
 
     public EnrichPolicy(StreamInput in) throws IOException {
         this(
@@ -122,10 +121,14 @@ public final class EnrichPolicy implements Writeable, ToXContentFragment {
     }
 
     public EnrichPolicy(String type, QuerySource query, List<String> indices, String matchField, List<String> enrichFields) {
-        this(type, query, indices, matchField, enrichFields, Version.CURRENT);
+        this.type = type;
+        this.query = query;
+        this.indices = indices;
+        this.matchField = matchField;
+        this.enrichFields = enrichFields;
     }
 
-    public EnrichPolicy(
+    private EnrichPolicy(
         String type,
         QuerySource query,
         List<String> indices,
@@ -133,12 +136,9 @@ public final class EnrichPolicy implements Writeable, ToXContentFragment {
         List<String> enrichFields,
         Version elasticsearchVersion
     ) {
-        this.type = type;
-        this.query = query;
-        this.indices = indices;
-        this.matchField = matchField;
-        this.enrichFields = enrichFields;
-        this.elasticsearchVersion = elasticsearchVersion != null ? elasticsearchVersion : Version.CURRENT;
+        // for backwards compatibility reasons, it is possible to pass in an elasticsearchVersion -- that version is
+        // completely ignored and does nothing.
+        this(type, query, indices, matchField, enrichFields);
     }
 
     public String getType() {
@@ -159,10 +159,6 @@ public final class EnrichPolicy implements Writeable, ToXContentFragment {
 
     public List<String> getEnrichFields() {
         return enrichFields;
-    }
-
-    public Version getElasticsearchVersion() {
-        return elasticsearchVersion;
     }
 
     public static String getBaseName(String policyName) {
@@ -202,7 +198,7 @@ public final class EnrichPolicy implements Writeable, ToXContentFragment {
         out.writeStringCollection(indices);
         out.writeString(matchField);
         out.writeStringCollection(enrichFields);
-        Version.writeVersion(elasticsearchVersion, out);
+        Version.writeVersion(Version.CURRENT, out);
     }
 
     @Override
@@ -233,13 +229,12 @@ public final class EnrichPolicy implements Writeable, ToXContentFragment {
             && Objects.equals(query, policy.query)
             && indices.equals(policy.indices)
             && matchField.equals(policy.matchField)
-            && enrichFields.equals(policy.enrichFields)
-            && elasticsearchVersion.equals(policy.elasticsearchVersion);
+            && enrichFields.equals(policy.enrichFields);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(type, query, indices, matchField, enrichFields, elasticsearchVersion);
+        return Objects.hash(type, query, indices, matchField, enrichFields);
     }
 
     public String toString() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/EnrichPolicy.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/EnrichPolicy.java
@@ -16,7 +16,6 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
-import org.elasticsearch.xcontent.ObjectParser.ValueType;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentFragment;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -58,7 +57,7 @@ public final class EnrichPolicy implements Writeable, ToXContentFragment {
             (List<String>) args[1],
             (String) args[2],
             (List<String>) args[3],
-            (Version) args[4]
+            (String) args[4]
         )
     );
 
@@ -75,12 +74,7 @@ public final class EnrichPolicy implements Writeable, ToXContentFragment {
         parser.declareStringArray(ConstructingObjectParser.constructorArg(), INDICES);
         parser.declareString(ConstructingObjectParser.constructorArg(), MATCH_FIELD);
         parser.declareStringArray(ConstructingObjectParser.constructorArg(), ENRICH_FIELDS);
-        parser.declareField(
-            ConstructingObjectParser.optionalConstructorArg(),
-            ((p, c) -> Version.fromString(p.text())),
-            ELASTICSEARCH_VERSION,
-            ValueType.STRING
-        );
+        parser.declareString(ConstructingObjectParser.optionalConstructorArg(), ELASTICSEARCH_VERSION);
     }
 
     public static EnrichPolicy fromXContent(XContentParser parser) throws IOException {
@@ -136,7 +130,7 @@ public final class EnrichPolicy implements Writeable, ToXContentFragment {
         List<String> indices,
         String matchField,
         List<String> enrichFields,
-        Version elasticsearchVersion
+        String elasticsearchVersion
     ) {
         // for backwards compatibility reasons, it is possible to pass in an elasticsearchVersion -- that version is
         // completely ignored and does nothing.
@@ -307,7 +301,7 @@ public final class EnrichPolicy implements Writeable, ToXContentFragment {
                     (List<String>) args[2],
                     (String) args[3],
                     (List<String>) args[4],
-                    (Version) args[5]
+                    (String) args[5]
                 )
             )
         );

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/action/PutEnrichPolicyAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/action/PutEnrichPolicyAction.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.core.enrich.action;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
@@ -39,11 +38,6 @@ public class PutEnrichPolicyAction extends ActionType<AcknowledgedResponse> {
 
         public Request(String name, EnrichPolicy policy) {
             this.name = Objects.requireNonNull(name, "name cannot be null");
-            if (Version.CURRENT.equals(policy.getElasticsearchVersion()) == false) {
-                throw new IllegalArgumentException(
-                    "Cannot set [version_created] field on enrich policy [" + name + "]. Found [" + policy.getElasticsearchVersion() + "]"
-                );
-            }
             this.policy = policy;
         }
 

--- a/x-pack/plugin/enrich/qa/common/src/main/java/org/elasticsearch/test/enrich/CommonEnrichRestTestCase.java
+++ b/x-pack/plugin/enrich/qa/common/src/main/java/org/elasticsearch/test/enrich/CommonEnrichRestTestCase.java
@@ -259,12 +259,6 @@ public abstract class CommonEnrichRestTestCase extends ESRestTestCase {
             }
             source.field("match_field", field);
             source.field("enrich_fields", new String[] { "globalRank", "tldRank", "tld" });
-
-            // technically it's possible to include an elasticsearch_version here. previously it had to match the current version of
-            // elasticsearch itself, but now it can be any string.
-            if (randomBoolean()) {
-                source.field("elasticsearch_version", randomAlphaOfLength(8));
-            }
         }
         source.endObject().endObject();
         return Strings.toString(source);

--- a/x-pack/plugin/enrich/qa/common/src/main/java/org/elasticsearch/test/enrich/CommonEnrichRestTestCase.java
+++ b/x-pack/plugin/enrich/qa/common/src/main/java/org/elasticsearch/test/enrich/CommonEnrichRestTestCase.java
@@ -15,7 +15,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.test.VersionUtils;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.json.JsonXContent;
@@ -261,10 +260,10 @@ public abstract class CommonEnrichRestTestCase extends ESRestTestCase {
             source.field("match_field", field);
             source.field("enrich_fields", new String[] { "globalRank", "tldRank", "tld" });
 
-            // technically it's possible to include an elasticsearch_version here. if the field is present,
-            // the value must be parseable as an elasticsearch version. none of this is documented anywhere.
+            // technically it's possible to include an elasticsearch_version here. previously it had to match the current version of
+            // elasticsearch itself, but now it can be any string.
             if (randomBoolean()) {
-                source.field("elasticsearch_version", VersionUtils.randomVersion(random()));
+                source.field("elasticsearch_version", randomAlphaOfLength(8));
             }
         }
         source.endObject().endObject();

--- a/x-pack/plugin/enrich/qa/common/src/main/java/org/elasticsearch/test/enrich/CommonEnrichRestTestCase.java
+++ b/x-pack/plugin/enrich/qa/common/src/main/java/org/elasticsearch/test/enrich/CommonEnrichRestTestCase.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.test.enrich;
 
 import org.apache.http.util.EntityUtils;
+import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
@@ -259,6 +260,12 @@ public abstract class CommonEnrichRestTestCase extends ESRestTestCase {
             }
             source.field("match_field", field);
             source.field("enrich_fields", new String[] { "globalRank", "tldRank", "tld" });
+
+            // technically it's possible to include an elasticsearch_version here. if the field is present,
+            // the value must be the current version. none of this is documented anywhere.
+            if (randomBoolean()) {
+                source.field("elasticsearch_version", Version.CURRENT);
+            }
         }
         source.endObject().endObject();
         return Strings.toString(source);

--- a/x-pack/plugin/enrich/qa/common/src/main/java/org/elasticsearch/test/enrich/CommonEnrichRestTestCase.java
+++ b/x-pack/plugin/enrich/qa/common/src/main/java/org/elasticsearch/test/enrich/CommonEnrichRestTestCase.java
@@ -7,7 +7,6 @@
 package org.elasticsearch.test.enrich;
 
 import org.apache.http.util.EntityUtils;
-import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
@@ -16,6 +15,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.test.VersionUtils;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.json.JsonXContent;
@@ -262,9 +262,9 @@ public abstract class CommonEnrichRestTestCase extends ESRestTestCase {
             source.field("enrich_fields", new String[] { "globalRank", "tldRank", "tld" });
 
             // technically it's possible to include an elasticsearch_version here. if the field is present,
-            // the value must be the current version. none of this is documented anywhere.
+            // the value must be parseable as an elasticsearch version. none of this is documented anywhere.
             if (randomBoolean()) {
-                source.field("elasticsearch_version", Version.CURRENT);
+                source.field("elasticsearch_version", VersionUtils.randomVersion(random()));
             }
         }
         source.endObject().endObject();

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunnerTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunnerTests.java
@@ -313,7 +313,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
             }
         );
         List<String> enrichFields = List.of("zipcode");
-        EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.RANGE_TYPE, null, List.of(sourceIndex), "range", enrichFields, null);
+        EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.RANGE_TYPE, null, List.of(sourceIndex), "range", enrichFields);
         String policyName = "test1";
 
         final long createTime = randomNonNegativeLong();

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/enrich/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/enrich/10_basic.yml
@@ -59,3 +59,28 @@ setup:
       enrich.delete_policy:
         name: policy-crud
   - is_true: acknowledged
+
+---
+"Test using the deprecated elasticsearch_version field results in a warning":
+  - skip:
+      version: " - 8.11.99"
+      reason: "elasticsearch_version field deprecated in 8.12.0, to be removed in 9.0"
+      features: warnings
+
+  - do:
+      warnings:
+        - "the [elasticsearch_version] field of an enrich policy has no effect and will be removed in Elasticsearch 9.0"
+      enrich.put_policy:
+        name: policy-crud-warning
+        body:
+          match:
+            indices: ["bar*"]
+            match_field: baz
+            enrich_fields: ["a", "b"]
+            elasticsearch_version: "any string here is acceptable"
+  - is_true: acknowledged
+
+  - do:
+      enrich.delete_policy:
+        name: policy-crud-warning
+  - is_true: acknowledged

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/enrich/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/enrich/10_basic.yml
@@ -1,6 +1,4 @@
----
-"Test enrich crud apis":
-
+setup:
   - do:
       indices.create:
         index: bar
@@ -13,8 +11,9 @@
                 type: keyword
               b:
                 type: keyword
-  - is_true: acknowledged
 
+---
+"Test enrich crud apis":
   - do:
       enrich.put_policy:
         name: policy-crud


### PR DESCRIPTION
There's been an undocumented, unused `elasticsearch_version` field that you could set as part of the body of a PUT enrich policy request. If you specified it, then the version that you specified had to match the version of the Elasticsearch server itself.

This PR deprecates that field and rips out the places in the logic where it was copied around. Additionally, to simplify the remaining code, there's no validation of the value anymore -- it can be any String. In 9.0 we'll remove the field entirely.