### PR TITLE
[8.11] Log more information in debug when synonyms fail updates (#102946)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/40_synonyms_sets_get.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/40_synonyms_sets_get.yml
@@ -23,7 +23,20 @@ setup:
         body:
           synonyms_set:
             - synonyms: "pc, computer"
+  # set logging to debug for issue: https://github.com/elastic/elasticsearch/issues/102261
+  - do:
+      cluster.put_settings:
+        body:
+          persistent:
+            logger.org.elasticsearch.synonyms: DEBUG
 
+---
+teardown:
+  - do:
+      cluster.put_settings:
+        body:
+          persistent:
+            logger.org.elasticsearch.synonyms: null
 ---
 "List synonyms set":
   - do:


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Log more information in debug when synonyms fail updates (#102946)