### PR TITLE
Fix SearchResponseMerger ref counting

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/MultiSearchResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/MultiSearchResponse.java
@@ -61,7 +61,12 @@ public class MultiSearchResponse extends ActionResponse implements Iterable<Mult
         private final SearchResponse response;
         private final Exception exception;
 
-        public Item(SearchResponse response, Exception exception) {
+        /**
+         *
+         * @param response search response that is considered owned by this instance after this constructor returns or {@code null}
+         * @param exception exception in case of search failure
+         */
+        public Item(@Nullable SearchResponse response, @Nullable Exception exception) {
             this.response = response;
             this.exception = exception;
         }

--- a/server/src/main/java/org/elasticsearch/action/search/SearchResponseMerger.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchResponseMerger.java
@@ -19,6 +19,7 @@ import org.elasticsearch.action.search.SearchPhaseController.TopDocsStats;
 import org.elasticsearch.action.search.SearchResponse.Clusters;
 import org.elasticsearch.action.search.TransportSearchAction.SearchTimeProvider;
 import org.elasticsearch.common.lucene.search.TopDocsAndMaxScore;
+import org.elasticsearch.core.Releasable;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.lucene.grouping.TopFieldGroups;
 import org.elasticsearch.search.SearchHit;
@@ -31,6 +32,7 @@ import org.elasticsearch.search.profile.SearchProfileResults;
 import org.elasticsearch.search.profile.SearchProfileShardResult;
 import org.elasticsearch.search.suggest.Suggest;
 import org.elasticsearch.search.suggest.completion.CompletionSuggestion;
+import org.elasticsearch.transport.LeakTracker;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -64,13 +66,19 @@ import static org.elasticsearch.action.search.SearchPhaseController.mergeTopDocs
 // TODO it may make sense to integrate the remote clusters responses as a shard response in the initial search phase and ignore hits coming
 // from the remote clusters in the fetch phase. This would be identical to the removed QueryAndFetch strategy except that only the remote
 // cluster response would have the fetch results.
-final class SearchResponseMerger {
+final class SearchResponseMerger implements Releasable {
     final int from;
     final int size;
     final int trackTotalHitsUpTo;
     private final SearchTimeProvider searchTimeProvider;
     private final AggregationReduceContext.Builder aggReduceContextBuilder;
     private final List<SearchResponse> searchResponses = new CopyOnWriteArrayList<>();
+
+    private final Releasable releasable = LeakTracker.wrap(() -> {
+        for (SearchResponse searchResponse : searchResponses) {
+            searchResponse.decRef();
+        }
+    });
 
     SearchResponseMerger(
         int from,
@@ -93,6 +101,7 @@ final class SearchResponseMerger {
      */
     void add(SearchResponse searchResponse) {
         assert searchResponse.getScrollId() == null : "merging scroll results is not supported";
+        searchResponse.mustIncRef();
         searchResponses.add(searchResponse);
     }
 
@@ -381,6 +390,11 @@ final class SearchResponseMerger {
             }
         }
         return new SearchHits(searchHits, topDocsStats.getTotalHits(), topDocsStats.getMaxScore(), sortFields, groupField, groupValues);
+    }
+
+    @Override
+    public void close() {
+        releasable.close();
     }
 
     private static final class FieldDocAndSearchHit extends FieldDoc {

--- a/server/src/main/java/org/elasticsearch/action/search/TransportMultiSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportMultiSearchAction.java
@@ -154,9 +154,10 @@ public class TransportMultiSearchAction extends HandledTransportAction<MultiSear
          * when we handle the response rather than going recursive, we fork to another thread, otherwise we recurse.
          */
         final Thread thread = Thread.currentThread();
-        client.search(request.request, new ActionListener<SearchResponse>() {
+        client.search(request.request, new ActionListener<>() {
             @Override
             public void onResponse(final SearchResponse searchResponse) {
+                searchResponse.mustIncRef(); // acquire reference on behalf of MultiSearchResponse.Item below
                 handleResponse(request.responseSlot, new MultiSearchResponse.Item(searchResponse, null));
             }
 

--- a/server/src/test/java/org/elasticsearch/action/search/SearchResponseMergerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchResponseMergerTests.java
@@ -98,367 +98,446 @@ public class SearchResponseMergerTests extends ESTestCase {
     public void testMergeTookInMillis() throws InterruptedException {
         long currentRelativeTime = randomNonNegativeLong();
         SearchTimeProvider timeProvider = new SearchTimeProvider(randomLong(), 0, () -> currentRelativeTime);
-        SearchResponseMerger merger = new SearchResponseMerger(
-            randomIntBetween(0, 1000),
-            randomIntBetween(0, 10000),
-            SearchContext.TRACK_TOTAL_HITS_ACCURATE,
-            timeProvider,
-            emptyReduceContextBuilder()
-        );
-        for (int i = 0; i < numResponses; i++) {
-            SearchResponse searchResponse = new SearchResponse(
-                InternalSearchResponse.EMPTY_WITH_TOTAL_HITS,
-                null,
-                1,
-                1,
-                0,
-                randomNonNegativeLong(),
-                ShardSearchFailure.EMPTY_ARRAY,
-                SearchResponseTests.randomClusters()
-            );
-            addResponse(merger, searchResponse);
+        try (
+            SearchResponseMerger merger = new SearchResponseMerger(
+                randomIntBetween(0, 1000),
+                randomIntBetween(0, 10000),
+                SearchContext.TRACK_TOTAL_HITS_ACCURATE,
+                timeProvider,
+                emptyReduceContextBuilder()
+            )
+        ) {
+            for (int i = 0; i < numResponses; i++) {
+                SearchResponse searchResponse = new SearchResponse(
+                    InternalSearchResponse.EMPTY_WITH_TOTAL_HITS,
+                    null,
+                    1,
+                    1,
+                    0,
+                    randomNonNegativeLong(),
+                    ShardSearchFailure.EMPTY_ARRAY,
+                    SearchResponseTests.randomClusters()
+                );
+                try {
+                    addResponse(merger, searchResponse);
+                } finally {
+                    searchResponse.decRef();
+                }
+            }
+            awaitResponsesAdded();
+            SearchResponse searchResponse = merger.getMergedResponse(SearchResponse.Clusters.EMPTY);
+            try {
+                assertEquals(TimeUnit.NANOSECONDS.toMillis(currentRelativeTime), searchResponse.getTook().millis());
+            } finally {
+                searchResponse.decRef();
+            }
         }
-        awaitResponsesAdded();
-        SearchResponse searchResponse = merger.getMergedResponse(SearchResponse.Clusters.EMPTY);
-        assertEquals(TimeUnit.NANOSECONDS.toMillis(currentRelativeTime), searchResponse.getTook().millis());
     }
 
     public void testMergeShardFailures() throws InterruptedException {
         SearchTimeProvider searchTimeProvider = new SearchTimeProvider(0, 0, () -> 0);
-        SearchResponseMerger merger = new SearchResponseMerger(
-            0,
-            0,
-            SearchContext.TRACK_TOTAL_HITS_ACCURATE,
-            searchTimeProvider,
-            emptyReduceContextBuilder()
-        );
-        PriorityQueue<Tuple<SearchShardTarget, ShardSearchFailure>> priorityQueue = new PriorityQueue<>(
-            Comparator.comparing(Tuple::v1, (o1, o2) -> {
-                int compareTo = o1.getShardId().compareTo(o2.getShardId());
-                if (compareTo != 0) {
-                    return compareTo;
-                }
-                return o1.getClusterAlias().compareTo(o2.getClusterAlias());
-            })
-        );
-        int numIndices = numResponses * randomIntBetween(1, 3);
-        Iterator<Map.Entry<String, Index[]>> indicesPerCluster = randomRealisticIndices(numIndices, numResponses).entrySet().iterator();
-        for (int i = 0; i < numResponses; i++) {
-            Map.Entry<String, Index[]> entry = indicesPerCluster.next();
-            String clusterAlias = entry.getKey();
-            Index[] indices = entry.getValue();
-            int numFailures = randomIntBetween(1, 10);
-            ShardSearchFailure[] shardSearchFailures = new ShardSearchFailure[numFailures];
-            for (int j = 0; j < numFailures; j++) {
-                ShardId shardId = new ShardId(randomFrom(indices), j);
-                SearchShardTarget searchShardTarget = new SearchShardTarget(randomAlphaOfLength(6), shardId, clusterAlias);
-                ShardSearchFailure failure = new ShardSearchFailure(new IllegalArgumentException(), searchShardTarget);
-                shardSearchFailures[j] = failure;
-                priorityQueue.add(Tuple.tuple(searchShardTarget, failure));
-            }
-            SearchResponse searchResponse = new SearchResponse(
-                InternalSearchResponse.EMPTY_WITH_TOTAL_HITS,
-                null,
-                1,
-                1,
+        try (
+            SearchResponseMerger merger = new SearchResponseMerger(
                 0,
-                100L,
-                shardSearchFailures,
-                SearchResponse.Clusters.EMPTY
+                0,
+                SearchContext.TRACK_TOTAL_HITS_ACCURATE,
+                searchTimeProvider,
+                emptyReduceContextBuilder()
+            )
+        ) {
+            PriorityQueue<Tuple<SearchShardTarget, ShardSearchFailure>> priorityQueue = new PriorityQueue<>(
+                Comparator.comparing(Tuple::v1, (o1, o2) -> {
+                    int compareTo = o1.getShardId().compareTo(o2.getShardId());
+                    if (compareTo != 0) {
+                        return compareTo;
+                    }
+                    return o1.getClusterAlias().compareTo(o2.getClusterAlias());
+                })
             );
-            addResponse(merger, searchResponse);
-        }
-        awaitResponsesAdded();
-        assertEquals(numResponses, merger.numResponses());
-        SearchResponse.Clusters clusters = SearchResponseTests.randomClusters();
-        SearchResponse mergedResponse = merger.getMergedResponse(clusters);
-        assertSame(clusters, mergedResponse.getClusters());
-        assertEquals(numResponses, mergedResponse.getTotalShards());
-        assertEquals(numResponses, mergedResponse.getSuccessfulShards());
-        assertEquals(0, mergedResponse.getSkippedShards());
-        assertEquals(priorityQueue.size(), mergedResponse.getFailedShards());
-        ShardSearchFailure[] shardFailures = mergedResponse.getShardFailures();
-        assertEquals(priorityQueue.size(), shardFailures.length);
-        for (ShardSearchFailure shardFailure : shardFailures) {
-            ShardSearchFailure expected = priorityQueue.poll().v2();
-            assertSame(expected, shardFailure);
+            int numIndices = numResponses * randomIntBetween(1, 3);
+            Iterator<Map.Entry<String, Index[]>> indicesPerCluster = randomRealisticIndices(numIndices, numResponses).entrySet().iterator();
+            for (int i = 0; i < numResponses; i++) {
+                Map.Entry<String, Index[]> entry = indicesPerCluster.next();
+                String clusterAlias = entry.getKey();
+                Index[] indices = entry.getValue();
+                int numFailures = randomIntBetween(1, 10);
+                ShardSearchFailure[] shardSearchFailures = new ShardSearchFailure[numFailures];
+                for (int j = 0; j < numFailures; j++) {
+                    ShardId shardId = new ShardId(randomFrom(indices), j);
+                    SearchShardTarget searchShardTarget = new SearchShardTarget(randomAlphaOfLength(6), shardId, clusterAlias);
+                    ShardSearchFailure failure = new ShardSearchFailure(new IllegalArgumentException(), searchShardTarget);
+                    shardSearchFailures[j] = failure;
+                    priorityQueue.add(Tuple.tuple(searchShardTarget, failure));
+                }
+                SearchResponse searchResponse = new SearchResponse(
+                    InternalSearchResponse.EMPTY_WITH_TOTAL_HITS,
+                    null,
+                    1,
+                    1,
+                    0,
+                    100L,
+                    shardSearchFailures,
+                    SearchResponse.Clusters.EMPTY
+                );
+                try {
+                    addResponse(merger, searchResponse);
+                } finally {
+                    searchResponse.decRef();
+                }
+            }
+            awaitResponsesAdded();
+            assertEquals(numResponses, merger.numResponses());
+            SearchResponse.Clusters clusters = SearchResponseTests.randomClusters();
+            SearchResponse mergedResponse = merger.getMergedResponse(clusters);
+            try {
+                assertSame(clusters, mergedResponse.getClusters());
+                assertEquals(numResponses, mergedResponse.getTotalShards());
+                assertEquals(numResponses, mergedResponse.getSuccessfulShards());
+                assertEquals(0, mergedResponse.getSkippedShards());
+                assertEquals(priorityQueue.size(), mergedResponse.getFailedShards());
+                ShardSearchFailure[] shardFailures = mergedResponse.getShardFailures();
+                assertEquals(priorityQueue.size(), shardFailures.length);
+                for (ShardSearchFailure shardFailure : shardFailures) {
+                    ShardSearchFailure expected = priorityQueue.poll().v2();
+                    assertSame(expected, shardFailure);
+                }
+            } finally {
+                mergedResponse.decRef();
+            }
         }
     }
 
     public void testMergeShardFailuresNullShardTarget() throws InterruptedException {
         SearchTimeProvider searchTimeProvider = new SearchTimeProvider(0, 0, () -> 0);
-        SearchResponseMerger merger = new SearchResponseMerger(
-            0,
-            0,
-            SearchContext.TRACK_TOTAL_HITS_ACCURATE,
-            searchTimeProvider,
-            emptyReduceContextBuilder()
-        );
-        PriorityQueue<Tuple<ShardId, ShardSearchFailure>> priorityQueue = new PriorityQueue<>(Comparator.comparing(Tuple::v1));
-        for (int i = 0; i < numResponses; i++) {
-            int numFailures = randomIntBetween(1, 10);
-            ShardSearchFailure[] shardSearchFailures = new ShardSearchFailure[numFailures];
-            for (int j = 0; j < numFailures; j++) {
-                String index = "index-" + i;
-                ShardId shardId = new ShardId(index, index + "-uuid", j);
-                ElasticsearchException elasticsearchException = new ElasticsearchException(new IllegalArgumentException());
-                elasticsearchException.setShard(shardId);
-                ShardSearchFailure failure = new ShardSearchFailure(elasticsearchException);
-                shardSearchFailures[j] = failure;
-                priorityQueue.add(Tuple.tuple(shardId, failure));
-            }
-            SearchResponse searchResponse = new SearchResponse(
-                InternalSearchResponse.EMPTY_WITH_TOTAL_HITS,
-                null,
-                1,
-                1,
+        try (
+            SearchResponseMerger merger = new SearchResponseMerger(
                 0,
-                100L,
-                shardSearchFailures,
-                SearchResponse.Clusters.EMPTY
-            );
-            addResponse(merger, searchResponse);
-        }
-        awaitResponsesAdded();
-        assertEquals(numResponses, merger.numResponses());
-        SearchResponse.Clusters clusters = SearchResponseTests.randomClusters();
-        SearchResponse mergedResponse = merger.getMergedResponse(clusters);
-        assertSame(clusters, mergedResponse.getClusters());
-        assertEquals(numResponses, mergedResponse.getTotalShards());
-        assertEquals(numResponses, mergedResponse.getSuccessfulShards());
-        assertEquals(0, mergedResponse.getSkippedShards());
-        assertEquals(priorityQueue.size(), mergedResponse.getFailedShards());
-        ShardSearchFailure[] shardFailures = mergedResponse.getShardFailures();
-        assertEquals(priorityQueue.size(), shardFailures.length);
-        for (ShardSearchFailure shardFailure : shardFailures) {
-            ShardSearchFailure expected = priorityQueue.poll().v2();
-            assertSame(expected, shardFailure);
+                0,
+                SearchContext.TRACK_TOTAL_HITS_ACCURATE,
+                searchTimeProvider,
+                emptyReduceContextBuilder()
+            )
+        ) {
+            PriorityQueue<Tuple<ShardId, ShardSearchFailure>> priorityQueue = new PriorityQueue<>(Comparator.comparing(Tuple::v1));
+            for (int i = 0; i < numResponses; i++) {
+                int numFailures = randomIntBetween(1, 10);
+                ShardSearchFailure[] shardSearchFailures = new ShardSearchFailure[numFailures];
+                for (int j = 0; j < numFailures; j++) {
+                    String index = "index-" + i;
+                    ShardId shardId = new ShardId(index, index + "-uuid", j);
+                    ElasticsearchException elasticsearchException = new ElasticsearchException(new IllegalArgumentException());
+                    elasticsearchException.setShard(shardId);
+                    ShardSearchFailure failure = new ShardSearchFailure(elasticsearchException);
+                    shardSearchFailures[j] = failure;
+                    priorityQueue.add(Tuple.tuple(shardId, failure));
+                }
+                SearchResponse searchResponse = new SearchResponse(
+                    InternalSearchResponse.EMPTY_WITH_TOTAL_HITS,
+                    null,
+                    1,
+                    1,
+                    0,
+                    100L,
+                    shardSearchFailures,
+                    SearchResponse.Clusters.EMPTY
+                );
+                try {
+                    addResponse(merger, searchResponse);
+                } finally {
+                    searchResponse.decRef();
+                }
+            }
+            awaitResponsesAdded();
+            assertEquals(numResponses, merger.numResponses());
+            SearchResponse.Clusters clusters = SearchResponseTests.randomClusters();
+            SearchResponse mergedResponse = merger.getMergedResponse(clusters);
+            try {
+                assertSame(clusters, mergedResponse.getClusters());
+                assertEquals(numResponses, mergedResponse.getTotalShards());
+                assertEquals(numResponses, mergedResponse.getSuccessfulShards());
+                assertEquals(0, mergedResponse.getSkippedShards());
+                assertEquals(priorityQueue.size(), mergedResponse.getFailedShards());
+                ShardSearchFailure[] shardFailures = mergedResponse.getShardFailures();
+                assertEquals(priorityQueue.size(), shardFailures.length);
+                for (ShardSearchFailure shardFailure : shardFailures) {
+                    ShardSearchFailure expected = priorityQueue.poll().v2();
+                    assertSame(expected, shardFailure);
+                }
+            } finally {
+                mergedResponse.decRef();
+            }
         }
     }
 
     public void testMergeShardFailuresNullShardId() throws InterruptedException {
         SearchTimeProvider searchTimeProvider = new SearchTimeProvider(0, 0, () -> 0);
-        SearchResponseMerger merger = new SearchResponseMerger(
-            0,
-            0,
-            SearchContext.TRACK_TOTAL_HITS_ACCURATE,
-            searchTimeProvider,
-            emptyReduceContextBuilder()
-        );
-        List<ShardSearchFailure> expectedFailures = new ArrayList<>();
-        for (int i = 0; i < numResponses; i++) {
-            int numFailures = randomIntBetween(1, 50);
-            ShardSearchFailure[] shardSearchFailures = new ShardSearchFailure[numFailures];
-            for (int j = 0; j < numFailures; j++) {
-                ShardSearchFailure shardSearchFailure = new ShardSearchFailure(new ElasticsearchException(new IllegalArgumentException()));
-                shardSearchFailures[j] = shardSearchFailure;
-                expectedFailures.add(shardSearchFailure);
-            }
-            SearchResponse searchResponse = new SearchResponse(
-                InternalSearchResponse.EMPTY_WITH_TOTAL_HITS,
-                null,
-                1,
-                1,
+        try (
+            SearchResponseMerger merger = new SearchResponseMerger(
                 0,
-                100L,
-                shardSearchFailures,
-                SearchResponse.Clusters.EMPTY
-            );
-            addResponse(merger, searchResponse);
+                0,
+                SearchContext.TRACK_TOTAL_HITS_ACCURATE,
+                searchTimeProvider,
+                emptyReduceContextBuilder()
+            )
+        ) {
+            List<ShardSearchFailure> expectedFailures = new ArrayList<>();
+            for (int i = 0; i < numResponses; i++) {
+                int numFailures = randomIntBetween(1, 50);
+                ShardSearchFailure[] shardSearchFailures = new ShardSearchFailure[numFailures];
+                for (int j = 0; j < numFailures; j++) {
+                    ShardSearchFailure shardSearchFailure = new ShardSearchFailure(
+                        new ElasticsearchException(new IllegalArgumentException())
+                    );
+                    shardSearchFailures[j] = shardSearchFailure;
+                    expectedFailures.add(shardSearchFailure);
+                }
+                SearchResponse searchResponse = new SearchResponse(
+                    InternalSearchResponse.EMPTY_WITH_TOTAL_HITS,
+                    null,
+                    1,
+                    1,
+                    0,
+                    100L,
+                    shardSearchFailures,
+                    SearchResponse.Clusters.EMPTY
+                );
+                try {
+                    addResponse(merger, searchResponse);
+                } finally {
+                    searchResponse.decRef();
+                }
+            }
+            awaitResponsesAdded();
+            assertEquals(numResponses, merger.numResponses());
+            var mergedResponse = merger.getMergedResponse(SearchResponse.Clusters.EMPTY);
+            try {
+                ShardSearchFailure[] shardFailures = mergedResponse.getShardFailures();
+                assertThat(Arrays.asList(shardFailures), containsInAnyOrder(expectedFailures.toArray(ShardSearchFailure.EMPTY_ARRAY)));
+            } finally {
+                mergedResponse.decRef();
+            }
         }
-        awaitResponsesAdded();
-        assertEquals(numResponses, merger.numResponses());
-        ShardSearchFailure[] shardFailures = merger.getMergedResponse(SearchResponse.Clusters.EMPTY).getShardFailures();
-        assertThat(Arrays.asList(shardFailures), containsInAnyOrder(expectedFailures.toArray(ShardSearchFailure.EMPTY_ARRAY)));
     }
 
     public void testMergeProfileResults() throws InterruptedException {
         SearchTimeProvider searchTimeProvider = new SearchTimeProvider(0, 0, () -> 0);
-        SearchResponseMerger merger = new SearchResponseMerger(
-            0,
-            0,
-            SearchContext.TRACK_TOTAL_HITS_ACCURATE,
-            searchTimeProvider,
-            emptyReduceContextBuilder()
-        );
-        Map<String, SearchProfileShardResult> expectedProfile = new HashMap<>();
-        for (int i = 0; i < numResponses; i++) {
-            SearchProfileResults profile = SearchProfileResultsTests.createTestItem();
-            expectedProfile.putAll(profile.getShardResults());
-            SearchHits searchHits = new SearchHits(new SearchHit[0], new TotalHits(0, TotalHits.Relation.EQUAL_TO), Float.NaN);
-            InternalSearchResponse internalSearchResponse = new InternalSearchResponse(searchHits, null, null, profile, false, null, 1);
-            SearchResponse searchResponse = new SearchResponse(
-                internalSearchResponse,
-                null,
-                1,
-                1,
+        try (
+            SearchResponseMerger merger = new SearchResponseMerger(
                 0,
-                100L,
-                ShardSearchFailure.EMPTY_ARRAY,
-                SearchResponse.Clusters.EMPTY
-            );
-            addResponse(merger, searchResponse);
+                0,
+                SearchContext.TRACK_TOTAL_HITS_ACCURATE,
+                searchTimeProvider,
+                emptyReduceContextBuilder()
+            )
+        ) {
+            Map<String, SearchProfileShardResult> expectedProfile = new HashMap<>();
+            for (int i = 0; i < numResponses; i++) {
+                SearchProfileResults profile = SearchProfileResultsTests.createTestItem();
+                expectedProfile.putAll(profile.getShardResults());
+                SearchHits searchHits = new SearchHits(new SearchHit[0], new TotalHits(0, TotalHits.Relation.EQUAL_TO), Float.NaN);
+                InternalSearchResponse internalSearchResponse = new InternalSearchResponse(searchHits, null, null, profile, false, null, 1);
+                SearchResponse searchResponse = new SearchResponse(
+                    internalSearchResponse,
+                    null,
+                    1,
+                    1,
+                    0,
+                    100L,
+                    ShardSearchFailure.EMPTY_ARRAY,
+                    SearchResponse.Clusters.EMPTY
+                );
+                try {
+                    addResponse(merger, searchResponse);
+                } finally {
+                    searchResponse.decRef();
+                }
+            }
+            awaitResponsesAdded();
+            assertEquals(numResponses, merger.numResponses());
+            SearchResponse.Clusters clusters = SearchResponseTests.randomClusters();
+            SearchResponse mergedResponse = merger.getMergedResponse(clusters);
+            try {
+                assertSame(clusters, mergedResponse.getClusters());
+                assertEquals(numResponses, mergedResponse.getTotalShards());
+                assertEquals(numResponses, mergedResponse.getSuccessfulShards());
+                assertEquals(0, mergedResponse.getSkippedShards());
+                assertEquals(0, mergedResponse.getFailedShards());
+                assertEquals(0, mergedResponse.getShardFailures().length);
+                assertEquals(expectedProfile, mergedResponse.getProfileResults());
+            } finally {
+                mergedResponse.decRef();
+            }
         }
-        awaitResponsesAdded();
-        assertEquals(numResponses, merger.numResponses());
-        SearchResponse.Clusters clusters = SearchResponseTests.randomClusters();
-        SearchResponse mergedResponse = merger.getMergedResponse(clusters);
-        assertSame(clusters, mergedResponse.getClusters());
-        assertEquals(numResponses, mergedResponse.getTotalShards());
-        assertEquals(numResponses, mergedResponse.getSuccessfulShards());
-        assertEquals(0, mergedResponse.getSkippedShards());
-        assertEquals(0, mergedResponse.getFailedShards());
-        assertEquals(0, mergedResponse.getShardFailures().length);
-        assertEquals(expectedProfile, mergedResponse.getProfileResults());
     }
 
     public void testMergeCompletionSuggestions() throws InterruptedException {
         String suggestionName = randomAlphaOfLengthBetween(4, 8);
         int size = randomIntBetween(1, 100);
-        SearchResponseMerger searchResponseMerger = new SearchResponseMerger(
-            0,
-            0,
-            0,
-            new SearchTimeProvider(0, 0, () -> 0),
-            emptyReduceContextBuilder()
-        );
-        for (int i = 0; i < numResponses; i++) {
-            List<Suggest.Suggestion<? extends Suggest.Suggestion.Entry<? extends Suggest.Suggestion.Entry.Option>>> suggestions =
-                new ArrayList<>();
-            CompletionSuggestion completionSuggestion = new CompletionSuggestion(suggestionName, size, false);
-            CompletionSuggestion.Entry options = new CompletionSuggestion.Entry(new Text("suggest"), 0, 10);
-            int docId = randomIntBetween(0, Integer.MAX_VALUE);
-            CompletionSuggestion.Entry.Option option = new CompletionSuggestion.Entry.Option(
-                docId,
-                new Text(randomAlphaOfLengthBetween(5, 10)),
-                i,
-                Collections.emptyMap()
-            );
-            SearchHit hit = new SearchHit(docId);
-            ShardId shardId = new ShardId(
-                randomAlphaOfLengthBetween(5, 10),
-                randomAlphaOfLength(10),
-                randomIntBetween(0, Integer.MAX_VALUE)
-            );
-            String clusterAlias = randomBoolean() ? "" : randomAlphaOfLengthBetween(5, 10);
-            hit.shard(new SearchShardTarget("node", shardId, clusterAlias));
-            option.setHit(hit);
-            options.addOption(option);
-            completionSuggestion.addTerm(options);
-            suggestions.add(completionSuggestion);
-            Suggest suggest = new Suggest(suggestions);
-            SearchHits searchHits = new SearchHits(new SearchHit[0], null, Float.NaN);
-            InternalSearchResponse internalSearchResponse = new InternalSearchResponse(searchHits, null, suggest, null, false, null, 1);
-            SearchResponse searchResponse = new SearchResponse(
-                internalSearchResponse,
-                null,
-                1,
-                1,
+        try (
+            SearchResponseMerger searchResponseMerger = new SearchResponseMerger(
                 0,
-                randomLong(),
-                ShardSearchFailure.EMPTY_ARRAY,
-                SearchResponse.Clusters.EMPTY
-            );
-            addResponse(searchResponseMerger, searchResponse);
-        }
-        awaitResponsesAdded();
-        assertEquals(numResponses, searchResponseMerger.numResponses());
-        SearchResponse.Clusters clusters = SearchResponseTests.randomClusters();
-        SearchResponse mergedResponse = searchResponseMerger.getMergedResponse(clusters);
-        assertSame(clusters, mergedResponse.getClusters());
-        assertEquals(numResponses, mergedResponse.getTotalShards());
-        assertEquals(numResponses, mergedResponse.getSuccessfulShards());
-        assertEquals(0, mergedResponse.getSkippedShards());
-        assertEquals(0, mergedResponse.getFailedShards());
-        assertEquals(0, mergedResponse.getShardFailures().length);
-        Suggest.Suggestion<? extends Suggest.Suggestion.Entry<? extends Suggest.Suggestion.Entry.Option>> suggestion = mergedResponse
-            .getSuggest()
-            .getSuggestion(suggestionName);
-        assertEquals(1, suggestion.getEntries().size());
-        Suggest.Suggestion.Entry<? extends Suggest.Suggestion.Entry.Option> options = suggestion.getEntries().get(0);
-        assertEquals(Math.min(numResponses, size), options.getOptions().size());
-        int i = numResponses;
-        for (Suggest.Suggestion.Entry.Option option : options) {
-            assertEquals(--i, option.getScore(), 0f);
+                0,
+                0,
+                new SearchTimeProvider(0, 0, () -> 0),
+                emptyReduceContextBuilder()
+            )
+        ) {
+            for (int i = 0; i < numResponses; i++) {
+                List<Suggest.Suggestion<? extends Suggest.Suggestion.Entry<? extends Suggest.Suggestion.Entry.Option>>> suggestions =
+                    new ArrayList<>();
+                CompletionSuggestion completionSuggestion = new CompletionSuggestion(suggestionName, size, false);
+                CompletionSuggestion.Entry options = new CompletionSuggestion.Entry(new Text("suggest"), 0, 10);
+                int docId = randomIntBetween(0, Integer.MAX_VALUE);
+                CompletionSuggestion.Entry.Option option = new CompletionSuggestion.Entry.Option(
+                    docId,
+                    new Text(randomAlphaOfLengthBetween(5, 10)),
+                    i,
+                    Collections.emptyMap()
+                );
+                SearchHit hit = new SearchHit(docId);
+                ShardId shardId = new ShardId(
+                    randomAlphaOfLengthBetween(5, 10),
+                    randomAlphaOfLength(10),
+                    randomIntBetween(0, Integer.MAX_VALUE)
+                );
+                String clusterAlias = randomBoolean() ? "" : randomAlphaOfLengthBetween(5, 10);
+                hit.shard(new SearchShardTarget("node", shardId, clusterAlias));
+                option.setHit(hit);
+                options.addOption(option);
+                completionSuggestion.addTerm(options);
+                suggestions.add(completionSuggestion);
+                Suggest suggest = new Suggest(suggestions);
+                SearchHits searchHits = new SearchHits(new SearchHit[0], null, Float.NaN);
+                InternalSearchResponse internalSearchResponse = new InternalSearchResponse(searchHits, null, suggest, null, false, null, 1);
+                SearchResponse searchResponse = new SearchResponse(
+                    internalSearchResponse,
+                    null,
+                    1,
+                    1,
+                    0,
+                    randomLong(),
+                    ShardSearchFailure.EMPTY_ARRAY,
+                    SearchResponse.Clusters.EMPTY
+                );
+                try {
+                    addResponse(searchResponseMerger, searchResponse);
+                } finally {
+                    searchResponse.decRef();
+                }
+            }
+            awaitResponsesAdded();
+            assertEquals(numResponses, searchResponseMerger.numResponses());
+            SearchResponse.Clusters clusters = SearchResponseTests.randomClusters();
+            SearchResponse mergedResponse = searchResponseMerger.getMergedResponse(clusters);
+            try {
+                assertSame(clusters, mergedResponse.getClusters());
+                assertEquals(numResponses, mergedResponse.getTotalShards());
+                assertEquals(numResponses, mergedResponse.getSuccessfulShards());
+                assertEquals(0, mergedResponse.getSkippedShards());
+                assertEquals(0, mergedResponse.getFailedShards());
+                assertEquals(0, mergedResponse.getShardFailures().length);
+                Suggest.Suggestion<? extends Suggest.Suggestion.Entry<? extends Suggest.Suggestion.Entry.Option>> suggestion =
+                    mergedResponse.getSuggest().getSuggestion(suggestionName);
+                assertEquals(1, suggestion.getEntries().size());
+                Suggest.Suggestion.Entry<? extends Suggest.Suggestion.Entry.Option> options = suggestion.getEntries().get(0);
+                assertEquals(Math.min(numResponses, size), options.getOptions().size());
+                int i = numResponses;
+                for (Suggest.Suggestion.Entry.Option option : options) {
+                    assertEquals(--i, option.getScore(), 0f);
+                }
+            } finally {
+                mergedResponse.decRef();
+            }
         }
     }
 
     public void testMergeCompletionSuggestionsTieBreak() throws InterruptedException {
         String suggestionName = randomAlphaOfLengthBetween(4, 8);
         int size = randomIntBetween(1, 100);
-        SearchResponseMerger searchResponseMerger = new SearchResponseMerger(
-            0,
-            0,
-            0,
-            new SearchTimeProvider(0, 0, () -> 0),
-            emptyReduceContextBuilder()
-        );
-        for (int i = 0; i < numResponses; i++) {
-            List<Suggest.Suggestion<? extends Suggest.Suggestion.Entry<? extends Suggest.Suggestion.Entry.Option>>> suggestions =
-                new ArrayList<>();
-            CompletionSuggestion completionSuggestion = new CompletionSuggestion(suggestionName, size, false);
-            CompletionSuggestion.Entry options = new CompletionSuggestion.Entry(new Text("suggest"), 0, 10);
-            int docId = randomIntBetween(0, Integer.MAX_VALUE);
-            CompletionSuggestion.Entry.Option option = new CompletionSuggestion.Entry.Option(
-                docId,
-                new Text("suggestion"),
-                1F,
-                Collections.emptyMap()
-            );
-            SearchHit searchHit = new SearchHit(docId);
-            searchHit.shard(
-                new SearchShardTarget(
-                    "node",
-                    new ShardId("index", "uuid", randomIntBetween(0, Integer.MAX_VALUE)),
-                    randomBoolean() ? RemoteClusterService.LOCAL_CLUSTER_GROUP_KEY : randomAlphaOfLengthBetween(5, 10)
-                )
-            );
-            option.setHit(searchHit);
-            options.addOption(option);
-            completionSuggestion.addTerm(options);
-            suggestions.add(completionSuggestion);
-            Suggest suggest = new Suggest(suggestions);
-            SearchHits searchHits = new SearchHits(new SearchHit[0], null, Float.NaN);
-            InternalSearchResponse internalSearchResponse = new InternalSearchResponse(searchHits, null, suggest, null, false, null, 1);
-            SearchResponse searchResponse = new SearchResponse(
-                internalSearchResponse,
-                null,
-                1,
-                1,
+        try (
+            SearchResponseMerger searchResponseMerger = new SearchResponseMerger(
                 0,
-                randomLong(),
-                ShardSearchFailure.EMPTY_ARRAY,
-                SearchResponse.Clusters.EMPTY
-            );
-            addResponse(searchResponseMerger, searchResponse);
-        }
-        awaitResponsesAdded();
-        assertEquals(numResponses, searchResponseMerger.numResponses());
-        SearchResponse.Clusters clusters = SearchResponseTests.randomClusters();
-        SearchResponse mergedResponse = searchResponseMerger.getMergedResponse(clusters);
-        assertSame(clusters, mergedResponse.getClusters());
-        assertEquals(numResponses, mergedResponse.getTotalShards());
-        assertEquals(numResponses, mergedResponse.getSuccessfulShards());
-        assertEquals(0, mergedResponse.getSkippedShards());
-        assertEquals(0, mergedResponse.getFailedShards());
-        assertEquals(0, mergedResponse.getShardFailures().length);
-        CompletionSuggestion suggestion = mergedResponse.getSuggest().getSuggestion(suggestionName);
-        assertEquals(1, suggestion.getEntries().size());
-        CompletionSuggestion.Entry options = suggestion.getEntries().get(0);
-        assertEquals(Math.min(numResponses, size), options.getOptions().size());
-        int lastShardId = 0;
-        String lastClusterAlias = null;
-        for (CompletionSuggestion.Entry.Option option : options) {
-            assertEquals("suggestion", option.getText().string());
-            SearchShardTarget shard = option.getHit().getShard();
-            int currentShardId = shard.getShardId().id();
-            assertThat(currentShardId, greaterThanOrEqualTo(lastShardId));
-            if (currentShardId == lastShardId) {
-                assertThat(shard.getClusterAlias(), greaterThan(lastClusterAlias));
-            } else {
-                lastShardId = currentShardId;
+                0,
+                0,
+                new SearchTimeProvider(0, 0, () -> 0),
+                emptyReduceContextBuilder()
+            )
+        ) {
+            for (int i = 0; i < numResponses; i++) {
+                List<Suggest.Suggestion<? extends Suggest.Suggestion.Entry<? extends Suggest.Suggestion.Entry.Option>>> suggestions =
+                    new ArrayList<>();
+                CompletionSuggestion completionSuggestion = new CompletionSuggestion(suggestionName, size, false);
+                CompletionSuggestion.Entry options = new CompletionSuggestion.Entry(new Text("suggest"), 0, 10);
+                int docId = randomIntBetween(0, Integer.MAX_VALUE);
+                CompletionSuggestion.Entry.Option option = new CompletionSuggestion.Entry.Option(
+                    docId,
+                    new Text("suggestion"),
+                    1F,
+                    Collections.emptyMap()
+                );
+                SearchHit searchHit = new SearchHit(docId);
+                searchHit.shard(
+                    new SearchShardTarget(
+                        "node",
+                        new ShardId("index", "uuid", randomIntBetween(0, Integer.MAX_VALUE)),
+                        randomBoolean() ? RemoteClusterService.LOCAL_CLUSTER_GROUP_KEY : randomAlphaOfLengthBetween(5, 10)
+                    )
+                );
+                option.setHit(searchHit);
+                options.addOption(option);
+                completionSuggestion.addTerm(options);
+                suggestions.add(completionSuggestion);
+                Suggest suggest = new Suggest(suggestions);
+                SearchHits searchHits = new SearchHits(new SearchHit[0], null, Float.NaN);
+                InternalSearchResponse internalSearchResponse = new InternalSearchResponse(searchHits, null, suggest, null, false, null, 1);
+                SearchResponse searchResponse = new SearchResponse(
+                    internalSearchResponse,
+                    null,
+                    1,
+                    1,
+                    0,
+                    randomLong(),
+                    ShardSearchFailure.EMPTY_ARRAY,
+                    SearchResponse.Clusters.EMPTY
+                );
+                try {
+                    addResponse(searchResponseMerger, searchResponse);
+                } finally {
+                    searchResponse.decRef();
+                }
             }
-            lastClusterAlias = shard.getClusterAlias();
+            awaitResponsesAdded();
+            assertEquals(numResponses, searchResponseMerger.numResponses());
+            SearchResponse.Clusters clusters = SearchResponseTests.randomClusters();
+            SearchResponse mergedResponse = searchResponseMerger.getMergedResponse(clusters);
+            try {
+                assertSame(clusters, mergedResponse.getClusters());
+                assertEquals(numResponses, mergedResponse.getTotalShards());
+                assertEquals(numResponses, mergedResponse.getSuccessfulShards());
+                assertEquals(0, mergedResponse.getSkippedShards());
+                assertEquals(0, mergedResponse.getFailedShards());
+                assertEquals(0, mergedResponse.getShardFailures().length);
+                CompletionSuggestion suggestion = mergedResponse.getSuggest().getSuggestion(suggestionName);
+                assertEquals(1, suggestion.getEntries().size());
+                CompletionSuggestion.Entry options = suggestion.getEntries().get(0);
+                assertEquals(Math.min(numResponses, size), options.getOptions().size());
+                int lastShardId = 0;
+                String lastClusterAlias = null;
+                for (CompletionSuggestion.Entry.Option option : options) {
+                    assertEquals("suggestion", option.getText().string());
+                    SearchShardTarget shard = option.getHit().getShard();
+                    int currentShardId = shard.getShardId().id();
+                    assertThat(currentShardId, greaterThanOrEqualTo(lastShardId));
+                    if (currentShardId == lastShardId) {
+                        assertThat(shard.getClusterAlias(), greaterThan(lastClusterAlias));
+                    } else {
+                        lastShardId = currentShardId;
+                    }
+                    lastClusterAlias = shard.getClusterAlias();
+                }
+            } finally {
+                mergedResponse.decRef();
+            }
         }
     }
 
@@ -476,101 +555,123 @@ public class SearchResponseMergerTests extends ESTestCase {
         );
 
         SearchHits searchHits = new SearchHits(new SearchHit[0], null, Float.NaN);
-        SearchResponseMerger searchResponseMerger = new SearchResponseMerger(
-            0,
-            0,
-            0,
-            new SearchTimeProvider(0, 0, () -> 0),
-            emptyReduceContextBuilder(new AggregatorFactories.Builder().addAggregator(new MaxAggregationBuilder("field1")))
-        );
-        for (Max max : Arrays.asList(max1, max2)) {
-            InternalAggregations aggs = InternalAggregations.from(Arrays.asList(max));
-            InternalSearchResponse internalSearchResponse = new InternalSearchResponse(searchHits, aggs, null, null, false, null, 1);
-            SearchResponse searchResponse = new SearchResponse(
-                internalSearchResponse,
-                null,
-                1,
-                1,
+        try (
+            SearchResponseMerger searchResponseMerger = new SearchResponseMerger(
                 0,
-                randomLong(),
-                ShardSearchFailure.EMPTY_ARRAY,
-                SearchResponse.Clusters.EMPTY
-            );
-            searchResponseMerger.add(searchResponse);
+                0,
+                0,
+                new SearchTimeProvider(0, 0, () -> 0),
+                emptyReduceContextBuilder(new AggregatorFactories.Builder().addAggregator(new MaxAggregationBuilder("field1")))
+            )
+        ) {
+            for (Max max : Arrays.asList(max1, max2)) {
+                InternalAggregations aggs = InternalAggregations.from(Arrays.asList(max));
+                InternalSearchResponse internalSearchResponse = new InternalSearchResponse(searchHits, aggs, null, null, false, null, 1);
+                SearchResponse searchResponse = new SearchResponse(
+                    internalSearchResponse,
+                    null,
+                    1,
+                    1,
+                    0,
+                    randomLong(),
+                    ShardSearchFailure.EMPTY_ARRAY,
+                    SearchResponse.Clusters.EMPTY
+                );
+                try {
+                    searchResponseMerger.add(searchResponse);
+                } finally {
+                    searchResponse.decRef();
+                }
+            }
+            SearchResponse.Clusters clusters = SearchResponseTests.randomClusters();
+            SearchResponse searchResponse = searchResponseMerger.getMergedResponse(clusters);
+            try {
+                Max mergedMax = searchResponse.getAggregations().get("field1");
+                assertEquals(mergedMax.getValueAsString(), "2021-05-01T00:00:00.000Z");
+            } finally {
+                searchResponse.decRef();
+            }
         }
-        SearchResponse.Clusters clusters = SearchResponseTests.randomClusters();
-        SearchResponse searchResponse = searchResponseMerger.getMergedResponse(clusters);
-        Max mergedMax = searchResponse.getAggregations().get("field1");
-        assertEquals(mergedMax.getValueAsString(), "2021-05-01T00:00:00.000Z");
     }
 
     public void testMergeAggs() throws InterruptedException {
         String maxAggName = randomAlphaOfLengthBetween(5, 8);
         String rangeAggName = randomAlphaOfLengthBetween(5, 8);
-        SearchResponseMerger searchResponseMerger = new SearchResponseMerger(
-            0,
-            0,
-            0,
-            new SearchTimeProvider(0, 0, () -> 0),
-            emptyReduceContextBuilder(
-                new AggregatorFactories.Builder().addAggregator(new MaxAggregationBuilder(maxAggName))
-                    .addAggregator(new DateRangeAggregationBuilder(rangeAggName))
-            )
-        );
-        int totalCount = 0;
-        double maxValue = Double.MIN_VALUE;
-        for (int i = 0; i < numResponses; i++) {
-            double value = randomDouble();
-            maxValue = Math.max(value, maxValue);
-            Max max = new Max(maxAggName, value, DocValueFormat.RAW, Collections.emptyMap());
-            InternalDateRange.Factory factory = new InternalDateRange.Factory();
-            int count = randomIntBetween(1, 1000);
-            totalCount += count;
-            InternalDateRange.Bucket bucket = factory.createBucket(
-                "bucket",
-                0D,
-                10000D,
-                count,
-                InternalAggregations.EMPTY,
-                false,
-                DocValueFormat.RAW
-            );
-            InternalDateRange range = factory.create(rangeAggName, singletonList(bucket), DocValueFormat.RAW, false, emptyMap());
-            InternalAggregations aggs = InternalAggregations.from(Arrays.asList(range, max));
-            SearchHits searchHits = new SearchHits(new SearchHit[0], null, Float.NaN);
-            InternalSearchResponse internalSearchResponse = new InternalSearchResponse(searchHits, aggs, null, null, false, null, 1);
-            SearchResponse searchResponse = new SearchResponse(
-                internalSearchResponse,
-                null,
-                1,
-                1,
+        try (
+            SearchResponseMerger searchResponseMerger = new SearchResponseMerger(
                 0,
-                randomLong(),
-                ShardSearchFailure.EMPTY_ARRAY,
-                SearchResponse.Clusters.EMPTY
-            );
-            addResponse(searchResponseMerger, searchResponse);
+                0,
+                0,
+                new SearchTimeProvider(0, 0, () -> 0),
+                emptyReduceContextBuilder(
+                    new AggregatorFactories.Builder().addAggregator(new MaxAggregationBuilder(maxAggName))
+                        .addAggregator(new DateRangeAggregationBuilder(rangeAggName))
+                )
+            )
+        ) {
+            int totalCount = 0;
+            double maxValue = Double.MIN_VALUE;
+            for (int i = 0; i < numResponses; i++) {
+                double value = randomDouble();
+                maxValue = Math.max(value, maxValue);
+                Max max = new Max(maxAggName, value, DocValueFormat.RAW, Collections.emptyMap());
+                InternalDateRange.Factory factory = new InternalDateRange.Factory();
+                int count = randomIntBetween(1, 1000);
+                totalCount += count;
+                InternalDateRange.Bucket bucket = factory.createBucket(
+                    "bucket",
+                    0D,
+                    10000D,
+                    count,
+                    InternalAggregations.EMPTY,
+                    false,
+                    DocValueFormat.RAW
+                );
+                InternalDateRange range = factory.create(rangeAggName, singletonList(bucket), DocValueFormat.RAW, false, emptyMap());
+                InternalAggregations aggs = InternalAggregations.from(Arrays.asList(range, max));
+                SearchHits searchHits = new SearchHits(new SearchHit[0], null, Float.NaN);
+                InternalSearchResponse internalSearchResponse = new InternalSearchResponse(searchHits, aggs, null, null, false, null, 1);
+                SearchResponse searchResponse = new SearchResponse(
+                    internalSearchResponse,
+                    null,
+                    1,
+                    1,
+                    0,
+                    randomLong(),
+                    ShardSearchFailure.EMPTY_ARRAY,
+                    SearchResponse.Clusters.EMPTY
+                );
+                try {
+                    addResponse(searchResponseMerger, searchResponse);
+                } finally {
+                    searchResponse.decRef();
+                }
+            }
+            awaitResponsesAdded();
+            assertEquals(numResponses, searchResponseMerger.numResponses());
+            SearchResponse.Clusters clusters = SearchResponseTests.randomClusters();
+            SearchResponse mergedResponse = searchResponseMerger.getMergedResponse(clusters);
+            try {
+                assertSame(clusters, mergedResponse.getClusters());
+                assertEquals(numResponses, mergedResponse.getTotalShards());
+                assertEquals(numResponses, mergedResponse.getSuccessfulShards());
+                assertEquals(0, mergedResponse.getSkippedShards());
+                assertEquals(0, mergedResponse.getFailedShards());
+                assertEquals(0, mergedResponse.getShardFailures().length);
+                assertEquals(0, mergedResponse.getHits().getHits().length);
+                assertEquals(2, mergedResponse.getAggregations().asList().size());
+                Max max = mergedResponse.getAggregations().get(maxAggName);
+                assertEquals(maxValue, max.value(), 0d);
+                Range range = mergedResponse.getAggregations().get(rangeAggName);
+                assertEquals(1, range.getBuckets().size());
+                Range.Bucket bucket = range.getBuckets().get(0);
+                assertEquals("0.0", bucket.getFromAsString());
+                assertEquals("10000.0", bucket.getToAsString());
+                assertEquals(totalCount, bucket.getDocCount());
+            } finally {
+                mergedResponse.decRef();
+            }
         }
-        awaitResponsesAdded();
-        assertEquals(numResponses, searchResponseMerger.numResponses());
-        SearchResponse.Clusters clusters = SearchResponseTests.randomClusters();
-        SearchResponse mergedResponse = searchResponseMerger.getMergedResponse(clusters);
-        assertSame(clusters, mergedResponse.getClusters());
-        assertEquals(numResponses, mergedResponse.getTotalShards());
-        assertEquals(numResponses, mergedResponse.getSuccessfulShards());
-        assertEquals(0, mergedResponse.getSkippedShards());
-        assertEquals(0, mergedResponse.getFailedShards());
-        assertEquals(0, mergedResponse.getShardFailures().length);
-        assertEquals(0, mergedResponse.getHits().getHits().length);
-        assertEquals(2, mergedResponse.getAggregations().asList().size());
-        Max max = mergedResponse.getAggregations().get(maxAggName);
-        assertEquals(maxValue, max.value(), 0d);
-        Range range = mergedResponse.getAggregations().get(rangeAggName);
-        assertEquals(1, range.getBuckets().size());
-        Range.Bucket bucket = range.getBuckets().get(0);
-        assertEquals("0.0", bucket.getFromAsString());
-        assertEquals("10000.0", bucket.getToAsString());
-        assertEquals(totalCount, bucket.getDocCount());
     }
 
     public void testMergeSearchHits() throws InterruptedException {
@@ -606,253 +707,294 @@ public class SearchResponseMergerTests extends ESTestCase {
         TotalHits.Relation totalHitsRelation = randomTrackTotalHits.v2();
 
         PriorityQueue<SearchHit> priorityQueue = new PriorityQueue<>(new SearchHitComparator(sortFields));
-        SearchResponseMerger searchResponseMerger = new SearchResponseMerger(
-            from,
-            size,
-            trackTotalHitsUpTo,
-            timeProvider,
-            emptyReduceContextBuilder()
-        );
+        try (
+            SearchResponseMerger searchResponseMerger = new SearchResponseMerger(
+                from,
+                size,
+                trackTotalHitsUpTo,
+                timeProvider,
+                emptyReduceContextBuilder()
+            )
+        ) {
 
-        TotalHits expectedTotalHits = null;
-        int expectedTotal = 0;
-        int expectedSuccessful = 0;
-        int expectedSkipped = 0;
-        int expectedReducePhases = 1;
-        boolean expectedTimedOut = false;
-        Boolean expectedTerminatedEarly = null;
-        float expectedMaxScore = Float.NEGATIVE_INFINITY;
-        int numIndices = requestedSize == 0 ? 0 : randomIntBetween(1, requestedSize);
-        Iterator<Map.Entry<String, Index[]>> indicesIterator = randomRealisticIndices(numIndices, numResponses).entrySet().iterator();
-        boolean hasHits = false;
-        for (int i = 0; i < numResponses; i++) {
-            Map.Entry<String, Index[]> entry = indicesIterator.next();
-            String clusterAlias = entry.getKey();
-            Index[] indices = entry.getValue();
-            int total = randomIntBetween(1, 1000);
-            expectedTotal += total;
-            int successful = randomIntBetween(1, total);
-            expectedSuccessful += successful;
-            int skipped = randomIntBetween(1, total);
-            expectedSkipped += skipped;
+            TotalHits expectedTotalHits = null;
+            int expectedTotal = 0;
+            int expectedSuccessful = 0;
+            int expectedSkipped = 0;
+            int expectedReducePhases = 1;
+            boolean expectedTimedOut = false;
+            Boolean expectedTerminatedEarly = null;
+            float expectedMaxScore = Float.NEGATIVE_INFINITY;
+            int numIndices = requestedSize == 0 ? 0 : randomIntBetween(1, requestedSize);
+            Iterator<Map.Entry<String, Index[]>> indicesIterator = randomRealisticIndices(numIndices, numResponses).entrySet().iterator();
+            boolean hasHits = false;
+            for (int i = 0; i < numResponses; i++) {
+                Map.Entry<String, Index[]> entry = indicesIterator.next();
+                String clusterAlias = entry.getKey();
+                Index[] indices = entry.getValue();
+                int total = randomIntBetween(1, 1000);
+                expectedTotal += total;
+                int successful = randomIntBetween(1, total);
+                expectedSuccessful += successful;
+                int skipped = randomIntBetween(1, total);
+                expectedSkipped += skipped;
 
-            TotalHits totalHits = null;
-            if (trackTotalHitsUpTo != SearchContext.TRACK_TOTAL_HITS_DISABLED) {
-                totalHits = new TotalHits(randomLongBetween(0, 1000), totalHitsRelation);
-                long previousValue = expectedTotalHits == null ? 0 : expectedTotalHits.value;
-                expectedTotalHits = new TotalHits(Math.min(previousValue + totalHits.value, trackTotalHitsUpTo), totalHitsRelation);
-            }
+                TotalHits totalHits = null;
+                if (trackTotalHitsUpTo != SearchContext.TRACK_TOTAL_HITS_DISABLED) {
+                    totalHits = new TotalHits(randomLongBetween(0, 1000), totalHitsRelation);
+                    long previousValue = expectedTotalHits == null ? 0 : expectedTotalHits.value;
+                    expectedTotalHits = new TotalHits(Math.min(previousValue + totalHits.value, trackTotalHitsUpTo), totalHitsRelation);
+                }
 
-            final int numDocs = totalHits == null || totalHits.value >= requestedSize ? requestedSize : (int) totalHits.value;
-            int scoreFactor = randomIntBetween(1, numResponses);
-            float maxScore = scoreSort ? numDocs * scoreFactor : Float.NaN;
-            SearchHit[] hits = randomSearchHitArray(
-                numDocs,
-                numResponses,
-                clusterAlias,
-                indices,
-                maxScore,
-                scoreFactor,
-                sortFields,
-                priorityQueue
-            );
-            hasHits |= hits.length > 0;
-            expectedMaxScore = Math.max(expectedMaxScore, maxScore);
+                final int numDocs = totalHits == null || totalHits.value >= requestedSize ? requestedSize : (int) totalHits.value;
+                int scoreFactor = randomIntBetween(1, numResponses);
+                float maxScore = scoreSort ? numDocs * scoreFactor : Float.NaN;
+                SearchHit[] hits = randomSearchHitArray(
+                    numDocs,
+                    numResponses,
+                    clusterAlias,
+                    indices,
+                    maxScore,
+                    scoreFactor,
+                    sortFields,
+                    priorityQueue
+                );
+                hasHits |= hits.length > 0;
+                expectedMaxScore = Math.max(expectedMaxScore, maxScore);
 
-            Object[] collapseValues = null;
-            if (collapseField != null) {
-                collapseValues = new Object[numDocs];
-                for (int j = 0; j < numDocs; j++) {
-                    // set different collapse values for each cluster for simplicity
-                    collapseValues[j] = j + 1000 * i;
+                Object[] collapseValues = null;
+                if (collapseField != null) {
+                    collapseValues = new Object[numDocs];
+                    for (int j = 0; j < numDocs; j++) {
+                        // set different collapse values for each cluster for simplicity
+                        collapseValues[j] = j + 1000 * i;
+                    }
+                }
+
+                SearchHits searchHits = new SearchHits(
+                    hits,
+                    totalHits,
+                    maxScore == Float.NEGATIVE_INFINITY ? Float.NaN : maxScore,
+                    sortFields,
+                    collapseField,
+                    collapseValues
+                );
+
+                int numReducePhases = randomIntBetween(1, 5);
+                expectedReducePhases += numReducePhases;
+                boolean timedOut = rarely();
+                expectedTimedOut = expectedTimedOut || timedOut;
+                Boolean terminatedEarly = frequently() ? null : true;
+                expectedTerminatedEarly = expectedTerminatedEarly == null ? terminatedEarly : expectedTerminatedEarly;
+
+                InternalSearchResponse internalSearchResponse = new InternalSearchResponse(
+                    searchHits,
+                    null,
+                    null,
+                    null,
+                    timedOut,
+                    terminatedEarly,
+                    numReducePhases
+                );
+
+                SearchResponse searchResponse = new SearchResponse(
+                    internalSearchResponse,
+                    null,
+                    total,
+                    successful,
+                    skipped,
+                    randomLong(),
+                    ShardSearchFailure.EMPTY_ARRAY,
+                    SearchResponseTests.randomClusters()
+                );
+                try {
+                    addResponse(searchResponseMerger, searchResponse);
+                } finally {
+                    searchResponse.decRef();
                 }
             }
 
-            SearchHits searchHits = new SearchHits(
-                hits,
-                totalHits,
-                maxScore == Float.NEGATIVE_INFINITY ? Float.NaN : maxScore,
-                sortFields,
-                collapseField,
-                collapseValues
-            );
+            awaitResponsesAdded();
+            assertEquals(numResponses, searchResponseMerger.numResponses());
+            final SearchResponse.Clusters clusters = SearchResponseTests.randomClusters();
+            SearchResponse searchResponse = searchResponseMerger.getMergedResponse(clusters);
+            try {
+                assertEquals(TimeUnit.NANOSECONDS.toMillis(currentRelativeTime), searchResponse.getTook().millis());
+                assertEquals(expectedTotal, searchResponse.getTotalShards());
+                assertEquals(expectedSuccessful, searchResponse.getSuccessfulShards());
+                assertEquals(expectedSkipped, searchResponse.getSkippedShards());
+                assertEquals(0, searchResponse.getShardFailures().length);
+                assertEquals(expectedReducePhases, searchResponse.getNumReducePhases());
+                assertEquals(expectedTimedOut, searchResponse.isTimedOut());
+                assertEquals(expectedTerminatedEarly, searchResponse.isTerminatedEarly());
 
-            int numReducePhases = randomIntBetween(1, 5);
-            expectedReducePhases += numReducePhases;
-            boolean timedOut = rarely();
-            expectedTimedOut = expectedTimedOut || timedOut;
-            Boolean terminatedEarly = frequently() ? null : true;
-            expectedTerminatedEarly = expectedTerminatedEarly == null ? terminatedEarly : expectedTerminatedEarly;
+                assertSame(clusters, searchResponse.getClusters());
+                assertNull(searchResponse.getScrollId());
 
-            InternalSearchResponse internalSearchResponse = new InternalSearchResponse(
-                searchHits,
-                null,
-                null,
-                null,
-                timedOut,
-                terminatedEarly,
-                numReducePhases
-            );
+                SearchHits searchHits = searchResponse.getHits();
+                // the sort fields and the collapse field are not returned when hits are empty
+                if (hasHits) {
+                    assertArrayEquals(sortFields, searchHits.getSortFields());
+                    assertEquals(collapseField, searchHits.getCollapseField());
+                } else {
+                    assertNull(searchHits.getSortFields());
+                    assertNull(searchHits.getCollapseField());
+                }
+                if (expectedTotalHits == null) {
+                    assertNull(searchHits.getTotalHits());
+                } else {
+                    assertNotNull(searchHits.getTotalHits());
+                    assertEquals(expectedTotalHits.value, searchHits.getTotalHits().value);
+                    assertSame(expectedTotalHits.relation, searchHits.getTotalHits().relation);
+                }
+                if (expectedMaxScore == Float.NEGATIVE_INFINITY) {
+                    assertTrue(Float.isNaN(searchHits.getMaxScore()));
+                } else {
+                    assertEquals(expectedMaxScore, searchHits.getMaxScore(), 0f);
+                }
 
-            SearchResponse searchResponse = new SearchResponse(
-                internalSearchResponse,
-                null,
-                total,
-                successful,
-                skipped,
-                randomLong(),
-                ShardSearchFailure.EMPTY_ARRAY,
-                SearchResponseTests.randomClusters()
-            );
-
-            addResponse(searchResponseMerger, searchResponse);
-        }
-
-        awaitResponsesAdded();
-        assertEquals(numResponses, searchResponseMerger.numResponses());
-        final SearchResponse.Clusters clusters = SearchResponseTests.randomClusters();
-        SearchResponse searchResponse = searchResponseMerger.getMergedResponse(clusters);
-
-        assertEquals(TimeUnit.NANOSECONDS.toMillis(currentRelativeTime), searchResponse.getTook().millis());
-        assertEquals(expectedTotal, searchResponse.getTotalShards());
-        assertEquals(expectedSuccessful, searchResponse.getSuccessfulShards());
-        assertEquals(expectedSkipped, searchResponse.getSkippedShards());
-        assertEquals(0, searchResponse.getShardFailures().length);
-        assertEquals(expectedReducePhases, searchResponse.getNumReducePhases());
-        assertEquals(expectedTimedOut, searchResponse.isTimedOut());
-        assertEquals(expectedTerminatedEarly, searchResponse.isTerminatedEarly());
-
-        assertSame(clusters, searchResponse.getClusters());
-        assertNull(searchResponse.getScrollId());
-
-        SearchHits searchHits = searchResponse.getHits();
-        // the sort fields and the collapse field are not returned when hits are empty
-        if (hasHits) {
-            assertArrayEquals(sortFields, searchHits.getSortFields());
-            assertEquals(collapseField, searchHits.getCollapseField());
-        } else {
-            assertNull(searchHits.getSortFields());
-            assertNull(searchHits.getCollapseField());
-        }
-        if (expectedTotalHits == null) {
-            assertNull(searchHits.getTotalHits());
-        } else {
-            assertNotNull(searchHits.getTotalHits());
-            assertEquals(expectedTotalHits.value, searchHits.getTotalHits().value);
-            assertSame(expectedTotalHits.relation, searchHits.getTotalHits().relation);
-        }
-        if (expectedMaxScore == Float.NEGATIVE_INFINITY) {
-            assertTrue(Float.isNaN(searchHits.getMaxScore()));
-        } else {
-            assertEquals(expectedMaxScore, searchHits.getMaxScore(), 0f);
-        }
-
-        for (int i = 0; i < from; i++) {
-            priorityQueue.poll();
-        }
-        SearchHit[] hits = searchHits.getHits();
-        if (collapseField != null
-            // the collapse field is not returned when hits are empty
-            && hasHits) {
-            assertEquals(hits.length, searchHits.getCollapseValues().length);
-        } else {
-            assertNull(searchHits.getCollapseValues());
-        }
-        assertThat(hits.length, lessThanOrEqualTo(size));
-        for (SearchHit hit : hits) {
-            SearchHit expected = priorityQueue.poll();
-            assertSame(expected, hit);
+                for (int i = 0; i < from; i++) {
+                    priorityQueue.poll();
+                }
+                SearchHit[] hits = searchHits.getHits();
+                if (collapseField != null
+                    // the collapse field is not returned when hits are empty
+                    && hasHits) {
+                    assertEquals(hits.length, searchHits.getCollapseValues().length);
+                } else {
+                    assertNull(searchHits.getCollapseValues());
+                }
+                assertThat(hits.length, lessThanOrEqualTo(size));
+                for (SearchHit hit : hits) {
+                    SearchHit expected = priorityQueue.poll();
+                    assertSame(expected, hit);
+                }
+            } finally {
+                searchResponse.decRef();
+            }
         }
     }
 
     public void testMergeNoResponsesAdded() {
         long currentRelativeTime = randomNonNegativeLong();
         final SearchTimeProvider timeProvider = new SearchTimeProvider(randomLong(), 0, () -> currentRelativeTime);
-        SearchResponseMerger merger = new SearchResponseMerger(0, 10, Integer.MAX_VALUE, timeProvider, emptyReduceContextBuilder());
-        SearchResponse.Clusters clusters = SearchResponseTests.randomClusters();
-        assertEquals(0, merger.numResponses());
-        SearchResponse response = merger.getMergedResponse(clusters);
-        assertSame(clusters, response.getClusters());
-        assertEquals(TimeUnit.NANOSECONDS.toMillis(currentRelativeTime), response.getTook().millis());
-        assertEquals(0, response.getTotalShards());
-        assertEquals(0, response.getSuccessfulShards());
-        assertEquals(0, response.getSkippedShards());
-        assertEquals(0, response.getFailedShards());
-        assertEquals(0, response.getNumReducePhases());
-        assertFalse(response.isTimedOut());
-        assertNotNull(response.getHits().getTotalHits());
-        assertEquals(0, response.getHits().getTotalHits().value);
-        assertEquals(0, response.getHits().getHits().length);
-        assertEquals(TotalHits.Relation.EQUAL_TO, response.getHits().getTotalHits().relation);
-        assertNull(response.getScrollId());
-        assertSame(InternalAggregations.EMPTY, response.getAggregations());
-        assertNull(response.getSuggest());
-        assertEquals(0, response.getProfileResults().size());
-        assertNull(response.isTerminatedEarly());
-        assertEquals(0, response.getShardFailures().length);
+        try (SearchResponseMerger merger = new SearchResponseMerger(0, 10, Integer.MAX_VALUE, timeProvider, emptyReduceContextBuilder())) {
+            SearchResponse.Clusters clusters = SearchResponseTests.randomClusters();
+            assertEquals(0, merger.numResponses());
+            SearchResponse response = merger.getMergedResponse(clusters);
+            try {
+                assertSame(clusters, response.getClusters());
+                assertEquals(TimeUnit.NANOSECONDS.toMillis(currentRelativeTime), response.getTook().millis());
+                assertEquals(0, response.getTotalShards());
+                assertEquals(0, response.getSuccessfulShards());
+                assertEquals(0, response.getSkippedShards());
+                assertEquals(0, response.getFailedShards());
+                assertEquals(0, response.getNumReducePhases());
+                assertFalse(response.isTimedOut());
+                assertNotNull(response.getHits().getTotalHits());
+                assertEquals(0, response.getHits().getTotalHits().value);
+                assertEquals(0, response.getHits().getHits().length);
+                assertEquals(TotalHits.Relation.EQUAL_TO, response.getHits().getTotalHits().relation);
+                assertNull(response.getScrollId());
+                assertSame(InternalAggregations.EMPTY, response.getAggregations());
+                assertNull(response.getSuggest());
+                assertEquals(0, response.getProfileResults().size());
+                assertNull(response.isTerminatedEarly());
+                assertEquals(0, response.getShardFailures().length);
+            } finally {
+                response.decRef();
+            }
+        }
     }
 
     public void testMergeEmptySearchHitsWithNonEmpty() {
         long currentRelativeTime = randomLong();
         final SearchTimeProvider timeProvider = new SearchTimeProvider(randomLong(), 0, () -> currentRelativeTime);
-        SearchResponseMerger merger = new SearchResponseMerger(0, 10, Integer.MAX_VALUE, timeProvider, emptyReduceContextBuilder());
-        SearchResponse.Clusters clusters = SearchResponseTests.randomClusters();
-        int numFields = randomIntBetween(1, 3);
-        SortField[] sortFields = new SortField[numFields];
-        for (int i = 0; i < numFields; i++) {
-            sortFields[i] = new SortField("field-" + i, SortField.Type.INT, randomBoolean());
-        }
-        PriorityQueue<SearchHit> priorityQueue = new PriorityQueue<>(new SearchHitComparator(sortFields));
-        SearchHit[] hits = randomSearchHitArray(
-            10,
-            1,
-            "remote",
-            new Index[] { new Index("index", "uuid") },
-            Float.NaN,
-            1,
-            sortFields,
-            priorityQueue
-        );
-        {
-            SearchHits searchHits = new SearchHits(hits, new TotalHits(10, TotalHits.Relation.EQUAL_TO), Float.NaN, sortFields, null, null);
-            InternalSearchResponse response = new InternalSearchResponse(searchHits, null, null, null, false, false, 1);
-            SearchResponse searchResponse = new SearchResponse(
-                response,
-                null,
+        try (SearchResponseMerger merger = new SearchResponseMerger(0, 10, Integer.MAX_VALUE, timeProvider, emptyReduceContextBuilder())) {
+            SearchResponse.Clusters clusters = SearchResponseTests.randomClusters();
+            int numFields = randomIntBetween(1, 3);
+            SortField[] sortFields = new SortField[numFields];
+            for (int i = 0; i < numFields; i++) {
+                sortFields[i] = new SortField("field-" + i, SortField.Type.INT, randomBoolean());
+            }
+            PriorityQueue<SearchHit> priorityQueue = new PriorityQueue<>(new SearchHitComparator(sortFields));
+            SearchHit[] hits = randomSearchHitArray(
+                10,
                 1,
+                "remote",
+                new Index[] { new Index("index", "uuid") },
+                Float.NaN,
                 1,
-                0,
-                1L,
-                ShardSearchFailure.EMPTY_ARRAY,
-                SearchResponse.Clusters.EMPTY
+                sortFields,
+                priorityQueue
             );
-            merger.add(searchResponse);
+            {
+                SearchHits searchHits = new SearchHits(
+                    hits,
+                    new TotalHits(10, TotalHits.Relation.EQUAL_TO),
+                    Float.NaN,
+                    sortFields,
+                    null,
+                    null
+                );
+                InternalSearchResponse response = new InternalSearchResponse(searchHits, null, null, null, false, false, 1);
+                SearchResponse searchResponse = new SearchResponse(
+                    response,
+                    null,
+                    1,
+                    1,
+                    0,
+                    1L,
+                    ShardSearchFailure.EMPTY_ARRAY,
+                    SearchResponse.Clusters.EMPTY
+                );
+                try {
+                    merger.add(searchResponse);
+                } finally {
+                    searchResponse.decRef();
+                }
+            }
+            {
+                SearchHits empty = new SearchHits(
+                    new SearchHit[0],
+                    new TotalHits(0, TotalHits.Relation.EQUAL_TO),
+                    Float.NaN,
+                    null,
+                    null,
+                    null
+                );
+                InternalSearchResponse response = new InternalSearchResponse(empty, null, null, null, false, false, 1);
+                SearchResponse searchResponse = new SearchResponse(
+                    response,
+                    null,
+                    1,
+                    1,
+                    0,
+                    1L,
+                    ShardSearchFailure.EMPTY_ARRAY,
+                    SearchResponse.Clusters.EMPTY
+                );
+                try {
+                    merger.add(searchResponse);
+                } finally {
+                    searchResponse.decRef();
+                }
+            }
+            assertEquals(2, merger.numResponses());
+            SearchResponse mergedResponse = merger.getMergedResponse(clusters);
+            try {
+                assertEquals(10, mergedResponse.getHits().getTotalHits().value);
+                assertEquals(10, mergedResponse.getHits().getHits().length);
+                assertEquals(2, mergedResponse.getTotalShards());
+                assertEquals(2, mergedResponse.getSuccessfulShards());
+                assertEquals(0, mergedResponse.getSkippedShards());
+                assertArrayEquals(sortFields, mergedResponse.getHits().getSortFields());
+                assertArrayEquals(hits, mergedResponse.getHits().getHits());
+                assertEquals(clusters, mergedResponse.getClusters());
+            } finally {
+                mergedResponse.decRef();
+            }
         }
-        {
-            SearchHits empty = new SearchHits(new SearchHit[0], new TotalHits(0, TotalHits.Relation.EQUAL_TO), Float.NaN, null, null, null);
-            InternalSearchResponse response = new InternalSearchResponse(empty, null, null, null, false, false, 1);
-            SearchResponse searchResponse = new SearchResponse(
-                response,
-                null,
-                1,
-                1,
-                0,
-                1L,
-                ShardSearchFailure.EMPTY_ARRAY,
-                SearchResponse.Clusters.EMPTY
-            );
-            merger.add(searchResponse);
-        }
-        assertEquals(2, merger.numResponses());
-        SearchResponse mergedResponse = merger.getMergedResponse(clusters);
-        assertEquals(10, mergedResponse.getHits().getTotalHits().value);
-        assertEquals(10, mergedResponse.getHits().getHits().length);
-        assertEquals(2, mergedResponse.getTotalShards());
-        assertEquals(2, mergedResponse.getSuccessfulShards());
-        assertEquals(0, mergedResponse.getSkippedShards());
-        assertArrayEquals(sortFields, mergedResponse.getHits().getSortFields());
-        assertArrayEquals(hits, mergedResponse.getHits().getHits());
-        assertEquals(clusters, mergedResponse.getClusters());
     }
 
     public void testMergeOnlyEmptyHits() {
@@ -862,32 +1004,41 @@ public class SearchResponseMergerTests extends ESTestCase {
         Tuple<Integer, TotalHits.Relation> randomTrackTotalHits = randomTrackTotalHits();
         int trackTotalHitsUpTo = randomTrackTotalHits.v1();
         TotalHits.Relation totalHitsRelation = randomTrackTotalHits.v2();
-        SearchResponseMerger merger = new SearchResponseMerger(0, 10, trackTotalHitsUpTo, timeProvider, emptyReduceContextBuilder());
-        int numResponses = randomIntBetween(1, 5);
-        TotalHits expectedTotalHits = null;
-        for (int i = 0; i < numResponses; i++) {
-            TotalHits totalHits = null;
-            if (trackTotalHitsUpTo != SearchContext.TRACK_TOTAL_HITS_DISABLED) {
-                totalHits = new TotalHits(randomLongBetween(0, 1000), totalHitsRelation);
-                long previousValue = expectedTotalHits == null ? 0 : expectedTotalHits.value;
-                expectedTotalHits = new TotalHits(Math.min(previousValue + totalHits.value, trackTotalHitsUpTo), totalHitsRelation);
+        try (SearchResponseMerger merger = new SearchResponseMerger(0, 10, trackTotalHitsUpTo, timeProvider, emptyReduceContextBuilder())) {
+            int numResponses = randomIntBetween(1, 5);
+            TotalHits expectedTotalHits = null;
+            for (int i = 0; i < numResponses; i++) {
+                TotalHits totalHits = null;
+                if (trackTotalHitsUpTo != SearchContext.TRACK_TOTAL_HITS_DISABLED) {
+                    totalHits = new TotalHits(randomLongBetween(0, 1000), totalHitsRelation);
+                    long previousValue = expectedTotalHits == null ? 0 : expectedTotalHits.value;
+                    expectedTotalHits = new TotalHits(Math.min(previousValue + totalHits.value, trackTotalHitsUpTo), totalHitsRelation);
+                }
+                SearchHits empty = new SearchHits(new SearchHit[0], totalHits, Float.NaN, null, null, null);
+                InternalSearchResponse response = new InternalSearchResponse(empty, null, null, null, false, false, 1);
+                SearchResponse searchResponse = new SearchResponse(
+                    response,
+                    null,
+                    1,
+                    1,
+                    0,
+                    1L,
+                    ShardSearchFailure.EMPTY_ARRAY,
+                    SearchResponse.Clusters.EMPTY
+                );
+                try {
+                    merger.add(searchResponse);
+                } finally {
+                    searchResponse.decRef();
+                }
             }
-            SearchHits empty = new SearchHits(new SearchHit[0], totalHits, Float.NaN, null, null, null);
-            InternalSearchResponse response = new InternalSearchResponse(empty, null, null, null, false, false, 1);
-            SearchResponse searchResponse = new SearchResponse(
-                response,
-                null,
-                1,
-                1,
-                0,
-                1L,
-                ShardSearchFailure.EMPTY_ARRAY,
-                SearchResponse.Clusters.EMPTY
-            );
-            merger.add(searchResponse);
+            SearchResponse mergedResponse = merger.getMergedResponse(clusters);
+            try {
+                assertEquals(expectedTotalHits, mergedResponse.getHits().getTotalHits());
+            } finally {
+                mergedResponse.decRef();
+            }
         }
-        SearchResponse mergedResponse = merger.getMergedResponse(clusters);
-        assertEquals(expectedTotalHits, mergedResponse.getHits().getTotalHits());
     }
 
     private static Tuple<Integer, TotalHits.Relation> randomTrackTotalHits() {

--- a/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
@@ -1094,23 +1094,33 @@ public class TransportSearchActionTests extends ESTestCase {
             assertEquals(-1, source.size());
             assertEquals(-1, source.from());
             assertNull(source.trackTotalHitsUpTo());
-            SearchResponseMerger merger = TransportSearchAction.createSearchResponseMerger(
-                source,
-                timeProvider,
-                emptyReduceContextBuilder()
-            );
-            assertEquals(0, merger.from);
-            assertEquals(10, merger.size);
-            assertEquals(SearchContext.DEFAULT_TRACK_TOTAL_HITS_UP_TO, merger.trackTotalHitsUpTo);
-            assertEquals(0, source.from());
-            assertEquals(10, source.size());
-            assertNull(source.trackTotalHitsUpTo());
+            try (
+                SearchResponseMerger merger = TransportSearchAction.createSearchResponseMerger(
+                    source,
+                    timeProvider,
+                    emptyReduceContextBuilder()
+                )
+            ) {
+                assertEquals(0, merger.from);
+                assertEquals(10, merger.size);
+                assertEquals(SearchContext.DEFAULT_TRACK_TOTAL_HITS_UP_TO, merger.trackTotalHitsUpTo);
+                assertEquals(0, source.from());
+                assertEquals(10, source.size());
+                assertNull(source.trackTotalHitsUpTo());
+            }
         }
         {
-            SearchResponseMerger merger = TransportSearchAction.createSearchResponseMerger(null, timeProvider, emptyReduceContextBuilder());
-            assertEquals(0, merger.from);
-            assertEquals(10, merger.size);
-            assertEquals(SearchContext.DEFAULT_TRACK_TOTAL_HITS_UP_TO, merger.trackTotalHitsUpTo);
+            try (
+                SearchResponseMerger merger = TransportSearchAction.createSearchResponseMerger(
+                    null,
+                    timeProvider,
+                    emptyReduceContextBuilder()
+                )
+            ) {
+                assertEquals(0, merger.from);
+                assertEquals(10, merger.size);
+                assertEquals(SearchContext.DEFAULT_TRACK_TOTAL_HITS_UP_TO, merger.trackTotalHitsUpTo);
+            }
         }
         {
             SearchSourceBuilder source = new SearchSourceBuilder();
@@ -1120,17 +1130,20 @@ public class TransportSearchActionTests extends ESTestCase {
             source.size(originalSize);
             int trackTotalHitsUpTo = randomIntBetween(0, Integer.MAX_VALUE);
             source.trackTotalHitsUpTo(trackTotalHitsUpTo);
-            SearchResponseMerger merger = TransportSearchAction.createSearchResponseMerger(
-                source,
-                timeProvider,
-                emptyReduceContextBuilder()
-            );
-            assertEquals(0, source.from());
-            assertEquals(originalFrom + originalSize, source.size());
-            assertEquals(trackTotalHitsUpTo, (int) source.trackTotalHitsUpTo());
-            assertEquals(originalFrom, merger.from);
-            assertEquals(originalSize, merger.size);
-            assertEquals(trackTotalHitsUpTo, merger.trackTotalHitsUpTo);
+            try (
+                SearchResponseMerger merger = TransportSearchAction.createSearchResponseMerger(
+                    source,
+                    timeProvider,
+                    emptyReduceContextBuilder()
+                )
+            ) {
+                assertEquals(0, source.from());
+                assertEquals(originalFrom + originalSize, source.size());
+                assertEquals(trackTotalHitsUpTo, (int) source.trackTotalHitsUpTo());
+                assertEquals(originalFrom, merger.from);
+                assertEquals(originalSize, merger.size);
+                assertEquals(trackTotalHitsUpTo, merger.trackTotalHitsUpTo);
+            }
         }
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/search/geo/BasePointShapeQueryTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/geo/BasePointShapeQueryTestCase.java
@@ -354,7 +354,8 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
         try {
             client().prepareSearch(defaultIndexName)
                 .setQuery(queryBuilder().shapeQuery(defaultFieldName, line).relation(ShapeRelation.WITHIN))
-                .get();
+                .get()
+                .decRef();
         } catch (SearchPhaseExecutionException e) {
             assertThat(e.getCause().getMessage(), containsString("Field [" + defaultFieldName + "] found an unsupported shape Line"));
         }


### PR DESCRIPTION
SearchResponseMerger holds references to SearchResponse instances. This commit makes it releasable to enable us to safely hold a reference to each of the SearchResponse that it will merge and safely release it in both merge and error cases.

Tip: review using `?w=1`, most of the changes here are just whitespace changes from necessary test adjustments.