### PR TITLE
x-pack/plugin/core: rename double_metrics template

### DIFF
--- a/docs/changelog/103033.yaml
+++ b/docs/changelog/103033.yaml
@@ -1,0 +1,5 @@
+pr: 103033
+summary: "X-pack/plugin/core: rename `double_metrics` template"
+area: Data streams
+type: enhancement
+issues: []

--- a/x-pack/plugin/apm-data/src/yamlRestTest/resources/rest-api-spec/test/10_apm.yml
+++ b/x-pack/plugin/apm-data/src/yamlRestTest/resources/rest-api-spec/test/10_apm.yml
@@ -175,7 +175,7 @@ setup:
               full_name: double_metric
               mapping:
                 double_metric:
-                  type: float
+                  type: double
                   index: false
             summary_metric:
               full_name: summary_metric

--- a/x-pack/plugin/core/template-resources/src/main/resources/metrics@mappings.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/metrics@mappings.json
@@ -12,10 +12,18 @@
           }
         },
         {
-          "double_metrics": {
+          "float_metrics": {
             "match_mapping_type": "double",
             "mapping": {
               "type": "float",
+              "index": false
+            }
+          }
+        },
+        {
+          "double_metrics": {
+            "mapping": {
+              "type": "double",
               "index": false
             }
           }


### PR DESCRIPTION
Rename `double_metrics` to `float_metrics`, and create a new `double_metrics` (with lower priority) that has no `match_mapping_type`. The new one is intended to be used with the `dynamic_templates` request parameter, as in https://github.com/elastic/elasticsearch/blob/6bba0efa7807c57b6884143012b7c518367615ca/x-pack/plugin/apm-data/src/main/resources/ingest-pipelines/metrics-apm%40pipeline.yaml#L43