### PR TITLE
[7.17] Reference stored scripts in snapshot restore (#102966)

### DIFF
--- a/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
+++ b/docs/reference/snapshot-restore/apis/restore-snapshot-api.asciidoc
@@ -165,6 +165,7 @@ The cluster state includes:
 * <<indices-templates-v1,Legacy index templates>>
 * <<ingest,Ingest pipelines>>
 * <<index-lifecycle-management,{ilm-init} policies>>
+* <<script-stored-scripts,Stored scripts>>
 * For snapshots taken after 7.12.0, <<feature-state,feature states>>
 // end::cluster-state-contents[]
 


### PR DESCRIPTION
Backports the following commits to 7.17:

Reference stored scripts in snapshot restore (Reference stored scripts in snapshot restore #102966)