### PR TITLE
[8.11] Fix Windows tcpretries as well (#103048)

### DIFF
--- a/docs/reference/setup/sysconfig/tcpretries.asciidoc
+++ b/docs/reference/setup/sysconfig/tcpretries.asciidoc
@@ -17,7 +17,7 @@ Most Linux distributions default to retransmitting any lost packets 15 times.
 Retransmissions back off exponentially, so these 15 retransmissions take over
 900 seconds to complete. This means it takes Linux many minutes to detect a
 network partition or a failed node with this method. Windows defaults to just 5
-retransmissions which corresponds with a timeout of around 6 seconds.
+retransmissions which corresponds with a timeout of around 13 seconds.
 
 The Linux default allows for communication over networks that may experience
 very long periods of packet loss, but this default is excessive and even harmful


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Fix Windows tcpretries as well (#103048)