### PR TITLE
 [Transform] Implement integration test for transform's `deduce_mappings` setting

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -1744,8 +1744,8 @@ public abstract class ESRestTestCase extends ESTestCase {
 
     @SuppressWarnings("unchecked")
     protected Map<String, Object> getIndexMappingAsMap(String index) throws IOException {
-        Map<String, Object> indexSettings = getIndexMapping(index);
-        return (Map<String, Object>) ((Map<String, Object>) indexSettings.get(index)).get("mappings");
+        Map<String, Object> indexMapping = getIndexMapping(index);
+        return (Map<String, Object>) ((Map<String, Object>) indexMapping.get(index)).get("mappings");
     }
 
     protected static boolean indexExists(String index) throws IOException {

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
@@ -380,7 +380,7 @@ public abstract class TransformRestTestCase extends ESRestTestCase {
         createReviewsTransform(transformId, null, null, config);
     }
 
-    private void createReviewsTransform(String transformId, String authHeader, String secondaryAuthHeader, String config)
+    protected void createReviewsTransform(String transformId, String authHeader, String secondaryAuthHeader, String config)
         throws IOException {
         final Request createTransformRequest = createRequestWithSecondaryAuth(
             "PUT",

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/Pivot.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/Pivot.java
@@ -148,9 +148,9 @@ public class Pivot extends AbstractCompositeAggFunction {
         // < 7.11 as epoch millis
         // >= 7.11 as string
         // note: it depends on the version when the transform has been created, not the version of the code
-        boolean datesAsEpoch = settings.getDatesAsEpochMillis() != null ? settings.getDatesAsEpochMillis()
-            : version.onOrAfter(TransformConfigVersion.V_7_11_0) ? false
-            : true;
+        boolean datesAsEpoch = settings.getDatesAsEpochMillis() != null
+            ? settings.getDatesAsEpochMillis()
+            : version.before(TransformConfigVersion.V_7_11_0);
 
         return AggregationResultUtils.extractCompositeAggregationResults(
             agg,

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/SchemaUtil.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/SchemaUtil.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.fieldcaps.FieldCapabilitiesRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.core.Tuple;
+import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.index.query.QueryBuilder;
@@ -28,6 +29,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -39,6 +41,11 @@ public final class SchemaUtil {
 
     // Full collection of numeric field type strings and whether they are floating point or not
     private static final Map<String, Boolean> NUMERIC_FIELD_MAPPER_TYPES;
+    // Full collection of date field type strings
+    private static final Set<String> DATE_FIELD_MAPPER_TYPES = Set.of(
+        DateFieldMapper.CONTENT_TYPE,
+        DateFieldMapper.DATE_NANOS_CONTENT_TYPE
+    );
     static {
         Map<String, Boolean> types = Stream.of(NumberFieldMapper.NumberType.values())
             .collect(Collectors.toMap(t -> t.typeName(), t -> t.numericType().isFloatingPoint()));
@@ -53,6 +60,10 @@ public final class SchemaUtil {
 
     public static boolean isNumericType(String type) {
         return type != null && NUMERIC_FIELD_MAPPER_TYPES.containsKey(type);
+    }
+
+    public static boolean isDateType(String type) {
+        return type != null && DATE_FIELD_MAPPER_TYPES.contains(type);
     }
 
     /**

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationResultUtilsTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationResultUtilsTests.java
@@ -1081,6 +1081,7 @@ public class AggregationResultUtilsTests extends ESTestCase {
         assertThat(extractor.value(1577836800000L, "date"), equalTo("2020-01-01T00:00:00.000Z"));
         assertThat(extractor.value(1577836800000L, "date_nanos"), equalTo("2020-01-01T00:00:00.000Z"));
         assertThat(extractor.value(1577836800000L, "long"), equalTo(1577836800000L));
+        assertThat(extractor.value(1577836800000L, null), equalTo(1577836800000L));
     }
 
     public void testDatesAsEpochBucketKeyExtractor() {
@@ -1091,6 +1092,7 @@ public class AggregationResultUtilsTests extends ESTestCase {
         assertThat(extractor.value(1577836800000L, "date"), equalTo(1577836800000L));
         assertThat(extractor.value(1577836800000L, "date_nanos"), equalTo(1577836800000L));
         assertThat(extractor.value(1577836800000L, "long"), equalTo(1577836800000L));
+        assertThat(extractor.value(1577836800000L, null), equalTo(1577836800000L));
     }
 
     private void executeTest(

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/SchemaUtilTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/SchemaUtilTests.java
@@ -218,6 +218,28 @@ public class SchemaUtilTests extends ESTestCase {
         }
     }
 
+    public void testIsNumericType() {
+        assertFalse(SchemaUtil.isNumericType(null));
+        assertFalse(SchemaUtil.isNumericType("non-existing"));
+        assertTrue(SchemaUtil.isNumericType("double"));
+        assertTrue(SchemaUtil.isNumericType("integer"));
+        assertTrue(SchemaUtil.isNumericType("long"));
+        assertFalse(SchemaUtil.isNumericType("date"));
+        assertFalse(SchemaUtil.isNumericType("date_nanos"));
+        assertFalse(SchemaUtil.isNumericType("keyword"));
+    }
+
+    public void testIsDateType() {
+        assertFalse(SchemaUtil.isDateType(null));
+        assertFalse(SchemaUtil.isDateType("non-existing"));
+        assertFalse(SchemaUtil.isDateType("double"));
+        assertFalse(SchemaUtil.isDateType("integer"));
+        assertFalse(SchemaUtil.isDateType("long"));
+        assertTrue(SchemaUtil.isDateType("date"));
+        assertTrue(SchemaUtil.isDateType("date_nanos"));
+        assertFalse(SchemaUtil.isDateType("keyword"));
+    }
+
     private static class FieldCapsMockClient extends NoOpClient {
         FieldCapsMockClient(ThreadPool threadPool) {
             super(threadPool);


### PR DESCRIPTION
This PR implements 2 integration tests for the transform's `deduce_mappings` setting (`testTransformDestIndexMappings_DeduceMappings`, `testTransformDestIndexMappings_NoDeduceMappings`).
It verifies that given presence of the index template, the dest index is created with correct mappings regardless of the value of `deduce_mappings` setting.

Additionally, this PR makes small cleanups in the code that do not affect the code's functionality.

Relates https://github.com/elastic/elasticsearch/issues/103115