### PR TITLE
Fix SLM detection in tests

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/RestTestLegacyFeatures.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/RestTestLegacyFeatures.java
@@ -59,6 +59,8 @@ public class RestTestLegacyFeatures implements FeatureSpecification {
     public static final NodeFeature ML_INDICES_HIDDEN = new NodeFeature("ml.indices_hidden");
     @UpdateForV9
     public static final NodeFeature ML_ANALYTICS_MAPPINGS = new NodeFeature("ml.analytics_mappings");
+    @UpdateForV9
+    public static final NodeFeature SLM_SUPPORTED = new NodeFeature("slm.supported");
 
     @Override
     public Map<NodeFeature, Version> getHistoricalFeatures() {
@@ -78,7 +80,8 @@ public class RestTestLegacyFeatures implements FeatureSpecification {
             entry(TRANSFORM_NEW_API_ENDPOINT, Version.V_7_5_0),
             entry(DATA_STREAMS_DATE_IN_INDEX_NAME, Version.V_7_11_0),
             entry(ML_INDICES_HIDDEN, Version.V_7_7_0),
-            entry(ML_ANALYTICS_MAPPINGS, Version.V_7_3_0)
+            entry(ML_ANALYTICS_MAPPINGS, Version.V_7_3_0),
+            entry(SLM_SUPPORTED, Version.V_7_4_0)
         );
     }
 }

--- a/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
@@ -594,7 +594,7 @@ public class FullClusterRestartIT extends AbstractXpackFullClusterRestartTestCas
             Collections.singletonMap("indices", Collections.singletonList("*")),
             null
         );
-        if (isRunningAgainstOldCluster() && has(ProductFeature.SLM)) {
+        if (isRunningAgainstOldCluster() && clusterHasFeature(RestTestLegacyFeatures.SLM_SUPPORTED)) {
             Request createRepoRequest = new Request("PUT", "_snapshot/test-repo");
             String repoCreateJson = "{" + " \"type\": \"fs\"," + " \"settings\": {" + "   \"location\": \"test-repo\"" + "  }" + "}";
             createRepoRequest.setJsonEntity(repoCreateJson);
@@ -608,7 +608,7 @@ public class FullClusterRestartIT extends AbstractXpackFullClusterRestartTestCas
             client().performRequest(createSlmPolicyRequest);
         }
 
-        if (isRunningAgainstOldCluster() == false && has(ProductFeature.SLM)) {
+        if (isRunningAgainstOldCluster() == false && clusterHasFeature(RestTestLegacyFeatures.SLM_SUPPORTED)) {
             Request getSlmPolicyRequest = new Request("GET", "_slm/policy/test-policy");
             Response response = client().performRequest(getSlmPolicyRequest);
             Map<String, Object> responseMap = entityAsMap(response);


### PR DESCRIPTION
Unfortunately `ProductFeature.SLM` (which is based on plugin detection) cannot be used reliably on BwC tests, as ILM and SLM plugins were once fused together (and ILM pre-dates SLM).
Introducing an explicit legacy feature instead.

Closes https://github.com/elastic/elasticsearch/issues/103049