### PR TITLE
[Connectors API] Add sync job status check to cancel connector sync job integration test.

### DIFF
--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/430_connector_sync_job_cancel.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/430_connector_sync_job_cancel.yml
@@ -20,12 +20,20 @@ setup:
           id: test-connector
           job_type: full
           trigger_method: on_demand
+
   - set: { id: sync-job-id-to-cancel }
+
   - do:
       connector_sync_job.cancel:
         connector_sync_job_id: $sync-job-id-to-cancel
 
   - match: { acknowledged: true }
+
+  - do:
+      connector_sync_job.get:
+        connector_sync_job_id: $sync-job-id-to-cancel
+
+  - match: { status: "canceling"}
 
 
 ---


### PR DESCRIPTION
Extends the cancel connector sync job integration test to also check that the status after cancelling is correct.
