### PR TITLE
[ML] Wait for download action created

### DIFF
--- a/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/action/TransportLoadTrainedModelPackage.java
+++ b/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/action/TransportLoadTrainedModelPackage.java
@@ -105,7 +105,7 @@ public class TransportLoadTrainedModelPackage extends TransportMasterNodeAction<
                 .execute(() -> importModel(client, taskManager, request, modelImporter, listener, downloadTask));
         } catch (Exception e) {
             taskManager.unregister(downloadTask);
-            throw e;
+            listener.onFailure(e);
         }
 
         if (request.isWaitForCompletion() == false) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutTrainedModelAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutTrainedModelAction.java
@@ -476,15 +476,8 @@ public class TransportPutTrainedModelAction extends TransportMasterNodeAction<Re
         client.execute(
             LoadTrainedModelPackageAction.INSTANCE,
             new LoadTrainedModelPackageAction.Request(modelId, modelPackageConfig, waitForCompletion),
-            ActionListener.wrap(ack -> {
-                if (waitForCompletion) {
-                    listener.onResponse(null);
-                }
-            }, listener::onFailure)
+            ActionListener.wrap(ack -> listener.onResponse(null), listener::onFailure)
         );
-        if (waitForCompletion == false) {
-            listener.onResponse(null);
-        }
     }
 
     private void resolvePackageConfig(String modelId, ActionListener<ModelPackageConfig> listener) {

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/3rd_party_deployment.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/3rd_party_deployment.yml
@@ -218,9 +218,6 @@ setup:
 
 ---
 "Test start deployment fails while model download in progress":
-  - skip:
-      version: "all"
-      reason: "Awaits fix: https://github.com/elastic/elasticsearch/issues/102948"
   - do:
       ml.put_trained_model:
         model_id: .elser_model_2


### PR DESCRIPTION
When creating a model hosted by Elastic ensure the download task has been created before responding to the PUT

Closes #102948