### PR TITLE
[8.11] [ILM] More resilient when a policy is added to searchable snapshot (#102741)

### DIFF
--- a/docs/changelog/102741.yaml
+++ b/docs/changelog/102741.yaml
@@ -1,0 +1,6 @@
+pr: 102741
+summary: "[ILM] More resilient when a policy is added to searchable snapshot"
+area: ILM+SLM
+type: bug
+issues:
+ - 101958

--- a/docs/reference/ilm/actions/ilm-delete.asciidoc
+++ b/docs/reference/ilm/actions/ilm-delete.asciidoc
@@ -16,6 +16,11 @@ Defaults to `true`.
 This option is applicable when the <<ilm-searchable-snapshot,searchable
 snapshot>> action is used in any previous phase.
 
+WARNING: If a policy with a searchable snapshot action is applied on an existing searchable snapshot index,
+the snapshot backing this index will NOT be deleted because it was not created by this policy. If you want
+to clean this snapshot, please delete it manually after the index is deleted using the <<delete-snapshot-api, delete snapshot API>>, you
+can find the repository and snapshot name using the <<indices-get-index, get index API>>.
+
 [[ilm-delete-action-ex]]
 ==== Example
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotAction.java
@@ -16,6 +16,7 @@ import org.elasticsearch.cluster.metadata.LifecycleExecutionState;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.license.LicenseUtils;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
@@ -32,6 +33,7 @@ import java.util.List;
 import java.util.Objects;
 
 import static org.elasticsearch.snapshots.SearchableSnapshotsSettings.SEARCHABLE_SNAPSHOTS_REPOSITORY_NAME_SETTING_KEY;
+import static org.elasticsearch.snapshots.SearchableSnapshotsSettings.SEARCHABLE_SNAPSHOTS_SNAPSHOT_NAME_SETTING_KEY;
 import static org.elasticsearch.snapshots.SearchableSnapshotsSettings.SEARCHABLE_SNAPSHOT_PARTIAL_SETTING_KEY;
 import static org.elasticsearch.xpack.core.searchablesnapshots.SearchableSnapshotsConstants.SEARCHABLE_SNAPSHOT_FEATURE;
 
@@ -141,10 +143,12 @@ public class SearchableSnapshotAction implements LifecycleAction {
                 IndexMetadata indexMetadata = clusterState.getMetadata().index(index);
                 assert indexMetadata != null : "index " + index.getName() + " must exist in the cluster state";
                 String policyName = indexMetadata.getLifecyclePolicyName();
-                if (indexMetadata.getSettings().get(LifecycleSettings.SNAPSHOT_INDEX_NAME) != null) {
+                SearchableSnapshotMetadata searchableSnapshotMetadata = extractSearchableSnapshotFromSettings(indexMetadata);
+                if (searchableSnapshotMetadata != null) {
+                    // TODO: allow this behavior instead of returning false, in this case the index is already a searchable a snapshot
+                    // so the most graceful way of recovery might be to use this repo
                     // The index is already a searchable snapshot, let's see if the repository matches
-                    String repo = indexMetadata.getSettings().get(SEARCHABLE_SNAPSHOTS_REPOSITORY_NAME_SETTING_KEY);
-                    if (this.snapshotRepository.equals(repo) == false) {
+                    if (this.snapshotRepository.equals(searchableSnapshotMetadata.repositoryName) == false) {
                         // Okay, different repo, we need to go ahead with the searchable snapshot
                         logger.debug(
                             "[{}] action is configured for index [{}] in policy [{}] which is already mounted as a searchable "
@@ -153,15 +157,14 @@ public class SearchableSnapshotAction implements LifecycleAction {
                             SearchableSnapshotAction.NAME,
                             index.getName(),
                             policyName,
-                            repo,
+                            searchableSnapshotMetadata.repositoryName,
                             this.snapshotRepository
                         );
                         return false;
                     }
 
                     // Check to the storage type to see if we need to convert between full <-> partial
-                    final boolean partial = indexMetadata.getSettings().getAsBoolean(SEARCHABLE_SNAPSHOT_PARTIAL_SETTING_KEY, false);
-                    MountSearchableSnapshotRequest.Storage existingType = partial
+                    MountSearchableSnapshotRequest.Storage existingType = searchableSnapshotMetadata.partial
                         ? MountSearchableSnapshotRequest.Storage.SHARED_CACHE
                         : MountSearchableSnapshotRequest.Storage.FULL_COPY;
                     MountSearchableSnapshotRequest.Storage type = getConcreteStorageType(preActionBranchingKey);
@@ -172,7 +175,7 @@ public class SearchableSnapshotAction implements LifecycleAction {
                             SearchableSnapshotAction.NAME,
                             index.getName(),
                             policyName,
-                            repo,
+                            searchableSnapshotMetadata.repositoryName,
                             type
                         );
                         return true;
@@ -215,7 +218,7 @@ public class SearchableSnapshotAction implements LifecycleAction {
         // When generating a snapshot, we either jump to the force merge step, or we skip the
         // forcemerge and go straight to steps for creating the snapshot
         StepKey keyForSnapshotGeneration = forceMergeIndex ? forceMergeStepKey : generateSnapshotNameKey;
-        // Branch, deciding whether there is an existing searchable snapshot snapshot that can be used for mounting the index
+        // Branch, deciding whether there is an existing searchable snapshot that can be used for mounting the index
         // (in which case, skip generating a new name and the snapshot cleanup), or if we need to generate a new snapshot
         BranchingStep skipGeneratingSnapshotStep = new BranchingStep(
             skipGeneratingSnapshotKey,
@@ -225,7 +228,8 @@ public class SearchableSnapshotAction implements LifecycleAction {
                 IndexMetadata indexMetadata = clusterState.getMetadata().index(index);
                 String policyName = indexMetadata.getLifecyclePolicyName();
                 LifecycleExecutionState lifecycleExecutionState = indexMetadata.getLifecycleExecutionState();
-                if (lifecycleExecutionState.snapshotName() == null) {
+                SearchableSnapshotMetadata searchableSnapshotMetadata = extractSearchableSnapshotFromSettings(indexMetadata);
+                if (lifecycleExecutionState.snapshotName() == null && searchableSnapshotMetadata == null) {
                     // No name exists, so it must be generated
                     logger.trace(
                         "no snapshot name for index [{}] in policy [{}] exists, so one will be generated",
@@ -234,8 +238,20 @@ public class SearchableSnapshotAction implements LifecycleAction {
                     );
                     return false;
                 }
+                String snapshotIndexName;
+                String snapshotName;
+                String repoName;
+                if (lifecycleExecutionState.snapshotName() != null) {
+                    snapshotIndexName = lifecycleExecutionState.snapshotIndexName();
+                    snapshotName = lifecycleExecutionState.snapshotName();
+                    repoName = lifecycleExecutionState.snapshotRepository();
+                } else {
+                    snapshotIndexName = searchableSnapshotMetadata.sourceIndex;
+                    snapshotName = searchableSnapshotMetadata.snapshotName;
+                    repoName = searchableSnapshotMetadata.repositoryName;
+                }
 
-                if (this.snapshotRepository.equals(lifecycleExecutionState.snapshotRepository()) == false) {
+                if (this.snapshotRepository.equals(repoName) == false) {
                     // A different repository is being used
                     // TODO: allow this behavior instead of throwing an exception
                     throw new IllegalArgumentException("searchable snapshot indices may be converted only within the same repository");
@@ -244,12 +260,14 @@ public class SearchableSnapshotAction implements LifecycleAction {
                 // We can skip the generate, initial cleanup, and snapshot taking for this index, as we already have a generated snapshot.
                 // This will jump ahead directly to the "mount snapshot" step
                 logger.debug(
-                    "an existing snapshot [{}] in repository [{}] (index name: [{}]) "
-                        + "will be used for mounting [{}] as a searchable snapshot",
-                    lifecycleExecutionState.snapshotName(),
-                    lifecycleExecutionState.snapshotRepository(),
-                    lifecycleExecutionState.snapshotIndexName(),
-                    index.getName()
+                    "Policy [{}] will use an existing snapshot [{}] in repository [{}] (index name: [{}]) "
+                        + "to mount [{}] as a searchable snapshot. This snapshot was found in the {}.",
+                    policyName,
+                    snapshotName,
+                    snapshotRepository,
+                    snapshotIndexName,
+                    index.getName(),
+                    lifecycleExecutionState.snapshotName() != null ? "lifecycle execution state" : "metadata of " + index.getName()
                 );
                 return true;
             }
@@ -411,4 +429,18 @@ public class SearchableSnapshotAction implements LifecycleAction {
     public int hashCode() {
         return Objects.hash(snapshotRepository, forceMergeIndex);
     }
+
+    @Nullable
+    static SearchableSnapshotMetadata extractSearchableSnapshotFromSettings(IndexMetadata indexMetadata) {
+        String indexName = indexMetadata.getSettings().get(LifecycleSettings.SNAPSHOT_INDEX_NAME);
+        if (indexName == null) {
+            return null;
+        }
+        String snapshotName = indexMetadata.getSettings().get(SEARCHABLE_SNAPSHOTS_SNAPSHOT_NAME_SETTING_KEY);
+        String repo = indexMetadata.getSettings().get(SEARCHABLE_SNAPSHOTS_REPOSITORY_NAME_SETTING_KEY);
+        final boolean partial = indexMetadata.getSettings().getAsBoolean(SEARCHABLE_SNAPSHOT_PARTIAL_SETTING_KEY, false);
+        return new SearchableSnapshotMetadata(indexName, repo, snapshotName, partial);
+    }
+
+    record SearchableSnapshotMetadata(String sourceIndex, String repositoryName, String snapshotName, boolean partial) {};
 }

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/SearchableSnapshotActionIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/SearchableSnapshotActionIT.java
@@ -58,6 +58,7 @@ import static org.elasticsearch.xpack.TimeSeriesRestDriver.getNumberOfPrimarySeg
 import static org.elasticsearch.xpack.TimeSeriesRestDriver.getStepKeyForIndex;
 import static org.elasticsearch.xpack.TimeSeriesRestDriver.indexDocument;
 import static org.elasticsearch.xpack.TimeSeriesRestDriver.rolloverMaxOneDocCondition;
+import static org.elasticsearch.xpack.core.ilm.DeleteAction.WITH_SNAPSHOT_DELETE;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -184,10 +185,7 @@ public class SearchableSnapshotActionIT extends ESRestTestCase {
         Map<String, LifecycleAction> coldActions = Map.of(SearchableSnapshotAction.NAME, new SearchableSnapshotAction(snapshotRepo));
         Map<String, Phase> phases = new HashMap<>();
         phases.put("cold", new Phase("cold", TimeValue.ZERO, coldActions));
-        phases.put(
-            "delete",
-            new Phase("delete", TimeValue.timeValueMillis(10000), singletonMap(DeleteAction.NAME, DeleteAction.WITH_SNAPSHOT_DELETE))
-        );
+        phases.put("delete", new Phase("delete", TimeValue.timeValueMillis(10000), singletonMap(DeleteAction.NAME, WITH_SNAPSHOT_DELETE)));
         LifecyclePolicy lifecyclePolicy = new LifecyclePolicy(policy, phases);
         // PUT policy
         XContentBuilder builder = jsonBuilder();
@@ -572,6 +570,218 @@ public class SearchableSnapshotActionIT extends ESRestTestCase {
                 aliasExists(searchableSnapMountedIndexName, SearchableSnapshotAction.FULL_RESTORED_INDEX_PREFIX + index)
             )
         );
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testResumingSearchableSnapshotFromFullToPartial() throws Exception {
+        String index = "myindex-" + randomAlphaOfLength(4).toLowerCase(Locale.ROOT);
+        createSnapshotRepo(client(), snapshotRepo, randomBoolean());
+        var policyCold = "policy-cold";
+        createPolicy(
+            client(),
+            policyCold,
+            null,
+            null,
+            new Phase(
+                "cold",
+                TimeValue.ZERO,
+                singletonMap(SearchableSnapshotAction.NAME, new SearchableSnapshotAction(snapshotRepo, randomBoolean()))
+            ),
+            null,
+            null
+        );
+        var policyFrozen = "policy-cold-frozen";
+        createPolicy(
+            client(),
+            policyFrozen,
+            null,
+            null,
+            new Phase(
+                "cold",
+                TimeValue.ZERO,
+                singletonMap(SearchableSnapshotAction.NAME, new SearchableSnapshotAction(snapshotRepo, randomBoolean()))
+            ),
+            new Phase(
+                "frozen",
+                TimeValue.ZERO,
+                singletonMap(SearchableSnapshotAction.NAME, new SearchableSnapshotAction(snapshotRepo, randomBoolean()))
+            ),
+            null
+        );
+
+        createIndex(index, Settings.EMPTY);
+        ensureGreen(index);
+        indexDocument(client(), index, true);
+
+        // enable ILM after we indexed a document as otherwise ILM might sometimes run so fast the indexDocument call will fail with
+        // `index_not_found_exception`
+        updateIndexSettings(index, Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, policyCold));
+
+        final String fullMountedIndexName = SearchableSnapshotAction.FULL_RESTORED_INDEX_PREFIX + index;
+
+        assertBusy(() -> {
+            logger.info("--> waiting for [{}] to exist...", fullMountedIndexName);
+            assertTrue(indexExists(fullMountedIndexName));
+        }, 30, TimeUnit.SECONDS);
+
+        assertBusy(() -> {
+            Step.StepKey stepKeyForIndex = getStepKeyForIndex(client(), fullMountedIndexName);
+            assertThat(stepKeyForIndex.phase(), is("cold"));
+            assertThat(stepKeyForIndex.name(), is(PhaseCompleteStep.NAME));
+        }, 30, TimeUnit.SECONDS);
+
+        // remove ILM
+        {
+            Request request = new Request("POST", "/" + fullMountedIndexName + "/_ilm/remove");
+            Map<String, Object> responseMap = responseAsMap(client().performRequest(request));
+            assertThat(responseMap.get("has_failures"), is(false));
+        }
+        // add cold-frozen
+        updateIndexSettings(index, Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, policyFrozen));
+        String partiallyMountedIndexName = SearchableSnapshotAction.PARTIAL_RESTORED_INDEX_PREFIX + fullMountedIndexName;
+        assertBusy(() -> {
+            logger.info("--> waiting for [{}] to exist...", partiallyMountedIndexName);
+            assertTrue(indexExists(partiallyMountedIndexName));
+        }, 30, TimeUnit.SECONDS);
+
+        assertBusy(() -> {
+            Step.StepKey stepKeyForIndex = getStepKeyForIndex(client(), partiallyMountedIndexName);
+            assertThat(stepKeyForIndex.phase(), is("frozen"));
+            assertThat(stepKeyForIndex.name(), is(PhaseCompleteStep.NAME));
+        }, 30, TimeUnit.SECONDS);
+
+        // Ensure the searchable snapshot is not deleted when the index was deleted because it was not created by this
+        // policy. We add the delete phase now to ensure that the index will not be deleted before we verify the above
+        // assertions
+        createPolicy(
+            client(),
+            policyFrozen,
+            null,
+            null,
+            new Phase(
+                "cold",
+                TimeValue.ZERO,
+                singletonMap(SearchableSnapshotAction.NAME, new SearchableSnapshotAction(snapshotRepo, randomBoolean()))
+            ),
+            new Phase(
+                "frozen",
+                TimeValue.ZERO,
+                singletonMap(SearchableSnapshotAction.NAME, new SearchableSnapshotAction(snapshotRepo, randomBoolean()))
+            ),
+            new Phase("delete", TimeValue.ZERO, singletonMap(DeleteAction.NAME, WITH_SNAPSHOT_DELETE))
+        );
+        assertBusy(() -> {
+            logger.info("--> waiting for [{}] to be deleted...", partiallyMountedIndexName);
+            assertThat(indexExists(partiallyMountedIndexName), is(false));
+            Request getSnaps = new Request("GET", "/_snapshot/" + snapshotRepo + "/_all");
+            Map<String, Object> responseMap = responseAsMap(client().performRequest(getSnaps));
+            assertThat(((List<Map<String, Object>>) responseMap.get("snapshots")).size(), equalTo(1));
+        }, 30, TimeUnit.SECONDS);
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testResumingSearchableSnapshotFromPartialToFull() throws Exception {
+        String index = "myindex-" + randomAlphaOfLength(4).toLowerCase(Locale.ROOT);
+        createSnapshotRepo(client(), snapshotRepo, randomBoolean());
+        var policyCold = "policy-cold";
+        createPolicy(
+            client(),
+            policyCold,
+            null,
+            null,
+            new Phase(
+                "cold",
+                TimeValue.ZERO,
+                singletonMap(SearchableSnapshotAction.NAME, new SearchableSnapshotAction(snapshotRepo, randomBoolean()))
+            ),
+            null,
+            null
+        );
+        var policyColdFrozen = "policy-cold-frozen";
+        createPolicy(
+            client(),
+            policyColdFrozen,
+
+            null,
+            null,
+            new Phase(
+                "cold",
+                TimeValue.ZERO,
+                singletonMap(SearchableSnapshotAction.NAME, new SearchableSnapshotAction(snapshotRepo, randomBoolean()))
+            ),
+            new Phase(
+                "frozen",
+                TimeValue.ZERO,
+                singletonMap(SearchableSnapshotAction.NAME, new SearchableSnapshotAction(snapshotRepo, randomBoolean()))
+            ),
+            null
+        );
+
+        createIndex(index, Settings.EMPTY);
+        ensureGreen(index);
+        indexDocument(client(), index, true);
+
+        // enable ILM after we indexed a document as otherwise ILM might sometimes run so fast the indexDocument call will fail with
+        // `index_not_found_exception`
+        updateIndexSettings(index, Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, policyColdFrozen));
+
+        final String fullMountedIndexName = SearchableSnapshotAction.FULL_RESTORED_INDEX_PREFIX + index;
+        final String partialMountedIndexName = SearchableSnapshotAction.PARTIAL_RESTORED_INDEX_PREFIX + fullMountedIndexName;
+
+        assertBusy(() -> {
+            logger.info("--> waiting for [{}] to exist...", partialMountedIndexName);
+            assertTrue(indexExists(partialMountedIndexName));
+        }, 30, TimeUnit.SECONDS);
+
+        assertBusy(() -> {
+            Step.StepKey stepKeyForIndex = getStepKeyForIndex(client(), partialMountedIndexName);
+            assertThat(stepKeyForIndex.phase(), is("frozen"));
+            assertThat(stepKeyForIndex.name(), is(PhaseCompleteStep.NAME));
+        }, 30, TimeUnit.SECONDS);
+
+        // remove ILM from the partially mounted searchable snapshot
+        {
+            Request request = new Request("POST", "/" + partialMountedIndexName + "/_ilm/remove");
+            Map<String, Object> responseMap = responseAsMap(client().performRequest(request));
+            assertThat(responseMap.get("has_failures"), is(false));
+        }
+        // add a policy that will only include the fully mounted searchable snapshot
+        updateIndexSettings(index, Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, policyCold));
+        String restoredPartiallyMountedIndexName = SearchableSnapshotAction.FULL_RESTORED_INDEX_PREFIX + partialMountedIndexName;
+        assertBusy(() -> {
+            logger.info("--> waiting for [{}] to exist...", restoredPartiallyMountedIndexName);
+            assertTrue(indexExists(restoredPartiallyMountedIndexName));
+        }, 30, TimeUnit.SECONDS);
+
+        assertBusy(() -> {
+            Step.StepKey stepKeyForIndex = getStepKeyForIndex(client(), restoredPartiallyMountedIndexName);
+            assertThat(stepKeyForIndex.phase(), is("cold"));
+            assertThat(stepKeyForIndex.name(), is(PhaseCompleteStep.NAME));
+        }, 30, TimeUnit.SECONDS);
+
+        // Ensure the searchable snapshot is not deleted when the index was deleted because it was not created by this
+        // policy. We add the delete phase now to ensure that the index will not be deleted before we verify the above
+        // assertions
+        createPolicy(
+            client(),
+            policyCold,
+            null,
+            null,
+            new Phase(
+                "cold",
+                TimeValue.ZERO,
+                singletonMap(SearchableSnapshotAction.NAME, new SearchableSnapshotAction(snapshotRepo, randomBoolean()))
+            ),
+            null,
+            new Phase("delete", TimeValue.ZERO, singletonMap(DeleteAction.NAME, WITH_SNAPSHOT_DELETE))
+        );
+        assertBusy(() -> {
+            logger.info("--> waiting for [{}] to be deleted...", restoredPartiallyMountedIndexName);
+            assertThat(indexExists(restoredPartiallyMountedIndexName), is(false));
+            Request getSnaps = new Request("GET", "/_snapshot/" + snapshotRepo + "/_all");
+            Map<String, Object> responseMap = responseAsMap(client().performRequest(getSnaps));
+            assertThat(((List<Map<String, Object>>) responseMap.get("snapshots")).size(), equalTo(1));
+        }, 30, TimeUnit.SECONDS);
     }
 
     public void testSecondSearchableSnapshotUsingDifferentRepoThrows() throws Exception {


### PR DESCRIPTION
Backports the following commits to 8.11:
 - [ILM] More resilient when a policy is added to searchable snapshot (#102741)