### PR TITLE
[Connectors API] Add error and status field checks to set sync job error integration tests

### DIFF
--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/450_connector_sync_job_error.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/450_connector_sync_job_error.yml
@@ -20,7 +20,9 @@ setup:
           id: test-connector
           job_type: full
           trigger_method: on_demand
+
   - set: { id: id }
+
   - do:
       connector_sync_job.error:
         connector_sync_job_id: $id
@@ -28,6 +30,13 @@ setup:
           error: error
 
   - match: { acknowledged: true }
+
+  - do:
+      connector_sync_job.get:
+        connector_sync_job_id: $id
+
+  - match: { error: error }
+  - match: { status: error }
 
 
 ---


### PR DESCRIPTION
Extend the set sync job error integration test to check the `status` and `error` field after setting an error.