### PR TITLE
[7.17] Update IronBank docker image base to ubi:9.3 (#102721)

### DIFF
--- a/distribution/docker/src/docker/Dockerfile
+++ b/distribution/docker/src/docker/Dockerfile
@@ -27,7 +27,7 @@
 
 ARG BASE_REGISTRY=registry1.dso.mil
 ARG BASE_IMAGE=ironbank/redhat/ubi/ubi9
-ARG BASE_TAG=9.2
+ARG BASE_TAG=9.3
 
 FROM ${base_image} AS builder
 

--- a/distribution/docker/src/docker/iron_bank/hardening_manifest.yaml
+++ b/distribution/docker/src/docker/iron_bank/hardening_manifest.yaml
@@ -14,7 +14,7 @@ tags:
 # Build args passed to Dockerfile ARGs
 args:
   BASE_IMAGE: "redhat/ubi/ubi9"
-  BASE_TAG: "9.2"
+  BASE_TAG: "9.3"
 
 # Docker image labels
 labels:


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Update IronBank docker image base to ubi:9.3 (#102721)