### PR TITLE
[8.11] Ensure dynamicMapping updates are handled in insertion order (#103047)

### DIFF
--- a/docs/changelog/103047.yaml
+++ b/docs/changelog/103047.yaml
@@ -1,0 +1,5 @@
+pr: 103047
+summary: Ensure `dynamicMapping` updates are handled in insertion order
+area: Mapping
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
@@ -22,8 +22,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -166,9 +166,9 @@ public abstract class DocumentParserContext {
             mappingParserContext,
             source,
             new HashSet<>(),
-            new HashMap<>(),
+            new LinkedHashMap<>(),
             new HashSet<>(),
-            new HashMap<>(),
+            new LinkedHashMap<>(),
             new ArrayList<>(),
             null,
             null,


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Ensure dynamicMapping updates are handled in insertion order (#103047)