### PR TITLE
Use latest version of entsearch ingestion pipeline

### DIFF
--- a/docs/changelog/103087.yaml
+++ b/docs/changelog/103087.yaml
@@ -1,0 +1,5 @@
+pr: 103087
+summary: Use latest version of entsearch ingestion pipeline
+area: Application
+type: bug
+issues: []

--- a/x-pack/plugin/core/template-resources/src/main/resources/entsearch/generic_ingestion_pipeline.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/entsearch/generic_ingestion_pipeline.json
@@ -1,5 +1,5 @@
 {
-  "version": 1,
+  "version": ${xpack.application.connector.template.version},
   "description": "Generic Enterprise Search ingest pipeline",
   "_meta": {
     "managed_by": "Enterprise Search",


### PR DESCRIPTION
This pipeline accidentally had a hard-coded version of "1", instead of using the registry version (like the other assets for this plugin). This led to lots of lines such as:

```
[2023-12-06T14:16:00,593][INFO ][o.e.x.c.t.IndexTemplateRegistry] [runTask-0] adding ingest pipeline ent-search-generic-ingestion
[2023-12-06T14:16:00,633][INFO ][o.e.x.c.t.IndexTemplateRegistry] [runTask-0] upgrading ingest pipeline [ent-search-generic-ingestion] for [enterprise_search] from version [1] to version [3]
[2023-12-06T14:16:00,634][INFO ][o.e.x.c.t.IndexTemplateRegistry] [runTask-0] adding ingest pipeline ent-search-generic-ingestion
[2023-12-06T14:16:00,680][INFO ][o.e.x.c.t.IndexTemplateRegistry] [runTask-0] upgrading ingest pipeline [ent-search-generic-ingestion] for [enterprise_search] from version [1] to version [3]
[2023-12-06T14:16:00,681][INFO ][o.e.x.c.t.IndexTemplateRegistry] [runTask-0] adding ingest pipeline ent-search-generic-ingestion
[2023-12-06T14:16:00,706][INFO ][o.e.x.c.t.IndexTemplateRegistry] [runTask-0] upgrading ingest pipeline [ent-search-generic-ingestion] for [enterprise_search] from version [1] to version [3]
[2023-12-06T14:16:00,707][INFO ][o.e.x.c.t.IndexTemplateRegistry] [runTask-0] adding ingest pipeline ent-search-generic-ingestion
[2023-12-06T14:16:00,731][INFO ][o.e.x.c.t.IndexTemplateRegistry] [runTask-0] upgrading ingest pipeline [ent-search-generic-ingestion] for [enterprise_search] from version [1] to version [3]
[2023-12-06T14:16:00,732][INFO ][o.e.x.c.t.IndexTemplateRegistry] [runTask-0] adding ingest pipeline ent-search-generic-ingestion
etc etc etc
```

Because the pipeline was installed at version 1, and then immediately "upgraded" to version 3, despite no changes.

Relates to #97463
