### PR TITLE
Fix FullClusterRestartIT BwC tests

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/cluster/metadata/DataStreamTestHelper.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/metadata/DataStreamTestHelper.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.cluster.metadata;
 
 import org.apache.lucene.tests.util.LuceneTestCase;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.indices.rollover.MetadataRolloverService;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
@@ -82,7 +81,6 @@ import static org.mockito.Mockito.when;
 
 public final class DataStreamTestHelper {
 
-    private static final Version DATE_IN_BACKING_INDEX_VERSION = Version.V_7_11_0;
     private static final Settings.Builder SETTINGS = ESTestCase.settings(IndexVersion.current()).put("index.hidden", true);
     private static final int NUMBER_OF_SHARDS = 1;
     private static final int NUMBER_OF_REPLICAS = 1;

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/RestTestLegacyFeatures.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/RestTestLegacyFeatures.java
@@ -54,8 +54,6 @@ public class RestTestLegacyFeatures implements FeatureSpecification {
     public static final NodeFeature TRANSFORM_NEW_API_ENDPOINT = new NodeFeature("transform.new_api_endpoint");
     // Ref: https://github.com/elastic/elasticsearch/pull/65205
     @UpdateForV9
-    public static final NodeFeature DATA_STREAMS_DATE_IN_INDEX_NAME = new NodeFeature("data-streams.date_in_index_name");
-    @UpdateForV9
     public static final NodeFeature ML_INDICES_HIDDEN = new NodeFeature("ml.indices_hidden");
     @UpdateForV9
     public static final NodeFeature ML_ANALYTICS_MAPPINGS = new NodeFeature("ml.analytics_mappings");
@@ -78,7 +76,6 @@ public class RestTestLegacyFeatures implements FeatureSpecification {
             entry(SECURITY_ROLE_DESCRIPTORS_OPTIONAL, Version.V_7_3_0),
             entry(SEARCH_AGGREGATIONS_FORCE_INTERVAL_SELECTION_DATE_HISTOGRAM, Version.V_7_2_0),
             entry(TRANSFORM_NEW_API_ENDPOINT, Version.V_7_5_0),
-            entry(DATA_STREAMS_DATE_IN_INDEX_NAME, Version.V_7_11_0),
             entry(ML_INDICES_HIDDEN, Version.V_7_7_0),
             entry(ML_ANALYTICS_MAPPINGS, Version.V_7_3_0),
             entry(SLM_SUPPORTED, Version.V_7_4_0)

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/RestTestLegacyFeatures.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/RestTestLegacyFeatures.java
@@ -57,8 +57,6 @@ public class RestTestLegacyFeatures implements FeatureSpecification {
     public static final NodeFeature ML_INDICES_HIDDEN = new NodeFeature("ml.indices_hidden");
     @UpdateForV9
     public static final NodeFeature ML_ANALYTICS_MAPPINGS = new NodeFeature("ml.analytics_mappings");
-    @UpdateForV9
-    public static final NodeFeature SLM_SUPPORTED = new NodeFeature("slm.supported");
 
     @Override
     public Map<NodeFeature, Version> getHistoricalFeatures() {
@@ -77,8 +75,7 @@ public class RestTestLegacyFeatures implements FeatureSpecification {
             entry(SEARCH_AGGREGATIONS_FORCE_INTERVAL_SELECTION_DATE_HISTOGRAM, Version.V_7_2_0),
             entry(TRANSFORM_NEW_API_ENDPOINT, Version.V_7_5_0),
             entry(ML_INDICES_HIDDEN, Version.V_7_7_0),
-            entry(ML_ANALYTICS_MAPPINGS, Version.V_7_3_0),
-            entry(SLM_SUPPORTED, Version.V_7_4_0)
+            entry(ML_ANALYTICS_MAPPINGS, Version.V_7_3_0)
         );
     }
 }

--- a/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
@@ -940,6 +940,10 @@ public class FullClusterRestartIT extends AbstractXpackFullClusterRestartTestCas
         var originalClusterSupportsDataStreams = parseLegacyVersion(getOldClusterVersion()).map(v -> v.onOrAfter(Version.V_7_9_0))
             .orElse(true);
 
+        @UpdateForV9
+        var originalClusterDataStreamHasDateInIndexName = parseLegacyVersion(getOldClusterVersion()).map(v -> v.onOrAfter(Version.V_7_11_0))
+            .orElse(true);
+
         assumeTrue("no data streams in versions before 7.9.0", originalClusterSupportsDataStreams);
         if (isRunningAgainstOldCluster()) {
             createComposableTemplate(client(), "dst", "ds");
@@ -977,12 +981,7 @@ public class FullClusterRestartIT extends AbstractXpackFullClusterRestartTestCas
         assertEquals("ds", ds.get("name"));
         assertEquals(1, indices.size());
         assertEquals(
-            DataStreamTestHelper.getLegacyDefaultBackingIndexName(
-                "ds",
-                1,
-                timestamp,
-                clusterHasFeature(RestTestLegacyFeatures.DATA_STREAMS_DATE_IN_INDEX_NAME)
-            ),
+            DataStreamTestHelper.getLegacyDefaultBackingIndexName("ds", 1, timestamp, originalClusterDataStreamHasDateInIndexName),
             indices.get(0).get("index_name")
         );
         assertNumHits("ds", 1, 1);

--- a/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
@@ -586,6 +586,9 @@ public class FullClusterRestartIT extends AbstractXpackFullClusterRestartTestCas
     }
 
     public void testSlmPolicyAndStats() throws IOException {
+        @UpdateForV9
+        var originalClusterSupportsSlm = parseLegacyVersion(getOldClusterVersion()).map(v -> v.onOrAfter(Version.V_7_4_0)).orElse(true);
+
         SnapshotLifecyclePolicy slmPolicy = new SnapshotLifecyclePolicy(
             "test-policy",
             "test-policy",
@@ -594,7 +597,7 @@ public class FullClusterRestartIT extends AbstractXpackFullClusterRestartTestCas
             Collections.singletonMap("indices", Collections.singletonList("*")),
             null
         );
-        if (isRunningAgainstOldCluster() && clusterHasFeature(RestTestLegacyFeatures.SLM_SUPPORTED)) {
+        if (isRunningAgainstOldCluster() && originalClusterSupportsSlm) {
             Request createRepoRequest = new Request("PUT", "_snapshot/test-repo");
             String repoCreateJson = "{" + " \"type\": \"fs\"," + " \"settings\": {" + "   \"location\": \"test-repo\"" + "  }" + "}";
             createRepoRequest.setJsonEntity(repoCreateJson);
@@ -608,7 +611,7 @@ public class FullClusterRestartIT extends AbstractXpackFullClusterRestartTestCas
             client().performRequest(createSlmPolicyRequest);
         }
 
-        if (isRunningAgainstOldCluster() == false && clusterHasFeature(RestTestLegacyFeatures.SLM_SUPPORTED)) {
+        if (isRunningAgainstOldCluster() == false && originalClusterSupportsSlm) {
             Request getSlmPolicyRequest = new Request("GET", "_slm/policy/test-policy");
             Response response = client().performRequest(getSlmPolicyRequest);
             Map<String, Object> responseMap = entityAsMap(response);


### PR DESCRIPTION
I failed to notice the check for naming scheme needs to be always against the OLD cluster.
This PR reverts back to checking against the old cluster version, instead of features (which are always read from the current cluster).

Closes https://github.com/elastic/elasticsearch/issues/102985