### PR TITLE
Add IndexVersion constant for 8.13

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexVersions.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersions.java
@@ -92,6 +92,7 @@ public class IndexVersions {
     public static final IndexVersion ES_VERSION_8_12 = def(8_500_004, Version.LUCENE_9_8_0);
     public static final IndexVersion NORMALIZED_VECTOR_COSINE = def(8_500_005, Version.LUCENE_9_8_0);
     public static final IndexVersion UPGRADE_LUCENE_9_9 = def(8_500_006, Version.LUCENE_9_9_0);
+    public static final IndexVersion ES_VERSION_8_13 = def(8_500_007, Version.LUCENE_9_8_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/index/IndexVersions.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersions.java
@@ -92,7 +92,7 @@ public class IndexVersions {
     public static final IndexVersion ES_VERSION_8_12 = def(8_500_004, Version.LUCENE_9_8_0);
     public static final IndexVersion NORMALIZED_VECTOR_COSINE = def(8_500_005, Version.LUCENE_9_8_0);
     public static final IndexVersion UPGRADE_LUCENE_9_9 = def(8_500_006, Version.LUCENE_9_9_0);
-    public static final IndexVersion ES_VERSION_8_13 = def(8_500_007, Version.LUCENE_9_8_0);
+    public static final IndexVersion ES_VERSION_8_13 = def(8_500_007, Version.LUCENE_9_9_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/x-pack/qa/rolling-upgrade-multi-cluster/src/test/java/org/elasticsearch/upgrades/CcrRollingUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade-multi-cluster/src/test/java/org/elasticsearch/upgrades/CcrRollingUpgradeIT.java
@@ -206,7 +206,6 @@ public class CcrRollingUpgradeIT extends AbstractMultiClusterUpgradeTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/103094")
     public void testCannotFollowLeaderInUpgradedCluster() throws Exception {
         if (upgradeState != UpgradeState.ALL) {
             return;


### PR DESCRIPTION
This commit adds a dummy IndexVersion constant for 8.13. It is needed for CCR tests which expect a different index version between current and previous releases.

closes #103094