### PR TITLE
Always allow sample size for stacktraces

### DIFF
--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetStackTracesRequest.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetStackTracesRequest.java
@@ -247,13 +247,6 @@ public class GetStackTracesRequest extends ActionRequest implements IndicesReque
                     validationException
                 );
             }
-            // we don't do downsampling when a custom index is provided
-            if (sampleSize != null) {
-                validationException = addValidationError(
-                    "[" + SAMPLE_SIZE_FIELD.getPreferredName() + "] must not be set",
-                    validationException
-                );
-            }
         } else {
             if (stackTraceIds != null) {
                 validationException = addValidationError(
@@ -261,8 +254,8 @@ public class GetStackTracesRequest extends ActionRequest implements IndicesReque
                     validationException
                 );
             }
-            validationException = requirePositive(SAMPLE_SIZE_FIELD, sampleSize, validationException);
         }
+        validationException = requirePositive(SAMPLE_SIZE_FIELD, sampleSize, validationException);
         validationException = requirePositive(REQUESTED_DURATION_FIELD, requestedDuration, validationException);
         validationException = requirePositive(AWS_COST_FACTOR_FIELD, awsCostFactor, validationException);
         validationException = requirePositive(CUSTOM_CO2_PER_KWH, customCO2PerKWH, validationException);

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/GetStackTracesRequestTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/GetStackTracesRequestTests.java
@@ -170,6 +170,23 @@ public class GetStackTracesRequestTests extends ESTestCase {
         assertTrue(validationErrors.get(0).contains("[sample_size] must be greater than 0,"));
     }
 
+    public void testValidateSampleSizeIsValidWithCustomIndices() {
+        GetStackTracesRequest request = new GetStackTracesRequest(
+            10,
+            1.0d,
+            1.0d,
+            null,
+            randomAlphaOfLength(7),
+            randomAlphaOfLength(3),
+            null,
+            null,
+            null,
+            null,
+            null
+        );
+        assertNull("Expecting no validation errors", request.validate());
+    }
+
     public void testValidateStacktraceWithoutIndices() {
         GetStackTracesRequest request = new GetStackTracesRequest(
             1,


### PR DESCRIPTION
The profiling get stacktraces API can be called from two different places:

1. In the native profiling UI
2. From within an APM context

In the latter case we disallowed the `sample_size` request body parameter because the implementation always considers all samples. However, as this will change in the future and we need to accept the `sample_size` parameter this will lead to rejected requests during upgrades. With this commit we always accept the `sample_size` request body parameter to avoid such cases.