### PR TITLE
[DOCS] Update SAML guide to reference attribute_delimiters.group

### DIFF
--- a/docs/reference/security/authentication/saml-guide.asciidoc
+++ b/docs/reference/security/authentication/saml-guide.asciidoc
@@ -328,24 +328,15 @@ groups:: _(Recommended)_
 +
 [NOTE]
 ====
-Some IdPs are configured to send the `groups` list as a comma-separated string,
-but {es} can't parse this string into an array of groups. To map this SAML
-attribute to the `attributes.groups` setting in the {es} realm, a cluster
-security administrator can use a wildcard when
-<<saml-role-mapping,configuring role mappings>>. While flexible, wildcards are
-less accurate and can match on unwanted patterns. Instead, a cluster security
-administrator can use a regular expression to create a role mapping rule that
-matches only a single group. For example, the following regular expression
-matches only on the `elasticsearch-admins` group:
+Some IdPs are configured to send the `groups` list as a single value, comma-separated
+string. To map this SAML attribute to the `attributes.groups` setting in the {es}
+realm, you can configure a string delimiter using the `attribute_delimiters.group`
+setting.
 
-[source,sh]
-----
-/^(.*,)?elasticsearch-admins(,.*)?$/
-----
-
-These regular expressions are based on Lucene’s
-{ref}/regexp-syntax.html[regular expression syntax], and can match more complex
-patterns. All regular expressions must start and end with a forward slash.
+For example, splitting the SAML attribute value
+`engineering,elasticsearch-admins,employees` on a delimiter value of `,` will
+result in `engineering`, `elasticsearch-admins`, and `employees` as the list of
+groups for the user.
 ====
 
 name:: _(Optional)_ The user's full name.

--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -1222,7 +1222,7 @@ _Distinguished Name_.
 `attribute_patterns.principal` {ess-icon}::
 (<<static-cluster-setting,Static>>)
 A Java regular expression that is matched against the SAML attribute specified
-by `attributes.pattern` before it is applied to the user's _principal_ property.
+by `attributes.principal` before it is applied to the user's _principal_ property.
 The attribute value must match the pattern and the value of the first
 _capturing group_ is used as the principal. For example, `^([^@]+)@example\\.com$`
 matches email addresses from the "example.com" domain and uses the local-part as
@@ -1257,13 +1257,13 @@ As per `attribute_patterns.principal`, but for the _dn_ property.
 `attribute_delimiters.groups` {ess-icon}::
 (<<static-cluster-setting,Static>>)
 A plain string that is used as a delimiter to split a single-valued SAML
-attribute specified by attributes.groups before it is applied to the user's
-groups property. For example, splitting the SAML attribute value
-engineering,elasticsearch-admins,employees on a delimiter value of , will
-result in engineering, elasticsearch-admins, and employees as the list of
+attribute specified by `attributes.groups` before it is applied to the user's
+_groups_ property. For example, splitting the SAML attribute value
+`engineering,elasticsearch-admins,employees` on a delimiter value of `,` will
+result in `engineering`, `elasticsearch-admins`, and `employees` as the list of
 groups for the user. The delimiter will always be split on, regardless of
 escaping in the input string. This setting does not support multi-valued SAML
-attributes. It cannot be used together with the attribute_patterns setting.
+attributes. It cannot be used together with the `attribute_patterns` setting.
 You can only configure this setting for the groups attribute.
 // end::saml-attributes-delimiters-groups-tag[]
 


### PR DESCRIPTION
This is a follow up PR from https://github.com/elastic/elasticsearch/pull/102769. The SAML realm can now be configured to split the `groups` attribute by delimiter, this updates the docs to mention that. 