### PR TITLE
[main] Update rrf.asciidoc (#103078)

### DIFF
--- a/docs/reference/search/rrf.asciidoc
+++ b/docs/reference/search/rrf.asciidoc
@@ -51,7 +51,7 @@ equal to `1`. Defaults to `60`.
 `window_size`::
 (Optional, integer) This value determines the size of the individual result sets per
 query. A higher value will improve result relevance at the cost of performance. The final
-ranked result set is pruned down to the search request's <<search-size-param, size>.
+ranked result set is pruned down to the search request's <<search-size-param, size>>.
 `window_size` must be greater than or equal to `size` and greater than or equal to `1`.
 Defaults to `100`.
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.11` to `main`:
 - [Update rrf.asciidoc (#103078)](https://github.com/elastic/elasticsearch/pull/103078)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)