### PR TITLE
ES|QL: Implement StickyLimit plan and push LIMIT past MV_EXPAND

### DIFF
--- a/docs/changelog/103111.yaml
+++ b/docs/changelog/103111.yaml
@@ -1,0 +1,7 @@
+pr: 103111
+summary: "ES|Q: Implement `StickyLimit` plan and push LIMIT past MV_EXPAND"
+area: ES|QL
+type: bug
+issues:
+ - 102084
+ - 102061

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/mv_expand.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/mv_expand.csv-spec
@@ -318,7 +318,7 @@ a         | a
 
 
 // see https://github.com/elastic/elasticsearch/issues/102061
-sortMvExpand#[skip:-8.12.2]
+sortMvExpand#[skip:-8.12.99]
 row a = 1 | sort a | mv_expand a;
 
 a:integer

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/mv_expand.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/mv_expand.csv-spec
@@ -316,3 +316,57 @@ a:keyword | e:keyword
 a         | a
 ;
 
+
+// see https://github.com/elastic/elasticsearch/issues/102061
+sortMvExpand#[skip:-8.12.2]
+row a = 1 | sort a | mv_expand a;
+
+a:integer
+1
+;
+
+
+// see https://github.com/elastic/elasticsearch/issues/102061
+limitSortMvExpand#[skip:-8.12.99]
+row a = 1 | limit 1 | sort a | mv_expand a;
+
+a:integer
+1
+;
+
+
+// see https://github.com/elastic/elasticsearch/issues/102061
+limitSortMultipleMvExpand#[skip:-8.12.99]
+row a = [1, 2, 3, 4, 5], b = 2, c = 3 |  sort a | mv_expand a | mv_expand b | mv_expand c | limit 3;
+
+a:integer | b:integer | c:integer
+1         | 2         | 3
+2         | 2         | 3
+3         | 2         | 3
+;
+
+
+multipleLimitSortMultipleMvExpand#[skip:-8.12.99]
+row a = [1, 2, 3, 4, 5], b = 2, c = 3 |  sort a | mv_expand a | limit 2 | mv_expand b | mv_expand c | limit 3;
+
+a:integer | b:integer | c:integer
+1         | 2         | 3
+2         | 2         | 3
+;
+
+
+multipleLimitSortMultipleMvExpand2#[skip:-8.12.99]
+row a = [1, 2, 3, 4, 5], b = 2, c = 3 |  sort a | mv_expand a | limit 3 | mv_expand b | mv_expand c | limit 2;
+
+a:integer | b:integer | c:integer
+1         | 2         | 3
+2         | 2         | 3
+;
+
+
+//see https://github.com/elastic/elasticsearch/issues/102084
+whereMvExpand#[skip:-8.12.99]
+row  a = 1, b = -15 | where b > 3   | mv_expand b;
+
+a:integer | b:integer
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypes.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypes.java
@@ -115,6 +115,7 @@ import org.elasticsearch.xpack.esql.plan.logical.Enrich;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.Grok;
 import org.elasticsearch.xpack.esql.plan.logical.MvExpand;
+import org.elasticsearch.xpack.esql.plan.logical.StickyLimit;
 import org.elasticsearch.xpack.esql.plan.logical.TopN;
 import org.elasticsearch.xpack.esql.plan.logical.local.EsqlProject;
 import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
@@ -266,6 +267,7 @@ public final class PlanNamedTypes {
             of(LogicalPlan.class, MvExpand.class, PlanNamedTypes::writeMvExpand, PlanNamedTypes::readMvExpand),
             of(LogicalPlan.class, OrderBy.class, PlanNamedTypes::writeOrderBy, PlanNamedTypes::readOrderBy),
             of(LogicalPlan.class, Project.class, PlanNamedTypes::writeProject, PlanNamedTypes::readProject),
+            of(LogicalPlan.class, StickyLimit.class, PlanNamedTypes::writeStickyLimit, PlanNamedTypes::readStickyLimit),
             of(LogicalPlan.class, TopN.class, PlanNamedTypes::writeTopN, PlanNamedTypes::readTopN),
             // Attributes
             of(Attribute.class, FieldAttribute.class, PlanNamedTypes::writeFieldAttribute, PlanNamedTypes::readFieldAttribute),
@@ -779,6 +781,16 @@ public final class PlanNamedTypes {
     }
 
     static void writeLimit(PlanStreamOutput out, Limit limit) throws IOException {
+        out.writeNoSource();
+        out.writeExpression(limit.limit());
+        out.writeLogicalPlanNode(limit.child());
+    }
+
+    static StickyLimit readStickyLimit(PlanStreamInput in) throws IOException {
+        return new StickyLimit(in.readSource(), in.readNamed(Expression.class), in.readLogicalPlanNode());
+    }
+
+    static void writeStickyLimit(PlanStreamOutput out, StickyLimit limit) throws IOException {
         out.writeNoSource();
         out.writeExpression(limit.limit());
         out.writeLogicalPlanNode(limit.child());

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/StickyLimit.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/logical/StickyLimit.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.esql.plan.logical;
+
+import org.elasticsearch.xpack.ql.expression.Expression;
+import org.elasticsearch.xpack.ql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.ql.plan.logical.UnaryPlan;
+import org.elasticsearch.xpack.ql.tree.NodeInfo;
+import org.elasticsearch.xpack.ql.tree.Source;
+
+import java.util.Objects;
+
+public class StickyLimit extends UnaryPlan {
+
+    private final Expression limit;
+
+    public StickyLimit(Source source, Expression limit, LogicalPlan child) {
+        super(source, child);
+        this.limit = limit;
+    }
+
+    @Override
+    protected NodeInfo<StickyLimit> info() {
+        return NodeInfo.create(this, StickyLimit::new, limit, child());
+    }
+
+    @Override
+    public StickyLimit replaceChild(LogicalPlan newChild) {
+        return new StickyLimit(source(), limit, newChild);
+    }
+
+    public Expression limit() {
+        return limit;
+    }
+
+    @Override
+    public boolean expressionsResolved() {
+        return limit.resolved();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(limit, child());
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        StickyLimit other = (StickyLimit) obj;
+
+        return Objects.equals(limit, other.limit) && Objects.equals(child(), other.child());
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/Mapper.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/Mapper.java
@@ -14,6 +14,7 @@ import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.Grok;
 import org.elasticsearch.xpack.esql.plan.logical.MvExpand;
 import org.elasticsearch.xpack.esql.plan.logical.Row;
+import org.elasticsearch.xpack.esql.plan.logical.StickyLimit;
 import org.elasticsearch.xpack.esql.plan.logical.TopN;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelation;
 import org.elasticsearch.xpack.esql.plan.logical.show.ShowFunctions;
@@ -160,6 +161,9 @@ public class Mapper {
         if (p instanceof Limit limit) {
             return map(limit, child);
         }
+        if (p instanceof StickyLimit limit) {
+            return map(limit, child);
+        }
 
         if (p instanceof OrderBy o) {
             return map(o, child);
@@ -207,6 +211,11 @@ public class Mapper {
     }
 
     private PhysicalPlan map(Limit limit, PhysicalPlan child) {
+        child = addExchangeForFragment(limit, child);
+        return new LimitExec(limit.source(), child, limit.limit());
+    }
+
+    private PhysicalPlan map(StickyLimit limit, PhysicalPlan child) {
         child = addExchangeForFragment(limit, child);
         return new LimitExec(limit.source(), child, limit.limit());
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypesTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypesTests.java
@@ -50,6 +50,7 @@ import org.elasticsearch.xpack.esql.plan.logical.Enrich;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.Grok;
 import org.elasticsearch.xpack.esql.plan.logical.MvExpand;
+import org.elasticsearch.xpack.esql.plan.logical.StickyLimit;
 import org.elasticsearch.xpack.esql.plan.logical.TopN;
 import org.elasticsearch.xpack.esql.plan.logical.local.EsqlProject;
 import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
@@ -169,6 +170,7 @@ public class PlanNamedTypesTests extends ESTestCase {
         MvExpand.class,
         OrderBy.class,
         Project.class,
+        StickyLimit.class,
         TopN.class
     );
 


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/102084
Fixes https://github.com/elastic/elasticsearch/issues/102061

Allow proper pushdown of `LIMIT` command past `MV_EXPAND`

This is an alternative approach to https://github.com/elastic/elasticsearch/pull/102545: instead of adding the limit inside `MV_EXPAND`, we add a new `StickyLimit` plan that does not get pushed down further.

In detail, a plan like 

```
Limit[10[INTEGER]]
\_MvExpand[first_name{f}#155]
``` 
becomes

```
StickyLimit[10[INTEGER]]
\_MvExpand[first_name{f}#155]\
  \_Limit[10[INTEGER]]
``` 

At physical plan level, StickyLimit becomes a normal LimitExec