### PR TITLE
Add JIT compiler excludes for computeCommonPrefixLengthAndBuildHistogram

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java
@@ -108,7 +108,10 @@ public class ElasticsearchTestBasePlugin implements Plugin<Project> {
                 "--add-opens=java.base/java.nio.file=ALL-UNNAMED",
                 "--add-opens=java.base/java.time=ALL-UNNAMED",
                 "--add-opens=java.management/java.lang.management=ALL-UNNAMED",
-                "-XX:+HeapDumpOnOutOfMemoryError"
+                "-XX:+HeapDumpOnOutOfMemoryError",
+                // REMOVE once bumped to a JDK greater than 21.0.1, https://github.com/elastic/elasticsearch/issues/103004
+                "-XX:CompileCommand=exclude,org.apache.lucene.util.MSBRadixSorter::computeCommonPrefixLengthAndBuildHistogram",
+                "-XX:CompileCommand=exclude,org.apache.lucene.util.RadixSelector::computeCommonPrefixLengthAndBuildHistogram"
             );
 
             test.getJvmArgumentProviders().add(new SimpleCommandLineArgumentProvider("-XX:HeapDumpPath=" + heapdumpDir));

--- a/distribution/src/config/jvm.options
+++ b/distribution/src/config/jvm.options
@@ -58,6 +58,10 @@
 # result in less optimal vector performance
 20-:--add-modules=jdk.incubator.vector
 
+# REMOVE once bumped to a JDK greater than 21.0.1, https://github.com/elastic/elasticsearch/issues/103004
+19-21:-XX:CompileCommand=exclude,org.apache.lucene.util.MSBRadixSorter::computeCommonPrefixLengthAndBuildHistogram
+19-21:-XX:CompileCommand=exclude,org.apache.lucene.util.RadixSelector::computeCommonPrefixLengthAndBuildHistogram
+
 ## heap dumps
 
 # generate a heap dump when an allocation from the Java heap fails; heap dumps

--- a/docs/changelog/103112.yaml
+++ b/docs/changelog/103112.yaml
@@ -1,0 +1,5 @@
+pr: 103112
+summary: Add JIT compiler excludes for `computeCommonPrefixLengthAndBuildHistogram`
+area: Search
+type: bug
+issues: []


### PR DESCRIPTION
This commit adds a temporary JIT compile command that excludes the compilation of a couple of Lucene methods which, if compiled, crash the JVM.

The excludes are added to:

1. The Gradle test plugin, so that tests run with the Gradle runner will not compile these methods - this the most impactful change as we see `RangeAggregatorTests` failing very frequently when run with `gradle :server:test`.

2. The distribution `jvm.options`, so that the distribution is protected from the potential crash. A consequence of this is that the log output will now emit a notice of these excludes - this is benign, e.g.

    ```
    $ ./build/distribution/local/elasticsearch-8.12.0-SNAPSHOT/bin/elasticsearch
    CompileCommand: exclude org/apache/lucene/util/MSBRadixSorter.computeCommonPrefixLengthAndBuildHistogram bool exclude = true
    CompileCommand: exclude org/apache/lucene/util/RadixSelector.computeCommonPrefixLengthAndBuildHistogram bool exclude = true
    Dec 07, 2023 10:35:02 AM sun.util.locale.provider.LocaleProviderAdapter <clinit>
    WARNING: COMPAT locale provider will be removed in a future release
    ...
    ```

One consequence of no.1 is that `RangeAggregatorTests` may still crash when run directly in the IDE, but this is of a lesser concern. And since the workaround is temporary (until JDK 21.0.2 is released), then this should be ok.

More specifics can be found in  #103004, which I will not repeat here.