### PR TITLE
Use variable template version in `generic_ingestion_pipeline.json`

### DIFF
--- a/docs/changelog/103117.yaml
+++ b/docs/changelog/103117.yaml
@@ -1,0 +1,5 @@
+pr: 103117
+summary: Use variable template version in `generic_ingestion_pipeline.json`
+area: Application
+type: bug
+issues: []

--- a/x-pack/plugin/core/template-resources/src/main/resources/entsearch/generic_ingestion_pipeline.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/entsearch/generic_ingestion_pipeline.json
@@ -1,5 +1,5 @@
 {
-  "version": 1,
+  "version": ${xpack.application.connector.template.version},
   "description": "Generic Enterprise Search ingest pipeline",
   "_meta": {
     "managed_by": "Enterprise Search",


### PR DESCRIPTION
We noticed that the logs were full with the following log lines:

```
upgrading ingest pipeline [ent-search-generic-ingestion] for [enterprise_search] from version [1] to version [3]
adding ingest pipeline ent-search-generic-ingestion
```

The issue was that with commit https://github.com/elastic/elasticsearch/commit/325f202cd819026152d3c74470e6e08ee4b09c78 we bumped the registry version of the `[ConnectorTemplateRegistry.java](https://github.com/elastic/elasticsearch/commit/325f202cd819026152d3c74470e6e08ee4b09c78#diff-bb5bec80bd2615ae4548ef15168459f44664a9edeec45761ce612987834b7934)` but this was not reflected in the pipeline https://github.com/elastic/elasticsearch/blob/a245fdcd8a7b4ec8b2a403a32b843ea005f2df12/x-pack/plugin/core/template-resources/src/main/resources/entsearch/generic_ingestion_pipeline.json#L2-L7 because the version was hardcoded.

In this PR we fix this by using the variable `xpack.application.connector.template.version` in the pipeline.