### PR TITLE
Streamline listeners in ApiKeyUserRoleDescriptorResolver#resolveUserRoleDescriptors

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/ApiKeyUserRoleDescriptorResolver.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/ApiKeyUserRoleDescriptorResolver.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.security.authc.support;
 
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
@@ -16,6 +15,7 @@ import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
 import org.elasticsearch.xpack.core.security.authz.support.DLSRoleQueryValidator;
 import org.elasticsearch.xpack.security.authz.store.CompositeRolesStore;
 
+import java.util.Collection;
 import java.util.Set;
 
 public class ApiKeyUserRoleDescriptorResolver {
@@ -28,29 +28,30 @@ public class ApiKeyUserRoleDescriptorResolver {
     }
 
     public void resolveUserRoleDescriptors(final Authentication authentication, final ActionListener<Set<RoleDescriptor>> listener) {
-        final ActionListener<Set<RoleDescriptor>> roleDescriptorsListener = ActionListener.wrap(roleDescriptors -> {
-            for (RoleDescriptor rd : roleDescriptors) {
-                try {
-                    DLSRoleQueryValidator.validateQueryField(rd.getIndicesPrivileges(), xContentRegistry);
-                } catch (ElasticsearchException | IllegalArgumentException e) {
-                    listener.onFailure(e);
-                    return;
-                }
-            }
-            listener.onResponse(roleDescriptors);
-        }, listener::onFailure);
 
         final Subject effectiveSubject = authentication.getEffectiveSubject();
 
         // Retain current behaviour that User of an API key authentication has no roles
         if (effectiveSubject.getType() == Subject.Type.API_KEY) {
-            roleDescriptorsListener.onResponse(Set.of());
+            listener.onResponse(Set.of());
             return;
         }
 
-        rolesStore.getRoleDescriptorsList(effectiveSubject, ActionListener.wrap(roleDescriptorsList -> {
-            assert roleDescriptorsList.size() == 1;
-            roleDescriptorsListener.onResponse(roleDescriptorsList.iterator().next());
-        }, roleDescriptorsListener::onFailure));
+        rolesStore.getRoleDescriptorsList(
+            effectiveSubject,
+            listener.delegateFailureAndWrap(this::handleRoleDescriptorsList)
+        );
+    }
+
+    private void handleRoleDescriptorsList(
+        ActionListener<Set<RoleDescriptor>> listener,
+        Collection<Set<RoleDescriptor>> roleDescriptorsList
+    ) {
+        assert roleDescriptorsList.size() == 1;
+        final var roleDescriptors = roleDescriptorsList.iterator().next();
+        for (RoleDescriptor rd : roleDescriptors) {
+            DLSRoleQueryValidator.validateQueryField(rd.getIndicesPrivileges(), xContentRegistry);
+        }
+        listener.onResponse(roleDescriptors);
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/ApiKeyUserRoleDescriptorResolver.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/ApiKeyUserRoleDescriptorResolver.java
@@ -37,10 +37,7 @@ public class ApiKeyUserRoleDescriptorResolver {
             return;
         }
 
-        rolesStore.getRoleDescriptorsList(
-            effectiveSubject,
-            listener.delegateFailureAndWrap(this::handleRoleDescriptorsList)
-        );
+        rolesStore.getRoleDescriptorsList(effectiveSubject, listener.delegateFailureAndWrap(this::handleRoleDescriptorsList));
     }
 
     private void handleRoleDescriptorsList(


### PR DESCRIPTION
There's no need for two layers of wrapping, and `delegateFailureAndWrap`
should be more efficient here. Also since the listener is wrapped
there's no need to catch specific exceptions. Also there's no need to go
via `roleDescriptorsListener` if we're returning an empty set.