### PR TITLE
[Connectors API] Check that the deleted sync job doesn't exist anymore in delete integration tests

### DIFF
--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/410_connector_sync_job_delete.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/410_connector_sync_job_delete.yml
@@ -20,13 +20,19 @@ setup:
           id: test-connector
           job_type: full
           trigger_method: on_demand
+
   - set: { id: sync-job-id-to-delete }
+
   - do:
       connector_sync_job.delete:
         connector_sync_job_id: $sync-job-id-to-delete
 
   - match: { acknowledged: true }
 
+  - do:
+      connector_sync_job.get:
+        connector_sync_job_id: $sync-job-id-to-delete
+      catch: missing
 
 ---
 "Delete Connector Sync Job - Connector Sync Job does not exist":


### PR DESCRIPTION
Extends the delete sync job integration test to verify, that the deleted sync job doesn't exist anymore.