### PR TITLE
[8.11] Use latest version of entsearch ingestion pipeline (#103087)

### DIFF
--- a/docs/changelog/103087.yaml
+++ b/docs/changelog/103087.yaml
@@ -1,0 +1,5 @@
+pr: 103087
+summary: Use latest version of entsearch ingestion pipeline
+area: Application
+type: bug
+issues: []

--- a/x-pack/plugin/core/template-resources/src/main/resources/entsearch/generic_ingestion_pipeline.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/entsearch/generic_ingestion_pipeline.json
@@ -1,5 +1,5 @@
 {
-  "version": 1,
+  "version": ${xpack.application.connector.template.version},
   "description": "Generic Enterprise Search ingest pipeline",
   "_meta": {
     "managed_by": "Enterprise Search",


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Use latest version of entsearch ingestion pipeline (#103087)