### PR TITLE
Add docs for the include_named_queries_score param

### DIFF
--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -111,6 +111,13 @@ By default, you cannot page through more than 10,000 hits using the `from` and
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=ignore_throttled]
 
+`include_named_queries_score`::
+(Optional, Boolean) If `true`, includes the score contribution from any named queries.
+This functionality reruns each named query on every hit in a search
+response. Typically, this adds a small overhead to a request. However, using
+computationally expensive named queries on a large number of hits may add
+significant overhead. Defaults to `false`.
+
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=lenient]


### PR DESCRIPTION
The only docs for this _search param were mentioned in the `bool` query docs. While it makes contextual sense to have it there, we should also add it as a `_search` parameter in the search API docs.

It was introduced in 8.8.