### PR TITLE
[8.12] Update docs for v8.11.2 release (#103088)

### DIFF
--- a/docs/reference/release-notes.asciidoc
+++ b/docs/reference/release-notes.asciidoc
@@ -7,6 +7,7 @@
 This section summarizes the changes in each release.
 
 * <<release-notes-8.12.0>>
+* <<release-notes-8.11.2>>
 * <<release-notes-8.11.1>>
 * <<release-notes-8.11.0>>
 * <<release-notes-8.10.4>>
@@ -56,6 +57,7 @@ This section summarizes the changes in each release.
 --
 
 include::release-notes/8.12.0.asciidoc[]
+include::release-notes/8.11.2.asciidoc[]
 include::release-notes/8.11.1.asciidoc[]
 include::release-notes/8.11.0.asciidoc[]
 include::release-notes/8.10.4.asciidoc[]

--- a/docs/reference/release-notes/8.11.2.asciidoc
+++ b/docs/reference/release-notes/8.11.2.asciidoc
@@ -1,0 +1,83 @@
+[[release-notes-8.11.2]]
+== {es} version 8.11.2
+
+Also see <<breaking-changes-8.11,Breaking changes in 8.11>>.
+
+[[known-issues-8.11.2]]
+[float]
+=== Known issues
+include::8.10.3.asciidoc[tag=no-preventive-gc-issue]
+
+[[bug-8.11.2]]
+[float]
+=== Bug fixes
+
+Allocation::
+* Improve failure handling in `ContinuousComputation` {es-pull}102281[#102281]
+
+Application::
+* Default `run_ml_inference` should be true {es-pull}102151[#102151]
+* [Query Rules] Fix bug where combining the same metadata with text/numeric values leads to error {es-pull}102891[#102891] (issue: {es-issue}102827[#102827])
+
+Cluster Coordination::
+* Synchronize Coordinator#onClusterStateApplied {es-pull}100986[#100986] (issue: {es-issue}99023[#99023])
+
+Data streams::
+* [Usage API] Count all the data streams that have lifecycle {es-pull}102259[#102259]
+
+ES|QL::
+* ES|QL: Fix drop of renamed grouping {es-pull}102282[#102282] (issue: {es-issue}102121[#102121])
+* ES|QL: Fix layout management for Project {es-pull}102399[#102399] (issue: {es-issue}102120[#102120])
+* Fix DISSECT with empty patterns {es-pull}102580[#102580] (issue: {es-issue}102577[#102577])
+* Fix leaking blocks in TopN {es-pull}102715[#102715] (issue: {es-issue}102646[#102646])
+* Fix leaking blocks in `BlockUtils` {es-pull}102716[#102716]
+* Fix memory tracking in TopN.Row {es-pull}102831[#102831] (issues: {es-issue}100640[#100640], {es-issue}102784[#102784], {es-issue}102790[#102790], {es-issue}102683[#102683])
+
+ILM+SLM::
+* [ILM] Fix downsample to skip already downsampled indices {es-pull}102250[#102250] (issue: {es-issue}102249[#102249])
+
+Infra/Circuit Breakers::
+* Add more logging to the real memory circuit breaker and lower minimum interval {es-pull}102396[#102396]
+
+Ingest Node::
+* Better processor stat merge {es-pull}102821[#102821]
+
+Machine Learning::
+* Ensure datafeed previews with no start or end time don't search the cold or frozen tiers {es-pull}102492[#102492]
+* Recreate the Elasticsearch private temporary directory if it doesn't exist when an ML job is opened {es-pull}102599[#102599]
+
+Mapping::
+* Fix dense_vector cluster stats indexed_vector_dim_min/max values {es-pull}102467[#102467] (issue: {es-issue}102416[#102416])
+
+Search::
+* Allow mismatched sort-by field types if there are no docs to sort {es-pull}102779[#102779]
+
+Security::
+* Fix double-completion in `SecurityUsageTransportAction` {es-pull}102114[#102114] (issue: {es-issue}102111[#102111])
+
+Snapshot/Restore::
+* Set region for the STS client via privileged calls in AWS SDK {es-pull}102230[#102230] (issue: {es-issue}102173[#102173])
+* Simplify `BlobStoreRepository` idle check {es-pull}102057[#102057] (issue: {es-issue}101948[#101948])
+
+Transform::
+* Ensure transform updates only modify the expected transform task {es-pull}102934[#102934] (issue: {es-issue}102933[#102933])
+* Exclude stack traces from transform audit messages and health {es-pull}102240[#102240]
+
+[[enhancement-8.11.2]]
+[float]
+=== Enhancements
+
+Machine Learning::
+* Add inference counts by model to the machine learning usage stats {es-pull}101915[#101915]
+
+Security::
+* Upgrade xmlsec to 2.3.4 {es-pull}102220[#102220]
+
+[[upgrade-8.11.2]]
+[float]
+=== Upgrades
+
+Snapshot/Restore::
+* Upgrade reactor netty http version {es-pull}102311[#102311]
+
+


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.11` to `8.12`:
 - [Update docs for v8.11.2 release (#103088)](https://github.com/elastic/elasticsearch/pull/103088)

<!--- Backport version: 9.2.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)