### PR TITLE
Improve docs around knn similarity search

### DIFF
--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -611,9 +611,10 @@ The `similarity` parameter is the direct vector similarity calculation.
 
 * `l2_norm`: also known as Euclidean, will include documents where the vector is within
 the `dims` dimensional hypersphere with radius `similarity` with origin at `query_vector`.
-* `cosine` & `dot_product`: Only return vectors where the cosine similarity or dot-product are at least the provided
+* `cosine`, `dot_product`, and `max_inner_product`: Only return vectors where the cosine similarity or dot-product are at least the provided
 `similarity`.
 --
+Read more here: <<knn-similarity-search, knn similarity search>>
 end::knn-similarity[]
 
 tag::lenient[]

--- a/docs/reference/search/search-your-data/knn-search.asciidoc
+++ b/docs/reference/search/search-your-data/knn-search.asciidoc
@@ -566,7 +566,7 @@ minimum similarity for a vector to be considered a match. The `knn` search flow 
 
 NOTE: `similarity` is the true <<dense-vector-similarity, similarity>> before it has been transformed into `_score` and boost applied.
 
-For each configured <<dense-vector-similarity, similarity>>, here is the corresponding inverted `_score` function.
+For each configured <<dense-vector-similarity, similarity>>, here is the corresponding inverted `_score` function. This is so if you are wanting to filter from a `_score` perspective, you can do this minor transformation to correctly reject irrelevant results.
 --
  - `l2_norm`: `sqrt((1 / _score) - 1)`
  - `cosine`: `(2 * _score) - 1`

--- a/docs/reference/search/search-your-data/knn-search.asciidoc
+++ b/docs/reference/search/search-your-data/knn-search.asciidoc
@@ -547,6 +547,7 @@ score = 0.9 * match_score + 0.1 * knn_score_image-vector + 0.5 * knn_score_title
 ```
 
 [discrete]
+[[knn-similarity-search]]
 ==== Search kNN with expected similarity
 
 While kNN is a powerful tool, it always tries to return `k` nearest neighbors. Consequently, when using `knn` with
@@ -561,6 +562,18 @@ minimum similarity for a vector to be considered a match. The `knn` search flow 
 * Apply any user provided `filter` queries
 * Explore the vector space to get `k` vectors
 * Do not return any vectors that are further away than the configured `similarity`
+--
+
+NOTE: `similarity` is the true <<dense-vector-similarity, similarity>> before it has been transformed into `_score` and boost applied.
+
+For each configured <<dense-vector-similarity, similarity>>, here is the corresponding inverted `_score` function.
+--
+ - `l2_norm`: `sqrt((1 / _score) - 1)`
+ - `cosine`: `(2 * _score) - 1`
+ - `dot_product`: `(2 * _score) - 1`
+ - `max_inner_product`:
+    - `_score < 1`: `1 - (1 / _score)`
+    - `_score >= 1`: `_score - 1`
 --
 
 Here is an example. In this example we search for the given `query_vector` for `k` nearest neighbors. However, with


### PR DESCRIPTION
Adding equations to the docs around how to best calculate similarity & score. The similarity parameter for search was added in 8.8.

The max-inner-product mentions will be removed for all versions before 8.11 when backporting.

closes: https://github.com/elastic/elasticsearch/issues/102924