### PR TITLE
Reduce concurrency level in ManyShardsIT

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ManyShardsIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/ManyShardsIT.java
@@ -60,8 +60,10 @@ public class ManyShardsIT extends AbstractEsqlIntegTestCase {
                     throw new AssertionError(e);
                 }
                 final var pragmas = Settings.builder();
-                if (canUseQueryPragmas()) {
-                    pragmas.put(randomPragmas().getSettings()).put("exchange_concurrent_clients", between(1, 2));
+                if (randomBoolean() && canUseQueryPragmas()) {
+                    pragmas.put(randomPragmas().getSettings())
+                        .put("task_concurrency", between(1, 2))
+                        .put("exchange_concurrent_clients", between(1, 2));
                 }
                 run("from test-* | stats count(user) by tags", new QueryPragmas(pragmas.build())).close();
             });


### PR DESCRIPTION
This test failed during testing with a single CPU. To prevent test failure in such cases, we should lower the concurrency level, ensuring that it doesn't spawn more than 1000 tasks.

Closes #103128