### PR TITLE
Validate settings in ReloadSecureSettings API

### DIFF
--- a/docs/changelog/103176.yaml
+++ b/docs/changelog/103176.yaml
@@ -1,0 +1,5 @@
+pr: 103176
+summary: Validate settings in `ReloadSecureSettings` API
+area: Client
+type: bug
+issues: []

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/ReloadSecureSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/ReloadSecureSettingsIT.java
@@ -11,10 +11,13 @@ package org.elasticsearch.action.admin;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.node.reload.NodesReloadSecureSettingsResponse;
+import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.KeyStoreWrapper;
+import org.elasticsearch.common.settings.SecureSetting;
 import org.elasticsearch.common.settings.SecureSettings;
 import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.plugins.Plugin;
@@ -42,6 +45,8 @@ import static org.hamcrest.Matchers.nullValue;
 
 @ESIntegTestCase.ClusterScope(minNumDataNodes = 2)
 public class ReloadSecureSettingsIT extends ESIntegTestCase {
+
+    private static final String VALID_SECURE_SETTING_NAME = "some.setting.that.exists";
 
     @BeforeClass
     public static void disableInFips() {
@@ -350,9 +355,46 @@ public class ReloadSecureSettingsIT extends ESIntegTestCase {
         }
     }
 
+    public void testInvalidKeyInSettings() throws Exception {
+        final Environment environment = internalCluster().getInstance(Environment.class);
+
+        try (KeyStoreWrapper keyStoreWrapper = KeyStoreWrapper.create()) {
+            keyStoreWrapper.setString(VALID_SECURE_SETTING_NAME, new char[0]);
+            keyStoreWrapper.save(environment.configFile(), new char[0], false);
+        }
+
+        PlainActionFuture<NodesReloadSecureSettingsResponse> actionFuture = new PlainActionFuture<>();
+        clusterAdmin().prepareReloadSecureSettings()
+            .setSecureStorePassword(new SecureString(new char[0]))
+            .setNodesIds(Strings.EMPTY_ARRAY)
+            .execute(actionFuture);
+
+        actionFuture.get().getNodes().forEach(nodeResponse -> assertThat(nodeResponse.reloadException(), nullValue()));
+
+        try (KeyStoreWrapper keyStoreWrapper = KeyStoreWrapper.create()) {
+            assertThat(keyStoreWrapper, notNullValue());
+            keyStoreWrapper.setString("some.setting.that.does.not.exist", new char[0]);
+            keyStoreWrapper.save(environment.configFile(), new char[0], false);
+        }
+
+        actionFuture = new PlainActionFuture<>();
+        clusterAdmin().prepareReloadSecureSettings()
+            .setSecureStorePassword(new SecureString(new char[0]))
+            .setNodesIds(Strings.EMPTY_ARRAY)
+            .execute(actionFuture);
+
+        actionFuture.get()
+            .getNodes()
+            .forEach(nodeResponse -> assertThat(nodeResponse.reloadException(), instanceOf(IllegalArgumentException.class)));
+    }
+
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
-        final List<Class<? extends Plugin>> plugins = Arrays.asList(MockReloadablePlugin.class, MisbehavingReloadablePlugin.class);
+        final List<Class<? extends Plugin>> plugins = Arrays.asList(
+            MockWithSecureSettingPlugin.class,
+            MockReloadablePlugin.class,
+            MisbehavingReloadablePlugin.class
+        );
         // shuffle as reload is called in order
         Collections.shuffle(plugins, random());
         return plugins;
@@ -454,5 +496,11 @@ public class ReloadSecureSettingsIT extends ESIntegTestCase {
             this.shouldThrow = shouldThrow;
         }
     }
+
+    public static class MockWithSecureSettingPlugin extends Plugin {
+        public List<Setting<?>> getSettings() {
+            return List.of(SecureSetting.secureString(VALID_SECURE_SETTING_NAME, null));
+        }
+    };
 
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/reload/TransportNodesReloadSecureSettingsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/reload/TransportNodesReloadSecureSettingsAction.java
@@ -122,6 +122,8 @@ public class TransportNodesReloadSecureSettingsAction extends TransportNodesActi
             keystore.decrypt(request.hasPassword() ? request.getSecureSettingsPassword().getChars() : new char[0]);
             // add the keystore to the original node settings object
             final Settings settingsWithKeystore = Settings.builder().put(environment.settings(), false).setSecureSettings(keystore).build();
+            clusterService.getClusterSettings().validate(settingsWithKeystore, true);
+
             final List<Exception> exceptions = new ArrayList<>();
             // broadcast the new settings object (with the open embedded keystore) to all reloadable plugins
             pluginsService.filterPlugins(ReloadablePlugin.class).forEach(p -> {

--- a/x-pack/qa/password-protected-keystore/src/javaRestTest/java/org/elasticsearch/password_protected_keystore/ReloadSecureSettingsWithPasswordProtectedKeystoreRestIT.java
+++ b/x-pack/qa/password-protected-keystore/src/javaRestTest/java/org/elasticsearch/password_protected_keystore/ReloadSecureSettingsWithPasswordProtectedKeystoreRestIT.java
@@ -12,6 +12,8 @@ import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.SettingsProvider;
+import org.elasticsearch.test.cluster.local.LocalClusterSpec;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.cluster.util.resource.Resource;
 import org.elasticsearch.test.rest.ESRestTestCase;
@@ -37,12 +39,12 @@ public class ReloadSecureSettingsWithPasswordProtectedKeystoreRestIT extends ESR
         .nodes(NUM_NODES)
         .keystorePassword(KEYSTORE_PASSWORD)
         .name("javaRestTest")
+        .keystore(nodeSpec -> Map.of("xpack.security.transport.ssl.secure_key_passphrase", "transport-password"))
         .setting("xpack.security.enabled", "true")
         .setting("xpack.security.authc.anonymous.roles", "anonymous")
         .setting("xpack.security.transport.ssl.enabled", "true")
         .setting("xpack.security.transport.ssl.certificate", "transport.crt")
         .setting("xpack.security.transport.ssl.key", "transport.key")
-        .setting("xpack.security.transport.ssl.key_passphrase", "transport-password")
         .setting("xpack.security.transport.ssl.certificate_authorities", "ca.crt")
         .rolesFile(Resource.fromClasspath("roles.yml"))
         .configFile("transport.key", Resource.fromClasspath("ssl/transport.key"))

--- a/x-pack/qa/password-protected-keystore/src/javaRestTest/java/org/elasticsearch/password_protected_keystore/ReloadSecureSettingsWithPasswordProtectedKeystoreRestIT.java
+++ b/x-pack/qa/password-protected-keystore/src/javaRestTest/java/org/elasticsearch/password_protected_keystore/ReloadSecureSettingsWithPasswordProtectedKeystoreRestIT.java
@@ -12,8 +12,6 @@ import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
-import org.elasticsearch.test.cluster.SettingsProvider;
-import org.elasticsearch.test.cluster.local.LocalClusterSpec;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.cluster.util.resource.Resource;
 import org.elasticsearch.test.rest.ESRestTestCase;


### PR DESCRIPTION
This adds validation of keys in the secure settings keystore to the `reload_secure_settings` API to address https://github.com/elastic/elasticsearch/issues/100844.

A failing validation will result in an exception for the node/nodes that had an invalid key in the keystore, for example: 

```
elasticsearch-keystore add "some.setting.that.does.not.exist"
```
Will result in the API returning an error for the node with the invalid setting:
```
POST _nodes/reload_secure_settings
{
    "_nodes": {
        "total": 1,
        "successful": 1,
        "failed": 0
    },
    "cluster_name": "runTask",
    "nodes": {
        "81t12MBRR5eyC0UkHDw58A": {
            "name": "runTask-0",
            "reload_exception": {
                "type": "illegal_argument_exception",
                "reason": "unknown secure setting [some.setting.that.does.not.exist] please check that any required plugins are installed, or check the breaking changes documentation for removed settings"
            }
        }
    }
}
```
This matches how the missing keystore validation works, example: 
```
{
    "_nodes": {
        "total": 1,
        "successful": 1,
        "failed": 0
    },
    "cluster_name": "runTask",
    "nodes": {
        "ZVavLX_8T1e_-DPQ8Nwmjg": {
            "name": "runTask-0",
            "reload_exception": {
                "type": "illegal_state_exception",
                "reason": "Keystore is missing"
            }
        }
    }
}
```
## Alternative Implementation
An alternative to solving this as proposed in this PR, failures could also be reported in the `_nodes` attribute, but that doesn't seem to be the current pattern. An example of that would be: 
```
{
    "_nodes": {
        "total": 1,
        "successful": 0,
        "failed": 1,
        "failures": [
            {
                "type": "failed_node_exception",
                "reason": "Failed node [EGp_GisWRK6g7aFYcdAxtw]",
                "node_id": "EGp_GisWRK6g7aFYcdAxtw",
                "caused_by": {
                    "type": "illegal_argument_exception",
                    "reason": "unknown secure setting [some.setting.that.does.not.exist] please check that any required plugins are installed, or check the breaking changes documentation for removed settings"
                }
            }
        ]
    },
    "cluster_name": "runTask",
    "nodes": {}
}
```

This could be addressed in a separate PR if desired. Looking for some guidance on what the correct approach is here. 

Relates: https://github.com/elastic/elasticsearch/issues/100844