### PR TITLE
[Connectors API| Check that last_seen updates correctly after check-in

### DIFF
--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/420_connector_sync_job_check_in.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/420_connector_sync_job_check_in.yml
@@ -2,6 +2,7 @@ setup:
   - skip:
       version: " - 8.11.99"
       reason: Introduced in 8.12.0
+      features: is_after
   - do:
       connector.put:
         connector_id: test-connector
@@ -20,13 +21,26 @@ setup:
           id: test-connector
           job_type: full
           trigger_method: on_demand
+
   - set: { id: sync-job-id-to-check-in }
+
+  - do:
+      connector_sync_job.get:
+        connector_sync_job_id: $sync-job-id-to-check-in
+
+  - set: { last_seen: last_seen_before_check_in }
+
   - do:
       connector_sync_job.check_in:
         connector_sync_job_id: $sync-job-id-to-check-in
 
   - match: { acknowledged: true }
 
+  - do:
+      connector_sync_job.get:
+        connector_sync_job_id: $sync-job-id-to-check-in
+
+  - is_after: { last_seen: $last_seen_before_check_in }
 
 ---
 "Check in a Connector Sync Job - Connector Sync Job does not exist":


### PR DESCRIPTION
Verify that `last_seen` after a check-in is after `last_seen` before a check-in in the integration test.