### PR TITLE
[8.12] More logging for ClusterHealthRestCancellationIT (#103193)

### DIFF
--- a/qa/smoke-test-http/src/javaRestTest/java/org/elasticsearch/http/ClusterHealthRestCancellationIT.java
+++ b/qa/smoke-test-http/src/javaRestTest/java/org/elasticsearch/http/ClusterHealthRestCancellationIT.java
@@ -33,6 +33,8 @@ public class ClusterHealthRestCancellationIT extends HttpSmokeTestCase {
     @TestIssueLogging(
         issueUrl = "https://github.com/elastic/elasticsearch/issues/100062",
         value = "org.elasticsearch.test.TaskAssertions:TRACE"
+            + ",org.elasticsearch.cluster.service.MasterService:TRACE"
+            + ",org.elasticsearch.tasks.TaskManager:TRACE"
     )
     public void testClusterHealthRestCancellation() throws Exception {
 


### PR DESCRIPTION
Backports the following commits to 8.12:
 - More logging for ClusterHealthRestCancellationIT (#103193)