### PR TITLE
[8.8] Add docs for the include_named_queries_score param (#103155)

### DIFF
--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -113,6 +113,13 @@ By default, you cannot page through more than 10,000 hits using the `from` and
 (Optional, Boolean) If `true`, concrete, expanded or aliased indices will be
 ignored when frozen. Defaults to `true`.
 
+`include_named_queries_score`::
+(Optional, Boolean) If `true`, includes the score contribution from any named queries.
+This functionality reruns each named query on every hit in a search
+response. Typically, this adds a small overhead to a request. However, using
+computationally expensive named queries on a large number of hits may add
+significant overhead. Defaults to `false`.
+
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=lenient]


### PR DESCRIPTION
Backports the following commits to 8.8:
 - Add docs for the include_named_queries_score param (#103155)