### PR TITLE
Wrap painless explain error (#103151)

### DIFF
--- a/docs/changelog/103151.yaml
+++ b/docs/changelog/103151.yaml
@@ -1,0 +1,6 @@
+pr: 103151
+summary: Wrap painless explain error
+area: Infra/Scripting
+type: bug
+issues:
+ - 103018

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/ErrorCauseWrapper.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/ErrorCauseWrapper.java
@@ -23,6 +23,7 @@ class ErrorCauseWrapper extends ElasticsearchException {
 
     private static final List<Class<? extends Error>> wrappedErrors = org.elasticsearch.core.List.of(
         PainlessError.class,
+        PainlessExplainError.class,
         OutOfMemoryError.class,
         StackOverflowError.class,
         LinkageError.class


### PR DESCRIPTION
In https://github.com/elastic/elasticsearch/pull/100872 Painless errors were wrapped so as to avoid throwing Errors outside scripting. However, one case was missed: PainlessExplainError which is used by Debug.explain. This commit adds the explain error to those that painless wraps.

closes #103018