### PR TITLE
Fix all SearchResponse leaks in x-pack security

### DIFF
--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DateMathExpressionIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DateMathExpressionIntegTests.java
@@ -10,7 +10,6 @@ import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.get.MultiGetResponse;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.client.internal.Client;
@@ -25,6 +24,7 @@ import java.util.Collections;
 
 import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
 import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.NONE;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.basicAuthHeaderValue;
 import static org.hamcrest.Matchers.containsString;
@@ -77,8 +77,7 @@ public class DateMathExpressionIntegTests extends SecurityIntegTestCase {
         if (refeshOnOperation == false) {
             client.admin().indices().prepareRefresh(expression).get();
         }
-        SearchResponse searchResponse = client.prepareSearch(expression).setQuery(QueryBuilders.matchAllQuery()).get();
-        assertThat(searchResponse.getHits().getTotalHits().value, is(1L));
+        assertHitCount(client.prepareSearch(expression).setQuery(QueryBuilders.matchAllQuery()), 1);
 
         assertResponse(
             client.prepareMultiSearch().add(client.prepareSearch(expression).setQuery(QueryBuilders.matchAllQuery()).request()),

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DlsFlsRequestCacheTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DlsFlsRequestCacheTests.java
@@ -11,7 +11,7 @@ import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.action.admin.indices.forcemerge.ForceMergeResponse;
 import org.elasticsearch.action.admin.indices.refresh.RefreshResponse;
-import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.SecureString;
@@ -191,31 +191,31 @@ public class DlsFlsRequestCacheTests extends SecuritySingleNodeTestCase {
         final Client limitedClient = limitedClient();
 
         // Search first with power client, it should see all docs
-        assertSearchResponse(powerClient.prepareSearch(DLS_INDEX).setRequestCache(true).get(), Set.of("101", "102"));
+        assertSearchResponse(powerClient.prepareSearch(DLS_INDEX).setRequestCache(true), Set.of("101", "102"));
         assertCacheState(DLS_INDEX, 0, 1);
 
         // Search with the limited client and it should see only one doc (i.e. it won't use cache entry for power client)
-        assertSearchResponse(limitedClient.prepareSearch(DLS_INDEX).setRequestCache(true).get(), Set.of("101"));
+        assertSearchResponse(limitedClient.prepareSearch(DLS_INDEX).setRequestCache(true), Set.of("101"));
         assertCacheState(DLS_INDEX, 0, 2);
 
         // Execute the above search again and it should use the cache entry for limited client
-        assertSearchResponse(limitedClient.prepareSearch(DLS_INDEX).setRequestCache(true).get(), Set.of("101"));
+        assertSearchResponse(limitedClient.prepareSearch(DLS_INDEX).setRequestCache(true), Set.of("101"));
         assertCacheState(DLS_INDEX, 1, 2);
 
         // Execute the search with power client again and it should still see all docs
-        assertSearchResponse(powerClient.prepareSearch(DLS_INDEX).setRequestCache(true).get(), Set.of("101", "102"));
+        assertSearchResponse(powerClient.prepareSearch(DLS_INDEX).setRequestCache(true), Set.of("101", "102"));
         assertCacheState(DLS_INDEX, 2, 2);
 
         // The limited client has a different DLS query for dls-alias compared to the underlying dls-index
-        assertSearchResponse(limitedClient.prepareSearch(DLS_ALIAS).setRequestCache(true).get(), Set.of("102"));
+        assertSearchResponse(limitedClient.prepareSearch(DLS_ALIAS).setRequestCache(true), Set.of("102"));
         assertCacheState(DLS_INDEX, 2, 3);
-        assertSearchResponse(limitedClient.prepareSearch(DLS_ALIAS).setRequestCache(true).get(), Set.of("102"));
+        assertSearchResponse(limitedClient.prepareSearch(DLS_ALIAS).setRequestCache(true), Set.of("102"));
         assertCacheState(DLS_INDEX, 3, 3);
 
         // Search with limited client for dls-alias and dls-index returns all docs. The cache entry is however different
         // from the power client, i.e. still no sharing even if the end results are the same. This is because the
         // search with limited client still have DLS queries attached to it.
-        assertSearchResponse(limitedClient.prepareSearch(DLS_ALIAS, DLS_INDEX).setRequestCache(true).get(), Set.of("101", "102"));
+        assertSearchResponse(limitedClient.prepareSearch(DLS_ALIAS, DLS_INDEX).setRequestCache(true), Set.of("101", "102"));
         assertCacheState(DLS_INDEX, 3, 4);
     }
 
@@ -224,37 +224,29 @@ public class DlsFlsRequestCacheTests extends SecuritySingleNodeTestCase {
         final Client limitedClient = limitedClient();
 
         // Search first with power client, it should see all fields
-        assertSearchResponse(
-            powerClient.prepareSearch(FLS_INDEX).setRequestCache(true).get(),
-            Set.of("201", "202"),
-            Set.of("public", "private")
-        );
+        assertSearchResponse(powerClient.prepareSearch(FLS_INDEX).setRequestCache(true), Set.of("201", "202"), Set.of("public", "private"));
         assertCacheState(FLS_INDEX, 0, 1);
 
         // Search with limited client and it should see only public field
-        assertSearchResponse(limitedClient.prepareSearch(FLS_INDEX).setRequestCache(true).get(), Set.of("201", "202"), Set.of("public"));
+        assertSearchResponse(limitedClient.prepareSearch(FLS_INDEX).setRequestCache(true), Set.of("201", "202"), Set.of("public"));
         assertCacheState(FLS_INDEX, 0, 2);
 
         // Search with limited client again and it should use the cache
-        assertSearchResponse(limitedClient.prepareSearch(FLS_INDEX).setRequestCache(true).get(), Set.of("201", "202"), Set.of("public"));
+        assertSearchResponse(limitedClient.prepareSearch(FLS_INDEX).setRequestCache(true), Set.of("201", "202"), Set.of("public"));
         assertCacheState(FLS_INDEX, 1, 2);
 
         // Search again with power client, it should use its own cache entry
-        assertSearchResponse(
-            powerClient.prepareSearch(FLS_INDEX).setRequestCache(true).get(),
-            Set.of("201", "202"),
-            Set.of("public", "private")
-        );
+        assertSearchResponse(powerClient.prepareSearch(FLS_INDEX).setRequestCache(true), Set.of("201", "202"), Set.of("public", "private"));
         assertCacheState(FLS_INDEX, 2, 2);
 
         // The fls-alias has a different FLS definition compared to its underlying fls-index.
-        assertSearchResponse(limitedClient.prepareSearch(FLS_ALIAS).setRequestCache(true).get(), Set.of("201", "202"), Set.of("private"));
+        assertSearchResponse(limitedClient.prepareSearch(FLS_ALIAS).setRequestCache(true), Set.of("201", "202"), Set.of("private"));
         assertCacheState(FLS_INDEX, 2, 3);
 
         // Search with the limited client for both fls-alias and fls-index and all docs and fields are also returned.
         // But request cache is not shared with the power client because it still has a different indexAccessControl
         assertSearchResponse(
-            limitedClient.prepareSearch(FLS_ALIAS, FLS_INDEX).setRequestCache(true).get(),
+            limitedClient.prepareSearch(FLS_ALIAS, FLS_INDEX).setRequestCache(true),
             Set.of("201", "202"),
             Set.of("public", "private")
         );
@@ -267,7 +259,7 @@ public class DlsFlsRequestCacheTests extends SecuritySingleNodeTestCase {
 
         // Search first with power client, it should see all fields
         assertSearchResponse(
-            powerClient.prepareSearch(INDEX).setRequestCache(true).get(),
+            powerClient.prepareSearch(INDEX).setRequestCache(true),
             Set.of("1", "2"),
             Set.of("number", "letter", "public", "private")
         );
@@ -278,25 +270,17 @@ public class DlsFlsRequestCacheTests extends SecuritySingleNodeTestCase {
         expectThrows(ElasticsearchSecurityException.class, () -> limitedClient.prepareSearch(INDEX).setRequestCache(true).get());
 
         // Search for alias1 that points to index and has DLS/FLS
-        assertSearchResponse(
-            limitedClient.prepareSearch(ALIAS1).setRequestCache(true).get(),
-            Set.of("1"),
-            Set.of("number", "letter", "public")
-        );
+        assertSearchResponse(limitedClient.prepareSearch(ALIAS1).setRequestCache(true), Set.of("1"), Set.of("number", "letter", "public"));
         assertCacheState(INDEX, 0, 2);
 
         // Search for alias2 that also points to index but has a different set of DLS/FLS
-        assertSearchResponse(
-            limitedClient.prepareSearch(ALIAS2).setRequestCache(true).get(),
-            Set.of("2"),
-            Set.of("number", "letter", "private")
-        );
+        assertSearchResponse(limitedClient.prepareSearch(ALIAS2).setRequestCache(true), Set.of("2"), Set.of("number", "letter", "private"));
         assertCacheState(INDEX, 0, 3);
 
         // Search for all-alias that has full read access to the underlying index
         // This makes it share the cache entry of the power client
         assertSearchResponse(
-            limitedClient.prepareSearch(ALL_ALIAS).setRequestCache(true).get(),
+            limitedClient.prepareSearch(ALL_ALIAS).setRequestCache(true),
             Set.of("1", "2"),
             Set.of("number", "letter", "public", "private")
         );
@@ -305,7 +289,7 @@ public class DlsFlsRequestCacheTests extends SecuritySingleNodeTestCase {
         // Similarly, search for alias1 and all-alias results in full read access to the index
         // and again reuse the cache entry of the power client
         assertSearchResponse(
-            limitedClient.prepareSearch(ALIAS1, ALL_ALIAS).setRequestCache(true).get(),
+            limitedClient.prepareSearch(ALIAS1, ALL_ALIAS).setRequestCache(true),
             Set.of("1", "2"),
             Set.of("number", "letter", "public", "private")
         );
@@ -314,7 +298,7 @@ public class DlsFlsRequestCacheTests extends SecuritySingleNodeTestCase {
         // Though search for both alias1 and alias2 is effectively full read access to index,
         // it does not share the cache entry of the power client because role queries still exist.
         assertSearchResponse(
-            limitedClient.prepareSearch(ALIAS1, ALIAS2).setRequestCache(true).get(),
+            limitedClient.prepareSearch(ALIAS1, ALIAS2).setRequestCache(true),
             Set.of("1", "2"),
             Set.of("number", "letter", "public", "private")
         );
@@ -325,7 +309,7 @@ public class DlsFlsRequestCacheTests extends SecuritySingleNodeTestCase {
 
         // It should not reuse any entries from the cache
         assertSearchResponse(
-            limitedClientApiKey.prepareSearch(ALL_ALIAS).setRequestCache(true).get(),
+            limitedClientApiKey.prepareSearch(ALL_ALIAS).setRequestCache(true),
             Set.of("1"),
             Set.of("letter", "public", "private")
         );
@@ -341,43 +325,23 @@ public class DlsFlsRequestCacheTests extends SecuritySingleNodeTestCase {
         );
 
         // Search first with user1 and only one document will be return with the corresponding username
-        assertSearchResponse(
-            client1.prepareSearch(DLS_TEMPLATE_ROLE_QUERY_INDEX).setRequestCache(true).get(),
-            Set.of("1"),
-            Set.of("username")
-        );
+        assertSearchResponse(client1.prepareSearch(DLS_TEMPLATE_ROLE_QUERY_INDEX).setRequestCache(true), Set.of("1"), Set.of("username"));
         assertCacheState(DLS_TEMPLATE_ROLE_QUERY_INDEX, 0, 1);
 
         // Search with user2 will not use user1's cache because template query is resolved differently for them
-        assertSearchResponse(
-            client2.prepareSearch(DLS_TEMPLATE_ROLE_QUERY_INDEX).setRequestCache(true).get(),
-            Set.of("2"),
-            Set.of("username")
-        );
+        assertSearchResponse(client2.prepareSearch(DLS_TEMPLATE_ROLE_QUERY_INDEX).setRequestCache(true), Set.of("2"), Set.of("username"));
         assertCacheState(DLS_TEMPLATE_ROLE_QUERY_INDEX, 0, 2);
 
         // Search with user1 again will use user1's cache
-        assertSearchResponse(
-            client1.prepareSearch(DLS_TEMPLATE_ROLE_QUERY_INDEX).setRequestCache(true).get(),
-            Set.of("1"),
-            Set.of("username")
-        );
+        assertSearchResponse(client1.prepareSearch(DLS_TEMPLATE_ROLE_QUERY_INDEX).setRequestCache(true), Set.of("1"), Set.of("username"));
         assertCacheState(DLS_TEMPLATE_ROLE_QUERY_INDEX, 1, 2);
 
         // Search with user2 again will use user2's cache
-        assertSearchResponse(
-            client2.prepareSearch(DLS_TEMPLATE_ROLE_QUERY_INDEX).setRequestCache(true).get(),
-            Set.of("2"),
-            Set.of("username")
-        );
+        assertSearchResponse(client2.prepareSearch(DLS_TEMPLATE_ROLE_QUERY_INDEX).setRequestCache(true), Set.of("2"), Set.of("username"));
         assertCacheState(DLS_TEMPLATE_ROLE_QUERY_INDEX, 2, 2);
 
         // Since the DLS for the alias uses a stored script, this should cause the request cached to be disabled
-        assertSearchResponse(
-            client1.prepareSearch(DLS_TEMPLATE_ROLE_QUERY_ALIAS).setRequestCache(true).get(),
-            Set.of("1"),
-            Set.of("username")
-        );
+        assertSearchResponse(client1.prepareSearch(DLS_TEMPLATE_ROLE_QUERY_ALIAS).setRequestCache(true), Set.of("1"), Set.of("username"));
         // No cache should be used
         assertCacheState(DLS_TEMPLATE_ROLE_QUERY_INDEX, 2, 2);
     }
@@ -455,19 +419,24 @@ public class DlsFlsRequestCacheTests extends SecuritySingleNodeTestCase {
         return client().filterWithHeader(Map.of("Authorization", "ApiKey " + base64ApiKey));
     }
 
-    private void assertSearchResponse(SearchResponse searchResponse, Set<String> docIds) {
-        assertSearchResponse(searchResponse, docIds, null);
+    private void assertSearchResponse(SearchRequestBuilder requestBuilder, Set<String> docIds) {
+        assertSearchResponse(requestBuilder, docIds, null);
     }
 
-    private void assertSearchResponse(SearchResponse searchResponse, Set<String> docIds, Set<String> fieldNames) {
-        assertThat(searchResponse.getFailedShards(), equalTo(0));
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo((long) docIds.size()));
-        final SearchHit[] hits = searchResponse.getHits().getHits();
-        assertThat(Arrays.stream(hits).map(SearchHit::getId).collect(Collectors.toUnmodifiableSet()), equalTo(docIds));
-        if (fieldNames != null) {
-            for (SearchHit hit : hits) {
-                assertThat(hit.getSourceAsMap().keySet(), equalTo(fieldNames));
+    private void assertSearchResponse(SearchRequestBuilder requestBuilder, Set<String> docIds, Set<String> fieldNames) {
+        var searchResponse = requestBuilder.get();
+        try {
+            assertThat(searchResponse.getFailedShards(), equalTo(0));
+            assertThat(searchResponse.getHits().getTotalHits().value, equalTo((long) docIds.size()));
+            final SearchHit[] hits = searchResponse.getHits().getHits();
+            assertThat(Arrays.stream(hits).map(SearchHit::getId).collect(Collectors.toUnmodifiableSet()), equalTo(docIds));
+            if (fieldNames != null) {
+                for (SearchHit hit : hits) {
+                    assertThat(hit.getSourceAsMap().keySet(), equalTo(fieldNames));
+                }
             }
+        } finally {
+            searchResponse.decRef();
         }
     }
 

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DocumentAndFieldLevelSecurityTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DocumentAndFieldLevelSecurityTests.java
@@ -14,7 +14,6 @@ import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.fieldcaps.FieldCapabilities;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesRequest;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.internal.Requests;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.common.settings.SecureString;
@@ -35,6 +34,7 @@ import java.util.Map;
 import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSearchHits;
 import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.BASIC_AUTH_HEADER;
 import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.basicAuthHeaderValue;
@@ -113,32 +113,41 @@ public class DocumentAndFieldLevelSecurityTests extends SecurityIntegTestCase {
         prepareIndex("test").setId("1").setSource("id", "1", "field1", "value1").setRefreshPolicy(IMMEDIATE).get();
         prepareIndex("test").setId("2").setSource("id", "2", "field2", "value2").setRefreshPolicy(IMMEDIATE).get();
 
-        SearchResponse response = client().filterWithHeader(
-            Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD))
-        ).prepareSearch("test").get();
-        assertHitCount(response, 1);
-        assertSearchHits(response, "1");
-        assertThat(response.getHits().getAt(0).getSourceAsMap().size(), equalTo(2));
-        assertThat(response.getHits().getAt(0).getSourceAsMap().get("field1").toString(), equalTo("value1"));
-        assertThat(response.getHits().getAt(0).getSourceAsMap().get("id").toString(), equalTo("1"));
+        assertResponse(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
+                .prepareSearch("test"),
+            response -> {
+                assertHitCount(response, 1);
+                assertSearchHits(response, "1");
+                assertThat(response.getHits().getAt(0).getSourceAsMap().size(), equalTo(2));
+                assertThat(response.getHits().getAt(0).getSourceAsMap().get("field1").toString(), equalTo("value1"));
+                assertThat(response.getHits().getAt(0).getSourceAsMap().get("id").toString(), equalTo("1"));
+            }
+        );
 
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2", USERS_PASSWD)))
-            .prepareSearch("test")
-            .get();
-        assertHitCount(response, 1);
-        assertSearchHits(response, "2");
-        assertThat(response.getHits().getAt(0).getSourceAsMap().size(), equalTo(2));
-        assertThat(response.getHits().getAt(0).getSourceAsMap().get("field2").toString(), equalTo("value2"));
-        assertThat(response.getHits().getAt(0).getSourceAsMap().get("id").toString(), equalTo("2"));
+        assertResponse(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2", USERS_PASSWD)))
+                .prepareSearch("test"),
+            response -> {
+                assertHitCount(response, 1);
+                assertSearchHits(response, "2");
+                assertThat(response.getHits().getAt(0).getSourceAsMap().size(), equalTo(2));
+                assertThat(response.getHits().getAt(0).getSourceAsMap().get("field2").toString(), equalTo("value2"));
+                assertThat(response.getHits().getAt(0).getSourceAsMap().get("id").toString(), equalTo("2"));
+            }
+        );
 
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user4", USERS_PASSWD)))
-            .prepareSearch("test")
-            .addSort("id", SortOrder.ASC)
-            .get();
-        assertHitCount(response, 2);
-        assertSearchHits(response, "1", "2");
-        assertThat(response.getHits().getAt(0).getSourceAsMap().get("field1").toString(), equalTo("value1"));
-        assertThat(response.getHits().getAt(1).getSourceAsMap().get("field2").toString(), equalTo("value2"));
+        assertResponse(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user4", USERS_PASSWD)))
+                .prepareSearch("test")
+                .addSort("id", SortOrder.ASC),
+            response -> {
+                assertHitCount(response, 2);
+                assertSearchHits(response, "1", "2");
+                assertThat(response.getHits().getAt(0).getSourceAsMap().get("field1").toString(), equalTo("value1"));
+                assertThat(response.getHits().getAt(1).getSourceAsMap().get("field2").toString(), equalTo("value2"));
+            }
+        );
     }
 
     public void testUpdatesAreRejected() {
@@ -181,13 +190,17 @@ public class DocumentAndFieldLevelSecurityTests extends SecurityIntegTestCase {
         prepareIndex("test").setId("1").setSource("field1", "value1", "field2", "value1").setRefreshPolicy(IMMEDIATE).get();
         prepareIndex("test").setId("2").setSource("field1", "value2", "field2", "value2").setRefreshPolicy(IMMEDIATE).get();
 
-        SearchResponse response = client().filterWithHeader(
-            Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user5", USERS_PASSWD))
-        ).prepareSearch("test").setQuery(QueryBuilders.termQuery("field1", "value2")).get();
-        assertHitCount(response, 1);
-        assertSearchHits(response, "2");
-        assertThat(response.getHits().getAt(0).getSourceAsMap().size(), equalTo(1));
-        assertThat(response.getHits().getAt(0).getSourceAsMap().get("field1").toString(), equalTo("value2"));
+        assertResponse(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user5", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(QueryBuilders.termQuery("field1", "value2")),
+            response -> {
+                assertHitCount(response, 1);
+                assertSearchHits(response, "2");
+                assertThat(response.getHits().getAt(0).getSourceAsMap().size(), equalTo(1));
+                assertThat(response.getHits().getAt(0).getSourceAsMap().get("field1").toString(), equalTo("value2"));
+            }
+        );
 
         assertHitCount(
             client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user5", USERS_PASSWD)))
@@ -209,48 +222,60 @@ public class DocumentAndFieldLevelSecurityTests extends SecurityIntegTestCase {
         // Both users have the same role query, but user3 has access to field2 and not field1, which should result in zero hits:
         int max = scaledRandomIntBetween(4, 32);
         for (int i = 0; i < max; i++) {
-            SearchResponse response = client().filterWithHeader(
-                Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD))
-            ).prepareSearch("test").get();
-            assertHitCount(response, 1);
-            assertThat(response.getHits().getAt(0).getId(), equalTo("1"));
-            assertThat(response.getHits().getAt(0).getSourceAsMap().size(), equalTo(2));
-            assertThat(response.getHits().getAt(0).getSourceAsMap().get("field1"), equalTo("value1"));
-            assertThat(response.getHits().getAt(0).getSourceAsMap().get("id"), equalTo("1"));
-            response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2", USERS_PASSWD)))
-                .prepareSearch("test")
-                .get();
-            assertHitCount(response, 1);
-            assertThat(response.getHits().getAt(0).getId(), equalTo("2"));
-            assertThat(response.getHits().getAt(0).getSourceAsMap().size(), equalTo(2));
-            assertThat(response.getHits().getAt(0).getSourceAsMap().get("field2"), equalTo("value2"));
-            assertThat(response.getHits().getAt(0).getSourceAsMap().get("id"), equalTo("2"));
+            assertResponse(
+                client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
+                    .prepareSearch("test"),
+                response -> {
+                    assertHitCount(response, 1);
+                    assertThat(response.getHits().getAt(0).getId(), equalTo("1"));
+                    assertThat(response.getHits().getAt(0).getSourceAsMap().size(), equalTo(2));
+                    assertThat(response.getHits().getAt(0).getSourceAsMap().get("field1"), equalTo("value1"));
+                    assertThat(response.getHits().getAt(0).getSourceAsMap().get("id"), equalTo("1"));
+                }
+            );
+            assertResponse(
+                client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2", USERS_PASSWD)))
+                    .prepareSearch("test"),
+                response -> {
+                    assertHitCount(response, 1);
+                    assertThat(response.getHits().getAt(0).getId(), equalTo("2"));
+                    assertThat(response.getHits().getAt(0).getSourceAsMap().size(), equalTo(2));
+                    assertThat(response.getHits().getAt(0).getSourceAsMap().get("field2"), equalTo("value2"));
+                    assertThat(response.getHits().getAt(0).getSourceAsMap().get("id"), equalTo("2"));
+                }
+            );
 
             // this is a bit weird the document level permission (all docs with field2:value2) don't match with the field level
             // permissions (field1),
             // this results in document 2 being returned but no fields are visible:
-            response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user3", USERS_PASSWD)))
-                .prepareSearch("test")
-                .get();
-            assertHitCount(response, 1);
-            assertThat(response.getHits().getAt(0).getId(), equalTo("2"));
-            assertThat(response.getHits().getAt(0).getSourceAsMap().size(), equalTo(1));
-            assertThat(response.getHits().getAt(0).getSourceAsMap().get("id"), equalTo("2"));
+            assertResponse(
+                client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user3", USERS_PASSWD)))
+                    .prepareSearch("test"),
+                response -> {
+                    assertHitCount(response, 1);
+                    assertThat(response.getHits().getAt(0).getId(), equalTo("2"));
+                    assertThat(response.getHits().getAt(0).getSourceAsMap().size(), equalTo(1));
+                    assertThat(response.getHits().getAt(0).getSourceAsMap().get("id"), equalTo("2"));
+                }
+            );
 
             // user4 has all roles
-            response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user4", USERS_PASSWD)))
-                .prepareSearch("test")
-                .addSort("id", SortOrder.ASC)
-                .get();
-            assertHitCount(response, 2);
-            assertThat(response.getHits().getAt(0).getId(), equalTo("1"));
-            assertThat(response.getHits().getAt(0).getSourceAsMap().size(), equalTo(2));
-            assertThat(response.getHits().getAt(0).getSourceAsMap().get("field1"), equalTo("value1"));
-            assertThat(response.getHits().getAt(0).getSourceAsMap().get("id"), equalTo("1"));
-            assertThat(response.getHits().getAt(1).getId(), equalTo("2"));
-            assertThat(response.getHits().getAt(1).getSourceAsMap().size(), equalTo(2));
-            assertThat(response.getHits().getAt(1).getSourceAsMap().get("field2"), equalTo("value2"));
-            assertThat(response.getHits().getAt(1).getSourceAsMap().get("id"), equalTo("2"));
+            assertResponse(
+                client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user4", USERS_PASSWD)))
+                    .prepareSearch("test")
+                    .addSort("id", SortOrder.ASC),
+                response -> {
+                    assertHitCount(response, 2);
+                    assertThat(response.getHits().getAt(0).getId(), equalTo("1"));
+                    assertThat(response.getHits().getAt(0).getSourceAsMap().size(), equalTo(2));
+                    assertThat(response.getHits().getAt(0).getSourceAsMap().get("field1"), equalTo("value1"));
+                    assertThat(response.getHits().getAt(0).getSourceAsMap().get("id"), equalTo("1"));
+                    assertThat(response.getHits().getAt(1).getId(), equalTo("2"));
+                    assertThat(response.getHits().getAt(1).getSourceAsMap().size(), equalTo(2));
+                    assertThat(response.getHits().getAt(1).getSourceAsMap().get("field2"), equalTo("value2"));
+                    assertThat(response.getHits().getAt(1).getSourceAsMap().get("id"), equalTo("2"));
+                }
+            );
         }
     }
 

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DocumentLevelSecurityRandomTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DocumentLevelSecurityRandomTests.java
@@ -8,7 +8,6 @@ package org.elasticsearch.integration;
 
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequestBuilder;
 import org.elasticsearch.action.index.IndexRequestBuilder;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -21,6 +20,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.BASIC_AUTH_HEADER;
 import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.basicAuthHeaderValue;
 import static org.hamcrest.Matchers.equalTo;
@@ -105,14 +105,17 @@ public class DocumentLevelSecurityRandomTests extends SecurityIntegTestCase {
         builder.get();
 
         for (int roleI = 1; roleI <= numberOfRoles; roleI++) {
-            SearchResponse searchResponse1 = client().filterWithHeader(
-                Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user" + roleI, USERS_PASSWD))
-            ).prepareSearch("test").get();
-            SearchResponse searchResponse2 = prepareSearch("alias" + roleI).get();
-            assertThat(searchResponse1.getHits().getTotalHits().value, equalTo(searchResponse2.getHits().getTotalHits().value));
-            for (int hitI = 0; hitI < searchResponse1.getHits().getHits().length; hitI++) {
-                assertThat(searchResponse1.getHits().getAt(hitI).getId(), equalTo(searchResponse2.getHits().getAt(hitI).getId()));
-            }
+            final int role = roleI;
+            assertResponse(
+                client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user" + roleI, USERS_PASSWD)))
+                    .prepareSearch("test"),
+                searchResponse1 -> assertResponse(prepareSearch("alias" + role), searchResponse2 -> {
+                    assertThat(searchResponse1.getHits().getTotalHits().value, equalTo(searchResponse2.getHits().getTotalHits().value));
+                    for (int hitI = 0; hitI < searchResponse1.getHits().getHits().length; hitI++) {
+                        assertThat(searchResponse1.getHits().getAt(hitI).getId(), equalTo(searchResponse2.getHits().getAt(hitI).getId()));
+                    }
+                })
+            );
         }
     }
 

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/FieldLevelSecurityRandomTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/FieldLevelSecurityRandomTests.java
@@ -7,7 +7,6 @@
 package org.elasticsearch.integration;
 
 import org.elasticsearch.action.index.IndexRequestBuilder;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Strings;
@@ -29,6 +28,7 @@ import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDI
 import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.BASIC_AUTH_HEADER;
 import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.basicAuthHeaderValue;
 import static org.hamcrest.Matchers.equalTo;
@@ -194,64 +194,74 @@ public class FieldLevelSecurityRandomTests extends SecurityIntegTestCase {
         }
         indexRandom(true, requests);
 
-        SearchResponse actual = client().filterWithHeader(
-            Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2", USERS_PASSWD))
-        )
-            .prepareSearch("test")
-            .addSort("id", SortOrder.ASC)
-            .setQuery(
-                QueryBuilders.boolQuery()
-                    .should(QueryBuilders.termQuery("field1", "value"))
-                    .should(QueryBuilders.termQuery("field2", "value"))
-                    .should(QueryBuilders.termQuery("field3", "value"))
+        assertResponse(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user2", USERS_PASSWD)))
+                .prepareSearch("test")
+                .addSort("id", SortOrder.ASC)
+                .setQuery(
+                    QueryBuilders.boolQuery()
+                        .should(QueryBuilders.termQuery("field1", "value"))
+                        .should(QueryBuilders.termQuery("field2", "value"))
+                        .should(QueryBuilders.termQuery("field3", "value"))
+                ),
+            actual -> assertResponse(
+                prepareSearch("test").addSort("id", SortOrder.ASC)
+                    .setQuery(QueryBuilders.boolQuery().should(QueryBuilders.termQuery("field1", "value"))),
+                expected -> {
+                    assertThat(actual.getHits().getTotalHits().value, equalTo(expected.getHits().getTotalHits().value));
+                    assertThat(actual.getHits().getHits().length, equalTo(expected.getHits().getHits().length));
+                    for (int i = 0; i < actual.getHits().getHits().length; i++) {
+                        assertThat(actual.getHits().getAt(i).getId(), equalTo(expected.getHits().getAt(i).getId()));
+                    }
+                }
             )
-            .get();
-        SearchResponse expected = prepareSearch("test").addSort("id", SortOrder.ASC)
-            .setQuery(QueryBuilders.boolQuery().should(QueryBuilders.termQuery("field1", "value")))
-            .get();
-        assertThat(actual.getHits().getTotalHits().value, equalTo(expected.getHits().getTotalHits().value));
-        assertThat(actual.getHits().getHits().length, equalTo(expected.getHits().getHits().length));
-        for (int i = 0; i < actual.getHits().getHits().length; i++) {
-            assertThat(actual.getHits().getAt(i).getId(), equalTo(expected.getHits().getAt(i).getId()));
-        }
+        );
 
-        actual = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user3", USERS_PASSWD)))
-            .prepareSearch("test")
-            .addSort("id", SortOrder.ASC)
-            .setQuery(
-                QueryBuilders.boolQuery()
-                    .should(QueryBuilders.termQuery("field1", "value"))
-                    .should(QueryBuilders.termQuery("field2", "value"))
-                    .should(QueryBuilders.termQuery("field3", "value"))
+        assertResponse(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user3", USERS_PASSWD)))
+                .prepareSearch("test")
+                .addSort("id", SortOrder.ASC)
+                .setQuery(
+                    QueryBuilders.boolQuery()
+                        .should(QueryBuilders.termQuery("field1", "value"))
+                        .should(QueryBuilders.termQuery("field2", "value"))
+                        .should(QueryBuilders.termQuery("field3", "value"))
+                ),
+            actual -> assertResponse(
+                prepareSearch("test").addSort("id", SortOrder.ASC)
+                    .setQuery(QueryBuilders.boolQuery().should(QueryBuilders.termQuery("field2", "value"))),
+                expected -> {
+                    assertThat(actual.getHits().getTotalHits().value, equalTo(expected.getHits().getTotalHits().value));
+                    assertThat(actual.getHits().getHits().length, equalTo(expected.getHits().getHits().length));
+                    for (int i = 0; i < actual.getHits().getHits().length; i++) {
+                        assertThat(actual.getHits().getAt(i).getId(), equalTo(expected.getHits().getAt(i).getId()));
+                    }
+                }
             )
-            .get();
-        expected = prepareSearch("test").addSort("id", SortOrder.ASC)
-            .setQuery(QueryBuilders.boolQuery().should(QueryBuilders.termQuery("field2", "value")))
-            .get();
-        assertThat(actual.getHits().getTotalHits().value, equalTo(expected.getHits().getTotalHits().value));
-        assertThat(actual.getHits().getHits().length, equalTo(expected.getHits().getHits().length));
-        for (int i = 0; i < actual.getHits().getHits().length; i++) {
-            assertThat(actual.getHits().getAt(i).getId(), equalTo(expected.getHits().getAt(i).getId()));
-        }
+        );
 
-        actual = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user4", USERS_PASSWD)))
-            .prepareSearch("test")
-            .addSort("id", SortOrder.ASC)
-            .setQuery(
-                QueryBuilders.boolQuery()
-                    .should(QueryBuilders.termQuery("field1", "value"))
-                    .should(QueryBuilders.termQuery("field2", "value"))
-                    .should(QueryBuilders.termQuery("field3", "value"))
+        assertResponse(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user4", USERS_PASSWD)))
+                .prepareSearch("test")
+                .addSort("id", SortOrder.ASC)
+                .setQuery(
+                    QueryBuilders.boolQuery()
+                        .should(QueryBuilders.termQuery("field1", "value"))
+                        .should(QueryBuilders.termQuery("field2", "value"))
+                        .should(QueryBuilders.termQuery("field3", "value"))
+                ),
+            actual -> assertResponse(
+                prepareSearch("test").addSort("id", SortOrder.ASC)
+                    .setQuery(QueryBuilders.boolQuery().should(QueryBuilders.termQuery("field3", "value"))),
+                expected -> {
+                    assertThat(actual.getHits().getTotalHits().value, equalTo(expected.getHits().getTotalHits().value));
+                    assertThat(actual.getHits().getHits().length, equalTo(expected.getHits().getHits().length));
+                    for (int i = 0; i < actual.getHits().getHits().length; i++) {
+                        assertThat(actual.getHits().getAt(i).getId(), equalTo(expected.getHits().getAt(i).getId()));
+                    }
+                }
             )
-            .get();
-        expected = prepareSearch("test").addSort("id", SortOrder.ASC)
-            .setQuery(QueryBuilders.boolQuery().should(QueryBuilders.termQuery("field3", "value")))
-            .get();
-        assertThat(actual.getHits().getTotalHits().value, equalTo(expected.getHits().getTotalHits().value));
-        assertThat(actual.getHits().getHits().length, equalTo(expected.getHits().getHits().length));
-        for (int i = 0; i < actual.getHits().getHits().length; i++) {
-            assertThat(actual.getHits().getAt(i).getId(), equalTo(expected.getHits().getAt(i).getId()));
-        }
+        );
     }
 
 }

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/IndicesPermissionsWithAliasesWildcardsAndRegexsTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/IndicesPermissionsWithAliasesWildcardsAndRegexsTests.java
@@ -11,7 +11,6 @@ import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
 import org.elasticsearch.action.admin.indices.template.put.PutComposableIndexTemplateAction;
 import org.elasticsearch.action.datastreams.CreateDataStreamAction;
 import org.elasticsearch.action.get.GetResponse;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.Template;
 import org.elasticsearch.common.settings.SecureString;
@@ -35,6 +34,7 @@ import java.util.Map;
 import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
 import static org.elasticsearch.cluster.metadata.MetadataIndexTemplateService.DEFAULT_TIMESTAMP_FIELD;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.BASIC_AUTH_HEADER;
 import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.basicAuthHeaderValue;
 import static org.hamcrest.Matchers.equalTo;
@@ -134,52 +134,67 @@ public class IndicesPermissionsWithAliasesWildcardsAndRegexsTests extends Securi
             .setRefreshPolicy(IMMEDIATE)
             .get();
 
-        SearchResponse response = client().filterWithHeader(
-            Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD))
-        ).prepareSearch("test").setQuery(QueryBuilders.termQuery("_id", "1")).get();
-        assertThat(response.getHits().getHits().length, equalTo(1));
-        Map<String, Object> source = response.getHits().getHits()[0].getSourceAsMap();
-        assertThat(source.size(), equalTo(1));
-        assertThat((String) source.get("field1"), equalTo("value1"));
+        assertResponse(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(QueryBuilders.termQuery("_id", "1")),
+            response -> {
+                assertThat(response.getHits().getHits().length, equalTo(1));
+                Map<String, Object> source = response.getHits().getHits()[0].getSourceAsMap();
+                assertThat(source.size(), equalTo(1));
+                assertThat((String) source.get("field1"), equalTo("value1"));
+            }
+        );
+        assertResponse(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
+                .prepareSearch("my_alias")
+                .setQuery(QueryBuilders.termQuery("_id", "1")),
+            response -> {
+                assertThat(response.getHits().getHits().length, equalTo(1));
+                var source = response.getHits().getHits()[0].getSourceAsMap();
+                assertThat(source.size(), equalTo(1));
+                assertThat((String) source.get("field2"), equalTo("value2"));
+            }
+        );
 
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
-            .prepareSearch("my_alias")
-            .setQuery(QueryBuilders.termQuery("_id", "1"))
-            .get();
-        assertThat(response.getHits().getHits().length, equalTo(1));
-        source = response.getHits().getHits()[0].getSourceAsMap();
-        assertThat(source.size(), equalTo(1));
-        assertThat((String) source.get("field2"), equalTo("value2"));
+        assertResponse(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
+                .prepareSearch("an_alias")
+                .setQuery(QueryBuilders.termQuery("_id", "1")),
+            response -> {
+                assertThat(response.getHits().getHits().length, equalTo(1));
+                var source = response.getHits().getHits()[0].getSourceAsMap();
+                assertThat(source.size(), equalTo(1));
+                assertThat((String) source.get("field3"), equalTo("value3"));
+            }
+        );
 
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
-            .prepareSearch("an_alias")
-            .setQuery(QueryBuilders.termQuery("_id", "1"))
-            .get();
-        assertThat(response.getHits().getHits().length, equalTo(1));
-        source = response.getHits().getHits()[0].getSourceAsMap();
-        assertThat(source.size(), equalTo(1));
-        assertThat((String) source.get("field3"), equalTo("value3"));
+        assertResponse(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
+                .prepareSearch("*_alias")
+                .setQuery(QueryBuilders.termQuery("_id", "1")),
+            response -> {
+                assertThat(response.getHits().getHits().length, equalTo(1));
+                var source = response.getHits().getHits()[0].getSourceAsMap();
+                assertThat(source.size(), equalTo(2));
+                assertThat((String) source.get("field2"), equalTo("value2"));
+                assertThat((String) source.get("field3"), equalTo("value3"));
+            }
+        );
 
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
-            .prepareSearch("*_alias")
-            .setQuery(QueryBuilders.termQuery("_id", "1"))
-            .get();
-        assertThat(response.getHits().getHits().length, equalTo(1));
-        source = response.getHits().getHits()[0].getSourceAsMap();
-        assertThat(source.size(), equalTo(2));
-        assertThat((String) source.get("field2"), equalTo("value2"));
-        assertThat((String) source.get("field3"), equalTo("value3"));
-
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
-            .prepareSearch("*_alias", "t*")
-            .setQuery(QueryBuilders.termQuery("_id", "1"))
-            .get();
-        assertThat(response.getHits().getHits().length, equalTo(1));
-        source = response.getHits().getHits()[0].getSourceAsMap();
-        assertThat(source.size(), equalTo(3));
-        assertThat((String) source.get("field1"), equalTo("value1"));
-        assertThat((String) source.get("field2"), equalTo("value2"));
-        assertThat((String) source.get("field3"), equalTo("value3"));
+        assertResponse(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
+                .prepareSearch("*_alias", "t*")
+                .setQuery(QueryBuilders.termQuery("_id", "1")),
+            response -> {
+                assertThat(response.getHits().getHits().length, equalTo(1));
+                var source = response.getHits().getHits()[0].getSourceAsMap();
+                assertThat(source.size(), equalTo(3));
+                assertThat((String) source.get("field1"), equalTo("value1"));
+                assertThat((String) source.get("field2"), equalTo("value2"));
+                assertThat((String) source.get("field3"), equalTo("value3"));
+            }
+        );
     }
 
     public void testSearchResolveDataStreams() throws Exception {
@@ -201,52 +216,68 @@ public class IndicesPermissionsWithAliasesWildcardsAndRegexsTests extends Securi
             .setRefreshPolicy(IMMEDIATE)
             .get();
 
-        SearchResponse response = client().filterWithHeader(
-            Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD))
-        ).prepareSearch("test").setQuery(QueryBuilders.termQuery("_id", "1")).get();
-        assertThat(response.getHits().getHits().length, equalTo(1));
-        Map<String, Object> source = response.getHits().getHits()[0].getSourceAsMap();
-        assertThat(source.size(), equalTo(1));
-        assertThat((String) source.get("field1"), equalTo("value1"));
+        assertResponse(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
+                .prepareSearch("test")
+                .setQuery(QueryBuilders.termQuery("_id", "1")),
+            response -> {
+                assertThat(response.getHits().getHits().length, equalTo(1));
+                Map<String, Object> source = response.getHits().getHits()[0].getSourceAsMap();
+                assertThat(source.size(), equalTo(1));
+                assertThat((String) source.get("field1"), equalTo("value1"));
+            }
+        );
 
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
-            .prepareSearch("my_alias")
-            .setQuery(QueryBuilders.termQuery("_id", "1"))
-            .get();
-        assertThat(response.getHits().getHits().length, equalTo(1));
-        source = response.getHits().getHits()[0].getSourceAsMap();
-        assertThat(source.size(), equalTo(1));
-        assertThat((String) source.get("field2"), equalTo("value2"));
+        assertResponse(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
+                .prepareSearch("my_alias")
+                .setQuery(QueryBuilders.termQuery("_id", "1")),
+            response -> {
+                assertThat(response.getHits().getHits().length, equalTo(1));
+                var source = response.getHits().getHits()[0].getSourceAsMap();
+                assertThat(source.size(), equalTo(1));
+                assertThat((String) source.get("field2"), equalTo("value2"));
+            }
+        );
 
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
-            .prepareSearch("an_alias")
-            .setQuery(QueryBuilders.termQuery("_id", "1"))
-            .get();
-        assertThat(response.getHits().getHits().length, equalTo(1));
-        source = response.getHits().getHits()[0].getSourceAsMap();
-        assertThat(source.size(), equalTo(1));
-        assertThat((String) source.get("field3"), equalTo("value3"));
+        assertResponse(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
+                .prepareSearch("an_alias")
+                .setQuery(QueryBuilders.termQuery("_id", "1")),
+            response -> {
+                assertThat(response.getHits().getHits().length, equalTo(1));
+                var source = response.getHits().getHits()[0].getSourceAsMap();
+                assertThat(source.size(), equalTo(1));
+                assertThat((String) source.get("field3"), equalTo("value3"));
+            }
+        );
 
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
-            .prepareSearch("*_alias")
-            .setQuery(QueryBuilders.termQuery("_id", "1"))
-            .get();
-        assertThat(response.getHits().getHits().length, equalTo(1));
-        source = response.getHits().getHits()[0].getSourceAsMap();
-        assertThat(source.size(), equalTo(2));
-        assertThat((String) source.get("field2"), equalTo("value2"));
-        assertThat((String) source.get("field3"), equalTo("value3"));
+        assertResponse(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
+                .prepareSearch("*_alias")
+                .setQuery(QueryBuilders.termQuery("_id", "1")),
+            response -> {
+                assertThat(response.getHits().getHits().length, equalTo(1));
+                var source = response.getHits().getHits()[0].getSourceAsMap();
+                assertThat(source.size(), equalTo(2));
+                assertThat((String) source.get("field2"), equalTo("value2"));
+                assertThat((String) source.get("field3"), equalTo("value3"));
+            }
+        );
 
-        response = client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
-            .prepareSearch("*_alias", "t*")
-            .setQuery(QueryBuilders.termQuery("_id", "1"))
-            .get();
-        assertThat(response.getHits().getHits().length, equalTo(1));
-        source = response.getHits().getHits()[0].getSourceAsMap();
-        assertThat(source.size(), equalTo(3));
-        assertThat((String) source.get("field1"), equalTo("value1"));
-        assertThat((String) source.get("field2"), equalTo("value2"));
-        assertThat((String) source.get("field3"), equalTo("value3"));
+        assertResponse(
+            client().filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD)))
+                .prepareSearch("*_alias", "t*")
+                .setQuery(QueryBuilders.termQuery("_id", "1")),
+            response -> {
+                assertThat(response.getHits().getHits().length, equalTo(1));
+                var source = response.getHits().getHits()[0].getSourceAsMap();
+                assertThat(source.size(), equalTo(3));
+                assertThat((String) source.get("field1"), equalTo("value1"));
+                assertThat((String) source.get("field2"), equalTo("value2"));
+                assertThat((String) source.get("field3"), equalTo("value3"));
+            }
+        );
     }
 
     private void putComposableIndexTemplate(String id, List<String> patterns) throws IOException {

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/KibanaUserRoleIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/KibanaUserRoleIntegTests.java
@@ -12,7 +12,6 @@ import org.elasticsearch.action.admin.indices.mapping.get.GetFieldMappingsRespon
 import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse;
 import org.elasticsearch.action.admin.indices.validate.query.ValidateQueryResponse;
 import org.elasticsearch.action.search.MultiSearchResponse;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.core.Strings;
@@ -24,6 +23,7 @@ import org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken
 import java.util.Map;
 
 import static java.util.Collections.singletonMap;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -102,32 +102,34 @@ public class KibanaUserRoleIntegTests extends NativeRealmIntegTestCase {
         final String field = "foo";
         indexRandom(true, prepareIndex(index).setSource(field, "bar"));
 
-        SearchResponse response = prepareSearch(index).setQuery(QueryBuilders.matchAllQuery()).get();
-        final long hits = response.getHits().getTotalHits().value;
-        assertThat(hits, greaterThan(0L));
-        response = client().filterWithHeader(
-            singletonMap("Authorization", UsernamePasswordToken.basicAuthHeaderValue("kibana_user", USERS_PASSWD))
-        ).prepareSearch(index).setQuery(QueryBuilders.matchAllQuery()).get();
-        assertEquals(response.getHits().getTotalHits().value, hits);
-
-        final long multiHits;
-        MultiSearchResponse multiSearchResponse = client().prepareMultiSearch()
-            .add(prepareSearch(index).setQuery(QueryBuilders.matchAllQuery()))
-            .get();
-        try {
-            multiHits = multiSearchResponse.getResponses()[0].getResponse().getHits().getTotalHits().value;
+        assertResponse(prepareSearch(index).setQuery(QueryBuilders.matchAllQuery()), response -> {
+            final long hits = response.getHits().getTotalHits().value;
             assertThat(hits, greaterThan(0L));
-        } finally {
-            multiSearchResponse.decRef();
-        }
-        multiSearchResponse = client().filterWithHeader(
-            singletonMap("Authorization", UsernamePasswordToken.basicAuthHeaderValue("kibana_user", USERS_PASSWD))
-        ).prepareMultiSearch().add(prepareSearch(index).setQuery(QueryBuilders.matchAllQuery())).get();
-        try {
-            assertEquals(multiSearchResponse.getResponses()[0].getResponse().getHits().getTotalHits().value, multiHits);
-        } finally {
-            multiSearchResponse.decRef();
-        }
+            assertResponse(
+                client().filterWithHeader(
+                    singletonMap("Authorization", UsernamePasswordToken.basicAuthHeaderValue("kibana_user", USERS_PASSWD))
+                ).prepareSearch(index).setQuery(QueryBuilders.matchAllQuery()),
+                response2 -> assertEquals(response2.getHits().getTotalHits().value, hits)
+            );
+            final long multiHits;
+            MultiSearchResponse multiSearchResponse = client().prepareMultiSearch()
+                .add(prepareSearch(index).setQuery(QueryBuilders.matchAllQuery()))
+                .get();
+            try {
+                multiHits = multiSearchResponse.getResponses()[0].getResponse().getHits().getTotalHits().value;
+                assertThat(hits, greaterThan(0L));
+            } finally {
+                multiSearchResponse.decRef();
+            }
+            multiSearchResponse = client().filterWithHeader(
+                singletonMap("Authorization", UsernamePasswordToken.basicAuthHeaderValue("kibana_user", USERS_PASSWD))
+            ).prepareMultiSearch().add(prepareSearch(index).setQuery(QueryBuilders.matchAllQuery())).get();
+            try {
+                assertEquals(multiSearchResponse.getResponses()[0].getResponse().getHits().getTotalHits().value, multiHits);
+            } finally {
+                multiSearchResponse.decRef();
+            }
+        });
     }
 
     public void testGetIndex() throws Exception {

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/MultipleIndicesPermissionsTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/MultipleIndicesPermissionsTests.java
@@ -15,7 +15,6 @@ import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
 import org.elasticsearch.action.admin.indices.shards.IndicesShardStoresResponse;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
 import org.elasticsearch.action.search.MultiSearchResponse;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
@@ -39,7 +38,9 @@ import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDI
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCountAndNoFailures;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.BASIC_AUTH_HEADER;
 import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.basicAuthHeaderValue;
@@ -144,19 +145,13 @@ public class MultipleIndicesPermissionsTests extends SecurityIntegTestCase {
         Client client = client();
 
         // no specifying an index, should replace indices with the permitted ones (test & test1)
-        SearchResponse searchResponse = client.prepareSearch().setQuery(matchAllQuery()).get();
-        assertNoFailures(searchResponse);
-        assertHitCount(searchResponse, 2);
+        assertHitCountAndNoFailures(prepareSearch().setQuery(matchAllQuery()), 2);
 
         // _all should expand to all the permitted indices
-        searchResponse = client.prepareSearch("_all").setQuery(matchAllQuery()).get();
-        assertNoFailures(searchResponse);
-        assertHitCount(searchResponse, 2);
+        assertHitCountAndNoFailures(client.prepareSearch("_all").setQuery(matchAllQuery()), 2);
 
         // wildcards should expand to all the permitted indices
-        searchResponse = client.prepareSearch("test*").setQuery(matchAllQuery()).get();
-        assertNoFailures(searchResponse);
-        assertHitCount(searchResponse, 2);
+        assertHitCountAndNoFailures(client.prepareSearch("test*").setQuery(matchAllQuery()), 2);
 
         try {
             client.prepareSearch("test", "test2").setQuery(matchAllQuery()).get();
@@ -174,7 +169,7 @@ public class MultipleIndicesPermissionsTests extends SecurityIntegTestCase {
             MultiSearchResponse.Item[] items = msearchResponse.getResponses();
             assertThat(items.length, is(2));
             assertThat(items[0].isFailure(), is(false));
-            searchResponse = items[0].getResponse();
+            var searchResponse = items[0].getResponse();
             assertNoFailures(searchResponse);
             assertHitCount(searchResponse, 1);
             assertThat(items[1].isFailure(), is(false));
@@ -252,18 +247,18 @@ public class MultipleIndicesPermissionsTests extends SecurityIntegTestCase {
 
         Client client = client();
 
-        SearchResponse response = client.filterWithHeader(
-            Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user_a", USERS_PASSWD))
-        ).prepareSearch("a").get();
-        assertNoFailures(response);
-        assertHitCount(response, 1);
+        assertHitCountAndNoFailures(
+            client.filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user_a", USERS_PASSWD)))
+                .prepareSearch("a"),
+            1
+        );
 
         String[] indices = randomDouble() < 0.3 ? new String[] { "_all" } : randomBoolean() ? new String[] { "*" } : new String[] {};
-        response = client.filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user_a", USERS_PASSWD)))
-            .prepareSearch(indices)
-            .get();
-        assertNoFailures(response);
-        assertHitCount(response, 1);
+        assertHitCountAndNoFailures(
+            client.filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user_a", USERS_PASSWD)))
+                .prepareSearch(indices),
+            1
+        );
 
         try {
             indices = randomBoolean() ? new String[] { "a", "b" } : new String[] { "b", "a" };
@@ -279,25 +274,25 @@ public class MultipleIndicesPermissionsTests extends SecurityIntegTestCase {
             assertThat(e.status(), is(RestStatus.FORBIDDEN));
         }
 
-        response = client.filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user_ab", USERS_PASSWD)))
-            .prepareSearch("b")
-            .get();
-        assertNoFailures(response);
-        assertHitCount(response, 1);
+        assertHitCountAndNoFailures(
+            client.filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user_ab", USERS_PASSWD)))
+                .prepareSearch("b"),
+            1
+        );
 
         indices = randomBoolean() ? new String[] { "a", "b" } : new String[] { "b", "a" };
-        response = client.filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user_ab", USERS_PASSWD)))
-            .prepareSearch(indices)
-            .get();
-        assertNoFailures(response);
-        assertHitCount(response, 2);
+        assertHitCountAndNoFailures(
+            client.filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user_ab", USERS_PASSWD)))
+                .prepareSearch(indices),
+            2
+        );
 
         indices = randomDouble() < 0.3 ? new String[] { "_all" } : randomBoolean() ? new String[] { "*" } : new String[] {};
-        response = client.filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user_ab", USERS_PASSWD)))
-            .prepareSearch(indices)
-            .get();
-        assertNoFailures(response);
-        assertHitCount(response, 2);
+        assertHitCountAndNoFailures(
+            client.filterWithHeader(Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user_ab", USERS_PASSWD)))
+                .prepareSearch(indices),
+            2
+        );
     }
 
     public void testMultiNamesWorkCorrectly() {
@@ -313,8 +308,10 @@ public class MultipleIndicesPermissionsTests extends SecurityIntegTestCase {
             Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user_a", USERS_PASSWD))
         );
 
-        final SearchResponse searchResponse = userAClient.prepareSearch("alias1").setSize(0).get();
-        assertThat(searchResponse.getHits().getTotalHits().value, equalTo(0L));
+        assertResponse(
+            userAClient.prepareSearch("alias1").setSize(0),
+            searchResponse -> assertThat(searchResponse.getHits().getTotalHits().value, equalTo(0L))
+        );
 
         final ElasticsearchSecurityException e1 = expectThrows(
             ElasticsearchSecurityException.class,

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/ScrollHelperIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/ScrollHelperIntegTests.java
@@ -92,21 +92,14 @@ public class ScrollHelperIntegTests extends ESSingleNodeTestCase {
             false,
             1
         );
-        SearchResponse response = new SearchResponse(
-            internalResponse,
-            scrollId,
-            1,
-            1,
-            0,
-            0,
-            ShardSearchFailure.EMPTY_ARRAY,
-            SearchResponse.Clusters.EMPTY
-        );
 
         Answer<?> returnResponse = invocation -> {
             @SuppressWarnings("unchecked")
             ActionListener<SearchResponse> listener = (ActionListener<SearchResponse>) invocation.getArguments()[1];
-            listener.onResponse(response);
+            ActionListener.respondAndRelease(
+                listener,
+                new SearchResponse(internalResponse, scrollId, 1, 1, 0, 0, ShardSearchFailure.EMPTY_ARRAY, SearchResponse.Clusters.EMPTY)
+            );
             return null;
         };
         doAnswer(returnResponse).when(client).search(eq(request), any());

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/esnative/NativeRealmIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/esnative/NativeRealmIntegTests.java
@@ -13,7 +13,6 @@ import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.Strings;
@@ -81,6 +80,7 @@ import java.util.concurrent.CountDownLatch;
 import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoTimeout;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.basicAuthHeaderValue;
 import static org.elasticsearch.xpack.core.security.test.TestRestrictedIndices.INTERNAL_SECURITY_MAIN_INDEX_7;
 import static org.elasticsearch.xpack.security.support.SecuritySystemIndices.SECURITY_MAIN_ALIAS;
@@ -319,9 +319,10 @@ public class NativeRealmIntegTests extends NativeRealmIntegTestCase {
         prepareIndex("idx").setId("1").setSource("body", "foo").setRefreshPolicy(IMMEDIATE).get();
 
         String token = basicAuthHeaderValue(username, new SecureString("s3krit-password"));
-        SearchResponse searchResp = client().filterWithHeader(Collections.singletonMap("Authorization", token)).prepareSearch("idx").get();
-
-        assertEquals(1L, searchResp.getHits().getTotalHits().value);
+        assertResponse(
+            client().filterWithHeader(Collections.singletonMap("Authorization", token)).prepareSearch("idx"),
+            searchResp -> assertEquals(1L, searchResp.getHits().getTotalHits().value)
+        );
 
         assertClusterHealthOnlyAuthorizesWhenAnonymousRoleActive(token);
     }
@@ -341,9 +342,10 @@ public class NativeRealmIntegTests extends NativeRealmIntegTestCase {
         // Index a document with the default test user
         prepareIndex("idx").setId("1").setSource("body", "foo").setRefreshPolicy(IMMEDIATE).get();
         String token = basicAuthHeaderValue("joe", new SecureString("s3krit-password"));
-        SearchResponse searchResp = client().filterWithHeader(Collections.singletonMap("Authorization", token)).prepareSearch("idx").get();
-
-        assertEquals(1L, searchResp.getHits().getTotalHits().value);
+        assertResponse(
+            client().filterWithHeader(Collections.singletonMap("Authorization", token)).prepareSearch("idx"),
+            searchResp -> assertEquals(1L, searchResp.getHits().getTotalHits().value)
+        );
 
         preparePutUser("joe", "s3krit-password2", hasher, SecuritySettingsSource.TEST_ROLE).get();
 
@@ -356,8 +358,10 @@ public class NativeRealmIntegTests extends NativeRealmIntegTestCase {
         }
 
         token = basicAuthHeaderValue("joe", new SecureString("s3krit-password2"));
-        searchResp = client().filterWithHeader(Collections.singletonMap("Authorization", token)).prepareSearch("idx").get();
-        assertEquals(1L, searchResp.getHits().getTotalHits().value);
+        assertResponse(
+            client().filterWithHeader(Collections.singletonMap("Authorization", token)).prepareSearch("idx"),
+            searchResp -> assertEquals(1L, searchResp.getHits().getTotalHits().value)
+        );
     }
 
     public void testCreateDeleteAuthenticate() {
@@ -375,9 +379,10 @@ public class NativeRealmIntegTests extends NativeRealmIntegTestCase {
         // Index a document with the default test user
         prepareIndex("idx").setId("1").setSource("body", "foo").setRefreshPolicy(IMMEDIATE).get();
         String token = basicAuthHeaderValue("joe", new SecureString("s3krit-password"));
-        SearchResponse searchResp = client().filterWithHeader(Collections.singletonMap("Authorization", token)).prepareSearch("idx").get();
-
-        assertEquals(1L, searchResp.getHits().getTotalHits().value);
+        assertResponse(
+            client().filterWithHeader(Collections.singletonMap("Authorization", token)).prepareSearch("idx"),
+            searchResp -> assertEquals(1L, searchResp.getHits().getTotalHits().value)
+        );
 
         DeleteUserResponse response = new DeleteUserRequestBuilder(client()).username("joe").get();
         assertThat(response.found(), is(true));

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authz/ReadActionsTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authz/ReadActionsTests.java
@@ -442,12 +442,7 @@ public class ReadActionsTests extends SecurityIntegTestCase {
     }
 
     private static void assertReturnedIndices(SearchRequestBuilder searchRequestBuilder, String... indices) {
-        var searchResponse = searchRequestBuilder.get();
-        try {
-            assertReturnedIndices(searchResponse, indices);
-        } finally {
-            searchResponse.decRef();
-        }
+        assertResponse(searchRequestBuilder, searchResponse -> assertReturnedIndices(searchResponse, indices));
     }
 
     private static void assertReturnedIndices(SearchResponse searchResponse, String... indices) {

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/profile/SecurityDomainIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/profile/SecurityDomainIntegTests.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.security.profile;
 
 import org.elasticsearch.ElasticsearchSecurityException;
-import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.MockSecureSettings;
 import org.elasticsearch.common.settings.Settings;
@@ -47,6 +46,7 @@ import java.util.Map;
 import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
 import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.NONE;
 import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.WAIT_UNTIL;
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
 import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.basicAuthHeaderValue;
 import static org.elasticsearch.xpack.security.support.SecuritySystemIndices.SECURITY_MAIN_ALIAS;
 import static org.hamcrest.Matchers.containsString;
@@ -368,26 +368,31 @@ public class SecurityDomainIntegTests extends AbstractProfileIntegTestCase {
             .get();
     }
 
-    private void assertAccessToken(CreateTokenResponse createTokenResponse) throws IOException {
+    private void assertAccessToken(CreateTokenResponse createTokenResponse) {
         client().filterWithHeader(Map.of("Authorization", "Bearer " + createTokenResponse.getTokenString()))
             .admin()
             .cluster()
             .prepareHealth()
             .get();
-        final SearchResponse searchResponse = prepareSearch(SecuritySystemIndices.SECURITY_TOKENS_ALIAS).get();
-
-        final String encodedAuthentication = createTokenResponse.getAuthentication().encode();
-        for (SearchHit searchHit : searchResponse.getHits().getHits()) {
-            final XContentTestUtils.JsonMapView responseView = XContentTestUtils.createJsonMapView(
-                new ByteArrayInputStream(searchHit.getSourceAsString().getBytes(StandardCharsets.UTF_8))
-            );
-            if (encodedAuthentication.equals(responseView.get("access_token.user_token.authentication"))) {
-                if (isOtherDomain) {
-                    assertThat(responseView.get("access_token.realm_domain"), equalTo(OTHER_DOMAIN_REALM_MAP));
-                } else {
-                    assertThat(responseView.get("access_token.realm_domain"), nullValue());
+        assertResponse(prepareSearch(SecuritySystemIndices.SECURITY_TOKENS_ALIAS), searchResponse -> {
+            final String encodedAuthentication;
+            try {
+                encodedAuthentication = createTokenResponse.getAuthentication().encode();
+            } catch (IOException e) {
+                throw new AssertionError(e);
+            }
+            for (SearchHit searchHit : searchResponse.getHits().getHits()) {
+                final XContentTestUtils.JsonMapView responseView = XContentTestUtils.createJsonMapView(
+                    new ByteArrayInputStream(searchHit.getSourceAsString().getBytes(StandardCharsets.UTF_8))
+                );
+                if (encodedAuthentication.equals(responseView.get("access_token.user_token.authentication"))) {
+                    if (isOtherDomain) {
+                        assertThat(responseView.get("access_token.realm_domain"), equalTo(OTHER_DOMAIN_REALM_MAP));
+                    } else {
+                        assertThat(responseView.get("access_token.realm_domain"), nullValue());
+                    }
                 }
             }
-        }
+        });
     }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/saml/TransportSamlInvalidateSessionActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/saml/TransportSamlInvalidateSessionActionTests.java
@@ -198,47 +198,51 @@ public class TransportSamlInvalidateSessionActionTests extends SamlTestCase {
                     SearchRequest searchRequest = (SearchRequest) request;
                     searchRequests.add(searchRequest);
                     final SearchHit[] hits = searchFunction.apply(searchRequest);
-                    final SearchResponse response = new SearchResponse(
-                        new SearchResponseSections(
-                            new SearchHits(hits, new TotalHits(hits.length, TotalHits.Relation.EQUAL_TO), 0f),
+                    ActionListener.respondAndRelease(
+                        listener,
+                        (Response) new SearchResponse(
+                            new SearchResponseSections(
+                                new SearchHits(hits, new TotalHits(hits.length, TotalHits.Relation.EQUAL_TO), 0f),
+                                null,
+                                null,
+                                false,
+                                false,
+                                null,
+                                1
+                            ),
+                            "_scrollId1",
+                            1,
+                            1,
+                            0,
+                            1,
                             null,
-                            null,
-                            false,
-                            false,
-                            null,
-                            1
-                        ),
-                        "_scrollId1",
-                        1,
-                        1,
-                        0,
-                        1,
-                        null,
-                        null
+                            null
+                        )
                     );
-                    listener.onResponse((Response) response);
                 } else if (TransportSearchScrollAction.TYPE.name().equals(action.name())) {
                     assertThat(request, instanceOf(SearchScrollRequest.class));
                     final SearchHit[] hits = new SearchHit[0];
-                    final SearchResponse response = new SearchResponse(
-                        new SearchResponseSections(
-                            new SearchHits(hits, new TotalHits(hits.length, TotalHits.Relation.EQUAL_TO), 0f),
+                    ActionListener.respondAndRelease(
+                        listener,
+                        (Response) new SearchResponse(
+                            new SearchResponseSections(
+                                new SearchHits(hits, new TotalHits(hits.length, TotalHits.Relation.EQUAL_TO), 0f),
+                                null,
+                                null,
+                                false,
+                                false,
+                                null,
+                                1
+                            ),
+                            "_scrollId1",
+                            1,
+                            1,
+                            0,
+                            1,
                             null,
-                            null,
-                            false,
-                            false,
-                            null,
-                            1
-                        ),
-                        "_scrollId1",
-                        1,
-                        1,
-                        0,
-                        1,
-                        null,
-                        null
+                            null
+                        )
                     );
-                    listener.onResponse((Response) response);
                 } else if (TransportClearScrollAction.NAME.equals(action.name())) {
                     assertThat(request, instanceOf(ClearScrollRequest.class));
                     ClearScrollRequest scrollRequest = (ClearScrollRequest) request;

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
@@ -275,7 +275,7 @@ public class ApiKeyServiceTests extends ESTestCase {
         doAnswer(invocationOnMock -> {
             searchRequest.set((SearchRequest) invocationOnMock.getArguments()[0]);
             ActionListener<SearchResponse> listener = (ActionListener<SearchResponse>) invocationOnMock.getArguments()[1];
-            listener.onResponse(SearchResponse.empty(() -> 1L, SearchResponse.Clusters.EMPTY));
+            ActionListener.respondAndRelease(listener, SearchResponse.empty(() -> 1L, SearchResponse.Clusters.EMPTY));
             return null;
         }).when(client).search(any(SearchRequest.class), anyActionListener());
         String[] realmNames = generateRandomStringArray(4, 4, true, true);
@@ -336,7 +336,7 @@ public class ApiKeyServiceTests extends ESTestCase {
         doAnswer(invocationOnMock -> {
             searchRequest.set((SearchRequest) invocationOnMock.getArguments()[0]);
             ActionListener<SearchResponse> listener = (ActionListener<SearchResponse>) invocationOnMock.getArguments()[1];
-            listener.onResponse(SearchResponse.empty(() -> 1L, SearchResponse.Clusters.EMPTY));
+            ActionListener.respondAndRelease(listener, SearchResponse.empty(() -> 1L, SearchResponse.Clusters.EMPTY));
             return null;
         }).when(client).search(any(SearchRequest.class), anyActionListener());
         PlainActionFuture<InvalidateApiKeyResponse> listener = new PlainActionFuture<>();
@@ -427,17 +427,10 @@ public class ApiKeyServiceTests extends ESTestCase {
                 null,
                 0
             );
-            final var searchResponse = new SearchResponse(
-                internalSearchResponse,
-                randomAlphaOfLengthBetween(3, 8),
-                1,
-                1,
-                0,
-                10,
-                null,
-                null
+            ActionListener.respondAndRelease(
+                listener,
+                new SearchResponse(internalSearchResponse, randomAlphaOfLengthBetween(3, 8), 1, 1, 0, 10, null, null)
             );
-            listener.onResponse(searchResponse);
             return null;
         }).when(client).search(any(SearchRequest.class), anyActionListener());
 
@@ -756,33 +749,35 @@ public class ApiKeyServiceTests extends ESTestCase {
         final AtomicReference<SearchRequest> searchRequest = new AtomicReference<>();
         doAnswer(invocationOnMock -> {
             searchRequest.set(invocationOnMock.getArgument(0));
-            final var searchResponse = new SearchResponse(
-                new InternalSearchResponse(
-                    new SearchHits(
-                        searchHits.toArray(SearchHit[]::new),
-                        new TotalHits(searchHits.size(), TotalHits.Relation.EQUAL_TO),
-                        randomFloat(),
-                        null,
-                        null,
-                        null
-                    ),
-                    null,
-                    null,
-                    null,
-                    false,
-                    null,
-                    0
-                ),
-                randomAlphaOfLengthBetween(3, 8),
-                1,
-                1,
-                0,
-                10,
-                null,
-                null
-            );
             final ActionListener<SearchResponse> listener = invocationOnMock.getArgument(1);
-            listener.onResponse(searchResponse);
+            ActionListener.respondAndRelease(
+                listener,
+                new SearchResponse(
+                    new InternalSearchResponse(
+                        new SearchHits(
+                            searchHits.toArray(SearchHit[]::new),
+                            new TotalHits(searchHits.size(), TotalHits.Relation.EQUAL_TO),
+                            randomFloat(),
+                            null,
+                            null,
+                            null
+                        ),
+                        null,
+                        null,
+                        null,
+                        false,
+                        null,
+                        0
+                    ),
+                    randomAlphaOfLengthBetween(3, 8),
+                    1,
+                    1,
+                    0,
+                    10,
+                    null,
+                    null
+                )
+            );
             return null;
         }).when(client).search(any(SearchRequest.class), anyActionListener());
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/IndexServiceAccountTokenStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/IndexServiceAccountTokenStoreTests.java
@@ -280,18 +280,10 @@ public class IndexServiceAccountTokenStoreTests extends ESTestCase {
                     null,
                     0
                 );
-
-                final SearchResponse searchResponse = new SearchResponse(
-                    internalSearchResponse,
-                    randomAlphaOfLengthBetween(3, 8),
-                    1,
-                    1,
-                    0,
-                    10,
-                    null,
-                    null
+                ActionListener.respondAndRelease(
+                    l,
+                    new SearchResponse(internalSearchResponse, randomAlphaOfLengthBetween(3, 8), 1, 1, 0, 10, null, null)
                 );
-                l.onResponse(searchResponse);
             } else if (r instanceof ClearScrollRequest) {
                 l.onResponse(new ClearScrollResponse(true, 1));
             } else {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/mapper/NativeRoleMappingStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/mapper/NativeRoleMappingStoreTests.java
@@ -371,17 +371,10 @@ public class NativeRoleMappingStoreTests extends ESTestCase {
                 null,
                 0
             );
-            final var searchResponse = new SearchResponse(
-                internalSearchResponse,
-                randomAlphaOfLengthBetween(3, 8),
-                1,
-                1,
-                0,
-                10,
-                null,
-                null
+            ActionListener.respondAndRelease(
+                listener,
+                new SearchResponse(internalSearchResponse, randomAlphaOfLengthBetween(3, 8), 1, 1, 0, 10, null, null)
             );
-            listener.onResponse(searchResponse);
             return null;
         }).when(client).search(any(SearchRequest.class), anyActionListener());
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/NativePrivilegeStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/NativePrivilegeStoreTests.java
@@ -134,7 +134,7 @@ public class NativePrivilegeStoreTests extends ESTestCase {
 
             @Override
             public void searchScroll(SearchScrollRequest request, ActionListener<SearchResponse> listener) {
-                listener.onResponse(SearchResponse.empty(() -> 1L, SearchResponse.Clusters.EMPTY));
+                ActionListener.respondAndRelease(listener, SearchResponse.empty(() -> 1L, SearchResponse.Clusters.EMPTY));
             }
         };
         securityIndex = mock(SecurityIndexManager.class);
@@ -189,7 +189,7 @@ public class NativePrivilegeStoreTests extends ESTestCase {
             {"term":{"type":{"value":"application-privilege\""""));
 
         final SearchHit[] hits = buildHits(sourcePrivileges);
-        listener.get().onResponse(buildSearchResponse(hits));
+        ActionListener.respondAndRelease(listener.get(), buildSearchResponse(hits));
 
         assertResult(sourcePrivileges, future);
     }
@@ -198,7 +198,7 @@ public class NativePrivilegeStoreTests extends ESTestCase {
         final PlainActionFuture<Collection<ApplicationPrivilegeDescriptor>> future = new PlainActionFuture<>();
         store.getPrivileges(List.of("myapp"), List.of("admin"), future);
         final SearchHit[] hits = new SearchHit[0];
-        listener.get().onResponse(buildSearchResponse(hits));
+        ActionListener.respondAndRelease(listener.get(), buildSearchResponse(hits));
 
         final Collection<ApplicationPrivilegeDescriptor> applicationPrivilegeDescriptors = future.get(1, TimeUnit.SECONDS);
         assertThat(applicationPrivilegeDescriptors, empty());
@@ -225,7 +225,7 @@ public class NativePrivilegeStoreTests extends ESTestCase {
             {"term":{"type":{"value":"application-privilege\""""));
 
         final SearchHit[] hits = buildHits(sourcePrivileges);
-        listener.get().onResponse(buildSearchResponse(hits));
+        ActionListener.respondAndRelease(listener.get(), buildSearchResponse(hits));
 
         assertResult(sourcePrivileges, future);
     }
@@ -283,7 +283,7 @@ public class NativePrivilegeStoreTests extends ESTestCase {
         }
 
         final SearchHit[] hits = buildHits(allowExpensiveQueries ? sourcePrivileges.subList(1, 4) : sourcePrivileges);
-        listener.get().onResponse(buildSearchResponse(hits));
+        ActionListener.respondAndRelease(listener.get(), buildSearchResponse(hits));
         // The first and last privilege should not be retrieved
         assertResult(sourcePrivileges.subList(1, 4), future);
     }
@@ -300,7 +300,7 @@ public class NativePrivilegeStoreTests extends ESTestCase {
         assertThat(query, containsString("{\"term\":{\"type\":{\"value\":\"application-privilege\""));
 
         final SearchHit[] hits = new SearchHit[0];
-        listener.get().onResponse(buildSearchResponse(hits));
+        ActionListener.respondAndRelease(listener.get(), buildSearchResponse(hits));
     }
 
     public void testGetAllPrivileges() throws Exception {
@@ -321,7 +321,7 @@ public class NativePrivilegeStoreTests extends ESTestCase {
         assertThat(query, not(containsString("{\"terms\"")));
 
         final SearchHit[] hits = buildHits(sourcePrivileges);
-        listener.get().onResponse(buildSearchResponse(hits));
+        ActionListener.respondAndRelease(listener.get(), buildSearchResponse(hits));
 
         assertResult(sourcePrivileges, future);
     }
@@ -337,7 +337,7 @@ public class NativePrivilegeStoreTests extends ESTestCase {
         store.getPrivileges(List.of("myapp", "yourapp"), null, future);
 
         final SearchHit[] hits = buildHits(sourcePrivileges);
-        listener.get().onResponse(buildSearchResponse(hits));
+        ActionListener.respondAndRelease(listener.get(), buildSearchResponse(hits));
 
         assertEquals(Set.of("myapp"), store.getApplicationNamesCache().get(Set.of("myapp", "yourapp")));
         assertEquals(Set.copyOf(sourcePrivileges), store.getDescriptorsCache().get("myapp"));
@@ -369,7 +369,7 @@ public class NativePrivilegeStoreTests extends ESTestCase {
         store.getPrivileges(Collections.singletonList("myapp"), singletonList("user"), future);
 
         final SearchHit[] hits = buildHits(sourcePrivileges);
-        listener.get().onResponse(buildSearchResponse(hits));
+        ActionListener.respondAndRelease(listener.get(), buildSearchResponse(hits));
 
         // Not caching names with no wildcard
         assertNull(store.getApplicationNamesCache().get(singleton("myapp")));
@@ -388,7 +388,7 @@ public class NativePrivilegeStoreTests extends ESTestCase {
         final PlainActionFuture<Collection<ApplicationPrivilegeDescriptor>> future = new PlainActionFuture<>();
         store.getPrivileges(Collections.singletonList("no-such-app"), null, future);
         final SearchHit[] hits = buildHits(emptyList());
-        listener.get().onResponse(buildSearchResponse(hits));
+        ActionListener.respondAndRelease(listener.get(), buildSearchResponse(hits));
 
         assertEquals(emptySet(), store.getApplicationNamesCache().get(singleton("no-such-app")));
         assertEquals(0, store.getDescriptorsCache().count());
@@ -405,7 +405,7 @@ public class NativePrivilegeStoreTests extends ESTestCase {
         final PlainActionFuture<Collection<ApplicationPrivilegeDescriptor>> future = new PlainActionFuture<>();
         store.getPrivileges(emptyList(), null, future);
         final SearchHit[] hits = buildHits(emptyList());
-        listener.get().onResponse(buildSearchResponse(hits));
+        ActionListener.respondAndRelease(listener.get(), buildSearchResponse(hits));
         assertEquals(emptySet(), store.getApplicationNamesCache().get(singleton("*")));
         assertEquals(1, store.getApplicationNamesCache().count());
         assertResult(emptyList(), future);
@@ -442,7 +442,7 @@ public class NativePrivilegeStoreTests extends ESTestCase {
             new ApplicationPrivilegeDescriptor("app2", "priv2b", Set.of("action:2b"), Map.of())
         );
         final SearchHit[] hits = buildHits(sourcePrivileges);
-        listener.get().onResponse(buildSearchResponse(hits));
+        ActionListener.respondAndRelease(listener.get(), buildSearchResponse(hits));
         assertEquals(Set.of("app1", "app2"), store.getApplicationNamesCache().get(singleton("*")));
         assertResult(sourcePrivileges, getFuture);
 
@@ -505,7 +505,7 @@ public class NativePrivilegeStoreTests extends ESTestCase {
         // Before the results can be cached, invalidate the cache to simulate stale search results
         store.getDescriptorsAndApplicationNamesCache().invalidateAll();
         final SearchHit[] hits = buildHits(sourcePrivileges);
-        listener.get().onResponse(buildSearchResponse(hits));
+        ActionListener.respondAndRelease(listener.get(), buildSearchResponse(hits));
 
         // Nothing should be cached since the results are stale
         assertEquals(0, store.getApplicationNamesCache().count());
@@ -553,7 +553,7 @@ public class NativePrivilegeStoreTests extends ESTestCase {
         final PlainActionFuture<Collection<ApplicationPrivilegeDescriptor>> future = new PlainActionFuture<>();
         store1.getPrivileges(null, null, future);
         final SearchHit[] hits = buildHits(sourcePrivileges);
-        listener.get().onResponse(buildSearchResponse(hits));
+        ActionListener.respondAndRelease(listener.get(), buildSearchResponse(hits));
 
         // Make sure the caching is about to happen
         getPrivilegeCountDown.await(5, TimeUnit.SECONDS);
@@ -779,7 +779,7 @@ public class NativePrivilegeStoreTests extends ESTestCase {
         final PlainActionFuture<Collection<ApplicationPrivilegeDescriptor>> future = new PlainActionFuture<>();
         store1.getPrivileges(singletonList("myapp"), null, future);
         final SearchHit[] hits = buildHits(sourcePrivileges);
-        listener.get().onResponse(buildSearchResponse(hits));
+        ActionListener.respondAndRelease(listener.get(), buildSearchResponse(hits));
 
         assertResult(sourcePrivileges, future);
     }


### PR DESCRIPTION
Just like everywhere else, only fixing the ref-counting here, no other changes to the tests.

for #102030 