### PR TITLE
[8.12] [Docs] Custom S3 CA must be reinstalled on upgrade (#103168)

### DIFF
--- a/docs/reference/snapshot-restore/repository-s3.asciidoc
+++ b/docs/reference/snapshot-restore/repository-s3.asciidoc
@@ -123,7 +123,9 @@ settings belong in the `elasticsearch.yml` file.
     `https`. Defaults to `https`. When using HTTPS, this repository type validates the
     repository's certificate chain using the JVM-wide truststore. Ensure that
     the root certificate authority is in this truststore using the JVM's
-    `keytool` tool.
+    `keytool` tool. If you have a custom certificate authority for your S3 repository
+    and you use the {es} <<jvm-version,bundled JDK>>, then you will need to reinstall your
+    CA certificate every time you upgrade {es}.
 
 `proxy.host`::
 


### PR DESCRIPTION
Backports the following commits to 8.12:
 - [Docs] Custom S3 CA must be reinstalled on upgrade (#103168)