### PR TITLE
[Profiling] Reduce number of executables queried

### DIFF
--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/StackTrace.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/StackTrace.java
@@ -215,6 +215,17 @@ final class StackTrace implements ToXContentObject {
         return new StackTrace(addressOrLines, fileIDs, frameIDs, typeIDs, 0, 0, 0);
     }
 
+    public void forNativeAndKernelFrames(java.util.function.Consumer<String> consumer) {
+        final int NATIVE_FRAME_TYPE = 3;
+        final int KERNEL_FRAME_TYPE = 4;
+        for (int i = 0; i < this.fileIds.size(); i++) {
+            Integer frameType = this.typeIds.get(i);
+            if (frameType != null && (frameType == NATIVE_FRAME_TYPE || frameType == KERNEL_FRAME_TYPE)) {
+                consumer.accept(this.fileIds.get(i));
+            }
+        }
+    }
+
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/StackTrace.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/StackTrace.java
@@ -17,8 +17,11 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Consumer;
 
 final class StackTrace implements ToXContentObject {
+    static final int NATIVE_FRAME_TYPE = 3;
+    static final int KERNEL_FRAME_TYPE = 4;
     List<Integer> addressOrLines;
     List<String> fileIds;
     List<String> frameIds;
@@ -215,9 +218,7 @@ final class StackTrace implements ToXContentObject {
         return new StackTrace(addressOrLines, fileIDs, frameIDs, typeIDs, 0, 0, 0);
     }
 
-    public void forNativeAndKernelFrames(java.util.function.Consumer<String> consumer) {
-        final int NATIVE_FRAME_TYPE = 3;
-        final int KERNEL_FRAME_TYPE = 4;
+    public void forNativeAndKernelFrames(Consumer<String> consumer) {
         for (int i = 0; i < this.fileIds.size(); i++) {
             Integer frameType = this.typeIds.get(i);
             if (frameType != null && (frameType == NATIVE_FRAME_TYPE || frameType == KERNEL_FRAME_TYPE)) {

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStackTracesAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStackTracesAction.java
@@ -526,7 +526,7 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
                         if (stackTracePerId.putIfAbsent(id, stacktrace) == null) {
                             totalFrames.addAndGet(stacktrace.frameIds.size());
                             stackFrameIds.addAll(stacktrace.frameIds);
-                            stacktrace.forNativeAndKernelFrames(executableId -> executableIds.add(executableId));
+                            stacktrace.forNativeAndKernelFrames(e -> executableIds.add(e));
                         }
                     }
                 }

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStackTracesAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStackTracesAction.java
@@ -526,23 +526,12 @@ public class TransportGetStackTracesAction extends HandledTransportAction<GetSta
                         if (stackTracePerId.putIfAbsent(id, stacktrace) == null) {
                             totalFrames.addAndGet(stacktrace.frameIds.size());
                             stackFrameIds.addAll(stacktrace.frameIds);
-                            forNativeAndKernelFrames(stacktrace, executableId -> executableIds.add(executableId));
+                            stacktrace.forNativeAndKernelFrames(executableId -> executableIds.add(executableId));
                         }
                     }
                 }
             }
             mayFinish();
-        }
-
-        private static void forNativeAndKernelFrames(StackTrace stacktrace, java.util.function.Consumer<String> consumer) {
-            final int NATIVE_FRAME_TYPE = 3;
-            final int KERNEL_FRAME_TYPE = 4;
-            for (int i = 0; i < stacktrace.fileIds.size(); i++) {
-                Integer frameType = stacktrace.typeIds.get(i);
-                if (frameType != null && (frameType == NATIVE_FRAME_TYPE || frameType == KERNEL_FRAME_TYPE)) {
-                    consumer.accept(stacktrace.fileIds.get(i));
-                }
-            }
         }
 
         public void onHostsResponse(SearchResponse searchResponse) {


### PR DESCRIPTION
This PR reduces the querying of executables to file IDs from native and kernel frames, as only these have entries in `profiling-executables`.

Here is an example (29496 docs queried before and 183 docs queried after).

**Before**
```
[2023-12-11T07:50:18,415][DEBUG][o.e.x.p.TransportGetStackTracesAction] [runTask-0] retrieveStackTraces found [16825] stack traces, [55939] frames, [29496] executables.
[2023-12-11T07:50:18,415][DEBUG][o.e.x.p.TransportGetStackTracesAction] [runTask-0] retrieveStackTraces took [725.197689 ms].
[2023-12-11T07:50:18,551][DEBUG][o.e.x.p.TransportGetStackTracesAction] [runTask-0] retrieveStackTraceDetails found [33079] stack frames, [182] executables.
[2023-12-11T07:50:18,551][DEBUG][o.e.x.p.TransportGetStackTracesAction] [runTask-0] retrieveStackTraceDetails took [133.946369 ms].
```

**After**
```
[2023-12-11T08:45:55,818][DEBUG][o.e.x.p.TransportGetStackTracesAction] [runTask-0] retrieveStackTraces found [16825] stack traces, [55939] frames, [183] executables.
[2023-12-11T08:45:55,818][DEBUG][o.e.x.p.TransportGetStackTracesAction] [runTask-0] retrieveStackTraces took [484.456895 ms].
[2023-12-11T08:45:55,973][DEBUG][o.e.x.p.TransportGetStackTracesAction] [runTask-0] retrieveStackTraceDetails found [33079] stack frames, [182] executables.
[2023-12-11T08:45:55,973][DEBUG][o.e.x.p.TransportGetStackTracesAction] [runTask-0] retrieveStackTraceDetails took [153.70309 ms].
```

The drop in latency for `retrieveStackTraces` might be an outlier or due to my local testing with just one node.
