### PR TITLE
Extract HotThreads#logLocalHotThreads utility

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/HotThreadsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/HotThreadsIT.java
@@ -7,14 +7,18 @@
  */
 package org.elasticsearch.action.admin;
 
+import org.apache.logging.log4j.Level;
 import org.apache.lucene.util.Constants;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.node.hotthreads.NodeHotThreads;
 import org.elasticsearch.action.admin.cluster.node.hotthreads.NodesHotThreadsRequestBuilder;
 import org.elasticsearch.action.admin.cluster.node.hotthreads.NodesHotThreadsResponse;
+import org.elasticsearch.common.ReferenceDocs;
+import org.elasticsearch.common.logging.ChunkedLoggingStreamTests;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.monitor.jvm.HotThreads;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.hamcrest.Matcher;
 
 import java.util.Map;
@@ -29,6 +33,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitC
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.not;
@@ -175,5 +180,26 @@ public class HotThreadsIT extends ESIntegTestCase {
                 assertTrue(result.indexOf("ignoreIdleThreads=true") != -1);
             }
         }
+    }
+
+    @TestLogging(reason = "testing logging at various levels", value = "org.elasticsearch.action.admin.HotThreadsIT:TRACE")
+    public void testLogLocalHotThreads() {
+        final var level = randomFrom(Level.TRACE, Level.DEBUG, Level.INFO, Level.WARN, Level.ERROR);
+        assertThat(
+            ChunkedLoggingStreamTests.getDecodedLoggedBody(
+                logger,
+                level,
+                getTestName(),
+                ReferenceDocs.LOGGING,
+                () -> HotThreads.logLocalHotThreads(logger, level, getTestName(), ReferenceDocs.LOGGING)
+            ).utf8ToString(),
+            allOf(
+                containsString("Hot threads at"),
+                containsString("interval=500ms"),
+                containsString("busiestThreads=500"),
+                containsString("ignoreIdleThreads=false"),
+                containsString("cpu usage by thread")
+            )
+        );
     }
 }

--- a/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -30,7 +30,6 @@ import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.ReferenceDocs;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.io.FileSystemUtils;
-import org.elasticsearch.common.logging.ChunkedLoggingStream;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
@@ -61,9 +60,7 @@ import org.elasticsearch.xcontent.NamedXContentRegistry;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.io.OutputStreamWriter;
 import java.io.UncheckedIOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.FileStore;
@@ -956,13 +953,7 @@ public final class NodeEnvironment implements Closeable {
                     return;
                 }
                 nextShardLockHotThreadsNanos = now + TimeUnit.SECONDS.toNanos(60);
-                final var hotThreads = new HotThreads().busiestThreads(500).ignoreIdleThreads(false).detect();
-                try (
-                    var stream = ChunkedLoggingStream.create(logger, Level.DEBUG, prefix, ReferenceDocs.SHARD_LOCK_TROUBLESHOOTING);
-                    var writer = new OutputStreamWriter(stream, StandardCharsets.UTF_8)
-                ) {
-                    writer.write(hotThreads);
-                }
+                HotThreads.logLocalHotThreads(logger, Level.DEBUG, prefix, ReferenceDocs.SHARD_LOCK_TROUBLESHOOTING);
             } catch (Exception e) {
                 logger.error(format("could not obtain %s", prefix), e);
             } finally {


### PR DESCRIPTION
Since #93458 we capture and log the local node's hot threads when
something is holding on to a shard lock for longer than expected. In
fact there's various other reasons we might want to automatically
capture and log the local node's hot threads. This commit extracts a
utility method to do this.