### PR TITLE
[8.12] Fix format string in OldLuceneVersions (#103185)

### DIFF
--- a/docs/changelog/103185.yaml
+++ b/docs/changelog/103185.yaml
@@ -1,0 +1,5 @@
+pr: 103185
+summary: Fix format string in `OldLuceneVersions`
+area: Search
+type: bug
+issues: []

--- a/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/OldLuceneVersions.java
+++ b/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/OldLuceneVersions.java
@@ -170,8 +170,8 @@ public class OldLuceneVersions extends Plugin implements IndexStorePlugin, Clust
             throw new UncheckedIOException(
                 Strings.format(
                     """
-                        Elasticsearch version [{}] has limited support for indices created with version [{}] but this index could not be \
-                        read. It may be using an unsupported feature, or it may be damaged or corrupt. See {} for further information.""",
+                        Elasticsearch version [%s] has limited support for indices created with version [%s] but this index could not be \
+                        read. It may be using an unsupported feature, or it may be damaged or corrupt. See %s for further information.""",
                     Build.current().version(),
                     IndexMetadata.SETTING_INDEX_VERSION_CREATED.get(indexShard.indexSettings().getSettings()),
                     ReferenceDocs.ARCHIVE_INDICES


### PR DESCRIPTION
Backports the following commits to 8.12:
 - Fix format string in OldLuceneVersions (#103185)