### PR TITLE
[8.12] [DOCS] Empty keys for ES|QL DISSECT (#102632)

### DIFF
--- a/docs/reference/esql/esql-process-data-with-dissect-grok.asciidoc
+++ b/docs/reference/esql/esql-process-data-with-dissect-grok.asciidoc
@@ -62,9 +62,8 @@ clientip:keyword | @timestamp:keyword | status:keyword
 
 include::../ingest/processors/dissect.asciidoc[tag=intro-example-explanation]
 
-A <<esql-named-skip-key,named skip key>> can be used to match values, but
-exclude the value from the output.
-// TODO: Change back to original text when https://github.com/elastic/elasticsearch/pull/102580 is merged
+An empty key (`%{}`) or <<esql-named-skip-key,named skip key>> can be used to
+match values, but exclude the value from the output.
 
 All matched values are output as keyword string data types. Use the
 <<esql-type-conversion-functions>> to convert to another data type.
@@ -137,8 +136,6 @@ include::{esql-specs}/docs.csv-spec[tag=dissectRightPaddingModifier]
 include::{esql-specs}/docs.csv-spec[tag=dissectRightPaddingModifier-result]
 |===
 
-////
-// TODO: Re-enable when https://github.com/elastic/elasticsearch/pull/102580 is merged
 include::../ingest/processors/dissect.asciidoc[tag=dissect-modifier-empty-right-padding]
 
 For example:
@@ -150,7 +147,6 @@ include::{esql-specs}/docs.csv-spec[tag=dissectEmptyRightPaddingModifier]
 |===
 include::{esql-specs}/docs.csv-spec[tag=dissectEmptyRightPaddingModifier-result]
 |===
-////
 
 [[esql-append-modifier]]
 ====== Append modifier (`+`)
@@ -180,11 +176,9 @@ include::{esql-specs}/docs.csv-spec[tag=dissectAppendWithOrderModifier-result]
 
 [[esql-named-skip-key]]
 ====== Named skip key (`?`)
-// include::../ingest/processors/dissect.asciidoc[tag=named-skip-key]
-// TODO: Re-enable when https://github.com/elastic/elasticsearch/pull/102580 is merged
-
-Dissect supports ignoring matches in the final result. This can be done with a
-named skip key using the `{?name}` syntax:
+include::../ingest/processors/dissect.asciidoc[tag=named-skip-key]
+This can be done with a named skip key using the `{?name}` syntax. In the
+following query, `ident` and `auth` are not added to the output table:
 
 [source.merge.styled,esql]
 ----
@@ -199,7 +193,7 @@ include::{esql-specs}/docs.csv-spec[tag=dissectNamedSkipKey-result]
 ===== Limitations
 
 // tag::dissect-limitations[]
-The `DISSECT` command does not support reference keys and empty keys.
+The `DISSECT` command does not support reference keys.
 // end::dissect-limitations[]
 
 [[esql-process-data-with-grok]]

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/docs.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/docs.csv-spec
@@ -574,7 +574,6 @@ dissectEmptyRightPaddingModifier
 ROW message="[1998-08-10T17:15:42]          [WARN]"
 | DISSECT message "[%{ts}]%{->}[%{level}]"
 // end::dissectEmptyRightPaddingModifier[]
-| KEEP message, ts, level
 ;
 
 // tag::dissectEmptyRightPaddingModifier-result[]


### PR DESCRIPTION
Backports the following commits to 8.12:
 - [DOCS] Empty keys for ES|QL DISSECT (#102632)