### PR TITLE
[Connectors API] Make nullable fields optional in the parser inside ConnectorSyncJob

### DIFF
--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/Connector.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/Connector.java
@@ -153,7 +153,7 @@ public class Connector implements NamedWriteable, ToXContentObject {
         this.error = error;
         this.features = features;
         this.filtering = Objects.requireNonNull(filtering, "[filtering] cannot be null");
-        this.indexName = Objects.requireNonNull(indexName, "[index_name] cannot be null");
+        this.indexName = indexName;
         this.isNative = isNative;
         this.language = language;
         this.lastSeen = lastSeen;

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobTests.java
@@ -242,6 +242,151 @@ public class ConnectorSyncJobTests extends ESTestCase {
         ConnectorSyncJob.fromXContentBytes(new BytesArray(content), XContentType.JSON);
     }
 
+    public void testSyncJobConnectorFromXContent_WithAllFieldsSet() throws IOException {
+        String content = XContentHelper.stripWhitespace("""
+            {
+                "id": "connector-id",
+                "filtering": [
+                    {
+                        "active": {
+                            "advanced_snippet": {
+                                "created_at": "2023-12-01T14:18:37.397819Z",
+                                "updated_at": "2023-12-01T14:18:37.397819Z",
+                                "value": {}
+                            },
+                            "rules": [
+                                {
+                                    "created_at": "2023-12-01T14:18:37.397819Z",
+                                    "field": "_",
+                                    "id": "DEFAULT",
+                                    "order": 0,
+                                    "policy": "include",
+                                    "rule": "regex",
+                                    "updated_at": "2023-12-01T14:18:37.397819Z",
+                                    "value": ".*"
+                                }
+                            ],
+                            "validation": {
+                                "errors": [],
+                                "state": "valid"
+                            }
+                        },
+                        "domain": "DEFAULT",
+                        "draft": {
+                            "advanced_snippet": {
+                                "created_at": "2023-12-01T14:18:37.397819Z",
+                                "updated_at": "2023-12-01T14:18:37.397819Z",
+                                "value": {}
+                            },
+                            "rules": [
+                                {
+                                    "created_at": "2023-12-01T14:18:37.397819Z",
+                                    "field": "_",
+                                    "id": "DEFAULT",
+                                    "order": 0,
+                                    "policy": "include",
+                                    "rule": "regex",
+                                    "updated_at": "2023-12-01T14:18:37.397819Z",
+                                    "value": ".*"
+                                }
+                            ],
+                            "validation": {
+                                "errors": [],
+                                "state": "valid"
+                            }
+                        }
+                    }
+                ],
+                "index_name": "search-connector",
+                "language": "english",
+                "pipeline": {
+                    "extract_binary_content": true,
+                    "name": "ent-search-generic-ingestion",
+                    "reduce_whitespace": true,
+                    "run_ml_inference": false
+                },
+                "service_type": "service type",
+                "configuration": {}
+            }
+            """);
+
+        Connector connector = ConnectorSyncJob.syncJobConnectorFromXContentBytes(new BytesArray(content), XContentType.JSON);
+
+        assertThat(connector.getConnectorId(), equalTo("connector-id"));
+        assertThat(connector.getFiltering().size(), equalTo(1));
+        assertThat(connector.getIndexName(), equalTo("search-connector"));
+        assertThat(connector.getLanguage(), equalTo("english"));
+        assertThat(connector.getPipeline(), notNullValue());
+        assertThat(connector.getServiceType(), equalTo("service type"));
+        assertThat(connector.getConfiguration(), notNullValue());
+    }
+
+    public void testSyncJobConnectorFromXContent_WithAllNonOptionalFieldsSet_DoesNotThrow() throws IOException {
+        String content = XContentHelper.stripWhitespace("""
+            {
+                "id": "connector-id",
+                "filtering": [
+                    {
+                        "active": {
+                            "advanced_snippet": {
+                                "created_at": "2023-12-01T14:18:37.397819Z",
+                                "updated_at": "2023-12-01T14:18:37.397819Z",
+                                "value": {}
+                            },
+                            "rules": [
+                                {
+                                    "created_at": "2023-12-01T14:18:37.397819Z",
+                                    "field": "_",
+                                    "id": "DEFAULT",
+                                    "order": 0,
+                                    "policy": "include",
+                                    "rule": "regex",
+                                    "updated_at": "2023-12-01T14:18:37.397819Z",
+                                    "value": ".*"
+                                }
+                            ],
+                            "validation": {
+                                "errors": [],
+                                "state": "valid"
+                            }
+                        },
+                        "domain": "DEFAULT",
+                        "draft": {
+                            "advanced_snippet": {
+                                "created_at": "2023-12-01T14:18:37.397819Z",
+                                "updated_at": "2023-12-01T14:18:37.397819Z",
+                                "value": {}
+                            },
+                            "rules": [
+                                {
+                                    "created_at": "2023-12-01T14:18:37.397819Z",
+                                    "field": "_",
+                                    "id": "DEFAULT",
+                                    "order": 0,
+                                    "policy": "include",
+                                    "rule": "regex",
+                                    "updated_at": "2023-12-01T14:18:37.397819Z",
+                                    "value": ".*"
+                                }
+                            ],
+                            "validation": {
+                                "errors": [],
+                                "state": "valid"
+                            }
+                        }
+                    }
+                ],
+                "index_name": null,
+                "language": null,
+                "pipeline": null,
+                "service_type": null,
+                "configuration": {}
+            }
+            """);
+
+        ConnectorSyncJob.syncJobConnectorFromXContentBytes(new BytesArray(content), XContentType.JSON);
+    }
+
     private void assertTransportSerialization(ConnectorSyncJob testInstance) throws IOException {
         ConnectorSyncJob deserializedInstance = copyInstance(testInstance);
         assertNotSame(testInstance, deserializedInstance);

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobTests.java
@@ -241,8 +241,8 @@ public class ConnectorSyncJobTests extends ESTestCase {
 
         ConnectorSyncJob.fromXContentBytes(new BytesArray(content), XContentType.JSON);
     }
-                                                        
-         public void testFromXContent_WithAllNullableFieldsSetToNull_DoesNotThrow() throws IOException {
+
+    public void testFromXContent_WithAllNullableFieldsSetToNull_DoesNotThrow() throws IOException {
         String content = XContentHelper.stripWhitespace("""
             {
             "cancelation_requested_at": null,


### PR DESCRIPTION
Adjust some fields in the connector parser inside `ConnectorSyncJob` to reflect that they're nullable. 