### PR TITLE
Enable APM tracing when --with-apm-server is used

### DIFF
--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/RunTask.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/RunTask.java
@@ -202,7 +202,8 @@ public abstract class RunTask extends DefaultTestClustersTask {
                         mockServer.start();
                         node.setting("telemetry.metrics.enabled", "true");
                         node.setting("tracing.apm.agent.enabled", "true");
-                        node.setting("tracing.apm.agent.transaction_sample_rate", "0.01");
+                        node.setting("tracing.apm.agent.transaction_sample_rate", "0.10");
+                        node.setting("tracing.apm.agent.metrics_interval", "10s");
                         node.setting("tracing.apm.agent.server_url", "http://127.0.0.1:" + mockServer.getPort());
                     } catch (IOException e) {
                         logger.warn("Unable to start APM server", e);

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/RunTask.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/RunTask.java
@@ -213,7 +213,7 @@ public abstract class RunTask extends DefaultTestClustersTask {
                 // if metrics were not enabled explicitly for gradlew run we should disable them
                 else if (node.getSettingKeys().contains("telemetry.metrics.enabled") == false) { // metrics
                     node.setting("telemetry.metrics.enabled", "false");
-                } else if (node.getSettingKeys().contains("tracing.apm.agent.enabled") == false) { //tracing
+                } else if (node.getSettingKeys().contains("tracing.apm.agent.enabled") == false) { // tracing
                     node.setting("tracing.apm.agent.enable", "false");
                 }
 

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/RunTask.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/RunTask.java
@@ -201,14 +201,19 @@ public abstract class RunTask extends DefaultTestClustersTask {
                     try {
                         mockServer.start();
                         node.setting("telemetry.metrics.enabled", "true");
+                        node.setting("tracing.apm.agent.enabled", "true");
+                        node.setting("tracing.apm.agent.transaction_sample_rate", "0.01");
                         node.setting("tracing.apm.agent.server_url", "http://127.0.0.1:" + mockServer.getPort());
                     } catch (IOException e) {
                         logger.warn("Unable to start APM server", e);
                     }
-                } else if (node.getSettingKeys().contains("telemetry.metrics.enabled") == false) {
-                    // in serverless metrics are enabled by default
-                    // if metrics were not enabled explicitly for gradlew run we should disable them
+                }
+                // in serverless metrics are enabled by default
+                // if metrics were not enabled explicitly for gradlew run we should disable them
+                else if (node.getSettingKeys().contains("telemetry.metrics.enabled") == false) { // metrics
                     node.setting("telemetry.metrics.enabled", "false");
+                } else if (node.getSettingKeys().contains("tracing.apm.agent.enabled") == false) { //tracing
+                    node.setting("tracing.apm.agent.enable", "false");
                 }
 
             }

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/APM.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/APM.java
@@ -73,7 +73,7 @@ public class APM extends Plugin implements NetworkPlugin, TelemetryPlugin {
         final APMMeterService apmMeter = new APMMeterService(settings);
         apmAgentSettings.addClusterSettingsListeners(services.clusterService(), telemetryProvider.get(), apmMeter);
         logger.info("Sending apm metrics is {}", APMAgentSettings.TELEMETRY_METRICS_ENABLED_SETTING.get(settings) ? "enabled" : "disabled");
-        logger.info("Sending apm traces is {}", APMAgentSettings.APM_ENABLED_SETTING.get(settings) ? "enabled" : "disabled");
+        logger.info("Sending apm tracing is {}", APMAgentSettings.APM_ENABLED_SETTING.get(settings) ? "enabled" : "disabled");
 
         return List.of(apmTracer, apmMeter);
     }


### PR DESCRIPTION
when runtask (gradlew run) task is run with --with-apm-server apm tracing should also be enabled

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
