### PR TITLE
Stream output from HotThreads

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/TransportNodesHotThreadsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/TransportNodesHotThreadsAction.java
@@ -25,6 +25,7 @@ import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
+import java.io.StringWriter;
 import java.util.List;
 
 public class TransportNodesHotThreadsAction extends TransportNodesAction<
@@ -79,8 +80,9 @@ public class TransportNodesHotThreadsAction extends TransportNodesAction<
             .interval(request.request.interval)
             .threadElementsSnapshotCount(request.request.snapshots)
             .ignoreIdleThreads(request.request.ignoreIdleThreads);
-        try {
-            return new NodeHotThreads(clusterService.localNode(), hotThreads.detect());
+        try (var writer = new StringWriter()) {
+            hotThreads.detect(writer);
+            return new NodeHotThreads(clusterService.localNode(), writer.toString());
         } catch (Exception e) {
             throw new ElasticsearchException("failed to detect hot threads", e);
         }

--- a/server/src/main/java/org/elasticsearch/monitor/jvm/HotThreads.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/HotThreads.java
@@ -14,6 +14,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.CollectionUtil;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.ReferenceDocs;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.logging.ChunkedLoggingStream;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.unit.ByteSizeValue;
@@ -21,8 +22,8 @@ import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.transport.Transports;
 
-import java.io.IOException;
 import java.io.OutputStreamWriter;
+import java.io.Writer;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
@@ -33,7 +34,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.ToLongFunction;
@@ -90,20 +90,12 @@ public class HotThreads {
             return;
         }
 
-        final String hotThreads;
-        try {
-            hotThreads = new HotThreads().busiestThreads(500).ignoreIdleThreads(false).detect();
-        } catch (Exception e) {
-            logger.error(() -> org.elasticsearch.common.Strings.format("failed to detect local hot threads with prefix [%s]", prefix), e);
-            return;
-        }
-
         try (
             var stream = ChunkedLoggingStream.create(logger, level, prefix, referenceDocs);
             var writer = new OutputStreamWriter(stream, StandardCharsets.UTF_8)
         ) {
-            writer.write(hotThreads);
-        } catch (IOException e) {
+            new HotThreads().busiestThreads(500).ignoreIdleThreads(false).detect(writer);
+        } catch (Exception e) {
             logger.error(() -> org.elasticsearch.common.Strings.format("failed to write local hot threads with prefix [%s]", prefix), e);
         }
     }
@@ -194,12 +186,12 @@ public class HotThreads {
         return this;
     }
 
-    public String detect() throws Exception {
+    public void detect(Writer writer) throws Exception {
         synchronized (mutex) {
-            return innerDetect(ManagementFactory.getThreadMXBean(), SunThreadInfo.INSTANCE, Thread.currentThread().getId(), (interval) -> {
+            innerDetect(ManagementFactory.getThreadMXBean(), SunThreadInfo.INSTANCE, Thread.currentThread().getId(), (interval) -> {
                 Thread.sleep(interval);
                 return null;
-            });
+            }, writer);
         }
     }
 
@@ -270,8 +262,13 @@ public class HotThreads {
         return (((double) time) / interval.nanos()) * 100;
     }
 
-    String innerDetect(ThreadMXBean threadBean, SunThreadInfo sunThreadInfo, long currentThreadId, SleepFunction<Long, Void> threadSleep)
-        throws Exception {
+    void innerDetect(
+        ThreadMXBean threadBean,
+        SunThreadInfo sunThreadInfo,
+        long currentThreadId,
+        SleepFunction<Long, Void> threadSleep,
+        Writer writer
+    ) throws Exception {
         if (threadBean.isThreadCpuTimeSupported() == false) {
             throw new ElasticsearchException("thread CPU time is not supported on this JDK");
         }
@@ -286,14 +283,14 @@ public class HotThreads {
             throw new ElasticsearchException("thread wait/blocked time accounting is not supported on this JDK");
         }
 
-        StringBuilder sb = new StringBuilder().append("Hot threads at ")
+        writer.append("Hot threads at ")
             .append(DATE_TIME_FORMATTER.format(LocalDateTime.now(Clock.systemUTC())))
             .append(", interval=")
-            .append(interval)
+            .append(interval.toString())
             .append(", busiestThreads=")
-            .append(busiestThreads)
+            .append(Integer.toString(busiestThreads))
             .append(", ignoreIdleThreads=")
-            .append(ignoreIdleThreads)
+            .append(Boolean.toString(ignoreIdleThreads))
             .append(":\n");
 
         // Capture before and after thread state with timings
@@ -343,9 +340,8 @@ public class HotThreads {
             ThreadTimeAccumulator topThread = topThreads.get(t);
 
             switch (type) {
-                case MEM -> sb.append(
-                    String.format(
-                        Locale.ROOT,
+                case MEM -> writer.append(
+                    Strings.format(
                         "%n%s memory allocated by thread '%s'%n",
                         ByteSizeValue.ofBytes(topThread.getAllocatedBytes()),
                         threadName
@@ -358,9 +354,8 @@ public class HotThreads {
                         : getTimeSharePercentage(topThread.getOtherTime());
                     double percentTotal = (Transports.isTransportThread(threadName)) ? percentCpu : percentOther + percentCpu;
                     String otherLabel = (Transports.isTransportThread(threadName)) ? "idle" : "other";
-                    sb.append(
-                        String.format(
-                            Locale.ROOT,
+                    writer.append(
+                        Strings.format(
                             "%n%4.1f%% [cpu=%1.1f%%, %s=%1.1f%%] (%s out of %s) %s usage by thread '%s'%n",
                             percentTotal,
                             percentCpu,
@@ -376,9 +371,8 @@ public class HotThreads {
                 default -> {
                     long time = ThreadTimeAccumulator.valueGetterForReportType(type).applyAsLong(topThread);
                     double percent = getTimeSharePercentage(time);
-                    sb.append(
-                        String.format(
-                            Locale.ROOT,
+                    writer.append(
+                        Strings.format(
                             "%n%4.1f%% (%s out of %s) %s usage by thread '%s'%n",
                             percent,
                             TimeValue.timeValueNanos(time),
@@ -417,29 +411,21 @@ public class HotThreads {
                 if (allInfos[i][t] != null) {
                     final StackTraceElement[] show = allInfos[i][t].getStackTrace();
                     if (count == 1) {
-                        sb.append(String.format(Locale.ROOT, "  unique snapshot%n"));
+                        writer.append(Strings.format("  unique snapshot%n"));
                         for (StackTraceElement frame : show) {
-                            sb.append(String.format(Locale.ROOT, "    %s%n", frame));
+                            writer.append(Strings.format("    %s%n", frame));
                         }
                     } else {
-                        sb.append(
-                            String.format(
-                                Locale.ROOT,
-                                "  %d/%d snapshots sharing following %d elements%n",
-                                count,
-                                threadElementsSnapshotCount,
-                                maxSim
-                            )
+                        writer.append(
+                            Strings.format("  %d/%d snapshots sharing following %d elements%n", count, threadElementsSnapshotCount, maxSim)
                         );
                         for (int l = show.length - maxSim; l < show.length; l++) {
-                            sb.append(String.format(Locale.ROOT, "    %s%n", show[l]));
+                            writer.append(Strings.format("    %s%n", show[l]));
                         }
                     }
                 }
             }
         }
-
-        return sb.toString();
     }
 
     static int similarity(ThreadInfo threadInfo, ThreadInfo threadInfo0) {

--- a/server/src/test/java/org/elasticsearch/monitor/jvm/HotThreadsTests.java
+++ b/server/src/test/java/org/elasticsearch/monitor/jvm/HotThreadsTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.mockito.ArgumentMatchers;
 import org.mockito.InOrder;
 
+import java.io.StringWriter;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
 import java.util.ArrayList;
@@ -302,7 +303,7 @@ public class HotThreadsTests extends ESTestCase {
             .threadElementsSnapshotCount(11)
             .ignoreIdleThreads(false);
 
-        String innerResult = hotThreads.innerDetect(mockedMXBean, mockedSunThreadInfo, mockCurrentThreadId, (interval) -> null);
+        String innerResult = innerDetect(hotThreads, mockedMXBean, mockedSunThreadInfo, mockCurrentThreadId);
 
         assertThat(innerResult, containsString("Hot threads at "));
         assertThat(innerResult, containsString("interval=10ms, busiestThreads=4, ignoreIdleThreads=false:"));
@@ -321,7 +322,7 @@ public class HotThreadsTests extends ESTestCase {
         assertThat(innerResult, containsString("org.elasticsearch.monitor.testOther.methodFinal(Some_File:1)"));
 
         // Let's ask again without progressing the CPU thread counters, e.g. resetting the mocks
-        innerResult = hotThreads.innerDetect(mockedMXBean, mockedSunThreadInfo, mockCurrentThreadId, (interval) -> null);
+        innerResult = innerDetect(hotThreads, mockedMXBean, mockedSunThreadInfo, mockCurrentThreadId);
 
         assertThat(innerResult, containsString("0.0% [cpu=0.0%, other=0.0%] (0s out of 10ms) cpu usage by thread 'Thread 4'"));
         assertThat(innerResult, containsString("0.0% [cpu=0.0%, other=0.0%] (0s out of 10ms) cpu usage by thread 'Thread 3'"));
@@ -340,7 +341,7 @@ public class HotThreadsTests extends ESTestCase {
             .threadElementsSnapshotCount(11)
             .ignoreIdleThreads(false);
 
-        innerResult = hotThreads.innerDetect(mockedMXBean, mockedSunThreadInfo, mockCurrentThreadId, (interval) -> null);
+        innerResult = innerDetect(hotThreads, mockedMXBean, mockedSunThreadInfo, mockCurrentThreadId);
 
         assertThat(innerResult, containsString("Hot threads at "));
         assertThat(innerResult, containsString("interval=10ms, busiestThreads=4, ignoreIdleThreads=false:"));
@@ -377,7 +378,7 @@ public class HotThreadsTests extends ESTestCase {
         List<ThreadInfo> waitOrderedInfos = List.of(allInfos.get(3), allInfos.get(1), allInfos.get(0), allInfos.get(2));
         when(mockedMXBean.getThreadInfo(ArgumentMatchers.any(), anyInt())).thenReturn(waitOrderedInfos.toArray(new ThreadInfo[0]));
 
-        String waitInnerResult = hotWaitingThreads.innerDetect(mockedMXBean, mockedSunThreadInfo, mockCurrentThreadId, (interval) -> null);
+        String waitInnerResult = innerDetect(hotWaitingThreads, mockedMXBean, mockedSunThreadInfo, mockCurrentThreadId);
 
         assertThat(
             waitInnerResult,
@@ -401,7 +402,7 @@ public class HotThreadsTests extends ESTestCase {
         waitOrderedInfos = List.of(allInfos.get(3), allInfos.get(1), allInfos.get(0), allInfos.get(2));
         when(mockedMXBean.getThreadInfo(ArgumentMatchers.any(), anyInt())).thenReturn(waitOrderedInfos.toArray(new ThreadInfo[0]));
 
-        waitInnerResult = hotWaitingThreads.innerDetect(mockedMXBean, mockedSunThreadInfo, mockCurrentThreadId, (interval) -> null);
+        waitInnerResult = innerDetect(hotWaitingThreads, mockedMXBean, mockedSunThreadInfo, mockCurrentThreadId);
 
         assertThat(
             waitInnerResult,
@@ -431,7 +432,7 @@ public class HotThreadsTests extends ESTestCase {
         List<ThreadInfo> blockOrderedInfos = List.of(allInfos.get(2), allInfos.get(0), allInfos.get(1), allInfos.get(3));
         when(mockedMXBean.getThreadInfo(ArgumentMatchers.any(), anyInt())).thenReturn(blockOrderedInfos.toArray(new ThreadInfo[0]));
 
-        String blockInnerResult = hotBlockedThreads.innerDetect(mockedMXBean, mockedSunThreadInfo, mockCurrentThreadId, (interval) -> null);
+        String blockInnerResult = innerDetect(hotBlockedThreads, mockedMXBean, mockedSunThreadInfo, mockCurrentThreadId);
 
         assertThat(
             blockInnerResult,
@@ -455,7 +456,7 @@ public class HotThreadsTests extends ESTestCase {
         blockOrderedInfos = List.of(allInfos.get(2), allInfos.get(0), allInfos.get(1), allInfos.get(3));
         when(mockedMXBean.getThreadInfo(ArgumentMatchers.any(), anyInt())).thenReturn(blockOrderedInfos.toArray(new ThreadInfo[0]));
 
-        blockInnerResult = hotBlockedThreads.innerDetect(mockedMXBean, mockedSunThreadInfo, mockCurrentThreadId, (interval) -> null);
+        blockInnerResult = innerDetect(hotBlockedThreads, mockedMXBean, mockedSunThreadInfo, mockCurrentThreadId);
 
         assertThat(
             blockInnerResult,
@@ -490,7 +491,7 @@ public class HotThreadsTests extends ESTestCase {
             .threadElementsSnapshotCount(1)
             .ignoreIdleThreads(false);
 
-        String memInnerResult = hotThreads.innerDetect(mockedMXBean, mockedSunThreadInfo, mockCurrentThreadId, (interval) -> null);
+        String memInnerResult = innerDetect(hotThreads, mockedMXBean, mockedSunThreadInfo, mockCurrentThreadId);
         assertThat(memInnerResult, containsString("  unique snapshot"));
         assertThat(
             memInnerResult,
@@ -519,7 +520,7 @@ public class HotThreadsTests extends ESTestCase {
             .threadElementsSnapshotCount(1)
             .ignoreIdleThreads(false);
 
-        memInnerResult = hotThreads.innerDetect(mockedMXBean, mockedSunThreadInfo, mockCurrentThreadId, (interval) -> null);
+        memInnerResult = innerDetect(hotThreads, mockedMXBean, mockedSunThreadInfo, mockCurrentThreadId);
         assertThat(memInnerResult, containsString("  unique snapshot"));
         assertThat(
             memInnerResult,
@@ -551,7 +552,7 @@ public class HotThreadsTests extends ESTestCase {
             .threadElementsSnapshotCount(1)
             .ignoreIdleThreads(false);
 
-        String singleResult = hotThreads.innerDetect(mockedMXBean, mockedSunThreadInfo, mockCurrentThreadId, (interval) -> null);
+        String singleResult = innerDetect(hotThreads, mockedMXBean, mockedSunThreadInfo, mockCurrentThreadId);
 
         assertThat(singleResult, containsString("  unique snapshot"));
         assertEquals(5, singleResult.split(" unique snapshot").length);
@@ -581,7 +582,7 @@ public class HotThreadsTests extends ESTestCase {
             .threadElementsSnapshotCount(11)
             .ignoreIdleThreads(false);
 
-        String innerResult = hotThreads.innerDetect(mockedMXBean, mock(SunThreadInfo.class), mockCurrentThreadId, (interval) -> null);
+        String innerResult = innerDetect(hotThreads, mockedMXBean, mock(SunThreadInfo.class), mockCurrentThreadId);
 
         assertEquals(1, innerResult.lines().count());
     }
@@ -811,7 +812,7 @@ public class HotThreadsTests extends ESTestCase {
 
         Exception e = expectThrows(
             ElasticsearchException.class,
-            () -> hotThreads.innerDetect(mockedMXBean, mock(SunThreadInfo.class), mockCurrentThreadId, (interval) -> null)
+            () -> innerDetect(hotThreads, mockedMXBean, mock(SunThreadInfo.class), mockCurrentThreadId)
         );
         assertEquals(e.getMessage(), "thread wait/blocked time accounting is not supported on this JDK");
 
@@ -846,7 +847,7 @@ public class HotThreadsTests extends ESTestCase {
 
         ElasticsearchException exception = expectThrows(
             ElasticsearchException.class,
-            () -> hotThreads0.innerDetect(mockedMXBean, mockedSunThreadInfo, 0L, (interval) -> null)
+            () -> innerDetect(hotThreads0, mockedMXBean, mockedSunThreadInfo, 0L)
         );
         assertThat(exception.getMessage(), equalTo("thread allocated memory is not supported on this JDK"));
     }
@@ -869,7 +870,7 @@ public class HotThreadsTests extends ESTestCase {
             .threadElementsSnapshotCount(11)
             .ignoreIdleThreads(false);
 
-        String innerResult = hotThreads.innerDetect(mockedMXBean, mockedSunThreadInfo, mockCurrentThreadId, (interval) -> null);
+        String innerResult = innerDetect(hotThreads, mockedMXBean, mockedSunThreadInfo, mockCurrentThreadId);
 
         assertThat(innerResult, containsString("Hot threads at "));
         assertThat(innerResult, containsString("interval=10ms, busiestThreads=4, ignoreIdleThreads=false:"));
@@ -888,7 +889,7 @@ public class HotThreadsTests extends ESTestCase {
         assertThat(innerResult, containsString("org.elasticsearch.monitor.testOther.methodFinal(Some_File:1)"));
 
         // Let's ask again without progressing the CPU thread counters, e.g. resetting the mocks
-        innerResult = hotThreads.innerDetect(mockedMXBean, mockedSunThreadInfo, mockCurrentThreadId, (interval) -> null);
+        innerResult = innerDetect(hotThreads, mockedMXBean, mockedSunThreadInfo, mockCurrentThreadId);
 
         assertThat(
             innerResult,
@@ -919,7 +920,7 @@ public class HotThreadsTests extends ESTestCase {
             .threadElementsSnapshotCount(11)
             .ignoreIdleThreads(false);
 
-        innerResult = hotThreads.innerDetect(mockedMXBean, mockedSunThreadInfo, mockCurrentThreadId, (interval) -> null);
+        innerResult = innerDetect(hotThreads, mockedMXBean, mockedSunThreadInfo, mockCurrentThreadId);
 
         assertThat(innerResult, containsString("Hot threads at "));
         assertThat(innerResult, containsString("interval=10ms, busiestThreads=4, ignoreIdleThreads=false:"));
@@ -936,5 +937,17 @@ public class HotThreadsTests extends ESTestCase {
         assertThat(innerResult, containsString("org.elasticsearch.monitor.test.method_0(Some_File:1)"));
         assertThat(innerResult, containsString("org.elasticsearch.monitor.test.method_1(Some_File:1)"));
         assertThat(innerResult, containsString("org.elasticsearch.monitor.testOther.methodFinal(Some_File:1)"));
+    }
+
+    private static String innerDetect(
+        HotThreads hotThreads,
+        ThreadMXBean mockedMthreadMXBeanBean,
+        SunThreadInfo sunThreadInfo,
+        long currentThreadId
+    ) throws Exception {
+        try (var writer = new StringWriter()) {
+            hotThreads.innerDetect(mockedMthreadMXBeanBean, sunThreadInfo, currentThreadId, (interval) -> null, writer);
+            return writer.toString();
+        }
     }
 }


### PR DESCRIPTION
The API to `HotThreads` today forces the allocation of one massive
string to hold the results. This change gives the caller the option of
consuming the results incrementally instead.