### PR TITLE
[8.12] Skip docs.DissectEmptyRightPaddingModifier for versions <8.11.2 (#103276)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/docs.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/docs.csv-spec
@@ -569,7 +569,7 @@ message:keyword  | ts:keyword | level:keyword
 // end::dissectRightPaddingModifier-result[]
 ;
 
-dissectEmptyRightPaddingModifier
+dissectEmptyRightPaddingModifier#[skip:-8.11.2, reason:Support for empty right padding modifiers introduced in 8.11.2]
 // tag::dissectEmptyRightPaddingModifier[]
 ROW message="[1998-08-10T17:15:42]          [WARN]"
 | DISSECT message "[%{ts}]%{->}[%{level}]"


### PR DESCRIPTION
Backports the following commits to 8.12:
 - Skip docs.DissectEmptyRightPaddingModifier for versions <8.11.2 (#103276)