### PR TITLE
ESQL: Shrink status in project

### DIFF
--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/ProjectOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/ProjectOperatorTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.compute.operator;
 
-import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.Block;
@@ -16,16 +15,14 @@ import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.core.Tuple;
-import org.elasticsearch.indices.breaker.CircuitBreakerService;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class ProjectOperatorTests extends OperatorTestCase {
     public void testProjectionOnEmptyPage() {
@@ -105,10 +102,13 @@ public class ProjectOperatorTests extends OperatorTestCase {
         return null;
     }
 
-    // A breaker service that always returns the given breaker for getBreaker(CircuitBreaker.REQUEST)
-    static CircuitBreakerService mockBreakerService(CircuitBreaker breaker) {
-        CircuitBreakerService breakerService = mock(CircuitBreakerService.class);
-        when(breakerService.getBreaker(CircuitBreaker.REQUEST)).thenReturn(breaker);
-        return breakerService;
+    public void testDescriptionOfMany() {
+        ProjectOperator.ProjectOperatorFactory factory = new ProjectOperator.ProjectOperatorFactory(
+            IntStream.range(0, 100).boxed().toList()
+        );
+        assertThat(factory.describe(), equalTo("ProjectOperator[projection = [100 fields]]"));
+        try (Operator op = factory.get(driverContext())) {
+            assertThat(op.toString(), equalTo("ProjectOperator[projection = [100 fields]]"));
+        }
     }
 }


### PR DESCRIPTION
If you are selecting 100s of fields project's status can be *huge*, this shrinks it.
