### PR TITLE
[8.12] Wait for reroute before acking put-shutdown (#103251)

### DIFF
--- a/docs/changelog/103251.yaml
+++ b/docs/changelog/103251.yaml
@@ -1,0 +1,5 @@
+pr: 103251
+summary: Wait for reroute before acking put-shutdown
+area: Infra/Node Lifecycle
+type: bug
+issues: []

--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportPutShutdownNodeAction.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportPutShutdownNodeAction.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.shutdown;
 
-import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
@@ -20,12 +19,10 @@ import org.elasticsearch.cluster.ClusterStateTaskListener;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
-import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.NodesShutdownMetadata;
 import org.elasticsearch.cluster.metadata.SingleNodeShutdownMetadata;
-import org.elasticsearch.cluster.routing.RerouteService;
+import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.cluster.service.MasterService;
 import org.elasticsearch.cluster.service.MasterServiceTaskQueue;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.inject.Inject;
@@ -40,10 +37,12 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Predicate;
 
+import static org.elasticsearch.cluster.routing.allocation.allocator.AllocationActionListener.rerouteCompletionIsNotRequired;
+
 public class TransportPutShutdownNodeAction extends AcknowledgedTransportMasterNodeAction<Request> {
     private static final Logger logger = LogManager.getLogger(TransportPutShutdownNodeAction.class);
 
-    private final RerouteService rerouteService;
+    private final AllocationService allocationService;
     private final MasterServiceTaskQueue<PutShutdownNodeTask> taskQueue;
 
     private final PutShutdownNodeExecutor executor = new PutShutdownNodeExecutor();
@@ -81,38 +80,6 @@ public class TransportPutShutdownNodeAction extends AcknowledgedTransportMasterN
         return true;
     }
 
-    private static void ackAndMaybeReroute(Request request, ActionListener<AcknowledgedResponse> listener, RerouteService rerouteService) {
-        boolean shouldReroute = switch (request.getType()) {
-            case REMOVE, SIGTERM, REPLACE -> true;
-            default -> false;
-        };
-
-        if (shouldReroute) {
-            rerouteService.reroute("node registered for removal from cluster", Priority.URGENT, new ActionListener<>() {
-                @Override
-                public void onResponse(Void ignored) {}
-
-                @Override
-                public void onFailure(Exception e) {
-                    logger.log(
-                        MasterService.isPublishFailureException(e) ? Level.DEBUG : Level.WARN,
-                        () -> "failed to reroute after registering node [" + request.getNodeId() + "] for shutdown",
-                        e
-                    );
-                }
-            });
-        } else {
-            logger.trace(
-                () -> "not starting reroute after registering node ["
-                    + request.getNodeId()
-                    + "] for shutdown of type ["
-                    + request.getType()
-                    + "]"
-            );
-        }
-        listener.onResponse(AcknowledgedResponse.TRUE);
-    }
-
     // package private for tests
     record PutShutdownNodeTask(Request request, ActionListener<AcknowledgedResponse> listener) implements ClusterStateTaskListener {
         @Override
@@ -130,6 +97,7 @@ public class TransportPutShutdownNodeAction extends AcknowledgedTransportMasterN
             var shutdownMetadata = new HashMap<>(initialState.metadata().nodeShutdowns().getAll());
             Predicate<String> nodeExistsPredicate = batchExecutionContext.initialState().getNodes()::nodeExists;
             boolean changed = false;
+            boolean needsReroute = false;
             for (final var taskContext : batchExecutionContext.taskContexts()) {
                 var request = taskContext.getTask().request();
                 try (var ignored = taskContext.captureResponseHeaders()) {
@@ -138,17 +106,34 @@ public class TransportPutShutdownNodeAction extends AcknowledgedTransportMasterN
                     taskContext.onFailure(e);
                     continue;
                 }
-                taskContext.success(() -> ackAndMaybeReroute(request, taskContext.getTask().listener(), rerouteService));
+                switch (request.getType()) {
+                    case REMOVE, SIGTERM, REPLACE -> needsReroute = true;
+                }
+                taskContext.success(() -> {
+                    logger.trace(
+                        () -> "finished registering node [" + request.getNodeId() + "] for shutdown of type [" + request.getType() + "]"
+                    );
+                    taskContext.getTask().listener.onResponse(AcknowledgedResponse.TRUE);
+                });
             }
             if (changed == false) {
-                return batchExecutionContext.initialState();
+                return initialState;
             }
-            return ClusterState.builder(batchExecutionContext.initialState())
-                .metadata(
-                    Metadata.builder(batchExecutionContext.initialState().metadata())
-                        .putCustom(NodesShutdownMetadata.TYPE, new NodesShutdownMetadata(shutdownMetadata))
-                )
-                .build();
+
+            final var updatedState = initialState.copyAndUpdateMetadata(
+                b -> b.putCustom(NodesShutdownMetadata.TYPE, new NodesShutdownMetadata(shutdownMetadata))
+            );
+
+            if (needsReroute == false) {
+                return updatedState;
+            }
+
+            // Reroute inline with the update, rather than using the RerouteService, in order to atomically update things like auto-expand
+            // replicas to account for the shutdown metadata. If the reroute were separate then the get-shutdown API might observe the
+            // intermediate state and report that nodes are ready to shut down prematurely. Even if the client were to wait for the
+            // put-shutdown API to complete there's a risk that it gets disconnected and retries, but the retry could well be a no-op which
+            // short-circuits past the cluster state update and therefore also doesn't wait for the background reroute.
+            return allocationService.reroute(updatedState, "reroute after put-shutdown", rerouteCompletionIsNotRequired());
         }
     }
 
@@ -156,7 +141,7 @@ public class TransportPutShutdownNodeAction extends AcknowledgedTransportMasterN
     public TransportPutShutdownNodeAction(
         TransportService transportService,
         ClusterService clusterService,
-        RerouteService rerouteService,
+        AllocationService allocationService,
         ThreadPool threadPool,
         ActionFilters actionFilters,
         IndexNameExpressionResolver indexNameExpressionResolver
@@ -172,7 +157,7 @@ public class TransportPutShutdownNodeAction extends AcknowledgedTransportMasterN
             indexNameExpressionResolver,
             EsExecutors.DIRECT_EXECUTOR_SERVICE
         );
-        this.rerouteService = rerouteService;
+        this.allocationService = allocationService;
         taskQueue = clusterService.createTaskQueue("put-shutdown", Priority.URGENT, new PutShutdownNodeExecutor());
     }
 

--- a/x-pack/plugin/shutdown/src/test/java/org/elasticsearch/xpack/shutdown/TransportPutShutdownNodeActionTests.java
+++ b/x-pack/plugin/shutdown/src/test/java/org/elasticsearch/xpack/shutdown/TransportPutShutdownNodeActionTests.java
@@ -15,7 +15,7 @@ import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateTaskExecutor.TaskContext;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.SingleNodeShutdownMetadata.Type;
-import org.elasticsearch.cluster.routing.RerouteService;
+import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.cluster.service.MasterServiceTaskQueue;
 import org.elasticsearch.core.TimeValue;
@@ -39,6 +39,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -64,7 +65,8 @@ public class TransportPutShutdownNodeActionTests extends ESTestCase {
         var threadPool = mock(ThreadPool.class);
         var transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor(threadPool);
         clusterService = mock(ClusterService.class);
-        var rerouteService = mock(RerouteService.class);
+        var allocationService = mock(AllocationService.class);
+        when(allocationService.reroute(any(ClusterState.class), anyString(), any())).then(invocation -> invocation.getArgument(0));
         var actionFilters = mock(ActionFilters.class);
         var indexNameExpressionResolver = mock(IndexNameExpressionResolver.class);
         when(clusterService.createTaskQueue(any(), any(), Mockito.<ClusterStateTaskExecutor<PutShutdownNodeTask>>any())).thenReturn(
@@ -73,7 +75,7 @@ public class TransportPutShutdownNodeActionTests extends ESTestCase {
         action = new TransportPutShutdownNodeAction(
             transportService,
             clusterService,
-            rerouteService,
+            allocationService,
             threadPool,
             actionFilters,
             indexNameExpressionResolver


### PR DESCRIPTION
Backports the following commits to 8.12:
 - Wait for reroute before acking put-shutdown (#103251)