### PR TITLE
[8.12] [Connector API] Add docs for create connector API (#103177)

### DIFF
--- a/docs/reference/connector/apis/connector-apis.asciidoc
+++ b/docs/reference/connector/apis/connector-apis.asciidoc
@@ -1,0 +1,37 @@
+[[connector-apis]]
+== Connector APIs
+
+preview::[]
+
+++++
+<titleabbrev>Connector APIs</titleabbrev>
+++++
+
+---
+
+The connector and sync jobs API provides a convenient way to create and manage Elastic connectors and sync jobs in an internal index.
+
+This API provides an alternative to relying solely on {kib} UI for connector and sync job management. The API comes with a set of
+validations and assertions to ensure that the state representation in the internal index remains valid.
+
+[discrete]
+[[elastic-connector-apis]]
+=== Connector APIs
+
+You can use these APIs to create, get, delete and update connectors.
+
+Use the following APIs to manage connectors:
+
+* <<create-connector-api>>
+
+
+[discrete]
+[[sync-job-apis]]
+=== Sync Job APIs
+
+You can use these APIs to create, cancel, delete and update sync jobs.
+
+Use the following APIs to manage sync jobs:
+
+
+include::create-connector-api.asciidoc[]

--- a/docs/reference/connector/apis/create-connector-api.asciidoc
+++ b/docs/reference/connector/apis/create-connector-api.asciidoc
@@ -1,0 +1,128 @@
+[[create-connector-api]]
+=== Create connector API
+++++
+<titleabbrev>Create connector</titleabbrev>
+++++
+
+Creates a connector.
+
+
+[source,console]
+--------------------------------------------------
+PUT _connector/my-connector
+{
+  "index_name": "search-google-drive",
+  "name": "My Connector",
+  "service_type": "google_drive"
+}
+--------------------------------------------------
+////
+[source,console]
+----
+DELETE _connector/my-connector
+----
+// TEST[continued]
+////
+
+[[create-connector-api-request]]
+==== {api-request-title}
+`POST _connector`
+
+`PUT _connector/<connector_id>`
+
+
+[[create-connector-api-prereqs]]
+==== {api-prereq-title}
+
+* To sync data using connectors, it's essential to have the Elastic connectors service running.
+* The `service_type` parameter should reference an existing connector service type.
+
+
+[[create-connector-api-desc]]
+==== {api-description-title}
+
+Creates a connector document in the internal index and initializes its configuration, filtering, and scheduling with default values. These values can be updated later as needed.
+
+[[create-connector-api-path-params]]
+==== {api-path-parms-title}
+
+`<connector_id>`::
+(Required, string) Unique identifier of a connector.
+
+
+[role="child_attributes"]
+[[create-connector-api-request-body]]
+==== {api-request-body-title}
+
+`description`::
+(Optional, string) The description of the connector.
+
+`index_name`::
+(Required, string) The target index for syncing data by the connector.
+
+`name`::
+(Optional, string) The name of the connector.
+
+`is_native`::
+(Optional, boolean) Indicates if it's a native connector. Defaults to `false`.
+
+`language`::
+(Optional, string) Language analyzer for the data. Limited to supported languages.
+
+`service_type`::
+(Optional, string) Connector service type. Can reference Elastic-supported connector types or a custom connector type.
+
+
+[role="child_attributes"]
+[[create-connector-api-response-body]]
+==== {api-response-body-title}
+
+`id`::
+  (string) The ID associated with the connector document. Returned when using a POST request.
+
+`result`::
+  (string) The result of the indexing operation, `created` or `updated`. Returned when using a PUT request.
+
+[[create-connector-api-response-codes]]
+==== {api-response-codes-title}
+
+`200`::
+Indicates that an existing connector was updated successfully.
+
+`201`::
+Indicates that the connector was created successfully.
+
+`400`::
+Indicates that the request was malformed.
+
+[[create-connector-api-example]]
+==== {api-examples-title}
+
+[source,console]
+----
+PUT _connector/my-connector
+{
+  "index_name": "search-google-drive",
+  "name": "My Connector",
+  "description": "My Connector to sync data to Elastic index from Google Drive",
+  "service_type": "google_drive",
+  "language": "english"
+}
+----
+
+
+The API returns the following result:
+
+[source,console-result]
+----
+{
+  "result": "created"
+}
+----
+////
+[source,console]
+----
+DELETE _connector/my-connector
+----
+// TEST[continued]
+////

--- a/docs/reference/rest-api/index.asciidoc
+++ b/docs/reference/rest-api/index.asciidoc
@@ -18,6 +18,7 @@ not be included yet.
 * <<cat, cat APIs>>
 * <<cluster, Cluster APIs>>
 * <<features-apis,Features APIs>>
+* <<connector-apis, Connector APIs>>
 * <<ccr-apis,{ccr-cap} APIs>>
 * <<data-stream-apis,Data stream APIs>>
 * <<docs, Document APIs>>
@@ -66,6 +67,7 @@ include::{es-repo-dir}/behavioral-analytics/apis/index.asciidoc[]
 include::{es-repo-dir}/cat.asciidoc[]
 include::{es-repo-dir}/cluster.asciidoc[]
 include::{es-repo-dir}/ccr/apis/ccr-apis.asciidoc[]
+include::{es-repo-dir}/connector/apis/connector-apis.asciidoc[]
 include::{es-repo-dir}/data-streams/data-stream-apis.asciidoc[]
 include::{es-repo-dir}/docs.asciidoc[]
 include::{es-repo-dir}/ingest/apis/enrich/index.asciidoc[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.12`:
 - [[Connector API] Add docs for create connector API (#103177)](https://github.com/elastic/elasticsearch/pull/103177)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)