### PR TITLE
[8.12] ES|QL: Improve resolution error management in mv_expand (#102967)

### DIFF
--- a/docs/changelog/102967.yaml
+++ b/docs/changelog/102967.yaml
@@ -1,0 +1,6 @@
+pr: 102967
+summary: "ES|QL: Improve resolution error management in `mv_expand`"
+area: ES|QL
+type: bug
+issues:
+ - 102964

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -351,7 +351,17 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                     p.source(),
                     p.child(),
                     resolved,
-                    new ReferenceAttribute(resolved.source(), resolved.name(), resolved.dataType(), null, resolved.nullable(), null, false)
+                    resolved.resolved()
+                        ? new ReferenceAttribute(
+                            resolved.source(),
+                            resolved.name(),
+                            resolved.dataType(),
+                            null,
+                            resolved.nullable(),
+                            null,
+                            false
+                        )
+                        : resolved
                 );
             }
             return p;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
@@ -1426,6 +1426,14 @@ public class AnalyzerTests extends ESTestCase {
         assertThat(e.getMessage(), containsString("Unknown column [x5], did you mean any of [x1, x2, x3]?"));
     }
 
+    public void testUnresolvedMvExpand() {
+        var e = expectThrows(VerificationException.class, () -> analyze("row foo = 1 | mv_expand bar"));
+        assertThat(e.getMessage(), containsString("Unknown column [bar]"));
+
+        e = expectThrows(VerificationException.class, () -> analyze("row foo = 1 | keep foo, foo | mv_expand foo"));
+        assertThat(e.getMessage(), containsString("Reference [foo] is ambiguous (to disambiguate use quotes or qualifiers)"));
+    }
+
     private void verifyUnsupported(String query, String errorMessage) {
         verifyUnsupported(query, errorMessage, "mapping-multi-field-variation.json");
     }


### PR DESCRIPTION
Backports the following commits to 8.12:
 - ES|QL: Improve resolution error management in mv_expand (#102967)