### PR TITLE
ESQL: Remove unused StringBuilder

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -814,9 +814,7 @@ public class LocalExecutionPlanner {
 
         @Override
         public String describe() {
-            StringBuilder sb = new StringBuilder();
-            sb.append(driverFactories.stream().map(DriverFactory::describe).collect(joining("\n")));
-            return sb.toString();
+            return driverFactories.stream().map(DriverFactory::describe).collect(joining("\n"));
         }
     }
 }


### PR DESCRIPTION
It's a small thing but it saves an extra copy that we don't need and makes the code easier to read.
