### PR TITLE
[8.12] [ML] Bug truncate input text for the inference API (#103027)

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
@@ -42,6 +42,7 @@ import org.elasticsearch.xpack.inference.action.TransportGetInferenceModelAction
 import org.elasticsearch.xpack.inference.action.TransportInferenceAction;
 import org.elasticsearch.xpack.inference.action.TransportInferenceUsageAction;
 import org.elasticsearch.xpack.inference.action.TransportPutInferenceModelAction;
+import org.elasticsearch.xpack.inference.common.Truncator;
 import org.elasticsearch.xpack.inference.external.http.HttpClientManager;
 import org.elasticsearch.xpack.inference.external.http.HttpSettings;
 import org.elasticsearch.xpack.inference.external.http.retry.RetrySettings;
@@ -114,7 +115,8 @@ public class InferencePlugin extends Plugin implements ActionPlugin, ExtensibleP
     @Override
     public Collection<?> createComponents(PluginServices services) {
         var throttlerManager = new ThrottlerManager(settings, services.threadPool(), services.clusterService());
-        serviceComponents.set(new ServiceComponents(services.threadPool(), throttlerManager, settings));
+        var truncator = new Truncator(settings, services.clusterService());
+        serviceComponents.set(new ServiceComponents(services.threadPool(), throttlerManager, settings, truncator));
 
         httpManager.set(HttpClientManager.create(settings, services.threadPool(), services.clusterService(), throttlerManager));
 
@@ -211,7 +213,8 @@ public class InferencePlugin extends Plugin implements ActionPlugin, ExtensibleP
             HttpClientManager.getSettings(),
             HttpRequestSenderFactory.HttpRequestSender.getSettings(),
             ThrottlerManager.getSettings(),
-            RetrySettings.getSettingsDefinitions()
+            RetrySettings.getSettingsDefinitions(),
+            Truncator.getSettings()
         ).flatMap(Collection::stream).collect(Collectors.toList());
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/common/Truncator.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/common/Truncator.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.common;
+
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.Nullable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Provides truncation logic for inference requests
+ */
+public class Truncator {
+
+    /**
+     * Defines the percentage to reduce the input text for an inference request.
+     */
+    static final Setting<Double> REDUCTION_PERCENTAGE_SETTING = Setting.doubleSetting(
+        "xpack.inference.truncator.reducation_percentage",
+        0.5,
+        0.01,
+        0.99,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    public static List<Setting<?>> getSettings() {
+        return List.of(REDUCTION_PERCENTAGE_SETTING);
+    }
+
+    /**
+     * OpenAI estimates that there are 4 characters per token
+     * <a href="https://help.openai.com/en/articles/4936856-what-are-tokens-and-how-to-count-them">here</a>.
+     * We'll take a conservative approach and assume there's a token every 3 characters.
+     */
+    private static final double CHARS_PER_TOKEN = 3;
+
+    public static double countTokens(String text) {
+        return Math.ceil(text.length() / CHARS_PER_TOKEN);
+    }
+
+    private volatile double reductionPercentage;
+
+    public Truncator(Settings settings, ClusterService clusterService) {
+        this.reductionPercentage = REDUCTION_PERCENTAGE_SETTING.get(settings);
+
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(REDUCTION_PERCENTAGE_SETTING, this::setReductionPercentage);
+    }
+
+    private void setReductionPercentage(double percentage) {
+        reductionPercentage = percentage;
+    }
+
+    /**
+     * Truncate each entry in the list to the specified number of tokens.
+     * @param input list of strings
+     * @param tokenLimit the number of tokens to limit the text to
+     * @return the resulting list of text and whether it was truncated
+     */
+    public static TruncationResult truncate(List<String> input, @Nullable Integer tokenLimit) {
+        if (tokenLimit == null) {
+            return new TruncationResult(input, new boolean[input.size()]);
+        }
+
+        var maxLength = maxLength(tokenLimit);
+
+        var truncatedText = new ArrayList<String>(input.size());
+        var wasTruncated = new boolean[input.size()];
+
+        for (int i = 0; i < input.size(); i++) {
+            var text = input.get(i);
+            var truncateResult = truncate(text, maxLength);
+            truncatedText.add(truncateResult.input);
+            wasTruncated[i] = truncateResult.truncated;
+        }
+
+        return new TruncationResult(truncatedText, wasTruncated);
+    }
+
+    private static int maxLength(Integer maxTokens) {
+        if (maxTokens == null) {
+            return Integer.MAX_VALUE;
+        }
+
+        return (int) Math.floor(maxTokens * CHARS_PER_TOKEN);
+    }
+
+    private static TruncationEntry truncate(String text, int textLength) {
+        var truncatedText = text.substring(0, Math.min(text.length(), textLength));
+        var truncated = truncatedText.length() < text.length();
+
+        return new TruncationEntry(truncatedText, truncated);
+    }
+
+    /**
+     * Truncate each entry in the list by the percentage value specified in the {@link #REDUCTION_PERCENTAGE_SETTING} setting.
+     * @param input list of strings
+     * @return the resulting list of text and whether it was truncated
+     */
+    public TruncationResult truncate(List<String> input) {
+        var truncatedText = new ArrayList<String>(input.size());
+        var wasTruncated = new boolean[input.size()];
+
+        for (int i = 0; i < input.size(); i++) {
+            var text = input.get(i);
+            var truncateResult = truncate(text);
+            truncatedText.add(truncateResult.input);
+            wasTruncated[i] = truncateResult.truncated;
+        }
+
+        return new TruncationResult(truncatedText, wasTruncated);
+    }
+
+    private TruncationEntry truncate(String text) {
+        var length = (int) Math.floor(text.length() * reductionPercentage);
+        return truncate(text, length);
+    }
+
+    private record TruncationEntry(String input, boolean truncated) {}
+
+    public record TruncationResult(List<String> input, boolean[] truncated) {
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            TruncationResult that = (TruncationResult) o;
+            return Objects.equals(input, that.input) && Arrays.equals(truncated, that.truncated);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(input, Arrays.hashCode(truncated));
+        }
+    }
+}

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/action/openai/OpenAiEmbeddingsAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/action/openai/OpenAiEmbeddingsAction.java
@@ -11,12 +11,12 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.InferenceServiceResults;
+import org.elasticsearch.xpack.inference.common.Truncator;
 import org.elasticsearch.xpack.inference.external.action.ExecutableAction;
 import org.elasticsearch.xpack.inference.external.http.sender.Sender;
 import org.elasticsearch.xpack.inference.external.openai.OpenAiAccount;
 import org.elasticsearch.xpack.inference.external.openai.OpenAiClient;
 import org.elasticsearch.xpack.inference.external.request.openai.OpenAiEmbeddingsRequest;
-import org.elasticsearch.xpack.inference.external.request.openai.OpenAiEmbeddingsRequestEntity;
 import org.elasticsearch.xpack.inference.services.ServiceComponents;
 import org.elasticsearch.xpack.inference.services.openai.embeddings.OpenAiEmbeddingsModel;
 
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Objects;
 
 import static org.elasticsearch.core.Strings.format;
+import static org.elasticsearch.xpack.inference.common.Truncator.truncate;
 import static org.elasticsearch.xpack.inference.external.action.ActionUtils.createInternalServerError;
 import static org.elasticsearch.xpack.inference.external.action.ActionUtils.wrapFailuresInElasticsearchException;
 
@@ -34,6 +35,7 @@ public class OpenAiEmbeddingsAction implements ExecutableAction {
     private final OpenAiClient client;
     private final OpenAiEmbeddingsModel model;
     private final String errorMessage;
+    private final Truncator truncator;
 
     public OpenAiEmbeddingsAction(Sender sender, OpenAiEmbeddingsModel model, ServiceComponents serviceComponents) {
         this.model = Objects.requireNonNull(model);
@@ -44,6 +46,7 @@ public class OpenAiEmbeddingsAction implements ExecutableAction {
         );
         this.client = new OpenAiClient(Objects.requireNonNull(sender), Objects.requireNonNull(serviceComponents));
         this.errorMessage = getErrorMessage(this.model.getServiceSettings().uri());
+        this.truncator = Objects.requireNonNull(serviceComponents.truncator());
     }
 
     private static String getErrorMessage(@Nullable URI uri) {
@@ -57,10 +60,9 @@ public class OpenAiEmbeddingsAction implements ExecutableAction {
     @Override
     public void execute(List<String> input, ActionListener<InferenceServiceResults> listener) {
         try {
-            OpenAiEmbeddingsRequest request = new OpenAiEmbeddingsRequest(
-                account,
-                new OpenAiEmbeddingsRequestEntity(input, model.getTaskSettings().model(), model.getTaskSettings().user())
-            );
+            var truncatedInput = truncate(input, model.getServiceSettings().maxInputTokens());
+
+            OpenAiEmbeddingsRequest request = new OpenAiEmbeddingsRequest(truncator, account, truncatedInput, model.getTaskSettings());
             ActionListener<InferenceServiceResults> wrappedListener = wrapFailuresInElasticsearchException(errorMessage, listener);
 
             client.send(request, wrappedListener);

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/AlwaysRetryingResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/AlwaysRetryingResponseHandler.java
@@ -12,6 +12,7 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.core.CheckedFunction;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
+import org.elasticsearch.xpack.inference.external.request.Request;
 import org.elasticsearch.xpack.inference.logging.ThrottlerManager;
 
 import java.io.IOException;
@@ -50,7 +51,7 @@ public class AlwaysRetryingResponseHandler implements ResponseHandler {
     }
 
     @Override
-    public InferenceServiceResults parseResult(HttpResult result) throws RetryException {
+    public InferenceServiceResults parseResult(Request request, HttpResult result) throws RetryException {
         try {
             return parseFunction.apply(result);
         } catch (Exception e) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/ContentTooLargeException.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/ContentTooLargeException.java
@@ -7,10 +7,19 @@
 
 package org.elasticsearch.xpack.inference.external.http.retry;
 
-import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.xpack.inference.external.request.Request;
 
-public interface Retrier {
-    void send(Request request, ResponseHandler responseHandler, ActionListener<InferenceServiceResults> listener);
+/**
+ * Provides an exception for truncating the request input.
+ */
+public class ContentTooLargeException extends RetryException {
+
+    public ContentTooLargeException(Throwable cause) {
+        super(true, cause);
+    }
+
+    @Override
+    public Request rebuildRequest(Request original) {
+        return original.truncate();
+    }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/ResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/ResponseHandler.java
@@ -11,6 +11,7 @@ import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
+import org.elasticsearch.xpack.inference.external.request.Request;
 import org.elasticsearch.xpack.inference.logging.ThrottlerManager;
 
 /**
@@ -34,11 +35,12 @@ public interface ResponseHandler {
 
     /**
      * A method for parsing the response from the server.
-     * @param result The wrapped response from the server.
+     * @param request The original request sent to the server
+     * @param result The wrapped response from the server
      * @return the parsed inference results
      * @throws RetryException if a parsing error occurs
      */
-    InferenceServiceResults parseResult(HttpResult result) throws RetryException;
+    InferenceServiceResults parseResult(Request request, HttpResult result) throws RetryException;
 
     /**
      * A string to uniquely identify the type of request that is being handled. This allows loggers to clarify which type of request

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/ResponseParser.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/ResponseParser.java
@@ -7,10 +7,13 @@
 
 package org.elasticsearch.xpack.inference.external.http.retry;
 
-import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.inference.InferenceServiceResults;
+import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.request.Request;
 
-public interface Retrier {
-    void send(Request request, ResponseHandler responseHandler, ActionListener<InferenceServiceResults> listener);
+import java.io.IOException;
+
+@FunctionalInterface
+public interface ResponseParser {
+    InferenceServiceResults apply(Request request, HttpResult result) throws IOException;
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/RetryException.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/RetryException.java
@@ -9,8 +9,9 @@ package org.elasticsearch.xpack.inference.external.http.retry;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchWrapperException;
+import org.elasticsearch.xpack.inference.external.request.Request;
 
-public class RetryException extends ElasticsearchException implements ElasticsearchWrapperException {
+public class RetryException extends ElasticsearchException implements ElasticsearchWrapperException, Retryable {
     private final boolean shouldRetry;
 
     public RetryException(boolean shouldRetry, Throwable cause) {
@@ -32,6 +33,12 @@ public class RetryException extends ElasticsearchException implements Elasticsea
         this.shouldRetry = shouldRetry;
     }
 
+    @Override
+    public Request rebuildRequest(Request original) {
+        return original;
+    }
+
+    @Override
     public boolean shouldRetry() {
         return shouldRetry;
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/Retryable.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/Retryable.java
@@ -7,10 +7,14 @@
 
 package org.elasticsearch.xpack.inference.external.http.retry;
 
-import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.xpack.inference.external.request.Request;
 
-public interface Retrier {
-    void send(Request request, ResponseHandler responseHandler, ActionListener<InferenceServiceResults> listener);
+/**
+ * Provides an interface for determining if an error should be retried and a way to modify
+ * the request to based on the type of failure that occurred.
+ */
+public interface Retryable {
+    Request rebuildRequest(Request original);
+
+    boolean shouldRetry();
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/RetryingHttpSender.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/RetryingHttpSender.java
@@ -18,6 +18,7 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.http.sender.Sender;
+import org.elasticsearch.xpack.inference.external.request.Request;
 import org.elasticsearch.xpack.inference.logging.ThrottlerManager;
 
 import java.io.IOException;
@@ -64,10 +65,10 @@ public class RetryingHttpSender implements Retrier {
     }
 
     private class InternalRetrier extends RetryableAction<InferenceServiceResults> {
-        private final HttpRequestBase request;
+        private Request request;
         private final ResponseHandler responseHandler;
 
-        InternalRetrier(HttpRequestBase request, ResponseHandler responseHandler, ActionListener<InferenceServiceResults> listener) {
+        InternalRetrier(Request request, ResponseHandler responseHandler, ActionListener<InferenceServiceResults> listener) {
             super(
                 logger,
                 threadPool,
@@ -83,27 +84,30 @@ public class RetryingHttpSender implements Retrier {
 
         @Override
         public void tryAction(ActionListener<InferenceServiceResults> listener) {
+            var httpRequest = request.createRequest();
+
             ActionListener<HttpResult> responseListener = ActionListener.wrap(result -> {
                 try {
-                    responseHandler.validateResponse(throttlerManager, logger, request, result);
-                    InferenceServiceResults inferenceResults = responseHandler.parseResult(result);
+                    responseHandler.validateResponse(throttlerManager, logger, httpRequest, result);
+                    InferenceServiceResults inferenceResults = responseHandler.parseResult(request, result);
 
                     listener.onResponse(inferenceResults);
                 } catch (Exception e) {
-                    logException(request, result, responseHandler.getRequestType(), e);
+                    logException(httpRequest, result, responseHandler.getRequestType(), e);
                     listener.onFailure(e);
                 }
             }, e -> {
-                logException(request, responseHandler.getRequestType(), e);
+                logException(httpRequest, responseHandler.getRequestType(), e);
                 listener.onFailure(transformIfRetryable(e));
             });
 
-            sender.send(request, responseListener);
+            sender.send(httpRequest, responseListener);
         }
 
         @Override
         public boolean shouldRetry(Exception e) {
-            if (e instanceof RetryException retry) {
+            if (e instanceof Retryable retry) {
+                request = retry.rebuildRequest(request);
                 return retry.shouldRetry();
             }
 
@@ -137,7 +141,7 @@ public class RetryingHttpSender implements Retrier {
     }
 
     @Override
-    public void send(HttpRequestBase request, ResponseHandler responseHandler, ActionListener<InferenceServiceResults> listener) {
+    public void send(Request request, ResponseHandler responseHandler, ActionListener<InferenceServiceResults> listener) {
         InternalRetrier retrier = new InternalRetrier(request, responseHandler, listener);
         retrier.run();
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/huggingface/HuggingFaceResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/huggingface/HuggingFaceResponseHandler.java
@@ -9,21 +9,19 @@ package org.elasticsearch.xpack.inference.external.huggingface;
 
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.core.CheckedFunction;
-import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.http.retry.BaseResponseHandler;
+import org.elasticsearch.xpack.inference.external.http.retry.ContentTooLargeException;
+import org.elasticsearch.xpack.inference.external.http.retry.ResponseParser;
 import org.elasticsearch.xpack.inference.external.http.retry.RetryException;
 import org.elasticsearch.xpack.inference.external.response.huggingface.HuggingFaceErrorResponseEntity;
 import org.elasticsearch.xpack.inference.logging.ThrottlerManager;
-
-import java.io.IOException;
 
 import static org.elasticsearch.xpack.inference.external.http.HttpUtils.checkForEmptyBody;
 
 public class HuggingFaceResponseHandler extends BaseResponseHandler {
 
-    public HuggingFaceResponseHandler(String requestType, CheckedFunction<HttpResult, InferenceServiceResults, IOException> parseFunction) {
+    public HuggingFaceResponseHandler(String requestType, ResponseParser parseFunction) {
         super(requestType, parseFunction, HuggingFaceErrorResponseEntity::fromResponse);
     }
 
@@ -52,6 +50,8 @@ public class HuggingFaceResponseHandler extends BaseResponseHandler {
             throw new RetryException(true, buildError(RATE_LIMIT, request, result));
         } else if (statusCode >= 500) {
             throw new RetryException(false, buildError(SERVER_ERROR, request, result));
+        } else if (statusCode == 413) {
+            throw new ContentTooLargeException(buildError(CONTENT_TOO_LARGE, request, result));
         } else if (statusCode == 401) {
             throw new RetryException(false, buildError(AUTHENTICATION, request, result));
         } else if (statusCode >= 300 && statusCode < 400) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/openai/OpenAiClient.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/openai/OpenAiClient.java
@@ -38,7 +38,7 @@ public class OpenAiClient {
     }
 
     public void send(OpenAiEmbeddingsRequest request, ActionListener<InferenceServiceResults> listener) throws IOException {
-        sender.send(request.createRequest(), EMBEDDINGS_HANDLER, listener);
+        sender.send(request, EMBEDDINGS_HANDLER, listener);
     }
 
     private static ResponseHandler createEmbeddingsHandler() {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/openai/OpenAiResponseHandler.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/openai/OpenAiResponseHandler.java
@@ -11,15 +11,13 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.core.CheckedFunction;
-import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.http.retry.BaseResponseHandler;
+import org.elasticsearch.xpack.inference.external.http.retry.ContentTooLargeException;
+import org.elasticsearch.xpack.inference.external.http.retry.ResponseParser;
 import org.elasticsearch.xpack.inference.external.http.retry.RetryException;
 import org.elasticsearch.xpack.inference.external.response.openai.OpenAiErrorResponseEntity;
 import org.elasticsearch.xpack.inference.logging.ThrottlerManager;
-
-import java.io.IOException;
 
 import static org.elasticsearch.xpack.inference.external.http.HttpUtils.checkForEmptyBody;
 
@@ -36,7 +34,9 @@ public class OpenAiResponseHandler extends BaseResponseHandler {
     // The remaining number of tokens that are permitted before exhausting the rate limit.
     static final String REMAINING_TOKENS = "x-ratelimit-remaining-tokens";
 
-    public OpenAiResponseHandler(String requestType, CheckedFunction<HttpResult, InferenceServiceResults, IOException> parseFunction) {
+    static final String CONTENT_TOO_LARGE_MESSAGE = "Please reduce your prompt; or completion length.";
+
+    public OpenAiResponseHandler(String requestType, ResponseParser parseFunction) {
         super(requestType, parseFunction, OpenAiErrorResponseEntity::fromResponse);
     }
 
@@ -65,7 +65,9 @@ public class OpenAiResponseHandler extends BaseResponseHandler {
         if (statusCode >= 500) {
             throw new RetryException(false, buildError(SERVER_ERROR, request, result));
         } else if (statusCode == 429) {
-            throw new RetryException(true, buildError(buildRateLimitErrorMessage(request, result), request, result));
+            throw new RetryException(true, buildError(buildRateLimitErrorMessage(result), request, result));
+        } else if (isContentTooLarge(result)) {
+            throw new ContentTooLargeException(buildError(CONTENT_TOO_LARGE, request, result));
         } else if (statusCode == 401) {
             throw new RetryException(false, buildError(AUTHENTICATION, request, result));
         } else if (statusCode >= 300 && statusCode < 400) {
@@ -75,9 +77,24 @@ public class OpenAiResponseHandler extends BaseResponseHandler {
         }
     }
 
-    static String buildRateLimitErrorMessage(HttpRequestBase request, HttpResult result) {
-        var response = result.response();
+    private static boolean isContentTooLarge(HttpResult result) {
         int statusCode = result.response().getStatusLine().getStatusCode();
+
+        if (statusCode == 413) {
+            return true;
+        }
+
+        if (statusCode == 400) {
+            var errorEntity = OpenAiErrorResponseEntity.fromResponse(result);
+
+            return errorEntity != null && errorEntity.getErrorMessage().contains(CONTENT_TOO_LARGE_MESSAGE);
+        }
+
+        return false;
+    }
+
+    static String buildRateLimitErrorMessage(HttpResult result) {
+        var response = result.response();
         var tokenLimit = getFirstHeaderOrUnknown(response, TOKENS_LIMIT);
         var remainingTokens = getFirstHeaderOrUnknown(response, REMAINING_TOKENS);
         var requestLimit = getFirstHeaderOrUnknown(response, REQUESTS_LIMIT);

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/Request.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/Request.java
@@ -9,6 +9,22 @@ package org.elasticsearch.xpack.inference.external.request;
 
 import org.apache.http.client.methods.HttpRequestBase;
 
+import java.net.URI;
+
 public interface Request {
     HttpRequestBase createRequest();
+
+    URI getURI();
+
+    /**
+     * Create a new request with less input text.
+     * @return a new {@link Request} with the truncated input text
+     */
+    Request truncate();
+
+    /**
+     * Returns an array of booleans indicating if the text input at that same array index was truncated in the request
+     * sent to the 3rd party server.
+     */
+    boolean[] getTruncationInfo();
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/huggingface/HuggingFaceInferenceRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/huggingface/HuggingFaceInferenceRequest.java
@@ -13,9 +13,11 @@ import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.entity.ByteArrayEntity;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.inference.common.Truncator;
 import org.elasticsearch.xpack.inference.external.huggingface.HuggingFaceAccount;
 import org.elasticsearch.xpack.inference.external.request.Request;
 
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
@@ -23,22 +25,42 @@ import static org.elasticsearch.xpack.inference.external.request.RequestUtils.cr
 
 public class HuggingFaceInferenceRequest implements Request {
 
+    private final Truncator truncator;
     private final HuggingFaceAccount account;
-    private final HuggingFaceInferenceRequestEntity entity;
+    private final Truncator.TruncationResult truncationResult;
 
-    public HuggingFaceInferenceRequest(HuggingFaceAccount account, HuggingFaceInferenceRequestEntity entity) {
+    public HuggingFaceInferenceRequest(Truncator truncator, HuggingFaceAccount account, Truncator.TruncationResult input) {
+        this.truncator = Objects.requireNonNull(truncator);
         this.account = Objects.requireNonNull(account);
-        this.entity = Objects.requireNonNull(entity);
+        this.truncationResult = Objects.requireNonNull(input);
     }
 
     public HttpRequestBase createRequest() {
         HttpPost httpPost = new HttpPost(account.url());
 
-        ByteArrayEntity byteEntity = new ByteArrayEntity(Strings.toString(entity).getBytes(StandardCharsets.UTF_8));
+        ByteArrayEntity byteEntity = new ByteArrayEntity(
+            Strings.toString(new HuggingFaceInferenceRequestEntity(truncationResult.input())).getBytes(StandardCharsets.UTF_8)
+        );
         httpPost.setEntity(byteEntity);
         httpPost.setHeader(HttpHeaders.CONTENT_TYPE, XContentType.JSON.mediaTypeWithoutParameters());
         httpPost.setHeader(createAuthBearerHeader(account.apiKey()));
 
         return httpPost;
+    }
+
+    public URI getURI() {
+        return account.url();
+    }
+
+    @Override
+    public Request truncate() {
+        var truncateResult = truncator.truncate(truncationResult.input());
+
+        return new HuggingFaceInferenceRequest(truncator, account, truncateResult);
+    }
+
+    @Override
+    public boolean[] getTruncationInfo() {
+        return truncationResult.truncated().clone();
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/response/huggingface/HuggingFaceElserResponseEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/response/huggingface/HuggingFaceElserResponseEntity.java
@@ -15,6 +15,7 @@ import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.results.SparseEmbeddingResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
+import org.elasticsearch.xpack.inference.external.request.Request;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -56,15 +57,16 @@ public class HuggingFaceElserResponseEntity {
      *   </code>
      * </pre>
      */
-    public static SparseEmbeddingResults fromResponse(HttpResult response) throws IOException {
+    public static SparseEmbeddingResults fromResponse(Request request, HttpResult response) throws IOException {
         var parserConfig = XContentParserConfiguration.EMPTY.withDeprecationHandler(LoggingDeprecationHandler.INSTANCE);
 
         try (XContentParser jsonParser = XContentFactory.xContent(XContentType.JSON).createParser(parserConfig, response.body())) {
             moveToFirstToken(jsonParser);
 
+            var truncationResults = request.getTruncationInfo();
             List<SparseEmbeddingResults.Embedding> parsedEmbeddings = XContentParserUtils.parseList(
                 jsonParser,
-                HuggingFaceElserResponseEntity::parseExpansionResult
+                (parser, index) -> HuggingFaceElserResponseEntity.parseExpansionResult(truncationResults, parser, index)
             );
 
             if (parsedEmbeddings.isEmpty()) {
@@ -75,7 +77,8 @@ public class HuggingFaceElserResponseEntity {
         }
     }
 
-    private static SparseEmbeddingResults.Embedding parseExpansionResult(XContentParser parser) throws IOException {
+    private static SparseEmbeddingResults.Embedding parseExpansionResult(boolean[] truncationResults, XContentParser parser, int index)
+        throws IOException {
         XContentParser.Token token = parser.currentToken();
         XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, token, parser);
 
@@ -89,9 +92,9 @@ public class HuggingFaceElserResponseEntity {
             weightedTokens.add(new SparseEmbeddingResults.WeightedToken(parser.currentName(), parser.floatValue()));
         }
 
-        // TODO how do we know if the tokens were truncated so we can set this appropriately?
-        // This will depend on whether we handle the tokenization or hugging face
-        return new SparseEmbeddingResults.Embedding(weightedTokens, false);
+        // prevent an out of bounds if for some reason the truncation list is smaller than the results
+        var isTruncated = truncationResults != null && index < truncationResults.length && truncationResults[index];
+        return new SparseEmbeddingResults.Embedding(weightedTokens, isTruncated);
     }
 
     private HuggingFaceElserResponseEntity() {}

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/response/huggingface/HuggingFaceEmbeddingsResponseEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/response/huggingface/HuggingFaceEmbeddingsResponseEntity.java
@@ -15,6 +15,7 @@ import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.results.TextEmbeddingResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
+import org.elasticsearch.xpack.inference.external.request.Request;
 
 import java.io.IOException;
 import java.util.List;
@@ -30,7 +31,7 @@ public class HuggingFaceEmbeddingsResponseEntity {
      * Parse the response from hugging face. The known formats are an array of arrays and object with an {@code embeddings} field containing
      * an array of arrays.
      */
-    public static TextEmbeddingResults fromResponse(HttpResult response) throws IOException {
+    public static TextEmbeddingResults fromResponse(Request request, HttpResult response) throws IOException {
         var parserConfig = XContentParserConfiguration.EMPTY.withDeprecationHandler(LoggingDeprecationHandler.INSTANCE);
 
         try (XContentParser jsonParser = XContentFactory.xContent(XContentType.JSON).createParser(parserConfig, response.body())) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/response/openai/OpenAiEmbeddingsResponseEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/response/openai/OpenAiEmbeddingsResponseEntity.java
@@ -15,6 +15,7 @@ import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.inference.results.TextEmbeddingResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
+import org.elasticsearch.xpack.inference.external.request.Request;
 
 import java.io.IOException;
 import java.util.List;
@@ -68,7 +69,7 @@ public class OpenAiEmbeddingsResponseEntity {
      * </code>
      * </pre>
      */
-    public static TextEmbeddingResults fromResponse(HttpResult response) throws IOException {
+    public static TextEmbeddingResults fromResponse(Request request, HttpResult response) throws IOException {
         var parserConfig = XContentParserConfiguration.EMPTY.withDeprecationHandler(LoggingDeprecationHandler.INSTANCE);
 
         try (XContentParser jsonParser = XContentFactory.xContent(XContentType.JSON).createParser(parserConfig, response.body())) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ServiceComponents.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ServiceComponents.java
@@ -9,9 +9,10 @@ package org.elasticsearch.xpack.inference.services;
 
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.inference.common.Truncator;
 import org.elasticsearch.xpack.inference.logging.ThrottlerManager;
 
 /**
  * A container for common components need at various levels of the inference services to instantiate their internals
  */
-public record ServiceComponents(ThreadPool threadPool, ThrottlerManager throttlerManager, Settings settings) {}
+public record ServiceComponents(ThreadPool threadPool, ThrottlerManager throttlerManager, Settings settings, Truncator truncator) {}

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/huggingface/HuggingFaceModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/huggingface/HuggingFaceModel.java
@@ -26,4 +26,6 @@ public abstract class HuggingFaceModel extends Model {
     public abstract URI getUri();
 
     public abstract SecureString getApiKey();
+
+    public abstract Integer getTokenLimit();
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/huggingface/HuggingFaceService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/huggingface/HuggingFaceService.java
@@ -67,7 +67,7 @@ public class HuggingFaceService extends HuggingFaceBaseService {
             model.getServiceSettings().uri(),
             null, // Similarity measure is unknown
             embeddingSize,
-            null  // max input tokens is unknown
+            model.getTokenLimit()
         );
 
         return new HuggingFaceEmbeddingsModel(model, serviceSettings);

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/huggingface/elser/HuggingFaceElserModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/huggingface/elser/HuggingFaceElserModel.java
@@ -70,4 +70,9 @@ public class HuggingFaceElserModel extends HuggingFaceModel {
     public SecureString getApiKey() {
         return getSecretSettings().apiKey();
     }
+
+    @Override
+    public Integer getTokenLimit() {
+        return getServiceSettings().maxInputTokens();
+    }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/huggingface/elser/HuggingFaceElserServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/huggingface/elser/HuggingFaceElserServiceSettings.java
@@ -20,12 +20,14 @@ import java.net.URI;
 import java.util.Map;
 import java.util.Objects;
 
-import static org.elasticsearch.xpack.inference.services.ServiceFields.URL;
+import static org.elasticsearch.xpack.inference.services.ServiceFields.MAX_INPUT_TOKENS;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.createUri;
 import static org.elasticsearch.xpack.inference.services.huggingface.HuggingFaceServiceSettings.extractUri;
 
-public record HuggingFaceElserServiceSettings(URI uri) implements ServiceSettings {
+public record HuggingFaceElserServiceSettings(URI uri, Integer maxInputTokens) implements ServiceSettings {
+
     public static final String NAME = "hugging_face_elser_service_settings";
+    private static final Integer ELSER_TOKEN_LIMIT = 512;
 
     static final String URL = "url";
 
@@ -35,7 +37,7 @@ public record HuggingFaceElserServiceSettings(URI uri) implements ServiceSetting
         if (validationException.validationErrors().isEmpty() == false) {
             throw validationException;
         }
-        return new HuggingFaceElserServiceSettings(uri);
+        return new HuggingFaceElserServiceSettings(uri, ELSER_TOKEN_LIMIT);
     }
 
     public HuggingFaceElserServiceSettings {
@@ -43,7 +45,7 @@ public record HuggingFaceElserServiceSettings(URI uri) implements ServiceSetting
     }
 
     public HuggingFaceElserServiceSettings(String url) {
-        this(createUri(url));
+        this(createUri(url), ELSER_TOKEN_LIMIT);
     }
 
     public HuggingFaceElserServiceSettings(StreamInput in) throws IOException {
@@ -54,6 +56,7 @@ public record HuggingFaceElserServiceSettings(URI uri) implements ServiceSetting
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         builder.field(URL, uri.toString());
+        builder.field(MAX_INPUT_TOKENS, maxInputTokens);
         builder.endObject();
 
         return builder;

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/huggingface/embeddings/HuggingFaceEmbeddingsModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/huggingface/embeddings/HuggingFaceEmbeddingsModel.java
@@ -68,6 +68,11 @@ public class HuggingFaceEmbeddingsModel extends HuggingFaceModel {
     }
 
     @Override
+    public Integer getTokenLimit() {
+        return getServiceSettings().maxInputTokens();
+    }
+
+    @Override
     public ExecutableAction accept(HuggingFaceActionVisitor creator) {
         return creator.create(this);
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/OpenAiService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/OpenAiService.java
@@ -165,7 +165,7 @@ public class OpenAiService extends SenderService {
             model.getServiceSettings().organizationId(),
             SimilarityMeasure.DOT_PRODUCT,
             embeddingSize,
-            null
+            model.getServiceSettings().maxInputTokens()
         );
 
         return new OpenAiEmbeddingsModel(model, serviceSettings);

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/Utils.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/Utils.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference;
+
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.threadpool.ScalingExecutorBuilder;
+import org.elasticsearch.xpack.inference.common.Truncator;
+import org.elasticsearch.xpack.inference.external.http.HttpClientManager;
+import org.elasticsearch.xpack.inference.external.http.HttpSettings;
+import org.elasticsearch.xpack.inference.external.http.retry.RetrySettings;
+import org.elasticsearch.xpack.inference.external.http.sender.HttpRequestSenderFactory;
+import org.elasticsearch.xpack.inference.logging.ThrottlerManager;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.elasticsearch.xpack.inference.InferencePlugin.UTILITY_THREAD_POOL_NAME;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class Utils {
+    public static ClusterService mockClusterServiceEmpty() {
+        return mockClusterService(Settings.EMPTY);
+    }
+
+    public static ClusterService mockClusterService(Settings settings) {
+        var clusterService = mock(ClusterService.class);
+
+        var registeredSettings = Stream.of(
+            HttpSettings.getSettings(),
+            HttpClientManager.getSettings(),
+            HttpRequestSenderFactory.HttpRequestSender.getSettings(),
+            ThrottlerManager.getSettings(),
+            RetrySettings.getSettingsDefinitions(),
+            Truncator.getSettings()
+        ).flatMap(Collection::stream).collect(Collectors.toSet());
+
+        var cSettings = new ClusterSettings(settings, registeredSettings);
+        when(clusterService.getClusterSettings()).thenReturn(cSettings);
+
+        return clusterService;
+    }
+
+    public static ScalingExecutorBuilder inferenceUtilityPool() {
+        return new ScalingExecutorBuilder(
+            UTILITY_THREAD_POOL_NAME,
+            1,
+            4,
+            TimeValue.timeValueMinutes(10),
+            false,
+            "xpack.inference.utility_thread_pool"
+        );
+    }
+}

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/common/TruncatorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/common/TruncatorTests.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.common;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.List;
+
+import static org.elasticsearch.xpack.inference.Utils.mockClusterServiceEmpty;
+import static org.elasticsearch.xpack.inference.common.Truncator.truncate;
+import static org.hamcrest.Matchers.is;
+
+public class TruncatorTests extends ESTestCase {
+
+    public void testTruncate_Percentage_ReducesLengthByHalf() {
+        var truncator = createTruncator();
+        assertThat(
+            truncator.truncate(List.of("123456", "awesome")),
+            is(new Truncator.TruncationResult(List.of("123", "awe"), new boolean[] { true, true }))
+        );
+    }
+
+    public void testTruncate_Percentage_OnlyTruncatesTheFirstEntry() {
+        var truncator = createTruncator();
+        assertThat(
+            truncator.truncate(List.of("123456", "")),
+            is(new Truncator.TruncationResult(List.of("123", ""), new boolean[] { true, false }))
+        );
+    }
+
+    public void testTruncate_Percentage_ReducesLengthToZero() {
+        var truncator = createTruncator();
+        assertThat(truncator.truncate(List.of("1")), is(new Truncator.TruncationResult(List.of(""), new boolean[] { true })));
+    }
+
+    public void testTruncate_Percentage_ReturnsAnEmptyString_WhenItIsAnEmptyString() {
+        var truncator = createTruncator();
+        assertThat(truncator.truncate(List.of("")), is(new Truncator.TruncationResult(List.of(""), new boolean[] { false })));
+    }
+
+    public void testTruncate_Percentage_ReturnsAnEmptyString_WhenPercentageIs0_01() {
+        var truncator = createTruncator(0.01);
+        assertThat(truncator.truncate(List.of("abc")), is(new Truncator.TruncationResult(List.of(""), new boolean[] { true })));
+    }
+
+    public void testTruncate_Percentage_ReturnsStringWithTwoCharacters_IfPercentageIs0_99() {
+        var truncator = createTruncator(0.99);
+        assertThat(truncator.truncate(List.of("abc")), is(new Truncator.TruncationResult(List.of("ab"), new boolean[] { true })));
+    }
+
+    public void testTruncate_Tokens_DoesNotTruncateWhenLimitIsNull() {
+        assertThat(
+            truncate(List.of("abcd", "123"), null),
+            is(new Truncator.TruncationResult(List.of("abcd", "123"), new boolean[] { false, false }))
+        );
+    }
+
+    public void testTruncate_Tokens_ReducesLengthTo3Characters() {
+        assertThat(
+            truncate(List.of("abcd", "123 abcd"), 1),
+            is(new Truncator.TruncationResult(List.of("abc", "123"), new boolean[] { true, true }))
+        );
+    }
+
+    public void testTruncate_Tokens_OnlyTruncatesTheFirstEntry() {
+        assertThat(
+            truncate(List.of("abcd", "123"), 1),
+            is(new Truncator.TruncationResult(List.of("abc", "123"), new boolean[] { true, false }))
+        );
+    }
+
+    public void testTruncate_Tokens_ReturnsAnEmptyString_WhenItIsAnEmptyString() {
+        assertThat(truncate(List.of(""), 1), is(new Truncator.TruncationResult(List.of(""), new boolean[] { false })));
+    }
+
+    public void testTruncate_Tokens_ReturnsAnEmptyString_WhenMaxTokensIs0() {
+        assertThat(truncate(List.of("abc"), 0), is(new Truncator.TruncationResult(List.of(""), new boolean[] { true })));
+    }
+
+    public void testTruncate_Tokens_ReturnsTheSameValueStringIfTokensIsGreaterThanStringSize() {
+        assertThat(truncate(List.of("abc"), 2), is(new Truncator.TruncationResult(List.of("abc"), new boolean[] { false })));
+    }
+
+    public void testTruncate_ThrowsIfPercentageIsGreaterThan0_99() {
+        expectThrows(IllegalArgumentException.class, () -> createTruncator(0.991));
+    }
+
+    public void testTruncate_ThrowsIfPercentageIsLessThan0_01() {
+        expectThrows(IllegalArgumentException.class, () -> createTruncator(0.0099));
+    }
+
+    public static Truncator createTruncator() {
+        return new Truncator(Settings.EMPTY, mockClusterServiceEmpty());
+    }
+
+    public static Truncator createTruncator(double percentage) {
+        var settings = Settings.builder().put(Truncator.REDUCTION_PERCENTAGE_SETTING.getKey(), percentage).build();
+        return new Truncator(settings, mockClusterServiceEmpty());
+    }
+}

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/action/huggingface/HuggingFaceActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/action/huggingface/HuggingFaceActionTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.inference.common.TruncatorTests;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.http.retry.AlwaysRetryingResponseHandler;
 import org.elasticsearch.xpack.inference.external.http.sender.Sender;
@@ -28,7 +29,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.core.Strings.format;
-import static org.elasticsearch.xpack.inference.external.http.Utils.inferenceUtilityPool;
+import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityPool;
 import static org.elasticsearch.xpack.inference.services.huggingface.elser.HuggingFaceElserModelTests.createModel;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
@@ -106,7 +107,7 @@ public class HuggingFaceActionTests extends ESTestCase {
         return new HuggingFaceAction(
             sender,
             model,
-            new ServiceComponents(threadPool, mock(ThrottlerManager.class), Settings.EMPTY),
+            new ServiceComponents(threadPool, mock(ThrottlerManager.class), Settings.EMPTY, TruncatorTests.createTruncator()),
             new AlwaysRetryingResponseHandler("test", (result) -> null),
             "test action"
         );

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/action/openai/OpenAiEmbeddingsActionTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/action/openai/OpenAiEmbeddingsActionTests.java
@@ -33,10 +33,10 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.core.Strings.format;
+import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityPool;
+import static org.elasticsearch.xpack.inference.Utils.mockClusterServiceEmpty;
 import static org.elasticsearch.xpack.inference.external.http.Utils.entityAsMap;
 import static org.elasticsearch.xpack.inference.external.http.Utils.getUrl;
-import static org.elasticsearch.xpack.inference.external.http.Utils.inferenceUtilityPool;
-import static org.elasticsearch.xpack.inference.external.http.Utils.mockClusterServiceEmpty;
 import static org.elasticsearch.xpack.inference.external.request.openai.OpenAiUtils.ORGANIZATION_HEADER;
 import static org.elasticsearch.xpack.inference.results.TextEmbeddingResultsTests.buildExpectation;
 import static org.elasticsearch.xpack.inference.services.ServiceComponentsTests.createWithEmptySettings;

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/HttpClientManagerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/HttpClientManagerTests.java
@@ -25,10 +25,10 @@ import org.junit.Before;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 
+import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityPool;
+import static org.elasticsearch.xpack.inference.Utils.mockClusterService;
+import static org.elasticsearch.xpack.inference.Utils.mockClusterServiceEmpty;
 import static org.elasticsearch.xpack.inference.external.http.HttpClientTests.createHttpPost;
-import static org.elasticsearch.xpack.inference.external.http.Utils.inferenceUtilityPool;
-import static org.elasticsearch.xpack.inference.external.http.Utils.mockClusterService;
-import static org.elasticsearch.xpack.inference.external.http.Utils.mockClusterServiceEmpty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/HttpClientTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/HttpClientTests.java
@@ -42,8 +42,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.core.Strings.format;
-import static org.elasticsearch.xpack.inference.external.http.Utils.inferenceUtilityPool;
-import static org.elasticsearch.xpack.inference.external.http.Utils.mockClusterService;
+import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityPool;
+import static org.elasticsearch.xpack.inference.Utils.mockClusterService;
 import static org.elasticsearch.xpack.inference.logging.ThrottlerManagerTests.mockThrottlerManager;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/IdleConnectionEvictorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/IdleConnectionEvictorTests.java
@@ -20,7 +20,7 @@ import org.junit.Before;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import static org.elasticsearch.xpack.inference.external.http.Utils.inferenceUtilityPool;
+import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityPool;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doAnswer;

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/Utils.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/Utils.java
@@ -7,56 +7,22 @@
 
 package org.elasticsearch.xpack.inference.external.http;
 
-import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.settings.ClusterSettings;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.http.MockWebServer;
-import org.elasticsearch.threadpool.ScalingExecutorBuilder;
 import org.elasticsearch.xcontent.DeprecationHandler;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
-import org.elasticsearch.xpack.inference.external.http.retry.RetrySettings;
-import org.elasticsearch.xpack.inference.external.http.sender.HttpRequestSenderFactory;
-import org.elasticsearch.xpack.inference.logging.ThrottlerManager;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.Collection;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.elasticsearch.core.Strings.format;
-import static org.elasticsearch.xpack.inference.InferencePlugin.UTILITY_THREAD_POOL_NAME;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class Utils {
-    public static ClusterService mockClusterServiceEmpty() {
-        return mockClusterService(Settings.EMPTY);
-    }
-
-    public static ClusterService mockClusterService(Settings settings) {
-        var clusterService = mock(ClusterService.class);
-
-        var registeredSettings = Stream.of(
-            HttpSettings.getSettings(),
-            HttpClientManager.getSettings(),
-            HttpRequestSenderFactory.HttpRequestSender.getSettings(),
-            ThrottlerManager.getSettings(),
-            RetrySettings.getSettingsDefinitions()
-        ).flatMap(Collection::stream).collect(Collectors.toSet());
-
-        var cSettings = new ClusterSettings(settings, registeredSettings);
-        when(clusterService.getClusterSettings()).thenReturn(cSettings);
-
-        return clusterService;
-    }
 
     public static String getUrl(MockWebServer webServer) {
         return format("http://%s:%s", webServer.getHostName(), webServer.getPort());
@@ -79,16 +45,5 @@ public class Utils {
         ) {
             return parser.map();
         }
-    }
-
-    public static ScalingExecutorBuilder inferenceUtilityPool() {
-        return new ScalingExecutorBuilder(
-            UTILITY_THREAD_POOL_NAME,
-            1,
-            4,
-            TimeValue.timeValueMinutes(10),
-            false,
-            "xpack.inference.utility_thread_pool"
-        );
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/retry/RetryingHttpSenderTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/retry/RetryingHttpSenderTests.java
@@ -12,6 +12,7 @@ import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.common.util.concurrent.DeterministicTaskQueue;
@@ -21,9 +22,12 @@ import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.http.sender.Sender;
+import org.elasticsearch.xpack.inference.external.request.Request;
 import org.elasticsearch.xpack.inference.logging.ThrottlerManager;
 import org.junit.Before;
 import org.mockito.stubbing.Answer;
+
+import java.net.UnknownHostException;
 
 import static org.elasticsearch.xpack.inference.external.http.retry.RetrySettingsTests.createDefaultRetrySettings;
 import static org.hamcrest.Matchers.is;
@@ -33,6 +37,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class RetryingHttpSenderTests extends ESTestCase {
@@ -64,7 +69,7 @@ public class RetryingHttpSenderTests extends ESTestCase {
         doThrow(new RetryException(true, "failed")).doNothing().when(handler).validateResponse(any(), any(), any(), any());
         // Mockito.thenReturn() does not compile when returning a
         // bounded wild card list, thenAnswer must be used instead.
-        when(handler.parseResult(any())).thenAnswer(answer);
+        when(handler.parseResult(any(), any())).thenAnswer(answer);
 
         var retrier = new RetryingHttpSender(
             sender,
@@ -76,10 +81,11 @@ public class RetryingHttpSenderTests extends ESTestCase {
         );
 
         var listener = new PlainActionFuture<InferenceServiceResults>();
-        executeTasks(() -> retrier.send(mock(HttpRequestBase.class), handler, listener), 1);
+        executeTasks(() -> retrier.send(mockRequest(), handler, listener), 1);
 
         assertThat(listener.actionGet(TIMEOUT), is(inferenceResults));
         verify(sender, times(2)).send(any(), any());
+        verifyNoMoreInteractions(sender);
     }
 
     public void testSend_CallsSenderAgain_WhenAFailureStatusCodeIsReturned() {
@@ -113,10 +119,11 @@ public class RetryingHttpSenderTests extends ESTestCase {
         );
 
         var listener = new PlainActionFuture<InferenceServiceResults>();
-        executeTasks(() -> retrier.send(mock(HttpRequestBase.class), handler, listener), 1);
+        executeTasks(() -> retrier.send(mockRequest(), handler, listener), 1);
 
         assertThat(listener.actionGet(TIMEOUT), is(inferenceResults));
         verify(sender, times(2)).send(any(), any());
+        verifyNoMoreInteractions(sender);
     }
 
     public void testSend_CallsSenderAgain_WhenParsingFailsOnce() {
@@ -135,7 +142,7 @@ public class RetryingHttpSenderTests extends ESTestCase {
         Answer<InferenceServiceResults> answer = (invocation) -> inferenceResults;
 
         var handler = mock(ResponseHandler.class);
-        when(handler.parseResult(any())).thenThrow(new RetryException(true, "failed")).thenAnswer(answer);
+        when(handler.parseResult(any(), any())).thenThrow(new RetryException(true, "failed")).thenAnswer(answer);
 
         var retrier = new RetryingHttpSender(
             sender,
@@ -147,10 +154,11 @@ public class RetryingHttpSenderTests extends ESTestCase {
         );
 
         var listener = new PlainActionFuture<InferenceServiceResults>();
-        executeTasks(() -> retrier.send(mock(HttpRequestBase.class), handler, listener), 1);
+        executeTasks(() -> retrier.send(mockRequest(), handler, listener), 1);
 
         assertThat(listener.actionGet(TIMEOUT), is(inferenceResults));
         verify(sender, times(2)).send(any(), any());
+        verifyNoMoreInteractions(sender);
     }
 
     public void testSend_DoesNotCallSenderAgain_WhenParsingFailsWithNonRetryableException() {
@@ -169,7 +177,7 @@ public class RetryingHttpSenderTests extends ESTestCase {
         Answer<InferenceServiceResults> answer = (invocation) -> inferenceResults;
 
         var handler = mock(ResponseHandler.class);
-        when(handler.parseResult(any())).thenThrow(new IllegalStateException("failed")).thenAnswer(answer);
+        when(handler.parseResult(any(), any())).thenThrow(new IllegalStateException("failed")).thenAnswer(answer);
 
         var retrier = new RetryingHttpSender(
             sender,
@@ -181,12 +189,13 @@ public class RetryingHttpSenderTests extends ESTestCase {
         );
 
         var listener = new PlainActionFuture<InferenceServiceResults>();
-        executeTasks(() -> retrier.send(mock(HttpRequestBase.class), handler, listener), 0);
+        executeTasks(() -> retrier.send(mockRequest(), handler, listener), 0);
 
         var thrownException = expectThrows(IllegalStateException.class, () -> listener.actionGet(TIMEOUT));
         assertThat(thrownException.getMessage(), is("failed"));
 
         verify(sender, times(1)).send(any(), any());
+        verifyNoMoreInteractions(sender);
     }
 
     public void testSend_CallsSenderAgain_WhenHttpResultListenerCallsOnFailureOnce() {
@@ -210,7 +219,7 @@ public class RetryingHttpSenderTests extends ESTestCase {
         Answer<InferenceServiceResults> answer = (invocation) -> inferenceResults;
 
         var handler = mock(ResponseHandler.class);
-        when(handler.parseResult(any())).thenAnswer(answer);
+        when(handler.parseResult(any(), any())).thenAnswer(answer);
 
         var retrier = new RetryingHttpSender(
             sender,
@@ -222,10 +231,51 @@ public class RetryingHttpSenderTests extends ESTestCase {
         );
 
         var listener = new PlainActionFuture<InferenceServiceResults>();
-        executeTasks(() -> retrier.send(mock(HttpRequestBase.class), handler, listener), 1);
+        executeTasks(() -> retrier.send(mockRequest(), handler, listener), 1);
 
         assertThat(listener.actionGet(TIMEOUT), is(inferenceResults));
         verify(sender, times(2)).send(any(), any());
+        verifyNoMoreInteractions(sender);
+    }
+
+    public void testSend_CallsSenderAgain_WhenHttpResultListenerCallsOnFailureOnce_WithContentTooLargeException() {
+        var sender = mock(Sender.class);
+
+        doAnswer(invocation -> {
+            @SuppressWarnings("unchecked")
+            ActionListener<HttpResult> listener = (ActionListener<HttpResult>) invocation.getArguments()[1];
+            listener.onFailure(new ContentTooLargeException(new IllegalStateException("failed")));
+
+            return Void.TYPE;
+        }).doAnswer(invocation -> {
+            @SuppressWarnings("unchecked")
+            ActionListener<HttpResult> listener = (ActionListener<HttpResult>) invocation.getArguments()[1];
+            listener.onResponse(new HttpResult(mock(HttpResponse.class), new byte[] { 'a' }));
+
+            return Void.TYPE;
+        }).when(sender).send(any(), any());
+
+        var inferenceResults = mock(InferenceServiceResults.class);
+        Answer<InferenceServiceResults> answer = (invocation) -> inferenceResults;
+
+        var handler = mock(ResponseHandler.class);
+        when(handler.parseResult(any(), any())).thenAnswer(answer);
+
+        var retrier = new RetryingHttpSender(
+            sender,
+            mock(ThrottlerManager.class),
+            mock(Logger.class),
+            createDefaultRetrySettings(),
+            taskQueue.getThreadPool(),
+            EsExecutors.DIRECT_EXECUTOR_SERVICE
+        );
+
+        var listener = new PlainActionFuture<InferenceServiceResults>();
+        executeTasks(() -> retrier.send(mockRequest(), handler, listener), 1);
+
+        assertThat(listener.actionGet(TIMEOUT), is(inferenceResults));
+        verify(sender, times(2)).send(any(), any());
+        verifyNoMoreInteractions(sender);
     }
 
     public void testSend_CallsSenderAgain_WhenHttpResultListenerCallsOnFailureOnceWithConnectionClosedException() {
@@ -249,7 +299,7 @@ public class RetryingHttpSenderTests extends ESTestCase {
         Answer<InferenceServiceResults> answer = (invocation) -> inferenceResults;
 
         var handler = mock(ResponseHandler.class);
-        when(handler.parseResult(any())).thenAnswer(answer);
+        when(handler.parseResult(any(), any())).thenAnswer(answer);
 
         var retrier = new RetryingHttpSender(
             sender,
@@ -261,10 +311,46 @@ public class RetryingHttpSenderTests extends ESTestCase {
         );
 
         var listener = new PlainActionFuture<InferenceServiceResults>();
-        executeTasks(() -> retrier.send(mock(HttpRequestBase.class), handler, listener), 1);
+        executeTasks(() -> retrier.send(mockRequest(), handler, listener), 1);
 
         assertThat(listener.actionGet(TIMEOUT), is(inferenceResults));
         verify(sender, times(2)).send(any(), any());
+        verifyNoMoreInteractions(sender);
+    }
+
+    public void testSend_ReturnsFailure_WhenHttpResultListenerCallsOnFailureOnceWithUnknownHostException() {
+        var sender = mock(Sender.class);
+
+        doAnswer(invocation -> {
+            @SuppressWarnings("unchecked")
+            ActionListener<HttpResult> listener = (ActionListener<HttpResult>) invocation.getArguments()[1];
+            listener.onFailure(new UnknownHostException("failed"));
+
+            return Void.TYPE;
+        }).when(sender).send(any(), any());
+
+        var inferenceResults = mock(InferenceServiceResults.class);
+        Answer<InferenceServiceResults> answer = (invocation) -> inferenceResults;
+
+        var handler = mock(ResponseHandler.class);
+        when(handler.parseResult(any(), any())).thenAnswer(answer);
+
+        var retrier = new RetryingHttpSender(
+            sender,
+            mock(ThrottlerManager.class),
+            mock(Logger.class),
+            createDefaultRetrySettings(),
+            taskQueue.getThreadPool(),
+            EsExecutors.DIRECT_EXECUTOR_SERVICE
+        );
+
+        var listener = new PlainActionFuture<InferenceServiceResults>();
+        executeTasks(() -> retrier.send(mockRequest(), handler, listener), 0);
+
+        var thrownException = expectThrows(ElasticsearchStatusException.class, () -> listener.actionGet(TIMEOUT));
+        assertThat(thrownException.getMessage(), is("Invalid host [null], please check that the URL is correct."));
+        verify(sender, times(1)).send(any(), any());
+        verifyNoMoreInteractions(sender);
     }
 
     public void testSend_ReturnsFailure_WhenValidateResponseThrowsAnException_AfterOneRetry() {
@@ -288,7 +374,7 @@ public class RetryingHttpSenderTests extends ESTestCase {
         doThrow(new RetryException(true, "failed")).doThrow(new IllegalStateException("failed again"))
             .when(handler)
             .validateResponse(any(), any(), any(), any());
-        when(handler.parseResult(any())).thenAnswer(answer);
+        when(handler.parseResult(any(), any())).thenAnswer(answer);
 
         var retrier = new RetryingHttpSender(
             sender,
@@ -300,7 +386,7 @@ public class RetryingHttpSenderTests extends ESTestCase {
         );
 
         var listener = new PlainActionFuture<InferenceServiceResults>();
-        executeTasks(() -> retrier.send(mock(HttpRequestBase.class), handler, listener), 1);
+        executeTasks(() -> retrier.send(mockRequest(), handler, listener), 1);
 
         var thrownException = expectThrows(IllegalStateException.class, () -> listener.actionGet(TIMEOUT));
         assertThat(thrownException.getMessage(), is("failed again"));
@@ -308,6 +394,7 @@ public class RetryingHttpSenderTests extends ESTestCase {
         assertThat(thrownException.getSuppressed()[0].getMessage(), is("failed"));
 
         verify(sender, times(2)).send(any(), any());
+        verifyNoMoreInteractions(sender);
     }
 
     public void testSend_ReturnsFailure_WhenValidateResponseThrowsAnElasticsearchException_AfterOneRetry() {
@@ -331,7 +418,7 @@ public class RetryingHttpSenderTests extends ESTestCase {
         doThrow(new RetryException(true, "failed")).doThrow(new RetryException(false, "failed again"))
             .when(handler)
             .validateResponse(any(), any(), any(), any());
-        when(handler.parseResult(any())).thenAnswer(answer);
+        when(handler.parseResult(any(), any())).thenAnswer(answer);
 
         var retrier = new RetryingHttpSender(
             sender,
@@ -343,13 +430,14 @@ public class RetryingHttpSenderTests extends ESTestCase {
         );
 
         var listener = new PlainActionFuture<InferenceServiceResults>();
-        executeTasks(() -> retrier.send(mock(HttpRequestBase.class), handler, listener), 1);
+        executeTasks(() -> retrier.send(mockRequest(), handler, listener), 1);
 
         var thrownException = expectThrows(RetryException.class, () -> listener.actionGet(TIMEOUT));
         assertThat(thrownException.getMessage(), is("failed again"));
         assertThat(thrownException.getSuppressed().length, is(1));
         assertThat(thrownException.getSuppressed()[0].getMessage(), is("failed"));
         verify(sender, times(2)).send(any(), any());
+        verifyNoMoreInteractions(sender);
     }
 
     public void testSend_ReturnsFailure_WhenHttpResultsListenerCallsOnFailure_AfterOneRetry() {
@@ -384,13 +472,14 @@ public class RetryingHttpSenderTests extends ESTestCase {
         );
 
         var listener = new PlainActionFuture<InferenceServiceResults>();
-        executeTasks(() -> retrier.send(mock(HttpRequestBase.class), handler, listener), 1);
+        executeTasks(() -> retrier.send(mockRequest(), handler, listener), 1);
 
         var thrownException = expectThrows(RetryException.class, () -> listener.actionGet(TIMEOUT));
         assertThat(thrownException.getMessage(), is("failed again"));
         assertThat(thrownException.getSuppressed().length, is(1));
         assertThat(thrownException.getSuppressed()[0].getMessage(), is("failed"));
         verify(sender, times(2)).send(any(), any());
+        verifyNoMoreInteractions(sender);
     }
 
     public void testSend_ReturnsFailure_WhenHttpResultsListenerCallsOnFailure_WithNonRetryableException() {
@@ -419,12 +508,13 @@ public class RetryingHttpSenderTests extends ESTestCase {
         );
 
         var listener = new PlainActionFuture<InferenceServiceResults>();
-        executeTasks(() -> retrier.send(mock(HttpRequestBase.class), handler, listener), 0);
+        executeTasks(() -> retrier.send(mockRequest(), handler, listener), 0);
 
         var thrownException = expectThrows(IllegalStateException.class, () -> listener.actionGet(TIMEOUT));
         assertThat(thrownException.getMessage(), is("failed"));
         assertThat(thrownException.getSuppressed().length, is(0));
         verify(sender, times(1)).send(any(), any());
+        verifyNoMoreInteractions(sender);
     }
 
     private static HttpResponse mockHttpResponse() {
@@ -447,5 +537,13 @@ public class RetryingHttpSenderTests extends ESTestCase {
             taskQueue.advanceTime();
             taskQueue.runAllRunnableTasks();
         }
+    }
+
+    private static Request mockRequest() {
+        var request = mock(Request.class);
+        when(request.truncate()).thenReturn(request);
+        when(request.createRequest()).thenReturn(mock(HttpRequestBase.class));
+
+        return request;
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/sender/HttpRequestExecutorServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/sender/HttpRequestExecutorServiceTests.java
@@ -28,8 +28,8 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.core.Strings.format;
+import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityPool;
 import static org.elasticsearch.xpack.inference.external.http.HttpClientTests.createHttpPost;
-import static org.elasticsearch.xpack.inference.external.http.Utils.inferenceUtilityPool;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/sender/HttpRequestSenderFactoryTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/sender/HttpRequestSenderFactoryTests.java
@@ -34,9 +34,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.elasticsearch.core.Strings.format;
+import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityPool;
+import static org.elasticsearch.xpack.inference.Utils.mockClusterServiceEmpty;
 import static org.elasticsearch.xpack.inference.external.http.HttpClientTests.createHttpPost;
-import static org.elasticsearch.xpack.inference.external.http.Utils.inferenceUtilityPool;
-import static org.elasticsearch.xpack.inference.external.http.Utils.mockClusterServiceEmpty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/sender/RequestTaskTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/sender/RequestTaskTests.java
@@ -37,10 +37,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.elasticsearch.core.Strings.format;
+import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityPool;
 import static org.elasticsearch.xpack.inference.external.http.HttpClientTests.createConnectionManager;
 import static org.elasticsearch.xpack.inference.external.http.HttpClientTests.createHttpPost;
 import static org.elasticsearch.xpack.inference.external.http.HttpClientTests.emptyHttpSettings;
-import static org.elasticsearch.xpack.inference.external.http.Utils.inferenceUtilityPool;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/openai/OpenAiClientTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/openai/OpenAiClientTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.test.http.MockResponse;
 import org.elasticsearch.test.http.MockWebServer;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.inference.common.TruncatorTests;
 import org.elasticsearch.xpack.inference.external.http.HttpClientManager;
 import org.elasticsearch.xpack.inference.external.http.sender.HttpRequestSenderFactory;
 import org.elasticsearch.xpack.inference.external.http.sender.Sender;
@@ -31,10 +32,10 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.core.Strings.format;
+import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityPool;
+import static org.elasticsearch.xpack.inference.Utils.mockClusterServiceEmpty;
 import static org.elasticsearch.xpack.inference.external.http.Utils.entityAsMap;
 import static org.elasticsearch.xpack.inference.external.http.Utils.getUrl;
-import static org.elasticsearch.xpack.inference.external.http.Utils.inferenceUtilityPool;
-import static org.elasticsearch.xpack.inference.external.http.Utils.mockClusterServiceEmpty;
 import static org.elasticsearch.xpack.inference.external.http.retry.RetrySettingsTests.buildSettingsWithRetryFields;
 import static org.elasticsearch.xpack.inference.external.request.openai.OpenAiEmbeddingsRequestTests.createRequest;
 import static org.elasticsearch.xpack.inference.external.request.openai.OpenAiUtils.ORGANIZATION_HEADER;
@@ -253,7 +254,12 @@ public class OpenAiClientTests extends ESTestCase {
                     threadPool,
                     mockThrottlerManager(),
                     // timeout as zero for no retries
-                    buildSettingsWithRetryFields(TimeValue.timeValueMillis(1), TimeValue.timeValueMinutes(1), TimeValue.timeValueSeconds(0))
+                    buildSettingsWithRetryFields(
+                        TimeValue.timeValueMillis(1),
+                        TimeValue.timeValueMinutes(1),
+                        TimeValue.timeValueSeconds(0)
+                    ),
+                    TruncatorTests.createTruncator()
                 )
             );
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/openai/OpenAiResponseHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/openai/OpenAiResponseHandlerTests.java
@@ -10,15 +10,18 @@ package org.elasticsearch.xpack.inference.external.openai;
 import org.apache.http.Header;
 import org.apache.http.HeaderElement;
 import org.apache.http.HttpResponse;
-import org.apache.http.RequestLine;
 import org.apache.http.StatusLine;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.message.BasicHeader;
 import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
+import org.elasticsearch.xpack.inference.external.http.retry.ContentTooLargeException;
 import org.elasticsearch.xpack.inference.external.http.retry.RetryException;
+
+import java.nio.charset.StandardCharsets;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.core.Is.is;
@@ -39,7 +42,7 @@ public class OpenAiResponseHandlerTests extends ESTestCase {
 
         var httpRequest = mock(HttpRequestBase.class);
         var httpResult = new HttpResult(httpResponse, new byte[] {});
-        var handler = new OpenAiResponseHandler("", result -> null);
+        var handler = new OpenAiResponseHandler("", (request, result) -> null);
 
         // 200 ok
         when(statusLine.getStatusCode()).thenReturn(200);
@@ -59,6 +62,41 @@ public class OpenAiResponseHandlerTests extends ESTestCase {
         assertTrue(retryException.shouldRetry());
         assertThat(retryException.getCause().getMessage(), containsString("Received a rate limit status code. Token limit"));
         assertThat(((ElasticsearchStatusException) retryException.getCause()).status(), is(RestStatus.TOO_MANY_REQUESTS));
+        // 413
+        when(statusLine.getStatusCode()).thenReturn(413);
+        retryException = expectThrows(ContentTooLargeException.class, () -> handler.checkForFailureStatusCode(httpRequest, httpResult));
+        assertTrue(retryException.shouldRetry());
+        assertThat(retryException.getCause().getMessage(), containsString("Received a content too large status code"));
+        assertThat(((ElasticsearchStatusException) retryException.getCause()).status(), is(RestStatus.REQUEST_ENTITY_TOO_LARGE));
+        // 400 content too large
+        retryException = expectThrows(
+            ContentTooLargeException.class,
+            () -> handler.checkForFailureStatusCode(httpRequest, createContentTooLargeResult(400))
+        );
+        assertTrue(retryException.shouldRetry());
+        assertThat(retryException.getCause().getMessage(), containsString("Received a content too large status code"));
+        assertThat(((ElasticsearchStatusException) retryException.getCause()).status(), is(RestStatus.BAD_REQUEST));
+        // 400 generic bad request should not be marked as a content too large
+        when(statusLine.getStatusCode()).thenReturn(400);
+        retryException = expectThrows(RetryException.class, () -> handler.checkForFailureStatusCode(httpRequest, httpResult));
+        assertFalse(retryException.shouldRetry());
+        assertThat(
+            retryException.getCause().getMessage(),
+            containsString("Received an unsuccessful status code for request [null] status [400]")
+        );
+        assertThat(((ElasticsearchStatusException) retryException.getCause()).status(), is(RestStatus.BAD_REQUEST));
+        // 400 is not flagged as a content too large when the error message is different
+        when(statusLine.getStatusCode()).thenReturn(400);
+        retryException = expectThrows(
+            RetryException.class,
+            () -> handler.checkForFailureStatusCode(httpRequest, createResult(400, "blah"))
+        );
+        assertFalse(retryException.shouldRetry());
+        assertThat(
+            retryException.getCause().getMessage(),
+            containsString("Received an unsuccessful status code for request [null] status [400]")
+        );
+        assertThat(((ElasticsearchStatusException) retryException.getCause()).status(), is(RestStatus.BAD_REQUEST));
         // 401
         when(statusLine.getStatusCode()).thenReturn(401);
         retryException = expectThrows(RetryException.class, () -> handler.checkForFailureStatusCode(httpRequest, httpResult));
@@ -89,10 +127,8 @@ public class OpenAiResponseHandlerTests extends ESTestCase {
         int statusCode = 429;
         var statusLine = mock(StatusLine.class);
         when(statusLine.getStatusCode()).thenReturn(statusCode);
-        var requestLine = mock(RequestLine.class);
         var response = mock(HttpResponse.class);
         when(response.getStatusLine()).thenReturn(statusLine);
-        var request = mock(HttpRequestBase.class);
         var httpResult = new HttpResult(response, new byte[] {});
 
         {
@@ -109,7 +145,7 @@ public class OpenAiResponseHandlerTests extends ESTestCase {
                 new BasicHeader(OpenAiResponseHandler.REMAINING_TOKENS, "99800")
             );
 
-            var error = OpenAiResponseHandler.buildRateLimitErrorMessage(request, httpResult);
+            var error = OpenAiResponseHandler.buildRateLimitErrorMessage(httpResult);
             assertThat(
                 error,
                 containsString("Token limit [10000], remaining tokens [99800]. Request limit [3000], remaining requests [2999]")
@@ -119,7 +155,7 @@ public class OpenAiResponseHandlerTests extends ESTestCase {
         {
             when(response.getFirstHeader(OpenAiResponseHandler.TOKENS_LIMIT)).thenReturn(null);
             when(response.getFirstHeader(OpenAiResponseHandler.REMAINING_TOKENS)).thenReturn(null);
-            var error = OpenAiResponseHandler.buildRateLimitErrorMessage(request, httpResult);
+            var error = OpenAiResponseHandler.buildRateLimitErrorMessage(httpResult);
             assertThat(
                 error,
                 containsString("Token limit [unknown], remaining tokens [unknown]. Request limit [3000], remaining requests [2999]")
@@ -133,7 +169,7 @@ public class OpenAiResponseHandlerTests extends ESTestCase {
             );
             when(response.getFirstHeader(OpenAiResponseHandler.TOKENS_LIMIT)).thenReturn(null);
             when(response.getFirstHeader(OpenAiResponseHandler.REMAINING_TOKENS)).thenReturn(null);
-            var error = OpenAiResponseHandler.buildRateLimitErrorMessage(request, httpResult);
+            var error = OpenAiResponseHandler.buildRateLimitErrorMessage(httpResult);
             assertThat(
                 error,
                 containsString("Token limit [unknown], remaining tokens [unknown]. Request limit [unknown], remaining requests [2999]")
@@ -149,11 +185,39 @@ public class OpenAiResponseHandlerTests extends ESTestCase {
                 new BasicHeader(OpenAiResponseHandler.TOKENS_LIMIT, "10000")
             );
             when(response.getFirstHeader(OpenAiResponseHandler.REMAINING_TOKENS)).thenReturn(null);
-            var error = OpenAiResponseHandler.buildRateLimitErrorMessage(request, httpResult);
+            var error = OpenAiResponseHandler.buildRateLimitErrorMessage(httpResult);
             assertThat(
                 error,
                 containsString("Token limit [10000], remaining tokens [unknown]. Request limit [unknown], remaining requests [2999]")
             );
         }
+    }
+
+    private static HttpResult createContentTooLargeResult(int statusCode) {
+        return createResult(
+            statusCode,
+            "This model's maximum context length is 8192 tokens, however you requested 13531 tokens (13531 in your prompt;"
+                + "0 for the completion). Please reduce your prompt; or completion length."
+        );
+    }
+
+    private static HttpResult createResult(int statusCode, String message) {
+        var statusLine = mock(StatusLine.class);
+        when(statusLine.getStatusCode()).thenReturn(statusCode);
+        var httpResponse = mock(HttpResponse.class);
+        when(httpResponse.getStatusLine()).thenReturn(statusLine);
+
+        String responseJson = Strings.format("""
+                {
+                    "error": {
+                        "message": "%s",
+                        "type": "content_too_large",
+                        "param": null,
+                        "code": null
+                    }
+                }
+            """, message);
+
+        return new HttpResult(httpResponse, responseJson.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/request/huggingface/HuggingFaceInferenceRequestEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/request/huggingface/HuggingFaceInferenceRequestEntityTests.java
@@ -18,7 +18,7 @@ import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
 
-public class HuggingFaceElserRequestEntityTests extends ESTestCase {
+public class HuggingFaceInferenceRequestEntityTests extends ESTestCase {
 
     public void testXContent() throws IOException {
         var entity = new HuggingFaceInferenceRequestEntity(List.of("abc"));

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/response/huggingface/HuggingFaceElserResponseEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/response/huggingface/HuggingFaceElserResponseEntityTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.xcontent.XContentEOFException;
 import org.elasticsearch.xcontent.XContentParseException;
 import org.elasticsearch.xpack.core.inference.results.SparseEmbeddingResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
+import org.elasticsearch.xpack.inference.external.request.Request;
 import org.elasticsearch.xpack.inference.results.SparseEmbeddingResultsTests;
 
 import java.io.IOException;
@@ -25,6 +26,7 @@ import static org.elasticsearch.xpack.inference.results.SparseEmbeddingResultsTe
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class HuggingFaceElserResponseEntityTests extends ESTestCase {
     public void testFromResponse_CreatesTextExpansionResults() throws IOException {
@@ -37,6 +39,7 @@ public class HuggingFaceElserResponseEntityTests extends ESTestCase {
             ]""";
 
         SparseEmbeddingResults parsedResults = HuggingFaceElserResponseEntity.fromResponse(
+            mock(Request.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -50,7 +53,34 @@ public class HuggingFaceElserResponseEntityTests extends ESTestCase {
         );
     }
 
-    public void testFromResponse_CreatesTextExpansionResultsForFirstItem() throws IOException {
+    public void testFromResponse_CreatesTextExpansionResults_ThatAreTruncated() throws IOException {
+        var request = mock(Request.class);
+        when(request.getTruncationInfo()).thenReturn(new boolean[] { true });
+
+        String responseJson = """
+            [
+                {
+                    ".": 0.133155956864357,
+                    "the": 0.6747211217880249
+                }
+            ]""";
+
+        SparseEmbeddingResults parsedResults = HuggingFaceElserResponseEntity.fromResponse(
+            request,
+            new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
+        );
+
+        assertThat(
+            parsedResults.asMap(),
+            is(
+                buildExpectation(
+                    List.of(new SparseEmbeddingResultsTests.EmbeddingExpectation(Map.of(".", 0.13315596f, "the", 0.67472112f), true))
+                )
+            )
+        );
+    }
+
+    public void testFromResponse_CreatesTextExpansionResultsForMultipleItems_TruncationIsNull() throws IOException {
         String responseJson = """
             [
                 {
@@ -64,6 +94,75 @@ public class HuggingFaceElserResponseEntityTests extends ESTestCase {
             ]""";
 
         SparseEmbeddingResults parsedResults = HuggingFaceElserResponseEntity.fromResponse(
+            mock(Request.class),
+            new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
+        );
+
+        assertThat(
+            parsedResults.asMap(),
+            is(
+                buildExpectation(
+                    List.of(
+                        new SparseEmbeddingResultsTests.EmbeddingExpectation(Map.of(".", 0.13315596f, "the", 0.67472112f), false),
+                        new SparseEmbeddingResultsTests.EmbeddingExpectation(Map.of("hi", 0.13315596f, "super", 0.67472112f), false)
+                    )
+                )
+            )
+        );
+    }
+
+    public void testFromResponse_CreatesTextExpansionResults_WithTruncation() throws IOException {
+        String responseJson = """
+            [
+                {
+                    ".": 0.133155956864357,
+                    "the": 0.6747211217880249
+                },
+                {
+                    "hi": 0.133155956864357,
+                    "super": 0.6747211217880249
+                }
+            ]""";
+
+        var request = mock(Request.class);
+        when(request.getTruncationInfo()).thenReturn(new boolean[] { true, false });
+
+        SparseEmbeddingResults parsedResults = HuggingFaceElserResponseEntity.fromResponse(
+            request,
+            new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
+        );
+
+        assertThat(
+            parsedResults.asMap(),
+            is(
+                buildExpectation(
+                    List.of(
+                        new SparseEmbeddingResultsTests.EmbeddingExpectation(Map.of(".", 0.13315596f, "the", 0.67472112f), true),
+                        new SparseEmbeddingResultsTests.EmbeddingExpectation(Map.of("hi", 0.13315596f, "super", 0.67472112f), false)
+                    )
+                )
+            )
+        );
+    }
+
+    public void testFromResponse_CreatesTextExpansionResults_WithTruncationLessArrayLessThanExpected() throws IOException {
+        String responseJson = """
+            [
+                {
+                    ".": 0.133155956864357,
+                    "the": 0.6747211217880249
+                },
+                {
+                    "hi": 0.133155956864357,
+                    "super": 0.6747211217880249
+                }
+            ]""";
+
+        var request = mock(Request.class);
+        when(request.getTruncationInfo()).thenReturn(new boolean[] {});
+
+        SparseEmbeddingResults parsedResults = HuggingFaceElserResponseEntity.fromResponse(
+            mock(Request.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -90,6 +189,7 @@ public class HuggingFaceElserResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             ParsingException.class,
             () -> HuggingFaceElserResponseEntity.fromResponse(
+                mock(Request.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
@@ -112,6 +212,7 @@ public class HuggingFaceElserResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             ParsingException.class,
             () -> HuggingFaceElserResponseEntity.fromResponse(
+                mock(Request.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
@@ -132,6 +233,7 @@ public class HuggingFaceElserResponseEntityTests extends ESTestCase {
             """;
 
         SparseEmbeddingResults parsedResults = HuggingFaceElserResponseEntity.fromResponse(
+            mock(Request.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -151,6 +253,7 @@ public class HuggingFaceElserResponseEntityTests extends ESTestCase {
             """;
 
         SparseEmbeddingResults parsedResults = HuggingFaceElserResponseEntity.fromResponse(
+            mock(Request.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -172,6 +275,7 @@ public class HuggingFaceElserResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             ParsingException.class,
             () -> HuggingFaceElserResponseEntity.fromResponse(
+                mock(Request.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
@@ -193,6 +297,7 @@ public class HuggingFaceElserResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             XContentEOFException.class,
             () -> HuggingFaceElserResponseEntity.fromResponse(
+                mock(Request.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
@@ -212,6 +317,7 @@ public class HuggingFaceElserResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             XContentParseException.class,
             () -> HuggingFaceElserResponseEntity.fromResponse(
+                mock(Request.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/response/huggingface/HuggingFaceEmbeddingsResponseEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/response/huggingface/HuggingFaceEmbeddingsResponseEntityTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.inference.results.TextEmbeddingResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
+import org.elasticsearch.xpack.inference.external.request.Request;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -32,6 +33,7 @@ public class HuggingFaceEmbeddingsResponseEntityTests extends ESTestCase {
             """;
 
         TextEmbeddingResults parsedResults = HuggingFaceEmbeddingsResponseEntity.fromResponse(
+            mock(Request.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -51,6 +53,7 @@ public class HuggingFaceEmbeddingsResponseEntityTests extends ESTestCase {
             """;
 
         TextEmbeddingResults parsedResults = HuggingFaceEmbeddingsResponseEntity.fromResponse(
+            mock(Request.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -72,6 +75,7 @@ public class HuggingFaceEmbeddingsResponseEntityTests extends ESTestCase {
             """;
 
         TextEmbeddingResults parsedResults = HuggingFaceEmbeddingsResponseEntity.fromResponse(
+            mock(Request.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -103,6 +107,7 @@ public class HuggingFaceEmbeddingsResponseEntityTests extends ESTestCase {
             """;
 
         TextEmbeddingResults parsedResults = HuggingFaceEmbeddingsResponseEntity.fromResponse(
+            mock(Request.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -127,6 +132,7 @@ public class HuggingFaceEmbeddingsResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             ParsingException.class,
             () -> HuggingFaceEmbeddingsResponseEntity.fromResponse(
+                mock(Request.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
@@ -152,6 +158,7 @@ public class HuggingFaceEmbeddingsResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             IllegalStateException.class,
             () -> HuggingFaceEmbeddingsResponseEntity.fromResponse(
+                mock(Request.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
@@ -174,6 +181,7 @@ public class HuggingFaceEmbeddingsResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             ParsingException.class,
             () -> HuggingFaceEmbeddingsResponseEntity.fromResponse(
+                mock(Request.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
@@ -196,6 +204,7 @@ public class HuggingFaceEmbeddingsResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             ParsingException.class,
             () -> HuggingFaceEmbeddingsResponseEntity.fromResponse(
+                mock(Request.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
@@ -220,6 +229,7 @@ public class HuggingFaceEmbeddingsResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             ParsingException.class,
             () -> HuggingFaceEmbeddingsResponseEntity.fromResponse(
+                mock(Request.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
@@ -240,6 +250,7 @@ public class HuggingFaceEmbeddingsResponseEntityTests extends ESTestCase {
             """;
 
         TextEmbeddingResults parsedResults = HuggingFaceEmbeddingsResponseEntity.fromResponse(
+            mock(Request.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -258,6 +269,7 @@ public class HuggingFaceEmbeddingsResponseEntityTests extends ESTestCase {
             """;
 
         TextEmbeddingResults parsedResults = HuggingFaceEmbeddingsResponseEntity.fromResponse(
+            mock(Request.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -274,6 +286,7 @@ public class HuggingFaceEmbeddingsResponseEntityTests extends ESTestCase {
             """;
 
         TextEmbeddingResults parsedResults = HuggingFaceEmbeddingsResponseEntity.fromResponse(
+            mock(Request.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -292,6 +305,7 @@ public class HuggingFaceEmbeddingsResponseEntityTests extends ESTestCase {
             """;
 
         TextEmbeddingResults parsedResults = HuggingFaceEmbeddingsResponseEntity.fromResponse(
+            mock(Request.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -312,6 +326,7 @@ public class HuggingFaceEmbeddingsResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             ParsingException.class,
             () -> HuggingFaceEmbeddingsResponseEntity.fromResponse(
+                mock(Request.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
@@ -330,6 +345,7 @@ public class HuggingFaceEmbeddingsResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             ParsingException.class,
             () -> HuggingFaceEmbeddingsResponseEntity.fromResponse(
+                mock(Request.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/response/openai/OpenAiEmbeddingsResponseEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/response/openai/OpenAiEmbeddingsResponseEntityTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.inference.results.TextEmbeddingResults;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
+import org.elasticsearch.xpack.inference.external.request.Request;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -44,6 +45,7 @@ public class OpenAiEmbeddingsResponseEntityTests extends ESTestCase {
             """;
 
         TextEmbeddingResults parsedResults = OpenAiEmbeddingsResponseEntity.fromResponse(
+            mock(Request.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -81,6 +83,7 @@ public class OpenAiEmbeddingsResponseEntityTests extends ESTestCase {
             """;
 
         TextEmbeddingResults parsedResults = OpenAiEmbeddingsResponseEntity.fromResponse(
+            mock(Request.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -120,6 +123,7 @@ public class OpenAiEmbeddingsResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             IllegalStateException.class,
             () -> OpenAiEmbeddingsResponseEntity.fromResponse(
+                mock(Request.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
@@ -152,6 +156,7 @@ public class OpenAiEmbeddingsResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             ParsingException.class,
             () -> OpenAiEmbeddingsResponseEntity.fromResponse(
+                mock(Request.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
@@ -187,6 +192,7 @@ public class OpenAiEmbeddingsResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             IllegalStateException.class,
             () -> OpenAiEmbeddingsResponseEntity.fromResponse(
+                mock(Request.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
@@ -218,6 +224,7 @@ public class OpenAiEmbeddingsResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             ParsingException.class,
             () -> OpenAiEmbeddingsResponseEntity.fromResponse(
+                mock(Request.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );
@@ -250,6 +257,7 @@ public class OpenAiEmbeddingsResponseEntityTests extends ESTestCase {
             """;
 
         TextEmbeddingResults parsedResults = OpenAiEmbeddingsResponseEntity.fromResponse(
+            mock(Request.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -278,6 +286,7 @@ public class OpenAiEmbeddingsResponseEntityTests extends ESTestCase {
             """;
 
         TextEmbeddingResults parsedResults = OpenAiEmbeddingsResponseEntity.fromResponse(
+            mock(Request.class),
             new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
         );
 
@@ -308,6 +317,7 @@ public class OpenAiEmbeddingsResponseEntityTests extends ESTestCase {
         var thrownException = expectThrows(
             ParsingException.class,
             () -> OpenAiEmbeddingsResponseEntity.fromResponse(
+                mock(Request.class),
                 new HttpResult(mock(HttpResponse.class), responseJson.getBytes(StandardCharsets.UTF_8))
             )
         );

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/logging/ThrottlerManagerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/logging/ThrottlerManagerTests.java
@@ -16,8 +16,8 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.After;
 import org.junit.Before;
 
-import static org.elasticsearch.xpack.inference.external.http.Utils.inferenceUtilityPool;
-import static org.elasticsearch.xpack.inference.external.http.Utils.mockClusterServiceEmpty;
+import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityPool;
+import static org.elasticsearch.xpack.inference.Utils.mockClusterServiceEmpty;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/logging/ThrottlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/logging/ThrottlerTests.java
@@ -22,7 +22,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import static org.elasticsearch.xpack.inference.external.http.Utils.inferenceUtilityPool;
+import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityPool;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/SenderServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/SenderServiceTests.java
@@ -28,7 +28,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import static org.elasticsearch.xpack.inference.external.http.Utils.inferenceUtilityPool;
+import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityPool;
 import static org.elasticsearch.xpack.inference.services.ServiceComponentsTests.createWithEmptySettings;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ServiceComponentsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/ServiceComponentsTests.java
@@ -10,11 +10,12 @@ package org.elasticsearch.xpack.inference.services;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.inference.common.TruncatorTests;
 
 import static org.elasticsearch.xpack.inference.logging.ThrottlerManagerTests.mockThrottlerManager;
 
 public class ServiceComponentsTests extends ESTestCase {
     public static ServiceComponents createWithEmptySettings(ThreadPool threadPool) {
-        return new ServiceComponents(threadPool, mockThrottlerManager(), Settings.EMPTY);
+        return new ServiceComponents(threadPool, mockThrottlerManager(), Settings.EMPTY, TruncatorTests.createTruncator());
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/huggingface/HuggingFaceBaseServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/huggingface/HuggingFaceBaseServiceTests.java
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import static org.elasticsearch.xpack.inference.external.http.Utils.inferenceUtilityPool;
+import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityPool;
 import static org.elasticsearch.xpack.inference.services.ServiceComponentsTests.createWithEmptySettings;
 import static org.elasticsearch.xpack.inference.services.Utils.getInvalidModel;
 import static org.hamcrest.CoreMatchers.is;

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/huggingface/HuggingFaceServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/huggingface/HuggingFaceServiceTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.inference.InferenceServiceResults;
+import org.elasticsearch.inference.Model;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.ModelSecrets;
 import org.elasticsearch.inference.TaskType;
@@ -42,10 +43,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityPool;
+import static org.elasticsearch.xpack.inference.Utils.mockClusterServiceEmpty;
 import static org.elasticsearch.xpack.inference.external.http.Utils.entityAsMap;
 import static org.elasticsearch.xpack.inference.external.http.Utils.getUrl;
-import static org.elasticsearch.xpack.inference.external.http.Utils.inferenceUtilityPool;
-import static org.elasticsearch.xpack.inference.external.http.Utils.mockClusterServiceEmpty;
 import static org.elasticsearch.xpack.inference.results.TextEmbeddingResultsTests.buildExpectation;
 import static org.elasticsearch.xpack.inference.services.ServiceComponentsTests.createWithEmptySettings;
 import static org.elasticsearch.xpack.inference.services.huggingface.HuggingFaceServiceSettingsTests.getServiceSettingsMap;
@@ -549,6 +550,31 @@ public class HuggingFaceServiceTests extends ESTestCase {
             var requestMap = entityAsMap(webServer.requests().get(0).getBody());
             assertThat(requestMap.size(), Matchers.is(1));
             assertThat(requestMap.get("inputs"), Matchers.is(List.of("abc")));
+        }
+    }
+
+    public void testCheckModelConfig_IncludesMaxTokens() throws IOException {
+        var senderFactory = new HttpRequestSenderFactory(threadPool, clientManager, mockClusterServiceEmpty(), Settings.EMPTY);
+
+        try (var service = new HuggingFaceService(new SetOnce<>(senderFactory), new SetOnce<>(createWithEmptySettings(threadPool)))) {
+
+            String responseJson = """
+                {
+                    "embeddings": [
+                        [
+                            -0.0123
+                        ]
+                    ]
+                {
+                """;
+            webServer.enqueue(new MockResponse().setResponseCode(200).setBody(responseJson));
+
+            var model = HuggingFaceEmbeddingsModelTests.createModel(getUrl(webServer), "secret", 1);
+            PlainActionFuture<Model> listener = new PlainActionFuture<>();
+            service.checkModelConfig(model, listener);
+
+            var result = listener.actionGet(TIMEOUT);
+            assertThat(result, is(HuggingFaceEmbeddingsModelTests.createModel(getUrl(webServer), "secret", 1, 1)));
         }
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/huggingface/embeddings/HuggingFaceEmbeddingsModelTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/huggingface/embeddings/HuggingFaceEmbeddingsModelTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.inference.services.huggingface.HuggingFaceServiceSettings;
 import org.elasticsearch.xpack.inference.services.settings.DefaultSecretSettings;
 
+import static org.elasticsearch.xpack.inference.services.ServiceUtils.createUri;
 import static org.hamcrest.Matchers.is;
 
 public class HuggingFaceEmbeddingsModelTests extends ESTestCase {
@@ -28,6 +29,26 @@ public class HuggingFaceEmbeddingsModelTests extends ESTestCase {
             TaskType.TEXT_EMBEDDING,
             "service",
             new HuggingFaceServiceSettings(url),
+            new DefaultSecretSettings(new SecureString(apiKey.toCharArray()))
+        );
+    }
+
+    public static HuggingFaceEmbeddingsModel createModel(String url, String apiKey, int tokenLimit) {
+        return new HuggingFaceEmbeddingsModel(
+            "id",
+            TaskType.TEXT_EMBEDDING,
+            "service",
+            new HuggingFaceServiceSettings(createUri(url), null, null, tokenLimit),
+            new DefaultSecretSettings(new SecureString(apiKey.toCharArray()))
+        );
+    }
+
+    public static HuggingFaceEmbeddingsModel createModel(String url, String apiKey, int tokenLimit, int dimensions) {
+        return new HuggingFaceEmbeddingsModel(
+            "id",
+            TaskType.TEXT_EMBEDDING,
+            "service",
+            new HuggingFaceServiceSettings(createUri(url), null, dimensions, tokenLimit),
             new DefaultSecretSettings(new SecureString(apiKey.toCharArray()))
         );
     }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsModelTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsModelTests.java
@@ -64,4 +64,41 @@ public class OpenAiEmbeddingsModelTests extends ESTestCase {
             new DefaultSecretSettings(new SecureString(apiKey.toCharArray()))
         );
     }
+
+    public static OpenAiEmbeddingsModel createModel(
+        String url,
+        @Nullable String org,
+        String apiKey,
+        String modelName,
+        @Nullable String user,
+        @Nullable Integer tokenLimit
+    ) {
+        return new OpenAiEmbeddingsModel(
+            "id",
+            TaskType.TEXT_EMBEDDING,
+            "service",
+            new OpenAiServiceSettings(url, org, SimilarityMeasure.DOT_PRODUCT, 1536, tokenLimit),
+            new OpenAiEmbeddingsTaskSettings(modelName, user),
+            new DefaultSecretSettings(new SecureString(apiKey.toCharArray()))
+        );
+    }
+
+    public static OpenAiEmbeddingsModel createModel(
+        String url,
+        @Nullable String org,
+        String apiKey,
+        String modelName,
+        @Nullable String user,
+        @Nullable Integer tokenLimit,
+        @Nullable Integer dimensions
+    ) {
+        return new OpenAiEmbeddingsModel(
+            "id",
+            TaskType.TEXT_EMBEDDING,
+            "service",
+            new OpenAiServiceSettings(url, org, SimilarityMeasure.DOT_PRODUCT, dimensions, tokenLimit),
+            new OpenAiEmbeddingsTaskSettings(modelName, user),
+            new DefaultSecretSettings(new SecureString(apiKey.toCharArray()))
+        );
+    }
 }


### PR DESCRIPTION
Backports the following commits to 8.12:
 - [ML] Bug truncate input text for the inference API (#103027)