### PR TITLE
[8.12] Add failure store feature flag to bwc testing (#103341)

### DIFF
--- a/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -112,6 +112,7 @@ public class FullClusterRestartIT extends ParameterizedFullClusterRestartTestCas
         .setting("indices.memory.shard_inactive_time", "60m")
         .apply(() -> clusterConfig)
         .feature(FeatureFlag.TIME_SERIES_MODE)
+        .feature(FeatureFlag.FAILURE_STORE_ENABLED)
         .build();
 
     @ClassRule


### PR DESCRIPTION
Backports the following commits to 8.12:
 - Add failure store feature flag to bwc testing (#103341)