### PR TITLE
Small cleanup to IndicesRequestCache

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/IndicesRequestCache.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesRequestCache.java
@@ -16,7 +16,6 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.cache.Cache;
 import org.elasticsearch.common.cache.CacheBuilder;
 import org.elasticsearch.common.cache.CacheLoader;
-import org.elasticsearch.common.cache.RemovalListener;
 import org.elasticsearch.common.cache.RemovalNotification;
 import org.elasticsearch.common.lucene.index.ElasticsearchDirectoryReader;
 import org.elasticsearch.common.settings.Setting;
@@ -48,7 +47,7 @@ import java.util.concurrent.ConcurrentMap;
  * There are still several TODOs left in this class, some easily addressable, some more complex, but the support
  * is functional.
  */
-public final class IndicesRequestCache implements RemovalListener<IndicesRequestCache.Key, BytesReference>, Closeable {
+public final class IndicesRequestCache implements Closeable {
 
     /**
      * A setting to enable or disable request caching on an index level. Its dynamic by default
@@ -73,18 +72,14 @@ public final class IndicesRequestCache implements RemovalListener<IndicesRequest
 
     private final ConcurrentMap<CleanupKey, Boolean> registeredClosedListeners = ConcurrentCollections.newConcurrentMap();
     private final Set<CleanupKey> keysToClean = ConcurrentCollections.newConcurrentSet();
-    private final ByteSizeValue size;
-    private final TimeValue expire;
     private final Cache<Key, BytesReference> cache;
 
     IndicesRequestCache(Settings settings) {
-        this.size = INDICES_CACHE_QUERY_SIZE.get(settings);
-        this.expire = INDICES_CACHE_QUERY_EXPIRE.exists(settings) ? INDICES_CACHE_QUERY_EXPIRE.get(settings) : null;
-        long sizeInBytes = size.getBytes();
+        TimeValue expire = INDICES_CACHE_QUERY_EXPIRE.exists(settings) ? INDICES_CACHE_QUERY_EXPIRE.get(settings) : null;
         CacheBuilder<Key, BytesReference> cacheBuilder = CacheBuilder.<Key, BytesReference>builder()
-            .setMaximumWeight(sizeInBytes)
+            .setMaximumWeight(INDICES_CACHE_QUERY_SIZE.get(settings).getBytes())
             .weigher((k, v) -> k.ramBytesUsed() + v.ramBytesUsed())
-            .removalListener(this);
+            .removalListener(notification -> notification.getKey().entity.onRemoval(notification));
         if (expire != null) {
             cacheBuilder.setExpireAfterAccess(expire);
         }
@@ -99,11 +94,6 @@ public final class IndicesRequestCache implements RemovalListener<IndicesRequest
     void clear(CacheEntity entity) {
         keysToClean.add(new CleanupKey(entity, null));
         cleanCache();
-    }
-
-    @Override
-    public void onRemoval(RemovalNotification<Key, BytesReference> notification) {
-        notification.getKey().entity.onRemoval(notification);
     }
 
     BytesReference getOrCompute(


### PR DESCRIPTION
Noticed this in reviewing a heap dump. We can simplify the removal listener logic here, this can just be a non-capturing lambda, no need to have the cache implement the listener interface. Also, removing 2 redundant fields.
