### PR TITLE
CODEOWNERS: reduce scope of elastic/apm-server

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,5 +23,6 @@ x-pack/plugin/core/src/main/resources/fleet-* @elastic/fleet
 # Kibana Security
 x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java @elastic/kibana-security
 
-# APM
-x-pack/plugin/apm-data @elastic/apm-server
+# APM Data index templates, etc.
+x-pack/plugin/apm-data/src/main/resources @elastic/apm-server
+x-pack/plugin/apm-data/src/yamlRestTest/resources @elastic/apm-server


### PR DESCRIPTION
Cross-cutting refactoring often pings the apm-server team and we're not really the best placed for reviewing these changes.

The apm-data plugin is structured so the apm-server team can work on the templates and ingest pipelines without touching any Java code, so reduce the scope to just the assets and YAML REST tests.