### PR TITLE
Handle exceptions thrown by joinLeaderInTerm

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -624,7 +624,7 @@ public class Coordinator extends AbstractLifecycleComponent implements ClusterSt
     private Join joinLeaderInTerm(StartJoinRequest startJoinRequest) {
         synchronized (mutex) {
             logger.debug("joinLeaderInTerm: for [{}] with term {}", startJoinRequest.getMasterCandidateNode(), startJoinRequest.getTerm());
-            final Join join = coordinationState.get().handleStartJoin(startJoinRequest);
+            final Join join = doHandleStartJoin(startJoinRequest);
             lastJoin = Optional.of(join);
             peerFinder.setCurrentTerm(getCurrentTerm());
             if (mode != Mode.CANDIDATE) {
@@ -634,6 +634,21 @@ public class Coordinator extends AbstractLifecycleComponent implements ClusterSt
                 preVoteCollector.update(getPreVoteResponse(), null);
             }
             return join;
+        }
+    }
+
+    private Join doHandleStartJoin(StartJoinRequest startJoinRequest) {
+        assert Thread.holdsLock(mutex);
+        try {
+            return coordinationState.get().handleStartJoin(startJoinRequest);
+        } catch (CoordinationStateRejectedException e) {
+            // term did not advance, we can just ignore this
+            assert startJoinRequest.getTerm() <= getCurrentTerm() : startJoinRequest + " vs " + getCurrentTerm();
+            throw e;
+        } catch (Exception e) {
+            logger.warn(Strings.format("doHandleStartJoin: failed to handle start-join request [%s]", startJoinRequest), e);
+            becomeCandidate("doHandleStartJoin");
+            throw e;
         }
     }
 
@@ -926,29 +941,31 @@ public class Coordinator extends AbstractLifecycleComponent implements ClusterSt
         leaderHeartbeatService.start(
             getLocalNode(),
             leaderTerm,
-            new ThreadedActionListener<>(transportService.getThreadPool().executor(Names.CLUSTER_COORDINATION), new ActionListener<>() {
-                @Override
-                public void onResponse(Long newTerm) {
-                    assert newTerm != null && newTerm > leaderTerm : newTerm + " vs " + leaderTerm;
-                    updateMaxTermSeen(newTerm);
-                }
+            ActionListener.assertOnce(
+                new ThreadedActionListener<>(transportService.getThreadPool().executor(Names.CLUSTER_COORDINATION), new ActionListener<>() {
+                    @Override
+                    public void onResponse(Long newTerm) {
+                        assert newTerm != null && newTerm > leaderTerm : newTerm + " vs " + leaderTerm;
+                        updateMaxTermSeen(newTerm);
+                    }
 
-                @Override
-                public void onFailure(Exception e) {
-                    // TODO tests for heartbeat failures
-                    logger.warn(() -> Strings.format("failed to write heartbeat for term [%s]", leaderTerm), e);
-                    synchronized (mutex) {
-                        if (getCurrentTerm() == leaderTerm) {
-                            becomeCandidate("leaderHeartbeatService");
+                    @Override
+                    public void onFailure(Exception e) {
+                        // TODO tests for heartbeat failures
+                        logger.warn(() -> Strings.format("failed to write heartbeat for term [%s]", leaderTerm), e);
+                        synchronized (mutex) {
+                            if (getCurrentTerm() == leaderTerm) {
+                                becomeCandidate("leaderHeartbeatService");
+                            }
                         }
                     }
-                }
 
-                @Override
-                public String toString() {
-                    return "term change heartbeat listener";
-                }
-            })
+                    @Override
+                    public String toString() {
+                        return "term change heartbeat listener";
+                    }
+                })
+            )
         );
 
         assert leaderChecker.leader() == null : leaderChecker.leader();
@@ -1416,7 +1433,13 @@ public class Coordinator extends AbstractLifecycleComponent implements ClusterSt
 
     private void handleJoin(Join join) {
         synchronized (mutex) {
-            ensureTermAtLeast(getLocalNode(), join.term()).ifPresent(this::handleJoin);
+            try {
+                ensureTermAtLeast(getLocalNode(), join.term()).ifPresent(this::handleJoin);
+            } catch (Exception e) {
+                // already logged at WARN, nothing else to be done
+                logger.debug(Strings.format("handleJoin: failed to increase term while handling join [%s]", join), e);
+                return;
+            }
 
             if (coordinationState.get().electionWon()) {
                 // If we have already won the election then the actual join does not matter for election purposes, so swallow any exception
@@ -1726,9 +1749,21 @@ public class Coordinator extends AbstractLifecycleComponent implements ClusterSt
 
         @Override
         protected void onActiveMasterFound(DiscoveryNode masterNode, long term) {
-            synchronized (mutex) {
-                ensureTermAtLeast(masterNode, term);
-                joinHelper.sendJoinRequest(masterNode, getCurrentTerm(), joinWithDestination(lastJoin, masterNode, term));
+            try {
+                synchronized (mutex) {
+                    ensureTermAtLeast(masterNode, term);
+                    joinHelper.sendJoinRequest(masterNode, getCurrentTerm(), joinWithDestination(lastJoin, masterNode, term));
+                }
+            } catch (Exception e) {
+                // already logged at WARN, nothing else to be done
+                logger.debug(
+                    () -> Strings.format(
+                        "onActiveMasterFound: failed to advance term to [%d] for [%s]",
+                        term,
+                        masterNode.descriptionWithoutAttributes()
+                    ),
+                    e
+                );
             }
         }
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
@@ -135,7 +135,7 @@ public class JoinHelper {
             JoinRequest::new,
             (request, channel, task) -> joinHandler.accept(
                 request,
-                new ChannelActionListener<Empty>(channel).map(ignored -> Empty.INSTANCE)
+                ActionListener.assertOnce(new ChannelActionListener<Empty>(channel).map(ignored -> Empty.INSTANCE))
             )
         );
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Publication.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Publication.java
@@ -256,7 +256,7 @@ public abstract class Publication {
             }
             assert state == PublicationTargetState.NOT_STARTED : state + " -> " + PublicationTargetState.SENT_PUBLISH_REQUEST;
             state = PublicationTargetState.SENT_PUBLISH_REQUEST;
-            Publication.this.sendPublishRequest(discoveryNode, publishRequest, new PublishResponseHandler());
+            Publication.this.sendPublishRequest(discoveryNode, publishRequest, ActionListener.assertOnce(new PublishResponseHandler()));
             assert publicationCompletedIffAllTargetsInactiveOrCancelled();
         }
 

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/AtomicRegisterCoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/AtomicRegisterCoordinatorTests.java
@@ -194,6 +194,12 @@ public class AtomicRegisterCoordinatorTests extends CoordinatorTests {
     @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/98488") // also #98419
     public void testElectionSchedulingAfterDiscoveryOutage() {}
 
+    public void testBecomesCandidateOnTermBumpFailure() {
+        /* TODO: need to check that a node which becomes leader but then cannot write its new term to the register falls back to CANDIDATE
+         *  (see exception handling in org.elasticsearch.cluster.coordination.Coordinator.joinLeaderInTerm)
+         */
+    }
+
     @Override
     protected CoordinatorStrategy createCoordinatorStrategy() {
         return new AtomicRegisterCoordinatorStrategy();

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
@@ -2051,6 +2051,8 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
             cluster.stabilise(
                 // Pinging all peers once should be enough to discover the other nodes
                 defaultMillis(DISCOVERY_FIND_PEERS_INTERVAL_SETTING)
+                    // pinging also requires a round-trip for the handshake and another for the discovery request
+                    + 4 * DEFAULT_DELAY_VARIABILITY
                     // Then wait for an election to be scheduled
                     + defaultMillis(ELECTION_INITIAL_TIMEOUT_SETTING)
                     // Allow two round-trips for pre-voting and voting


### PR DESCRIPTION
If there's some kind of IO problem when bumping a term then
`Coordinator#joinLeaderInTerm` will throw an exception. In that case we
should definitely become `CANDIDATE` again, and log a warning. Moreover
there's a couple of places where this might happen while handling a
transport response, such that the exception bubbles up out of the
response handler. We do our best to handle that by treating it similarly
to a remote exception, but really we shouldn't double-complete the
response handler like that.

This commit adds a little extra exception handling to deal with this.