### PR TITLE
[main] fix typo (#103149)

### DIFF
--- a/docs/reference/mapping/types/flattened.asciidoc
+++ b/docs/reference/mapping/types/flattened.asciidoc
@@ -294,8 +294,8 @@ The following mapping parameters are accepted:
 <<null-value,`null_value`>>::
 
     A string value which is substituted for any explicit `null` values within
-    the flattened object field. Defaults to `null`, which means null sields are
-    treated as if it were missing.
+    the flattened object field. Defaults to `null`, which means null fields are
+    treated as if they were missing.
 
 <<similarity,`similarity`>>::
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.11` to `main`:
 - [fix typo (#103149)](https://github.com/elastic/elasticsearch/pull/103149)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)