### PR TITLE
Avoid blocking during concurrent hot threads calls

### DIFF
--- a/server/src/main/java/org/elasticsearch/monitor/jvm/HotThreads.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/HotThreads.java
@@ -42,7 +42,9 @@ import java.util.function.ToLongFunction;
 public class HotThreads {
 
     private static final Semaphore permits = new Semaphore(1);
-    static final String ALREADY_RUNNING_MESSAGE = "hot threads already running";
+    static final String ALREADY_RUNNING_MESSAGE = """
+        Elasticsearch is already running the hot threads API, and cannot execute this API concurrently on multiple threads. Please wait for
+        the other invocation to finish and then try again.""";
 
     private static final StackTraceElement[] EMPTY = new StackTraceElement[0];
     private static final DateFormatter DATE_TIME_FORMATTER = DateFormatter.forPattern("date_optional_time");

--- a/server/src/test/java/org/elasticsearch/monitor/jvm/HotThreadsTests.java
+++ b/server/src/test/java/org/elasticsearch/monitor/jvm/HotThreadsTests.java
@@ -983,8 +983,6 @@ public class HotThreadsTests extends ESTestCase {
         try (var stringWriter = new StringWriter()) {
             new HotThreads().detect(stringWriter);
             assertEquals(ALREADY_RUNNING_MESSAGE, stringWriter.toString());
-        } catch (Exception e) {
-            fail(e);
         } finally {
             safeAwait(barrier);
             backgroundThread.join();


### PR DESCRIPTION
Today we avoid concurrent hot threads detections using a mutex, but the
user controls how long each detection takes. An abusive call could block
lots of other threads for a very long time. This commit changes the
behaviour to bail out early with an informative message if there is
already a detection in progress.