### PR TITLE
[8.12] Clarify that we need stack dumps of the main process (#103391)

### DIFF
--- a/docs/reference/troubleshooting/network-timeouts.asciidoc
+++ b/docs/reference/troubleshooting/network-timeouts.asciidoc
@@ -34,9 +34,9 @@ end::troubleshooting-network-timeouts-packet-capture-fault-detection[]
 
 tag::troubleshooting-network-timeouts-threads[]
 * Long waits for particular threads to be available can be identified by taking
-stack dumps (for example, using `jstack`) or a profiling trace (for example,
-using Java Flight Recorder) in the few seconds leading up to the relevant log
-message.
+stack dumps of the main {es} process (for example, using `jstack`) or a
+profiling trace (for example, using Java Flight Recorder) in the few seconds
+leading up to the relevant log message.
 +
 The <<cluster-nodes-hot-threads>> API sometimes yields useful information, but
 bear in mind that this API also requires a number of `transport_worker` and


### PR DESCRIPTION
Backports the following commits to 8.12:
 - Clarify that we need stack dumps of the main process (#103391)