### PR TITLE
Cache component versions

### DIFF
--- a/docs/changelog/103408.yaml
+++ b/docs/changelog/103408.yaml
@@ -1,0 +1,6 @@
+pr: 103408
+summary: Cache component versions
+area: Infra/Core
+type: bug
+issues:
+ - 102103

--- a/server/src/main/java/org/elasticsearch/node/NodeService.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeService.java
@@ -62,6 +62,7 @@ public class NodeService implements Closeable {
     private final AggregationUsageService aggregationUsageService;
     private final Coordinator coordinator;
     private final RepositoriesService repositoriesService;
+    private final Map<String, Integer> componentVersions;
 
     NodeService(
         Settings settings,
@@ -100,6 +101,7 @@ public class NodeService implements Closeable {
         this.indexingPressure = indexingPressure;
         this.aggregationUsageService = aggregationUsageService;
         this.repositoriesService = repositoriesService;
+        this.componentVersions = findComponentVersions(pluginService)
         clusterService.addStateApplier(ingestService);
     }
 
@@ -122,7 +124,7 @@ public class NodeService implements Closeable {
             Version.CURRENT.toString(),
             TransportVersion.current(),
             IndexVersion.current(),
-            findComponentVersions(),
+            componentVersions,
             Build.current(),
             transportService.getLocalNode(),
             settings ? settingsFilter.filter(this.settings) : null,
@@ -140,7 +142,7 @@ public class NodeService implements Closeable {
         );
     }
 
-    private Map<String, Integer> findComponentVersions() {
+    private static Map<String, Integer> findComponentVersions(PluginsService pluginService) {
         var versions = pluginService.loadServiceProviders(ComponentVersionNumber.class)
             .stream()
             .collect(Collectors.toUnmodifiableMap(ComponentVersionNumber::componentId, cvn -> cvn.versionNumber().id()));

--- a/server/src/main/java/org/elasticsearch/node/NodeService.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeService.java
@@ -101,7 +101,7 @@ public class NodeService implements Closeable {
         this.indexingPressure = indexingPressure;
         this.aggregationUsageService = aggregationUsageService;
         this.repositoriesService = repositoriesService;
-        this.componentVersions = findComponentVersions(pluginService)
+        this.componentVersions = findComponentVersions(pluginService);
         clusterService.addStateApplier(ingestService);
     }
 


### PR DESCRIPTION
Looking up component versions through SPI should not change. This commit captures the component versions of the running node once during startup, rather than every time node info is called.

closes #102103