### PR TITLE
Propagate 'isCI' system property to BWC build tasks

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcSetupExtension.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcSetupExtension.java
@@ -109,6 +109,10 @@ public class BwcSetupExtension {
                 loggedExec.args("-Dorg.elasticsearch.build.cache.url=" + buildCacheUrl);
             }
 
+            if (System.getProperty("isCI") != null) {
+                loggedExec.args("-DisCI");
+            }
+
             loggedExec.args("-Dbuild.snapshot=true", "-Dscan.tag.NESTED");
             final LogLevel logLevel = project.getGradle().getStartParameter().getLogLevel();
             List<LogLevel> nonDefaultLogLevels = Arrays.asList(LogLevel.QUIET, LogLevel.WARN, LogLevel.INFO, LogLevel.DEBUG);


### PR DESCRIPTION
As a follow up to #103346 we also want to propagate the `isCI` system property down to BWC build tasks.