### PR TITLE
[ci] Offset periodic pipeline triggers for each branch

### DIFF
--- a/.buildkite/scripts/periodic.trigger.sh
+++ b/.buildkite/scripts/periodic.trigger.sh
@@ -6,10 +6,23 @@ echo "steps:"
 
 source .buildkite/scripts/branches.sh
 
+IS_FIRST=true
 for BRANCH in "${BRANCHES[@]}"; do
   INTAKE_PIPELINE_SLUG="elasticsearch-intake"
   BUILD_JSON=$(curl -sH "Authorization: Bearer ${BUILDKITE_API_TOKEN}" "https://api.buildkite.com/v2/organizations/elastic/pipelines/${INTAKE_PIPELINE_SLUG}/builds?branch=${BRANCH}&state=passed&per_page=1" | jq '.[0] | {commit: .commit, url: .web_url}')
   LAST_GOOD_COMMIT=$(echo "${BUILD_JSON}" | jq -r '.commit')
+
+  # Put a delay between each branch's set of pipelines by prepending each non-first branch with a sleep
+  # This is to smooth out the spike in agent requests
+  if [[ "$IS_FIRST" != "true" ]]; then
+      cat <<EOF
+  - command: sleep 540
+    soft_fail: true
+  - wait: ~
+    continue_on_failure: true
+EOF
+  fi
+  IS_FIRST=false
 
   cat <<EOF
   - trigger: elasticsearch-periodic

--- a/.buildkite/scripts/periodic.trigger.sh
+++ b/.buildkite/scripts/periodic.trigger.sh
@@ -7,6 +7,8 @@ echo "steps:"
 source .buildkite/scripts/branches.sh
 
 IS_FIRST=true
+SKIP_DELAY="${SKIP_DELAY:-false}"
+
 for BRANCH in "${BRANCHES[@]}"; do
   INTAKE_PIPELINE_SLUG="elasticsearch-intake"
   BUILD_JSON=$(curl -sH "Authorization: Bearer ${BUILDKITE_API_TOKEN}" "https://api.buildkite.com/v2/organizations/elastic/pipelines/${INTAKE_PIPELINE_SLUG}/builds?branch=${BRANCH}&state=passed&per_page=1" | jq '.[0] | {commit: .commit, url: .web_url}')
@@ -14,7 +16,7 @@ for BRANCH in "${BRANCHES[@]}"; do
 
   # Put a delay between each branch's set of pipelines by prepending each non-first branch with a sleep
   # This is to smooth out the spike in agent requests
-  if [[ "$IS_FIRST" != "true" ]]; then
+  if [[ "$IS_FIRST" != "true" && "$SKIP_DELAY" != "true" ]]; then
       cat <<EOF
   - command: sleep 540
     soft_fail: true


### PR DESCRIPTION
Other Elastic users are seeing delays in agent provisioning when our periodic pipelines kick off. Let's put a delay between the branches, so the spike in requests is smoothed out a bit.

`SKIP_DELAY` can be passed in to skip the delay in a manual build, if desired. The individual pipelines can also be triggered manually.

I know having a small agent do the sleep is not ideal. This is just the easiest way I could think to do a quick mitigation.

ES-7557