### PR TITLE
Update search-template.asciidoc

### DIFF
--- a/docs/reference/search/search-your-data/search-template.asciidoc
+++ b/docs/reference/search/search-your-data/search-template.asciidoc
@@ -853,14 +853,16 @@ PUT _scripts/my-search-template
 {
   "script": {
     "lang": "mustache",
-    "source": {
+    "source": 
+    """
+    {
       "query":{
         "multi-match":{
           "query": "{{query_string}}",
-          "fields": """[{{#text_fields}}{{user_name}}{{^last}},{{/last}}{{/text_fields}}]"""
+          "fields": [{{#text_fields}}"{{user_name}}"{{^last}},{{/last}}{{/text_fields}}]
         }
       }
-    }
+    }"""
   }
 }
 ----
@@ -897,7 +899,7 @@ When rendered the template outputs:
     "query": {
       "multi-match": {
         "query": "My string",
-        "fields": "[John,kimchy]"
+        "fields": ["John","kimchy"]
       }
     }
   }


### PR DESCRIPTION
The example using the inverted section in the list topic does not produce a query with the correct syntax, 

https://www.elastic.co/guide/en/elasticsearch/reference/current/search-template.html#search-template-lists

```
{
  "template_output": {
    "query": {
      "multi-match": {
        "query": "My string",
        "fields": "[John,kimchy]"
      }
    }
  }
}
```

The above query does not have the correct syntax.

Fix the example so it creates the correct query.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->
