### PR TITLE
Add codeowners configuration for delivery team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,4 +37,3 @@ build-tools-internal @elastic/es-delivery
 .ci @elastic/es-delivery
 .idea @elastic/es-delivery
 distribution @elastic/es-delivery
-

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -36,4 +36,6 @@ build-tools-internal @elastic/es-delivery
 .buildkite @elastic/es-delivery
 .ci @elastic/es-delivery
 .idea @elastic/es-delivery
-distribution @elastic/es-delivery
+distribution/src @elastic/es-delivery
+distribution/packages/src @elastic/es-delivery
+distribution/docker/src @elastic/es-delivery

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,3 +26,15 @@ x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/sto
 # APM Data index templates, etc.
 x-pack/plugin/apm-data/src/main/resources @elastic/apm-server
 x-pack/plugin/apm-data/src/yamlRestTest/resources @elastic/apm-server
+
+# Delivery
+gradle @elastic/es-delivery
+build-conventions @elastic/es-delivery
+build-tools @elastic/es-delivery
+build-tools-internal @elastic/es-delivery
+*.gradle @elastic/es-delivery
+.buildkite @elastic/es-delivery
+.ci @elastic/es-delivery
+.idea @elastic/es-delivery
+distribution @elastic/es-delivery
+


### PR DESCRIPTION
configure the delivery team as code owner for all build, ci and distribution packaging related changes in the es codebase