### PR TITLE
semantic_text - add plugin pipelines infrastructure

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -192,6 +192,7 @@ public class TransportVersions {
     public static final TransportVersion INFERENCE_SERVICE_EMBEDDING_SIZE_ADDED = def(8_559_00_0);
     public static final TransportVersion ENRICH_ELASTICSEARCH_VERSION_REMOVED = def(8_560_00_0);
     public static final TransportVersion NODE_STATS_REQUEST_SIMPLIFIED = def(8_561_00_0);
+    public static final TransportVersion SEMANTIC_TEXT_FIELD = def(8_562_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -303,12 +303,11 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
         final long startTime = relativeTime();
 
         boolean hasIndexRequestsWithPipelines = false;
-        final Metadata metadata = clusterService.state().getMetadata();
         for (DocWriteRequest<?> actionRequest : bulkRequest.requests) {
             IndexRequest indexRequest = getIndexWriteRequest(actionRequest);
             if (indexRequest != null) {
-                ingestService.resolvePipelinesAndUpdateIndexRequest(actionRequest, indexRequest, metadata);
-                hasIndexRequestsWithPipelines |= ingestService.hasPipeline(indexRequest);
+                ingestService.resolvePipelinesAndUpdateIndexRequest(actionRequest, indexRequest);
+                hasIndexRequestsWithPipelines |= IngestService.hasPipeline(indexRequest);
             }
 
             if (actionRequest instanceof IndexRequest ir) {

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -307,8 +307,8 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
         for (DocWriteRequest<?> actionRequest : bulkRequest.requests) {
             IndexRequest indexRequest = getIndexWriteRequest(actionRequest);
             if (indexRequest != null) {
-                IngestService.resolvePipelinesAndUpdateIndexRequest(actionRequest, indexRequest, metadata);
-                hasIndexRequestsWithPipelines |= IngestService.hasPipeline(indexRequest);
+                ingestService.resolvePipelinesAndUpdateIndexRequest(actionRequest, indexRequest, metadata);
+                hasIndexRequestsWithPipelines |= ingestService.hasPipeline(indexRequest);
             }
 
             if (actionRequest instanceof IndexRequest ir) {

--- a/server/src/main/java/org/elasticsearch/action/index/IndexRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/index/IndexRequest.java
@@ -102,6 +102,7 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
 
     private String pipeline;
     private String finalPipeline;
+    private String pluginsPipeline;
 
     private boolean isPipelineResolved;
 
@@ -188,6 +189,9 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
                     ? null
                     : new ArrayList<>(possiblyImmutableExecutedPipelines);
             }
+        }
+        if (in.getTransportVersion().onOrAfter(TransportVersions.SEMANTIC_TEXT_FIELD)) {
+            this.pluginsPipeline = in.readOptionalString();
         }
     }
 
@@ -353,6 +357,15 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
      */
     public String getFinalPipeline() {
         return this.finalPipeline;
+    }
+
+    public String getPluginsPipeline() {
+        return pluginsPipeline;
+    }
+
+    public IndexRequest setPluginsPipeline(String pluginsPipeline) {
+        this.pluginsPipeline = pluginsPipeline;
+        return this;
     }
 
     /**
@@ -733,6 +746,9 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
             if (listExecutedPipelines) {
                 out.writeOptionalCollection(executedPipelines, StreamOutput::writeString);
             }
+        }
+        if (out.getTransportVersion().onOrAfter(TransportVersions.SEMANTIC_TEXT_FIELD)) {
+            out.writeOptionalString(pluginsPipeline);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -500,7 +500,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
         }
     }
 
-    private List<Pipeline> getPluginsPipelines(String id) {
+    List<Pipeline> getPluginsPipelines(String id) {
         if (id == null) {
             return null;
         }
@@ -1138,7 +1138,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
         updatePluginPipelines(event);
     }
 
-    private synchronized void updatePluginPipelines(ClusterChangedEvent event) {
+    synchronized void updatePluginPipelines(ClusterChangedEvent event) {
 
         Map<String, List<Pipeline>> updatedPluginPipelines = new HashMap<>(pluginPipelines);
 
@@ -1170,6 +1170,10 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
         }
 
         pluginPipelines = Map.copyOf(updatedPluginPipelines);
+    }
+
+    Map<String, List<Pipeline>> getPluginsPipelines() {
+        return pluginPipelines;
     }
 
     synchronized void innerUpdatePipelines(IngestMetadata newIngestMetadata) {

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -1404,7 +1404,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
         if (v2Template != null) {
             final Settings settings = MetadataIndexTemplateService.resolveSettings(metadata, v2Template);
             return Optional.of(
-                new Pipelines(IndexSettings.DEFAULT_PIPELINE.get(settings), IndexSettings.FINAL_PIPELINE.get(settings), null)
+                new Pipelines(IndexSettings.DEFAULT_PIPELINE.get(settings), IndexSettings.FINAL_PIPELINE.get(settings), NOOP_PIPELINE_NAME)
             );
         }
 

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -508,6 +508,10 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
         return this.pluginPipelines.get(id);
     }
 
+    void setPluginsPipelines(String id, List<Pipeline> pipelines) {
+        this.pluginPipelines = Map.of(id, pipelines);
+    }
+
     public Map<String, Processor.Factory> getProcessorFactories() {
         return processorFactories;
     }

--- a/server/src/main/java/org/elasticsearch/plugins/IngestPlugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/IngestPlugin.java
@@ -8,9 +8,12 @@
 
 package org.elasticsearch.plugins;
 
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.ingest.Pipeline;
 import org.elasticsearch.ingest.Processor;
 
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * An extension point for {@link Plugin} implementations to add custom ingest processors
@@ -26,5 +29,9 @@ public interface IngestPlugin {
      */
     default Map<String, Processor.Factory> getProcessors(Processor.Parameters parameters) {
         return Map.of();
+    }
+
+    default Optional<Pipeline> getIngestPipeline(IndexMetadata indexMetadata, Processor.Parameters parameters) {
+        return Optional.empty();
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionIndicesThatCannotBeCreatedTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionIndicesThatCannotBeCreatedTests.java
@@ -29,6 +29,7 @@ import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.IndexingPressure;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.indices.EmptySystemIndices;
+import org.elasticsearch.ingest.IngestServiceTests;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.MockUtils;
@@ -118,7 +119,7 @@ public class TransportBulkActionIndicesThatCannotBeCreatedTests extends ESTestCa
             threadPool,
             transportService,
             clusterService,
-            null,
+            IngestServiceTests.createIngestService(),
             null,
             mock(ActionFilters.class),
             indexNameExpressionResolver,

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.update.UpdateRequest;
+import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.IndexAbstraction;
@@ -30,6 +31,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.IndexNotFoundException;
@@ -40,6 +42,9 @@ import org.elasticsearch.index.VersionType;
 import org.elasticsearch.indices.EmptySystemIndices;
 import org.elasticsearch.indices.SystemIndexDescriptorUtils;
 import org.elasticsearch.indices.SystemIndices;
+import org.elasticsearch.ingest.IngestService;
+import org.elasticsearch.ingest.IngestServiceTests;
+import org.elasticsearch.plugins.internal.DocumentParsingObserver;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.VersionUtils;
 import org.elasticsearch.test.index.IndexVersionUtils;
@@ -61,6 +66,9 @@ import static org.elasticsearch.cluster.metadata.MetadataCreateDataStreamService
 import static org.elasticsearch.test.ClusterServiceUtils.createClusterService;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class TransportBulkActionTests extends ESTestCase {
 
@@ -82,7 +90,7 @@ public class TransportBulkActionTests extends ESTestCase {
                 TransportBulkActionTests.this.threadPool,
                 transportService,
                 clusterService,
-                null,
+                IngestServiceTests.createIngestService(),
                 null,
                 new ActionFilters(Collections.emptySet()),
                 new Resolver(),

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTests.java
@@ -20,7 +20,6 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.update.UpdateRequest;
-import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.IndexAbstraction;
@@ -31,7 +30,6 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.IndexNotFoundException;
@@ -42,9 +40,7 @@ import org.elasticsearch.index.VersionType;
 import org.elasticsearch.indices.EmptySystemIndices;
 import org.elasticsearch.indices.SystemIndexDescriptorUtils;
 import org.elasticsearch.indices.SystemIndices;
-import org.elasticsearch.ingest.IngestService;
 import org.elasticsearch.ingest.IngestServiceTests;
-import org.elasticsearch.plugins.internal.DocumentParsingObserver;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.VersionUtils;
 import org.elasticsearch.test.index.IndexVersionUtils;
@@ -66,9 +62,6 @@ import static org.elasticsearch.cluster.metadata.MetadataCreateDataStreamService
 import static org.elasticsearch.test.ClusterServiceUtils.createClusterService;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class TransportBulkActionTests extends ESTestCase {
 


### PR DESCRIPTION
Add a new pipeline list to IndexRequests that can be contributed by `IngestPlugin`s.

`IngestPlugins` get a new `getIngestPipeline` method, that receives an `IndexMetadata` and processor `Parameters` so plugins may instantiate an ingestion pipeline for an index.

`IngestService` checks for changes on `IndexMetadata` and asks `IngestPlugin`s for pipelines for the index. These plugin contributed pipelines are kept separate of the user contributed pipelines.

`IngestService` runs pipelines contributed by plugins as part of the ingestion pipeline process, after both default and final pipelines have run.

This pipeline infrastructure will be used in future PRs to make ML plugin contribute an inference pipeline for indices that have `semantic_text` fields.

