### PR TITLE
[Connector API] Fix bug with nullable tooltip field in parser

### DIFF
--- a/docs/changelog/103427.yaml
+++ b/docs/changelog/103427.yaml
@@ -1,0 +1,5 @@
+pr: 103427
+summary: "[Connector API] Fix bug with nullable tooltip field in parser"
+area: Application
+type: bug
+issues: []

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/335_connector_update_configuration.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/335_connector_update_configuration.yml
@@ -86,6 +86,41 @@ setup:
   - match: { status: configured }
 
 ---
+"Update Connector Configuration with null tooltip":
+  - do:
+      connector.update_configuration:
+        connector_id: test-connector
+        body:
+          configuration:
+            some_field:
+              default_value: null
+              depends_on:
+                - field: some_field
+                  value: 31
+              display: numeric
+              label: Very important field
+              options: [ ]
+              order: 4
+              required: true
+              sensitive: false
+              tooltip: null
+              type: str
+              ui_restrictions: [ ]
+              validations:
+                - constraint: 0
+                  type: greater_than
+              value: 123
+
+
+  - match: { result: updated }
+
+  - do:
+      connector.get:
+        connector_id: test-connector
+
+  - match: { configuration.some_field.tooltip: null }
+
+---
 "Update Connector Configuration - Connector doesn't exist":
   - do:
       catch: "missing"

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorConfiguration.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorConfiguration.java
@@ -54,6 +54,7 @@ public class ConnectorConfiguration implements Writeable, ToXContentObject {
     private final String placeholder;
     private final boolean required;
     private final boolean sensitive;
+    @Nullable
     private final String tooltip;
     private final ConfigurationFieldType type;
     private final List<String> uiRestrictions;
@@ -199,7 +200,7 @@ public class ConnectorConfiguration implements Writeable, ToXContentObject {
         PARSER.declareString(optionalConstructorArg(), PLACEHOLDER_FIELD);
         PARSER.declareBoolean(constructorArg(), REQUIRED_FIELD);
         PARSER.declareBoolean(constructorArg(), SENSITIVE_FIELD);
-        PARSER.declareStringOrNull(constructorArg(), TOOLTIP_FIELD);
+        PARSER.declareStringOrNull(optionalConstructorArg(), TOOLTIP_FIELD);
         PARSER.declareField(
             constructorArg(),
             (p, c) -> ConfigurationFieldType.fieldType(p.text()),

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorTests.java
@@ -98,6 +98,31 @@ public class ConnectorTests extends ESTestCase {
                         }
                      ],
                      "value":""
+                  },
+                   "field_with_null_tooltip":{
+                     "default_value":null,
+                     "depends_on":[
+                        {
+                           "field":"some_field",
+                           "value":true
+                        }
+                     ],
+                     "display":"textbox",
+                     "label":"Very important field",
+                     "options":[],
+                     "order":4,
+                     "required":true,
+                     "sensitive":false,
+                     "tooltip":null,
+                     "type":"str",
+                     "ui_restrictions":[],
+                     "validations":[
+                        {
+                           "constraint":0,
+                           "type":"greater_than"
+                        }
+                     ],
+                     "value":""
                   }
                },
                "description":"test-connector",


### PR DESCRIPTION
### Bug description
- According to [connector protocol](https://github.com/elastic/connectors/blob/main/docs/DEVELOPING.md?plain=1#L250) the tooltip field is defined as string
- Looking at native connectors config declaration in Kibana ([code ref](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/native_connectors.ts#L1091)) tooltip can also be a null which was causing issues with the connector configuration parser when updating or reading the connector configuration

### Changes
- Mark `tooltip` field as nullable field in class definition and in parser
- Add unit and e2e test cases to make sure that we handle `null` values in the payload correctly