### PR TITLE
[Connectors API] Fix bug with missing TEXT DisplayType enum

### DIFF
--- a/docs/changelog/103430.yaml
+++ b/docs/changelog/103430.yaml
@@ -1,0 +1,5 @@
+pr: 103430
+summary: "[Connectors API] Fix bug with missing TEXT `DisplayType` enum"
+area: Application
+type: bug
+issues: []

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/configuration/ConfigurationDisplayType.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/configuration/ConfigurationDisplayType.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.application.connector.configuration;
 import java.util.Locale;
 
 public enum ConfigurationDisplayType {
+    TEXT,
     TEXTBOX,
     TEXTAREA,
     NUMERIC,


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

### Bug description
- There is an inconsistency between definitions of configuration display type field 
  - [Kibana references](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/types/connectors.ts#L22) `textbox`  
  - [Connectors framework](https://github.com/elastic/connectors/blob/main/docs/DEVELOPING.md?plain=1#L245) references `text` 
- Right now, the configuration with `text` coming from self-hosted connector clients fails as the `text` display type is unknown according to ES definition

### Changes short-term
- Add `TEXT` to supported `DisplayType` as a mitigation to failing parsing logic

### Long-term
- We need to align connectors framework, kibana and ES to decide if we want to support both `text` and `textbox` (since those fields are in use since `8.8` or even earlier) or if we want to migrate to a single type