### PR TITLE
Dispatch ClusterStateAction#buildResponse to executor

### DIFF
--- a/docs/changelog/103435.yaml
+++ b/docs/changelog/103435.yaml
@@ -1,0 +1,5 @@
+pr: 103435
+summary: Dispatch `ClusterStateAction#buildResponse` to executor
+area: Distributed
+type: bug
+issues: []


### PR DESCRIPTION
If waiting for a particular cluster state (e.g. on the CCR leader) we
will compute the resulting cluster state and serialize it on the cluster
applier thread, which can be too expensive in a large cluster for this
thread. With this commit we dispatch the final action back to the
original executor.