### PR TITLE
[8.12] Dispatch ClusterStateAction#buildResponse to executor (#103435)

### DIFF
--- a/docs/changelog/103435.yaml
+++ b/docs/changelog/103435.yaml
@@ -1,0 +1,5 @@
+pr: 103435
+summary: Dispatch `ClusterStateAction#buildResponse` to executor
+area: Distributed
+type: bug
+issues: []


### PR DESCRIPTION
Backports the following commits to 8.12:
 - Dispatch ClusterStateAction#buildResponse to executor (#103435)