### PR TITLE
[Fleet] added missing privileges to fleet-server-remote account

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
@@ -157,14 +157,7 @@ final class ElasticServiceAccounts {
             new String[] { "monitor", "manage_own_api_key" },
             new RoleDescriptor.IndicesPrivileges[] {
                 RoleDescriptor.IndicesPrivileges.builder()
-                    .indices(
-                        "logs-*",
-                        "metrics-*",
-                        "traces-*",
-                        ".logs-endpoint.diagnostic.collection-*",
-                        ".logs-endpoint.action.responses-*",
-                        ".logs-endpoint.heartbeat-*"
-                    )
+                    .indices("logs-*", "metrics-*", "traces-*")
                     .privileges("write", "create_index", "auto_configure")
                     .build(), },
             null,

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
@@ -157,7 +157,14 @@ final class ElasticServiceAccounts {
             new String[] { "monitor", "manage_own_api_key" },
             new RoleDescriptor.IndicesPrivileges[] {
                 RoleDescriptor.IndicesPrivileges.builder()
-                    .indices("logs-*", "metrics-*")
+                    .indices(
+                        "logs-*",
+                        "metrics-*",
+                        "traces-*",
+                        ".logs-endpoint.diagnostic.collection-*",
+                        ".logs-endpoint.action.responses-*",
+                        ".logs-endpoint.heartbeat-*"
+                    )
                     .privileges("write", "create_index", "auto_configure")
                     .build(), },
             null,


### PR DESCRIPTION
Related to https://github.com/elastic/kibana/issues/173237

Since we are opening up remote elasticsearch output feature in Fleet for integration data, agents have to get access to `traces-*` .

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? yes
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)? yes
- If submitting code, have you built your formula locally prior to submission with `gradle check`? yes
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)? yes
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.