### PR TITLE
[8.12] [Connectors API] Add get connector sync job docs (#103425)

### DIFF
--- a/docs/reference/connector/apis/connector-apis.asciidoc
+++ b/docs/reference/connector/apis/connector-apis.asciidoc
@@ -38,6 +38,7 @@ Use the following APIs to manage sync jobs:
 
 * <<create-connector-sync-job-api>>
 * <<delete-connector-sync-job-api>
+* <<get-connector-sync-job-api>>
 * <<list-connector-sync-jobs-api>>
 
 include::create-connector-api.asciidoc[]
@@ -45,5 +46,6 @@ include::create-connector-sync-job-api.asciidoc[]
 include::delete-connector-api.asciidoc[]
 include::delete-connector-sync-job-api.asciidoc[]
 include::get-connector-api.asciidoc[]
+include::get-connector-sync-job-api.asciidoc[]
 include::list-connectors-api.asciidoc[]
 include::list-connector-sync-jobs-api.asciidoc[]

--- a/docs/reference/connector/apis/get-connector-sync-job-api.asciidoc
+++ b/docs/reference/connector/apis/get-connector-sync-job-api.asciidoc
@@ -1,0 +1,44 @@
+[[get-connector-sync-job-api]]
+=== Get connector sync job API
+preview::[]
+++++
+<titleabbrev>Get connector sync job</titleabbrev>
+++++
+
+Retrieves the details about a connector sync job.
+
+[[get-connector-sync-job-api-request]]
+==== {api-request-title}
+
+`GET _connector/_sync_job/<connector_sync_job_id>`
+
+[[get-connector-sync-job-api-prereq]]
+==== {api-prereq-title}
+
+* To sync data using connectors, it's essential to have the Elastic connectors service running.
+
+[[get-connector-sync-job-api-path-params]]
+==== {api-path-parms-title}
+
+`<connector_sync_job_id>`::
+(Required, string)
+
+[[get-connector-sync-job-api-response-codes]]
+==== {api-response-codes-title}
+
+`400`::
+The `connector_sync_job_id` was not provided.
+
+`404` (Missing resources)::
+No connector sync job matching `connector_sync_job_id` could be found.
+
+[[get-connector-sync-job-api-example]]
+==== {api-examples-title}
+
+The following example gets the connector sync job `my-connector-sync-job`:
+
+[source,console]
+----
+GET _connector/_sync_job/my-connector-sync-job
+----
+// TEST[skip:there's no way to clean up after creating a connector sync job, as we don't know the id ahead of time. Therefore, skip this test.]


### PR DESCRIPTION
Backports the following commits to 8.12:
 - [Connectors API] Add get connector sync job docs (#103425)