### PR TITLE
[8.12] [Connectors API] Fix bug with missing TEXT DisplayType enum (#103430)

### DIFF
--- a/docs/changelog/103430.yaml
+++ b/docs/changelog/103430.yaml
@@ -1,0 +1,5 @@
+pr: 103430
+summary: "[Connectors API] Fix bug with missing TEXT `DisplayType` enum"
+area: Application
+type: bug
+issues: []

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/configuration/ConfigurationDisplayType.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/configuration/ConfigurationDisplayType.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.application.connector.configuration;
 import java.util.Locale;
 
 public enum ConfigurationDisplayType {
+    TEXT,
     TEXTBOX,
     TEXTAREA,
     NUMERIC,


### PR DESCRIPTION
Backports the following commits to 8.12:
 - [Connectors API] Fix bug with missing TEXT DisplayType enum (#103430)