### PR TITLE
Add debug logger when registering a metric

### DIFF
--- a/modules/apm/NAMING.md
+++ b/modules/apm/NAMING.md
@@ -64,3 +64,10 @@ Attribute names should follow the same rules. In particular, these rules apply t
 * pluralization (when an attribute represents a measurement)
 
 For **pluralization**, when an attribute represents an entity, the attribute name should be singular (e.g.` es.security.realm_type`, not` es.security.realms_type` or `es.security.realm_types`), unless it represents a collection (e.g.` es.rest.request_headers`)
+
+
+### List of previously registered metric names
+You can run all previously registered metrics names with
+`./gradlew run -Dtests.es.logger.org.elasticsearch.telemetry.apm=debug`
+This should help you find out the already registered group that your meteric
+might fit

--- a/modules/apm/NAMING.md
+++ b/modules/apm/NAMING.md
@@ -67,7 +67,7 @@ For **pluralization**, when an attribute represents an entity, the attribute nam
 
 
 ### List of previously registered metric names
-You can run all previously registered metrics names with
+You can inspect all previously registered metrics names with
 `./gradlew run -Dtests.es.logger.org.elasticsearch.telemetry.apm=debug`
 This should help you find out the already registered group that your meteric
 might fit

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/APMMeterRegistry.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/APMMeterRegistry.java
@@ -10,6 +10,8 @@ package org.elasticsearch.telemetry.apm;
 
 import io.opentelemetry.api.metrics.Meter;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.common.util.concurrent.ReleasableLock;
 import org.elasticsearch.telemetry.apm.internal.metrics.DoubleAsyncCounterAdapter;
@@ -47,6 +49,7 @@ import java.util.function.Supplier;
  * {@link #setProvider(Meter)} is used to change the provider for all existing meterRegistrar.
  */
 public class APMMeterRegistry implements MeterRegistry {
+    private static final Logger logger = LogManager.getLogger(APMMeterRegistry.class);
     private final Registrar<DoubleCounterAdapter> doubleCounters = new Registrar<>();
     private final Registrar<DoubleAsyncCounterAdapter> doubleAsynchronousCounters = new Registrar<>();
     private final Registrar<DoubleUpDownCounterAdapter> doubleUpDownCounters = new Registrar<>();
@@ -207,6 +210,7 @@ public class APMMeterRegistry implements MeterRegistry {
 
     private <T extends AbstractInstrument<?>> T register(Registrar<T> registrar, T adapter) {
         assert registrars.contains(registrar) : "usage of unknown registrar";
+        logger.debug("Registering an instrument "+adapter.getName());
         return registrar.register(adapter);
     }
 

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/APMMeterRegistry.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/APMMeterRegistry.java
@@ -210,7 +210,7 @@ public class APMMeterRegistry implements MeterRegistry {
 
     private <T extends AbstractInstrument<?>> T register(Registrar<T> registrar, T adapter) {
         assert registrars.contains(registrar) : "usage of unknown registrar";
-        logger.debug("Registering an instrument "+adapter.getName());
+        logger.debug("Registering an instrument with name: " + adapter.getName());
         return registrar.register(adapter);
     }
 


### PR DESCRIPTION
This commit adds a log message at debug level when a metric is registered. This allows to start elasticsearch with a level changed for the apm package and get a list of metric names.
It should be useful when trying to came up with a new meteric name the command to run
 ./gradlew run -Dtests.es.logger.org.elasticsearch.telemetry.apm=debug

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
