### PR TITLE
semantic_text - add plugin pipelines infrastructure

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -192,6 +192,7 @@ public class TransportVersions {
     public static final TransportVersion INFERENCE_SERVICE_EMBEDDING_SIZE_ADDED = def(8_559_00_0);
     public static final TransportVersion ENRICH_ELASTICSEARCH_VERSION_REMOVED = def(8_560_00_0);
     public static final TransportVersion NODE_STATS_REQUEST_SIMPLIFIED = def(8_561_00_0);
+    public static final TransportVersion SEMANTIC_TEXT_FIELD = def(8_562_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -303,12 +303,11 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
         final long startTime = relativeTime();
 
         boolean hasIndexRequestsWithPipelines = false;
-        final Metadata metadata = clusterService.state().getMetadata();
         for (DocWriteRequest<?> actionRequest : bulkRequest.requests) {
             IndexRequest indexRequest = getIndexWriteRequest(actionRequest);
             if (indexRequest != null) {
-                ingestService.resolvePipelinesAndUpdateIndexRequest(actionRequest, indexRequest, metadata);
-                hasIndexRequestsWithPipelines |= ingestService.hasPipeline(indexRequest);
+                ingestService.resolvePipelinesAndUpdateIndexRequest(actionRequest, indexRequest);
+                hasIndexRequestsWithPipelines |= IngestService.hasPipeline(indexRequest);
             }
 
             if (actionRequest instanceof IndexRequest ir) {

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -307,8 +307,8 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
         for (DocWriteRequest<?> actionRequest : bulkRequest.requests) {
             IndexRequest indexRequest = getIndexWriteRequest(actionRequest);
             if (indexRequest != null) {
-                IngestService.resolvePipelinesAndUpdateIndexRequest(actionRequest, indexRequest, metadata);
-                hasIndexRequestsWithPipelines |= IngestService.hasPipeline(indexRequest);
+                ingestService.resolvePipelinesAndUpdateIndexRequest(actionRequest, indexRequest, metadata);
+                hasIndexRequestsWithPipelines |= ingestService.hasPipeline(indexRequest);
             }
 
             if (actionRequest instanceof IndexRequest ir) {

--- a/server/src/main/java/org/elasticsearch/action/index/IndexRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/index/IndexRequest.java
@@ -102,6 +102,7 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
 
     private String pipeline;
     private String finalPipeline;
+    private String pluginsPipeline;
 
     private boolean isPipelineResolved;
 
@@ -188,6 +189,9 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
                     ? null
                     : new ArrayList<>(possiblyImmutableExecutedPipelines);
             }
+        }
+        if (in.getTransportVersion().onOrAfter(TransportVersions.SEMANTIC_TEXT_FIELD)) {
+            this.pluginsPipeline = in.readOptionalString();
         }
     }
 
@@ -353,6 +357,15 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
      */
     public String getFinalPipeline() {
         return this.finalPipeline;
+    }
+
+    public String getPluginsPipeline() {
+        return pluginsPipeline;
+    }
+
+    public IndexRequest setPluginsPipeline(String pluginsPipeline) {
+        this.pluginsPipeline = pluginsPipeline;
+        return this;
     }
 
     /**
@@ -733,6 +746,9 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
             if (listExecutedPipelines) {
                 out.writeOptionalCollection(executedPipelines, StreamOutput::writeString);
             }
+        }
+        if (out.getTransportVersion().onOrAfter(TransportVersions.SEMANTIC_TEXT_FIELD)) {
+            out.writeOptionalString(pluginsPipeline);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -500,7 +500,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
         }
     }
 
-    private List<Pipeline> getPluginsPipelines(String id) {
+    List<Pipeline> getPluginsPipelines(String id) {
         if (id == null) {
             return null;
         }
@@ -1138,7 +1138,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
         updatePluginPipelines(event);
     }
 
-    private synchronized void updatePluginPipelines(ClusterChangedEvent event) {
+    synchronized void updatePluginPipelines(ClusterChangedEvent event) {
 
         Map<String, List<Pipeline>> updatedPluginPipelines = new HashMap<>(pluginPipelines);
 
@@ -1170,6 +1170,10 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
         }
 
         pluginPipelines = Map.copyOf(updatedPluginPipelines);
+    }
+
+    Map<String, List<Pipeline>> getPluginsPipelines() {
+        return pluginPipelines;
     }
 
     synchronized void innerUpdatePipelines(IngestMetadata newIngestMetadata) {

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -253,10 +253,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
      * @param originalRequest Original write request received.
      * @param indexRequest    The {@link org.elasticsearch.action.index.IndexRequest} object to update.
      */
-    public void resolvePipelinesAndUpdateIndexRequest(
-        final DocWriteRequest<?> originalRequest,
-        final IndexRequest indexRequest
-    ) {
+    public void resolvePipelinesAndUpdateIndexRequest(final DocWriteRequest<?> originalRequest, final IndexRequest indexRequest) {
         resolvePipelinesAndUpdateIndexRequest(originalRequest, indexRequest, System.currentTimeMillis());
     }
 

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -776,12 +776,8 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
 
         final String pluginPipelineId = indexRequest.getPluginsPipeline();
         indexRequest.setPluginsPipeline(NOOP_PIPELINE_NAME);
-        List<Pipeline> pluginsPipelines = null;
-        if (pluginPipelineId != null) {
-            pluginsPipelines = getPluginsPipelines(pluginPipelineId);
-        }
 
-        return new PipelineIterator(pipelineId, finalPipelineId, pluginsPipelines);
+        return new PipelineIterator(pipelineId, finalPipelineId, pluginPipelineId);
     }
 
     /**
@@ -801,14 +797,14 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
 
         private final String defaultPipeline;
         private final String finalPipeline;
-        private final List<Pipeline> pluginsPipelines;
+        private final String pluginsPipelines;
 
         private final Iterator<PipelineSlot> pipelineSlotIterator;
 
-        private PipelineIterator(String defaultPipeline, String finalPipeline, List<Pipeline> pluginsPipelines) {
+        private PipelineIterator(String defaultPipeline, String finalPipeline, String pluginsPipelines) {
             this.defaultPipeline = NOOP_PIPELINE_NAME.equals(defaultPipeline) ? null : defaultPipeline;
             this.finalPipeline = NOOP_PIPELINE_NAME.equals(finalPipeline) ? null : finalPipeline;
-            this.pluginsPipelines = pluginsPipelines;
+            this.pluginsPipelines = NOOP_PIPELINE_NAME.equals(pluginsPipelines) ? null : pluginsPipelines;
             this.pipelineSlotIterator = iterator();
         }
 
@@ -825,7 +821,9 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
                 slotList.add(new PipelineSlot(finalPipeline, getPipeline(finalPipeline), true));
             }
             if (pluginsPipelines != null) {
-                slotList.addAll(pluginsPipelines.stream().map(pipeline -> new PipelineSlot("plugins", pipeline, false)).toList());
+                slotList.addAll(
+                    getPluginsPipelines(pluginsPipelines).stream().map(pipeline -> new PipelineSlot("plugins", pipeline, false)).toList()
+                );
             }
             return slotList.iterator();
         }

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -1404,7 +1404,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
         if (v2Template != null) {
             final Settings settings = MetadataIndexTemplateService.resolveSettings(metadata, v2Template);
             return Optional.of(
-                new Pipelines(IndexSettings.DEFAULT_PIPELINE.get(settings), IndexSettings.FINAL_PIPELINE.get(settings), null)
+                new Pipelines(IndexSettings.DEFAULT_PIPELINE.get(settings), IndexSettings.FINAL_PIPELINE.get(settings), NOOP_PIPELINE_NAME)
             );
         }
 

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -508,6 +508,10 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
         return this.pluginPipelines.get(id);
     }
 
+    void setPluginsPipelines(String id, List<Pipeline> pipelines) {
+        this.pluginPipelines = Map.of(id, pipelines);
+    }
+
     public Map<String, Processor.Factory> getProcessorFactories() {
         return processorFactories;
     }

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -112,6 +112,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
     // processor factories rely on other node services. Custom metadata is statically registered when classes
     // are loaded, so in the cluster state we just save the pipeline config and here we keep the actual pipelines around.
     private volatile Map<String, PipelineHolder> pipelines = Map.of();
+    // Plugin contributed pipelines, that are executed after the default and final pipelines.
     private volatile Map<String, List<Pipeline>> pluginPipelines = Map.of();
 
     private final ThreadPool threadPool;
@@ -1137,6 +1138,12 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
         updatePluginPipelines(event);
     }
 
+    /**
+     * Updates plugin pipelines based on the current cluster state. It will ask plugins for pipelines
+     * for each index in the cluster state and update the pluginPipelines map with new / removed pipelines.
+     *
+     * @param event cluster changed event
+     */
     synchronized void updatePluginPipelines(ClusterChangedEvent event) {
 
         Map<String, List<Pipeline>> updatedPluginPipelines = new HashMap<>(pluginPipelines);
@@ -1439,7 +1446,8 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
         defaultPipeline = Objects.requireNonNullElse(defaultPipeline, NOOP_PIPELINE_NAME);
         finalPipeline = Objects.requireNonNullElse(finalPipeline, NOOP_PIPELINE_NAME);
 
-        // TODO We can't resolve yet the plugins pipeline as we don't have the IndexMetadata. Check if we can do it.
+        // TODO We're not adding plugin pipelines here yet - we could have a separate method that contains the ComposableIndextemplate
+        // so plugins can decide to add pipelines based on template information
         return Optional.of(new Pipelines(defaultPipeline, finalPipeline, NOOP_PIPELINE_NAME));
     }
 

--- a/server/src/main/java/org/elasticsearch/plugins/IngestPlugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/IngestPlugin.java
@@ -8,9 +8,12 @@
 
 package org.elasticsearch.plugins;
 
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.ingest.Pipeline;
 import org.elasticsearch.ingest.Processor;
 
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * An extension point for {@link Plugin} implementations to add custom ingest processors
@@ -26,5 +29,9 @@ public interface IngestPlugin {
      */
     default Map<String, Processor.Factory> getProcessors(Processor.Parameters parameters) {
         return Map.of();
+    }
+
+    default Optional<Pipeline> getIngestPipeline(IndexMetadata indexMetadata, Processor.Parameters parameters) {
+        return Optional.empty();
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionIndicesThatCannotBeCreatedTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionIndicesThatCannotBeCreatedTests.java
@@ -29,6 +29,7 @@ import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.IndexingPressure;
 import org.elasticsearch.index.VersionType;
 import org.elasticsearch.indices.EmptySystemIndices;
+import org.elasticsearch.ingest.IngestServiceTests;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.MockUtils;
@@ -118,7 +119,7 @@ public class TransportBulkActionIndicesThatCannotBeCreatedTests extends ESTestCa
             threadPool,
             transportService,
             clusterService,
-            null,
+            IngestServiceTests.createIngestService(),
             null,
             mock(ActionFilters.class),
             indexNameExpressionResolver,

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionIngestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionIngestTests.java
@@ -235,7 +235,7 @@ public class TransportBulkActionIngestTests extends ESTestCase {
         ingestService = spy(
             new IngestService(
                 clusterService,
-                createThreadPool(),
+                threadPool,
                 null,
                 null,
                 null,

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.update.UpdateRequest;
+import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.IndexAbstraction;
@@ -30,6 +31,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.IndexNotFoundException;
@@ -40,6 +42,9 @@ import org.elasticsearch.index.VersionType;
 import org.elasticsearch.indices.EmptySystemIndices;
 import org.elasticsearch.indices.SystemIndexDescriptorUtils;
 import org.elasticsearch.indices.SystemIndices;
+import org.elasticsearch.ingest.IngestService;
+import org.elasticsearch.ingest.IngestServiceTests;
+import org.elasticsearch.plugins.internal.DocumentParsingObserver;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.VersionUtils;
 import org.elasticsearch.test.index.IndexVersionUtils;
@@ -61,6 +66,9 @@ import static org.elasticsearch.cluster.metadata.MetadataCreateDataStreamService
 import static org.elasticsearch.test.ClusterServiceUtils.createClusterService;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class TransportBulkActionTests extends ESTestCase {
 
@@ -82,7 +90,7 @@ public class TransportBulkActionTests extends ESTestCase {
                 TransportBulkActionTests.this.threadPool,
                 transportService,
                 clusterService,
-                null,
+                IngestServiceTests.createIngestService(),
                 null,
                 new ActionFilters(Collections.emptySet()),
                 new Resolver(),

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTests.java
@@ -20,7 +20,6 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.update.UpdateRequest;
-import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.IndexAbstraction;
@@ -31,7 +30,6 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.IndexNotFoundException;
@@ -42,9 +40,7 @@ import org.elasticsearch.index.VersionType;
 import org.elasticsearch.indices.EmptySystemIndices;
 import org.elasticsearch.indices.SystemIndexDescriptorUtils;
 import org.elasticsearch.indices.SystemIndices;
-import org.elasticsearch.ingest.IngestService;
 import org.elasticsearch.ingest.IngestServiceTests;
-import org.elasticsearch.plugins.internal.DocumentParsingObserver;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.VersionUtils;
 import org.elasticsearch.test.index.IndexVersionUtils;
@@ -66,9 +62,6 @@ import static org.elasticsearch.cluster.metadata.MetadataCreateDataStreamService
 import static org.elasticsearch.test.ClusterServiceUtils.createClusterService;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class TransportBulkActionTests extends ESTestCase {
 

--- a/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
@@ -2074,7 +2074,7 @@ public class IngestServiceTests extends ESTestCase {
 
         when(mockedIndexRequest.isPipelineResolved()).thenReturn(true);
 
-        ingestService.resolvePipelinesAndUpdateIndexRequest(mockedRequest, mockedIndexRequest, mockedMetadata);
+        ingestService.resolvePipelinesAndUpdateIndexRequest(mockedRequest, mockedIndexRequest);
 
         verify(mockedIndexRequest, times(1)).isPipelineResolved();
         verifyNoMoreInteractions(mockedIndexRequest);
@@ -2085,22 +2085,22 @@ public class IngestServiceTests extends ESTestCase {
         var indexRequest = new IndexRequest("idx").isPipelineResolved(true);
 
         indexRequest.setPipeline(NOOP_PIPELINE_NAME).setFinalPipeline(NOOP_PIPELINE_NAME).setPluginsPipeline(NOOP_PIPELINE_NAME);
-        assertFalse(ingestService.hasPipeline(indexRequest));
+        assertFalse(IngestService.hasPipeline(indexRequest));
 
         indexRequest.setPipeline("some-pipeline").setFinalPipeline(NOOP_PIPELINE_NAME).setPluginsPipeline(NOOP_PIPELINE_NAME);
         ;
-        assertTrue(ingestService.hasPipeline(indexRequest));
+        assertTrue(IngestService.hasPipeline(indexRequest));
 
         indexRequest.setPipeline(NOOP_PIPELINE_NAME).setFinalPipeline("some-final-pipeline").setPluginsPipeline(NOOP_PIPELINE_NAME);
         ;
-        assertTrue(ingestService.hasPipeline(indexRequest));
+        assertTrue(IngestService.hasPipeline(indexRequest));
 
         indexRequest.setPipeline("some-pipeline").setFinalPipeline("some-final-pipeline").setPluginsPipeline(NOOP_PIPELINE_NAME);
         ;
-        assertTrue(ingestService.hasPipeline(indexRequest));
+        assertTrue(IngestService.hasPipeline(indexRequest));
 
         indexRequest.setPipeline(NOOP_PIPELINE_NAME).setFinalPipeline(NOOP_PIPELINE_NAME).setPluginsPipeline("some-plugins-pipeline");
-        assertTrue(ingestService.hasPipeline(indexRequest));
+        assertTrue(IngestService.hasPipeline(indexRequest));
     }
 
     public void testResolveRequiredOrDefaultPipelineDefaultPipeline() {
@@ -2113,15 +2113,15 @@ public class IngestServiceTests extends ESTestCase {
 
         // index name matches with IDM:
         IndexRequest indexRequest = new IndexRequest("idx");
-        ingestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
-        assertTrue(ingestService.hasPipeline(indexRequest));
+        ingestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest);
+        assertTrue(IngestService.hasPipeline(indexRequest));
         assertTrue(indexRequest.isPipelineResolved());
         assertThat(indexRequest.getPipeline(), equalTo("default-pipeline"));
 
         // alias name matches with IDM:
         indexRequest = new IndexRequest("alias");
-        ingestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
-        assertTrue(ingestService.hasPipeline(indexRequest));
+        ingestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest);
+        assertTrue(IngestService.hasPipeline(indexRequest));
         assertTrue(indexRequest.isPipelineResolved());
         assertThat(indexRequest.getPipeline(), equalTo("default-pipeline"));
 
@@ -2131,8 +2131,8 @@ public class IngestServiceTests extends ESTestCase {
             .settings(settings(IndexVersion.current()).put(IndexSettings.DEFAULT_PIPELINE.getKey(), "default-pipeline"));
         metadata = Metadata.builder().put(templateBuilder).build();
         indexRequest = new IndexRequest("idx");
-        ingestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
-        assertTrue(ingestService.hasPipeline(indexRequest));
+        ingestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest);
+        assertTrue(IngestService.hasPipeline(indexRequest));
         assertTrue(indexRequest.isPipelineResolved());
         assertThat(indexRequest.getPipeline(), equalTo("default-pipeline"));
     }
@@ -2147,16 +2147,16 @@ public class IngestServiceTests extends ESTestCase {
 
         // index name matches with IDM:
         IndexRequest indexRequest = new IndexRequest("idx");
-        ingestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
-        assertTrue(ingestService.hasPipeline(indexRequest));
+        ingestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest);
+        assertTrue(IngestService.hasPipeline(indexRequest));
         assertTrue(indexRequest.isPipelineResolved());
         assertThat(indexRequest.getPipeline(), equalTo("_none"));
         assertThat(indexRequest.getFinalPipeline(), equalTo("final-pipeline"));
 
         // alias name matches with IDM:
         indexRequest = new IndexRequest("alias");
-        ingestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
-        assertTrue(ingestService.hasPipeline(indexRequest));
+        ingestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest);
+        assertTrue(IngestService.hasPipeline(indexRequest));
         assertTrue(indexRequest.isPipelineResolved());
         assertThat(indexRequest.getPipeline(), equalTo("_none"));
         assertThat(indexRequest.getFinalPipeline(), equalTo("final-pipeline"));
@@ -2167,8 +2167,8 @@ public class IngestServiceTests extends ESTestCase {
             .settings(settings(IndexVersion.current()).put(IndexSettings.FINAL_PIPELINE.getKey(), "final-pipeline"));
         metadata = Metadata.builder().put(templateBuilder).build();
         indexRequest = new IndexRequest("idx");
-        ingestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
-        assertTrue(ingestService.hasPipeline(indexRequest));
+        ingestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest);
+        assertTrue(IngestService.hasPipeline(indexRequest));
         assertTrue(indexRequest.isPipelineResolved());
         assertThat(indexRequest.getPipeline(), equalTo("_none"));
         assertThat(indexRequest.getFinalPipeline(), equalTo("final-pipeline"));
@@ -2185,8 +2185,8 @@ public class IngestServiceTests extends ESTestCase {
 
         // index name matches with IDM:
         IndexRequest indexRequest = new IndexRequest("<idx-{now/d}>");
-        ingestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata, epochMillis);
-        assertTrue(ingestService.hasPipeline(indexRequest));
+        ingestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, epochMillis);
+        assertTrue(IngestService.hasPipeline(indexRequest));
         assertTrue(indexRequest.isPipelineResolved());
         assertThat(indexRequest.getPipeline(), equalTo("_none"));
         assertThat(indexRequest.getFinalPipeline(), equalTo("final-pipeline"));
@@ -2197,8 +2197,8 @@ public class IngestServiceTests extends ESTestCase {
         {
             Metadata metadata = Metadata.builder().build();
             IndexRequest indexRequest = new IndexRequest("idx");
-            ingestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
-            assertFalse(ingestService.hasPipeline(indexRequest));
+            ingestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest);
+            assertFalse(IngestService.hasPipeline(indexRequest));
             assertTrue(indexRequest.isPipelineResolved());
             assertThat(indexRequest.getPipeline(), equalTo(NOOP_PIPELINE_NAME));
             assertThat(indexRequest.getPluginsPipeline(), equalTo(NOOP_PIPELINE_NAME));
@@ -2208,8 +2208,8 @@ public class IngestServiceTests extends ESTestCase {
         {
             Metadata metadata = Metadata.builder().build();
             IndexRequest indexRequest = new IndexRequest("idx").setPipeline("request-pipeline");
-            ingestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
-            assertTrue(ingestService.hasPipeline(indexRequest));
+            ingestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest);
+            assertTrue(IngestService.hasPipeline(indexRequest));
             assertTrue(indexRequest.isPipelineResolved());
             assertThat(indexRequest.getPipeline(), equalTo("request-pipeline"));
             assertThat(indexRequest.getPluginsPipeline(), equalTo(NOOP_PIPELINE_NAME));
@@ -2223,8 +2223,8 @@ public class IngestServiceTests extends ESTestCase {
                 .numberOfReplicas(0);
             Metadata metadata = Metadata.builder().put(builder).build();
             IndexRequest indexRequest = new IndexRequest("idx").setPipeline("request-pipeline");
-            ingestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
-            assertTrue(ingestService.hasPipeline(indexRequest));
+            ingestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest);
+            assertTrue(IngestService.hasPipeline(indexRequest));
             assertTrue(indexRequest.isPipelineResolved());
             assertThat(indexRequest.getPipeline(), equalTo("request-pipeline"));
             assertThat(indexRequest.getPluginsPipeline(), equalTo(NOOP_PIPELINE_NAME));
@@ -2238,8 +2238,8 @@ public class IngestServiceTests extends ESTestCase {
                 .numberOfReplicas(0);
             Metadata metadata = Metadata.builder().put(builder).build();
             IndexRequest indexRequest = new IndexRequest("idx").setPipeline("request-pipeline");
-            ingestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
-            assertTrue(ingestService.hasPipeline(indexRequest));
+            ingestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest);
+            assertTrue(IngestService.hasPipeline(indexRequest));
             assertTrue(indexRequest.isPipelineResolved());
             assertThat(indexRequest.getPipeline(), equalTo("request-pipeline"));
             assertThat(indexRequest.getFinalPipeline(), equalTo("final-pipeline"));
@@ -2431,8 +2431,8 @@ public class IngestServiceTests extends ESTestCase {
         {
             Metadata metadata = Metadata.builder().build();
             IndexRequest indexRequest = new IndexRequest("idx");
-            ingestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
-            assertFalse(ingestService.hasPipeline(indexRequest));
+            ingestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest);
+            assertFalse(IngestService.hasPipeline(indexRequest));
             assertTrue(indexRequest.isPipelineResolved());
             assertThat(indexRequest.getPipeline(), equalTo(NOOP_PIPELINE_NAME));
             assertThat(indexRequest.getPluginsPipeline(), equalTo(NOOP_PIPELINE_NAME));
@@ -2442,8 +2442,8 @@ public class IngestServiceTests extends ESTestCase {
         {
             Metadata metadata = Metadata.builder().build();
             IndexRequest indexRequest = new IndexRequest("idx").setPipeline("request-pipeline");
-            ingestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
-            assertTrue(ingestService.hasPipeline(indexRequest));
+            ingestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest);
+            assertTrue(IngestService.hasPipeline(indexRequest));
             assertTrue(indexRequest.isPipelineResolved());
             assertThat(indexRequest.getPipeline(), equalTo("request-pipeline"));
             assertThat(indexRequest.getPluginsPipeline(), equalTo(NOOP_PIPELINE_NAME));
@@ -2457,8 +2457,8 @@ public class IngestServiceTests extends ESTestCase {
                 .numberOfReplicas(0);
             Metadata metadata = Metadata.builder().put(builder).build();
             IndexRequest indexRequest = new IndexRequest("idx").setPipeline("request-pipeline");
-            ingestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
-            assertTrue(ingestService.hasPipeline(indexRequest));
+            ingestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest);
+            assertTrue(IngestService.hasPipeline(indexRequest));
             assertTrue(indexRequest.isPipelineResolved());
             assertThat(indexRequest.getPipeline(), equalTo("request-pipeline"));
             assertThat(indexRequest.getPluginsPipeline(), equalTo("idx"));
@@ -2472,8 +2472,8 @@ public class IngestServiceTests extends ESTestCase {
                 .numberOfReplicas(0);
             Metadata metadata = Metadata.builder().put(builder).build();
             IndexRequest indexRequest = new IndexRequest("idx").setPipeline("request-pipeline");
-            ingestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
-            assertTrue(ingestService.hasPipeline(indexRequest));
+            ingestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest);
+            assertTrue(IngestService.hasPipeline(indexRequest));
             assertTrue(indexRequest.isPipelineResolved());
             assertThat(indexRequest.getPipeline(), equalTo("request-pipeline"));
             assertThat(indexRequest.getFinalPipeline(), equalTo("final-pipeline"));
@@ -2486,8 +2486,8 @@ public class IngestServiceTests extends ESTestCase {
         {
             Metadata metadata = Metadata.builder().build();
             IndexRequest indexRequest = new IndexRequest("idx").setPipeline(NOOP_PIPELINE_NAME);
-            ingestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
-            assertFalse(ingestService.hasPipeline(indexRequest));
+            ingestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest);
+            assertFalse(IngestService.hasPipeline(indexRequest));
             assertTrue(indexRequest.isPipelineResolved());
             assertThat(indexRequest.getPipeline(), equalTo(NOOP_PIPELINE_NAME));
             assertThat(indexRequest.getPluginsPipeline(), equalTo(NOOP_PIPELINE_NAME));
@@ -2501,8 +2501,8 @@ public class IngestServiceTests extends ESTestCase {
                 .numberOfReplicas(0);
             Metadata metadata = Metadata.builder().put(builder).build();
             IndexRequest indexRequest = new IndexRequest("idx");
-            ingestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
-            assertFalse(ingestService.hasPipeline(indexRequest));
+            ingestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest);
+            assertFalse(IngestService.hasPipeline(indexRequest));
             assertTrue(indexRequest.isPipelineResolved());
             assertThat(indexRequest.getPipeline(), equalTo(NOOP_PIPELINE_NAME));
             assertThat(indexRequest.getPluginsPipeline(), equalTo(NOOP_PIPELINE_NAME));
@@ -2516,8 +2516,8 @@ public class IngestServiceTests extends ESTestCase {
                 .numberOfReplicas(0);
             Metadata metadata = Metadata.builder().put(builder).build();
             IndexRequest indexRequest = new IndexRequest("idx").setPipeline("pipeline1");
-            ingestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
-            assertTrue(ingestService.hasPipeline(indexRequest));
+            ingestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest);
+            assertTrue(IngestService.hasPipeline(indexRequest));
             assertTrue(indexRequest.isPipelineResolved());
             assertThat(indexRequest.getPipeline(), equalTo("pipeline1"));
             assertThat(indexRequest.getPluginsPipeline(), equalTo(NOOP_PIPELINE_NAME));
@@ -2531,8 +2531,8 @@ public class IngestServiceTests extends ESTestCase {
                 .numberOfReplicas(0);
             Metadata metadata = Metadata.builder().put(builder).build();
             IndexRequest indexRequest = new IndexRequest("idx").setPipeline(NOOP_PIPELINE_NAME);
-            ingestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
-            assertFalse(ingestService.hasPipeline(indexRequest));
+            ingestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest);
+            assertFalse(IngestService.hasPipeline(indexRequest));
             assertTrue(indexRequest.isPipelineResolved());
             assertThat(indexRequest.getPipeline(), equalTo(NOOP_PIPELINE_NAME));
             assertThat(indexRequest.getPluginsPipeline(), equalTo(NOOP_PIPELINE_NAME));
@@ -2546,8 +2546,8 @@ public class IngestServiceTests extends ESTestCase {
                 .numberOfReplicas(0);
             Metadata metadata = Metadata.builder().put(builder).build();
             IndexRequest indexRequest = new IndexRequest("idx").setPipeline(NOOP_PIPELINE_NAME);
-            ingestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
-            assertTrue(ingestService.hasPipeline(indexRequest));
+            ingestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest);
+            assertTrue(IngestService.hasPipeline(indexRequest));
             assertTrue(indexRequest.isPipelineResolved());
             assertThat(indexRequest.getPipeline(), equalTo(NOOP_PIPELINE_NAME));
             assertThat(indexRequest.getFinalPipeline(), equalTo("final-pipeline"));
@@ -2562,8 +2562,8 @@ public class IngestServiceTests extends ESTestCase {
                 .numberOfReplicas(0);
             Metadata metadata = Metadata.builder().put(builder).build();
             IndexRequest indexRequest = new IndexRequest("idx").setPipeline("pipeline1");
-            ingestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
-            assertTrue(ingestService.hasPipeline(indexRequest));
+            ingestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest);
+            assertTrue(IngestService.hasPipeline(indexRequest));
             assertTrue(indexRequest.isPipelineResolved());
             assertThat(indexRequest.getPipeline(), equalTo("pipeline1"));
             assertThat(indexRequest.getFinalPipeline(), equalTo(NOOP_PIPELINE_NAME));
@@ -2662,8 +2662,10 @@ public class IngestServiceTests extends ESTestCase {
     private static IngestService createIngestService(List<IngestPlugin> ingestPlugins) {
         Client client = mock(Client.class);
 
-        return new IngestService(
-            mock(ClusterService.class),
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.state()).thenReturn(ClusterState.EMPTY_STATE);
+        IngestService ingestService = new IngestService(
+            clusterService,
             createThreadPool(),
             null,
             null,
@@ -2673,6 +2675,8 @@ public class IngestServiceTests extends ESTestCase {
             null,
             () -> DocumentParsingObserver.EMPTY_INSTANCE
         );
+        ingestService.applyClusterState(new ClusterChangedEvent("", ClusterState.EMPTY_STATE, ClusterState.EMPTY_STATE));
+        return ingestService;
     }
 
     private static ThreadPool createThreadPool() {

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
@@ -1921,23 +1921,25 @@ public class SnapshotResiliencyTests extends ESTestCase {
                 final MappingUpdatedAction mappingUpdatedAction = new MappingUpdatedAction(settings, clusterSettings);
                 final IndexingPressure indexingMemoryLimits = new IndexingPressure(settings);
                 mappingUpdatedAction.setClient(client);
+                IngestService ingestService = new IngestService(
+                    clusterService,
+                    threadPool,
+                    environment,
+                    scriptService,
+                    new AnalysisModule(environment, Collections.emptyList(), new StablePluginsRegistry()).getAnalysisRegistry(),
+                    Collections.emptyList(),
+                    client,
+                    null,
+                    () -> DocumentParsingObserver.EMPTY_INSTANCE
+                );
+                ingestService.applyClusterState(new ClusterChangedEvent("test", ClusterState.EMPTY_STATE, ClusterState.EMPTY_STATE));
                 actions.put(
                     BulkAction.INSTANCE,
                     new TransportBulkAction(
                         threadPool,
                         transportService,
                         clusterService,
-                        new IngestService(
-                            clusterService,
-                            threadPool,
-                            environment,
-                            scriptService,
-                            new AnalysisModule(environment, Collections.emptyList(), new StablePluginsRegistry()).getAnalysisRegistry(),
-                            Collections.emptyList(),
-                            client,
-                            null,
-                            () -> DocumentParsingObserver.EMPTY_INSTANCE
-                        ),
+                        ingestService,
                         client,
                         actionFilters,
                         indexNameExpressionResolver,


### PR DESCRIPTION
### Summary

Add a new pipeline list to IndexRequests that can be contributed by `IngestPlugin`s.

`IngestPlugins` get a new `getIngestPipeline` method, that receives an `IndexMetadata` and processor `Parameters` so plugins may instantiate an ingestion pipeline for an index.

`IngestService` checks for changes on `IndexMetadata` and asks `IngestPlugin`s for pipelines for the index. These plugin contributed pipelines are kept separate of the user contributed pipelines.

`IngestService` runs pipelines contributed by plugins as part of the ingestion pipeline process, after both default and final pipelines have run.

This pipeline infrastructure will be used in future PRs to make ML plugin contribute an inference pipeline for indices that have `semantic_text` fields.


### Pending work
 - [x] Fix tests
 - [ ] Add tests specific to plugin contributed pipelines
