### PR TITLE
[ci] Add amazon-2023 to platform-support matrix

### DIFF
--- a/.buildkite/pipelines/periodic-platform-support.yml
+++ b/.buildkite/pipelines/periodic-platform-support.yml
@@ -80,3 +80,19 @@ steps:
           diskName: /dev/sda1
         env:
           GRADLE_TASK: "{{matrix.GRADLE_TASK}}"
+  - group: platform-support-unix-aws
+    steps:
+      - label: "{{matrix.image}} / platform-support-aws"
+        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true functionalTests
+        timeout_in_minutes: 420
+        matrix:
+          setup:
+            image:
+              - amazonlinux-2023
+        agents:
+          provider: aws
+          imagePrefix: elasticsearch-{{matrix.image}}
+          instanceType: m6a.8xlarge
+          diskSizeGb: 350
+          diskType: gp3
+          diskName: /dev/sda1


### PR DESCRIPTION
I'm having issues getting amazon-2 to work, so I'm adding just amazon-2023 so that we at least have that in the meantime.