### PR TITLE
[8.12] [Connectors API] Add set connector sync job error API docs (#103456)

### DIFF
--- a/docs/reference/connector/apis/connector-apis.asciidoc
+++ b/docs/reference/connector/apis/connector-apis.asciidoc
@@ -37,9 +37,10 @@ You can use these APIs to create, cancel, delete and update sync jobs.
 Use the following APIs to manage sync jobs:
 
 * <<create-connector-sync-job-api>>
-* <<delete-connector-sync-job-api>
+* <<delete-connector-sync-job-api>>
 * <<get-connector-sync-job-api>>
 * <<list-connector-sync-jobs-api>>
+* <<set-connector-sync-job-error-api>>
 
 include::create-connector-api.asciidoc[]
 include::create-connector-sync-job-api.asciidoc[]
@@ -49,3 +50,4 @@ include::get-connector-api.asciidoc[]
 include::get-connector-sync-job-api.asciidoc[]
 include::list-connectors-api.asciidoc[]
 include::list-connector-sync-jobs-api.asciidoc[]
+include::set-connector-sync-job-error-api.asciidoc[]

--- a/docs/reference/connector/apis/set-connector-sync-job-error-api.asciidoc
+++ b/docs/reference/connector/apis/set-connector-sync-job-error-api.asciidoc
@@ -1,0 +1,58 @@
+[[set-connector-sync-job-error-api]]
+=== Set connector sync job error API
+++++
+<titleabbrev>Set connector sync job error</titleabbrev>
+++++
+
+Sets a connector sync job error.
+
+[[set-connector-sync-job-error-api-request]]
+==== {api-request-title}
+`PUT _connector/_sync_job/<connector_sync_job_id>/_error`
+
+[[set-connector-sync-job-error-api-prereqs]]
+==== {api-prereq-title}
+
+* To sync data using connectors, it's essential to have the Elastic connectors service running.
+* The `connector_sync_job_id` parameter should reference an existing connector sync job.
+
+[[set-connector-sync-job-error-api-desc]]
+==== {api-description-title}
+
+Sets the `error` field for the specified connector sync job and sets its `status` to `error`.
+
+[[set-connector-sync-job-error-api-path-params]]
+==== {api-path-parms-title}
+
+`<connector_sync_job_id>`::
+(Required, string)
+
+[role="child_attributes"]
+[[set-connector-sync-job-error-api-request-body]]
+==== {api-request-body-title}
+
+`error`::
+(Required, string) The error to set the connector sync job `error` field to.
+
+[[set-connector-sync-job-api-response-codes]]
+==== {api-response-codes-title}
+
+`200`::
+Indicates that the connector sync job error was set successfully.
+
+`404`::
+No connector sync job matching `connector_sync_job_id` could be found.
+
+[[set-connector-sync-job-error-api-example]]
+==== {api-examples-title}
+
+The following example sets the error `some-error` in the connector sync job `my-connector-sync-job`:
+
+[source,console]
+----
+PUT _connector/_sync_job/my-connector-sync-job/_error
+{
+    "error": "some-error"
+}
+----
+// TEST[skip:there's no way to clean up after creating a connector sync job, as we don't know the id ahead of time. Therefore, skip this test.]


### PR DESCRIPTION
Backports the following commits to 8.12:
 - [Connectors API] Add set connector sync job error API docs (#103456)