### PR TITLE
Fix text_expansion yaml flakey test

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/text_expansion_search.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/text_expansion_search.yml
@@ -222,12 +222,12 @@ setup:
           query:
             weighted_tokens:
               ml.tokens:
-                tokens: [{"the": 1.0}, {"octopus":1.0}, {"comforter":1.0}]
+                tokens: [{"the": 1.0}, {"comforter":1.0}, {"smells":1.0}, {"bad": 1.0}]
                 pruning_config:
                   tokens_freq_ratio_threshold: 1
                   tokens_weight_threshold: 0.4
                   only_score_pruned_tokens: false
-  - match: { hits.total.value: 4 }
+  - match: { hits.total.value: 5 }
   - match: { hits.hits.0._source.source_text: "the octopus comforter smells" }
 
 ---
@@ -243,9 +243,9 @@ setup:
           query:
             weighted_tokens:
               ml.tokens:
-                tokens: [{"the": 1.0}, {"octopus":1.0}, {"comforter":1.0}]
+                tokens: [{"the": 1.0}, {"comforter":1.0}, {"smells":1.0}, {"bad": 1.0}]
                 pruning_config: {}
-  - match: { hits.total.value: 4 }
+  - match: { hits.total.value: 5 }
   - match: { hits.hits.0._source.source_text: "the octopus comforter smells" }
 
 ---
@@ -261,7 +261,7 @@ setup:
           query:
             weighted_tokens:
               ml.tokens:
-                tokens: [{"the": 1.0}, {"octopus":1.0}, {"comforter":1.0}]
+                tokens: [{"the": 1.0}, {"comforter":1.0}, {"smells":1.0}, {"bad": 1.0}]
                 pruning_config:
                   tokens_freq_ratio_threshold: 4
                   tokens_weight_threshold: 0.4


### PR DESCRIPTION
Related to: https://github.com/elastic/elasticsearch/issues/103442 

This test failure is an edge case that's happening because the first two results ("the octopus comforter smells" and "the octopus comforter is leaking") have the exact same score of 3.0. I consider this an edge case because this tests assigns a weight of 1.0 to all tokens, and these two queries just happen to be equally relevant for "the octopus comforter". This PR resolves the test's flakiness by creating a query where there is one high scoring document. 