### PR TITLE
[8.12] [ML] Prevent attempts to access non-existent node information during rebalancing (#103361)

### DIFF
--- a/docs/changelog/103361.yaml
+++ b/docs/changelog/103361.yaml
@@ -1,0 +1,5 @@
+pr: 103361
+summary: Prevent attempts to access non-existent node information during rebalancing
+area: Machine Learning
+type: bug
+issues: [ ]

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartTrainedModelDeploymentAction.java
@@ -374,8 +374,10 @@ public class StartTrainedModelDeploymentAction extends ActionType<CreateTrainedM
         // TODO add support for other roles? If so, it may have to be an instance method...
         // NOTE, whatever determines assignment should not be dynamically set on the node
         // Otherwise assignment logic might fail
-        public static boolean mayAssignToNode(DiscoveryNode node) {
-            return node.getRoles().contains(DiscoveryNodeRole.ML_ROLE) && MlConfigVersion.fromNode(node).onOrAfter(VERSION_INTRODUCED);
+        public static boolean mayAssignToNode(@Nullable DiscoveryNode node) {
+            return node != null
+                && node.getRoles().contains(DiscoveryNodeRole.ML_ROLE)
+                && MlConfigVersion.fromNode(node).onOrAfter(VERSION_INTRODUCED);
         }
 
         public static final MlConfigVersion VERSION_INTRODUCED = MlConfigVersion.V_8_0_0;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
@@ -1099,31 +1099,61 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
         // it may get re-allocated to that node when another node is added/removed...
         boolean nodesShutdownChanged = event.changedCustomMetadataSet().contains(NodesShutdownMetadata.TYPE);
         if (event.nodesChanged() || nodesShutdownChanged) {
+            // This is just to track the various log messages that happen in this function to help with debugging in the future
+            // so that we can reasonably assume they're all related
+            // If the log messages printed from this method get interlaced across nodes it can make debugging difficult
+            var eventIdentity = Long.toHexString(System.nanoTime());
+
             Set<String> shuttingDownNodes = nodesShuttingDown(event.state());
             DiscoveryNodes.Delta nodesDelta = event.nodesDelta();
 
             Set<String> removedNodes = nodesDelta.removedNodes().stream().map(DiscoveryNode::getId).collect(Collectors.toSet());
             Set<String> addedNodes = nodesDelta.addedNodes().stream().map(DiscoveryNode::getId).collect(Collectors.toSet());
 
+            logger.debug(
+                () -> format(
+                    "Initial node change info; identity: %s; removed nodes: %s; added nodes: %s; shutting down nodes: %s",
+                    eventIdentity,
+                    removedNodes,
+                    addedNodes,
+                    shuttingDownNodes
+                )
+            );
+
             Set<String> exitingShutDownNodes;
             if (nodesShutdownChanged) {
                 Set<String> previousShuttingDownNodes = nodesShuttingDown(event.previousState());
+                Set<String> presentNodes = event.state().nodes().stream().map(DiscoveryNode::getId).collect(Collectors.toSet());
 
                 // Add nodes that where marked for shutdown in the previous state
                 // but are no longer marked as shutdown in the current state.
-                Set<String> returningShutDownNodes = Sets.difference(previousShuttingDownNodes, shuttingDownNodes);
+                // The intersection is to only include the nodes that actually exist
+                Set<String> returningShutDownNodes = Sets.intersection(
+                    presentNodes,
+                    Sets.difference(previousShuttingDownNodes, shuttingDownNodes)
+                );
                 addedNodes.addAll(returningShutDownNodes);
 
                 // and nodes that are marked for shutdown in this event only
                 exitingShutDownNodes = Sets.difference(shuttingDownNodes, previousShuttingDownNodes);
                 removedNodes.addAll(exitingShutDownNodes);
+
+                logger.debug(
+                    () -> format(
+                        "Shutting down nodes were changed; identity: %s; previous shutting down nodes: %s; returning nodes: %s",
+                        eventIdentity,
+                        previousShuttingDownNodes,
+                        returningShutDownNodes
+                    )
+                );
             } else {
                 exitingShutDownNodes = Collections.emptySet();
             }
 
             logger.debug(
                 () -> format(
-                    "added nodes %s; removed nodes %s; shutting down nodes %s; exiting shutdown nodes %s",
+                    "identity: %s; added nodes %s; removed nodes %s; shutting down nodes %s; exiting shutdown nodes %s",
+                    eventIdentity,
                     addedNodes,
                     removedNodes,
                     shuttingDownNodes,


### PR DESCRIPTION
Backports the following commits to 8.12:
 - [ML] Prevent attempts to access non-existent node information during rebalancing (#103361)