### PR TITLE
Slightly simplify setup tsds section

### DIFF
--- a/docs/reference/data-streams/set-up-tsds.asciidoc
+++ b/docs/reference/data-streams/set-up-tsds.asciidoc
@@ -176,9 +176,7 @@ PUT _component_template/my-weather-sensor-mappings
 Optionally, the index settings component template for a TSDS can include:
 
 * Your lifecycle policy in the `index.lifecycle.name` index setting.
-* The <<tsds-look-ahead-time,`index.look_ahead_time`>> index setting.
-* The <<tsds-look-back-time,`index.look_back_time`>> index setting.
-* Other index settings, such as <<index-codec,`index.codec`>>, for your TSDS's
+* Other index settings, such as <<dynamic-index-number-of-replicas,`index.number_of_replicas`>>, for your TSDS's
 backing indices.
 
 IMPORTANT: Don't specify the `index.routing_path` index setting in a component
@@ -191,8 +189,7 @@ PUT _component_template/my-weather-sensor-settings
 {
   "template": {
     "settings": {
-      "index.lifecycle.name": "my-lifecycle-policy",
-      "index.look_ahead_time": "3h"
+      "index.lifecycle.name": "my-lifecycle-policy"
     }
   },
   "_meta": {


### PR DESCRIPTION
* By not encouraging to use index.look_ahead index setting. The default should work well out of the box and changing this setting can cause a time series data stream to not work correctly.
* Not mentioning the index.codec setting. This is a low level setting has no real benefit in case of tsds. And setting it to best compression can hurt performance without any real benefit.