### PR TITLE
[7.17] [ci] Add amazon-2023 to platform-support matrix (#103466)

### DIFF
--- a/.buildkite/pipelines/periodic-platform-support.yml
+++ b/.buildkite/pipelines/periodic-platform-support.yml
@@ -71,3 +71,19 @@ steps:
           diskSizeGb: 350
           diskType: gp3
           diskName: /dev/sda1
+  - group: platform-support-unix-aws
+    steps:
+      - label: "{{matrix.image}} / platform-support-aws"
+        command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true functionalTests
+        timeout_in_minutes: 420
+        matrix:
+          setup:
+            image:
+              - amazonlinux-2023
+        agents:
+          provider: aws
+          imagePrefix: elasticsearch-{{matrix.image}}
+          instanceType: m6a.8xlarge
+          diskSizeGb: 350
+          diskType: gp3
+          diskName: /dev/sda1


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[ci] Add amazon-2023 to platform-support matrix (#103466)](https://github.com/elastic/elasticsearch/pull/103466)

<!--- Backport version: 9.2.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)