### PR TITLE
Test Fix: Add failure store feature flag to ccs rolling upgrade tests

### DIFF
--- a/qa/ccs-rolling-upgrade-remote-cluster/build.gradle
+++ b/qa/ccs-rolling-upgrade-remote-cluster/build.gradle
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 
+import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
@@ -32,6 +33,7 @@ BuildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
     versions = [bwcVersion.toString(), project.version]
     setting 'cluster.remote.node.attr', 'gateway'
     setting 'xpack.security.enabled', 'false'
+    requiresFeature 'es.failure_store_feature_flag_enabled', new Version(8, 12, 0)
   }
   def remoteCluster = testClusters.register("${baseName}-remote") {
     numberOfNodes = 3
@@ -39,6 +41,7 @@ BuildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
     firstNode.setting 'node.attr.gateway', 'true'
     lastNode.setting 'node.attr.gateway', 'true'
     setting 'xpack.security.enabled', 'false'
+    requiresFeature 'es.failure_store_feature_flag_enabled', new Version(8, 12, 0)
   }
 
 


### PR DESCRIPTION
Tested with 
```
./gradlew ':qa:ccs-rolling-upgrade-remote-cluster:v8.10.4#fullUpgraded' -Dtests.class="org.elasticsearch.upgrades.SearchStatesIT" -Dtests.method="testCanMatch" -Dtests.seed=B61BF2F991120A4D -Dtests.bwc=true -Dtests.locale=ja -Dtests.timezone=Europe/Gibraltar -Druntime.java=21
```

fixes #103358