### PR TITLE
Improve span queries documentation

### DIFF
--- a/docs/reference/query-dsl/span-containing-query.asciidoc
+++ b/docs/reference/query-dsl/span-containing-query.asciidoc
@@ -4,8 +4,7 @@
 <titleabbrev>Span containing</titleabbrev>
 ++++
 
-Returns matches which enclose another span query. The span containing
-query maps to Lucene `SpanContainingQuery`. Here is an example:
+Returns matches which enclose another span query. Here is an example:
 
 [source,console]
 --------------------------------------------------

--- a/docs/reference/query-dsl/span-field-masking-query.asciidoc
+++ b/docs/reference/query-dsl/span-field-masking-query.asciidoc
@@ -4,11 +4,11 @@
 <titleabbrev>Span field masking</titleabbrev>
 ++++
 
-Wrapper to allow span queries to participate in composite single-field span queries by 'lying' about their search field. The span field masking query maps to Lucene's `SpanFieldMaskingQuery`
+Wrapper to allow span queries to participate in composite single-field span queries by 'lying' about their search field.
 
 This can be used to support queries like `span-near` or `span-or` across different fields, which is not ordinarily permitted.
 
-Span field masking query is invaluable in conjunction with *multi-fields* when same content is indexed with multiple analyzers. For instance we could index a field with the standard analyzer which breaks text up into words, and again with the english analyzer which stems words into their root form.
+Span field masking query is invaluable in conjunction with *multi-fields* when same content is indexed with multiple analyzers. For instance, we could index a field with the standard analyzer which breaks text up into words, and again with the english analyzer which stems words into their root form.
 
 Example:
 
@@ -28,18 +28,33 @@ GET /_search
           "span_field_masking": {
             "query": {
               "span_term": {
-                "text.stems": "fox"
+                "text.stems": "fox" <1>
               }
             },
-            "field": "text"
+            "field": "text" <2>
           }
         }
       ],
       "slop": 5,
       "in_order": false
     }
+  },
+  "highlight": {
+    "require_field_match" : false, <3>
+    "fields": {
+      "*": {}
+    }
   }
 }
 --------------------------------------------------
+<1> Original field on which we do the search
+<2> Masked field, which we are masking with the original field
+<3> Use "require_field_match" : false to highlight the masked field
 
-Note: as span field masking query returns the masked field, scoring will be done using the norms of the field name supplied. This may lead to unexpected scoring behaviour.
+Note: `span_field_masking` query may have unexpected scoring and highlighting
+behaviour. This is because the query returns and highlights the masked field,
+but scoring and highlighting are done using the terms statistics and offsets
+of the original field.
+
+Note: For highlighting to work the parameter: `require_field_match` should
+be set to `false` on the highlighter.

--- a/docs/reference/query-dsl/span-first-query.asciidoc
+++ b/docs/reference/query-dsl/span-first-query.asciidoc
@@ -4,8 +4,7 @@
 <titleabbrev>Span first</titleabbrev>
 ++++
 
-Matches spans near the beginning of a field. The span first query maps
-to Lucene `SpanFirstQuery`. Here is an example:
+Matches spans near the beginning of a field. Here is an example:
 
 [source,console]
 --------------------------------------------------
@@ -19,7 +18,7 @@ GET /_search
       "end": 3
     }
   }
-}   
+}
 --------------------------------------------------
 
 The `match` clause can be any other span type query. The `end` controls

--- a/docs/reference/query-dsl/span-near-query.asciidoc
+++ b/docs/reference/query-dsl/span-near-query.asciidoc
@@ -6,8 +6,7 @@
 
 Matches spans which are near one another. One can specify _slop_, the
 maximum number of intervening unmatched positions, as well as whether
-matches are required to be in-order. The span near query maps to Lucene
-`SpanNearQuery`. Here is an example:
+matches are required to be in-order. Here is an example:
 
 [source,console]
 --------------------------------------------------

--- a/docs/reference/query-dsl/span-not-query.asciidoc
+++ b/docs/reference/query-dsl/span-not-query.asciidoc
@@ -6,8 +6,8 @@
 
 Removes matches which overlap with another span query or which are
 within x tokens before (controlled by the parameter `pre`) or y tokens
-after (controlled by the parameter `post`) another SpanQuery. The span not
-query maps to Lucene `SpanNotQuery`. Here is an example:
+after (controlled by the parameter `post`) another SpanQuery.
+Here is an example:
 
 [source,console]
 --------------------------------------------------

--- a/docs/reference/query-dsl/span-or-query.asciidoc
+++ b/docs/reference/query-dsl/span-or-query.asciidoc
@@ -4,8 +4,7 @@
 <titleabbrev>Span or</titleabbrev>
 ++++
 
-Matches the union of its span clauses. The span or query maps to Lucene
-`SpanOrQuery`. Here is an example:
+Matches the union of its span clauses. Here is an example:
 
 [source,console]
 --------------------------------------------------

--- a/docs/reference/query-dsl/span-term-query.asciidoc
+++ b/docs/reference/query-dsl/span-term-query.asciidoc
@@ -4,8 +4,7 @@
 <titleabbrev>Span term</titleabbrev>
 ++++
 
-Matches spans containing a term. The span term query maps to Lucene
-`SpanTermQuery`. Here is an example:
+Matches spans containing a term. Here is an example:
 
 [source,console]
 --------------------------------------------------
@@ -14,7 +13,7 @@ GET /_search
   "query": {
     "span_term" : { "user.id" : "kimchy" }
   }
-}    
+}
 --------------------------------------------------
 
 A boost can also be associated with the query:
@@ -26,7 +25,7 @@ GET /_search
   "query": {
     "span_term" : { "user.id" : { "value" : "kimchy", "boost" : 2.0 } }
   }
-}    
+}
 --------------------------------------------------
 
 Or :
@@ -38,5 +37,5 @@ GET /_search
   "query": {
     "span_term" : { "user.id" : { "term" : "kimchy", "boost" : 2.0 } }
   }
-}    
+}
 --------------------------------------------------

--- a/docs/reference/query-dsl/span-within-query.asciidoc
+++ b/docs/reference/query-dsl/span-within-query.asciidoc
@@ -4,8 +4,8 @@
 <titleabbrev>Span within</titleabbrev>
 ++++
 
-Returns matches which are enclosed inside another span query. The span within
-query maps to Lucene `SpanWithinQuery`. Here is an example:
+Returns matches which are enclosed inside another span query.
+Here is an example:
 
 [source,console]
 --------------------------------------------------


### PR DESCRIPTION
Improvement includes:
1. Remove reference to Lucene queries (this information is not necessary 
for Elastic users, and can be outdated)
2. For `span_field_masking` include a note to use 
"require_field_match" : false parameter for highlighters to work.

Closes #101804
