### PR TITLE
ESQL: Reading points from source (using primitives in Block)

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/MultivalueDedupeBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/MultivalueDedupeBenchmark.java
@@ -167,7 +167,7 @@ public class MultivalueDedupeBenchmark {
                     Randomness.shuffle(values);
                     builder.beginPositionEntry();
                     for (SpatialPoint v : values) {
-                        builder.appendPoint(v);
+                        builder.appendPoint(v.getX(), v.getY());
                     }
                     builder.endPositionEntry();
                 }

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/ValuesSourceReaderBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/ValuesSourceReaderBenchmark.java
@@ -168,6 +168,11 @@ public class ValuesSourceReaderBenchmark {
                 }
 
                 @Override
+                public boolean forStats() {
+                    return false;
+                }
+
+                @Override
                 public SearchLookup lookup() {
                     throw new UnsupportedOperationException();
                 }

--- a/docs/changelog/102880.yaml
+++ b/docs/changelog/102880.yaml
@@ -1,5 +1,5 @@
 pr: 102880
-summary: WIP started working on ESQL reading points from source
-area: Geo
+summary: Reading points from source to reduce precision loss
+area: ES|QL
 type: enhancement
 issues: []

--- a/docs/changelog/102880.yaml
+++ b/docs/changelog/102880.yaml
@@ -1,0 +1,5 @@
+pr: 102880
+summary: WIP started working on ESQL reading points from source
+area: Geo
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/common/geo/SpatialPoint.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/SpatialPoint.java
@@ -8,12 +8,49 @@
 
 package org.elasticsearch.common.geo;
 
+import java.util.Locale;
+
 /**
  * To facilitate maximizing the use of common code between GeoPoint and projected CRS
  * we introduced this ElasticPoint as an interface of commonality.
  */
-public interface SpatialPoint {
-    double getX();
+public class SpatialPoint {
 
-    double getY();
+    protected double x;
+    protected double y;
+
+    public SpatialPoint(double x, double y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    public SpatialPoint(SpatialPoint template) {
+        this(template.getX(), template.getY());
+    }
+
+    public final double getX() {
+        return x;
+    }
+
+    public final double getY() {
+        return y;
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * Double.hashCode(x) + Double.hashCode(y);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+        SpatialPoint point = (SpatialPoint) obj;
+        return (Double.compare(point.x, x) != 0) && Double.compare(point.y, y) == 0;
+    }
+
+    @Override
+    public String toString() {
+        return String.format(Locale.ROOT, "POINT (%f %f)", x, y);
+    }
 }

--- a/server/src/main/java/org/elasticsearch/common/geo/SpatialPoint.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/SpatialPoint.java
@@ -14,7 +14,7 @@ import java.util.Locale;
  * To facilitate maximizing the use of common code between GeoPoint and projected CRS
  * we introduced this ElasticPoint as an interface of commonality.
  */
-public class SpatialPoint {
+public class SpatialPoint implements Comparable<SpatialPoint> {
 
     protected double x;
     protected double y;
@@ -38,7 +38,7 @@ public class SpatialPoint {
 
     @Override
     public int hashCode() {
-        return 31 * Double.hashCode(x) + Double.hashCode(y);
+        return 31 * 31 * getClass().getSimpleName().hashCode() + 31 * Double.hashCode(x) + Double.hashCode(y);
     }
 
     @Override
@@ -46,11 +46,28 @@ public class SpatialPoint {
         if (this == obj) return true;
         if (obj == null || getClass() != obj.getClass()) return false;
         SpatialPoint point = (SpatialPoint) obj;
-        return (Double.compare(point.x, x) != 0) && Double.compare(point.y, y) == 0;
+        return (Double.compare(point.x, x) == 0) && Double.compare(point.y, y) == 0;
     }
 
     @Override
     public String toString() {
         return String.format(Locale.ROOT, "POINT (%f %f)", x, y);
+    }
+
+    @Override
+    public int compareTo(SpatialPoint other) {
+        if (this.getClass().equals(other.getClass())) {
+            double xd = this.getX() - other.getX();
+            double yd = this.getY() - other.getY();
+            return (xd == 0) ? comparison(yd) : comparison(xd);
+        } else {
+            // TODO: Rather separate based on CRS, but since we don't have that yet, we use class name
+            // The sort order here is unimportant and does not (yet) introduce BWC issues, so we are free to change it later with CRS
+            return this.getClass().getSimpleName().compareTo(other.getClass().getSimpleName());
+        }
+    }
+
+    private int comparison(double delta) {
+        return delta == 0 ? 0 : delta < 0 ? -1 : 1;
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -21,7 +21,6 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.geo.GeoPoint;
-import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.common.util.Maps;
@@ -794,7 +793,6 @@ public abstract class StreamInput extends InputStream {
             case 28 -> readDuration();
             case 29 -> readPeriod();
             case 30 -> readNamedWriteable(GenericNamedWriteable.class);
-            case 31 -> readPoint();
             default -> throw new IOException("Can't read unknown type [" + type + "]");
         };
     }
@@ -862,13 +860,6 @@ public abstract class StreamInput extends InputStream {
      */
     public GeoPoint readGeoPoint() throws IOException {
         return new GeoPoint(readDouble(), readDouble());
-    }
-
-    /**
-     * Reads a {@link SpatialPoint} from this stream input
-     */
-    public SpatialPoint readPoint() throws IOException {
-        return new SpatialPoint(readDouble(), readDouble());
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -21,6 +21,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.geo.GeoPoint;
+import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.common.util.Maps;
@@ -793,6 +794,7 @@ public abstract class StreamInput extends InputStream {
             case 28 -> readDuration();
             case 29 -> readPeriod();
             case 30 -> readNamedWriteable(GenericNamedWriteable.class);
+            case 31 -> readSpatialPoint();
             default -> throw new IOException("Can't read unknown type [" + type + "]");
         };
     }
@@ -860,6 +862,13 @@ public abstract class StreamInput extends InputStream {
      */
     public GeoPoint readGeoPoint() throws IOException {
         return new GeoPoint(readDouble(), readDouble());
+    }
+
+    /**
+     * Reads a {@link SpatialPoint} from this stream input
+     */
+    public SpatialPoint readSpatialPoint() throws IOException {
+        return new SpatialPoint(readDouble(), readDouble());
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -794,7 +794,7 @@ public abstract class StreamInput extends InputStream {
             case 28 -> readDuration();
             case 29 -> readPeriod();
             case 30 -> readNamedWriteable(GenericNamedWriteable.class);
-            case 31 -> readSpatialPoint();
+            case 31 -> readPoint();
             default -> throw new IOException("Can't read unknown type [" + type + "]");
         };
     }
@@ -867,7 +867,7 @@ public abstract class StreamInput extends InputStream {
     /**
      * Reads a {@link SpatialPoint} from this stream input
      */
-    public SpatialPoint readSpatialPoint() throws IOException {
+    public SpatialPoint readPoint() throws IOException {
         return new SpatialPoint(readDouble(), readDouble());
     }
 

--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -18,7 +18,6 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.geo.GeoPoint;
-import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.common.io.stream.Writeable.Writer;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.text.Text;
@@ -783,12 +782,6 @@ public abstract class StreamOutput extends OutputStream {
             }
             o.writeByte((byte) 30);
             o.writeNamedWriteable(genericNamedWriteable);
-        }),
-        entry(SpatialPoint.class, (o, v) -> {
-            // TODO: assert on minSupportedVersion or feature or transportversion
-            // TODO: Consider merging this into GeoPoint above (ie. upgrade GeoPoint to handle SpatialPoint coordinate order)
-            o.writeByte((byte) 31);
-            o.writePoint((SpatialPoint) v);
         })
     );
 
@@ -1018,14 +1011,6 @@ public abstract class StreamOutput extends OutputStream {
     public void writeGeoPoint(GeoPoint geoPoint) throws IOException {
         writeDouble(geoPoint.lat());
         writeDouble(geoPoint.lon());
-    }
-
-    /**
-     * Writes the given {@link SpatialPoint} to the stream
-     */
-    public void writePoint(SpatialPoint spatialPoint) throws IOException {
-        writeDouble(spatialPoint.getX());
-        writeDouble(spatialPoint.getY());
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -18,6 +18,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.geo.GeoPoint;
+import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.common.io.stream.Writeable.Writer;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.text.Text;
@@ -782,6 +783,12 @@ public abstract class StreamOutput extends OutputStream {
             }
             o.writeByte((byte) 30);
             o.writeNamedWriteable(genericNamedWriteable);
+        }),
+        entry(SpatialPoint.class, (o, v) -> {
+            // TODO: assert on minSupportedVersion or feature or transportversion
+            // TODO: Consider merging this into GeoPoint above (ie. upgrade GeoPoint to handle SpatialPoint coordinate order)
+            o.writeByte((byte) 31);
+            o.writeSpatialPoint((SpatialPoint) v);
         })
     );
 
@@ -1011,6 +1018,14 @@ public abstract class StreamOutput extends OutputStream {
     public void writeGeoPoint(GeoPoint geoPoint) throws IOException {
         writeDouble(geoPoint.lat());
         writeDouble(geoPoint.lon());
+    }
+
+    /**
+     * Writes the given {@link SpatialPoint} to the stream
+     */
+    public void writeSpatialPoint(SpatialPoint spatialPoint) throws IOException {
+        writeDouble(spatialPoint.getX());
+        writeDouble(spatialPoint.getY());
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -788,7 +788,7 @@ public abstract class StreamOutput extends OutputStream {
             // TODO: assert on minSupportedVersion or feature or transportversion
             // TODO: Consider merging this into GeoPoint above (ie. upgrade GeoPoint to handle SpatialPoint coordinate order)
             o.writeByte((byte) 31);
-            o.writeSpatialPoint((SpatialPoint) v);
+            o.writePoint((SpatialPoint) v);
         })
     );
 
@@ -1023,7 +1023,7 @@ public abstract class StreamOutput extends OutputStream {
     /**
      * Writes the given {@link SpatialPoint} to the stream
      */
-    public void writeSpatialPoint(SpatialPoint spatialPoint) throws IOException {
+    public void writePoint(SpatialPoint spatialPoint) throws IOException {
         writeDouble(spatialPoint.getX());
         writeDouble(spatialPoint.getY());
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractGeometryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractGeometryFieldMapper.java
@@ -143,9 +143,9 @@ public abstract class AbstractGeometryFieldMapper<T> extends FieldMapper {
         @Override
         public BlockLoader blockLoader(BlockLoaderContext blContext) {
             // TODO: If we have doc-values we have to use them, due to BlockSourceReader.columnAtATimeReader() returning null
-            // if (hasDocValues()) {
-            // return new BlockDocValuesReader.LongsBlockLoader(name());
-            // }
+            if (blContext.forStats() && hasDocValues()) {
+                return new BlockDocValuesReader.LongsBlockLoader(name());
+            }
             // TODO: Enhance BlockLoaderContext with knowledge about preferring to load from source (see EsPhysicalOperationProviders)
             return new BlockSourceReader.PointsBlockLoader(
                 valueFetcher(blContext.sourcePaths(name()), nullValue, GeometryFormatterFactory.WKT)

--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractGeometryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractGeometryFieldMapper.java
@@ -87,6 +87,7 @@ public abstract class AbstractGeometryFieldMapper<T> extends FieldMapper {
     public abstract static class AbstractGeometryFieldType<T> extends MappedFieldType {
 
         protected final Parser<T> geometryParser;
+        private final T nullValue;
 
         protected AbstractGeometryFieldType(
             String name,
@@ -94,9 +95,11 @@ public abstract class AbstractGeometryFieldMapper<T> extends FieldMapper {
             boolean stored,
             boolean hasDocValues,
             Parser<T> geometryParser,
+            T nullValue,
             Map<String, String> meta
         ) {
             super(name, indexed, stored, hasDocValues, TextSearchInfo.NONE, meta);
+            this.nullValue = nullValue;
             this.geometryParser = geometryParser;
         }
 
@@ -135,6 +138,18 @@ public abstract class AbstractGeometryFieldMapper<T> extends FieldMapper {
                     return formatter.apply(values);
                 }
             };
+        }
+
+        @Override
+        public BlockLoader blockLoader(BlockLoaderContext blContext) {
+            // TODO: If we have doc-values we have to use them, due to BlockSourceReader.columnAtATimeReader() returning null
+            // if (hasDocValues()) {
+            // return new BlockDocValuesReader.LongsBlockLoader(name());
+            // }
+            // TODO: Enhance BlockLoaderContext with knowledge about preferring to load from source (see EsPhysicalOperationProviders)
+            return new BlockSourceReader.PointsBlockLoader(
+                valueFetcher(blContext.sourcePaths(name()), nullValue, GeometryFormatterFactory.WKT)
+            );
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractShapeGeometryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractShapeGeometryFieldMapper.java
@@ -55,12 +55,18 @@ public abstract class AbstractShapeGeometryFieldMapper<T> extends AbstractGeomet
             Orientation orientation,
             Map<String, String> meta
         ) {
-            super(name, isSearchable, isStored, hasDocValues, parser, meta);
+            super(name, isSearchable, isStored, hasDocValues, parser, null, meta);
             this.orientation = orientation;
         }
 
         public Orientation orientation() {
             return this.orientation;
+        }
+
+        @Override
+        public BlockLoader blockLoader(BlockLoaderContext blContext) {
+            // TODO: Support shapes in ESQL
+            return null;
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/BlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BlockLoader.java
@@ -12,6 +12,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortedDocValues;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.search.fetch.StoredFieldsSpec;
 import org.elasticsearch.search.lookup.Source;
@@ -349,6 +350,11 @@ public interface BlockLoader {
         BytesRefBuilder bytesRefs(int expectedCount);
 
         /**
+         * Build a builder to load {@link SpatialPoint}s without any loading constraints.
+         */
+        PointBuilder points(int expectedCount);
+
+        /**
          * Build a builder to load doubles as loaded from doc values.
          * Doc values load doubles deduplicated and in sorted order.
          */
@@ -451,6 +457,13 @@ public interface BlockLoader {
          * Appends a BytesRef to the current entry.
          */
         BytesRefBuilder appendBytesRef(BytesRef value);
+    }
+
+    interface PointBuilder extends Builder {
+        /**
+         * Appends a SpatialPoint to the current entry.
+         */
+        PointBuilder appendPoint(SpatialPoint value);
     }
 
     interface DoubleBuilder extends Builder {

--- a/server/src/main/java/org/elasticsearch/index/mapper/BlockLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BlockLoader.java
@@ -461,9 +461,9 @@ public interface BlockLoader {
 
     interface PointBuilder extends Builder {
         /**
-         * Appends a SpatialPoint to the current entry.
+         * Appends a spatial point to the current entry.
          */
-        PointBuilder appendPoint(SpatialPoint value);
+        PointBuilder appendPoint(double x, double y);
     }
 
     interface DoubleBuilder extends Builder {

--- a/server/src/main/java/org/elasticsearch/index/mapper/BlockSourceReader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BlockSourceReader.java
@@ -181,12 +181,13 @@ public abstract class BlockSourceReader implements BlockLoader.RowStrideReader {
         @Override
         protected void append(BlockLoader.Builder builder, Object v) {
             if (v instanceof SpatialPoint point) {
-                ((BlockLoader.PointBuilder) builder).appendPoint((SpatialPoint) v);
+                ((BlockLoader.PointBuilder) builder).appendPoint(point);
             } else if (v instanceof String wkt) {
                 try {
                     // TODO: figure out why this is not already happening in the GeoPointFieldMapper
                     Geometry geometry = WellKnownText.fromWKT(GeometryValidator.NOOP, false, wkt);
                     if (geometry instanceof Point point) {
+                        // TODO: perhaps we should not create points for later GC here, and pass in primitives only?
                         ((BlockLoader.PointBuilder) builder).appendPoint(new SpatialPoint(point.getX(), point.getY()));
                     } else {
                         throw new IllegalArgumentException("Cannot convert geometry into point:: " + geometry.type());
@@ -201,7 +202,7 @@ public abstract class BlockSourceReader implements BlockLoader.RowStrideReader {
 
         @Override
         public String toString() {
-            return "BlockSourceReader.Bytes";
+            return "BlockSourceReader.Points";
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/BlockSourceReader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BlockSourceReader.java
@@ -181,14 +181,13 @@ public abstract class BlockSourceReader implements BlockLoader.RowStrideReader {
         @Override
         protected void append(BlockLoader.Builder builder, Object v) {
             if (v instanceof SpatialPoint point) {
-                ((BlockLoader.PointBuilder) builder).appendPoint(point);
+                ((BlockLoader.PointBuilder) builder).appendPoint(point.getX(), point.getY());
             } else if (v instanceof String wkt) {
                 try {
                     // TODO: figure out why this is not already happening in the GeoPointFieldMapper
                     Geometry geometry = WellKnownText.fromWKT(GeometryValidator.NOOP, false, wkt);
                     if (geometry instanceof Point point) {
-                        // TODO: perhaps we should not create points for later GC here, and pass in primitives only?
-                        ((BlockLoader.PointBuilder) builder).appendPoint(new SpatialPoint(point.getX(), point.getY()));
+                        ((BlockLoader.PointBuilder) builder).appendPoint(point.getX(), point.getY());
                     } else {
                         throw new IllegalArgumentException("Cannot convert geometry into point:: " + geometry.type());
                     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
@@ -485,9 +485,9 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<GeoPoi
         @Override
         public BlockLoader blockLoader(BlockLoaderContext blContext) {
             // TODO: If we have doc-values we have to use them, due to BlockSourceReader.columnAtATimeReader() returning null
-//            if (hasDocValues()) {
-//                return new BlockDocValuesReader.LongsBlockLoader(name());
-//            }
+            // if (hasDocValues()) {
+            // return new BlockDocValuesReader.LongsBlockLoader(name());
+            // }
             return new BlockSourceReader.PointsBlockLoader(
                 valueFetcher(blContext.sourcePaths(name()), nullValue, GeometryFormatterFactory.WKT)
             );

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
@@ -484,11 +484,11 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<GeoPoi
 
         @Override
         public BlockLoader blockLoader(BlockLoaderContext blContext) {
-            if (hasDocValues()) {
-                return new BlockDocValuesReader.LongsBlockLoader(name());
-            }
-            // TODO: Currently we use longs in the compute engine and render to WKT in ESQL
-            return new BlockSourceReader.LongsBlockLoader(
+            // TODO: If we have doc-values we have to use them, due to BlockSourceReader.columnAtATimeReader() returning null
+//            if (hasDocValues()) {
+//                return new BlockDocValuesReader.LongsBlockLoader(name());
+//            }
+            return new BlockSourceReader.PointsBlockLoader(
                 valueFetcher(blContext.sourcePaths(name()), nullValue, GeometryFormatterFactory.WKT)
             );
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
@@ -488,6 +488,7 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<GeoPoi
             // if (hasDocValues()) {
             // return new BlockDocValuesReader.LongsBlockLoader(name());
             // }
+            // TODO: Enhance BlockLoaderContext with knowledge about preferring to load from source (see EsPhysicalOperationProviders)
             return new BlockSourceReader.PointsBlockLoader(
                 valueFetcher(blContext.sourcePaths(name()), nullValue, GeometryFormatterFactory.WKT)
             );

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
@@ -364,7 +364,6 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<GeoPoi
             List.of(new SimpleVectorTileFormatter())
         );
 
-        private final GeoPoint nullValue;
         private final FieldValues<GeoPoint> scriptValues;
         private final IndexMode indexMode;
 
@@ -380,8 +379,7 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<GeoPoi
             TimeSeriesParams.MetricType metricType,
             IndexMode indexMode
         ) {
-            super(name, indexed, stored, hasDocValues, parser, meta);
-            this.nullValue = nullValue;
+            super(name, indexed, stored, hasDocValues, parser, nullValue, meta);
             this.scriptValues = scriptValues;
             this.metricType = metricType;
             this.indexMode = indexMode;
@@ -480,18 +478,6 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<GeoPoi
             }
 
             throw new IllegalStateException("unknown field data type [" + operation.name() + "]");
-        }
-
-        @Override
-        public BlockLoader blockLoader(BlockLoaderContext blContext) {
-            // TODO: If we have doc-values we have to use them, due to BlockSourceReader.columnAtATimeReader() returning null
-            // if (hasDocValues()) {
-            // return new BlockDocValuesReader.LongsBlockLoader(name());
-            // }
-            // TODO: Enhance BlockLoaderContext with knowledge about preferring to load from source (see EsPhysicalOperationProviders)
-            return new BlockSourceReader.PointsBlockLoader(
-                valueFetcher(blContext.sourcePaths(name()), nullValue, GeometryFormatterFactory.WKT)
-            );
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
@@ -650,6 +650,14 @@ public abstract class MappedFieldType {
         String indexName();
 
         /**
+         * Whether the data will be used in stats.
+         * This is relevant to some types, where the choice between doc-values or reading from source is dependent on the usage.
+         * For example, spatial types use doc-values for stats, but read from source for search because doc-values are modified
+         * from the original.
+         */
+        boolean forStats();
+
+        /**
          * {@link SearchLookup} used for building scripts.
          */
         SearchLookup lookup();

--- a/server/src/test/java/org/elasticsearch/common/geo/SpatialPointTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/SpatialPointTests.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.common.geo;
+
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.not;
+
+public class SpatialPointTests extends ESTestCase {
+
+    public void testEqualsAndHashcode() {
+        for (int i = 0; i < 100; i++) {
+            SpatialPoint point = randomGeoPoint();
+            GeoPoint geoPoint = new GeoPoint(point);
+            TestPoint testPoint = new TestPoint(point);
+            TestPoint testPoint2 = new TestPoint(point);
+            assertEqualsAndHashcode("Same point", point, point);
+            assertEqualsAndHashcode("Same geo-point", point, geoPoint);
+            assertNotEqualsAndHashcode("Same location, but different class", point, testPoint);
+            assertEqualsAndHashcode("Same location, same class", testPoint, testPoint2);
+        }
+    }
+
+    public void testCompareTo() {
+        for (int i = 0; i < 100; i++) {
+            SpatialPoint point = randomValueOtherThanMany(p -> p.getX() < -170 || p.getX() > 170, ESTestCase::randomGeoPoint);
+            GeoPoint smaller = new GeoPoint(point.getY(), point.getX() - 1);
+            GeoPoint bigger = new GeoPoint(point.getY(), point.getX() + 1);
+            TestPoint testSmaller = new TestPoint(smaller);
+            TestPoint testBigger = new TestPoint(bigger);
+            assertThat(smaller + " smaller than " + point, smaller.compareTo(point), lessThan(0));
+            assertThat(bigger + " bigger than " + point, bigger.compareTo(point), greaterThan(0));
+            assertThat(testSmaller + " smaller than " + testBigger, testSmaller.compareTo(testBigger), lessThan(0));
+            // TestPoint always greater than GeoPoint
+            assertThat(testSmaller + " bigger than " + point, testSmaller.compareTo(point), greaterThan(0));
+            assertThat(testBigger + " bigger than " + point, testBigger.compareTo(point), greaterThan(0));
+        }
+    }
+
+    private void assertEqualsAndHashcode(String message, SpatialPoint a, SpatialPoint b) {
+        assertThat("Equals: " + message, a, equalTo(b));
+        assertThat("Hashcode: " + message, a.hashCode(), equalTo(b.hashCode()));
+        assertThat("Compare: " + message, a.compareTo(b), equalTo(0));
+    }
+
+    private void assertNotEqualsAndHashcode(String message, SpatialPoint a, SpatialPoint b) {
+        assertThat("Equals: " + message, a, not(equalTo(b)));
+        assertThat("Hashcode: " + message, a.hashCode(), not(equalTo(b.hashCode())));
+        assertThat("Compare: " + message, a.compareTo(b), not(equalTo(0)));
+    }
+
+    private static class TestPoint extends SpatialPoint {
+
+        private TestPoint(SpatialPoint template) {
+            super(template);
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/index/mapper/GeoPointFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/GeoPointFieldMapperTests.java
@@ -713,9 +713,9 @@ public class GeoPointFieldMapperTests extends MapperTestCase {
     }
 
     @Override
-    protected boolean shouldUseColumnAtATimeReader(MapperService mapper, MappedFieldType ft) {
+    protected SupportedReaders getSupportedReaders(MapperService mapper, MappedFieldType ft) {
         // TODO: Support testing both reading from source as well as reading from doc-values
         GeoPointFieldMapper.GeoPointFieldType text = (GeoPointFieldMapper.GeoPointFieldType) ft;
-        return text.isIndexed() == false && ft.hasDocValues();
+        return new SupportedReaders(text.isIndexed() == false && ft.hasDocValues(), false);
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/GeoPointFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/GeoPointFieldMapperTests.java
@@ -711,4 +711,11 @@ public class GeoPointFieldMapperTests extends MapperTestCase {
             return l;
         }
     }
+
+    @Override
+    protected boolean shouldUseColumnAtATimeReader(MapperService mapper, MappedFieldType ft) {
+        // TODO: Support testing both reading from source as well as reading from doc-values
+        GeoPointFieldMapper.GeoPointFieldType text = (GeoPointFieldMapper.GeoPointFieldType) ft;
+        return text.isIndexed() == false && ft.hasDocValues();
+    }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
@@ -1328,7 +1328,7 @@ public class TextFieldMapperTests extends MapperTestCase {
     }
 
     @Override
-    protected boolean supportsColumnAtATimeReader(MapperService mapper, MappedFieldType ft) {
+    protected boolean shouldUseColumnAtATimeReader(MapperService mapper, MappedFieldType ft) {
         String parentName = mapper.mappingLookup().parentField(ft.name());
         if (parentName == null) {
             TextFieldMapper.TextFieldType text = (TextFieldType) ft;

--- a/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
@@ -1328,18 +1328,18 @@ public class TextFieldMapperTests extends MapperTestCase {
     }
 
     @Override
-    protected boolean shouldUseColumnAtATimeReader(MapperService mapper, MappedFieldType ft) {
+    protected SupportedReaders getSupportedReaders(MapperService mapper, MappedFieldType ft) {
         String parentName = mapper.mappingLookup().parentField(ft.name());
         if (parentName == null) {
             TextFieldMapper.TextFieldType text = (TextFieldType) ft;
-            return text.syntheticSourceDelegate() != null && text.syntheticSourceDelegate().hasDocValues();
+            return new SupportedReaders(text.syntheticSourceDelegate() != null && text.syntheticSourceDelegate().hasDocValues(), true);
         }
         MappedFieldType parent = mapper.fieldType(parentName);
         if (false == parent.typeName().equals(KeywordFieldMapper.CONTENT_TYPE)) {
             throw new UnsupportedOperationException();
         }
         KeywordFieldMapper.KeywordFieldType kwd = (KeywordFieldMapper.KeywordFieldType) parent;
-        return kwd.hasDocValues();
+        return new SupportedReaders(kwd.hasDocValues(), true);
     }
 
     public void testBlockLoaderFromParentColumnReader() throws IOException {

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/AbstractScriptFieldTypeTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/AbstractScriptFieldTypeTestCase.java
@@ -423,6 +423,11 @@ public abstract class AbstractScriptFieldTypeTestCase extends MapperServiceTestC
             }
 
             @Override
+            public boolean forStats() {
+                return false;
+            }
+
+            @Override
             public SearchLookup lookup() {
                 return mockContext().lookup();
             }

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
@@ -1283,6 +1283,11 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
             }
 
             @Override
+            public boolean forStats() {
+                return false;
+            }
+
+            @Override
             public SearchLookup lookup() {
                 return searchLookup;
             }

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
@@ -1248,10 +1248,10 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
     }
 
     /**
-     *  Should teh doc-values reader be used instead of reading from source.
+     *  Should the doc-values reader be used instead of reading from source.
      *  For most ESQL types the preference is to read from doc-values if they exist, so that is the default behaviour here.
-     *  However, for spatial types, the doc-values involve precision loss, and therefor they prefer to read from source.
-     *  And for text fields, doc values are not easily convertable to original values either.
+     *  However, for spatial types, the doc-values involve precision loss, and therefor it is preferable to read from source.
+     *  And for text fields, doc values are not easily convertable to original values either, so special cases exist.
      */
     protected boolean shouldUseColumnAtATimeReader(MapperService mapper, MappedFieldType ft) {
         return ft.hasDocValues();

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
@@ -1247,7 +1247,13 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
         testBlockLoader(false);
     }
 
-    protected boolean supportsColumnAtATimeReader(MapperService mapper, MappedFieldType ft) {
+    /**
+     *  Should teh doc-values reader be used instead of reading from source.
+     *  For most ESQL types the preference is to read from doc-values if they exist, so that is the default behaviour here.
+     *  However, for spatial types, the doc-values involve precision loss, and therefor they prefer to read from source.
+     *  And for text fields, doc values are not easily convertable to original values either.
+     */
+    protected boolean shouldUseColumnAtATimeReader(MapperService mapper, MappedFieldType ft) {
         return ft.hasDocValues();
     }
 
@@ -1302,7 +1308,7 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
                 LeafReaderContext ctx = reader.leaves().get(0);
                 TestBlock block;
                 if (columnReader) {
-                    if (supportsColumnAtATimeReader(mapper, mapper.fieldType(loaderFieldName))) {
+                    if (shouldUseColumnAtATimeReader(mapper, mapper.fieldType(loaderFieldName))) {
                         block = (TestBlock) loader.columnAtATimeReader(ctx)
                             .read(TestBlock.factory(ctx.reader().numDocs()), TestBlock.docs(0));
                     } else {

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/TestBlock.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/TestBlock.java
@@ -11,6 +11,7 @@ package org.elasticsearch.index.mapper;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortedDocValues;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.geo.SpatialPoint;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -55,6 +56,19 @@ public class TestBlock implements BlockLoader.Block {
                     }
                 }
                 return new BytesRefsBuilder();
+            }
+
+            @Override
+            public BlockLoader.PointBuilder points(int expectedCount) {
+                class PointsBuilder extends TestBlock.Builder implements BlockLoader.PointBuilder {
+                    @Override
+                    public PointsBuilder appendPoint(SpatialPoint value) {
+                        add(value.getX());
+                        add(value.getY());
+                        return this;
+                    }
+                }
+                return new PointsBuilder();
             }
 
             @Override

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/TestBlock.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/TestBlock.java
@@ -11,7 +11,6 @@ package org.elasticsearch.index.mapper;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortedDocValues;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.geo.SpatialPoint;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -62,9 +61,9 @@ public class TestBlock implements BlockLoader.Block {
             public BlockLoader.PointBuilder points(int expectedCount) {
                 class PointsBuilder extends TestBlock.Builder implements BlockLoader.PointBuilder {
                     @Override
-                    public PointsBuilder appendPoint(SpatialPoint value) {
-                        add(value.getX());
-                        add(value.getY());
+                    public PointsBuilder appendPoint(double x, double y) {
+                        add(x);
+                        add(y);
                         return this;
                     }
                 }

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -49,7 +49,6 @@ import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.bytes.CompositeBytesReference;
-import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.NamedWriteable;
@@ -1195,7 +1194,9 @@ public abstract class ESTestCase extends LuceneTestCase {
      * Generate a random valid point constrained to geographic ranges (lat, lon ranges).
      */
     public static SpatialPoint randomGeoPoint() {
-        return new GeoPoint(randomDoubleBetween(-90, 90, true), randomDoubleBetween(-180, 180, true));
+        double lat = randomDoubleBetween(-90, 90, true);
+        double lon = randomDoubleBetween(-180, 180, true);
+        return new SpatialPoint(lon, lat);
     }
 
     /**
@@ -1204,17 +1205,7 @@ public abstract class ESTestCase extends LuceneTestCase {
     public static SpatialPoint randomCartesianPoint() {
         double x = randomDoubleBetween(-Float.MAX_VALUE, Float.MAX_VALUE, true);
         double y = randomDoubleBetween(-Float.MAX_VALUE, Float.MAX_VALUE, true);
-        return new SpatialPoint() {
-            @Override
-            public double getX() {
-                return x;
-            }
-
-            @Override
-            public double getY() {
-                return y;
-            }
-        };
+        return new SpatialPoint(x, y);
     }
 
     /**

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -49,6 +49,7 @@ import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.bytes.CompositeBytesReference;
+import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.NamedWriteable;
@@ -1196,7 +1197,7 @@ public abstract class ESTestCase extends LuceneTestCase {
     public static SpatialPoint randomGeoPoint() {
         double lat = randomDoubleBetween(-90, 90, true);
         double lon = randomDoubleBetween(-180, 180, true);
-        return new SpatialPoint(lon, lat);
+        return new GeoPoint(lat, lon);
     }
 
     /**

--- a/x-pack/plugin/esql/compute/build.gradle
+++ b/x-pack/plugin/esql/compute/build.gradle
@@ -41,6 +41,7 @@ def prop(Type, type, TYPE, BYTES) {
     "long" : type == "long" ? "true" : "",
     "double" : type == "double" ? "true" : "",
     "BytesRef" : type == "BytesRef" ? "true" : "",
+    "Point" : type == "Point" ? "true" : "",
     "boolean" : type == "boolean" ? "true" : "",
   ]
 }
@@ -50,6 +51,7 @@ tasks.named('stringTemplates').configure {
   var longProperties     = prop("Long", "long", "LONG", "Long.BYTES")
   var doubleProperties   = prop("Double", "double", "DOUBLE", "Double.BYTES")
   var bytesRefProperties = prop("BytesRef", "BytesRef", "BYTES_REF", "org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF")
+  var pointProperties    = prop("Point", "Point", "POINT", "16")
   var booleanProperties  = prop("Boolean", "boolean", "BOOLEAN", "Byte.BYTES")
   // primitive vectors
   File vectorInputFile = new File("${projectDir}/src/main/java/org/elasticsearch/compute/data/X-Vector.java.st")
@@ -72,6 +74,11 @@ tasks.named('stringTemplates').configure {
     it.properties = bytesRefProperties
     it.inputFile =  vectorInputFile
     it.outputFile = "org/elasticsearch/compute/data/BytesRefVector.java"
+  }
+  template {
+    it.properties = pointProperties
+    it.inputFile =  vectorInputFile
+    it.outputFile = "org/elasticsearch/compute/data/PointVector.java"
   }
   template {
     it.properties = booleanProperties
@@ -99,6 +106,11 @@ tasks.named('stringTemplates').configure {
     it.properties = bytesRefProperties
     it.inputFile =  arrayVectorInputFile
     it.outputFile = "org/elasticsearch/compute/data/BytesRefArrayVector.java"
+  }
+  template {
+    it.properties = pointProperties
+    it.inputFile =  arrayVectorInputFile
+    it.outputFile = "org/elasticsearch/compute/data/PointArrayVector.java"
   }
   template {
     it.properties = booleanProperties
@@ -150,6 +162,11 @@ tasks.named('stringTemplates').configure {
     it.outputFile = "org/elasticsearch/compute/data/ConstantBytesRefVector.java"
   }
   template {
+    it.properties = pointProperties
+    it.inputFile =  constantVectorInputFile
+    it.outputFile = "org/elasticsearch/compute/data/ConstantPointVector.java"
+  }
+  template {
     it.properties = booleanProperties
     it.inputFile =  constantVectorInputFile
     it.outputFile = "org/elasticsearch/compute/data/ConstantBooleanVector.java"
@@ -175,6 +192,11 @@ tasks.named('stringTemplates').configure {
     it.properties = bytesRefProperties
     it.inputFile =  blockInputFile
     it.outputFile = "org/elasticsearch/compute/data/BytesRefBlock.java"
+  }
+  template {
+    it.properties = pointProperties
+    it.inputFile =  blockInputFile
+    it.outputFile = "org/elasticsearch/compute/data/PointBlock.java"
   }
   template {
     it.properties = booleanProperties
@@ -204,6 +226,11 @@ tasks.named('stringTemplates').configure {
     it.outputFile = "org/elasticsearch/compute/data/BytesRefArrayBlock.java"
   }
   template {
+    it.properties = pointProperties
+    it.inputFile =  arrayBlockInputFile
+    it.outputFile = "org/elasticsearch/compute/data/PointArrayBlock.java"
+  }
+  template {
     it.properties = booleanProperties
     it.inputFile =  arrayBlockInputFile
     it.outputFile = "org/elasticsearch/compute/data/BooleanArrayBlock.java"
@@ -229,6 +256,11 @@ tasks.named('stringTemplates').configure {
     it.properties = bytesRefProperties
     it.inputFile =  vectorBlockInputFile
     it.outputFile = "org/elasticsearch/compute/data/BytesRefVectorBlock.java"
+  }
+  template {
+    it.properties = pointProperties
+    it.inputFile =  vectorBlockInputFile
+    it.outputFile = "org/elasticsearch/compute/data/PointVectorBlock.java"
   }
   template {
     it.properties = booleanProperties
@@ -258,6 +290,11 @@ tasks.named('stringTemplates').configure {
     it.outputFile = "org/elasticsearch/compute/data/BytesRefBlockBuilder.java"
   }
   template {
+    it.properties = pointProperties
+    it.inputFile =  blockBuildersInputFile
+    it.outputFile = "org/elasticsearch/compute/data/PointBlockBuilder.java"
+  }
+  template {
     it.properties = booleanProperties
     it.inputFile =  blockBuildersInputFile
     it.outputFile = "org/elasticsearch/compute/data/BooleanBlockBuilder.java"
@@ -283,6 +320,11 @@ tasks.named('stringTemplates').configure {
     it.properties = bytesRefProperties
     it.inputFile =  vectorBuildersInputFile
     it.outputFile = "org/elasticsearch/compute/data/BytesRefVectorBuilder.java"
+  }
+  template {
+    it.properties = pointProperties
+    it.inputFile =  vectorBuildersInputFile
+    it.outputFile = "org/elasticsearch/compute/data/PointVectorBuilder.java"
   }
   template {
     it.properties = booleanProperties
@@ -363,11 +405,21 @@ tasks.named('stringTemplates').configure {
     it.inputFile =  multivalueDedupeInputFile
     it.outputFile = "org/elasticsearch/compute/operator/MultivalueDedupeBytesRef.java"
   }
+  template {
+    it.properties = pointProperties
+    it.inputFile =  multivalueDedupeInputFile
+    it.outputFile = "org/elasticsearch/compute/operator/MultivalueDedupePoint.java"
+  }
   File keyExtractorInputFile = new File("${projectDir}/src/main/java/org/elasticsearch/compute/operator/topn/X-KeyExtractor.java.st")
   template {
     it.properties = bytesRefProperties
     it.inputFile =  keyExtractorInputFile
     it.outputFile = "org/elasticsearch/compute/operator/topn/KeyExtractorForBytesRef.java"
+  }
+  template {
+    it.properties = pointProperties
+    it.inputFile =  keyExtractorInputFile
+    it.outputFile = "org/elasticsearch/compute/operator/topn/KeyExtractorForPoint.java"
   }
   template {
     it.properties = booleanProperties
@@ -396,6 +448,11 @@ tasks.named('stringTemplates').configure {
     it.outputFile = "org/elasticsearch/compute/operator/topn/ValueExtractorForBytesRef.java"
   }
   template {
+    it.properties = pointProperties
+    it.inputFile =  valueExtractorInputFile
+    it.outputFile = "org/elasticsearch/compute/operator/topn/ValueExtractorForPoint.java"
+  }
+  template {
     it.properties = booleanProperties
     it.inputFile =  valueExtractorInputFile
     it.outputFile = "org/elasticsearch/compute/operator/topn/ValueExtractorForBoolean.java"
@@ -420,6 +477,11 @@ tasks.named('stringTemplates').configure {
     it.properties = bytesRefProperties
     it.inputFile =  resultBuilderInputFile
     it.outputFile = "org/elasticsearch/compute/operator/topn/ResultBuilderForBytesRef.java"
+  }
+  template {
+    it.properties = pointProperties
+    it.inputFile =  resultBuilderInputFile
+    it.outputFile = "org/elasticsearch/compute/operator/topn/ResultBuilderForPoint.java"
   }
   template {
     it.properties = booleanProperties

--- a/x-pack/plugin/esql/compute/build.gradle
+++ b/x-pack/plugin/esql/compute/build.gradle
@@ -447,6 +447,11 @@ tasks.named('stringTemplates').configure {
     it.inputFile =  keyExtractorInputFile
     it.outputFile = "org/elasticsearch/compute/operator/topn/KeyExtractorForDouble.java"
   }
+  template {
+    it.properties = pointProperties
+    it.inputFile =  keyExtractorInputFile
+    it.outputFile = "org/elasticsearch/compute/operator/topn/KeyExtractorForPoint.java"
+  }
   File valueExtractorInputFile = new File("${projectDir}/src/main/java/org/elasticsearch/compute/operator/topn/X-ValueExtractor.java.st")
   template {
     it.properties = bytesRefProperties

--- a/x-pack/plugin/esql/compute/build.gradle
+++ b/x-pack/plugin/esql/compute/build.gradle
@@ -30,30 +30,34 @@ spotless {
   }
 }
 
-def prop(Type, type, TYPE, BYTES, Array) {
+def prop(Type, type, TYPE, BYTES, Array, typeValue, value, typeArrayValues, arrayValues) {
   return [
     "Type" : Type,
     "type" : type,
     "TYPE" : TYPE,
     "BYTES" : BYTES,
     "Array" : Array,
+    "typeValue" : typeValue,
+    "value": value,
+    "typeArrayValues" : typeArrayValues,
+    "arrayValues" : arrayValues,
 
-    "int" : type == "int" ? "true" : "",
-    "long" : type == "long" ? "true" : "",
-    "double" : type == "double" ? "true" : "",
-    "BytesRef" : type == "BytesRef" ? "true" : "",
-    "Point" : type == "SpatialPoint" ? "true" : "",
-    "boolean" : type == "boolean" ? "true" : "",
+    "int" : Type == "Int" ? "true" : "",
+    "long" : Type == "Long" ? "true" : "",
+    "double" : Type == "Double" ? "true" : "",
+    "BytesRef" : Type == "BytesRef" ? "true" : "",
+    "Point" : Type == "Point" ? "true" : "",
+    "boolean" : Type == "Boolean" ? "true" : "",
   ]
 }
 
 tasks.named('stringTemplates').configure {
-  var intProperties      = prop("Int", "int", "INT", "Integer.BYTES", "IntArray")
-  var longProperties     = prop("Long", "long", "LONG", "Long.BYTES", "LongArray")
-  var doubleProperties   = prop("Double", "double", "DOUBLE", "Double.BYTES", "DoubleArray")
-  var bytesRefProperties = prop("BytesRef", "BytesRef", "BYTES_REF", "org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF", "")
-  var pointProperties    = prop("Point", "SpatialPoint", "POINT", "16", "ObjectArray<SpatialPoint>")
-  var booleanProperties  = prop("Boolean", "boolean", "BOOLEAN", "Byte.BYTES", "BitArray")
+  var intProperties      = prop("Int", "int", "INT", "Integer.BYTES", "IntArray", "int value", "value", "int[] values", "values")
+  var longProperties     = prop("Long", "long", "LONG", "Long.BYTES", "LongArray", "long value", "value", "long[] values", "values")
+  var doubleProperties   = prop("Double", "double", "DOUBLE", "Double.BYTES", "DoubleArray", "double value", "value", "double[] values", "values")
+  var bytesRefProperties = prop("BytesRef", "BytesRef", "BYTES_REF", "org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF", "", "BytesRef value", "value", "BytesRefArray values", "values")
+  var pointProperties    = prop("Point", "double", "POINT", "16", "DoubleArray", "double x, double y", "x, y", "double[] xValues, double[] yValues", "xValues, yValues")
+  var booleanProperties  = prop("Boolean", "boolean", "BOOLEAN", "Byte.BYTES", "BitArray", "boolean value", "value", "boolean[] values", "values")
   // primitive vectors
   File vectorInputFile = new File("${projectDir}/src/main/java/org/elasticsearch/compute/data/X-Vector.java.st")
   template {

--- a/x-pack/plugin/esql/compute/build.gradle
+++ b/x-pack/plugin/esql/compute/build.gradle
@@ -473,6 +473,11 @@ tasks.named('stringTemplates').configure {
     it.inputFile =  valueExtractorInputFile
     it.outputFile = "org/elasticsearch/compute/operator/topn/ValueExtractorForDouble.java"
   }
+  template {
+    it.properties = pointProperties
+    it.inputFile =  valueExtractorInputFile
+    it.outputFile = "org/elasticsearch/compute/operator/topn/ValueExtractorForPoint.java"
+  }
   File resultBuilderInputFile = new File("${projectDir}/src/main/java/org/elasticsearch/compute/operator/topn/X-ResultBuilder.java.st")
   template {
     it.properties = bytesRefProperties
@@ -498,5 +503,10 @@ tasks.named('stringTemplates').configure {
     it.properties = doubleProperties
     it.inputFile =  resultBuilderInputFile
     it.outputFile = "org/elasticsearch/compute/operator/topn/ResultBuilderForDouble.java"
+  }
+  template {
+    it.properties = pointProperties
+    it.inputFile =  resultBuilderInputFile
+    it.outputFile = "org/elasticsearch/compute/operator/topn/ResultBuilderForPoint.java"
   }
 }

--- a/x-pack/plugin/esql/compute/build.gradle
+++ b/x-pack/plugin/esql/compute/build.gradle
@@ -30,29 +30,30 @@ spotless {
   }
 }
 
-def prop(Type, type, TYPE, BYTES) {
+def prop(Type, type, TYPE, BYTES, Array) {
   return [
     "Type" : Type,
     "type" : type,
     "TYPE" : TYPE,
     "BYTES" : BYTES,
+    "Array" : Array,
 
     "int" : type == "int" ? "true" : "",
     "long" : type == "long" ? "true" : "",
     "double" : type == "double" ? "true" : "",
     "BytesRef" : type == "BytesRef" ? "true" : "",
-    "Point" : type == "Point" ? "true" : "",
+    "Point" : type == "SpatialPoint" ? "true" : "",
     "boolean" : type == "boolean" ? "true" : "",
   ]
 }
 
 tasks.named('stringTemplates').configure {
-  var intProperties      = prop("Int", "int", "INT", "Integer.BYTES")
-  var longProperties     = prop("Long", "long", "LONG", "Long.BYTES")
-  var doubleProperties   = prop("Double", "double", "DOUBLE", "Double.BYTES")
-  var bytesRefProperties = prop("BytesRef", "BytesRef", "BYTES_REF", "org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF")
-  var pointProperties    = prop("Point", "Point", "POINT", "16")
-  var booleanProperties  = prop("Boolean", "boolean", "BOOLEAN", "Byte.BYTES")
+  var intProperties      = prop("Int", "int", "INT", "Integer.BYTES", "IntArray")
+  var longProperties     = prop("Long", "long", "LONG", "Long.BYTES", "LongArray")
+  var doubleProperties   = prop("Double", "double", "DOUBLE", "Double.BYTES", "DoubleArray")
+  var bytesRefProperties = prop("BytesRef", "BytesRef", "BYTES_REF", "org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF", "")
+  var pointProperties    = prop("Point", "SpatialPoint", "POINT", "16", "ObjectArray<SpatialPoint>")
+  var booleanProperties  = prop("Boolean", "boolean", "BOOLEAN", "Byte.BYTES", "BitArray")
   // primitive vectors
   File vectorInputFile = new File("${projectDir}/src/main/java/org/elasticsearch/compute/data/X-Vector.java.st")
   template {
@@ -133,6 +134,11 @@ tasks.named('stringTemplates').configure {
     it.properties = doubleProperties
     it.inputFile =  bigArrayVectorInputFile
     it.outputFile = "org/elasticsearch/compute/data/DoubleBigArrayVector.java"
+  }
+  template {
+    it.properties = pointProperties
+    it.inputFile =  bigArrayVectorInputFile
+    it.outputFile = "org/elasticsearch/compute/data/PointBigArrayVector.java"
   }
   template {
     it.properties = booleanProperties
@@ -348,6 +354,11 @@ tasks.named('stringTemplates').configure {
     it.outputFile = "org/elasticsearch/compute/data/DoubleVectorFixedBuilder.java"
   }
   template {
+    it.properties = pointProperties
+    it.inputFile =  vectorFixedBuildersInputFile
+    it.outputFile = "org/elasticsearch/compute/data/PointVectorFixedBuilder.java"
+  }
+  template {
     it.properties = booleanProperties
     it.inputFile =  vectorFixedBuildersInputFile
     it.outputFile = "org/elasticsearch/compute/data/BooleanVectorFixedBuilder.java"
@@ -401,25 +412,20 @@ tasks.named('stringTemplates').configure {
     it.outputFile = "org/elasticsearch/compute/operator/MultivalueDedupeDouble.java"
   }
   template {
-    it.properties = bytesRefProperties
-    it.inputFile =  multivalueDedupeInputFile
-    it.outputFile = "org/elasticsearch/compute/operator/MultivalueDedupeBytesRef.java"
-  }
-  template {
     it.properties = pointProperties
     it.inputFile =  multivalueDedupeInputFile
     it.outputFile = "org/elasticsearch/compute/operator/MultivalueDedupePoint.java"
+  }
+  template {
+    it.properties = bytesRefProperties
+    it.inputFile =  multivalueDedupeInputFile
+    it.outputFile = "org/elasticsearch/compute/operator/MultivalueDedupeBytesRef.java"
   }
   File keyExtractorInputFile = new File("${projectDir}/src/main/java/org/elasticsearch/compute/operator/topn/X-KeyExtractor.java.st")
   template {
     it.properties = bytesRefProperties
     it.inputFile =  keyExtractorInputFile
     it.outputFile = "org/elasticsearch/compute/operator/topn/KeyExtractorForBytesRef.java"
-  }
-  template {
-    it.properties = pointProperties
-    it.inputFile =  keyExtractorInputFile
-    it.outputFile = "org/elasticsearch/compute/operator/topn/KeyExtractorForPoint.java"
   }
   template {
     it.properties = booleanProperties
@@ -448,11 +454,6 @@ tasks.named('stringTemplates').configure {
     it.outputFile = "org/elasticsearch/compute/operator/topn/ValueExtractorForBytesRef.java"
   }
   template {
-    it.properties = pointProperties
-    it.inputFile =  valueExtractorInputFile
-    it.outputFile = "org/elasticsearch/compute/operator/topn/ValueExtractorForPoint.java"
-  }
-  template {
     it.properties = booleanProperties
     it.inputFile =  valueExtractorInputFile
     it.outputFile = "org/elasticsearch/compute/operator/topn/ValueExtractorForBoolean.java"
@@ -477,11 +478,6 @@ tasks.named('stringTemplates').configure {
     it.properties = bytesRefProperties
     it.inputFile =  resultBuilderInputFile
     it.outputFile = "org/elasticsearch/compute/operator/topn/ResultBuilderForBytesRef.java"
-  }
-  template {
-    it.properties = pointProperties
-    it.inputFile =  resultBuilderInputFile
-    it.outputFile = "org/elasticsearch/compute/operator/topn/ResultBuilderForPoint.java"
   }
   template {
     it.properties = booleanProperties

--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/Methods.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/Methods.java
@@ -41,6 +41,11 @@ import static org.elasticsearch.compute.gen.Types.LONG_BLOCK_BUILDER;
 import static org.elasticsearch.compute.gen.Types.LONG_VECTOR;
 import static org.elasticsearch.compute.gen.Types.LONG_VECTOR_BUILDER;
 import static org.elasticsearch.compute.gen.Types.LONG_VECTOR_FIXED_BUILDER;
+import static org.elasticsearch.compute.gen.Types.POINT_BLOCK;
+import static org.elasticsearch.compute.gen.Types.POINT_BLOCK_BUILDER;
+import static org.elasticsearch.compute.gen.Types.POINT_VECTOR;
+import static org.elasticsearch.compute.gen.Types.POINT_VECTOR_BUILDER;
+import static org.elasticsearch.compute.gen.Types.POINT_VECTOR_FIXED_BUILDER;
 
 /**
  * Finds declared methods for the code generator.
@@ -106,6 +111,9 @@ public class Methods {
         if (t.equals(TypeName.DOUBLE) || t.equals(DOUBLE_BLOCK) || t.equals(DOUBLE_VECTOR)) {
             return "appendDouble";
         }
+        if (t.equals(Types.POINT) || t.equals(POINT_BLOCK) || t.equals(POINT_VECTOR)) {
+            return "appendPoint";
+        }
         throw new IllegalArgumentException("unknown append method for [" + t + "]");
     }
 
@@ -156,6 +164,15 @@ public class Methods {
         if (t.equals(DOUBLE_VECTOR_FIXED_BUILDER)) {
             return "newDoubleVectorFixedBuilder";
         }
+        if (t.equals(POINT_BLOCK_BUILDER)) {
+            return "newPointBlockBuilder";
+        }
+        if (t.equals(POINT_VECTOR_BUILDER)) {
+            return "newPointVectorBuilder";
+        }
+        if (t.equals(POINT_VECTOR_FIXED_BUILDER)) {
+            return "newPointVectorFixedBuilder";
+        }
         throw new IllegalArgumentException("unknown build method for [" + t + "]");
     }
 
@@ -179,6 +196,9 @@ public class Methods {
         if (elementType.equals(TypeName.DOUBLE)) {
             return "getDouble";
         }
+        if (elementType.equals(Types.POINT)) {
+            return "getPoint";
+        }
         throw new IllegalArgumentException("unknown get method for [" + elementType + "]");
     }
 
@@ -192,6 +212,7 @@ public class Methods {
             case "INT" -> "getInt";
             case "LONG" -> "getLong";
             case "DOUBLE" -> "getDouble";
+            case "POINT" -> "getPoint";
             case "BYTES_REF" -> "getBytesRef";
             default -> throw new IllegalArgumentException(
                 "don't know how to fetch primitive values from " + elementTypeName + ". define combineStates."

--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/Types.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/Types.java
@@ -41,12 +41,14 @@ public class Types {
     static final ClassName INT_BLOCK = ClassName.get(DATA_PACKAGE, "IntBlock");
     static final ClassName LONG_BLOCK = ClassName.get(DATA_PACKAGE, "LongBlock");
     static final ClassName DOUBLE_BLOCK = ClassName.get(DATA_PACKAGE, "DoubleBlock");
+    static final ClassName POINT_BLOCK = ClassName.get(DATA_PACKAGE, "PointBlock");
 
     static final ClassName BOOLEAN_BLOCK_BUILDER = BOOLEAN_BLOCK.nestedClass("Builder");
     static final ClassName BYTES_REF_BLOCK_BUILDER = BYTES_REF_BLOCK.nestedClass("Builder");
     static final ClassName INT_BLOCK_BUILDER = INT_BLOCK.nestedClass("Builder");
     static final ClassName LONG_BLOCK_BUILDER = LONG_BLOCK.nestedClass("Builder");
     static final ClassName DOUBLE_BLOCK_BUILDER = DOUBLE_BLOCK.nestedClass("Builder");
+    static final ClassName POINT_BLOCK_BUILDER = POINT_BLOCK.nestedClass("Builder");
 
     static final ClassName ELEMENT_TYPE = ClassName.get(DATA_PACKAGE, "ElementType");
 
@@ -55,35 +57,41 @@ public class Types {
     static final ClassName INT_VECTOR = ClassName.get(DATA_PACKAGE, "IntVector");
     static final ClassName LONG_VECTOR = ClassName.get(DATA_PACKAGE, "LongVector");
     static final ClassName DOUBLE_VECTOR = ClassName.get(DATA_PACKAGE, "DoubleVector");
+    static final ClassName POINT_VECTOR = ClassName.get(DATA_PACKAGE, "PointVector");
 
     static final ClassName BOOLEAN_VECTOR_BUILDER = ClassName.get(DATA_PACKAGE, "BooleanVector", "Builder");
     static final ClassName BYTES_REF_VECTOR_BUILDER = ClassName.get(DATA_PACKAGE, "BytesRefVector", "Builder");
     static final ClassName INT_VECTOR_BUILDER = ClassName.get(DATA_PACKAGE, "IntVector", "Builder");
     static final ClassName LONG_VECTOR_BUILDER = ClassName.get(DATA_PACKAGE, "LongVector", "Builder");
     static final ClassName DOUBLE_VECTOR_BUILDER = ClassName.get(DATA_PACKAGE, "DoubleVector", "Builder");
+    static final ClassName POINT_VECTOR_BUILDER = ClassName.get(DATA_PACKAGE, "PointVector", "Builder");
 
     static final ClassName BOOLEAN_VECTOR_FIXED_BUILDER = ClassName.get(DATA_PACKAGE, "BooleanVector", "FixedBuilder");
     static final ClassName INT_VECTOR_FIXED_BUILDER = ClassName.get(DATA_PACKAGE, "IntVector", "FixedBuilder");
     static final ClassName LONG_VECTOR_FIXED_BUILDER = ClassName.get(DATA_PACKAGE, "LongVector", "FixedBuilder");
     static final ClassName DOUBLE_VECTOR_FIXED_BUILDER = ClassName.get(DATA_PACKAGE, "DoubleVector", "FixedBuilder");
+    static final ClassName POINT_VECTOR_FIXED_BUILDER = ClassName.get(DATA_PACKAGE, "PointVector", "FixedBuilder");
 
     static final ClassName BOOLEAN_ARRAY_VECTOR = ClassName.get(DATA_PACKAGE, "BooleanArrayVector");
     static final ClassName BYTES_REF_ARRAY_VECTOR = ClassName.get(DATA_PACKAGE, "BytesRefArrayVector");
     static final ClassName INT_ARRAY_VECTOR = ClassName.get(DATA_PACKAGE, "IntArrayVector");
     static final ClassName LONG_ARRAY_VECTOR = ClassName.get(DATA_PACKAGE, "LongArrayVector");
     static final ClassName DOUBLE_ARRAY_VECTOR = ClassName.get(DATA_PACKAGE, "DoubleArrayVector");
+    static final ClassName POINT_ARRAY_VECTOR = ClassName.get(DATA_PACKAGE, "PointArrayVector");
 
     static final ClassName BOOLEAN_ARRAY_BLOCK = ClassName.get(DATA_PACKAGE, "BooleanArrayBlock");
     static final ClassName BYTES_REF_ARRAY_BLOCK = ClassName.get(DATA_PACKAGE, "BytesRefArrayBlock");
     static final ClassName INT_ARRAY_BLOCK = ClassName.get(DATA_PACKAGE, "IntArrayBlock");
     static final ClassName LONG_ARRAY_BLOCK = ClassName.get(DATA_PACKAGE, "LongArrayBlock");
     static final ClassName DOUBLE_ARRAY_BLOCK = ClassName.get(DATA_PACKAGE, "DoubleArrayBlock");
+    static final ClassName POINT_ARRAY_BLOCK = ClassName.get(DATA_PACKAGE, "PointArrayBlock");
 
     static final ClassName BOOLEAN_CONSTANT_VECTOR = ClassName.get(DATA_PACKAGE, "ConstantBooleanVector");
     static final ClassName BYTES_REF_CONSTANT_VECTOR = ClassName.get(DATA_PACKAGE, "ConstantBytesRefVector");
     static final ClassName INT_CONSTANT_VECTOR = ClassName.get(DATA_PACKAGE, "ConstantIntVector");
     static final ClassName LONG_CONSTANT_VECTOR = ClassName.get(DATA_PACKAGE, "ConstantLongVector");
     static final ClassName DOUBLE_CONSTANT_VECTOR = ClassName.get(DATA_PACKAGE, "ConstantDoubleVector");
+    static final ClassName POINT_CONSTANT_VECTOR = ClassName.get(DATA_PACKAGE, "ConstantPointVector");
 
     static final ClassName AGGREGATOR_FUNCTION = ClassName.get(AGGREGATION_PACKAGE, "AggregatorFunction");
     static final ClassName AGGREGATOR_FUNCTION_SUPPLIER = ClassName.get(AGGREGATION_PACKAGE, "AggregatorFunctionSupplier");
@@ -123,6 +131,7 @@ public class Types {
     static final ClassName SOURCE = ClassName.get("org.elasticsearch.xpack.ql.tree", "Source");
 
     static final ClassName BYTES_REF = ClassName.get("org.apache.lucene.util", "BytesRef");
+    static final ClassName POINT = ClassName.get("org.elasticsearch.common.geo", "SpatialPoint");
 
     static final ClassName RELEASABLE = ClassName.get("org.elasticsearch.core", "Releasable");
     static final ClassName RELEASABLES = ClassName.get("org.elasticsearch.core", "Releasables");
@@ -143,6 +152,9 @@ public class Types {
         if (elementType.equals(TypeName.DOUBLE)) {
             return DOUBLE_BLOCK;
         }
+        if (elementType.equals(POINT)) {
+            return POINT_BLOCK;
+        }
         throw new IllegalArgumentException("unknown block type for [" + elementType + "]");
     }
 
@@ -161,6 +173,9 @@ public class Types {
         }
         if (elementType.equalsIgnoreCase(TypeName.DOUBLE.toString())) {
             return DOUBLE_BLOCK;
+        }
+        if (elementType.equalsIgnoreCase("POINT")) {
+            return POINT_BLOCK;
         }
         throw new IllegalArgumentException("unknown vector type for [" + elementType + "]");
     }
@@ -181,6 +196,9 @@ public class Types {
         if (elementType.equals(TypeName.DOUBLE)) {
             return DOUBLE_VECTOR;
         }
+        if (elementType.equals(POINT)) {
+            return POINT_VECTOR;
+        }
         throw new IllegalArgumentException("unknown vector type for [" + elementType + "]");
     }
 
@@ -199,6 +217,9 @@ public class Types {
         }
         if (elementType.equalsIgnoreCase(TypeName.DOUBLE.toString())) {
             return DOUBLE_VECTOR;
+        }
+        if (elementType.equalsIgnoreCase("POINT")) {
+            return POINT_VECTOR;
         }
         throw new IllegalArgumentException("unknown vector type for [" + elementType + "]");
     }
@@ -234,6 +255,12 @@ public class Types {
         if (resultType.equals(DOUBLE_VECTOR)) {
             return DOUBLE_VECTOR_BUILDER;
         }
+        if (resultType.equals(POINT_BLOCK)) {
+            return POINT_BLOCK_BUILDER;
+        }
+        if (resultType.equals(POINT_VECTOR)) {
+            return POINT_VECTOR_BUILDER;
+        }
         throw new IllegalArgumentException("unknown builder type for [" + resultType + "]");
     }
 
@@ -249,6 +276,9 @@ public class Types {
         }
         if (elementType.equals(TypeName.DOUBLE)) {
             return DOUBLE_VECTOR_FIXED_BUILDER;
+        }
+        if (elementType.equals(POINT)) {
+            return POINT_VECTOR_FIXED_BUILDER;
         }
         throw new IllegalArgumentException("unknown vector fixed builder type for [" + elementType + "]");
     }
@@ -269,6 +299,9 @@ public class Types {
         if (elementType.equals(TypeName.DOUBLE)) {
             return DOUBLE_ARRAY_VECTOR;
         }
+        if (elementType.equals(POINT)) {
+            return POINT_ARRAY_VECTOR;
+        }
         throw new IllegalArgumentException("unknown vector type for [" + elementType + "]");
     }
 
@@ -287,6 +320,9 @@ public class Types {
         }
         if (elementType.equals(TypeName.DOUBLE)) {
             return DOUBLE_ARRAY_BLOCK;
+        }
+        if (elementType.equals(POINT)) {
+            return POINT_ARRAY_BLOCK;
         }
         throw new IllegalArgumentException("unknown vector type for [" + elementType + "]");
     }
@@ -307,6 +343,9 @@ public class Types {
         if (elementType.equals(TypeName.DOUBLE)) {
             return DOUBLE_CONSTANT_VECTOR;
         }
+        if (elementType.equals(POINT)) {
+            return POINT_CONSTANT_VECTOR;
+        }
         throw new IllegalArgumentException("unknown vector type for [" + elementType + "]");
     }
 
@@ -325,6 +364,9 @@ public class Types {
         }
         if (t.equals(DOUBLE_BLOCK) || t.equals(DOUBLE_VECTOR) || t.equals(DOUBLE_BLOCK_BUILDER)) {
             return TypeName.DOUBLE;
+        }
+        if (t.equals(POINT_BLOCK) || t.equals(POINT_VECTOR) || t.equals(POINT_BLOCK_BUILDER)) {
+            return POINT;
         }
         throw new IllegalArgumentException("unknown element type for [" + t + "]");
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayVector.java
@@ -12,7 +12,7 @@ import org.apache.lucene.util.RamUsageEstimator;
 import java.util.Arrays;
 
 /**
- * Vector implementation that stores an array of boolean values.
+ * Vector implementation that stores an array of Boolean values.
  * This class is generated. Do not edit it.
  */
 public final class BooleanArrayVector extends AbstractVector implements BooleanVector {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBlock.java
@@ -15,7 +15,7 @@ import org.elasticsearch.index.mapper.BlockLoader;
 import java.io.IOException;
 
 /**
- * Block that stores boolean values.
+ * Block that stores Boolean values.
  * This class is generated. Do not edit it.
  */
 public sealed interface BooleanBlock extends Block permits BooleanArrayBlock, BooleanVectorBlock, ConstantNullBlock {
@@ -236,14 +236,14 @@ public sealed interface BooleanBlock extends Block permits BooleanArrayBlock, Bo
         Builder mvOrdering(Block.MvOrdering mvOrdering);
 
         /**
-         * Appends the all values of the given block into a the current position
+         * Appends the all values of the given block into the current position
          * in this builder.
          */
         @Override
         Builder appendAllValuesToCurrentPosition(Block block);
 
         /**
-         * Appends the all values of the given block into a the current position
+         * Appends the all values of the given block into the current position
          * in this builder.
          */
         Builder appendAllValuesToCurrentPosition(BooleanBlock block);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBlockBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBlockBuilder.java
@@ -108,8 +108,8 @@ final class BooleanBlockBuilder extends AbstractBlockBuilder implements BooleanB
             for (int p = 0; p < positionCount; p++) {
                 int count = block.getValueCount(p);
                 int i = block.getFirstValueIndex(p);
-                for (int v = 0; v < count; v++) {
-                    appendBoolean(block.getBoolean(i++));
+                for (int v = 0; v < count; v++, i++) {
+                    appendBoolean(block.getBoolean(i));
                 }
             }
         }
@@ -158,8 +158,8 @@ final class BooleanBlockBuilder extends AbstractBlockBuilder implements BooleanB
                 beginPositionEntry();
             }
             int i = block.getFirstValueIndex(p);
-            for (int v = 0; v < count; v++) {
-                appendBoolean(block.getBoolean(i++));
+            for (int v = 0; v < count; v++, i++) {
+                appendBoolean(block.getBoolean(i));
             }
             if (count > 1) {
                 endPositionEntry();
@@ -187,8 +187,8 @@ final class BooleanBlockBuilder extends AbstractBlockBuilder implements BooleanB
             if (hasNonNullValue && positionCount == 1 && valueCount == 1) {
                 theBlock = blockFactory.newConstantBooleanBlockWith(values[0], 1, estimatedBytes);
             } else {
-                if (values.length - valueCount > 1024 || valueCount < (values.length / 2)) {
-                    values = Arrays.copyOf(values, valueCount);
+                if (valuesLength() - valueCount > 1024 || valueCount < (valuesLength() / 2)) {
+                    growValuesArray(valueCount);
                 }
                 if (isDense() && singleValued()) {
                     theBlock = blockFactory.newBooleanArrayVector(values, positionCount, estimatedBytes).asBlock();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVector.java
@@ -13,7 +13,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import java.io.IOException;
 
 /**
- * Vector that stores boolean values.
+ * Vector that stores Boolean values.
  * This class is generated. Do not edit it.
  */
 public sealed interface BooleanVector extends Vector permits ConstantBooleanVector, BooleanArrayVector, BooleanBigArrayVector,

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVectorBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVectorBuilder.java
@@ -54,8 +54,8 @@ final class BooleanVectorBuilder extends AbstractVectorBuilder implements Boolea
         if (valueCount == 1) {
             vector = blockFactory.newConstantBooleanBlockWith(values[0], 1, estimatedBytes).asVector();
         } else {
-            if (values.length - valueCount > 1024 || valueCount < (values.length / 2)) {
-                values = Arrays.copyOf(values, valueCount);
+            if (valuesLength() - valueCount > 1024 || valueCount < (valuesLength() / 2)) {
+                growValuesArray(valueCount);
             }
             vector = blockFactory.newBooleanArrayVector(values, valueCount, estimatedBytes);
         }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVectorFixedBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVectorFixedBuilder.java
@@ -46,20 +46,24 @@ final class BooleanVectorFixedBuilder implements BooleanVector.FixedBuilder {
             );
     }
 
+    private int valuesLength() {
+        return values.length;
+    }
+
     @Override
     public BooleanVector build() {
         if (nextIndex < 0) {
             throw new IllegalStateException("already closed");
         }
-        if (nextIndex != values.length) {
-            throw new IllegalStateException("expected to write [" + values.length + "] entries but wrote [" + nextIndex + "]");
+        if (nextIndex != valuesLength()) {
+            throw new IllegalStateException("expected to write [" + valuesLength() + "] entries but wrote [" + nextIndex + "]");
         }
         nextIndex = -1;
         BooleanVector vector;
-        if (values.length == 1) {
+        if (valuesLength() == 1) {
             vector = blockFactory.newConstantBooleanBlockWith(values[0], 1, preAdjustedBytes).asVector();
         } else {
-            vector = blockFactory.newBooleanArrayVector(values, values.length, preAdjustedBytes);
+            vector = blockFactory.newBooleanArrayVector(values, valuesLength(), preAdjustedBytes);
         }
         assert vector.ramBytesUsed() == preAdjustedBytes : "fixed Builders should estimate the exact ram bytes used";
         return vector;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefBlock.java
@@ -241,14 +241,14 @@ public sealed interface BytesRefBlock extends Block permits BytesRefArrayBlock, 
         Builder mvOrdering(Block.MvOrdering mvOrdering);
 
         /**
-         * Appends the all values of the given block into a the current position
+         * Appends the all values of the given block into the current position
          * in this builder.
          */
         @Override
         Builder appendAllValuesToCurrentPosition(Block block);
 
         /**
-         * Appends the all values of the given block into a the current position
+         * Appends the all values of the given block into the current position
          * in this builder.
          */
         Builder appendAllValuesToCurrentPosition(BytesRefBlock block);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefBlockBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefBlockBuilder.java
@@ -117,8 +117,8 @@ final class BytesRefBlockBuilder extends AbstractBlockBuilder implements BytesRe
             for (int p = 0; p < positionCount; p++) {
                 int count = block.getValueCount(p);
                 int i = block.getFirstValueIndex(p);
-                for (int v = 0; v < count; v++) {
-                    appendBytesRef(block.getBytesRef(i++, scratch));
+                for (int v = 0; v < count; v++, i++) {
+                    appendBytesRef(block.getBytesRef(i, scratch));
                 }
             }
         }
@@ -168,8 +168,8 @@ final class BytesRefBlockBuilder extends AbstractBlockBuilder implements BytesRe
                 beginPositionEntry();
             }
             int i = block.getFirstValueIndex(p);
-            for (int v = 0; v < count; v++) {
-                appendBytesRef(block.getBytesRef(i++, scratch));
+            for (int v = 0; v < count; v++, i++) {
+                appendBytesRef(block.getBytesRef(i, scratch));
             }
             if (count > 1) {
                 endPositionEntry();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVectorBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVectorBuilder.java
@@ -11,7 +11,6 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BytesRefArray;
 import org.elasticsearch.core.Releasables;
-
 /**
  * Builder for {@link BytesRefVector}s that grows as needed.
  * This class is generated. Do not edit it.

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVectorBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVectorBuilder.java
@@ -11,6 +11,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BytesRefArray;
 import org.elasticsearch.core.Releasables;
+
 /**
  * Builder for {@link BytesRefVector}s that grows as needed.
  * This class is generated. Do not edit it.

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantPointVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantPointVector.java
@@ -7,8 +7,8 @@
 
 package org.elasticsearch.compute.data;
 
-import org.elasticsearch.common.geo.SpatialPoint;
 import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.geo.SpatialPoint;
 
 /**
  * Vector implementation that stores a constant SpatialPoint value.

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantPointVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantPointVector.java
@@ -8,33 +8,37 @@
 package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.RamUsageEstimator;
-import org.elasticsearch.common.geo.SpatialPoint;
 
 /**
- * Vector implementation that stores a constant SpatialPoint value.
+ * Vector implementation that stores a constant double value.
  * This class is generated. Do not edit it.
  */
 public final class ConstantPointVector extends AbstractVector implements PointVector {
 
     static final long RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(ConstantPointVector.class);
 
-    private final SpatialPoint value;
-
+    private final double x, y;
     private final PointBlock block;
 
-    public ConstantPointVector(SpatialPoint value, int positionCount) {
-        this(value, positionCount, BlockFactory.getNonBreakingInstance());
+    public ConstantPointVector(double x, double y, int positionCount) {
+        this(x, y, positionCount, BlockFactory.getNonBreakingInstance());
     }
 
-    public ConstantPointVector(SpatialPoint value, int positionCount, BlockFactory blockFactory) {
+    public ConstantPointVector(double x, double y, int positionCount, BlockFactory blockFactory) {
         super(positionCount, blockFactory);
-        this.value = value;
+        this.x = x;
+        this.y = y;
         this.block = new PointVectorBlock(this);
     }
 
     @Override
-    public SpatialPoint getPoint(int position) {
-        return value;
+    public double getX(int position) {
+        return x;
+    }
+
+    @Override
+    public double getY(int position) {
+        return y;
     }
 
     @Override
@@ -44,7 +48,7 @@ public final class ConstantPointVector extends AbstractVector implements PointVe
 
     @Override
     public PointVector filter(int... positions) {
-        return new ConstantPointVector(value, positions.length);
+        return new ConstantPointVector(x, y, positions.length);
     }
 
     @Override
@@ -76,7 +80,7 @@ public final class ConstantPointVector extends AbstractVector implements PointVe
     }
 
     public String toString() {
-        return getClass().getSimpleName() + "[positions=" + getPositionCount() + ", value=" + value + ']';
+        return getClass().getSimpleName() + "[positions=" + getPositionCount() + ", x=" + x + ", y=" + y + ']';
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantPointVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantPointVector.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data;
+
+import org.elasticsearch.common.geo.SpatialPoint;
+import org.apache.lucene.util.RamUsageEstimator;
+
+/**
+ * Vector implementation that stores a constant SpatialPoint value.
+ * This class is generated. Do not edit it.
+ */
+public final class ConstantPointVector extends AbstractVector implements PointVector {
+
+    static final long RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(ConstantPointVector.class);
+
+    private final SpatialPoint value;
+
+    private final PointBlock block;
+
+    public ConstantPointVector(SpatialPoint value, int positionCount) {
+        this(value, positionCount, BlockFactory.getNonBreakingInstance());
+    }
+
+    public ConstantPointVector(SpatialPoint value, int positionCount, BlockFactory blockFactory) {
+        super(positionCount, blockFactory);
+        this.value = value;
+        this.block = new PointVectorBlock(this);
+    }
+
+    @Override
+    public SpatialPoint getPoint(int position) {
+        return value;
+    }
+
+    @Override
+    public PointBlock asBlock() {
+        return block;
+    }
+
+    @Override
+    public PointVector filter(int... positions) {
+        return new ConstantPointVector(value, positions.length);
+    }
+
+    @Override
+    public ElementType elementType() {
+        return ElementType.POINT;
+    }
+
+    @Override
+    public boolean isConstant() {
+        return true;
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return RAM_BYTES_USED;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof PointVector that) {
+            return PointVector.equals(this, that);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return PointVector.hash(this);
+    }
+
+    public String toString() {
+        return getClass().getSimpleName() + "[positions=" + getPositionCount() + ", value=" + value + ']';
+    }
+
+    @Override
+    public void close() {
+        if (released) {
+            throw new IllegalStateException("can't release already released vector [" + this + "]");
+        }
+        released = true;
+        blockFactory().adjustBreaker(-ramBytesUsed(), true);
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayVector.java
@@ -12,7 +12,7 @@ import org.apache.lucene.util.RamUsageEstimator;
 import java.util.Arrays;
 
 /**
- * Vector implementation that stores an array of double values.
+ * Vector implementation that stores an array of Double values.
  * This class is generated. Do not edit it.
  */
 public final class DoubleArrayVector extends AbstractVector implements DoubleVector {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBigArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBigArrayVector.java
@@ -61,7 +61,7 @@ public final class DoubleBigArrayVector extends AbstractVector implements Double
     @Override
     public DoubleVector filter(int... positions) {
         var blockFactory = blockFactory();
-        final DoubleArray filtered = blockFactory.bigArrays().newDoubleArray(positions.length, true);
+        final DoubleArray filtered = blockFactory.bigArrays().newDoubleArray(positions.length);
         for (int i = 0; i < positions.length; i++) {
             filtered.set(i, values.get(positions[i]));
         }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBlock.java
@@ -15,7 +15,7 @@ import org.elasticsearch.index.mapper.BlockLoader;
 import java.io.IOException;
 
 /**
- * Block that stores double values.
+ * Block that stores Double values.
  * This class is generated. Do not edit it.
  */
 public sealed interface DoubleBlock extends Block permits DoubleArrayBlock, DoubleVectorBlock, ConstantNullBlock {
@@ -237,14 +237,14 @@ public sealed interface DoubleBlock extends Block permits DoubleArrayBlock, Doub
         Builder mvOrdering(Block.MvOrdering mvOrdering);
 
         /**
-         * Appends the all values of the given block into a the current position
+         * Appends the all values of the given block into the current position
          * in this builder.
          */
         @Override
         Builder appendAllValuesToCurrentPosition(Block block);
 
         /**
-         * Appends the all values of the given block into a the current position
+         * Appends the all values of the given block into the current position
          * in this builder.
          */
         Builder appendAllValuesToCurrentPosition(DoubleBlock block);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBlockBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBlockBuilder.java
@@ -108,8 +108,8 @@ final class DoubleBlockBuilder extends AbstractBlockBuilder implements DoubleBlo
             for (int p = 0; p < positionCount; p++) {
                 int count = block.getValueCount(p);
                 int i = block.getFirstValueIndex(p);
-                for (int v = 0; v < count; v++) {
-                    appendDouble(block.getDouble(i++));
+                for (int v = 0; v < count; v++, i++) {
+                    appendDouble(block.getDouble(i));
                 }
             }
         }
@@ -158,8 +158,8 @@ final class DoubleBlockBuilder extends AbstractBlockBuilder implements DoubleBlo
                 beginPositionEntry();
             }
             int i = block.getFirstValueIndex(p);
-            for (int v = 0; v < count; v++) {
-                appendDouble(block.getDouble(i++));
+            for (int v = 0; v < count; v++, i++) {
+                appendDouble(block.getDouble(i));
             }
             if (count > 1) {
                 endPositionEntry();
@@ -187,8 +187,8 @@ final class DoubleBlockBuilder extends AbstractBlockBuilder implements DoubleBlo
             if (hasNonNullValue && positionCount == 1 && valueCount == 1) {
                 theBlock = blockFactory.newConstantDoubleBlockWith(values[0], 1, estimatedBytes);
             } else {
-                if (values.length - valueCount > 1024 || valueCount < (values.length / 2)) {
-                    values = Arrays.copyOf(values, valueCount);
+                if (valuesLength() - valueCount > 1024 || valueCount < (valuesLength() / 2)) {
+                    growValuesArray(valueCount);
                 }
                 if (isDense() && singleValued()) {
                     theBlock = blockFactory.newDoubleArrayVector(values, positionCount, estimatedBytes).asBlock();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleVector.java
@@ -13,7 +13,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import java.io.IOException;
 
 /**
- * Vector that stores double values.
+ * Vector that stores Double values.
  * This class is generated. Do not edit it.
  */
 public sealed interface DoubleVector extends Vector permits ConstantDoubleVector, DoubleArrayVector, DoubleBigArrayVector,

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleVectorBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleVectorBuilder.java
@@ -54,8 +54,8 @@ final class DoubleVectorBuilder extends AbstractVectorBuilder implements DoubleV
         if (valueCount == 1) {
             vector = blockFactory.newConstantDoubleBlockWith(values[0], 1, estimatedBytes).asVector();
         } else {
-            if (values.length - valueCount > 1024 || valueCount < (values.length / 2)) {
-                values = Arrays.copyOf(values, valueCount);
+            if (valuesLength() - valueCount > 1024 || valueCount < (valuesLength() / 2)) {
+                growValuesArray(valueCount);
             }
             vector = blockFactory.newDoubleArrayVector(values, valueCount, estimatedBytes);
         }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleVectorFixedBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleVectorFixedBuilder.java
@@ -46,20 +46,24 @@ final class DoubleVectorFixedBuilder implements DoubleVector.FixedBuilder {
             );
     }
 
+    private int valuesLength() {
+        return values.length;
+    }
+
     @Override
     public DoubleVector build() {
         if (nextIndex < 0) {
             throw new IllegalStateException("already closed");
         }
-        if (nextIndex != values.length) {
-            throw new IllegalStateException("expected to write [" + values.length + "] entries but wrote [" + nextIndex + "]");
+        if (nextIndex != valuesLength()) {
+            throw new IllegalStateException("expected to write [" + valuesLength() + "] entries but wrote [" + nextIndex + "]");
         }
         nextIndex = -1;
         DoubleVector vector;
-        if (values.length == 1) {
+        if (valuesLength() == 1) {
             vector = blockFactory.newConstantDoubleBlockWith(values[0], 1, preAdjustedBytes).asVector();
         } else {
-            vector = blockFactory.newDoubleArrayVector(values, values.length, preAdjustedBytes);
+            vector = blockFactory.newDoubleArrayVector(values, valuesLength(), preAdjustedBytes);
         }
         assert vector.ramBytesUsed() == preAdjustedBytes : "fixed Builders should estimate the exact ram bytes used";
         return vector;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayVector.java
@@ -12,7 +12,7 @@ import org.apache.lucene.util.RamUsageEstimator;
 import java.util.Arrays;
 
 /**
- * Vector implementation that stores an array of int values.
+ * Vector implementation that stores an array of Int values.
  * This class is generated. Do not edit it.
  */
 public final class IntArrayVector extends AbstractVector implements IntVector {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBigArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBigArrayVector.java
@@ -61,7 +61,7 @@ public final class IntBigArrayVector extends AbstractVector implements IntVector
     @Override
     public IntVector filter(int... positions) {
         var blockFactory = blockFactory();
-        final IntArray filtered = blockFactory.bigArrays().newIntArray(positions.length, true);
+        final IntArray filtered = blockFactory.bigArrays().newIntArray(positions.length);
         for (int i = 0; i < positions.length; i++) {
             filtered.set(i, values.get(positions[i]));
         }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBlock.java
@@ -15,7 +15,7 @@ import org.elasticsearch.index.mapper.BlockLoader;
 import java.io.IOException;
 
 /**
- * Block that stores int values.
+ * Block that stores Int values.
  * This class is generated. Do not edit it.
  */
 public sealed interface IntBlock extends Block permits IntArrayBlock, IntVectorBlock, ConstantNullBlock {
@@ -236,14 +236,14 @@ public sealed interface IntBlock extends Block permits IntArrayBlock, IntVectorB
         Builder mvOrdering(Block.MvOrdering mvOrdering);
 
         /**
-         * Appends the all values of the given block into a the current position
+         * Appends the all values of the given block into the current position
          * in this builder.
          */
         @Override
         Builder appendAllValuesToCurrentPosition(Block block);
 
         /**
-         * Appends the all values of the given block into a the current position
+         * Appends the all values of the given block into the current position
          * in this builder.
          */
         Builder appendAllValuesToCurrentPosition(IntBlock block);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBlockBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBlockBuilder.java
@@ -108,8 +108,8 @@ final class IntBlockBuilder extends AbstractBlockBuilder implements IntBlock.Bui
             for (int p = 0; p < positionCount; p++) {
                 int count = block.getValueCount(p);
                 int i = block.getFirstValueIndex(p);
-                for (int v = 0; v < count; v++) {
-                    appendInt(block.getInt(i++));
+                for (int v = 0; v < count; v++, i++) {
+                    appendInt(block.getInt(i));
                 }
             }
         }
@@ -158,8 +158,8 @@ final class IntBlockBuilder extends AbstractBlockBuilder implements IntBlock.Bui
                 beginPositionEntry();
             }
             int i = block.getFirstValueIndex(p);
-            for (int v = 0; v < count; v++) {
-                appendInt(block.getInt(i++));
+            for (int v = 0; v < count; v++, i++) {
+                appendInt(block.getInt(i));
             }
             if (count > 1) {
                 endPositionEntry();
@@ -187,8 +187,8 @@ final class IntBlockBuilder extends AbstractBlockBuilder implements IntBlock.Bui
             if (hasNonNullValue && positionCount == 1 && valueCount == 1) {
                 theBlock = blockFactory.newConstantIntBlockWith(values[0], 1, estimatedBytes);
             } else {
-                if (values.length - valueCount > 1024 || valueCount < (values.length / 2)) {
-                    values = Arrays.copyOf(values, valueCount);
+                if (valuesLength() - valueCount > 1024 || valueCount < (valuesLength() / 2)) {
+                    growValuesArray(valueCount);
                 }
                 if (isDense() && singleValued()) {
                     theBlock = blockFactory.newIntArrayVector(values, positionCount, estimatedBytes).asBlock();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVector.java
@@ -13,7 +13,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import java.io.IOException;
 
 /**
- * Vector that stores int values.
+ * Vector that stores Int values.
  * This class is generated. Do not edit it.
  */
 public sealed interface IntVector extends Vector permits ConstantIntVector, IntArrayVector, IntBigArrayVector, ConstantNullVector {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVectorBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVectorBuilder.java
@@ -54,8 +54,8 @@ final class IntVectorBuilder extends AbstractVectorBuilder implements IntVector.
         if (valueCount == 1) {
             vector = blockFactory.newConstantIntBlockWith(values[0], 1, estimatedBytes).asVector();
         } else {
-            if (values.length - valueCount > 1024 || valueCount < (values.length / 2)) {
-                values = Arrays.copyOf(values, valueCount);
+            if (valuesLength() - valueCount > 1024 || valueCount < (valuesLength() / 2)) {
+                growValuesArray(valueCount);
             }
             vector = blockFactory.newIntArrayVector(values, valueCount, estimatedBytes);
         }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVectorFixedBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVectorFixedBuilder.java
@@ -46,20 +46,24 @@ final class IntVectorFixedBuilder implements IntVector.FixedBuilder {
             );
     }
 
+    private int valuesLength() {
+        return values.length;
+    }
+
     @Override
     public IntVector build() {
         if (nextIndex < 0) {
             throw new IllegalStateException("already closed");
         }
-        if (nextIndex != values.length) {
-            throw new IllegalStateException("expected to write [" + values.length + "] entries but wrote [" + nextIndex + "]");
+        if (nextIndex != valuesLength()) {
+            throw new IllegalStateException("expected to write [" + valuesLength() + "] entries but wrote [" + nextIndex + "]");
         }
         nextIndex = -1;
         IntVector vector;
-        if (values.length == 1) {
+        if (valuesLength() == 1) {
             vector = blockFactory.newConstantIntBlockWith(values[0], 1, preAdjustedBytes).asVector();
         } else {
-            vector = blockFactory.newIntArrayVector(values, values.length, preAdjustedBytes);
+            vector = blockFactory.newIntArrayVector(values, valuesLength(), preAdjustedBytes);
         }
         assert vector.ramBytesUsed() == preAdjustedBytes : "fixed Builders should estimate the exact ram bytes used";
         return vector;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayVector.java
@@ -12,7 +12,7 @@ import org.apache.lucene.util.RamUsageEstimator;
 import java.util.Arrays;
 
 /**
- * Vector implementation that stores an array of long values.
+ * Vector implementation that stores an array of Long values.
  * This class is generated. Do not edit it.
  */
 public final class LongArrayVector extends AbstractVector implements LongVector {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBigArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBigArrayVector.java
@@ -61,7 +61,7 @@ public final class LongBigArrayVector extends AbstractVector implements LongVect
     @Override
     public LongVector filter(int... positions) {
         var blockFactory = blockFactory();
-        final LongArray filtered = blockFactory.bigArrays().newLongArray(positions.length, true);
+        final LongArray filtered = blockFactory.bigArrays().newLongArray(positions.length);
         for (int i = 0; i < positions.length; i++) {
             filtered.set(i, values.get(positions[i]));
         }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBlock.java
@@ -15,7 +15,7 @@ import org.elasticsearch.index.mapper.BlockLoader;
 import java.io.IOException;
 
 /**
- * Block that stores long values.
+ * Block that stores Long values.
  * This class is generated. Do not edit it.
  */
 public sealed interface LongBlock extends Block permits LongArrayBlock, LongVectorBlock, ConstantNullBlock {
@@ -237,14 +237,14 @@ public sealed interface LongBlock extends Block permits LongArrayBlock, LongVect
         Builder mvOrdering(Block.MvOrdering mvOrdering);
 
         /**
-         * Appends the all values of the given block into a the current position
+         * Appends the all values of the given block into the current position
          * in this builder.
          */
         @Override
         Builder appendAllValuesToCurrentPosition(Block block);
 
         /**
-         * Appends the all values of the given block into a the current position
+         * Appends the all values of the given block into the current position
          * in this builder.
          */
         Builder appendAllValuesToCurrentPosition(LongBlock block);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBlockBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBlockBuilder.java
@@ -108,8 +108,8 @@ final class LongBlockBuilder extends AbstractBlockBuilder implements LongBlock.B
             for (int p = 0; p < positionCount; p++) {
                 int count = block.getValueCount(p);
                 int i = block.getFirstValueIndex(p);
-                for (int v = 0; v < count; v++) {
-                    appendLong(block.getLong(i++));
+                for (int v = 0; v < count; v++, i++) {
+                    appendLong(block.getLong(i));
                 }
             }
         }
@@ -158,8 +158,8 @@ final class LongBlockBuilder extends AbstractBlockBuilder implements LongBlock.B
                 beginPositionEntry();
             }
             int i = block.getFirstValueIndex(p);
-            for (int v = 0; v < count; v++) {
-                appendLong(block.getLong(i++));
+            for (int v = 0; v < count; v++, i++) {
+                appendLong(block.getLong(i));
             }
             if (count > 1) {
                 endPositionEntry();
@@ -187,8 +187,8 @@ final class LongBlockBuilder extends AbstractBlockBuilder implements LongBlock.B
             if (hasNonNullValue && positionCount == 1 && valueCount == 1) {
                 theBlock = blockFactory.newConstantLongBlockWith(values[0], 1, estimatedBytes);
             } else {
-                if (values.length - valueCount > 1024 || valueCount < (values.length / 2)) {
-                    values = Arrays.copyOf(values, valueCount);
+                if (valuesLength() - valueCount > 1024 || valueCount < (valuesLength() / 2)) {
+                    growValuesArray(valueCount);
                 }
                 if (isDense() && singleValued()) {
                     theBlock = blockFactory.newLongArrayVector(values, positionCount, estimatedBytes).asBlock();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVector.java
@@ -13,7 +13,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import java.io.IOException;
 
 /**
- * Vector that stores long values.
+ * Vector that stores Long values.
  * This class is generated. Do not edit it.
  */
 public sealed interface LongVector extends Vector permits ConstantLongVector, LongArrayVector, LongBigArrayVector, ConstantNullVector {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVectorBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVectorBuilder.java
@@ -54,8 +54,8 @@ final class LongVectorBuilder extends AbstractVectorBuilder implements LongVecto
         if (valueCount == 1) {
             vector = blockFactory.newConstantLongBlockWith(values[0], 1, estimatedBytes).asVector();
         } else {
-            if (values.length - valueCount > 1024 || valueCount < (values.length / 2)) {
-                values = Arrays.copyOf(values, valueCount);
+            if (valuesLength() - valueCount > 1024 || valueCount < (valuesLength() / 2)) {
+                growValuesArray(valueCount);
             }
             vector = blockFactory.newLongArrayVector(values, valueCount, estimatedBytes);
         }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVectorFixedBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVectorFixedBuilder.java
@@ -46,20 +46,24 @@ final class LongVectorFixedBuilder implements LongVector.FixedBuilder {
             );
     }
 
+    private int valuesLength() {
+        return values.length;
+    }
+
     @Override
     public LongVector build() {
         if (nextIndex < 0) {
             throw new IllegalStateException("already closed");
         }
-        if (nextIndex != values.length) {
-            throw new IllegalStateException("expected to write [" + values.length + "] entries but wrote [" + nextIndex + "]");
+        if (nextIndex != valuesLength()) {
+            throw new IllegalStateException("expected to write [" + valuesLength() + "] entries but wrote [" + nextIndex + "]");
         }
         nextIndex = -1;
         LongVector vector;
-        if (values.length == 1) {
+        if (valuesLength() == 1) {
             vector = blockFactory.newConstantLongBlockWith(values[0], 1, preAdjustedBytes).asVector();
         } else {
-            vector = blockFactory.newLongArrayVector(values, values.length, preAdjustedBytes);
+            vector = blockFactory.newLongArrayVector(values, valuesLength(), preAdjustedBytes);
         }
         assert vector.ramBytesUsed() == preAdjustedBytes : "fixed Builders should estimate the exact ram bytes used";
         return vector;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointArrayBlock.java
@@ -7,8 +7,8 @@
 
 package org.elasticsearch.compute.data;
 
-import org.elasticsearch.common.geo.SpatialPoint;
 import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.geo.SpatialPoint;
 
 import java.util.Arrays;
 import java.util.BitSet;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointArrayBlock.java
@@ -14,6 +14,8 @@ import java.util.Arrays;
 import java.util.BitSet;
 
 import static org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_ARRAY_HEADER;
+import static org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF;
+import static org.apache.lucene.util.RamUsageEstimator.alignObjectSize;
 
 /**
  * Block implementation that stores an array of SpatialPoint.
@@ -104,9 +106,9 @@ public final class PointArrayBlock extends AbstractArrayBlock implements PointBl
     }
 
     public static long ramBytesEstimated(SpatialPoint[] values, int[] firstValueIndexes, BitSet nullsMask) {
-        long valuesEstimate = RamUsageEstimator.alignObjectSize((long) NUM_BYTES_ARRAY_HEADER + (long) Long.BYTES * values.length * 2);
-        return BASE_RAM_BYTES_USED + valuesEstimate + BlockRamUsageEstimator.sizeOf(firstValueIndexes) + BlockRamUsageEstimator
-            .sizeOfBitSet(nullsMask);
+        long valuesEstimate = (long) NUM_BYTES_ARRAY_HEADER + ((long) Long.BYTES * 2 + (long) NUM_BYTES_OBJECT_REF) * values.length;
+        return BASE_RAM_BYTES_USED + alignObjectSize(valuesEstimate) + BlockRamUsageEstimator.sizeOf(firstValueIndexes)
+            + BlockRamUsageEstimator.sizeOfBitSet(nullsMask);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointArrayVector.java
@@ -7,12 +7,13 @@
 
 package org.elasticsearch.compute.data;
 
-import org.elasticsearch.common.geo.SpatialPoint;
 import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.geo.SpatialPoint;
 
 import java.util.Arrays;
 
 import static org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_ARRAY_HEADER;
+
 /**
  * Vector implementation that stores an array of SpatialPoint values.
  * This class is generated. Do not edit it.

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointArrayVector.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data;
+
+import org.elasticsearch.common.geo.SpatialPoint;
+import org.apache.lucene.util.RamUsageEstimator;
+
+import java.util.Arrays;
+
+import static org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_ARRAY_HEADER;
+/**
+ * Vector implementation that stores an array of SpatialPoint values.
+ * This class is generated. Do not edit it.
+ */
+public final class PointArrayVector extends AbstractVector implements PointVector {
+
+    static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(PointArrayVector.class);
+
+    private final SpatialPoint[] values;
+
+    private final PointBlock block;
+
+    public PointArrayVector(SpatialPoint[] values, int positionCount) {
+        this(values, positionCount, BlockFactory.getNonBreakingInstance());
+    }
+
+    public PointArrayVector(SpatialPoint[] values, int positionCount, BlockFactory blockFactory) {
+        super(positionCount, blockFactory);
+        this.values = values;
+        this.block = new PointVectorBlock(this);
+    }
+
+    @Override
+    public PointBlock asBlock() {
+        return block;
+    }
+
+    @Override
+    public SpatialPoint getPoint(int position) {
+        return values[position];
+    }
+
+    @Override
+    public ElementType elementType() {
+        return ElementType.POINT;
+    }
+
+    @Override
+    public boolean isConstant() {
+        return false;
+    }
+
+    @Override
+    public PointVector filter(int... positions) {
+        try (PointVector.Builder builder = blockFactory().newPointVectorBuilder(positions.length)) {
+            for (int pos : positions) {
+                builder.appendPoint(values[pos]);
+            }
+            return builder.build();
+        }
+    }
+
+    public static long ramBytesEstimated(SpatialPoint[] values) {
+        long valuesEstimate = RamUsageEstimator.alignObjectSize((long) NUM_BYTES_ARRAY_HEADER + (long) Long.BYTES * values.length * 2);
+        return BASE_RAM_BYTES_USED + valuesEstimate;
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return ramBytesEstimated(values);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof PointVector that) {
+            return PointVector.equals(this, that);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return PointVector.hash(this);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "[positions=" + getPositionCount() + ", values=" + Arrays.toString(values) + ']';
+    }
+
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointArrayVector.java
@@ -13,6 +13,8 @@ import org.elasticsearch.common.geo.SpatialPoint;
 import java.util.Arrays;
 
 import static org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_ARRAY_HEADER;
+import static org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF;
+import static org.apache.lucene.util.RamUsageEstimator.alignObjectSize;
 
 /**
  * Vector implementation that stores an array of SpatialPoint values.
@@ -67,8 +69,8 @@ public final class PointArrayVector extends AbstractVector implements PointVecto
     }
 
     public static long ramBytesEstimated(SpatialPoint[] values) {
-        long valuesEstimate = RamUsageEstimator.alignObjectSize((long) NUM_BYTES_ARRAY_HEADER + (long) Long.BYTES * values.length * 2);
-        return BASE_RAM_BYTES_USED + valuesEstimate;
+        long valuesEstimate = (long) NUM_BYTES_ARRAY_HEADER + ((long) Long.BYTES * 2 + (long) NUM_BYTES_OBJECT_REF) * values.length;
+        return BASE_RAM_BYTES_USED + alignObjectSize(valuesEstimate);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointBigArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointBigArrayVector.java
@@ -8,49 +8,45 @@
 package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.RamUsageEstimator;
-$if(Point)$
 import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.common.util.ObjectArray;
-$else$
-import org.elasticsearch.common.util.$Array$;
-$endif$
 import org.elasticsearch.core.Releasable;
 
 /**
- * Vector implementation that defers to an enclosed $Type$Array.
+ * Vector implementation that defers to an enclosed PointArray.
  * This class is generated. Do not edit it.
  */
-public final class $Type$BigArrayVector extends AbstractVector implements $Type$Vector, Releasable {
+public final class PointBigArrayVector extends AbstractVector implements PointVector, Releasable {
 
-    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance($Type$BigArrayVector.class);
+    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(PointBigArrayVector.class);
 
-    private final $Array$ values;
+    private final ObjectArray<SpatialPoint> values;
 
-    private final $Type$Block block;
+    private final PointBlock block;
 
-    public $Type$BigArrayVector($Array$ values, int positionCount) {
+    public PointBigArrayVector(ObjectArray<SpatialPoint> values, int positionCount) {
         this(values, positionCount, BlockFactory.getNonBreakingInstance());
     }
 
-    public $Type$BigArrayVector($Array$ values, int positionCount, BlockFactory blockFactory) {
+    public PointBigArrayVector(ObjectArray<SpatialPoint> values, int positionCount, BlockFactory blockFactory) {
         super(positionCount, blockFactory);
         this.values = values;
-        this.block = new $Type$VectorBlock(this);
+        this.block = new PointVectorBlock(this);
     }
 
     @Override
-    public $Type$Block asBlock() {
+    public PointBlock asBlock() {
         return block;
     }
 
     @Override
-    public $type$ get$Type$(int position) {
+    public SpatialPoint getPoint(int position) {
         return values.get(position);
     }
 
     @Override
     public ElementType elementType() {
-        return ElementType.$TYPE$;
+        return ElementType.POINT;
     }
 
     @Override
@@ -64,27 +60,13 @@ public final class $Type$BigArrayVector extends AbstractVector implements $Type$
     }
 
     @Override
-    public $Type$Vector filter(int... positions) {
+    public PointVector filter(int... positions) {
         var blockFactory = blockFactory();
-    $if(boolean)$
-        final BitArray filtered = new BitArray(positions.length, blockFactory.bigArrays());
-    $elseif(Point)$
-        final $Array$ filtered = blockFactory.bigArrays().newObjectArray(positions.length);
-    $else$
-        final $Array$ filtered = blockFactory.bigArrays().new$Array$(positions.length);
-    $endif$
-    $if(boolean)$
-        for (int i = 0; i < positions.length; i++) {
-            if (values.get(positions[i])) {
-                filtered.set(i);
-            }
-        }
-    $else$
+        final ObjectArray<SpatialPoint> filtered = blockFactory.bigArrays().newObjectArray(positions.length);
         for (int i = 0; i < positions.length; i++) {
             filtered.set(i, values.get(positions[i]));
         }
-    $endif$
-        return new $Type$BigArrayVector(filtered, positions.length, blockFactory);
+        return new PointBigArrayVector(filtered, positions.length, blockFactory);
     }
 
     @Override
@@ -98,15 +80,15 @@ public final class $Type$BigArrayVector extends AbstractVector implements $Type$
 
     @Override
     public boolean equals(Object obj) {
-        if (obj instanceof $Type$Vector that) {
-            return $Type$Vector.equals(this, that);
+        if (obj instanceof PointVector that) {
+            return PointVector.equals(this, that);
         }
         return false;
     }
 
     @Override
     public int hashCode() {
-        return $Type$Vector.hash(this);
+        return PointVector.hash(this);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointBlock.java
@@ -63,7 +63,7 @@ public sealed interface PointBlock extends Block permits PointArrayBlock, PointV
                     final int valueCount = in.readVInt();
                     builder.beginPositionEntry();
                     for (int valueIndex = 0; valueIndex < valueCount; valueIndex++) {
-                        builder.appendPoint(in.readPoint());
+                        builder.appendPoint(new SpatialPoint(in.readDouble(), in.readDouble()));
                     }
                     builder.endPositionEntry();
                 }
@@ -89,7 +89,9 @@ public sealed interface PointBlock extends Block permits PointArrayBlock, PointV
                     final int valueCount = getValueCount(pos);
                     out.writeVInt(valueCount);
                     for (int valueIndex = 0; valueIndex < valueCount; valueIndex++) {
-                        out.writePoint(getPoint(getFirstValueIndex(pos) + valueIndex));
+                        SpatialPoint point = getPoint(getFirstValueIndex(pos) + valueIndex);
+                        out.writeDouble(point.getX());
+                        out.writeDouble(point.getY());
                     }
                 }
             }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointBlock.java
@@ -63,8 +63,7 @@ public sealed interface PointBlock extends Block permits PointArrayBlock, PointV
                     final int valueCount = in.readVInt();
                     builder.beginPositionEntry();
                     for (int valueIndex = 0; valueIndex < valueCount; valueIndex++) {
-                        SpatialPoint element = new SpatialPoint(in.readDouble(), in.readDouble());
-                        builder.appendPoint(element);
+                        builder.appendPoint(in.readPoint());
                     }
                     builder.endPositionEntry();
                 }
@@ -90,9 +89,7 @@ public sealed interface PointBlock extends Block permits PointArrayBlock, PointV
                     final int valueCount = getValueCount(pos);
                     out.writeVInt(valueCount);
                     for (int valueIndex = 0; valueIndex < valueCount; valueIndex++) {
-                        SpatialPoint element = getPoint(getFirstValueIndex(pos) + valueIndex);
-                        out.writeDouble(element.getX());
-                        out.writeDouble(element.getY());
+                        out.writePoint(getPoint(getFirstValueIndex(pos) + valueIndex));
                     }
                 }
             }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointBlock.java
@@ -137,8 +137,7 @@ public sealed interface PointBlock extends Block permits PointArrayBlock, PointV
                 final int b1ValueIdx = block1.getFirstValueIndex(pos);
                 final int b2ValueIdx = block2.getFirstValueIndex(pos);
                 for (int valueIndex = 0; valueIndex < valueCount; valueIndex++) {
-                    if (block1.getPoint(b1ValueIdx + valueIndex)
-                        .equals(block2.getPoint(b2ValueIdx + valueIndex)) == false) {
+                    if (block1.getPoint(b1ValueIdx + valueIndex).equals(block2.getPoint(b2ValueIdx + valueIndex)) == false) {
                         return false;
                     }
                 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointBlock.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.mapper.BlockLoader;
+
+import java.io.IOException;
+
+/**
+ * Block that stores SpatialPoint values.
+ * This class is generated. Do not edit it.
+ */
+public sealed interface PointBlock extends Block permits BytesRefArrayBlock, BytesRefVectorBlock, ConstantNullBlock {
+
+    BytesRef NULL_VALUE = new BytesRef();
+
+    /**
+     * Retrieves the BytesRef value stored at the given value index.
+     *
+     * <p> Values for a given position are between getFirstValueIndex(position) (inclusive) and
+     * getFirstValueIndex(position) + getValueCount(position) (exclusive).
+     *
+     * @param valueIndex the value index
+     * @param dest the destination
+     * @return the data value (as a BytesRef)
+     */
+    BytesRef getBytesRef(int valueIndex, BytesRef dest);
+
+    @Override
+    BytesRefVector asVector();
+
+    @Override
+    PointBlock filter(int... positions);
+
+    @Override
+    default String getWriteableName() {
+        return "BytesRefBlock";
+    }
+
+    NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Block.class, "BytesRefBlock", PointBlock::readFrom);
+
+    private static PointBlock readFrom(StreamInput in) throws IOException {
+        return readFrom((BlockStreamInput) in);
+    }
+
+    private static PointBlock readFrom(BlockStreamInput in) throws IOException {
+        final boolean isVector = in.readBoolean();
+        if (isVector) {
+            return BytesRefVector.readFrom(in.blockFactory(), in).asBlock();
+        }
+        final int positions = in.readVInt();
+        try (PointBlock.Builder builder = in.blockFactory().newBytesRefBlockBuilder(positions)) {
+            for (int i = 0; i < positions; i++) {
+                if (in.readBoolean()) {
+                    builder.appendNull();
+                } else {
+                    final int valueCount = in.readVInt();
+                    builder.beginPositionEntry();
+                    for (int valueIndex = 0; valueIndex < valueCount; valueIndex++) {
+                        builder.appendBytesRef(in.readBytesRef());
+                    }
+                    builder.endPositionEntry();
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    @Override
+    default void writeTo(StreamOutput out) throws IOException {
+        BytesRefVector vector = asVector();
+        out.writeBoolean(vector != null);
+        if (vector != null) {
+            vector.writeTo(out);
+        } else {
+            final int positions = getPositionCount();
+            out.writeVInt(positions);
+            for (int pos = 0; pos < positions; pos++) {
+                if (isNull(pos)) {
+                    out.writeBoolean(true);
+                } else {
+                    out.writeBoolean(false);
+                    final int valueCount = getValueCount(pos);
+                    out.writeVInt(valueCount);
+                    for (int valueIndex = 0; valueIndex < valueCount; valueIndex++) {
+                        out.writeBytesRef(getBytesRef(getFirstValueIndex(pos) + valueIndex, new BytesRef()));
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Compares the given object with this block for equality. Returns {@code true} if and only if the
+     * given object is a BytesRefBlock, and both blocks are {@link #equals(PointBlock, PointBlock) equal}.
+     */
+    @Override
+    boolean equals(Object obj);
+
+    /** Returns the hash code of this block, as defined by {@link #hash(PointBlock)}. */
+    @Override
+    int hashCode();
+
+    /**
+     * Returns {@code true} if the given blocks are equal to each other, otherwise {@code false}.
+     * Two blocks are considered equal if they have the same position count, and contain the same
+     * values (including absent null values) in the same order. This definition ensures that the
+     * equals method works properly across different implementations of the BytesRefBlock interface.
+     */
+    static boolean equals(PointBlock block1, PointBlock block2) {
+        if (block1 == block2) {
+            return true;
+        }
+        final int positions = block1.getPositionCount();
+        if (positions != block2.getPositionCount()) {
+            return false;
+        }
+        for (int pos = 0; pos < positions; pos++) {
+            if (block1.isNull(pos) || block2.isNull(pos)) {
+                if (block1.isNull(pos) != block2.isNull(pos)) {
+                    return false;
+                }
+            } else {
+                final int valueCount = block1.getValueCount(pos);
+                if (valueCount != block2.getValueCount(pos)) {
+                    return false;
+                }
+                final int b1ValueIdx = block1.getFirstValueIndex(pos);
+                final int b2ValueIdx = block2.getFirstValueIndex(pos);
+                for (int valueIndex = 0; valueIndex < valueCount; valueIndex++) {
+                    if (block1.getBytesRef(b1ValueIdx + valueIndex, new BytesRef())
+                        .equals(block2.getBytesRef(b2ValueIdx + valueIndex, new BytesRef())) == false) {
+                        return false;
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Generates the hash code for the given block. The hash code is computed from the block's values.
+     * This ensures that {@code block1.equals(block2)} implies that {@code block1.hashCode()==block2.hashCode()}
+     * for any two blocks, {@code block1} and {@code block2}, as required by the general contract of
+     * {@link Object#hashCode}.
+     */
+    static int hash(PointBlock block) {
+        final int positions = block.getPositionCount();
+        int result = 1;
+        for (int pos = 0; pos < positions; pos++) {
+            if (block.isNull(pos)) {
+                result = 31 * result - 1;
+            } else {
+                final int valueCount = block.getValueCount(pos);
+                result = 31 * result + valueCount;
+                final int firstValueIdx = block.getFirstValueIndex(pos);
+                for (int valueIndex = 0; valueIndex < valueCount; valueIndex++) {
+                    result = 31 * result + block.getBytesRef(firstValueIdx + valueIndex, new BytesRef()).hashCode();
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Returns a builder using the {@link BlockFactory#getNonBreakingInstance non-breaking block factory}.
+     * @deprecated use {@link BlockFactory#newBytesRefBlockBuilder}
+     */
+    // Eventually, we want to remove this entirely, always passing an explicit BlockFactory
+    @Deprecated
+    static Builder newBlockBuilder(int estimatedSize) {
+        return newBlockBuilder(estimatedSize, BlockFactory.getNonBreakingInstance());
+    }
+
+    /**
+     * Returns a builder.
+     * @deprecated use {@link BlockFactory#newBytesRefBlockBuilder}
+     */
+    @Deprecated
+    static Builder newBlockBuilder(int estimatedSize, BlockFactory blockFactory) {
+        return blockFactory.newBytesRefBlockBuilder(estimatedSize);
+    }
+
+    /**
+     * Returns a constant block built by the {@link BlockFactory#getNonBreakingInstance non-breaking block factory}.
+     * @deprecated use {@link BlockFactory#newConstantBytesRefBlockWith}
+     */
+    // Eventually, we want to remove this entirely, always passing an explicit BlockFactory
+    @Deprecated
+    static PointBlock newConstantBlockWith(BytesRef value, int positions) {
+        return newConstantBlockWith(value, positions, BlockFactory.getNonBreakingInstance());
+    }
+
+    /**
+     * Returns a constant block.
+     * @deprecated use {@link BlockFactory#newConstantBytesRefBlockWith}
+     */
+    @Deprecated
+    static PointBlock newConstantBlockWith(BytesRef value, int positions, BlockFactory blockFactory) {
+        return blockFactory.newConstantBytesRefBlockWith(value, positions);
+    }
+
+    /**
+     * Builder for {@link PointBlock}
+     */
+    sealed interface Builder extends Block.Builder, BlockLoader.BytesRefBuilder permits BytesRefBlockBuilder {
+        /**
+         * Appends a BytesRef to the current entry.
+         */
+        @Override
+        Builder appendBytesRef(BytesRef value);
+
+        /**
+         * Copy the values in {@code block} from {@code beginInclusive} to
+         * {@code endExclusive} into this builder.
+         */
+        Builder copyFrom(PointBlock block, int beginInclusive, int endExclusive);
+
+        @Override
+        Builder appendNull();
+
+        @Override
+        Builder beginPositionEntry();
+
+        @Override
+        Builder endPositionEntry();
+
+        @Override
+        Builder copyFrom(Block block, int beginInclusive, int endExclusive);
+
+        @Override
+        Builder mvOrdering(MvOrdering mvOrdering);
+
+        /**
+         * Appends the all values of the given block into a the current position
+         * in this builder.
+         */
+        @Override
+        Builder appendAllValuesToCurrentPosition(Block block);
+
+        /**
+         * Appends the all values of the given block into a the current position
+         * in this builder.
+         */
+        Builder appendAllValuesToCurrentPosition(PointBlock block);
+
+        @Override
+        PointBlock build();
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointBlockBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointBlockBuilder.java
@@ -7,11 +7,12 @@
 
 package org.elasticsearch.compute.data;
 
-import org.elasticsearch.common.geo.SpatialPoint;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.geo.SpatialPoint;
 
 import java.util.Arrays;
+
 /**
  * Block build of PointBlocks.
  * This class is generated. Do not edit it.

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointBlockBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointBlockBuilder.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.BytesRefArray;
+import org.elasticsearch.core.Releasables;
+
+/**
+ * Block build of BytesRefBlocks.
+ * This class is generated. Do not edit it.
+ */
+final class PointBlockBuilder extends AbstractBlockBuilder implements PointBlock.Builder {
+
+    private BytesRefArray values;
+
+    PointBlockBuilder(int estimatedSize, BlockFactory blockFactory) {
+        this(estimatedSize, BigArrays.NON_RECYCLING_INSTANCE, blockFactory);
+    }
+
+    PointBlockBuilder(int estimatedSize, BigArrays bigArrays, BlockFactory blockFactory) {
+        super(blockFactory);
+        values = new BytesRefArray(Math.max(estimatedSize, 2), bigArrays);
+    }
+
+    @Override
+    public PointBlockBuilder appendBytesRef(BytesRef value) {
+        ensureCapacity();
+        values.append(value);
+        hasNonNullValue = true;
+        valueCount++;
+        updatePosition();
+        return this;
+    }
+
+    @Override
+    protected int elementSize() {
+        return -1;
+    }
+
+    @Override
+    protected int valuesLength() {
+        return Integer.MAX_VALUE; // allow the BytesRefArray through its own append
+    }
+
+    @Override
+    protected void growValuesArray(int newSize) {
+        throw new AssertionError("should not reach here");
+    }
+
+    @Override
+    public PointBlockBuilder appendNull() {
+        super.appendNull();
+        return this;
+    }
+
+    @Override
+    public PointBlockBuilder beginPositionEntry() {
+        super.beginPositionEntry();
+        return this;
+    }
+
+    @Override
+    public PointBlockBuilder endPositionEntry() {
+        super.endPositionEntry();
+        return this;
+    }
+
+    @Override
+    protected void writeNullValue() {
+        values.append(BytesRefBlock.NULL_VALUE);
+    }
+
+    /**
+     * Appends the all values of the given block into a the current position
+     * in this builder.
+     */
+    @Override
+    public PointBlockBuilder appendAllValuesToCurrentPosition(Block block) {
+        if (block.areAllValuesNull()) {
+            return appendNull();
+        }
+        return appendAllValuesToCurrentPosition((BytesRefBlock) block);
+    }
+
+    /**
+     * Appends the all values of the given block into a the current position
+     * in this builder.
+     */
+    @Override
+    public PointBlockBuilder appendAllValuesToCurrentPosition(BytesRefBlock block) {
+        final int positionCount = block.getPositionCount();
+        if (positionCount == 0) {
+            return appendNull();
+        }
+        final int totalValueCount = block.getTotalValueCount();
+        if (totalValueCount == 0) {
+            return appendNull();
+        }
+        if (totalValueCount > 1) {
+            beginPositionEntry();
+        }
+        BytesRef scratch = new BytesRef();
+        final BytesRefVector vector = block.asVector();
+        if (vector != null) {
+            for (int p = 0; p < positionCount; p++) {
+                appendBytesRef(vector.getBytesRef(p, scratch));
+            }
+        } else {
+            for (int p = 0; p < positionCount; p++) {
+                int count = block.getValueCount(p);
+                int i = block.getFirstValueIndex(p);
+                for (int v = 0; v < count; v++) {
+                    appendBytesRef(block.getBytesRef(i++, scratch));
+                }
+            }
+        }
+        if (totalValueCount > 1) {
+            endPositionEntry();
+        }
+        return this;
+    }
+
+    @Override
+    public PointBlockBuilder copyFrom(Block block, int beginInclusive, int endExclusive) {
+        if (block.areAllValuesNull()) {
+            for (int p = beginInclusive; p < endExclusive; p++) {
+                appendNull();
+            }
+            return this;
+        }
+        return copyFrom((BytesRefBlock) block, beginInclusive, endExclusive);
+    }
+
+    /**
+     * Copy the values in {@code block} from {@code beginInclusive} to
+     * {@code endExclusive} into this builder.
+     */
+    public PointBlockBuilder copyFrom(BytesRefBlock block, int beginInclusive, int endExclusive) {
+        if (endExclusive > block.getPositionCount()) {
+            throw new IllegalArgumentException("can't copy past the end [" + endExclusive + " > " + block.getPositionCount() + "]");
+        }
+        BytesRefVector vector = block.asVector();
+        if (vector != null) {
+            copyFromVector(vector, beginInclusive, endExclusive);
+        } else {
+            copyFromBlock(block, beginInclusive, endExclusive);
+        }
+        return this;
+    }
+
+    private void copyFromBlock(BytesRefBlock block, int beginInclusive, int endExclusive) {
+        BytesRef scratch = new BytesRef();
+        for (int p = beginInclusive; p < endExclusive; p++) {
+            if (block.isNull(p)) {
+                appendNull();
+                continue;
+            }
+            int count = block.getValueCount(p);
+            if (count > 1) {
+                beginPositionEntry();
+            }
+            int i = block.getFirstValueIndex(p);
+            for (int v = 0; v < count; v++) {
+                appendBytesRef(block.getBytesRef(i++, scratch));
+            }
+            if (count > 1) {
+                endPositionEntry();
+            }
+        }
+    }
+
+    private void copyFromVector(BytesRefVector vector, int beginInclusive, int endExclusive) {
+        BytesRef scratch = new BytesRef();
+        for (int p = beginInclusive; p < endExclusive; p++) {
+            appendBytesRef(vector.getBytesRef(p, scratch));
+        }
+    }
+
+    @Override
+    public PointBlockBuilder mvOrdering(Block.MvOrdering mvOrdering) {
+        this.mvOrdering = mvOrdering;
+        return this;
+    }
+
+    @Override
+    public BytesRefBlock build() {
+        try {
+            finish();
+            BytesRefBlock theBlock;
+            assert estimatedBytes == 0 || firstValueIndexes != null;
+            if (hasNonNullValue && positionCount == 1 && valueCount == 1) {
+                theBlock = new ConstantBytesRefVector(BytesRef.deepCopyOf(values.get(0, new BytesRef())), 1, blockFactory).asBlock();
+                /*
+                 * Update the breaker with the actual bytes used.
+                 * We pass false below even though we've used the bytes. That's weird,
+                 * but if we break here we will throw away the used memory, letting
+                 * it be deallocated. The exception will bubble up and the builder will
+                 * still technically be open, meaning the calling code should close it
+                 * which will return all used memory to the breaker.
+                 */
+                blockFactory.adjustBreaker(theBlock.ramBytesUsed() - estimatedBytes, false);
+                Releasables.closeExpectNoException(values);
+            } else {
+                if (isDense() && singleValued()) {
+                    theBlock = new BytesRefArrayVector(values, positionCount, blockFactory).asBlock();
+                } else {
+                    theBlock = new BytesRefArrayBlock(values, positionCount, firstValueIndexes, nullsMask, mvOrdering, blockFactory);
+                }
+                /*
+                 * Update the breaker with the actual bytes used.
+                 * We pass false below even though we've used the bytes. That's weird,
+                 * but if we break here we will throw away the used memory, letting
+                 * it be deallocated. The exception will bubble up and the builder will
+                 * still technically be open, meaning the calling code should close it
+                 * which will return all used memory to the breaker.
+                 */
+                blockFactory.adjustBreaker(theBlock.ramBytesUsed() - estimatedBytes - values.bigArraysRamBytesUsed(), false);
+            }
+            values = null;
+            built();
+            return theBlock;
+        } catch (CircuitBreakingException e) {
+            close();
+            throw e;
+        }
+    }
+
+    @Override
+    public void extraClose() {
+        Releasables.closeExpectNoException(values);
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointVector.java
@@ -81,13 +81,11 @@ public sealed interface PointVector extends Vector permits ConstantPointVector, 
         final int positions = in.readVInt();
         final boolean constant = in.readBoolean();
         if (constant && positions > 0) {
-            SpatialPoint element = new SpatialPoint(in.readDouble(), in.readDouble());
-            return blockFactory.newConstantPointVector(element, positions);
+            return blockFactory.newConstantPointVector(in.readPoint(), positions);
         } else {
             try (var builder = blockFactory.newPointVectorFixedBuilder(positions)) {
                 for (int i = 0; i < positions; i++) {
-                    SpatialPoint element = new SpatialPoint(in.readDouble(), in.readDouble());
-                    builder.appendPoint(element);
+                    builder.appendPoint(in.readPoint());
                 }
                 return builder.build();
             }
@@ -100,14 +98,10 @@ public sealed interface PointVector extends Vector permits ConstantPointVector, 
         out.writeVInt(positions);
         out.writeBoolean(isConstant());
         if (isConstant() && positions > 0) {
-            SpatialPoint value = getPoint(0);
-            out.writeDouble(value.getX());
-            out.writeDouble(value.getY());
+            out.writePoint(getPoint(0));
         } else {
             for (int i = 0; i < positions; i++) {
-                SpatialPoint value = getPoint(i);
-                out.writeDouble(value.getX());
-                out.writeDouble(value.getY());
+                out.writePoint(getPoint(i));
             }
         }
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointVector.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data;
+
+import org.elasticsearch.common.geo.SpatialPoint;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
+/**
+ * Vector that stores SpatialPoint values.
+ * This class is generated. Do not edit it.
+ */
+public sealed interface PointVector extends Vector permits ConstantPointVector, PointArrayVector, PointBigArrayVector, ConstantNullVector {
+
+    SpatialPoint getPoint(int position);
+
+    @Override
+    PointBlock asBlock();
+
+    @Override
+    PointVector filter(int... positions);
+
+    /**
+     * Compares the given object with this vector for equality. Returns {@code true} if and only if the
+     * given object is a PointVector, and both vectors are {@link #equals(PointVector, PointVector) equal}.
+     */
+    @Override
+    boolean equals(Object obj);
+
+    /** Returns the hash code of this vector, as defined by {@link #hash(PointVector)}. */
+    @Override
+    int hashCode();
+
+    /**
+     * Returns {@code true} if the given vectors are equal to each other, otherwise {@code false}.
+     * Two vectors are considered equal if they have the same position count, and contain the same
+     * values in the same order. This definition ensures that the equals method works properly
+     * across different implementations of the PointVector interface.
+     */
+    static boolean equals(PointVector vector1, PointVector vector2) {
+        final int positions = vector1.getPositionCount();
+        if (positions != vector2.getPositionCount()) {
+            return false;
+        }
+        for (int pos = 0; pos < positions; pos++) {
+            if (vector1.getPoint(pos).equals(vector2.getPoint(pos)) == false) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Generates the hash code for the given vector. The hash code is computed from the vector's values.
+     * This ensures that {@code vector1.equals(vector2)} implies that {@code vector1.hashCode()==vector2.hashCode()}
+     * for any two vectors, {@code vector1} and {@code vector2}, as required by the general contract of
+     * {@link Object#hashCode}.
+     */
+    static int hash(PointVector vector) {
+        final int len = vector.getPositionCount();
+        int result = 1;
+        for (int pos = 0; pos < len; pos++) {
+            SpatialPoint point = vector.getPoint(pos);
+            long element = Double.doubleToLongBits(point.getX());
+            result = 31 * result + (int) (element ^ (element >>> 32));
+            element = Double.doubleToLongBits(point.getY());
+            result = 31 * result + (int) (element ^ (element >>> 32));
+        }
+        return result;
+    }
+
+    /** Deserializes a Vector from the given stream input. */
+    static PointVector readFrom(BlockFactory blockFactory, StreamInput in) throws IOException {
+        final int positions = in.readVInt();
+        final boolean constant = in.readBoolean();
+        if (constant && positions > 0) {
+            SpatialPoint element = new SpatialPoint(in.readDouble(), in.readDouble());
+            return blockFactory.newConstantPointVector(element, positions);
+        } else {
+            try (var builder = blockFactory.newPointVectorFixedBuilder(positions)) {
+                for (int i = 0; i < positions; i++) {
+                    SpatialPoint element = new SpatialPoint(in.readDouble(), in.readDouble());
+                    builder.appendPoint(element);
+                }
+                return builder.build();
+            }
+        }
+    }
+
+    /** Serializes this Vector to the given stream output. */
+    default void writeTo(StreamOutput out) throws IOException {
+        final int positions = getPositionCount();
+        out.writeVInt(positions);
+        out.writeBoolean(isConstant());
+        if (isConstant() && positions > 0) {
+            SpatialPoint value = getPoint(0);
+            out.writeDouble(value.getX());
+            out.writeDouble(value.getY());
+        } else {
+            for (int i = 0; i < positions; i++) {
+                SpatialPoint value = getPoint(i);
+                out.writeDouble(value.getX());
+                out.writeDouble(value.getY());
+            }
+        }
+    }
+
+    /**
+     * Returns a builder using the {@link BlockFactory#getNonBreakingInstance nonbreaking block factory}.
+     * @deprecated use {@link BlockFactory#newPointVectorBuilder}
+     */
+    // Eventually, we want to remove this entirely, always passing an explicit BlockFactory
+    @Deprecated
+    static Builder newVectorBuilder(int estimatedSize) {
+        return newVectorBuilder(estimatedSize, BlockFactory.getNonBreakingInstance());
+    }
+
+    /**
+     * Creates a builder that grows as needed. Prefer {@link #newVectorFixedBuilder}
+     * if you know the size up front because it's faster.
+     * @deprecated use {@link BlockFactory#newPointVectorBuilder}
+     */
+    @Deprecated
+    static Builder newVectorBuilder(int estimatedSize, BlockFactory blockFactory) {
+        return blockFactory.newPointVectorBuilder(estimatedSize);
+    }
+
+    /**
+     * Creates a builder that never grows. Prefer this over {@link #newVectorBuilder}
+     * if you know the size up front because it's faster.
+     * @deprecated use {@link BlockFactory#newPointVectorFixedBuilder}
+     */
+    @Deprecated
+    static FixedBuilder newVectorFixedBuilder(int size, BlockFactory blockFactory) {
+        return blockFactory.newPointVectorFixedBuilder(size);
+    }
+
+    /**
+     * A builder that grows as needed.
+     */
+    sealed interface Builder extends Vector.Builder permits PointVectorBuilder {
+        /**
+         * Appends a SpatialPoint to the current entry.
+         */
+        Builder appendPoint(SpatialPoint value);
+
+        @Override
+        PointVector build();
+    }
+
+    /**
+     * A builder that never grows.
+     */
+    sealed interface FixedBuilder extends Vector.Builder permits PointVectorFixedBuilder {
+        /**
+         * Appends a SpatialPoint to the current entry.
+         */
+        FixedBuilder appendPoint(SpatialPoint value);
+
+        @Override
+        PointVector build();
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointVector.java
@@ -81,11 +81,11 @@ public sealed interface PointVector extends Vector permits ConstantPointVector, 
         final int positions = in.readVInt();
         final boolean constant = in.readBoolean();
         if (constant && positions > 0) {
-            return blockFactory.newConstantPointVector(in.readPoint(), positions);
+            return blockFactory.newConstantPointVector(new SpatialPoint(in.readDouble(), in.readDouble()), positions);
         } else {
             try (var builder = blockFactory.newPointVectorFixedBuilder(positions)) {
                 for (int i = 0; i < positions; i++) {
-                    builder.appendPoint(in.readPoint());
+                    builder.appendPoint(new SpatialPoint(in.readDouble(), in.readDouble()));
                 }
                 return builder.build();
             }
@@ -98,10 +98,14 @@ public sealed interface PointVector extends Vector permits ConstantPointVector, 
         out.writeVInt(positions);
         out.writeBoolean(isConstant());
         if (isConstant() && positions > 0) {
-            out.writePoint(getPoint(0));
+            SpatialPoint point = getPoint(0);
+            out.writeDouble(point.getX());
+            out.writeDouble(point.getY());
         } else {
             for (int i = 0; i < positions; i++) {
-                out.writePoint(getPoint(i));
+                SpatialPoint point = getPoint(i);
+                out.writeDouble(point.getX());
+                out.writeDouble(point.getY());
             }
         }
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointVectorBlock.java
@@ -89,4 +89,9 @@ public final class PointVectorBlock extends AbstractVectorBlock implements Point
     public void allowPassingToDifferentDriver() {
         vector.allowPassingToDifferentDriver();
     }
+
+    @Override
+    public BlockFactory blockFactory() {
+        return vector.blockFactory();
+    }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointVectorBlock.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.compute.data;
 
-import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.core.Releasables;
 
 /**
@@ -32,8 +31,13 @@ public final class PointVectorBlock extends AbstractVectorBlock implements Point
     }
 
     @Override
-    public SpatialPoint getPoint(int valueIndex) {
-        return vector.getPoint(valueIndex);
+    public double getX(int valueIndex) {
+        return vector.getX(valueIndex);
+    }
+
+    @Override
+    public double getY(int valueIndex) {
+        return vector.getY(valueIndex);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointVectorBlock.java
@@ -7,43 +7,33 @@
 
 package org.elasticsearch.compute.data;
 
-$if(BytesRef)$
-import org.apache.lucene.util.BytesRef;
-$endif$
-$if(Point)$
 import org.elasticsearch.common.geo.SpatialPoint;
-$endif$
 import org.elasticsearch.core.Releasables;
 
 /**
- * Block view of a $Type$Vector.
+ * Block view of a PointVector.
  * This class is generated. Do not edit it.
  */
-public final class $Type$VectorBlock extends AbstractVectorBlock implements $Type$Block {
+public final class PointVectorBlock extends AbstractVectorBlock implements PointBlock {
 
-    private final $Type$Vector vector;
+    private final PointVector vector;
 
     /**
      * @param vector considered owned by the current block; must not be used in any other {@code Block}
      */
-    $Type$VectorBlock($Type$Vector vector) {
+    PointVectorBlock(PointVector vector) {
         super(vector.getPositionCount(), vector.blockFactory());
         this.vector = vector;
     }
 
     @Override
-    public $Type$Vector asVector() {
+    public PointVector asVector() {
         return vector;
     }
 
     @Override
-$if(BytesRef)$
-    public BytesRef getBytesRef(int valueIndex, BytesRef dest) {
-        return vector.getBytesRef(valueIndex, dest);
-$else$
-    public $type$ get$Type$(int valueIndex) {
-        return vector.get$Type$(valueIndex);
-$endif$
+    public SpatialPoint getPoint(int valueIndex) {
+        return vector.getPoint(valueIndex);
     }
 
     @Override
@@ -57,7 +47,7 @@ $endif$
     }
 
     @Override
-    public $Type$Block filter(int... positions) {
+    public PointBlock filter(int... positions) {
         return vector.filter(positions).asBlock();
     }
 
@@ -68,15 +58,15 @@ $endif$
 
     @Override
     public boolean equals(Object obj) {
-        if (obj instanceof $Type$Block that) {
-            return $Type$Block.equals(this, that);
+        if (obj instanceof PointBlock that) {
+            return PointBlock.equals(this, that);
         }
         return false;
     }
 
     @Override
     public int hashCode() {
-        return $Type$Block.hash(this);
+        return PointBlock.hash(this);
     }
 
     @Override
@@ -98,10 +88,5 @@ $endif$
     @Override
     public void allowPassingToDifferentDriver() {
         vector.allowPassingToDifferentDriver();
-    }
-
-    @Override
-    public BlockFactory blockFactory() {
-        return vector.blockFactory();
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointVectorBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointVectorBuilder.java
@@ -10,6 +10,7 @@ package org.elasticsearch.compute.data;
 import org.elasticsearch.common.geo.SpatialPoint;
 
 import java.util.Arrays;
+
 /**
  * Builder for {@link PointVector}s that grows as needed.
  * This class is generated. Do not edit it.

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointVectorBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointVectorBuilder.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data;
+
+import org.elasticsearch.common.geo.SpatialPoint;
+
+import java.util.Arrays;
+/**
+ * Builder for {@link PointVector}s that grows as needed.
+ * This class is generated. Do not edit it.
+ */
+final class PointVectorBuilder extends AbstractVectorBuilder implements PointVector.Builder {
+
+    private SpatialPoint[] values;
+
+    PointVectorBuilder(int estimatedSize, BlockFactory blockFactory) {
+        super(blockFactory);
+        int initialSize = Math.max(estimatedSize, 2);
+        adjustBreaker(initialSize);
+        values = new SpatialPoint[Math.max(estimatedSize, 2)];
+    }
+
+    @Override
+    public PointVectorBuilder appendPoint(SpatialPoint value) {
+        ensureCapacity();
+        values[valueCount] = value;
+        valueCount++;
+        return this;
+    }
+
+    @Override
+    protected int elementSize() {
+        return 16;
+    }
+
+    @Override
+    protected int valuesLength() {
+        return values.length;
+    }
+
+    @Override
+    protected void growValuesArray(int newSize) {
+        values = Arrays.copyOf(values, newSize);
+    }
+
+    @Override
+    public PointVector build() {
+        finish();
+        PointVector vector;
+        if (valueCount == 1) {
+            vector = blockFactory.newConstantPointBlockWith(values[0], 1, estimatedBytes).asVector();
+        } else {
+            if (values.length - valueCount > 1024 || valueCount < (values.length / 2)) {
+                values = Arrays.copyOf(values, valueCount);
+            }
+            vector = blockFactory.newPointArrayVector(values, valueCount, estimatedBytes);
+        }
+        built();
+        return vector;
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointVectorFixedBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointVectorFixedBuilder.java
@@ -10,7 +10,6 @@ package org.elasticsearch.compute.data;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.geo.SpatialPoint;
 
-
 /**
  * Builder for {@link PointVector}s that never grows. Prefer this to
  * {@link PointVectorBuilder} if you know the precise size up front because

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointVectorFixedBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointVectorFixedBuilder.java
@@ -10,6 +10,8 @@ package org.elasticsearch.compute.data;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.geo.SpatialPoint;
 
+import static org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF;
+
 /**
  * Builder for {@link PointVector}s that never grows. Prefer this to
  * {@link PointVectorBuilder} if you know the precise size up front because
@@ -43,7 +45,7 @@ final class PointVectorFixedBuilder implements PointVector.FixedBuilder {
         return size == 1
             ? ConstantPointVector.RAM_BYTES_USED
             : PointArrayVector.BASE_RAM_BYTES_USED + RamUsageEstimator.alignObjectSize(
-                (long) RamUsageEstimator.NUM_BYTES_ARRAY_HEADER + size * 16
+                (long) RamUsageEstimator.NUM_BYTES_ARRAY_HEADER + (long) size * (16 + NUM_BYTES_OBJECT_REF)
             );
     }
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointVectorFixedBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointVectorFixedBuilder.java
@@ -10,8 +10,6 @@ package org.elasticsearch.compute.data;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.geo.SpatialPoint;
 
-import static org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF;
-
 /**
  * Builder for {@link PointVector}s that never grows. Prefer this to
  * {@link PointVectorBuilder} if you know the precise size up front because
@@ -45,7 +43,7 @@ final class PointVectorFixedBuilder implements PointVector.FixedBuilder {
         return size == 1
             ? ConstantPointVector.RAM_BYTES_USED
             : PointArrayVector.BASE_RAM_BYTES_USED + RamUsageEstimator.alignObjectSize(
-                (long) RamUsageEstimator.NUM_BYTES_ARRAY_HEADER + (long) size * (16 + NUM_BYTES_OBJECT_REF)
+                (long) RamUsageEstimator.NUM_BYTES_ARRAY_HEADER + (long) size * (16 + RamUsageEstimator.NUM_BYTES_OBJECT_REF)
             );
     }
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointVectorFixedBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/PointVectorFixedBuilder.java
@@ -8,20 +8,18 @@
 package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.RamUsageEstimator;
-$if(Point)$
 import org.elasticsearch.common.geo.SpatialPoint;
-$endif$
 
 
 /**
- * Builder for {@link $Type$Vector}s that never grows. Prefer this to
- * {@link $Type$VectorBuilder} if you know the precise size up front because
+ * Builder for {@link PointVector}s that never grows. Prefer this to
+ * {@link PointVectorBuilder} if you know the precise size up front because
  * it's faster.
  * This class is generated. Do not edit it.
  */
-final class $Type$VectorFixedBuilder implements $Type$Vector.FixedBuilder {
+final class PointVectorFixedBuilder implements PointVector.FixedBuilder {
     private final BlockFactory blockFactory;
-    private final $type$[] values;
+    private final SpatialPoint[] values;
     private final long preAdjustedBytes;
     /**
      * The next value to write into. {@code -1} means the vector has already
@@ -29,29 +27,29 @@ final class $Type$VectorFixedBuilder implements $Type$Vector.FixedBuilder {
      */
     private int nextIndex;
 
-    $Type$VectorFixedBuilder(int size, BlockFactory blockFactory) {
+    PointVectorFixedBuilder(int size, BlockFactory blockFactory) {
         preAdjustedBytes = ramBytesUsed(size);
         blockFactory.adjustBreaker(preAdjustedBytes, false);
         this.blockFactory = blockFactory;
-        this.values = new $type$[size];
+        this.values = new SpatialPoint[size];
     }
 
     @Override
-    public $Type$VectorFixedBuilder append$Type$($type$ value) {
+    public PointVectorFixedBuilder appendPoint(SpatialPoint value) {
         values[nextIndex++] = value;
         return this;
     }
 
     private static long ramBytesUsed(int size) {
         return size == 1
-            ? Constant$Type$Vector.RAM_BYTES_USED
-            : $Type$ArrayVector.BASE_RAM_BYTES_USED + RamUsageEstimator.alignObjectSize(
-                (long) RamUsageEstimator.NUM_BYTES_ARRAY_HEADER + size * $BYTES$
+            ? ConstantPointVector.RAM_BYTES_USED
+            : PointArrayVector.BASE_RAM_BYTES_USED + RamUsageEstimator.alignObjectSize(
+                (long) RamUsageEstimator.NUM_BYTES_ARRAY_HEADER + size * 16
             );
     }
 
     @Override
-    public $Type$Vector build() {
+    public PointVector build() {
         if (nextIndex < 0) {
             throw new IllegalStateException("already closed");
         }
@@ -59,11 +57,11 @@ final class $Type$VectorFixedBuilder implements $Type$Vector.FixedBuilder {
             throw new IllegalStateException("expected to write [" + values.length + "] entries but wrote [" + nextIndex + "]");
         }
         nextIndex = -1;
-        $Type$Vector vector;
+        PointVector vector;
         if (values.length == 1) {
-            vector = blockFactory.newConstant$Type$BlockWith(values[0], 1, preAdjustedBytes).asVector();
+            vector = blockFactory.newConstantPointBlockWith(values[0], 1, preAdjustedBytes).asVector();
         } else {
-            vector = blockFactory.new$Type$ArrayVector(values, values.length, preAdjustedBytes);
+            vector = blockFactory.newPointArrayVector(values, values.length, preAdjustedBytes);
         }
         assert vector.ramBytesUsed() == preAdjustedBytes : "fixed Builders should estimate the exact ram bytes used";
         return vector;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/MultivalueDedupeBytesRef.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/MultivalueDedupeBytesRef.java
@@ -162,8 +162,8 @@ public class MultivalueDedupeBytesRef {
                         builder.appendInt(0);
                     }
                     case 1 -> {
-                        BytesRef v = block.getBytesRef(first, work[0]);
-                        hash(builder, hash, v);
+                        BytesRef value = block.getBytesRef(first, work[0]);
+                        hash(builder, hash, value);
                     }
                     default -> {
                         if (count < ALWAYS_COPY_MISSING) {
@@ -204,13 +204,13 @@ public class MultivalueDedupeBytesRef {
                     switch (count) {
                         case 0 -> encodeNull();
                         case 1 -> {
-                            BytesRef v = block.getBytesRef(first, work[0]);
-                            if (hasCapacity(v.length, 1)) {
+                            BytesRef value = block.getBytesRef(first, work[0]);
+                            if (hasCapacity(value.length, 1)) {
                                 startPosition();
-                                encode(v);
+                                encode(value);
                                 endPosition();
                             } else {
-                                work[0] = v;
+                                work[0] = value;
                                 w = 1;
                                 return;
                             }
@@ -391,7 +391,7 @@ public class MultivalueDedupeBytesRef {
         }
     }
 
-    private void hash(IntBlock.Builder builder, BytesRefHash hash, BytesRef v) {
-        builder.appendInt(Math.toIntExact(BlockHash.hashOrdToGroupNullReserved(hash.add(v))));
+    private void hash(IntBlock.Builder builder, BytesRefHash hash, BytesRef value) {
+        builder.appendInt(Math.toIntExact(BlockHash.hashOrdToGroupNullReserved(hash.add(value))));
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/MultivalueDedupeDouble.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/MultivalueDedupeDouble.java
@@ -159,8 +159,8 @@ public class MultivalueDedupeDouble {
                         builder.appendInt(0);
                     }
                     case 1 -> {
-                        double v = block.getDouble(first);
-                        hash(builder, hash, v);
+                        double value = block.getDouble(first);
+                        hash(builder, hash, value);
                     }
                     default -> {
                         if (count < ALWAYS_COPY_MISSING) {
@@ -201,13 +201,13 @@ public class MultivalueDedupeDouble {
                     switch (count) {
                         case 0 -> encodeNull();
                         case 1 -> {
-                            double v = block.getDouble(first);
+                            double value = block.getDouble(first);
                             if (hasCapacity(1)) {
                                 startPosition();
-                                encode(v);
+                                encode(value);
                                 endPosition();
                             } else {
-                                work[0] = v;
+                                work[0] = value;
                                 w = 1;
                                 return;
                             }
@@ -369,7 +369,7 @@ public class MultivalueDedupeDouble {
         work = ArrayUtil.grow(work, size);
     }
 
-    private void hash(IntBlock.Builder builder, LongHash hash, double v) {
-        builder.appendInt(Math.toIntExact(BlockHash.hashOrdToGroupNullReserved(hash.add(Double.doubleToLongBits(v)))));
+    private void hash(IntBlock.Builder builder, LongHash hash, double value) {
+        builder.appendInt(Math.toIntExact(BlockHash.hashOrdToGroupNullReserved(hash.add(Double.doubleToLongBits(value)))));
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/MultivalueDedupeInt.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/MultivalueDedupeInt.java
@@ -28,6 +28,7 @@ public class MultivalueDedupeInt {
      * The choice of number has been experimentally derived.
      */
     private static final int ALWAYS_COPY_MISSING = 300;
+
     private final IntBlock block;
     private int[] work = new int[ArrayUtil.oversize(2, Integer.BYTES)];
     private int w;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/MultivalueDedupeInt.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/MultivalueDedupeInt.java
@@ -159,8 +159,8 @@ public class MultivalueDedupeInt {
                         builder.appendInt(0);
                     }
                     case 1 -> {
-                        int v = block.getInt(first);
-                        hash(builder, hash, v);
+                        int value = block.getInt(first);
+                        hash(builder, hash, value);
                     }
                     default -> {
                         if (count < ALWAYS_COPY_MISSING) {
@@ -201,13 +201,13 @@ public class MultivalueDedupeInt {
                     switch (count) {
                         case 0 -> encodeNull();
                         case 1 -> {
-                            int v = block.getInt(first);
+                            int value = block.getInt(first);
                             if (hasCapacity(1)) {
                                 startPosition();
-                                encode(v);
+                                encode(value);
                                 endPosition();
                             } else {
-                                work[0] = v;
+                                work[0] = value;
                                 w = 1;
                                 return;
                             }
@@ -369,7 +369,7 @@ public class MultivalueDedupeInt {
         work = ArrayUtil.grow(work, size);
     }
 
-    private void hash(IntBlock.Builder builder, LongHash hash, int v) {
-        builder.appendInt(Math.toIntExact(BlockHash.hashOrdToGroupNullReserved(hash.add(v))));
+    private void hash(IntBlock.Builder builder, LongHash hash, int value) {
+        builder.appendInt(Math.toIntExact(BlockHash.hashOrdToGroupNullReserved(hash.add(value))));
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/MultivalueDedupeLong.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/MultivalueDedupeLong.java
@@ -160,8 +160,8 @@ public class MultivalueDedupeLong {
                         builder.appendInt(0);
                     }
                     case 1 -> {
-                        long v = block.getLong(first);
-                        hash(builder, hash, v);
+                        long value = block.getLong(first);
+                        hash(builder, hash, value);
                     }
                     default -> {
                         if (count < ALWAYS_COPY_MISSING) {
@@ -202,13 +202,13 @@ public class MultivalueDedupeLong {
                     switch (count) {
                         case 0 -> encodeNull();
                         case 1 -> {
-                            long v = block.getLong(first);
+                            long value = block.getLong(first);
                             if (hasCapacity(1)) {
                                 startPosition();
-                                encode(v);
+                                encode(value);
                                 endPosition();
                             } else {
-                                work[0] = v;
+                                work[0] = value;
                                 w = 1;
                                 return;
                             }
@@ -370,7 +370,7 @@ public class MultivalueDedupeLong {
         work = ArrayUtil.grow(work, size);
     }
 
-    private void hash(IntBlock.Builder builder, LongHash hash, long v) {
-        builder.appendInt(Math.toIntExact(BlockHash.hashOrdToGroupNullReserved(hash.add(v))));
+    private void hash(IntBlock.Builder builder, LongHash hash, long value) {
+        builder.appendInt(Math.toIntExact(BlockHash.hashOrdToGroupNullReserved(hash.add(value))));
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/MultivalueDedupePoint.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/MultivalueDedupePoint.java
@@ -29,8 +29,7 @@ public class MultivalueDedupePoint {
      * with low overhead to an {@code n*log(n)} strategy with higher overhead.
      * The choice of number has been experimentally derived.
      */
-    private static final int ALWAYS_COPY_MISSING = 300;
-
+    private static final int ALWAYS_COPY_MISSING = 110;
     private final PointBlock block;
     private SpatialPoint[] work = new SpatialPoint[ArrayUtil.oversize(2, 16)];
     private int w;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/MultivalueDedupePoint.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/MultivalueDedupePoint.java
@@ -14,8 +14,8 @@ import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
 import org.elasticsearch.compute.aggregation.blockhash.BlockHash;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
-import org.elasticsearch.compute.data.PointBlock;
 import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.PointBlock;
 
 import java.util.Arrays;
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/topn/KeyExtractorForPoint.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/topn/KeyExtractorForPoint.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.operator.topn;
+
+import org.elasticsearch.common.geo.SpatialPoint;
+import org.elasticsearch.compute.data.PointBlock;
+import org.elasticsearch.compute.data.PointVector;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
+
+abstract class KeyExtractorForPoint implements KeyExtractor {
+    static KeyExtractorForPoint extractorFor(TopNEncoder encoder, boolean ascending, byte nul, byte nonNul, PointBlock block) {
+        PointVector v = block.asVector();
+        if (v != null) {
+            return new KeyExtractorForPoint.ForVector(encoder, nul, nonNul, v);
+        }
+        if (ascending) {
+            return block.mvSortedAscending()
+                ? new KeyExtractorForPoint.MinForAscending(encoder, nul, nonNul, block)
+                : new KeyExtractorForPoint.MinForUnordered(encoder, nul, nonNul, block);
+        }
+        return block.mvSortedAscending()
+            ? new KeyExtractorForPoint.MaxForAscending(encoder, nul, nonNul, block)
+            : new KeyExtractorForPoint.MaxForUnordered(encoder, nul, nonNul, block);
+    }
+
+    private final byte nul;
+    private final byte nonNul;
+
+    KeyExtractorForPoint(TopNEncoder encoder, byte nul, byte nonNul) {
+        assert encoder == TopNEncoder.DEFAULT_SORTABLE;
+        this.nul = nul;
+        this.nonNul = nonNul;
+    }
+
+    protected final int nonNul(BreakingBytesRefBuilder key, SpatialPoint value) {
+        key.append(nonNul);
+        TopNEncoder.DEFAULT_SORTABLE.encodePoint(value, key);
+        return 16 + 1;
+    }
+
+    protected final int nul(BreakingBytesRefBuilder key) {
+        key.append(nul);
+        return 1;
+    }
+
+    static class ForVector extends KeyExtractorForPoint {
+        private final PointVector vector;
+
+        ForVector(TopNEncoder encoder, byte nul, byte nonNul, PointVector vector) {
+            super(encoder, nul, nonNul);
+            this.vector = vector;
+        }
+
+        @Override
+        public int writeKey(BreakingBytesRefBuilder key, int position) {
+            return nonNul(key, vector.getPoint(position));
+        }
+    }
+
+    static class MinForAscending extends KeyExtractorForPoint {
+        private final PointBlock block;
+
+        MinForAscending(TopNEncoder encoder, byte nul, byte nonNul, PointBlock block) {
+            super(encoder, nul, nonNul);
+            this.block = block;
+        }
+
+        @Override
+        public int writeKey(BreakingBytesRefBuilder key, int position) {
+            if (block.isNull(position)) {
+                return nul(key);
+            }
+            return nonNul(key, block.getPoint(block.getFirstValueIndex(position)));
+        }
+    }
+
+    static class MaxForAscending extends KeyExtractorForPoint {
+        private final PointBlock block;
+
+        MaxForAscending(TopNEncoder encoder, byte nul, byte nonNul, PointBlock block) {
+            super(encoder, nul, nonNul);
+            this.block = block;
+        }
+
+        @Override
+        public int writeKey(BreakingBytesRefBuilder key, int position) {
+            if (block.isNull(position)) {
+                return nul(key);
+            }
+            return nonNul(key, block.getPoint(block.getFirstValueIndex(position) + block.getValueCount(position) - 1));
+        }
+    }
+
+    static class MinForUnordered extends KeyExtractorForPoint {
+        private final PointBlock block;
+
+        MinForUnordered(TopNEncoder encoder, byte nul, byte nonNul, PointBlock block) {
+            super(encoder, nul, nonNul);
+            this.block = block;
+        }
+
+        @Override
+        public int writeKey(BreakingBytesRefBuilder key, int position) {
+            int size = block.getValueCount(position);
+            if (size == 0) {
+                return nul(key);
+            }
+            int start = block.getFirstValueIndex(position);
+            int end = start + size;
+            SpatialPoint min = block.getPoint(start);
+            for (int i = start + 1; i < end; i++) {
+                SpatialPoint other = block.getPoint(i);
+                if (other.compareTo(min) < 0) {
+                    min = other;
+                }
+            }
+            return nonNul(key, min);
+        }
+    }
+
+    static class MaxForUnordered extends KeyExtractorForPoint {
+        private final PointBlock block;
+
+        MaxForUnordered(TopNEncoder encoder, byte nul, byte nonNul, PointBlock block) {
+            super(encoder, nul, nonNul);
+            this.block = block;
+        }
+
+        @Override
+        public int writeKey(BreakingBytesRefBuilder key, int position) {
+            int size = block.getValueCount(position);
+            if (size == 0) {
+                return nul(key);
+            }
+            int start = block.getFirstValueIndex(position);
+            int end = start + size;
+            SpatialPoint max = block.getPoint(start);
+            for (int i = start + 1; i < end; i++) {
+                SpatialPoint other = block.getPoint(i);
+                if (other.compareTo(max) > 0) {
+                    max = other;
+                }
+            }
+            return nonNul(key, max);
+        }
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/topn/ResultBuilderForPoint.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/topn/ResultBuilderForPoint.java
@@ -20,6 +20,7 @@ class ResultBuilderForPoint implements ResultBuilder {
     /**
      * The value previously set by {@link #decodeKey}.
      */
+    // TODO: we should be able to get rid of this object
     private SpatialPoint key;
 
     ResultBuilderForPoint(BlockFactory blockFactory, TopNEncoder encoder, boolean inKey, int initialSize) {
@@ -41,11 +42,15 @@ class ResultBuilderForPoint implements ResultBuilder {
             case 0 -> {
                 builder.appendNull();
             }
-            case 1 -> builder.appendPoint(inKey ? key : readValueFromValues(values));
+            case 1 -> {
+                SpatialPoint value = inKey ? key : readValueFromValues(values);
+                builder.appendPoint(value.getX(), value.getY());
+            }
             default -> {
                 builder.beginPositionEntry();
                 for (int i = 0; i < count; i++) {
-                    builder.appendPoint(readValueFromValues(values));
+                    SpatialPoint point = readValueFromValues(values);
+                    builder.appendPoint(point.getX(), point.getY());
                 }
                 builder.endPositionEntry();
             }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/topn/ValueExtractorForPoint.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/topn/ValueExtractorForPoint.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.operator.topn;
+
+import org.elasticsearch.common.geo.SpatialPoint;
+import org.elasticsearch.compute.data.PointBlock;
+import org.elasticsearch.compute.data.PointVector;
+import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
+
+abstract class ValueExtractorForPoint implements ValueExtractor {
+    static ValueExtractorForPoint extractorFor(TopNEncoder encoder, boolean inKey, PointBlock block) {
+        PointVector vector = block.asVector();
+        if (vector != null) {
+            return new ValueExtractorForPoint.ForVector(encoder, inKey, vector);
+        }
+        return new ValueExtractorForPoint.ForBlock(encoder, inKey, block);
+    }
+
+    protected final boolean inKey;
+
+    ValueExtractorForPoint(TopNEncoder encoder, boolean inKey) {
+        assert encoder == TopNEncoder.DEFAULT_UNSORTABLE : encoder.toString();
+        this.inKey = inKey;
+    }
+
+    protected final void writeCount(BreakingBytesRefBuilder values, int count) {
+        TopNEncoder.DEFAULT_UNSORTABLE.encodeVInt(count, values);
+    }
+
+    protected final void actualWriteValue(BreakingBytesRefBuilder values, SpatialPoint value) {
+        TopNEncoder.DEFAULT_UNSORTABLE.encodePoint(value, values);
+    }
+
+    static class ForVector extends ValueExtractorForPoint {
+        private final PointVector vector;
+
+        ForVector(TopNEncoder encoder, boolean inKey, PointVector vector) {
+            super(encoder, inKey);
+            this.vector = vector;
+        }
+
+        @Override
+        public void writeValue(BreakingBytesRefBuilder values, int position) {
+            writeCount(values, 1);
+            if (inKey) {
+                // will read results from the key
+                return;
+            }
+            actualWriteValue(values, vector.getPoint(position));
+        }
+    }
+
+    static class ForBlock extends ValueExtractorForPoint {
+        private final PointBlock block;
+
+        ForBlock(TopNEncoder encoder, boolean inKey, PointBlock block) {
+            super(encoder, inKey);
+            this.block = block;
+        }
+
+        @Override
+        public void writeValue(BreakingBytesRefBuilder values, int position) {
+            int size = block.getValueCount(position);
+            writeCount(values, size);
+            if (size == 1 && inKey) {
+                // Will read results from the key
+                return;
+            }
+            int start = block.getFirstValueIndex(position);
+            int end = start + size;
+            for (int i = start; i < end; i++) {
+                actualWriteValue(values, block.getPoint(i));
+            }
+        }
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/topn/ValueExtractorForPoint.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/topn/ValueExtractorForPoint.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.compute.operator.topn;
 
-import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.compute.data.PointBlock;
 import org.elasticsearch.compute.data.PointVector;
 import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
@@ -32,8 +31,8 @@ abstract class ValueExtractorForPoint implements ValueExtractor {
         TopNEncoder.DEFAULT_UNSORTABLE.encodeVInt(count, values);
     }
 
-    protected final void actualWriteValue(BreakingBytesRefBuilder values, SpatialPoint value) {
-        TopNEncoder.DEFAULT_UNSORTABLE.encodePoint(value, values);
+    protected final void actualWriteValue(BreakingBytesRefBuilder values, double x, double y) {
+        TopNEncoder.DEFAULT_UNSORTABLE.encodePoint(x, y, values);
     }
 
     static class ForVector extends ValueExtractorForPoint {
@@ -51,7 +50,7 @@ abstract class ValueExtractorForPoint implements ValueExtractor {
                 // will read results from the key
                 return;
             }
-            actualWriteValue(values, vector.getPoint(position));
+            actualWriteValue(values, vector.getX(position), vector.getY(position));
         }
     }
 
@@ -74,7 +73,7 @@ abstract class ValueExtractorForPoint implements ValueExtractor {
             int start = block.getFirstValueIndex(position);
             int end = start + size;
             for (int i = start; i < end; i++) {
-                actualWriteValue(values, block.getPoint(i));
+                actualWriteValue(values, block.getX(i), block.getY(i));
             }
         }
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-ArrayState.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-ArrayState.java.st
@@ -57,7 +57,7 @@ final class $Type$ArrayState extends AbstractArrayState implements GroupingAggre
         return groupId < values.size() ? values.get(groupId) : init;
     }
 
-    void set(int groupId, $type$ value) {
+    void set(int groupId, $typeValue$) {
         ensureCapacity(groupId);
         values.set(groupId, value);
         trackGroupId(groupId);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-State.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-State.java.st
@@ -15,7 +15,7 @@ import org.elasticsearch.compute.operator.DriverContext;
  * This class is generated. Do not edit it.
  */
 final class $Type$State implements AggregatorState {
-    private $type$ value;
+    private $typeValue$;
     private boolean seen;
 
     $Type$State() {
@@ -30,7 +30,7 @@ final class $Type$State implements AggregatorState {
         return value;
     }
 
-    void $type$Value($type$ value) {
+    void $type$Value($typeValue$) {
         this.value = value;
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Block.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Block.java
@@ -254,6 +254,7 @@ public interface Block extends Accountable, BlockLoader.Block, NamedWriteable, R
             IntBlock.ENTRY,
             LongBlock.ENTRY,
             DoubleBlock.ENTRY,
+            PointBlock.ENTRY,
             BytesRefBlock.ENTRY,
             BooleanBlock.ENTRY,
             ConstantNullBlock.ENTRY

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockFactory.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockFactory.java
@@ -11,7 +11,6 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
-import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BytesRefArray;
@@ -392,24 +391,26 @@ public class BlockFactory {
     }
 
     public final PointBlock newPointArrayBlock(
-        SpatialPoint[] values,
+        double[] xValues,
+        double[] yValues,
         int pc,
         int[] firstValueIndexes,
         BitSet nulls,
         MvOrdering mvOrdering
     ) {
-        return newPointArrayBlock(values, pc, firstValueIndexes, nulls, mvOrdering, 0L);
+        return newPointArrayBlock(xValues, yValues, pc, firstValueIndexes, nulls, mvOrdering, 0L);
     }
 
     public PointBlock newPointArrayBlock(
-        SpatialPoint[] values,
+        double[] xValues,
+        double[] yValues,
         int pc,
         int[] fvi,
         BitSet nulls,
         MvOrdering mvOrdering,
         long preAdjustedBytes
     ) {
-        var b = new PointArrayBlock(values, pc, fvi, nulls, mvOrdering, this);
+        var b = new PointArrayBlock(xValues, yValues, pc, fvi, nulls, mvOrdering, this);
         adjustBreaker(b.ramBytesUsed() - preAdjustedBytes, true);
         return b;
     }
@@ -425,29 +426,29 @@ public class BlockFactory {
         return new PointVectorFixedBuilder(size, this);
     }
 
-    public final PointVector newPointArrayVector(SpatialPoint[] values, int positionCount) {
-        return newPointArrayVector(values, positionCount, 0L);
+    public final PointVector newPointArrayVector(double[] xValues, double[] yValues, int positionCount) {
+        return newPointArrayVector(xValues, yValues, positionCount, 0L);
     }
 
-    public PointVector newPointArrayVector(SpatialPoint[] values, int positionCount, long preAdjustedBytes) {
-        var b = new PointArrayVector(values, positionCount, this);
+    public PointVector newPointArrayVector(double[] xValues, double[] yValues, int positionCount, long preAdjustedBytes) {
+        var b = new PointArrayVector(xValues, yValues, positionCount, this);
         adjustBreaker(b.ramBytesUsed() - preAdjustedBytes, true);
         return b;
     }
 
-    public final PointBlock newConstantPointBlockWith(SpatialPoint value, int positions) {
-        return newConstantPointBlockWith(value, positions, 0L);
+    public final PointBlock newConstantPointBlockWith(double x, double y, int positions) {
+        return newConstantPointBlockWith(x, y, positions, 0L);
     }
 
-    public PointBlock newConstantPointBlockWith(SpatialPoint value, int positions, long preAdjustedBytes) {
-        var b = new ConstantPointVector(value, positions, this).asBlock();
+    public PointBlock newConstantPointBlockWith(double x, double y, int positions, long preAdjustedBytes) {
+        var b = new ConstantPointVector(x, y, positions, this).asBlock();
         adjustBreaker(b.ramBytesUsed() - preAdjustedBytes, true);
         return b;
     }
 
-    public PointVector newConstantPointVector(SpatialPoint value, int positions) {
+    public PointVector newConstantPointVector(double x, double y, int positions) {
         adjustBreaker(ConstantPointVector.RAM_BYTES_USED, false);
-        var v = new ConstantPointVector(value, positions, this);
+        var v = new ConstantPointVector(x, y, positions, this);
         assert v.ramBytesUsed() == ConstantPointVector.RAM_BYTES_USED;
         return v;
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockFactory.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockFactory.java
@@ -11,6 +11,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BytesRefArray;
@@ -357,7 +358,7 @@ public class BlockFactory {
     }
 
     public PointBlock.Builder newPointBlockBuilder(int estimatedSize) {
-        return new PointBlockBuilder(estimatedSize, bigArrays, this);
+        return new PointBlockBuilder(estimatedSize, this);
     }
 
     public BytesRefBlock newBytesRefArrayBlock(BytesRefArray values, int pc, int[] firstValueIndexes, BitSet nulls, MvOrdering mvOrdering) {
@@ -387,6 +388,72 @@ public class BlockFactory {
         adjustBreaker(preadjusted, false);
         var v = new ConstantBytesRefVector(value, positions, this);
         assert v.ramBytesUsed() == preadjusted;
+        return v;
+    }
+
+    /**
+     * Build a {@link PointVector.FixedBuilder} that never grows.
+     */
+    public PointVector.FixedBuilder newPointVectorFixedBuilder(int size) {
+        return new PointVectorFixedBuilder(size, this);
+    }
+
+    public PointVector.Builder newPointVectorBuilder(int estimatedSize) {
+        return new PointVectorBuilder(estimatedSize, this);
+    }
+
+    public final PointBlock newPointArrayBlock(
+        SpatialPoint[] values,
+        int pc,
+        int[] firstValueIndexes,
+        BitSet nulls,
+        MvOrdering mvOrdering
+    ) {
+        return newPointArrayBlock(values, pc, firstValueIndexes, nulls, mvOrdering, 0L);
+
+    }
+
+    public PointBlock newPointArrayBlock(
+        SpatialPoint[] values,
+        int pc,
+        int[] fvi,
+        BitSet nulls,
+        MvOrdering mvOrdering,
+        long preAdjustedBytes
+    ) {
+        var b = new PointArrayBlock(values, pc, fvi, nulls, mvOrdering, this);
+        adjustBreaker(b.ramBytesUsed() - preAdjustedBytes, true);
+        return b;
+    }
+
+    public PointVector newPointArrayVector(SpatialPoint[] values, int positionCount) {
+        return new PointArrayVector(values, positionCount);
+    }
+
+    public PointVector newPointArrayVector(SpatialPoint[] values, int positionCount, long preAdjustedBytes) {
+        var b = new PointArrayVector(values, positionCount, this);
+        adjustBreaker(b.ramBytesUsed() - preAdjustedBytes, true);
+        return b;
+    }
+
+    public final PointBlock newConstantPointBlockWith(SpatialPoint value, int positions) {
+        return newConstantPointBlockWith(value, positions, 0L);
+    }
+
+    public PointBlock newConstantPointBlockWith(SpatialPoint value, int positions, long preAdjustedBytes) {
+        var b = new ConstantPointVector(value, positions, this).asBlock();
+        adjustBreaker(b.ramBytesUsed() - preAdjustedBytes, true);
+        return b;
+    }
+
+    public PointVector newConstantPointVector(double x, double y, int positions) {
+        return newConstantPointVector(new SpatialPoint(x, y), positions);
+    }
+
+    public PointVector newConstantPointVector(SpatialPoint value, int positions) {
+        adjustBreaker(ConstantPointVector.RAM_BYTES_USED, false);
+        var v = new ConstantPointVector(value, positions, this);
+        assert v.ramBytesUsed() == ConstantPointVector.RAM_BYTES_USED;
         return v;
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockFactory.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockFactory.java
@@ -356,6 +356,10 @@ public class BlockFactory {
         return new BytesRefBlockBuilder(estimatedSize, bigArrays, this);
     }
 
+    public PointBlock.Builder newPointBlockBuilder(int estimatedSize) {
+        return new PointBlockBuilder(estimatedSize, bigArrays, this);
+    }
+
     public BytesRefBlock newBytesRefArrayBlock(BytesRefArray values, int pc, int[] firstValueIndexes, BitSet nulls, MvOrdering mvOrdering) {
         var b = new BytesRefArrayBlock(values, pc, firstValueIndexes, nulls, mvOrdering, this);
         adjustBreaker(b.ramBytesUsed() - values.bigArraysRamBytesUsed(), true);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockFactory.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockFactory.java
@@ -357,10 +357,6 @@ public class BlockFactory {
         return new BytesRefBlockBuilder(estimatedSize, bigArrays, this);
     }
 
-    public PointBlock.Builder newPointBlockBuilder(int estimatedSize) {
-        return new PointBlockBuilder(estimatedSize, this);
-    }
-
     public BytesRefBlock newBytesRefArrayBlock(BytesRefArray values, int pc, int[] firstValueIndexes, BitSet nulls, MvOrdering mvOrdering) {
         var b = new BytesRefArrayBlock(values, pc, firstValueIndexes, nulls, mvOrdering, this);
         adjustBreaker(b.ramBytesUsed() - values.bigArraysRamBytesUsed(), true);
@@ -391,15 +387,8 @@ public class BlockFactory {
         return v;
     }
 
-    /**
-     * Build a {@link PointVector.FixedBuilder} that never grows.
-     */
-    public PointVector.FixedBuilder newPointVectorFixedBuilder(int size) {
-        return new PointVectorFixedBuilder(size, this);
-    }
-
-    public PointVector.Builder newPointVectorBuilder(int estimatedSize) {
-        return new PointVectorBuilder(estimatedSize, this);
+    public PointBlock.Builder newPointBlockBuilder(int estimatedSize) {
+        return new PointBlockBuilder(estimatedSize, this);
     }
 
     public final PointBlock newPointArrayBlock(
@@ -410,7 +399,6 @@ public class BlockFactory {
         MvOrdering mvOrdering
     ) {
         return newPointArrayBlock(values, pc, firstValueIndexes, nulls, mvOrdering, 0L);
-
     }
 
     public PointBlock newPointArrayBlock(
@@ -426,8 +414,19 @@ public class BlockFactory {
         return b;
     }
 
-    public PointVector newPointArrayVector(SpatialPoint[] values, int positionCount) {
-        return new PointArrayVector(values, positionCount);
+    public PointVector.Builder newPointVectorBuilder(int estimatedSize) {
+        return new PointVectorBuilder(estimatedSize, this);
+    }
+
+    /**
+     * Build a {@link PointVector.FixedBuilder} that never grows.
+     */
+    public PointVector.FixedBuilder newPointVectorFixedBuilder(int size) {
+        return new PointVectorFixedBuilder(size, this);
+    }
+
+    public final PointVector newPointArrayVector(SpatialPoint[] values, int positionCount) {
+        return newPointArrayVector(values, positionCount, 0L);
     }
 
     public PointVector newPointArrayVector(SpatialPoint[] values, int positionCount, long preAdjustedBytes) {
@@ -444,10 +443,6 @@ public class BlockFactory {
         var b = new ConstantPointVector(value, positions, this).asBlock();
         adjustBreaker(b.ramBytesUsed() - preAdjustedBytes, true);
         return b;
-    }
-
-    public PointVector newConstantPointVector(double x, double y, int positions) {
-        return newConstantPointVector(new SpatialPoint(x, y), positions);
     }
 
     public PointVector newConstantPointVector(SpatialPoint value, int positions) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockUtils.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockUtils.java
@@ -211,7 +211,7 @@ public final class BlockUtils {
             case BYTES_REF -> ((BytesRefBlock.Builder) builder).appendBytesRef(toBytesRef(val));
             case DOUBLE -> ((DoubleBlock.Builder) builder).appendDouble((Double) val);
             case BOOLEAN -> ((BooleanBlock.Builder) builder).appendBoolean((Boolean) val);
-            case POINT -> ((PointBlock.Builder) builder).appendPoint((SpatialPoint) val);
+            case POINT -> ((PointBlock.Builder) builder).appendPoint(((SpatialPoint) val).getX(), ((SpatialPoint) val).getY());
             default -> throw new UnsupportedOperationException("unsupported element type [" + type + "]");
         }
     }
@@ -232,7 +232,7 @@ public final class BlockUtils {
             case BYTES_REF -> BytesRefBlock.newConstantBlockWith(toBytesRef(val), size, blockFactory);
             case DOUBLE -> DoubleBlock.newConstantBlockWith((double) val, size, blockFactory);
             case BOOLEAN -> BooleanBlock.newConstantBlockWith((boolean) val, size, blockFactory);
-            case POINT -> PointBlock.newConstantBlockWith((SpatialPoint) val, size, blockFactory);
+            case POINT -> PointBlock.newConstantBlockWith(((SpatialPoint) val).getX(), ((SpatialPoint) val).getY(), size, blockFactory);
             default -> throw new UnsupportedOperationException("unsupported element type [" + type + "]");
         };
     }
@@ -275,7 +275,7 @@ public final class BlockUtils {
                 DocVector v = ((DocBlock) block).asVector();
                 yield new Doc(v.shards().getInt(offset), v.segments().getInt(offset), v.docs().getInt(offset));
             }
-            case POINT -> ((PointBlock) block).getPoint(offset);
+            case POINT -> new SpatialPoint(((PointBlock) block).getX(offset), ((PointBlock) block).getY(offset));
             case UNKNOWN -> throw new IllegalArgumentException("can't read values from [" + block + "]");
         };
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockUtils.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockUtils.java
@@ -9,6 +9,7 @@ package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Randomness;
+import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 
@@ -210,6 +211,7 @@ public final class BlockUtils {
             case BYTES_REF -> ((BytesRefBlock.Builder) builder).appendBytesRef(toBytesRef(val));
             case DOUBLE -> ((DoubleBlock.Builder) builder).appendDouble((Double) val);
             case BOOLEAN -> ((BooleanBlock.Builder) builder).appendBoolean((Boolean) val);
+            case POINT -> ((PointBlock.Builder) builder).appendPoint((SpatialPoint) val);
             default -> throw new UnsupportedOperationException("unsupported element type [" + type + "]");
         }
     }
@@ -230,6 +232,7 @@ public final class BlockUtils {
             case BYTES_REF -> BytesRefBlock.newConstantBlockWith(toBytesRef(val), size, blockFactory);
             case DOUBLE -> DoubleBlock.newConstantBlockWith((double) val, size, blockFactory);
             case BOOLEAN -> BooleanBlock.newConstantBlockWith((boolean) val, size, blockFactory);
+            case POINT -> PointBlock.newConstantBlockWith((SpatialPoint) val, size, blockFactory);
             default -> throw new UnsupportedOperationException("unsupported element type [" + type + "]");
         };
     }
@@ -272,6 +275,7 @@ public final class BlockUtils {
                 DocVector v = ((DocBlock) block).asVector();
                 yield new Doc(v.shards().getInt(offset), v.segments().getInt(offset), v.docs().getInt(offset));
             }
+            case POINT -> ((PointBlock) block).getPoint(offset);
             case UNKNOWN -> throw new IllegalArgumentException("can't read values from [" + block + "]");
         };
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ConstantNullBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ConstantNullBlock.java
@@ -9,7 +9,6 @@ package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.RamUsageEstimator;
-import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -230,7 +229,13 @@ public final class ConstantNullBlock extends AbstractBlock
     }
 
     @Override
-    public SpatialPoint getPoint(int valueIndex) {
+    public double getX(int valueIndex) {
+        assert false : "null block";
+        throw new UnsupportedOperationException("null block");
+    }
+
+    @Override
+    public double getY(int valueIndex) {
         assert false : "null block";
         throw new UnsupportedOperationException("null block");
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ConstantNullBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ConstantNullBlock.java
@@ -9,6 +9,7 @@ package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -19,7 +20,14 @@ import java.util.Objects;
 /**
  * Block implementation representing a constant null value.
  */
-public final class ConstantNullBlock extends AbstractBlock implements BooleanBlock, IntBlock, LongBlock, DoubleBlock, BytesRefBlock {
+public final class ConstantNullBlock extends AbstractBlock
+    implements
+        BooleanBlock,
+        IntBlock,
+        LongBlock,
+        DoubleBlock,
+        BytesRefBlock,
+        PointBlock {
 
     private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(ConstantNullBlock.class);
 
@@ -217,6 +225,12 @@ public final class ConstantNullBlock extends AbstractBlock implements BooleanBlo
 
     @Override
     public double getDouble(int valueIndex) {
+        assert false : "null block";
+        throw new UnsupportedOperationException("null block");
+    }
+
+    @Override
+    public SpatialPoint getPoint(int valueIndex) {
         assert false : "null block";
         throw new UnsupportedOperationException("null block");
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ConstantNullVector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ConstantNullVector.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
@@ -66,7 +65,13 @@ public final class ConstantNullVector extends AbstractVector
     }
 
     @Override
-    public SpatialPoint getPoint(int position) {
+    public double getX(int position) {
+        assert false : "null vector";
+        throw new UnsupportedOperationException("null vector");
+    }
+
+    @Override
+    public double getY(int position) {
         assert false : "null vector";
         throw new UnsupportedOperationException("null vector");
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ConstantNullVector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ConstantNullVector.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
@@ -15,7 +16,14 @@ import java.io.IOException;
 /**
  * This vector is never instantiated. This class serves as a type holder for {@link ConstantNullBlock#asVector()}.
  */
-public final class ConstantNullVector extends AbstractVector implements BooleanVector, IntVector, LongVector, DoubleVector, BytesRefVector {
+public final class ConstantNullVector extends AbstractVector
+    implements
+        BooleanVector,
+        IntVector,
+        LongVector,
+        DoubleVector,
+        BytesRefVector,
+        PointVector {
 
     private ConstantNullVector(int positionCount, BlockFactory blockFactory) {
         super(positionCount, blockFactory);
@@ -53,6 +61,12 @@ public final class ConstantNullVector extends AbstractVector implements BooleanV
 
     @Override
     public double getDouble(int position) {
+        assert false : "null vector";
+        throw new UnsupportedOperationException("null vector");
+    }
+
+    @Override
+    public SpatialPoint getPoint(int position) {
         assert false : "null vector";
         throw new UnsupportedOperationException("null vector");
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ElementType.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ElementType.java
@@ -76,7 +76,7 @@ public enum ElementType {
             elementType = DOUBLE;
         } else if (type == String.class || type == BytesRef.class) {
             elementType = BYTES_REF;
-        } else if (type.isAssignableFrom(SpatialPoint.class)) {
+        } else if (SpatialPoint.class.isAssignableFrom(type)) {
             elementType = POINT;
         } else if (type == Boolean.class) {
             elementType = BOOLEAN;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ElementType.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ElementType.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.geo.SpatialPoint;
 
 /**
  * The type of elements in {@link Block} and {@link Vector}
@@ -23,6 +24,11 @@ public enum ElementType {
     NULL((estimatedSize, blockFactory) -> new ConstantNullBlock.Builder(blockFactory)),
 
     BYTES_REF(BytesRefBlock::newBlockBuilder),
+
+    /**
+     * geo_point and cartesian_point
+     */
+    POINT(PointBlock::newBlockBuilder),
 
     /**
      * Blocks that reference individual lucene documents.
@@ -70,6 +76,8 @@ public enum ElementType {
             elementType = DOUBLE;
         } else if (type == String.class || type == BytesRef.class) {
             elementType = BYTES_REF;
+        } else if (type.isAssignableFrom(SpatialPoint.class)) {
+            elementType = POINT;
         } else if (type == Boolean.class) {
             elementType = BOOLEAN;
         } else if (type == null || type == Void.class) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
@@ -13,23 +13,12 @@ import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.util.BytesRefArray;
 import org.elasticsearch.core.Releasables;
 
-$elseif(Point)$
-import org.apache.lucene.util.RamUsageEstimator;
-import org.elasticsearch.common.geo.SpatialPoint;
-
-import java.util.Arrays;
 $else$
 import org.apache.lucene.util.RamUsageEstimator;
 
 import java.util.Arrays;
 $endif$
 import java.util.BitSet;
-
-$if(Point)$
-import static org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_ARRAY_HEADER;
-import static org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF;
-import static org.apache.lucene.util.RamUsageEstimator.alignObjectSize;
-$endif$
 
 /**
  * Block implementation that stores an array of $type$.
@@ -42,16 +31,38 @@ public final class $Type$ArrayBlock extends AbstractArrayBlock implements $Type$
 $if(BytesRef)$
     private final BytesRefArray values;
 
+$elseif(Point)$
+    private final double[] xValues, yValues;
+
 $else$
     private final $type$[] values;
 $endif$
 
+$if(Point)$
+    public $Type$ArrayBlock(
+        double[] xValues,
+        double[] yValues,
+        int positionCount,
+        int[] firstValueIndexes,
+        BitSet nulls,
+        MvOrdering mvOrdering
+    ) {
+        this(xValues, yValues, positionCount, firstValueIndexes, nulls, mvOrdering, BlockFactory.getNonBreakingInstance());
+    }
+
+$else$
     public $Type$ArrayBlock($if(BytesRef)$BytesRefArray$else$$type$[]$endif$ values, int positionCount, int[] firstValueIndexes, BitSet nulls, MvOrdering mvOrdering) {
         this(values, positionCount, firstValueIndexes, nulls, mvOrdering, BlockFactory.getNonBreakingInstance());
     }
+$endif$
 
     public $Type$ArrayBlock(
+$if(Point)$
+        double[] xValues,
+        double[] yValues,
+$else$
         $if(BytesRef)$BytesRefArray$else$$type$[]$endif$ values,
+$endif$
         int positionCount,
         int[] firstValueIndexes,
         BitSet nulls,
@@ -59,7 +70,12 @@ $endif$
         BlockFactory blockFactory
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
+$if(Point)$
+        this.xValues = xValues;
+        this.yValues = yValues;
+$else$
         this.values = values;
+$endif$
     }
 
     @Override
@@ -71,6 +87,14 @@ $endif$
 $if(BytesRef)$
     public BytesRef getBytesRef(int valueIndex, BytesRef dest) {
         return values.get(valueIndex, dest);
+$elseif(Point)$
+    public double getX(int valueIndex) {
+        return xValues[valueIndex];
+    }
+
+    @Override
+    public double getY(int valueIndex) {
+        return yValues[valueIndex];
 $else$
     public $type$ get$Type$(int valueIndex) {
         return values[valueIndex];
@@ -91,11 +115,19 @@ $endif$
                 int valueCount = getValueCount(pos);
                 int first = getFirstValueIndex(pos);
                 if (valueCount == 1) {
+$if(Point)$
+                    builder.append$Type$(getX(getFirstValueIndex(pos)), getY(getFirstValueIndex(pos)));
+$else$
                     builder.append$Type$(get$Type$(getFirstValueIndex(pos)$if(BytesRef)$, scratch$endif$));
+$endif$
                 } else {
                     builder.beginPositionEntry();
                     for (int c = 0; c < valueCount; c++) {
+$if(Point)$
+                        builder.appendPoint(getX(first + c), getY(first + c));
+$else$
                         builder.append$Type$(get$Type$(first + c$if(BytesRef)$, scratch$endif$));
+$endif$
                     }
                     builder.endPositionEntry();
                 }
@@ -130,6 +162,8 @@ $endif$
                 for (int i = first; i < end; i++) {
 $if(BytesRef)$
                     builder.append$Type$(get$Type$(i, scratch));
+$elseif(Point)$
+                    builder.append$Type$(getX(i), getY(i));
 $else$
                     builder.append$Type$(get$Type$(i));
 $endif$
@@ -140,19 +174,13 @@ $endif$
     }
 
     public static long ramBytesEstimated($if(BytesRef)$BytesRefArray$else$$type$[]$endif$ values, int[] firstValueIndexes, BitSet nullsMask) {
-    $if(Point)$
-        long valuesEstimate = (long) NUM_BYTES_ARRAY_HEADER + ((long) Long.BYTES * 2 + (long) NUM_BYTES_OBJECT_REF) * values.length;
-        return BASE_RAM_BYTES_USED + alignObjectSize(valuesEstimate) + BlockRamUsageEstimator.sizeOf(firstValueIndexes)
+        return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(values)$if(Point)$ * 2$endif$ + BlockRamUsageEstimator.sizeOf(firstValueIndexes)
             + BlockRamUsageEstimator.sizeOfBitSet(nullsMask);
-    $else$
-        return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(values) + BlockRamUsageEstimator.sizeOf(firstValueIndexes)
-            + BlockRamUsageEstimator.sizeOfBitSet(nullsMask);
-    $endif$
     }
 
     @Override
     public long ramBytesUsed() {
-        return ramBytesEstimated(values, firstValueIndexes, nullsMask);
+        return ramBytesEstimated($if(Point)$xValues$else$values$endif$, firstValueIndexes, nullsMask);
     }
 
     @Override
@@ -178,6 +206,11 @@ $endif$
 $if(BytesRef)$
             + ", values="
             + values.size()
+$elseif(Point)$
+            + ", x="
+            + Arrays.toString(xValues)
+            + ", y="
+            + Arrays.toString(yValues)
 $else$
             + ", values="
             + Arrays.toString(values)

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
@@ -14,8 +14,8 @@ import org.elasticsearch.common.util.BytesRefArray;
 import org.elasticsearch.core.Releasables;
 
 $elseif(Point)$
-import org.elasticsearch.common.geo.SpatialPoint;
 import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.geo.SpatialPoint;
 
 import java.util.Arrays;
 $else$

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
@@ -27,6 +27,8 @@ import java.util.BitSet;
 
 $if(Point)$
 import static org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_ARRAY_HEADER;
+import static org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF;
+import static org.apache.lucene.util.RamUsageEstimator.alignObjectSize;
 $endif$
 
 /**
@@ -139,9 +141,9 @@ $endif$
 
     public static long ramBytesEstimated($if(BytesRef)$BytesRefArray$else$$type$[]$endif$ values, int[] firstValueIndexes, BitSet nullsMask) {
     $if(Point)$
-        long valuesEstimate = RamUsageEstimator.alignObjectSize((long) NUM_BYTES_ARRAY_HEADER + (long) Long.BYTES * values.length * 2);
-        return BASE_RAM_BYTES_USED + valuesEstimate + BlockRamUsageEstimator.sizeOf(firstValueIndexes) + BlockRamUsageEstimator
-            .sizeOfBitSet(nullsMask);
+        long valuesEstimate = (long) NUM_BYTES_ARRAY_HEADER + ((long) Long.BYTES * 2 + (long) NUM_BYTES_OBJECT_REF) * values.length;
+        return BASE_RAM_BYTES_USED + alignObjectSize(valuesEstimate) + BlockRamUsageEstimator.sizeOf(firstValueIndexes)
+            + BlockRamUsageEstimator.sizeOfBitSet(nullsMask);
     $else$
         return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(values) + BlockRamUsageEstimator.sizeOf(firstValueIndexes)
             + BlockRamUsageEstimator.sizeOfBitSet(nullsMask);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayVector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayVector.java.st
@@ -13,6 +13,13 @@ import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.util.BytesRefArray;
 import org.elasticsearch.core.Releasables;
 
+$elseif(Point)$
+import org.elasticsearch.common.geo.SpatialPoint;
+import org.apache.lucene.util.RamUsageEstimator;
+
+import java.util.Arrays;
+
+import static org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_ARRAY_HEADER;
 $else$
 import org.apache.lucene.util.RamUsageEstimator;
 
@@ -92,7 +99,12 @@ $endif$
     }
 
     public static long ramBytesEstimated($if(BytesRef)$BytesRefArray$else$$type$[]$endif$ values) {
+    $if(Point)$
+        long valuesEstimate = RamUsageEstimator.alignObjectSize((long) NUM_BYTES_ARRAY_HEADER + (long) Long.BYTES * values.length * 2);
+        return BASE_RAM_BYTES_USED + valuesEstimate;
+    $else$
         return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(values);
+    $endif$
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayVector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayVector.java.st
@@ -14,12 +14,13 @@ import org.elasticsearch.common.util.BytesRefArray;
 import org.elasticsearch.core.Releasables;
 
 $elseif(Point)$
-import org.elasticsearch.common.geo.SpatialPoint;
 import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.geo.SpatialPoint;
 
 import java.util.Arrays;
 
 import static org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_ARRAY_HEADER;
+
 $else$
 import org.apache.lucene.util.RamUsageEstimator;
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayVector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayVector.java.st
@@ -20,6 +20,8 @@ import org.elasticsearch.common.geo.SpatialPoint;
 import java.util.Arrays;
 
 import static org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_ARRAY_HEADER;
+import static org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF;
+import static org.apache.lucene.util.RamUsageEstimator.alignObjectSize;
 
 $else$
 import org.apache.lucene.util.RamUsageEstimator;
@@ -101,8 +103,8 @@ $endif$
 
     public static long ramBytesEstimated($if(BytesRef)$BytesRefArray$else$$type$[]$endif$ values) {
     $if(Point)$
-        long valuesEstimate = RamUsageEstimator.alignObjectSize((long) NUM_BYTES_ARRAY_HEADER + (long) Long.BYTES * values.length * 2);
-        return BASE_RAM_BYTES_USED + valuesEstimate;
+        long valuesEstimate = (long) NUM_BYTES_ARRAY_HEADER + ((long) Long.BYTES * 2 + (long) NUM_BYTES_OBJECT_REF) * values.length;
+        return BASE_RAM_BYTES_USED + alignObjectSize(valuesEstimate);
     $else$
         return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(values);
     $endif$

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayVector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayVector.java.st
@@ -13,16 +13,6 @@ import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.util.BytesRefArray;
 import org.elasticsearch.core.Releasables;
 
-$elseif(Point)$
-import org.apache.lucene.util.RamUsageEstimator;
-import org.elasticsearch.common.geo.SpatialPoint;
-
-import java.util.Arrays;
-
-import static org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_ARRAY_HEADER;
-import static org.apache.lucene.util.RamUsageEstimator.NUM_BYTES_OBJECT_REF;
-import static org.apache.lucene.util.RamUsageEstimator.alignObjectSize;
-
 $else$
 import org.apache.lucene.util.RamUsageEstimator;
 
@@ -30,7 +20,7 @@ import java.util.Arrays;
 $endif$
 
 /**
- * Vector implementation that stores an array of $type$ values.
+ * Vector implementation that stores an array of $Type$ values.
  * This class is generated. Do not edit it.
  */
 public final class $Type$ArrayVector extends AbstractVector implements $Type$Vector {
@@ -40,19 +30,27 @@ public final class $Type$ArrayVector extends AbstractVector implements $Type$Vec
 $if(BytesRef)$
     private final BytesRefArray values;
 
+$elseif(Point)$
+    private final double[] xValues, yValues;
+
 $else$
     private final $type$[] values;
 $endif$
 
     private final $Type$Block block;
 
-    public $Type$ArrayVector($if(BytesRef)$BytesRefArray$else$$type$[]$endif$ values, int positionCount) {
-        this(values, positionCount, BlockFactory.getNonBreakingInstance());
+    public $Type$ArrayVector($typeArrayValues$, int positionCount) {
+        this($arrayValues$, positionCount, BlockFactory.getNonBreakingInstance());
     }
 
-    public $Type$ArrayVector($if(BytesRef)$BytesRefArray$else$$type$[]$endif$ values, int positionCount, BlockFactory blockFactory) {
+    public $Type$ArrayVector($typeArrayValues$, int positionCount, BlockFactory blockFactory) {
         super(positionCount, blockFactory);
+$if(Point)$
+        this.xValues = xValues;
+        this.yValues = yValues;
+$else$
         this.values = values;
+$endif$
         this.block = new $Type$VectorBlock(this);
     }
 
@@ -65,6 +63,17 @@ $if(BytesRef)$
     @Override
     public BytesRef getBytesRef(int position, BytesRef dest) {
         return values.get(position, dest);
+    }
+
+$elseif(Point)$
+    @Override
+    public double getX(int position) {
+        return xValues[position];
+    }
+
+    @Override
+    public double getY(int position) {
+        return yValues[position];
     }
 
 $else$
@@ -93,6 +102,8 @@ $endif$
             for (int pos : positions) {
             $if(BytesRef)$
                 builder.append$Type$(values.get(pos, scratch));
+            $elseif(Point)$
+                builder.append$Type$(xValues[pos], yValues[pos]);
             $else$
                 builder.append$Type$(values[pos]);
             $endif$
@@ -101,10 +112,9 @@ $endif$
         }
     }
 
-    public static long ramBytesEstimated($if(BytesRef)$BytesRefArray$else$$type$[]$endif$ values) {
+    public static long ramBytesEstimated($typeArrayValues$) {
     $if(Point)$
-        long valuesEstimate = (long) NUM_BYTES_ARRAY_HEADER + ((long) Long.BYTES * 2 + (long) NUM_BYTES_OBJECT_REF) * values.length;
-        return BASE_RAM_BYTES_USED + alignObjectSize(valuesEstimate);
+        return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(xValues) * 2;
     $else$
         return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(values);
     $endif$
@@ -112,7 +122,7 @@ $endif$
 
     @Override
     public long ramBytesUsed() {
-        return ramBytesEstimated(values);
+        return ramBytesEstimated($arrayValues$);
     }
 
     @Override
@@ -132,6 +142,15 @@ $endif$
     public String toString() {
 $if(BytesRef)$
         return getClass().getSimpleName() + "[positions=" + getPositionCount() + ']';
+$elseif(Point)$
+        return getClass().getSimpleName()
+            + "[positions="
+            + getPositionCount()
+            + ", x="
+            + Arrays.toString(xValues)
+            + ", y="
+            + Arrays.toString(yValues)
+            + ']';
 $else$
         return getClass().getSimpleName() + "[positions=" + getPositionCount() + ", values=" + Arrays.toString(values) + ']';
 $endif$

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BigArrayVector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BigArrayVector.java.st
@@ -8,12 +8,7 @@
 package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.RamUsageEstimator;
-$if(Point)$
-import org.elasticsearch.common.geo.SpatialPoint;
-import org.elasticsearch.common.util.ObjectArray;
-$else$
 import org.elasticsearch.common.util.$Array$;
-$endif$
 import org.elasticsearch.core.Releasable;
 
 /**
@@ -24,17 +19,30 @@ public final class $Type$BigArrayVector extends AbstractVector implements $Type$
 
     private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance($Type$BigArrayVector.class);
 
-    private final $Array$ values;
+    private final $Array$ $arrayValues$;
 
     private final $Type$Block block;
 
+$if(Point)$
+    public $Type$BigArrayVector($Array$ xValues, $Array$ yValues, int positionCount) {
+$else$
     public $Type$BigArrayVector($Array$ values, int positionCount) {
-        this(values, positionCount, BlockFactory.getNonBreakingInstance());
+$endif$
+        this($arrayValues$, positionCount, BlockFactory.getNonBreakingInstance());
     }
 
+$if(Point)$
+    public $Type$BigArrayVector($Array$ xValues, $Array$ yValues, int positionCount, BlockFactory blockFactory) {
+$else$
     public $Type$BigArrayVector($Array$ values, int positionCount, BlockFactory blockFactory) {
+$endif$
         super(positionCount, blockFactory);
+$if(Point)$
+        this.xValues = xValues;
+        this.yValues = yValues;
+$else$
         this.values = values;
+$endif$
         this.block = new $Type$VectorBlock(this);
     }
 
@@ -43,11 +51,24 @@ public final class $Type$BigArrayVector extends AbstractVector implements $Type$
         return block;
     }
 
+$if(Point)$
+    @Override
+    public double getX(int position) {
+        return xValues.get(position);
+    }
+
+    @Override
+    public double getY(int position) {
+        return yValues.get(position);
+    }
+
+$else$
     @Override
     public $type$ get$Type$(int position) {
         return values.get(position);
     }
 
+$endif$
     @Override
     public ElementType elementType() {
         return ElementType.$TYPE$;
@@ -60,7 +81,11 @@ public final class $Type$BigArrayVector extends AbstractVector implements $Type$
 
     @Override
     public long ramBytesUsed() {
+$if(Point)$
+        return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(xValues) * 2;
+$else$
         return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(values);
+$endif$
     }
 
     @Override
@@ -69,7 +94,8 @@ public final class $Type$BigArrayVector extends AbstractVector implements $Type$
     $if(boolean)$
         final BitArray filtered = new BitArray(positions.length, blockFactory.bigArrays());
     $elseif(Point)$
-        final $Array$ filtered = blockFactory.bigArrays().newObjectArray(positions.length);
+        final $Array$ xFiltered = blockFactory.bigArrays().new$Array$(positions.length);
+        final $Array$ yFiltered = blockFactory.bigArrays().new$Array$(positions.length);
     $else$
         final $Array$ filtered = blockFactory.bigArrays().new$Array$(positions.length);
     $endif$
@@ -79,12 +105,21 @@ public final class $Type$BigArrayVector extends AbstractVector implements $Type$
                 filtered.set(i);
             }
         }
+    $elseif(Point)$
+        for (int i = 0; i < positions.length; i++) {
+            xFiltered.set(i, xValues.get(positions[i]));
+            yFiltered.set(i, yValues.get(positions[i]));
+        }
     $else$
         for (int i = 0; i < positions.length; i++) {
             filtered.set(i, values.get(positions[i]));
         }
     $endif$
+    $if(Point)$
+        return new $Type$BigArrayVector(xFiltered, yFiltered, positions.length, blockFactory);
+    $else$
         return new $Type$BigArrayVector(filtered, positions.length, blockFactory);
+    $endif$
     }
 
     @Override
@@ -93,7 +128,12 @@ public final class $Type$BigArrayVector extends AbstractVector implements $Type$
             throw new IllegalStateException("can't release already released vector [" + this + "]");
         }
         released = true;
+$if(Point)$
+        xValues.close();
+        yValues.close();
+$else$
         values.close();
+$endif$
     }
 
     @Override
@@ -111,6 +151,10 @@ public final class $Type$BigArrayVector extends AbstractVector implements $Type$
 
     @Override
     public String toString() {
+$if(Point)$
+        return getClass().getSimpleName() + "[positions=" + getPositionCount() + ", x=" + xValues + ", y=" + yValues + ']';
+$else$
         return getClass().getSimpleName() + "[positions=" + getPositionCount() + ", values=" + values + ']';
+$endif$
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Block.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Block.java.st
@@ -168,8 +168,7 @@ $if(BytesRef)$
                     if (block1.getBytesRef(b1ValueIdx + valueIndex, new BytesRef())
                         .equals(block2.getBytesRef(b2ValueIdx + valueIndex, new BytesRef())) == false) {
 $elseif(Point)$
-                    if (block1.get$Type$(b1ValueIdx + valueIndex)
-                        .equals(block2.get$Type$(b2ValueIdx + valueIndex)) == false) {
+                    if (block1.get$Type$(b1ValueIdx + valueIndex).equals(block2.get$Type$(b2ValueIdx + valueIndex)) == false) {
 $else$
                     if (block1.get$Type$(b1ValueIdx + valueIndex) != block2.get$Type$(b2ValueIdx + valueIndex)) {
 $endif$

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Block.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Block.java.st
@@ -80,12 +80,7 @@ $endif$
                     final int valueCount = in.readVInt();
                     builder.beginPositionEntry();
                     for (int valueIndex = 0; valueIndex < valueCount; valueIndex++) {
-    $if(Point)$
-                        $type$ element = new $type$(in.readDouble(), in.readDouble());
-                        builder.append$Type$(element);
-    $else$
                         builder.append$Type$(in.read$Type$());
-    $endif$
                     }
                     builder.endPositionEntry();
                 }
@@ -113,10 +108,6 @@ $endif$
                     for (int valueIndex = 0; valueIndex < valueCount; valueIndex++) {
     $if(BytesRef)$
                         out.write$Type$(get$Type$(getFirstValueIndex(pos) + valueIndex, new BytesRef()));
-    $elseif(Point)$
-                        $type$ element = get$Type$(getFirstValueIndex(pos) + valueIndex);
-                        out.writeDouble(element.getX());
-                        out.writeDouble(element.getY());
     $else$
                         out.write$Type$(get$Type$(getFirstValueIndex(pos) + valueIndex));
     $endif$

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Block.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Block.java.st
@@ -21,7 +21,7 @@ import org.elasticsearch.index.mapper.BlockLoader;
 import java.io.IOException;
 
 /**
- * Block that stores $type$ values.
+ * Block that stores $Type$ values.
  * This class is generated. Do not edit it.
  */
 public sealed interface $Type$Block extends Block permits $Type$ArrayBlock, $Type$VectorBlock, ConstantNullBlock {
@@ -31,7 +31,7 @@ $if(BytesRef)$
 
 $endif$
     /**
-     * Retrieves the $type$ value stored at the given value index.
+     * Retrieves the $typeValue$ stored at the given value index.
      *
      * <p> Values for a given position are between getFirstValueIndex(position) (inclusive) and
      * getFirstValueIndex(position) + getValueCount(position) (exclusive).
@@ -44,6 +44,15 @@ $endif$
      */
 $if(BytesRef)$
     BytesRef getBytesRef(int valueIndex, BytesRef dest);
+
+$elseif(Point)$
+    $type$ getX(int valueIndex);
+
+    $type$ getY(int valueIndex);
+
+    default SpatialPoint get$Type$(int valueIndex) {
+        return new SpatialPoint(getX(valueIndex), getY(valueIndex));
+    }
 
 $else$
     $type$ get$Type$(int valueIndex);
@@ -81,7 +90,7 @@ $endif$
                     builder.beginPositionEntry();
                     for (int valueIndex = 0; valueIndex < valueCount; valueIndex++) {
 $if(Point)$
-                        builder.appendPoint(new SpatialPoint(in.readDouble(), in.readDouble()));
+                        builder.appendPoint(in.readDouble(), in.readDouble());
 $else$
                         builder.append$Type$(in.read$Type$());
 $endif$
@@ -113,9 +122,8 @@ $endif$
 $if(BytesRef)$
                         out.write$Type$(get$Type$(getFirstValueIndex(pos) + valueIndex, new BytesRef()));
 $elseif(Point)$
-                        SpatialPoint point = getPoint(getFirstValueIndex(pos) + valueIndex);
-                        out.writeDouble(point.getX());
-                        out.writeDouble(point.getY());
+                        out.writeDouble(getX(getFirstValueIndex(pos) + valueIndex));
+                        out.writeDouble(getY(getFirstValueIndex(pos) + valueIndex));
 $else$
                         out.write$Type$(get$Type$(getFirstValueIndex(pos) + valueIndex));
 $endif$
@@ -167,7 +175,8 @@ $if(BytesRef)$
                     if (block1.getBytesRef(b1ValueIdx + valueIndex, new BytesRef())
                         .equals(block2.getBytesRef(b2ValueIdx + valueIndex, new BytesRef())) == false) {
 $elseif(Point)$
-                    if (block1.get$Type$(b1ValueIdx + valueIndex).equals(block2.get$Type$(b2ValueIdx + valueIndex)) == false) {
+                    if (block1.getX(b1ValueIdx + valueIndex) != block2.getX(b2ValueIdx + valueIndex)
+                        || block1.getY(b1ValueIdx + valueIndex) != block2.getY(b2ValueIdx + valueIndex)) {
 $else$
                     if (block1.get$Type$(b1ValueIdx + valueIndex) != block2.get$Type$(b2ValueIdx + valueIndex)) {
 $endif$
@@ -209,10 +218,9 @@ $elseif(double)$
                     long element = Double.doubleToLongBits(block.getDouble(firstValueIdx + valueIndex));
                     result = 31 * result + (int) (element ^ (element >>> 32));
 $elseif(Point)$
-                    $type$ value = block.get$Type$(firstValueIdx + valueIndex);
-                    long element = Double.doubleToLongBits(value.getX());
+                    long element = Double.doubleToLongBits(block.getX(firstValueIdx + valueIndex));
                     result = 31 * result + (int) (element ^ (element >>> 32));
-                    element = Double.doubleToLongBits(value.getY());
+                    element = Double.doubleToLongBits(block.getY(firstValueIdx + valueIndex));
                     result = 31 * result + (int) (element ^ (element >>> 32));
 $endif$
                 }
@@ -246,8 +254,8 @@ $endif$
      */
     // Eventually, we want to remove this entirely, always passing an explicit BlockFactory
     @Deprecated
-    static $Type$Block newConstantBlockWith($type$ value, int positions) {
-        return newConstantBlockWith(value, positions, BlockFactory.getNonBreakingInstance());
+    static $Type$Block newConstantBlockWith($typeValue$, int positions) {
+        return newConstantBlockWith($value$, positions, BlockFactory.getNonBreakingInstance());
     }
 
     /**
@@ -255,8 +263,8 @@ $endif$
      * @deprecated use {@link BlockFactory#newConstant$Type$BlockWith}
      */
     @Deprecated
-    static $Type$Block newConstantBlockWith($type$ value, int positions, BlockFactory blockFactory) {
-        return blockFactory.newConstant$Type$BlockWith(value, positions);
+    static $Type$Block newConstantBlockWith($typeValue$, int positions, BlockFactory blockFactory) {
+        return blockFactory.newConstant$Type$BlockWith($value$, positions);
     }
 
     /**
@@ -267,7 +275,7 @@ $endif$
          * Appends a $type$ to the current entry.
          */
         @Override
-        Builder append$Type$($type$ value);
+        Builder append$Type$($typeValue$);
 
         /**
          * Copy the values in {@code block} from {@code beginInclusive} to
@@ -291,14 +299,14 @@ $endif$
         Builder mvOrdering(Block.MvOrdering mvOrdering);
 
         /**
-         * Appends the all values of the given block into a the current position
+         * Appends the all values of the given block into the current position
          * in this builder.
          */
         @Override
         Builder appendAllValuesToCurrentPosition(Block block);
 
         /**
-         * Appends the all values of the given block into a the current position
+         * Appends the all values of the given block into the current position
          * in this builder.
          */
         Builder appendAllValuesToCurrentPosition($Type$Block block);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Block.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Block.java.st
@@ -80,7 +80,11 @@ $endif$
                     final int valueCount = in.readVInt();
                     builder.beginPositionEntry();
                     for (int valueIndex = 0; valueIndex < valueCount; valueIndex++) {
+$if(Point)$
+                        builder.appendPoint(new SpatialPoint(in.readDouble(), in.readDouble()));
+$else$
                         builder.append$Type$(in.read$Type$());
+$endif$
                     }
                     builder.endPositionEntry();
                 }
@@ -106,11 +110,15 @@ $endif$
                     final int valueCount = getValueCount(pos);
                     out.writeVInt(valueCount);
                     for (int valueIndex = 0; valueIndex < valueCount; valueIndex++) {
-    $if(BytesRef)$
+$if(BytesRef)$
                         out.write$Type$(get$Type$(getFirstValueIndex(pos) + valueIndex, new BytesRef()));
-    $else$
+$elseif(Point)$
+                        SpatialPoint point = getPoint(getFirstValueIndex(pos) + valueIndex);
+                        out.writeDouble(point.getX());
+                        out.writeDouble(point.getY());
+$else$
                         out.write$Type$(get$Type$(getFirstValueIndex(pos) + valueIndex));
-    $endif$
+$endif$
                     }
                 }
             }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Block.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Block.java.st
@@ -9,6 +9,8 @@ package org.elasticsearch.compute.data;
 
 $if(BytesRef)$
 import org.apache.lucene.util.BytesRef;
+$elseif(Point)$
+import org.elasticsearch.common.geo.SpatialPoint;
 $else$
 $endif$
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
@@ -78,7 +80,12 @@ $endif$
                     final int valueCount = in.readVInt();
                     builder.beginPositionEntry();
                     for (int valueIndex = 0; valueIndex < valueCount; valueIndex++) {
+    $if(Point)$
+                        $type$ element = new $type$(in.readDouble(), in.readDouble());
+                        builder.append$Type$(element);
+    $else$
                         builder.append$Type$(in.read$Type$());
+    $endif$
                     }
                     builder.endPositionEntry();
                 }
@@ -106,6 +113,10 @@ $endif$
                     for (int valueIndex = 0; valueIndex < valueCount; valueIndex++) {
     $if(BytesRef)$
                         out.write$Type$(get$Type$(getFirstValueIndex(pos) + valueIndex, new BytesRef()));
+    $elseif(Point)$
+                        $type$ element = get$Type$(getFirstValueIndex(pos) + valueIndex);
+                        out.writeDouble(element.getX());
+                        out.writeDouble(element.getY());
     $else$
                         out.write$Type$(get$Type$(getFirstValueIndex(pos) + valueIndex));
     $endif$
@@ -156,6 +167,9 @@ $endif$
 $if(BytesRef)$
                     if (block1.getBytesRef(b1ValueIdx + valueIndex, new BytesRef())
                         .equals(block2.getBytesRef(b2ValueIdx + valueIndex, new BytesRef())) == false) {
+$elseif(Point)$
+                    if (block1.get$Type$(b1ValueIdx + valueIndex)
+                        .equals(block2.get$Type$(b2ValueIdx + valueIndex)) == false) {
 $else$
                     if (block1.get$Type$(b1ValueIdx + valueIndex) != block2.get$Type$(b2ValueIdx + valueIndex)) {
 $endif$
@@ -195,6 +209,12 @@ $elseif(long)$
                     result = 31 * result + (int) (element ^ (element >>> 32));
 $elseif(double)$
                     long element = Double.doubleToLongBits(block.getDouble(firstValueIdx + valueIndex));
+                    result = 31 * result + (int) (element ^ (element >>> 32));
+$elseif(Point)$
+                    $type$ value = block.get$Type$(firstValueIdx + valueIndex);
+                    long element = Double.doubleToLongBits(value.getX());
+                    result = 31 * result + (int) (element ^ (element >>> 32));
+                    element = Double.doubleToLongBits(value.getY());
                     result = 31 * result + (int) (element ^ (element >>> 32));
 $endif$
                 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BlockBuilder.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BlockBuilder.java.st
@@ -15,11 +15,12 @@ import org.elasticsearch.common.util.BytesRefArray;
 import org.elasticsearch.core.Releasables;
 
 $elseif(Point)$
-import org.elasticsearch.common.geo.SpatialPoint;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.geo.SpatialPoint;
 
 import java.util.Arrays;
+
 $else$
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.breaker.CircuitBreakingException;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BlockBuilder.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BlockBuilder.java.st
@@ -14,13 +14,6 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BytesRefArray;
 import org.elasticsearch.core.Releasables;
 
-$elseif(Point)$
-import org.apache.lucene.util.RamUsageEstimator;
-import org.elasticsearch.common.breaker.CircuitBreakingException;
-import org.elasticsearch.common.geo.SpatialPoint;
-
-import java.util.Arrays;
-
 $else$
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
@@ -46,8 +39,19 @@ $if(BytesRef)$
         values = new BytesRefArray(Math.max(estimatedSize, 2), bigArrays);
     }
 
+$elseif(Point)$
+    private $type$[] $arrayValues$;
+
+    $Type$BlockBuilder(int estimatedSize, BlockFactory blockFactory) {
+        super(blockFactory);
+        int initialSize = Math.max(estimatedSize, 2);
+        adjustBreaker(RamUsageEstimator.NUM_BYTES_ARRAY_HEADER + initialSize * elementSize());
+        xValues = new $type$[initialSize];
+        yValues = new $type$[initialSize];
+    }
+
 $else$
-    private $type$[] values;
+    private $type$[] $arrayValues$;
 
     $Type$BlockBuilder(int estimatedSize, BlockFactory blockFactory) {
         super(blockFactory);
@@ -58,10 +62,13 @@ $else$
 $endif$
 
     @Override
-    public $Type$BlockBuilder append$Type$($type$ value) {
+    public $Type$BlockBuilder append$Type$($typeValue$) {
         ensureCapacity();
 $if(BytesRef)$
         values.append(value);
+$elseif(Point)$
+        xValues[valueCount] = x;
+        yValues[valueCount] = y;
 $else$
         values[valueCount] = value;
 $endif$
@@ -80,6 +87,8 @@ $endif$
     protected int valuesLength() {
 $if(BytesRef)$
         return Integer.MAX_VALUE; // allow the BytesRefArray through its own append
+$elseif(Point)$
+        return xValues.length;
 $else$
         return values.length;
 $endif$
@@ -89,6 +98,9 @@ $endif$
     protected void growValuesArray(int newSize) {
 $if(BytesRef)$
         throw new AssertionError("should not reach here");
+$elseif(Point)$
+        xValues = Arrays.copyOf(xValues, newSize);
+        yValues = Arrays.copyOf(yValues, newSize);
 $else$
         values = Arrays.copyOf(values, newSize);
 $endif$
@@ -156,6 +168,8 @@ $endif$
             for (int p = 0; p < positionCount; p++) {
 $if(BytesRef)$
                 appendBytesRef(vector.getBytesRef(p, scratch));
+$elseif(Point)$
+                append$Type$(vector.getX(p), vector.getY(p));
 $else$
                 append$Type$(vector.get$Type$(p));
 $endif$
@@ -164,11 +178,13 @@ $endif$
             for (int p = 0; p < positionCount; p++) {
                 int count = block.getValueCount(p);
                 int i = block.getFirstValueIndex(p);
-                for (int v = 0; v < count; v++) {
+                for (int v = 0; v < count; v++, i++) {
 $if(BytesRef)$
-                    appendBytesRef(block.getBytesRef(i++, scratch));
+                    appendBytesRef(block.getBytesRef(i, scratch));
+$elseif(Point)$
+                    append$Type$(block.getX(i), block.getY(i));
 $else$
-                    append$Type$(block.get$Type$(i++));
+                    append$Type$(block.get$Type$(i));
 $endif$
                 }
             }
@@ -221,11 +237,13 @@ $endif$
                 beginPositionEntry();
             }
             int i = block.getFirstValueIndex(p);
-            for (int v = 0; v < count; v++) {
+            for (int v = 0; v < count; v++, i++) {
 $if(BytesRef)$
-                appendBytesRef(block.getBytesRef(i++, scratch));
+                appendBytesRef(block.getBytesRef(i, scratch));
+$elseif(Point)$
+                append$Type$(block.getX(i), block.getY(i));
 $else$
-                append$Type$(block.get$Type$(i++));
+                append$Type$(block.get$Type$(i));
 $endif$
             }
             if (count > 1) {
@@ -241,6 +259,8 @@ $endif$
         for (int p = beginInclusive; p < endExclusive; p++) {
 $if(BytesRef)$
             appendBytesRef(vector.getBytesRef(p, scratch));
+$elseif(Point)$
+            append$Type$(vector.getX(p), vector.getY(p));
 $else$
             append$Type$(vector.get$Type$(p));
 $endif$
@@ -291,16 +311,21 @@ $endif$
             values = null;
     $else$
             if (hasNonNullValue && positionCount == 1 && valueCount == 1) {
-                theBlock = blockFactory.newConstant$Type$BlockWith(values[0], 1, estimatedBytes);
+                theBlock = blockFactory.newConstant$Type$BlockWith($if(Point)$xValues[0], yValues[0]$else$values[0]$endif$, 1, estimatedBytes);
             } else {
-                if (values.length - valueCount > 1024 || valueCount < (values.length / 2)) {
-                    values = Arrays.copyOf(values, valueCount);
+                if (valuesLength() - valueCount > 1024 || valueCount < (valuesLength() / 2)) {
+                    growValuesArray(valueCount);
                 }
                 if (isDense() && singleValued()) {
-                    theBlock = blockFactory.new$Type$ArrayVector(values, positionCount, estimatedBytes).asBlock();
+                    theBlock = blockFactory.new$Type$ArrayVector($arrayValues$, positionCount, estimatedBytes).asBlock();
                 } else {
                     theBlock = blockFactory.new$Type$ArrayBlock(
-                        values,
+$if(Point)$
+                        xValues,
+                        yValues,
+$else$
+                        $arrayValues$,
+$endif$
                         positionCount,
                         firstValueIndexes,
                         nullsMask,

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BlockBuilder.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BlockBuilder.java.st
@@ -14,6 +14,12 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BytesRefArray;
 import org.elasticsearch.core.Releasables;
 
+$elseif(Point)$
+import org.elasticsearch.common.geo.SpatialPoint;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+
+import java.util.Arrays;
 $else$
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.breaker.CircuitBreakingException;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ConstantVector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ConstantVector.java.st
@@ -9,6 +9,8 @@ package org.elasticsearch.compute.data;
 
 $if(BytesRef)$
 import org.apache.lucene.util.BytesRef;
+$elseif(Point)$
+import org.elasticsearch.common.geo.SpatialPoint;
 $endif$
 import org.apache.lucene.util.RamUsageEstimator;
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ConstantVector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ConstantVector.java.st
@@ -9,10 +9,15 @@ package org.elasticsearch.compute.data;
 
 $if(BytesRef)$
 import org.apache.lucene.util.BytesRef;
-$elseif(Point)$
-import org.elasticsearch.common.geo.SpatialPoint;
-$endif$
 import org.apache.lucene.util.RamUsageEstimator;
+
+$elseif(Point)$
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.geo.SpatialPoint;
+
+$else$
+import org.apache.lucene.util.RamUsageEstimator;
+$endif$
 
 /**
  * Vector implementation that stores a constant $type$ value.

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ConstantVector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ConstantVector.java.st
@@ -9,15 +9,8 @@ package org.elasticsearch.compute.data;
 
 $if(BytesRef)$
 import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.RamUsageEstimator;
-
-$elseif(Point)$
-import org.apache.lucene.util.RamUsageEstimator;
-import org.elasticsearch.common.geo.SpatialPoint;
-
-$else$
-import org.apache.lucene.util.RamUsageEstimator;
 $endif$
+import org.apache.lucene.util.RamUsageEstimator;
 
 /**
  * Vector implementation that stores a constant $type$ value.
@@ -32,27 +25,45 @@ $else$
     static final long RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(Constant$Type$Vector.class);
 $endif$
 
-    private final $type$ value;
+$if(Point)$
+    private final double x, y;
+$else$
+    private final $typeValue$;
+$endif$
 
     private final $Type$Block block;
 
-    public Constant$Type$Vector($type$ value, int positionCount) {
-        this(value, positionCount, BlockFactory.getNonBreakingInstance());
+    public Constant$Type$Vector($typeValue$, int positionCount) {
+        this($value$, positionCount, BlockFactory.getNonBreakingInstance());
     }
 
-    public Constant$Type$Vector($type$ value, int positionCount, BlockFactory blockFactory) {
+    public Constant$Type$Vector($typeValue$, int positionCount, BlockFactory blockFactory) {
         super(positionCount, blockFactory);
+$if(Point)$
+        this.x = x;
+        this.y = y;
+$else$
         this.value = value;
+$endif$
         this.block = new $Type$VectorBlock(this);
     }
 
     @Override
 $if(BytesRef)$
     public BytesRef getBytesRef(int position, BytesRef ignore) {
+        return value;
+$elseif(Point)$
+    public double getX(int position) {
+        return x;
+    }
+
+    @Override
+    public double getY(int position) {
+        return y;
 $else$
     public $type$ get$Type$(int position) {
-$endif$
         return value;
+$endif$
     }
 
     @Override
@@ -62,7 +73,7 @@ $endif$
 
     @Override
     public $Type$Vector filter(int... positions) {
-        return new Constant$Type$Vector(value, positions.length);
+        return new Constant$Type$Vector($value$, positions.length);
     }
 
     @Override
@@ -106,7 +117,11 @@ $endif$
     }
 
     public String toString() {
+$if(Point)$
+        return getClass().getSimpleName() + "[positions=" + getPositionCount() + ", x=" + x + ", y=" + y + ']';
+$else$
         return getClass().getSimpleName() + "[positions=" + getPositionCount() + ", value=" + value + ']';
+$endif$
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Vector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Vector.java.st
@@ -10,6 +10,9 @@ package org.elasticsearch.compute.data;
 $if(BytesRef)$
 import org.apache.lucene.util.BytesRef;
 $endif$
+$if(Point)$
+import org.elasticsearch.common.geo.SpatialPoint;
+$endif$
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -69,6 +72,8 @@ $endif$
         for (int pos = 0; pos < positions; pos++) {
 $if(BytesRef)$
             if (vector1.getBytesRef(pos, new BytesRef()).equals(vector2.getBytesRef(pos, new BytesRef())) == false) {
+$elseif(Point)$
+            if (vector1.getPoint(pos).equals(vector2.getPoint(pos)) == false) {
 $else$
             if (vector1.get$Type$(pos) != vector2.get$Type$(pos)) {
 $endif$
@@ -100,6 +105,12 @@ $elseif(long)$
 $elseif(double)$
             long element = Double.doubleToLongBits(vector.getDouble(pos));
             result = 31 * result + (int) (element ^ (element >>> 32));
+$elseif(Point)$
+            SpatialPoint point = vector.getPoint(pos);
+            long element = Double.doubleToLongBits(point.getX());
+            result = 31 * result + (int) (element ^ (element >>> 32));
+            element = Double.doubleToLongBits(point.getY());
+            result = 31 * result + (int) (element ^ (element >>> 32));
 $endif$
         }
         return result;
@@ -110,11 +121,21 @@ $endif$
         final int positions = in.readVInt();
         final boolean constant = in.readBoolean();
         if (constant && positions > 0) {
+$if(Point)$
+            $type$ element = new $type$(in.readDouble(), in.readDouble());
+            return blockFactory.newConstant$Type$Vector(element, positions);
+$else$
             return blockFactory.newConstant$Type$Vector(in.read$Type$(), positions);
+$endif$
         } else {
             try (var builder = blockFactory.new$Type$Vector$if(BytesRef)$$else$Fixed$endif$Builder(positions)) {
                 for (int i = 0; i < positions; i++) {
+$if(Point)$
+                    $type$ element = new $type$(in.readDouble(), in.readDouble());
+                    builder.append$Type$(element);
+$else$
                     builder.append$Type$(in.read$Type$());
+$endif$
                 }
                 return builder.build();
             }
@@ -129,6 +150,10 @@ $endif$
         if (isConstant() && positions > 0) {
 $if(BytesRef)$
             out.write$Type$(get$Type$(0, new BytesRef()));
+$elseif(Point)$
+            $type$ value = get$Type$(0);
+            out.writeDouble(value.getX());
+            out.writeDouble(value.getY());
 $else$
             out.write$Type$(get$Type$(0));
 $endif$
@@ -136,6 +161,10 @@ $endif$
             for (int i = 0; i < positions; i++) {
 $if(BytesRef)$
                 out.write$Type$(get$Type$(i, new BytesRef()));
+$elseif(Point)$
+                $type$ value = get$Type$(i);
+                out.writeDouble(value.getX());
+                out.writeDouble(value.getY());
 $else$
                 out.write$Type$(get$Type$(i));
 $endif$

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Vector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Vector.java.st
@@ -121,21 +121,11 @@ $endif$
         final int positions = in.readVInt();
         final boolean constant = in.readBoolean();
         if (constant && positions > 0) {
-$if(Point)$
-            $type$ element = new $type$(in.readDouble(), in.readDouble());
-            return blockFactory.newConstant$Type$Vector(element, positions);
-$else$
             return blockFactory.newConstant$Type$Vector(in.read$Type$(), positions);
-$endif$
         } else {
             try (var builder = blockFactory.new$Type$Vector$if(BytesRef)$$else$Fixed$endif$Builder(positions)) {
                 for (int i = 0; i < positions; i++) {
-$if(Point)$
-                    $type$ element = new $type$(in.readDouble(), in.readDouble());
-                    builder.append$Type$(element);
-$else$
                     builder.append$Type$(in.read$Type$());
-$endif$
                 }
                 return builder.build();
             }
@@ -150,10 +140,6 @@ $endif$
         if (isConstant() && positions > 0) {
 $if(BytesRef)$
             out.write$Type$(get$Type$(0, new BytesRef()));
-$elseif(Point)$
-            $type$ value = get$Type$(0);
-            out.writeDouble(value.getX());
-            out.writeDouble(value.getY());
 $else$
             out.write$Type$(get$Type$(0));
 $endif$
@@ -161,10 +147,6 @@ $endif$
             for (int i = 0; i < positions; i++) {
 $if(BytesRef)$
                 out.write$Type$(get$Type$(i, new BytesRef()));
-$elseif(Point)$
-                $type$ value = get$Type$(i);
-                out.writeDouble(value.getX());
-                out.writeDouble(value.getY());
 $else$
                 out.write$Type$(get$Type$(i));
 $endif$

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Vector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Vector.java.st
@@ -19,7 +19,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import java.io.IOException;
 
 /**
- * Vector that stores $type$ values.
+ * Vector that stores $Type$ values.
  * This class is generated. Do not edit it.
  */
 $if(BytesRef)$
@@ -36,6 +36,15 @@ $endif$
 
 $if(BytesRef)$
     BytesRef getBytesRef(int position, BytesRef dest);
+
+$elseif(Point)$
+    double getX(int position);
+
+    double getY(int position);
+
+    default SpatialPoint get$Type$(int valueIndex) {
+        return new SpatialPoint(getX(valueIndex), getY(valueIndex));
+    }
 
 $else$
     $type$ get$Type$(int position);
@@ -73,7 +82,7 @@ $endif$
 $if(BytesRef)$
             if (vector1.getBytesRef(pos, new BytesRef()).equals(vector2.getBytesRef(pos, new BytesRef())) == false) {
 $elseif(Point)$
-            if (vector1.getPoint(pos).equals(vector2.getPoint(pos)) == false) {
+            if (vector1.getX(pos) != vector2.getY(pos) || vector1.getY(pos) != vector2.getY(pos)) {
 $else$
             if (vector1.get$Type$(pos) != vector2.get$Type$(pos)) {
 $endif$
@@ -106,10 +115,11 @@ $elseif(double)$
             long element = Double.doubleToLongBits(vector.getDouble(pos));
             result = 31 * result + (int) (element ^ (element >>> 32));
 $elseif(Point)$
-            SpatialPoint point = vector.getPoint(pos);
-            long element = Double.doubleToLongBits(point.getX());
+            double x = vector.getX(pos);
+            double y = vector.getY(pos);
+            long element = Double.doubleToLongBits(x);
             result = 31 * result + (int) (element ^ (element >>> 32));
-            element = Double.doubleToLongBits(point.getY());
+            element = Double.doubleToLongBits(y);
             result = 31 * result + (int) (element ^ (element >>> 32));
 $endif$
         }
@@ -122,7 +132,7 @@ $endif$
         final boolean constant = in.readBoolean();
         if (constant && positions > 0) {
 $if(Point)$
-            return blockFactory.newConstantPointVector(new SpatialPoint(in.readDouble(), in.readDouble()), positions);
+            return blockFactory.newConstant$Type$Vector(in.readDouble(), in.readDouble(), positions);
 $else$
             return blockFactory.newConstant$Type$Vector(in.read$Type$(), positions);
 $endif$
@@ -130,7 +140,7 @@ $endif$
             try (var builder = blockFactory.new$Type$Vector$if(BytesRef)$$else$Fixed$endif$Builder(positions)) {
                 for (int i = 0; i < positions; i++) {
 $if(Point)$
-                    builder.appendPoint(new SpatialPoint(in.readDouble(), in.readDouble()));
+                    builder.append$Type$(in.readDouble(), in.readDouble());
 $else$
                     builder.append$Type$(in.read$Type$());
 $endif$
@@ -149,9 +159,8 @@ $endif$
 $if(BytesRef)$
             out.write$Type$(get$Type$(0, new BytesRef()));
 $elseif(Point)$
-            SpatialPoint point = getPoint(0);
-            out.writeDouble(point.getX());
-            out.writeDouble(point.getY());
+            out.writeDouble(getX(0));
+            out.writeDouble(getY(0));
 $else$
             out.write$Type$(get$Type$(0));
 $endif$
@@ -160,9 +169,8 @@ $endif$
 $if(BytesRef)$
                 out.write$Type$(get$Type$(i, new BytesRef()));
 $elseif(Point)$
-                SpatialPoint point = getPoint(i);
-                out.writeDouble(point.getX());
-                out.writeDouble(point.getY());
+                out.writeDouble(getX(i));
+                out.writeDouble(getY(i));
 $else$
                 out.write$Type$(get$Type$(i));
 $endif$
@@ -228,7 +236,7 @@ $endif$
         /**
          * Appends a $type$ to the current entry.
          */
-        Builder append$Type$($type$ value);
+        Builder append$Type$($typeValue$);
 
         @Override
         $Type$Vector build();
@@ -243,7 +251,7 @@ $else$
         /**
          * Appends a $type$ to the current entry.
          */
-        FixedBuilder append$Type$($type$ value);
+        FixedBuilder append$Type$($typeValue$);
 
         @Override
         $Type$Vector build();

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Vector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Vector.java.st
@@ -121,11 +121,19 @@ $endif$
         final int positions = in.readVInt();
         final boolean constant = in.readBoolean();
         if (constant && positions > 0) {
+$if(Point)$
+            return blockFactory.newConstantPointVector(new SpatialPoint(in.readDouble(), in.readDouble()), positions);
+$else$
             return blockFactory.newConstant$Type$Vector(in.read$Type$(), positions);
+$endif$
         } else {
             try (var builder = blockFactory.new$Type$Vector$if(BytesRef)$$else$Fixed$endif$Builder(positions)) {
                 for (int i = 0; i < positions; i++) {
+$if(Point)$
+                    builder.appendPoint(new SpatialPoint(in.readDouble(), in.readDouble()));
+$else$
                     builder.append$Type$(in.read$Type$());
+$endif$
                 }
                 return builder.build();
             }
@@ -140,6 +148,10 @@ $endif$
         if (isConstant() && positions > 0) {
 $if(BytesRef)$
             out.write$Type$(get$Type$(0, new BytesRef()));
+$elseif(Point)$
+            SpatialPoint point = getPoint(0);
+            out.writeDouble(point.getX());
+            out.writeDouble(point.getY());
 $else$
             out.write$Type$(get$Type$(0));
 $endif$
@@ -147,6 +159,10 @@ $endif$
             for (int i = 0; i < positions; i++) {
 $if(BytesRef)$
                 out.write$Type$(get$Type$(i, new BytesRef()));
+$elseif(Point)$
+                SpatialPoint point = getPoint(i);
+                out.writeDouble(point.getX());
+                out.writeDouble(point.getY());
 $else$
                 out.write$Type$(get$Type$(i));
 $endif$

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorBlock.java.st
@@ -10,9 +10,6 @@ package org.elasticsearch.compute.data;
 $if(BytesRef)$
 import org.apache.lucene.util.BytesRef;
 $endif$
-$if(Point)$
-import org.elasticsearch.common.geo.SpatialPoint;
-$endif$
 import org.elasticsearch.core.Releasables;
 
 /**
@@ -40,6 +37,14 @@ public final class $Type$VectorBlock extends AbstractVectorBlock implements $Typ
 $if(BytesRef)$
     public BytesRef getBytesRef(int valueIndex, BytesRef dest) {
         return vector.getBytesRef(valueIndex, dest);
+$elseif(Point)$
+    public double getX(int valueIndex) {
+        return vector.getX(valueIndex);
+    }
+
+    @Override
+    public double getY(int valueIndex) {
+        return vector.getY(valueIndex);
 $else$
     public $type$ get$Type$(int valueIndex) {
         return vector.get$Type$(valueIndex);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorBuilder.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorBuilder.java.st
@@ -12,7 +12,10 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BytesRefArray;
 import org.elasticsearch.core.Releasables;
+$elseif(Point)$
+import org.elasticsearch.common.geo.SpatialPoint;
 
+import java.util.Arrays;
 $else$
 import java.util.Arrays;
 $endif$

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorBuilder.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorBuilder.java.st
@@ -13,11 +13,6 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BytesRefArray;
 import org.elasticsearch.core.Releasables;
 
-$elseif(Point)$
-import org.elasticsearch.common.geo.SpatialPoint;
-
-import java.util.Arrays;
-
 $else$
 import java.util.Arrays;
 $endif$
@@ -40,8 +35,19 @@ $if(BytesRef)$
         values = new BytesRefArray(Math.max(estimatedSize, 2), bigArrays);
     }
 
+$elseif(Point)$
+    private $type$[] $arrayValues$;
+
+    $Type$VectorBuilder(int estimatedSize, BlockFactory blockFactory) {
+        super(blockFactory);
+        int initialSize = Math.max(estimatedSize, 2);
+        adjustBreaker(initialSize);
+        xValues = new $type$[Math.max(estimatedSize, 2)];
+        yValues = new $type$[Math.max(estimatedSize, 2)];
+    }
+
 $else$
-    private $type$[] values;
+    private $type$[] $arrayValues$;
 
     $Type$VectorBuilder(int estimatedSize, BlockFactory blockFactory) {
         super(blockFactory);
@@ -52,10 +58,13 @@ $else$
 $endif$
 
     @Override
-    public $Type$VectorBuilder append$Type$($type$ value) {
+    public $Type$VectorBuilder append$Type$($typeValue$) {
         ensureCapacity();
 $if(BytesRef)$
         values.append(value);
+$elseif(Point)$
+        xValues[valueCount] = x;
+        yValues[valueCount] = y;
 $else$
         values[valueCount] = value;
 $endif$
@@ -72,6 +81,8 @@ $endif$
     protected int valuesLength() {
 $if(BytesRef)$
         return Integer.MAX_VALUE; // allow the BytesRefArray through its own append
+$elseif(Point)$
+        return xValues.length;
 $else$
         return values.length;
 $endif$
@@ -81,6 +92,9 @@ $endif$
     protected void growValuesArray(int newSize) {
 $if(BytesRef)$
         throw new AssertionError("should not reach here");
+$elseif(Point)$
+        xValues = Arrays.copyOf(xValues, newSize);
+        yValues = Arrays.copyOf(yValues, newSize);
 $else$
         values = Arrays.copyOf(values, newSize);
 $endif$
@@ -117,14 +131,23 @@ $if(BytesRef)$
             blockFactory.adjustBreaker(vector.ramBytesUsed() - values.bigArraysRamBytesUsed(), false);
         }
         values = null;
+$elseif(Point)$
+        if (valueCount == 1) {
+            vector = blockFactory.newConstant$Type$BlockWith(xValues[0], yValues[0], 1, estimatedBytes).asVector();
+        } else {
+            if (valuesLength() - valueCount > 1024 || valueCount < (valuesLength() / 2)) {
+                growValuesArray(valueCount);
+            }
+            vector = blockFactory.new$Type$ArrayVector($arrayValues$, valueCount, estimatedBytes);
+        }
 $else$
         if (valueCount == 1) {
             vector = blockFactory.newConstant$Type$BlockWith(values[0], 1, estimatedBytes).asVector();
         } else {
-            if (values.length - valueCount > 1024 || valueCount < (values.length / 2)) {
-                values = Arrays.copyOf(values, valueCount);
+            if (valuesLength() - valueCount > 1024 || valueCount < (valuesLength() / 2)) {
+                growValuesArray(valueCount);
             }
-            vector = blockFactory.new$Type$ArrayVector(values, valueCount, estimatedBytes);
+            vector = blockFactory.new$Type$ArrayVector($arrayValues$, valueCount, estimatedBytes);
         }
 $endif$
         built();

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorBuilder.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorBuilder.java.st
@@ -12,10 +12,12 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BytesRefArray;
 import org.elasticsearch.core.Releasables;
+
 $elseif(Point)$
 import org.elasticsearch.common.geo.SpatialPoint;
 
 import java.util.Arrays;
+
 $else$
 import java.util.Arrays;
 $endif$

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorFixedBuilder.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorFixedBuilder.java.st
@@ -7,11 +7,13 @@
 
 package org.elasticsearch.compute.data;
 
-import org.apache.lucene.util.RamUsageEstimator;
 $if(Point)$
+import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.geo.SpatialPoint;
-$endif$
 
+$else$
+import org.apache.lucene.util.RamUsageEstimator;
+$endif$
 
 /**
  * Builder for {@link $Type$Vector}s that never grows. Prefer this to

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorFixedBuilder.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorFixedBuilder.java.st
@@ -45,11 +45,19 @@ final class $Type$VectorFixedBuilder implements $Type$Vector.FixedBuilder {
     }
 
     private static long ramBytesUsed(int size) {
+$if(Point)$
+        return size == 1
+            ? ConstantPointVector.RAM_BYTES_USED
+            : PointArrayVector.BASE_RAM_BYTES_USED + RamUsageEstimator.alignObjectSize(
+                (long) RamUsageEstimator.NUM_BYTES_ARRAY_HEADER + (long) size * ($BYTES$ + RamUsageEstimator.NUM_BYTES_OBJECT_REF)
+            );
+$else$
         return size == 1
             ? Constant$Type$Vector.RAM_BYTES_USED
             : $Type$ArrayVector.BASE_RAM_BYTES_USED + RamUsageEstimator.alignObjectSize(
                 (long) RamUsageEstimator.NUM_BYTES_ARRAY_HEADER + size * $BYTES$
             );
+$endif$
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorFixedBuilder.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorFixedBuilder.java.st
@@ -7,13 +7,7 @@
 
 package org.elasticsearch.compute.data;
 
-$if(Point)$
 import org.apache.lucene.util.RamUsageEstimator;
-import org.elasticsearch.common.geo.SpatialPoint;
-
-$else$
-import org.apache.lucene.util.RamUsageEstimator;
-$endif$
 
 /**
  * Builder for {@link $Type$Vector}s that never grows. Prefer this to
@@ -23,7 +17,7 @@ $endif$
  */
 final class $Type$VectorFixedBuilder implements $Type$Vector.FixedBuilder {
     private final BlockFactory blockFactory;
-    private final $type$[] values;
+    private final $type$[] $arrayValues$;
     private final long preAdjustedBytes;
     /**
      * The next value to write into. {@code -1} means the vector has already
@@ -35,28 +29,38 @@ final class $Type$VectorFixedBuilder implements $Type$Vector.FixedBuilder {
         preAdjustedBytes = ramBytesUsed(size);
         blockFactory.adjustBreaker(preAdjustedBytes, false);
         this.blockFactory = blockFactory;
+$if(Point)$
+        this.xValues = new $type$[size];
+        this.yValues = new $type$[size];
+$else$
         this.values = new $type$[size];
+$endif$
     }
 
     @Override
-    public $Type$VectorFixedBuilder append$Type$($type$ value) {
+    public $Type$VectorFixedBuilder append$Type$($typeValue$) {
+$if(Point)$
+        xValues[nextIndex++] = x;
+        yValues[nextIndex++] = y;
+$else$
         values[nextIndex++] = value;
+$endif$
         return this;
     }
 
     private static long ramBytesUsed(int size) {
-$if(Point)$
-        return size == 1
-            ? ConstantPointVector.RAM_BYTES_USED
-            : PointArrayVector.BASE_RAM_BYTES_USED + RamUsageEstimator.alignObjectSize(
-                (long) RamUsageEstimator.NUM_BYTES_ARRAY_HEADER + (long) size * ($BYTES$ + RamUsageEstimator.NUM_BYTES_OBJECT_REF)
-            );
-$else$
         return size == 1
             ? Constant$Type$Vector.RAM_BYTES_USED
             : $Type$ArrayVector.BASE_RAM_BYTES_USED + RamUsageEstimator.alignObjectSize(
                 (long) RamUsageEstimator.NUM_BYTES_ARRAY_HEADER + size * $BYTES$
             );
+    }
+
+    private int valuesLength() {
+$if(Point)$
+        return xValues.length;
+$else$
+        return values.length;
 $endif$
     }
 
@@ -65,15 +69,15 @@ $endif$
         if (nextIndex < 0) {
             throw new IllegalStateException("already closed");
         }
-        if (nextIndex != values.length) {
-            throw new IllegalStateException("expected to write [" + values.length + "] entries but wrote [" + nextIndex + "]");
+        if (nextIndex != valuesLength()) {
+            throw new IllegalStateException("expected to write [" + valuesLength() + "] entries but wrote [" + nextIndex + "]");
         }
         nextIndex = -1;
         $Type$Vector vector;
-        if (values.length == 1) {
-            vector = blockFactory.newConstant$Type$BlockWith(values[0], 1, preAdjustedBytes).asVector();
+        if (valuesLength() == 1) {
+            vector = blockFactory.newConstant$Type$BlockWith($if(Point)$xValues[0], yValues[0]$else$values[0]$endif$, 1, preAdjustedBytes).asVector();
         } else {
-            vector = blockFactory.new$Type$ArrayVector(values, values.length, preAdjustedBytes);
+            vector = blockFactory.new$Type$ArrayVector($arrayValues$, valuesLength(), preAdjustedBytes);
         }
         assert vector.ramBytesUsed() == preAdjustedBytes : "fixed Builders should estimate the exact ram bytes used";
         return vector;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/BlockReaderFactories.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/BlockReaderFactories.java
@@ -32,7 +32,12 @@ public final class BlockReaderFactories {
      * @param asUnsupportedSource should the field be loaded as "unsupported"?
      *                            These will always have {@code null} values
      */
-    public static List<BlockLoader> loaders(List<SearchContext> searchContexts, String fieldName, boolean asUnsupportedSource) {
+    public static List<BlockLoader> loaders(
+        List<SearchContext> searchContexts,
+        String fieldName,
+        boolean asUnsupportedSource,
+        final boolean forStats
+    ) {
         List<BlockLoader> loaders = new ArrayList<>(searchContexts.size());
 
         for (SearchContext searchContext : searchContexts) {
@@ -51,6 +56,11 @@ public final class BlockReaderFactories {
                 @Override
                 public String indexName() {
                     return ctx.getFullyQualifiedIndex().getName();
+                }
+
+                @Override
+                public boolean forStats() {
+                    return forStats;
                 }
 
                 @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/ValuesSourceReaderOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/ValuesSourceReaderOperator.java
@@ -508,6 +508,7 @@ public class ValuesSourceReaderOperator extends AbstractPageMappingOperator {
         public BlockLoader.BytesRefBuilder bytesRefs(int expectedCount) {
             return factory.newBytesRefBlockBuilder(expectedCount);
         }
+
         @Override
         public BlockLoader.PointBuilder points(int expectedCount) {
             return factory.newPointBlockBuilder(expectedCount);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/ValuesSourceReaderOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/ValuesSourceReaderOperator.java
@@ -508,6 +508,10 @@ public class ValuesSourceReaderOperator extends AbstractPageMappingOperator {
         public BlockLoader.BytesRefBuilder bytesRefs(int expectedCount) {
             return factory.newBytesRefBlockBuilder(expectedCount);
         }
+        @Override
+        public BlockLoader.PointBuilder points(int expectedCount) {
+            return factory.newPointBlockBuilder(expectedCount);
+        }
 
         @Override
         public BlockLoader.DoubleBuilder doublesFromDocValues(int expectedCount) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/BatchEncoder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/BatchEncoder.java
@@ -554,7 +554,7 @@ public abstract class BatchEncoder implements Accountable {
             doubleHandle.set(dst.bytes(), before, v.getX());
             doubleHandle.set(dst.bytes(), before + Double.BYTES, v.getY());
             dst.setLength(after);
-            return Double.BYTES;
+            return Double.BYTES * 2;
         }
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/BatchEncoder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/BatchEncoder.java
@@ -12,6 +12,7 @@ import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
 import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BytesRefBlock;
@@ -19,6 +20,7 @@ import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.PointBlock;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
@@ -49,6 +51,7 @@ public abstract class BatchEncoder implements Accountable {
             case DOUBLE -> new DoublesDecoder();
             case BYTES_REF -> new BytesRefsDecoder();
             case BOOLEAN -> new BooleansDecoder();
+            case POINT -> new PointsDecoder();
             default -> throw new IllegalArgumentException("can't encode " + elementType);
         };
     }
@@ -499,6 +502,78 @@ public abstract class BatchEncoder implements Accountable {
                     b.appendDouble((double) doubleHandle.get(e.bytes, e.offset));
                     e.offset += Double.BYTES;
                     e.length -= Double.BYTES;
+                }
+            }
+        }
+    }
+
+    protected abstract static class Points extends MVEncoder {
+        protected Points(int batchSize) {
+            super(batchSize);
+        }
+
+        /**
+         * Is there capacity for this many {@code SpatialPoint}s?
+         */
+        protected final boolean hasCapacity(int count) {
+            return bytes.length() + count * Double.BYTES * 2 <= bytesCapacity();
+        }
+
+        /**
+         * Make sure there is capacity for this many {@code double}s, growing
+         * the buffer if needed.
+         */
+        protected final void ensureCapacity(int count) {
+            // TODO some protection against growing to gigabytes or whatever
+            bytes.grow(count * Double.BYTES * 2);
+        }
+
+        /**
+         * Encode a {@code SpatialPoint} and advance to the next position.
+         */
+        protected final void encode(SpatialPoint v) {
+            addingValue();
+            doubleHandle.set(bytes.bytes(), bytes.length(), v.getX());
+            bytes.setLength(bytes.length() + Double.BYTES);
+            doubleHandle.set(bytes.bytes(), bytes.length(), v.getY());
+            bytes.setLength(bytes.length() + Double.BYTES);
+        }
+    }
+
+    protected static final class DirectPoints extends DirectEncoder {
+        DirectPoints(PointBlock block) {
+            super(block);
+        }
+
+        @Override
+        protected int readValueAtBlockIndex(int valueIndex, BytesRefBuilder dst) {
+            int before = dst.length();
+            int after = before + Double.BYTES * 2;
+            dst.grow(after);
+            SpatialPoint v = ((PointBlock) block).getPoint(valueIndex);
+            doubleHandle.set(dst.bytes(), before, v.getX());
+            doubleHandle.set(dst.bytes(), before + Double.BYTES, v.getY());
+            dst.setLength(after);
+            return Double.BYTES;
+        }
+    }
+
+    private static class PointsDecoder implements Decoder {
+        @Override
+        public void decode(Block.Builder builder, IsNull isNull, BytesRef[] encoded, int count) {
+            PointBlock.Builder b = (PointBlock.Builder) builder;
+            for (int i = 0; i < count; i++) {
+                if (isNull.isNull(i)) {
+                    b.appendNull();
+                } else {
+                    BytesRef e = encoded[i];
+                    double x = (double) doubleHandle.get(e.bytes, e.offset);
+                    e.offset += Double.BYTES;
+                    e.length -= Double.BYTES;
+                    double y = (double) doubleHandle.get(e.bytes, e.offset);
+                    e.offset += Double.BYTES;
+                    e.length -= Double.BYTES;
+                    b.appendPoint(new SpatialPoint(x, y));
                 }
             }
         }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/BatchEncoder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/BatchEncoder.java
@@ -12,7 +12,6 @@ import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefBuilder;
 import org.apache.lucene.util.RamUsageEstimator;
-import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BytesRefBlock;
@@ -531,11 +530,11 @@ public abstract class BatchEncoder implements Accountable {
         /**
          * Encode a {@code SpatialPoint} and advance to the next position.
          */
-        protected final void encode(SpatialPoint v) {
+        protected final void encode(double x, double y) {
             addingValue();
-            doubleHandle.set(bytes.bytes(), bytes.length(), v.getX());
+            doubleHandle.set(bytes.bytes(), bytes.length(), x);
             bytes.setLength(bytes.length() + Double.BYTES);
-            doubleHandle.set(bytes.bytes(), bytes.length(), v.getY());
+            doubleHandle.set(bytes.bytes(), bytes.length(), y);
             bytes.setLength(bytes.length() + Double.BYTES);
         }
     }
@@ -550,9 +549,8 @@ public abstract class BatchEncoder implements Accountable {
             int before = dst.length();
             int after = before + Double.BYTES * 2;
             dst.grow(after);
-            SpatialPoint v = ((PointBlock) block).getPoint(valueIndex);
-            doubleHandle.set(dst.bytes(), before, v.getX());
-            doubleHandle.set(dst.bytes(), before + Double.BYTES, v.getY());
+            doubleHandle.set(dst.bytes(), before, ((PointBlock) block).getX(valueIndex));
+            doubleHandle.set(dst.bytes(), before + Double.BYTES, ((PointBlock) block).getY(valueIndex));
             dst.setLength(after);
             return Double.BYTES * 2;
         }
@@ -573,7 +571,7 @@ public abstract class BatchEncoder implements Accountable {
                     double y = (double) doubleHandle.get(e.bytes, e.offset);
                     e.offset += Double.BYTES;
                     e.length -= Double.BYTES;
-                    b.appendPoint(new SpatialPoint(x, y));
+                    b.appendPoint(x, y);
                 }
             }
         }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/MultivalueDedupe.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/MultivalueDedupe.java
@@ -16,6 +16,7 @@ import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.data.PointBlock;
 import org.elasticsearch.compute.operator.EvalOperator.ExpressionEvaluator;
 
 import java.util.function.BiFunction;
@@ -35,6 +36,7 @@ public final class MultivalueDedupe {
             case INT -> new MultivalueDedupeInt((IntBlock) block).dedupeToBlockAdaptive(blockFactory);
             case LONG -> new MultivalueDedupeLong((LongBlock) block).dedupeToBlockAdaptive(blockFactory);
             case DOUBLE -> new MultivalueDedupeDouble((DoubleBlock) block).dedupeToBlockAdaptive(blockFactory);
+            case POINT -> new MultivalueDedupePoint((PointBlock) block).dedupeToBlockAdaptive(blockFactory);
             default -> throw new IllegalArgumentException();
         };
     }
@@ -52,6 +54,7 @@ public final class MultivalueDedupe {
             case INT -> new MultivalueDedupeInt((IntBlock) block).dedupeToBlockUsingCopyMissing(blockFactory);
             case LONG -> new MultivalueDedupeLong((LongBlock) block).dedupeToBlockUsingCopyMissing(blockFactory);
             case DOUBLE -> new MultivalueDedupeDouble((DoubleBlock) block).dedupeToBlockUsingCopyMissing(blockFactory);
+            case POINT -> new MultivalueDedupePoint((PointBlock) block).dedupeToBlockUsingCopyMissing(blockFactory);
             default -> throw new IllegalArgumentException();
         };
     }
@@ -71,6 +74,7 @@ public final class MultivalueDedupe {
             case INT -> new MultivalueDedupeInt((IntBlock) block).dedupeToBlockUsingCopyAndSort(blockFactory);
             case LONG -> new MultivalueDedupeLong((LongBlock) block).dedupeToBlockUsingCopyAndSort(blockFactory);
             case DOUBLE -> new MultivalueDedupeDouble((DoubleBlock) block).dedupeToBlockUsingCopyAndSort(blockFactory);
+            case POINT -> new MultivalueDedupePoint((PointBlock) block).dedupeToBlockUsingCopyAndSort(blockFactory);
             default -> throw new IllegalArgumentException();
         };
     }
@@ -101,6 +105,10 @@ public final class MultivalueDedupe {
                 field,
                 (blockFactory, block) -> new MultivalueDedupeDouble((DoubleBlock) block).dedupeToBlockAdaptive(blockFactory)
             );
+            case POINT -> new EvaluatorFactory(
+                field,
+                (blockFactory, block) -> new MultivalueDedupePoint((PointBlock) block).dedupeToBlockAdaptive(blockFactory)
+            );
             case NULL -> field; // The page is all nulls and when you dedupe that it's still all nulls
             default -> throw new IllegalArgumentException("unsupported type [" + elementType + "]");
         };
@@ -128,6 +136,7 @@ public final class MultivalueDedupe {
                 case INT -> new BatchEncoder.DirectInts((IntBlock) block);
                 case LONG -> new BatchEncoder.DirectLongs((LongBlock) block);
                 case DOUBLE -> new BatchEncoder.DirectDoubles((DoubleBlock) block);
+                case POINT -> new BatchEncoder.DirectPoints((PointBlock) block);
                 default -> throw new IllegalArgumentException("Unknown [" + elementType + "]");
             };
         } else {
@@ -137,6 +146,7 @@ public final class MultivalueDedupe {
                 case INT -> new MultivalueDedupeInt((IntBlock) block).batchEncoder(batchSize);
                 case LONG -> new MultivalueDedupeLong((LongBlock) block).batchEncoder(batchSize);
                 case DOUBLE -> new MultivalueDedupeDouble((DoubleBlock) block).batchEncoder(batchSize);
+                case POINT -> new MultivalueDedupePoint((PointBlock) block).batchEncoder(batchSize);
                 default -> throw new IllegalArgumentException();
             };
         }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/X-MultivalueDedupe.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/X-MultivalueDedupe.java.st
@@ -60,7 +60,12 @@ $else$
 $endif$
 
     private final $Type$Block block;
+$if(Point)$
+    // TODO: figure out a way to remove this object array, currently needed for Arrays.sort() below
+    private SpatialPoint[] work = new SpatialPoint[ArrayUtil.oversize(2, $BYTES$)];
+$else$
     private $type$[] work = new $type$[ArrayUtil.oversize(2, $BYTES$)];
+$endif$
     private int w;
 
     public MultivalueDedupe$Type$($Type$Block block) {
@@ -88,6 +93,8 @@ $endif$
                     case 0 -> builder.appendNull();
     $if(BytesRef)$
                     case 1 -> builder.appendBytesRef(block.getBytesRef(first, work[0]));
+    $elseif(Point)$
+                    case 1 -> builder.append$Type$(block.getX(first), block.getY(first));
     $else$
                     case 1 -> builder.append$Type$(block.get$Type$(first));
     $endif$
@@ -142,6 +149,8 @@ $endif$
                     case 0 -> builder.appendNull();
     $if(BytesRef)$
                     case 1 -> builder.appendBytesRef(block.getBytesRef(first, work[0]));
+    $elseif(Point)$
+                    case 1 -> builder.append$Type$(block.getX(first), block.getY(first));
     $else$
                     case 1 -> builder.append$Type$(block.get$Type$(first));
     $endif$
@@ -176,6 +185,8 @@ $endif$
                     case 0 -> builder.appendNull();
     $if(BytesRef)$
                     case 1 -> builder.appendBytesRef(block.getBytesRef(first, work[0]));
+    $elseif(Point)$
+                    case 1 -> builder.appendPoint(block.getX(first), block.getY(first));
     $else$
                     case 1 -> builder.append$Type$(block.get$Type$(first));
     $endif$
@@ -210,11 +221,14 @@ $endif$
                     }
                     case 1 -> {
 $if(BytesRef)$
-                        BytesRef v = block.getBytesRef(first, work[0]);
+                        BytesRef value = block.getBytesRef(first, work[0]);
+$elseif(Point)$
+                        double x = block.getX(first);
+                        double y = block.getY(first);
 $else$
-                        $type$ v = block.get$Type$(first);
+                        $typeValue$ = block.get$Type$(first);
 $endif$
-                        hash(builder, hash, v);
+                        hash(builder, hash, $value$);
                     }
                     default -> {
                         if (count < ALWAYS_COPY_MISSING) {
@@ -260,17 +274,26 @@ $endif$
                         case 0 -> encodeNull();
                         case 1 -> {
 $if(BytesRef)$
-                            BytesRef v = block.getBytesRef(first, work[0]);
-                            if (hasCapacity(v.length, 1)) {
+                            BytesRef value = block.getBytesRef(first, work[0]);
+                            if (hasCapacity(value.length, 1)) {
+$elseif(Point)$
+                            double x = block.getX(first);
+                            double y = block.getY(first);
+                            if (hasCapacity(1)) {
 $else$
-                            $type$ v = block.get$Type$(first);
+                            $typeValue$ = block.get$Type$(first);
                             if (hasCapacity(1)) {
 $endif$
                                 startPosition();
-                                encode(v);
+                                encode($value$);
                                 endPosition();
                             } else {
-                                work[0] = v;
+$if(Point)$
+                                // We should be able to replace this with two double[] if we can figure out the sorting below
+                                work[0] = new SpatialPoint(x, y);
+$else$
+                                work[0] = value;
+$endif$
                                 w = 1;
                                 return;
                             }
@@ -323,6 +346,8 @@ $endif$
 $if(BytesRef)$
             work[w] = block.getBytesRef(i, work[w]);
             w++;
+$elseif(Point)$
+            work[w++] = new SpatialPoint(block.getX(i), block.getY(i));
 $else$
             work[w++] = block.get$Type$(i);
 $endif$
@@ -341,6 +366,8 @@ $endif$
 
 $if(BytesRef)$
         work[0] = block.getBytesRef(first, work[0]);
+$elseif(Point)$
+        work[0] = new SpatialPoint(block.getX(first), block.getY(first));
 $else$
         work[0] = block.get$Type$(first);
 $endif$
@@ -348,6 +375,8 @@ $endif$
         i: for (int i = first + 1; i < end; i++) {
 $if(BytesRef)$
             $type$ v = block.getBytesRef(i, work[w]);
+$elseif(Point)$
+            SpatialPoint v = new SpatialPoint(block.getX(i), block.getY(i));
 $else$
             $type$ v = block.get$Type$(i);
 $endif$
@@ -371,12 +400,20 @@ $endif$
      */
     private void writeUniquedWork($Type$Block.Builder builder) {
         if (w == 1) {
+$if(Point)$
+            builder.appendPoint(work[0].getX(), work[0].getY());
+$else$
             builder.append$Type$(work[0]);
+$endif$
             return;
         }
         builder.beginPositionEntry();
         for (int i = 0; i < w; i++) {
+$if(Point)$
+            builder.appendPoint(work[i].getX(), work[i].getY());
+$else$
             builder.append$Type$(work[i]);
+$endif$
         }
         builder.endPositionEntry();
     }
@@ -386,12 +423,21 @@ $endif$
      */
     private void writeSortedWork($Type$Block.Builder builder) {
         if (w == 1) {
+$if(Point)$
+            builder.appendPoint(work[0].getX(), work[0].getY());
+$else$
             builder.append$Type$(work[0]);
+$endif$
             return;
         }
         builder.beginPositionEntry();
+$if(Point)$
+        SpatialPoint prev = work[0];
+        builder.appendPoint(prev.getX(), prev.getY());
+$else$
         $type$ prev = work[0];
         builder.append$Type$(prev);
+$endif$
         for (int i = 1; i < w; i++) {
 $if(BytesRef)$
             if (false == prev.equals(work[i])) {
@@ -401,7 +447,11 @@ $else$
             if (prev != work[i]) {
 $endif$
                 prev = work[i];
+$if(Point)$
+                builder.appendPoint(prev.getX(), prev.getY());
+$else$
                 builder.append$Type$(prev);
+$endif$
             }
         }
         builder.endPositionEntry();
@@ -416,12 +466,20 @@ $else$
     private void hashUniquedWork(LongHash hash, IntBlock.Builder builder) {
 $endif$
         if (w == 1) {
+$if(Point)$
+            hash(builder, hash, work[0].getX(), work[0].getY());
+$else$
             hash(builder, hash, work[0]);
+$endif$
             return;
         }
         builder.beginPositionEntry();
         for (int i = 0; i < w; i++) {
+$if(Point)$
+            hash(builder, hash, work[i].getX(), work[i].getY());
+$else$
             hash(builder, hash, work[i]);
+$endif$
         }
         builder.endPositionEntry();
     }
@@ -435,12 +493,21 @@ $else$
     private void hashSortedWork(LongHash hash, IntBlock.Builder builder) {
 $endif$
         if (w == 1) {
+$if(Point)$
+            hash(builder, hash, work[0].getX(), work[0].getY());
+$else$
             hash(builder, hash, work[0]);
+$endif$
             return;
         }
         builder.beginPositionEntry();
+$if(Point)$
+        SpatialPoint prev = work[0];
+        hash(builder, hash, prev.getX(), prev.getY());
+$else$
         $type$ prev = work[0];
         hash(builder, hash, prev);
+$endif$
         for (int i = 1; i < w; i++) {
 $if(BytesRef)$
             if (false == prev.equals(work[i])) {
@@ -450,7 +517,11 @@ $else$
             if (prev != work[i]) {
 $endif$
                 prev = work[i];
+$if(Point)$
+                hash(builder, hash, prev.getX(), prev.getY());
+$else$
                 hash(builder, hash, prev);
+$endif$
             }
         }
         builder.endPositionEntry();
@@ -461,7 +532,11 @@ $endif$
      */
     private void encodeUniquedWork(BatchEncoder.$Type$s encoder) {
         for (int i = 0; i < w; i++) {
+$if(Point)$
+            encoder.encode(work[i].getX(), work[i].getY());
+$else$
             encoder.encode(work[i]);
+$endif$
         }
     }
 
@@ -469,7 +544,11 @@ $endif$
      * Converts {@link #work} from sorted array to a deduplicated array.
      */
     private void convertSortedWorkToUnique() {
+$if(Point)$
+        SpatialPoint prev = work[0];
+$else$
         $type$ prev = work[0];
+$endif$
         int end = w;
         w = 1;
         for (int i = 1; i < end; i++) {
@@ -514,16 +593,16 @@ $if(BytesRef)$
 $endif$
 
 $if(BytesRef)$
-    private void hash(IntBlock.Builder builder, BytesRefHash hash, BytesRef v) {
+    private void hash(IntBlock.Builder builder, BytesRefHash hash, BytesRef value) {
 $else$
-    private void hash(IntBlock.Builder builder, LongHash hash, $type$ v) {
+    private void hash(IntBlock.Builder builder, LongHash hash, $typeValue$) {
 $endif$
 $if(double)$
-        builder.appendInt(Math.toIntExact(BlockHash.hashOrdToGroupNullReserved(hash.add(Double.doubleToLongBits(v)))));
+        builder.appendInt(Math.toIntExact(BlockHash.hashOrdToGroupNullReserved(hash.add(Double.doubleToLongBits(value)))));
 $elseif(Point)$
-        builder.appendInt(Math.toIntExact(BlockHash.hashOrdToGroupNullReserved(hash.add(v.hashCode()))));
+        builder.appendInt(Math.toIntExact(BlockHash.hashOrdToGroupNullReserved(hash.add(31L * Double.hashCode(x) + Double.hashCode(y)))));
 $else$
-        builder.appendInt(Math.toIntExact(BlockHash.hashOrdToGroupNullReserved(hash.add(v))));
+        builder.appendInt(Math.toIntExact(BlockHash.hashOrdToGroupNullReserved(hash.add(value))));
 $endif$
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/X-MultivalueDedupe.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/X-MultivalueDedupe.java.st
@@ -19,20 +19,20 @@ import org.elasticsearch.common.util.LongHash;
 $endif$
 import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
 import org.elasticsearch.compute.aggregation.blockhash.BlockHash;
-$if(int)$
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
+$if(int)$
 import org.elasticsearch.compute.data.IntBlock;
 
 $elseif(long)$
-import org.elasticsearch.compute.data.Block;
-import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
 
+$elseif(Point)$
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.PointBlock;
+
 $else$
-import org.elasticsearch.compute.data.Block;
-import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.$Type$Block;
 import org.elasticsearch.compute.data.IntBlock;
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/X-MultivalueDedupe.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/X-MultivalueDedupe.java.st
@@ -53,8 +53,8 @@ $if(BytesRef)$
     private static final int ALWAYS_COPY_MISSING = 20;  // TODO BytesRef should try adding to the hash *first* and then comparing.
 $elseif(double)$
     private static final int ALWAYS_COPY_MISSING = 110;
-$elseif(int)$
-    private static final int ALWAYS_COPY_MISSING = 300;
+$elseif(Point)$
+    private static final int ALWAYS_COPY_MISSING = 110;
 $else$
     private static final int ALWAYS_COPY_MISSING = 300;
 $endif$

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/DefaultUnsortableTopNEncoder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/DefaultUnsortableTopNEncoder.java
@@ -140,10 +140,10 @@ final class DefaultUnsortableTopNEncoder implements TopNEncoder {
     }
 
     @Override
-    public void encodePoint(SpatialPoint value, BreakingBytesRefBuilder bytesRefBuilder) {
+    public void encodePoint(double x, double y, BreakingBytesRefBuilder bytesRefBuilder) {
         bytesRefBuilder.grow(bytesRefBuilder.length() + Double.BYTES * 2);
-        DOUBLE.set(bytesRefBuilder.bytes(), bytesRefBuilder.length(), value.getX());
-        DOUBLE.set(bytesRefBuilder.bytes(), bytesRefBuilder.length() + Double.BYTES, value.getY());
+        DOUBLE.set(bytesRefBuilder.bytes(), bytesRefBuilder.length(), x);
+        DOUBLE.set(bytesRefBuilder.bytes(), bytesRefBuilder.length() + Double.BYTES, y);
         bytesRefBuilder.setLength(bytesRefBuilder.length() + Long.BYTES * 2);
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/KeyExtractor.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/KeyExtractor.java
@@ -14,6 +14,7 @@ import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.PointBlock;
 import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 
 /**
@@ -32,6 +33,7 @@ interface KeyExtractor {
             case INT -> KeyExtractorForInt.extractorFor(encoder, ascending, nul, nonNul, (IntBlock) block);
             case LONG -> KeyExtractorForLong.extractorFor(encoder, ascending, nul, nonNul, (LongBlock) block);
             case DOUBLE -> KeyExtractorForDouble.extractorFor(encoder, ascending, nul, nonNul, (DoubleBlock) block);
+            case POINT -> KeyExtractorForPoint.extractorFor(encoder, ascending, nul, nonNul, (PointBlock) block);
             case NULL -> new KeyExtractorForNull(nul);
             default -> {
                 assert false : "No key extractor for [" + block.elementType() + "]";

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/ResultBuilder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/ResultBuilder.java
@@ -51,6 +51,7 @@ interface ResultBuilder extends Releasable {
             case INT -> new ResultBuilderForInt(blockFactory, encoder, inKey, positions);
             case LONG -> new ResultBuilderForLong(blockFactory, encoder, inKey, positions);
             case DOUBLE -> new ResultBuilderForDouble(blockFactory, encoder, inKey, positions);
+            case POINT -> new ResultBuilderForPoint(blockFactory, encoder, inKey, positions);
             case NULL -> new ResultBuilderForNull(blockFactory);
             case DOC -> new ResultBuilderForDoc(blockFactory, positions);
             default -> {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/SortableTopNEncoder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/SortableTopNEncoder.java
@@ -71,10 +71,10 @@ public abstract class SortableTopNEncoder implements TopNEncoder {
     }
 
     @Override
-    public final void encodePoint(SpatialPoint value, BreakingBytesRefBuilder bytesRefBuilder) {
+    public final void encodePoint(double x, double y, BreakingBytesRefBuilder bytesRefBuilder) {
         bytesRefBuilder.grow(bytesRefBuilder.length() + Long.BYTES * 2);
-        long xi = NumericUtils.doubleToSortableLong(value.getX());
-        long yi = NumericUtils.doubleToSortableLong(value.getY());
+        long xi = NumericUtils.doubleToSortableLong(x);
+        long yi = NumericUtils.doubleToSortableLong(y);
         NumericUtils.longToSortableBytes(xi, bytesRefBuilder.bytes(), bytesRefBuilder.length());
         NumericUtils.longToSortableBytes(yi, bytesRefBuilder.bytes(), bytesRefBuilder.length() + Long.BYTES);
         bytesRefBuilder.setLength(bytesRefBuilder.length() + Long.BYTES * 2);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/TopNEncoder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/TopNEncoder.java
@@ -59,7 +59,7 @@ public interface TopNEncoder {
 
     double decodeDouble(BytesRef bytes);
 
-    void encodePoint(SpatialPoint value, BreakingBytesRefBuilder bytesRefBuilder);
+    void encodePoint(double x, double y, BreakingBytesRefBuilder bytesRefBuilder);
 
     SpatialPoint decodePoint(BytesRef bytes);
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/TopNEncoder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/TopNEncoder.java
@@ -9,6 +9,7 @@ package org.elasticsearch.compute.operator.topn;
 
 import org.apache.lucene.document.InetAddressPoint;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 
 /**
@@ -57,6 +58,10 @@ public interface TopNEncoder {
     void encodeDouble(double value, BreakingBytesRefBuilder bytesRefBuilder);
 
     double decodeDouble(BytesRef bytes);
+
+    void encodePoint(SpatialPoint value, BreakingBytesRefBuilder bytesRefBuilder);
+
+    SpatialPoint decodePoint(BytesRef bytes);
 
     void encodeBoolean(boolean value, BreakingBytesRefBuilder bytesRefBuilder);
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/TopNOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/TopNOperator.java
@@ -334,8 +334,6 @@ public class TopNOperator implements Operator, Accountable {
 
     @Override
     public void addInput(Page page) {
-        RowFiller rowFiller = new RowFiller(elementTypes, encoders, sortOrders, page);
-
         /*
          * Since row tracks memory we have to be careful to close any unused rows,
          * including any rows that fail while constructing because they allocate
@@ -347,6 +345,8 @@ public class TopNOperator implements Operator, Accountable {
          * inputQueue or because we hit an allocation failure while building it.
          */
         try {
+            RowFiller rowFiller = new RowFiller(elementTypes, encoders, sortOrders, page);
+
             for (int i = 0; i < page.getPositionCount(); i++) {
                 if (spare == null) {
                     spare = new Row(breaker, sortOrders);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/ValueExtractor.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/ValueExtractor.java
@@ -25,10 +25,6 @@ interface ValueExtractor {
     void writeValue(BreakingBytesRefBuilder values, int position);
 
     static ValueExtractor extractorFor(ElementType elementType, TopNEncoder encoder, boolean inKey, Block block) {
-        // TODO: figure out why sometimes the integration tests have LongBlock instead of PointBlock
-        if (elementType == ElementType.POINT && block.elementType() == ElementType.LONG) {
-            return ValueExtractorForLong.extractorFor(encoder, inKey, (LongBlock) block);
-        }
         if (false == (elementType == block.elementType() || ElementType.NULL == block.elementType())) {
             throw new IllegalArgumentException("Expected [" + elementType + "] but was [" + block.elementType() + "]");
         }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/ValueExtractor.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/ValueExtractor.java
@@ -25,6 +25,10 @@ interface ValueExtractor {
     void writeValue(BreakingBytesRefBuilder values, int position);
 
     static ValueExtractor extractorFor(ElementType elementType, TopNEncoder encoder, boolean inKey, Block block) {
+        // TODO: figure out why sometimes the integration tests have LongBlock instead of PointBlock
+        if (elementType == ElementType.POINT && block.elementType() == ElementType.LONG) {
+            return ValueExtractorForLong.extractorFor(encoder, inKey, (LongBlock) block);
+        }
         if (false == (elementType == block.elementType() || ElementType.NULL == block.elementType())) {
             throw new IllegalArgumentException("Expected [" + elementType + "] but was [" + block.elementType() + "]");
         }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/ValueExtractor.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/ValueExtractor.java
@@ -15,6 +15,7 @@ import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.PointBlock;
 import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 
 /**
@@ -33,6 +34,7 @@ interface ValueExtractor {
             case INT -> ValueExtractorForInt.extractorFor(encoder, inKey, (IntBlock) block);
             case LONG -> ValueExtractorForLong.extractorFor(encoder, inKey, (LongBlock) block);
             case DOUBLE -> ValueExtractorForDouble.extractorFor(encoder, inKey, (DoubleBlock) block);
+            case POINT -> ValueExtractorForPoint.extractorFor(encoder, inKey, (PointBlock) block);
             case NULL -> new ValueExtractorForNull();
             case DOC -> new ValueExtractorForDoc(encoder, ((DocBlock) block).asVector());
             default -> {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/X-KeyExtractor.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/X-KeyExtractor.java.st
@@ -9,8 +9,6 @@ package org.elasticsearch.compute.operator.topn;
 
 $if(BytesRef)$
 import org.apache.lucene.util.BytesRef;
-$elseif(Point)$
-import org.elasticsearch.common.geo.SpatialPoint;
 $endif$
 import org.elasticsearch.compute.data.$Type$Block;
 import org.elasticsearch.compute.data.$Type$Vector;
@@ -49,15 +47,15 @@ $endif$
         this.nonNul = nonNul;
     }
 
-    protected final int nonNul(BreakingBytesRefBuilder key, $type$ value) {
+    protected final int nonNul(BreakingBytesRefBuilder key, $typeValue$) {
         key.append(nonNul);
 $if(BytesRef)$
-        return encoder.encodeBytesRef(value, key) + 1;
+        return encoder.encodeBytesRef($value$, key) + 1;
 $elseif(boolean)$
-        TopNEncoder.DEFAULT_SORTABLE.encodeBoolean(value, key);
+        TopNEncoder.DEFAULT_SORTABLE.encodeBoolean($value$, key);
         return Byte.BYTES + 1;
 $else$
-        TopNEncoder.DEFAULT_SORTABLE.encode$Type$(value, key);
+        TopNEncoder.DEFAULT_SORTABLE.encode$Type$($value$, key);
         return $BYTES$ + 1;
 $endif$
     }
@@ -79,6 +77,8 @@ $endif$
         public int writeKey(BreakingBytesRefBuilder key, int position) {
 $if(BytesRef)$
             return nonNul(key, vector.get$Type$(position, scratch));
+$elseif(Point)$
+            return nonNul(key, vector.getX(position), vector.getY(position));
 $else$
             return nonNul(key, vector.get$Type$(position));
 $endif$
@@ -100,6 +100,9 @@ $endif$
             }
 $if(BytesRef)$
             return nonNul(key, block.get$Type$(block.getFirstValueIndex(position), scratch));
+$elseif(Point)$
+            int index = block.getFirstValueIndex(position);
+            return nonNul(key, block.getX(index), block.getY(index));
 $else$
             return nonNul(key, block.get$Type$(block.getFirstValueIndex(position)));
 $endif$
@@ -121,6 +124,9 @@ $endif$
             }
 $if(BytesRef)$
             return nonNul(key, block.get$Type$(block.getFirstValueIndex(position) + block.getValueCount(position) - 1, scratch));
+$elseif(Point)$
+            int index = block.getFirstValueIndex(position) + block.getValueCount(position) - 1;
+            return nonNul(key, block.getX(index), block.getY(index));
 $else$
             return nonNul(key, block.get$Type$(block.getFirstValueIndex(position) + block.getValueCount(position) - 1));
 $endif$
@@ -166,14 +172,19 @@ $elseif(boolean)$
             }
             return nonNul(key, true);
 $elseif(Point)$
-            $type$ min = block.get$Type$(start);
+            double minX = block.getX(start);
+            double minY = block.getY(start);
             for (int i = start + 1; i < end; i++) {
-                SpatialPoint other = block.getPoint(i);
-                if (other.compareTo(min) < 0) {
-                    min = other;
+                double x = block.getX(i);
+                double y = block.getY(i);
+                if (x < minX) {
+                    minX = x;
+                }
+                if (y < minY) {
+                    minY = y;
                 }
             }
-            return nonNul(key, min);
+            return nonNul(key, minX, minY);
 $else$
             $type$ min = block.get$Type$(start);
             for (int i = start + 1; i < end; i++) {
@@ -223,14 +234,19 @@ $elseif(boolean)$
             }
             return nonNul(key, false);
 $elseif(Point)$
-            $type$ max = block.get$Type$(start);
+            double maxX = block.getX(start);
+            double maxY = block.getY(start);
             for (int i = start + 1; i < end; i++) {
-                SpatialPoint other = block.getPoint(i);
-                if (other.compareTo(max) > 0) {
-                    max = other;
+                double x = block.getX(i);
+                double y = block.getY(i);
+                if (x > maxX) {
+                    maxX = x;
+                }
+                if (y > maxY) {
+                    maxY = y;
                 }
             }
-            return nonNul(key, max);
+            return nonNul(key, maxX, maxY);
 $else$
             $type$ max = block.get$Type$(start);
             for (int i = start + 1; i < end; i++) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/X-KeyExtractor.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/X-KeyExtractor.java.st
@@ -9,6 +9,8 @@ package org.elasticsearch.compute.operator.topn;
 
 $if(BytesRef)$
 import org.apache.lucene.util.BytesRef;
+$elseif(Point)$
+import org.elasticsearch.common.geo.SpatialPoint;
 $endif$
 import org.elasticsearch.compute.data.$Type$Block;
 import org.elasticsearch.compute.data.$Type$Vector;
@@ -163,6 +165,15 @@ $elseif(boolean)$
                 }
             }
             return nonNul(key, true);
+$elseif(Point)$
+            $type$ min = block.get$Type$(start);
+            for (int i = start + 1; i < end; i++) {
+                SpatialPoint other = block.getPoint(i);
+                if (other.compareTo(min) < 0) {
+                    min = other;
+                }
+            }
+            return nonNul(key, min);
 $else$
             $type$ min = block.get$Type$(start);
             for (int i = start + 1; i < end; i++) {
@@ -211,6 +222,15 @@ $elseif(boolean)$
                 }
             }
             return nonNul(key, false);
+$elseif(Point)$
+            $type$ max = block.get$Type$(start);
+            for (int i = start + 1; i < end; i++) {
+                SpatialPoint other = block.getPoint(i);
+                if (other.compareTo(max) > 0) {
+                    max = other;
+                }
+            }
+            return nonNul(key, max);
 $else$
             $type$ max = block.get$Type$(start);
             for (int i = start + 1; i < end; i++) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/X-ResultBuilder.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/X-ResultBuilder.java.st
@@ -28,7 +28,13 @@ $endif$
     /**
      * The value previously set by {@link #decodeKey}.
      */
+$if(Point)$
+    // TODO: we should be able to get rid of this object
+    private SpatialPoint key;
+
+$else$
     private $type$ key;
+$endif$
 
     ResultBuilderFor$Type$(BlockFactory blockFactory, TopNEncoder encoder, boolean inKey, int initialSize) {
 $if(BytesRef)$
@@ -45,6 +51,8 @@ $endif$
         assert inKey;
 $if(BytesRef)$
         key = encoder.toSortable().decodeBytesRef(keys, scratch);
+$elseif(Point)$
+        key = TopNEncoder.DEFAULT_SORTABLE.decode$Type$(keys);
 $else$
         key = TopNEncoder.DEFAULT_SORTABLE.decode$Type$(keys);
 $endif$
@@ -57,18 +65,34 @@ $endif$
             case 0 -> {
                 builder.appendNull();
             }
+$if(Point)$
+            case 1 -> {
+                SpatialPoint value = inKey ? key : readValueFromValues(values);
+                builder.appendPoint(value.getX(), value.getY());
+            }
+$else$
             case 1 -> builder.append$Type$(inKey ? key : readValueFromValues(values));
+$endif$
             default -> {
                 builder.beginPositionEntry();
                 for (int i = 0; i < count; i++) {
+$if(Point)$
+                    SpatialPoint point = readValueFromValues(values);
+                    builder.appendPoint(point.getX(), point.getY());
+$else$
                     builder.append$Type$(readValueFromValues(values));
+$endif$
                 }
                 builder.endPositionEntry();
             }
         }
     }
 
+$if(Point)$
+    private SpatialPoint readValueFromValues(BytesRef values) {
+$else$
     private $type$ readValueFromValues(BytesRef values) {
+$endif$
 $if(BytesRef)$
         return encoder.toUnsortable().decodeBytesRef(values, scratch);
 $else$

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/X-ValueExtractor.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/X-ValueExtractor.java.st
@@ -9,8 +9,6 @@ package org.elasticsearch.compute.operator.topn;
 
 $if(BytesRef)$
 import org.apache.lucene.util.BytesRef;
-$elseif(Point)$
-import org.elasticsearch.common.geo.SpatialPoint;
 $endif$
 import org.elasticsearch.compute.data.$Type$Block;
 import org.elasticsearch.compute.data.$Type$Vector;
@@ -46,11 +44,11 @@ $endif$
         TopNEncoder.DEFAULT_UNSORTABLE.encodeVInt(count, values);
     }
 
-    protected final void actualWriteValue(BreakingBytesRefBuilder values, $type$ value) {
+    protected final void actualWriteValue(BreakingBytesRefBuilder values, $typeValue$) {
 $if(BytesRef)$
         encoder.encodeBytesRef(value, values);
 $else$
-        TopNEncoder.DEFAULT_UNSORTABLE.encode$Type$(value, values);
+        TopNEncoder.DEFAULT_UNSORTABLE.encode$Type$($value$, values);
 $endif$
     }
 
@@ -71,6 +69,8 @@ $endif$
             }
 $if(BytesRef)$
             actualWriteValue(values, vector.get$Type$(position, scratch));
+$elseif(Point)$
+            actualWriteValue(values, vector.getX(position), vector.getY(position));
 $else$
             actualWriteValue(values, vector.get$Type$(position));
 $endif$
@@ -98,6 +98,8 @@ $endif$
             for (int i = start; i < end; i++) {
 $if(BytesRef)$
                 actualWriteValue(values, block.getBytesRef(i, scratch));
+$elseif(Point)$
+                actualWriteValue(values, block.getX(i), block.getY(i));
 $else$
                 actualWriteValue(values, block.get$Type$(i));
 $endif$

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/X-ValueExtractor.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/topn/X-ValueExtractor.java.st
@@ -9,6 +9,8 @@ package org.elasticsearch.compute.operator.topn;
 
 $if(BytesRef)$
 import org.apache.lucene.util.BytesRef;
+$elseif(Point)$
+import org.elasticsearch.common.geo.SpatialPoint;
 $endif$
 import org.elasticsearch.compute.data.$Type$Block;
 import org.elasticsearch.compute.data.$Type$Vector;

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicBlockTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicBlockTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BytesRefArray;
@@ -822,6 +823,7 @@ public class BasicBlockTests extends ESTestCase {
                     case DOUBLE -> ((DoubleBlock) block).getDouble(i++);
                     case BYTES_REF -> ((BytesRefBlock) block).getBytesRef(i++, new BytesRef());
                     case BOOLEAN -> ((BooleanBlock) block).getBoolean(i++);
+                    case POINT -> ((PointBlock) block).getPoint(i++);
                     default -> throw new IllegalArgumentException("unsupported element type [" + block.elementType() + "]");
                 });
             }
@@ -908,6 +910,11 @@ public class BasicBlockTests extends ESTestCase {
                             boolean b = randomBoolean();
                             valuesAtPosition.add(b);
                             ((BooleanBlock.Builder) builder).appendBoolean(b);
+                        }
+                        case POINT -> {
+                            SpatialPoint pt = randomBoolean() ? randomGeoPoint() : randomCartesianPoint();
+                            valuesAtPosition.add(pt);
+                            ((PointBlock.Builder) builder).appendPoint(pt);
                         }
                         default -> throw new IllegalArgumentException("unsupported element type [" + elementType + "]");
                     }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicBlockTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicBlockTests.java
@@ -916,7 +916,7 @@ public class BasicBlockTests extends ESTestCase {
                         case POINT -> {
                             SpatialPoint pt = new SpatialPoint(pointSupplier.get());
                             valuesAtPosition.add(pt);
-                            ((PointBlock.Builder) builder).appendPoint(pt);
+                            ((PointBlock.Builder) builder).appendPoint(pt.getX(), pt.getY());
                         }
                         default -> throw new IllegalArgumentException("unsupported element type [" + elementType + "]");
                     }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicBlockTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicBlockTests.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.BitSet;
 import java.util.List;
 import java.util.function.BiConsumer;
+import java.util.function.Supplier;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 
@@ -871,6 +872,7 @@ public class BasicBlockTests extends ESTestCase {
     ) {
         List<List<Object>> values = new ArrayList<>();
         try (var builder = elementType.newBlockBuilder(positionCount, blockFactory)) {
+            Supplier<SpatialPoint> pointSupplier = randomBoolean() ? ESTestCase::randomGeoPoint : ESTestCase::randomCartesianPoint;
             for (int p = 0; p < positionCount; p++) {
                 int valueCount = between(minValuesPerPosition, maxValuesPerPosition);
                 if (valueCount == 0 || nullAllowed && randomBoolean()) {
@@ -912,7 +914,7 @@ public class BasicBlockTests extends ESTestCase {
                             ((BooleanBlock.Builder) builder).appendBoolean(b);
                         }
                         case POINT -> {
-                            SpatialPoint pt = randomBoolean() ? randomGeoPoint() : randomCartesianPoint();
+                            SpatialPoint pt = new SpatialPoint(pointSupplier.get());
                             valuesAtPosition.add(pt);
                             ((PointBlock.Builder) builder).appendPoint(pt);
                         }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockTestUtils.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockTestUtils.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.geo.SpatialPoint;
 import org.hamcrest.Matcher;
 
 import java.util.ArrayList;
@@ -16,7 +17,9 @@ import java.util.List;
 import static org.elasticsearch.compute.data.BlockUtils.toJavaObject;
 import static org.elasticsearch.test.ESTestCase.between;
 import static org.elasticsearch.test.ESTestCase.randomBoolean;
+import static org.elasticsearch.test.ESTestCase.randomCartesianPoint;
 import static org.elasticsearch.test.ESTestCase.randomDouble;
+import static org.elasticsearch.test.ESTestCase.randomGeoPoint;
 import static org.elasticsearch.test.ESTestCase.randomInt;
 import static org.elasticsearch.test.ESTestCase.randomLong;
 import static org.elasticsearch.test.ESTestCase.randomRealisticUnicodeOfCodepointLengthBetween;
@@ -36,6 +39,7 @@ public class BlockTestUtils {
             case BOOLEAN -> randomBoolean();
             case DOC -> new BlockUtils.Doc(randomInt(), randomInt(), between(0, Integer.MAX_VALUE));
             case NULL -> null;
+            case POINT -> randomBoolean() ? randomGeoPoint() : randomCartesianPoint();
             case UNKNOWN -> throw new IllegalArgumentException("can't make random values for [" + e + "]");
         };
     }
@@ -59,6 +63,8 @@ public class BlockTestUtils {
             b.appendBoolean(v);
         } else if (builder instanceof DocBlock.Builder b && value instanceof BlockUtils.Doc v) {
             b.appendShard(v.shard()).appendSegment(v.segment()).appendDoc(v.doc());
+        } else if (builder instanceof PointBlock.Builder b && value instanceof SpatialPoint v) {
+            b.appendPoint(v);
         } else {
             throw new IllegalArgumentException("Can't append [" + value + "/" + value.getClass() + "] to [" + builder + "]");
         }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockTestUtils.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockTestUtils.java
@@ -17,7 +17,6 @@ import java.util.List;
 import static org.elasticsearch.compute.data.BlockUtils.toJavaObject;
 import static org.elasticsearch.test.ESTestCase.between;
 import static org.elasticsearch.test.ESTestCase.randomBoolean;
-import static org.elasticsearch.test.ESTestCase.randomCartesianPoint;
 import static org.elasticsearch.test.ESTestCase.randomDouble;
 import static org.elasticsearch.test.ESTestCase.randomGeoPoint;
 import static org.elasticsearch.test.ESTestCase.randomInt;
@@ -39,7 +38,7 @@ public class BlockTestUtils {
             case BOOLEAN -> randomBoolean();
             case DOC -> new BlockUtils.Doc(randomInt(), randomInt(), between(0, Integer.MAX_VALUE));
             case NULL -> null;
-            case POINT -> randomBoolean() ? randomGeoPoint() : randomCartesianPoint();
+            case POINT -> randomSpatialPoint();
             case UNKNOWN -> throw new IllegalArgumentException("can't make random values for [" + e + "]");
         };
     }
@@ -115,5 +114,14 @@ public class BlockTestUtils {
 
     public static List<Page> deepCopyOf(List<Page> pages, BlockFactory blockFactory) {
         return pages.stream().map(page -> deepCopyOf(page, blockFactory)).toList();
+    }
+
+    public static SpatialPoint randomSpatialPoint() {
+        // For testing purposes we use only SpatialPoint, not GeoPoint, to ensure the equals methods works without knowing the mapping
+        if (randomBoolean()) {
+            return new SpatialPoint(randomGeoPoint());  // Destroy geo type information
+        } else {
+            return randomSpatialPoint();
+        }
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockTestUtils.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockTestUtils.java
@@ -63,7 +63,7 @@ public class BlockTestUtils {
         } else if (builder instanceof DocBlock.Builder b && value instanceof BlockUtils.Doc v) {
             b.appendShard(v.shard()).appendSegment(v.segment()).appendDoc(v.doc());
         } else if (builder instanceof PointBlock.Builder b && value instanceof SpatialPoint v) {
-            b.appendPoint(v);
+            b.appendPoint(v.getX(), v.getY());
         } else {
             throw new IllegalArgumentException("Can't append [" + value + "/" + value.getClass() + "] to [" + builder + "]");
         }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockValueAsserter.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockValueAsserter.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.geo.SpatialPoint;
 
 import java.util.List;
 
@@ -35,6 +36,7 @@ public class BlockValueAsserter {
                     case DOUBLE -> assertDoubleRowValues((DoubleBlock) block, firstValueIndex, valueCount, expectedRowValues);
                     case BYTES_REF -> assertBytesRefRowValues((BytesRefBlock) block, firstValueIndex, valueCount, expectedRowValues);
                     case BOOLEAN -> assertBooleanRowValues((BooleanBlock) block, firstValueIndex, valueCount, expectedRowValues);
+                    case POINT -> assertPointRowValues((PointBlock) block, firstValueIndex, valueCount, expectedRowValues);
                     default -> throw new IllegalArgumentException("Unsupported element type [" + block.elementType() + "]");
                 }
             }
@@ -85,6 +87,13 @@ public class BlockValueAsserter {
                 expectedValue = (Boolean) expectedRowValues.get(valueIndex);
             }
             assertThat(block.getBoolean(firstValueIndex + valueIndex), is(equalTo(expectedValue)));
+        }
+    }
+
+    private static void assertPointRowValues(PointBlock block, int firstValueIndex, int valueCount, List<Object> expectedRowValues) {
+        for (int valueIndex = 0; valueIndex < valueCount; valueIndex++) {
+            SpatialPoint expectedValue = (SpatialPoint) expectedRowValues.get(valueIndex);
+            assertThat(block.getPoint(firstValueIndex + valueIndex), is(equalTo(expectedValue)));
         }
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/VectorBuilderTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/VectorBuilderTests.java
@@ -119,6 +119,7 @@ public class VectorBuilderTests extends ESTestCase {
             case DOUBLE -> DoubleVector.newVectorBuilder(estimatedSize, blockFactory);
             case INT -> IntVector.newVectorBuilder(estimatedSize, blockFactory);
             case LONG -> LongVector.newVectorBuilder(estimatedSize, blockFactory);
+            case POINT -> PointVector.newVectorBuilder(estimatedSize, blockFactory);
         };
     }
 
@@ -148,6 +149,11 @@ public class VectorBuilderTests extends ESTestCase {
             case LONG -> {
                 for (int p = 0; p < from.getPositionCount(); p++) {
                     ((LongVector.Builder) builder).appendLong(((LongVector) from).getLong(p));
+                }
+            }
+            case POINT -> {
+                for (int p = 0; p < from.getPositionCount(); p++) {
+                    ((PointVector.Builder) builder).appendPoint(((PointVector) from).getPoint(p));
                 }
             }
         }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/VectorBuilderTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/VectorBuilderTests.java
@@ -153,7 +153,7 @@ public class VectorBuilderTests extends ESTestCase {
             }
             case POINT -> {
                 for (int p = 0; p < from.getPositionCount(); p++) {
-                    ((PointVector.Builder) builder).appendPoint(((PointVector) from).getPoint(p));
+                    ((PointVector.Builder) builder).appendPoint(((PointVector) from).getX(p), ((PointVector) from).getY(p));
                 }
             }
         }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/VectorFixedBuilderTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/VectorFixedBuilderTests.java
@@ -120,6 +120,7 @@ public class VectorFixedBuilderTests extends ESTestCase {
             case DOUBLE -> DoubleVector.newVectorFixedBuilder(size, blockFactory);
             case INT -> IntVector.newVectorFixedBuilder(size, blockFactory);
             case LONG -> LongVector.newVectorFixedBuilder(size, blockFactory);
+            case POINT -> PointVector.newVectorFixedBuilder(size, blockFactory);
         };
     }
 
@@ -144,6 +145,11 @@ public class VectorFixedBuilderTests extends ESTestCase {
             case LONG -> {
                 for (int p = 0; p < from.getPositionCount(); p++) {
                     ((LongVector.FixedBuilder) builder).appendLong(((LongVector) from).getLong(p));
+                }
+            }
+            case POINT -> {
+                for (int p = 0; p < from.getPositionCount(); p++) {
+                    ((PointVector.FixedBuilder) builder).appendPoint(((PointVector) from).getPoint(p));
                 }
             }
         }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/VectorFixedBuilderTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/VectorFixedBuilderTests.java
@@ -149,7 +149,7 @@ public class VectorFixedBuilderTests extends ESTestCase {
             }
             case POINT -> {
                 for (int p = 0; p < from.getPositionCount(); p++) {
-                    ((PointVector.FixedBuilder) builder).appendPoint(((PointVector) from).getPoint(p));
+                    ((PointVector.FixedBuilder) builder).appendPoint(((PointVector) from).getX(p), ((PointVector) from).getY(p));
                 }
             }
         }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/ValuesSourceReaderOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/ValuesSourceReaderOperatorTests.java
@@ -364,6 +364,11 @@ public class ValuesSourceReaderOperatorTests extends OperatorTestCase {
             }
 
             @Override
+            public boolean forStats() {
+                return false;
+            }
+
+            @Override
             public SearchLookup lookup() {
                 throw new UnsupportedOperationException();
             }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/MultivalueDedupeTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/MultivalueDedupeTests.java
@@ -48,6 +48,7 @@ import java.util.function.Function;
 import java.util.function.LongFunction;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.compute.data.BlockTestUtils.randomSpatialPoint;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -60,7 +61,7 @@ public class MultivalueDedupeTests extends ESTestCase {
         List<ElementType> supported = new ArrayList<>();
         for (ElementType elementType : ElementType.values()) {
             // TODO: get working for POINT (also BlockHashRandomizedTests)
-            if (oneOf(elementType, ElementType.UNKNOWN, ElementType.NULL, ElementType.DOC, ElementType.POINT)) {
+            if (oneOf(elementType, ElementType.UNKNOWN, ElementType.NULL, ElementType.DOC)) {
                 continue;
             }
             supported.add(elementType);
@@ -82,7 +83,7 @@ public class MultivalueDedupeTests extends ESTestCase {
         List<Object[]> params = new ArrayList<>();
         for (ElementType elementType : supportedTypes()) {
             // TODO: get working for POINT (also BlockHashRandomizedTests)
-            if (oneOf(elementType, ElementType.UNKNOWN, ElementType.NULL, ElementType.DOC, ElementType.POINT)) {
+            if (oneOf(elementType, ElementType.UNKNOWN, ElementType.NULL, ElementType.DOC)) {
                 continue;
             }
             for (boolean nullAllowed : new boolean[] { false, true }) {
@@ -231,7 +232,7 @@ public class MultivalueDedupeTests extends ESTestCase {
                 int prevSize = between(1, 10000);
                 Set<SpatialPoint> previousValues = new HashSet<>(prevSize);
                 while (previousValues.size() < prevSize) {
-                    previousValues.add(randomBoolean() ? randomGeoPoint() : randomCartesianPoint());
+                    previousValues.add(randomSpatialPoint());
                 }
                 assertPointHash(previousValues, b);
             }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/MultivalueDedupeTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/MultivalueDedupeTests.java
@@ -447,18 +447,18 @@ public class MultivalueDedupeTests extends ESTestCase {
             return c;
         })); // Sort for easier visual comparison of errors
         // TODO: Remove this once fully debugged
-//        if (false == equalTo(expected).matches(actual)) {
-//            if (expected.size() != actual.size()) {
-//                System.out.println("Different sizes: " + expected.size() + " != " + actual.size());
-//            } else {
-//                for (int i = 0; i < actual.size(); i++) {
-//                    System.out.println(i);
-//                    System.out.println("Expected: " + expected.get(i));
-//                    System.out.println("Actual:   " + actual.get(i));
-//                    System.out.println("Equal: " + expected.get(i).equals(actual.get(i)));
-//                }
-//            }
-//        }
+        // if (false == equalTo(expected).matches(actual)) {
+        // if (expected.size() != actual.size()) {
+        // System.out.println("Different sizes: " + expected.size() + " != " + actual.size());
+        // } else {
+        // for (int i = 0; i < actual.size(); i++) {
+        // System.out.println(i);
+        // System.out.println("Expected: " + expected.get(i));
+        // System.out.println("Actual: " + actual.get(i));
+        // System.out.println("Equal: " + expected.get(i).equals(actual.get(i)));
+        // }
+        // }
+        // }
         assertThat(actual, equalTo(expected));
         return valueOffset;
     }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/MultivalueDedupeTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/MultivalueDedupeTests.java
@@ -59,7 +59,8 @@ public class MultivalueDedupeTests extends ESTestCase {
     public static List<ElementType> supportedTypes() {
         List<ElementType> supported = new ArrayList<>();
         for (ElementType elementType : ElementType.values()) {
-            if (elementType == ElementType.UNKNOWN || elementType == ElementType.NULL || elementType == ElementType.DOC) {
+            // TODO: get working for POINT (also BlockHashRandomizedTests)
+            if (oneOf(elementType, ElementType.UNKNOWN, ElementType.NULL, ElementType.DOC, ElementType.POINT)) {
                 continue;
             }
             supported.add(elementType);
@@ -67,11 +68,21 @@ public class MultivalueDedupeTests extends ESTestCase {
         return supported;
     }
 
+    private static boolean oneOf(ElementType elementType, ElementType... others) {
+        for (ElementType other : others) {
+            if (elementType == other) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     @ParametersFactory
     public static List<Object[]> params() {
         List<Object[]> params = new ArrayList<>();
         for (ElementType elementType : supportedTypes()) {
-            if (elementType == ElementType.UNKNOWN || elementType == ElementType.NULL || elementType == ElementType.DOC) {
+            // TODO: get working for POINT (also BlockHashRandomizedTests)
+            if (oneOf(elementType, ElementType.UNKNOWN, ElementType.NULL, ElementType.DOC, ElementType.POINT)) {
                 continue;
             }
             for (boolean nullAllowed : new boolean[] { false, true }) {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/ExtractorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/ExtractorTests.java
@@ -87,6 +87,9 @@ public class ExtractorTests extends ESTestCase {
                         ) }
                 );
                 case NULL -> cases.add(valueTestCase("null", e, TopNEncoder.DEFAULT_UNSORTABLE, () -> null));
+                case POINT -> {
+                    // TODO should we support SpatialPoint in topN? Probably not, but lets think about it.
+                }
                 default -> {
                     cases.add(valueTestCase("single " + e, e, TopNEncoder.DEFAULT_UNSORTABLE, () -> BlockTestUtils.randomValue(e)));
                     cases.add(

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/ExtractorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/ExtractorTests.java
@@ -87,9 +87,6 @@ public class ExtractorTests extends ESTestCase {
                         ) }
                 );
                 case NULL -> cases.add(valueTestCase("null", e, TopNEncoder.DEFAULT_UNSORTABLE, () -> null));
-                case POINT -> {
-                    // TODO should we support SpatialPoint in topN? Probably not, but lets think about it.
-                }
                 default -> {
                     cases.add(valueTestCase("single " + e, e, TopNEncoder.DEFAULT_UNSORTABLE, () -> BlockTestUtils.randomValue(e)));
                     cases.add(

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/TopNOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/TopNOperatorTests.java
@@ -506,8 +506,7 @@ public class TopNOperatorTests extends OperatorTestCase {
         encoders.add(DEFAULT_SORTABLE);
 
         for (ElementType e : ElementType.values()) {
-            // TODO: Get working for POINT
-            if (e == ElementType.UNKNOWN || e == ElementType.POINT) {
+            if (e == ElementType.UNKNOWN) {
                 continue;
             }
             elementTypes.add(e);
@@ -579,8 +578,7 @@ public class TopNOperatorTests extends OperatorTestCase {
 
         for (int type = 0; type < blocksCount; type++) {
             ElementType e = randomFrom(ElementType.values());
-            // TODO: Get working for POINT
-            if (e == ElementType.UNKNOWN || e == ElementType.POINT) {
+            if (e == ElementType.UNKNOWN) {
                 continue;
             }
             elementTypes.add(e);
@@ -966,9 +964,8 @@ public class TopNOperatorTests extends OperatorTestCase {
         }
 
         for (int type = 0; type < blocksCount; type++) {
-            // TODO Get working for POINT
             ElementType e = randomValueOtherThanMany(
-                t -> t == ElementType.UNKNOWN || t == ElementType.DOC || t == ElementType.POINT,
+                t -> t == ElementType.UNKNOWN || t == ElementType.DOC,
                 () -> randomFrom(ElementType.values())
             );
             elementTypes.add(e);

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/TopNOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/TopNOperatorTests.java
@@ -506,7 +506,8 @@ public class TopNOperatorTests extends OperatorTestCase {
         encoders.add(DEFAULT_SORTABLE);
 
         for (ElementType e : ElementType.values()) {
-            if (e == ElementType.UNKNOWN) {
+            // TODO: Get working for POINT
+            if (e == ElementType.UNKNOWN || e == ElementType.POINT) {
                 continue;
             }
             elementTypes.add(e);
@@ -578,7 +579,8 @@ public class TopNOperatorTests extends OperatorTestCase {
 
         for (int type = 0; type < blocksCount; type++) {
             ElementType e = randomFrom(ElementType.values());
-            if (e == ElementType.UNKNOWN) {
+            // TODO: Get working for POINT
+            if (e == ElementType.UNKNOWN || e == ElementType.POINT) {
                 continue;
             }
             elementTypes.add(e);
@@ -964,8 +966,9 @@ public class TopNOperatorTests extends OperatorTestCase {
         }
 
         for (int type = 0; type < blocksCount; type++) {
+            // TODO Get working for POINT
             ElementType e = randomValueOtherThanMany(
-                t -> t == ElementType.UNKNOWN || t == ElementType.DOC,
+                t -> t == ElementType.UNKNOWN || t == ElementType.DOC || t == ElementType.POINT,
                 () -> randomFrom(ElementType.values())
             );
             elementTypes.add(e);

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvAssert.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvAssert.java
@@ -8,6 +8,8 @@
 package org.elasticsearch.xpack.esql;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.geo.GeoPoint;
+import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.search.DocValueFormat;
@@ -29,8 +31,6 @@ import static org.elasticsearch.xpack.esql.CsvTestUtils.Type.UNSIGNED_LONG;
 import static org.elasticsearch.xpack.esql.CsvTestUtils.logMetaData;
 import static org.elasticsearch.xpack.ql.util.DateUtils.UTC_DATE_TIME_FORMATTER;
 import static org.elasticsearch.xpack.ql.util.NumericUtils.unsignedLongAsNumber;
-import static org.elasticsearch.xpack.ql.util.SpatialCoordinateTypes.CARTESIAN;
-import static org.elasticsearch.xpack.ql.util.SpatialCoordinateTypes.GEO;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -119,7 +119,7 @@ public final class CsvAssert {
             for (int pageIndex = 0; pageIndex < pages.size(); pageIndex++) {
                 var page = pages.get(pageIndex);
                 var block = page.getBlock(column);
-                var blockType = Type.asType(block.elementType());
+                var blockType = Type.asType(block.elementType(), actualType);
 
                 if (blockType == Type.LONG
                     && (expectedType == Type.DATETIME
@@ -155,7 +155,15 @@ public final class CsvAssert {
     }
 
     static void assertData(ExpectedResults expected, ActualResults actual, boolean ignoreOrder, Logger logger) {
-        assertData(expected, actual.values(), ignoreOrder, logger, Function.identity());
+        assertData(expected, actual.values(), ignoreOrder, logger, CsvAssert::pointNormalizer);
+    }
+
+    private static Object pointNormalizer(Object obj) {
+        if (obj instanceof GeoPoint geoPoint) {
+            // The block type for all points is SpatialPoint and knowledge of the CRS is lost
+            return new SpatialPoint(geoPoint);
+        }
+        return obj;
     }
 
     public static void assertData(
@@ -202,9 +210,9 @@ public final class CsvAssert {
                         if (expectedType == Type.DATETIME) {
                             expectedValue = rebuildExpected(expectedValue, Long.class, x -> UTC_DATE_TIME_FORMATTER.formatMillis((long) x));
                         } else if (expectedType == Type.GEO_POINT) {
-                            expectedValue = rebuildExpected(expectedValue, Long.class, x -> GEO.longAsPoint((long) x));
+                            expectedValue = rebuildExpected(expectedValue, SpatialPoint.class, x -> x);
                         } else if (expectedType == Type.CARTESIAN_POINT) {
-                            expectedValue = rebuildExpected(expectedValue, Long.class, x -> CARTESIAN.longAsPoint((long) x));
+                            expectedValue = rebuildExpected(expectedValue, SpatialPoint.class, x -> x);
                         } else if (expectedType == Type.IP) {
                             // convert BytesRef-packed IP to String, allowing subsequent comparison with what's expected
                             expectedValue = rebuildExpected(expectedValue, BytesRef.class, x -> DocValueFormat.IP.format((BytesRef) x));

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestUtils.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestUtils.java
@@ -448,6 +448,7 @@ public final class CsvTestUtils {
                 case NULL -> NULL;
                 case BYTES_REF -> KEYWORD;
                 case BOOLEAN -> BOOLEAN;
+                case POINT -> GEO_POINT;    // TODO: how to differentiate between geo and cartesian points
                 case DOC -> throw new IllegalArgumentException("can't assert on doc blocks");
                 case UNKNOWN -> throw new IllegalArgumentException("Unknown block types cannot be handled");
             };

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/spatial.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/spatial.csv-spec
@@ -38,19 +38,19 @@ wkt:keyword                                                                     
 simpleLoad#[skip:-8.11.99, reason:spatial type geo_point only added in 8.12]
 FROM airports | WHERE scalerank == 9 | SORT abbrev | WHERE length(name) > 12;
 
-abbrev:keyword | location:geo_point                           | name:text                   | scalerank:i | type:k     
-CJJ            | POINT(127.49591611325741 36.72202274668962)  | Cheongju Int'l              | 9           | major
-HOD            | POINT(42.97109629958868 14.7552534006536)    | Hodeidah Int'l              | 9           | mid
-IDR            | POINT(75.80929149873555 22.72774917539209)   | Devi Ahilyabai Holkar Int'l | 9           | mid
-IXC            | POINT(76.80172610096633 30.6707248929888)    | Chandigarh Int'l            | 9           | [major, military]
-LYP            | POINT(72.98781909048557 31.362743536010385)  | Faisalabad Int'l            | 9           | [mid, military]
-MLG            | POINT(112.71141858771443 -7.9299800377339125)| Abdul Rachman Saleh         | 9           | [mid, military]
-OMS            | POINT(73.3163595199585 54.95764828752726)    | Omsk Tsentralny             | 9           | mid
-OVB            | POINT(82.6671524439007 55.00958469696343)    | Novosibirsk Tolmachev       | 9           | mid
-OZH            | POINT(35.301872827112675 47.87326351739466)  | Zaporozhye Int'l            | 9           | [mid, military]
-TRZ            | POINT(78.7089578434825 10.760357128456235)   | Tiruchirappalli             | 9           | mid
-WIIT           | POINT(105.17606039531529 -5.242566782981157) | Radin Inten II              | 9           | mid
-ZAH            | POINT(60.9007085300982 29.47529417462647)    | Zahedan Int'l               | 9           | mid
+abbrev:keyword | location:geo_point                        | name:text                   | scalerank:i | type:k     
+CJJ            | POINT(127.495916124681 36.7220227766673)  | Cheongju Int'l              | 9           | major
+HOD            | POINT(78.2172186546348 26.285487697937)   | Hodeidah Int'l              | 9           | mid
+IDR            | POINT(75.8092915005895 22.727749187571)   | Devi Ahilyabai Holkar Int'l | 9           | mid
+IXC            | POINT(76.8017261105242 30.6707248949667)  | Chandigarh Int'l            | 9           | [major, military]
+LYP            | POINT(72.9878190922305 31.3627435480862)  | Faisalabad Int'l            | 9           | [mid, military]
+MLG            | POINT(112.711418617258 -7.92998002840567) | Abdul Rachman Saleh         | 9           | [mid, military]
+OMS            | POINT(73.3163595376585 54.9576482934059)  | Omsk Tsentralny             | 9           | mid
+OVB            | POINT(82.6671524525865 55.0095847136264)  | Novosibirsk Tolmachev       | 9           | mid
+OZH            | POINT(35.3018728575279 47.8732635579023)  | Zaporozhye Int'l            | 9           | [mid, military]
+TRZ            | POINT(78.7089578747476 10.7603571306554)  | Tiruchirappalli             | 9           | mid
+WIIT           | POINT(105.176060419161 -5.242566777132)   | Radin Inten II              | 9           | mid
+ZAH            | POINT(60.900708564915 29.4752941956573)   | Zahedan Int'l               | 9           | mid
 ;
 
 convertCartesianFromLong#[skip:-8.11.99, reason:spatial type cartesian_point only added in 8.12]

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/spatial.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/spatial.csv-spec
@@ -3,7 +3,7 @@ row long = 1512146573982606908
 | eval pt = to_geopoint(long);
 
 long:long           |pt:geo_point
-1512146573982606908 |POINT(42.97109630194 14.7552534413725)
+1512146573982606908 |POINT(42.97109629958868 14.7552534006536)
 ;
 
 convertFromString#[skip:-8.11.99, reason:spatial type geo_point only added in 8.12]
@@ -24,7 +24,7 @@ row long = [1512146573982606908, 2329183180959557901]
 | eval pt = to_geopoint(long);
 
 long:long                                  |pt:geo_point
-[1512146573982606908, 2329183180959557901] |[POINT(42.97109630194 14.7552534413725), POINT(75.8092915005895 22.727749187571)]
+[1512146573982606908, 2329183180959557901] |[POINT(42.97109629958868 14.7552534006536), POINT(75.80929149873555 22.72774917539209)]
 ;
 
 convertFromStringArray#[skip:-8.11.99, reason:spatial type geo_point only added in 8.12]
@@ -40,7 +40,7 @@ FROM airports | WHERE scalerank == 9 | SORT abbrev | WHERE length(name) > 12;
 
 abbrev:keyword | location:geo_point                        | name:text                   | scalerank:i | type:k     
 CJJ            | POINT(127.495916124681 36.7220227766673)  | Cheongju Int'l              | 9           | major
-HOD            | POINT(78.2172186546348 26.285487697937)   | Hodeidah Int'l              | 9           | mid
+HOD            | POINT(42.97109630194 14.7552534413725)    | Hodeidah Int'l              | 9           | mid
 IDR            | POINT(75.8092915005895 22.727749187571)   | Devi Ahilyabai Holkar Int'l | 9           | mid
 IXC            | POINT(76.8017261105242 30.6707248949667)  | Chandigarh Int'l            | 9           | [major, military]
 LYP            | POINT(72.9878190922305 31.3627435480862)  | Faisalabad Int'l            | 9           | [mid, military]
@@ -58,7 +58,7 @@ row long = 5009771769843126025
 | eval pt = to_cartesianpoint(long);
 
 long:long           |pt:cartesian_point
-5009771769843126025 |POINT(4297.11 -1475.53)
+5009771769843126025 |POINT(4297.10986328125 -1475.530029296875)
 ;
 
 convertCartesianFromString#[skip:-8.11.99, reason:spatial type cartesian_point only added in 8.12]
@@ -81,7 +81,7 @@ row long = [5009771769843126025, 5038656556796611666]
 | eval pt = to_cartesianpoint(long);
 
 long:long                                  |pt:cartesian_point
-[5009771769843126025, 5038656556796611666] |[POINT(4297.11 -1475.53), POINT(7580.93 2272.77)]
+[5009771769843126025, 5038656556796611666] |[POINT(4297.10986328125 -1475.530029296875), POINT(7580.93017578125 2272.77001953125)]
 ;
 
 convertCartesianFromStringArray#[skip:-8.11.99, reason:spatial type cartesian_point only added in 8.12]
@@ -95,13 +95,13 @@ wkt:keyword                                                                     
 simpleCartesianLoad#[skip:-8.11.99, reason:spatial type cartesian_point only added in 8.12]
 FROM airports_web | WHERE scalerank == 9 | SORT abbrev | WHERE length(name) > 12;
 
-abbrev:keyword | location:cartesian_point        | name:text                   | scalerank:i | type:k
-CJJ            | POINT (14192780.0 4400431.0)    | Cheongju Int'l              | 9           | major
-HOD            | POINT (4783520.5 1661010.0)     | Hodeidah Int'l              | 9           | mid
-IDR            | POINT (8439052.0 2599127.5)     | Devi Ahilyabai Holkar Int'l | 9           | mid
-OMS            | POINT (8161540.0 7353651.0)     | Omsk Tsentralny             | 9           | mid
-OVB            | POINT (9202465.0 7363726.5)     | Novosibirsk Tolmachev       | 9           | mid
-TRZ            | POINT (8761841.0 1204941.5)     | Tiruchirappalli             | 9           | mid
-WIIT           | POINT (11708145.0 -584415.9375) | Radin Inten II              | 9           | mid
-ZAH            | POINT (6779436.0 3436280.5)     | Zahedan Int'l               | 9           | mid
+abbrev:keyword | location:cartesian_point                      | name:text                   | scalerank:i | type:k
+CJJ            | POINT(14192780.461221408 4400430.851323913)   | Cheongju Int'l              | 9           | major
+HOD            | POINT (4783520.559160681 1661010.0197476079)  | Hodeidah Int'l              | 9           | mid
+IDR            | POINT (8439051.727244465 2599127.5424638605)  | Devi Ahilyabai Holkar Int'l | 9           | mid
+OMS            | POINT (8161539.810548711 7353650.845101996)   | Omsk Tsentralny             | 9           | mid
+OVB            | POINT (9202465.316351846 7363726.532780712)   | Novosibirsk Tolmachev       | 9           | mid
+TRZ            | POINT (8761841.111486122 1204941.537981898)   | Tiruchirappalli             | 9           | mid
+WIIT           | POINT (11708145.489503577 -584415.9142832769) | Radin Inten II              | 9           | mid
+ZAH            | POINT (6779435.866395892 3436280.545331025)   | Zahedan Int'l               | 9           | mid
 ;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/spatial.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/spatial.csv-spec
@@ -1,4 +1,19 @@
-convertFromLong#[skip:-8.11.99, reason:spatial type geo_point only added in 8.12]
+###############################################
+# Tests for GEO_POINT type
+#
+
+# This first test is only here to verify type support in older versions, all other tests are for newer versions
+convertToAndFromLong#[skip:-8.11.99, reason:spatial type geo_point only added in 8.12]
+row long = 1512146573982606908
+| eval pt = to_geopoint(long)
+| eval l = to_long(pt)
+| keep long, l;
+
+long:long           |l:long
+1512146573982606908 |1512146573982606908
+;
+
+convertFromLong#[skip:-8.12.99, reason:spatial type geo_point improved precision in 8.13]
 row long = 1512146573982606908
 | eval pt = to_geopoint(long);
 
@@ -6,7 +21,7 @@ long:long           |pt:geo_point
 1512146573982606908 |POINT(42.97109629958868 14.7552534006536)
 ;
 
-convertFromString#[skip:-8.11.99, reason:spatial type geo_point only added in 8.12]
+convertFromString#[skip:-8.12.99, reason:spatial type geo_point improved precision in 8.13]
 // tag::to_geopoint-str[]
 row wkt = "POINT(42.97109630194 14.7552534413725)"
 | eval pt = to_geopoint(wkt)
@@ -19,7 +34,7 @@ wkt:keyword                              |pt:geo_point
 // end::to_geopoint-str-result[]
 ;
 
-convertFromLongArray#[skip:-8.11.99, reason:spatial type geo_point only added in 8.12]
+convertFromLongArray#[skip:-8.12.99, reason:spatial type geo_point improved precision in 8.13]
 row long = [1512146573982606908, 2329183180959557901]
 | eval pt = to_geopoint(long);
 
@@ -27,7 +42,7 @@ long:long                                  |pt:geo_point
 [1512146573982606908, 2329183180959557901] |[POINT(42.97109629958868 14.7552534006536), POINT(75.80929149873555 22.72774917539209)]
 ;
 
-convertFromStringArray#[skip:-8.11.99, reason:spatial type geo_point only added in 8.12]
+convertFromStringArray#[skip:-8.12.99, reason:spatial type geo_point improved precision in 8.13]
 row wkt = ["POINT(42.97109630194 14.7552534413725)", "POINT(75.8092915005895 22.727749187571)"]
 | eval pt = to_geopoint(wkt);
 
@@ -35,7 +50,7 @@ wkt:keyword                                                                     
 ["POINT(42.97109630194 14.7552534413725)", "POINT(75.8092915005895 22.727749187571)"] |[POINT(42.97109630194 14.7552534413725), POINT(75.8092915005895 22.727749187571)]
 ;
 
-simpleLoad#[skip:-8.11.99, reason:spatial type geo_point only added in 8.12]
+simpleLoad#[skip:-8.12.99, reason:spatial type geo_point improved precision in 8.13]
 FROM airports | WHERE scalerank == 9 | SORT abbrev | WHERE length(name) > 12;
 
 abbrev:keyword | location:geo_point                        | name:text                   | scalerank:i | type:k     
@@ -53,7 +68,22 @@ WIIT           | POINT(105.176060419161 -5.242566777132)   | Radin Inten II     
 ZAH            | POINT(60.900708564915 29.4752941956573)   | Zahedan Int'l               | 9           | mid
 ;
 
-convertCartesianFromLong#[skip:-8.11.99, reason:spatial type cartesian_point only added in 8.12]
+###############################################
+# Tests for CARTESIAN_POINT type
+#
+
+# This first test is only here to verify type support in older versions, all other tests are for newer versions
+convertCartesianToAndFromLong#[skip:-8.11.99, reason:spatial type cartesian_point only added in 8.12]
+row long = 5009771769843126025
+| eval pt = to_cartesianpoint(long)
+| eval l = to_long(pt)
+| keep long, l;
+
+long:long           |l:long
+5009771769843126025 |5009771769843126025
+;
+
+convertCartesianFromLong#[skip:-8.12.99, reason:spatial type cartesian_point improved precision in 8.13]
 row long = 5009771769843126025
 | eval pt = to_cartesianpoint(long);
 
@@ -61,7 +91,7 @@ long:long           |pt:cartesian_point
 5009771769843126025 |POINT(4297.10986328125 -1475.530029296875)
 ;
 
-convertCartesianFromString#[skip:-8.11.99, reason:spatial type cartesian_point only added in 8.12]
+convertCartesianFromString#[skip:-8.12.99, reason:spatial type cartesian_point improved precision in 8.13]
 // tag::to_cartesianpoint-str[]
 row wkt = ["POINT(4297.11 -1475.53)", "POINT(7580.93 2272.77)"]
 | mv_expand wkt
@@ -76,7 +106,7 @@ wkt:keyword               |pt:cartesian_point
 // end::to_cartesianpoint-str-result[]
 ;
 
-convertCartesianFromLongArray#[skip:-8.11.99, reason:spatial type cartesian_point only added in 8.12]
+convertCartesianFromLongArray#[skip:-8.12.99, reason:spatial type cartesian_point improved precision in 8.13]
 row long = [5009771769843126025, 5038656556796611666]
 | eval pt = to_cartesianpoint(long);
 
@@ -84,7 +114,7 @@ long:long                                  |pt:cartesian_point
 [5009771769843126025, 5038656556796611666] |[POINT(4297.10986328125 -1475.530029296875), POINT(7580.93017578125 2272.77001953125)]
 ;
 
-convertCartesianFromStringArray#[skip:-8.11.99, reason:spatial type cartesian_point only added in 8.12]
+convertCartesianFromStringArray#[skip:-8.12.99, reason:spatial type cartesian_point improved precision in 8.13]
 row wkt = ["POINT(4297.11 -1475.53)", "POINT(7580.93 2272.77)"]
 | eval pt = to_cartesianpoint(wkt);
 
@@ -92,7 +122,7 @@ wkt:keyword                                                                     
 ["POINT(4297.11 -1475.53)", "POINT(7580.93 2272.77)"] |[POINT(4297.11 -1475.53), POINT(7580.93 2272.77)]
 ;
 
-simpleCartesianLoad#[skip:-8.11.99, reason:spatial type cartesian_point only added in 8.12]
+simpleCartesianLoad#[skip:-8.12.99, reason:spatial type cartesian_point improved precision in 8.13]
 FROM airports_web | WHERE scalerank == 9 | SORT abbrev | WHERE length(name) > 12;
 
 abbrev:keyword | location:cartesian_point                      | name:text                   | scalerank:i | type:k

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/spatial.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/spatial.csv-spec
@@ -68,6 +68,58 @@ WIIT           | POINT(105.176060419161 -5.242566777132)   | Radin Inten II     
 ZAH            | POINT(60.900708564915 29.4752941956573)   | Zahedan Int'l               | 9           | mid
 ;
 
+geoPointEquals#[skip:-8.12.99, reason:spatial type geo_point improved in 8.13]
+// tag::to_geopoint-equals[]
+ROW wkt = ["POINT(42.97109630194 14.7552534413725)", "POINT(75.8092915005895 22.727749187571)"]
+| MV_EXPAND wkt
+| EVAL pt = to_geopoint(wkt)
+| WHERE pt == to_geopoint("POINT(42.97109630194 14.7552534413725)")
+// end::to_geopoint-equals[]
+;
+
+// tag::to_geopoint-equals-result[]
+wkt:keyword                              |pt:geo_point
+"POINT(42.97109630194 14.7552534413725)" |POINT(42.97109630194 14.7552534413725)
+// end::to_geopoint-equals-result[]
+;
+
+geoPointNotEquals#[skip:-8.12.99, reason:spatial type geo_point improved in 8.13]
+// tag::to_geopoint-not-equals[]
+ROW wkt = ["POINT(42.97109630194 14.7552534413725)", "POINT(75.8092915005895 22.727749187571)"]
+| MV_EXPAND wkt
+| EVAL pt = to_geopoint(wkt)
+| WHERE pt != to_geopoint("POINT(42.97109630194 14.7552534413725)")
+// end::to_geopoint-not-equals[]
+;
+
+// tag::to_geopoint-not-equals-result[]
+wkt:keyword                               |pt:geo_point
+"POINT(75.8092915005895 22.727749187571)" |POINT(75.8092915005895 22.727749187571)
+// end::to_geopoint-not-equals-result[]
+;
+
+convertFromStringParseError#[skip:-8.12.99, reason:spatial type geo_point improved in 8.13]
+// tag::to_geopoint-str-parse-error[]
+row wkt = ["POINTX(42.97109630194 14.7552534413725)", "POINT(75.8092915005895 22.727749187571)", "POINT(111)"]
+| mv_expand wkt
+| eval pt = to_geopoint(wkt)
+// end::to_geopoint-str-parse-error[]
+;
+
+// tag::to_geopoint-str-parse-error-warning[]
+warning:Line 3:13: evaluation of [to_geopoint(wkt)] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 3:13: java.lang.IllegalArgumentException: Failed to parse WKT: Unknown geometry type: pointx
+warning:Line 3:13: java.lang.IllegalArgumentException: Failed to parse WKT: expected number but found: ')'
+// end::to_geopoint-str-parse-error-warning[]
+
+// tag::to_geopoint-str-parse-error-result[]
+wkt:keyword                               |pt:geo_point
+"POINTX(42.97109630194 14.7552534413725)" |null
+"POINT(75.8092915005895 22.727749187571)" |POINT(75.8092915005895 22.727749187571)
+"POINT(111)"                              |null
+// end::to_geopoint-str-parse-error-result[]
+;
+
 ###############################################
 # Tests for CARTESIAN_POINT type
 #
@@ -134,4 +186,56 @@ OVB            | POINT (9202465.316351846 7363726.532780712)   | Novosibirsk Tol
 TRZ            | POINT (8761841.111486122 1204941.537981898)   | Tiruchirappalli             | 9           | mid
 WIIT           | POINT (11708145.489503577 -584415.9142832769) | Radin Inten II              | 9           | mid
 ZAH            | POINT (6779435.866395892 3436280.545331025)   | Zahedan Int'l               | 9           | mid
+;
+
+cartesianPointEquals#[skip:-8.12.99, reason:spatial type cartesian_point improved in 8.13]
+// tag::to_cartesianpoint-equals[]
+ROW wkt = ["POINT(4297.11 -1475.53)", "POINT(7580.93 2272.77)"]
+| MV_EXPAND wkt
+| EVAL pt = to_cartesianpoint(wkt)
+| WHERE pt == to_cartesianpoint("POINT(4297.11 -1475.53)")
+// end::to_cartesianpoint-equals[]
+;
+
+// tag::to_cartesianpoint-equals-result[]
+wkt:keyword               |pt:cartesian_point
+"POINT(4297.11 -1475.53)" |POINT(4297.11 -1475.53)
+// end::to_cartesianpoint-equals-result[]
+;
+
+cartesianPointNotEquals#[skip:-8.12.99, reason:spatial type cartesian_point improved in 8.13]
+// tag::to_cartesianpoint-not-equals[]
+ROW wkt = ["POINT(4297.11 -1475.53)", "POINT(7580.93 2272.77)"]
+| MV_EXPAND wkt
+| EVAL pt = to_cartesianpoint(wkt)
+| WHERE pt != to_cartesianpoint("POINT(4297.11 -1475.53)")
+// end::to_cartesianpoint-not-equals[]
+;
+
+// tag::to_cartesianpoint-not-equals-result[]
+wkt:keyword              |pt:cartesian_point
+"POINT(7580.93 2272.77)" |POINT(7580.93 2272.77)
+// end::to_cartesianpoint-not-equals-result[]
+;
+
+convertCartesianFromStringParseError#[skip:-8.12.99, reason:spatial type cartesian_point improved in 8.13]
+// tag::to_cartesianpoint-str-parse-error[]
+row wkt = ["POINTX(4297.11 -1475.53)", "POINT(7580.93 2272.77)", "POINT(111)"]
+| mv_expand wkt
+| eval pt = to_cartesianpoint(wkt)
+// end::to_cartesianpoint-str-parse-error[]
+;
+
+// tag::to_cartesianpoint-str-parse-error-warning[]
+warning:Line 3:13: evaluation of [to_cartesianpoint(wkt)] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 3:13: java.lang.IllegalArgumentException: Failed to parse WKT: Unknown geometry type: pointx
+warning:Line 3:13: java.lang.IllegalArgumentException: Failed to parse WKT: expected number but found: ')'
+// end::to_cartesianpoint-str-parse-error-warning[]
+
+// tag::to_cartesianpoint-str-parse-error-result[]
+wkt:keyword                |pt:cartesian_point
+"POINTX(4297.11 -1475.53)" |null
+"POINT(7580.93 2272.77)"   |POINT(7580.93 2272.77)
+"POINT(111)"               |null
+// end::to_cartesianpoint-str-parse-error-result[]
 ;

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/evaluator/predicate/operator/comparison/EqualsPointsEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/evaluator/predicate/operator/comparison/EqualsPointsEvaluator.java
@@ -1,0 +1,134 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.evaluator.predicate.operator.comparison;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.BooleanVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.data.PointBlock;
+import org.elasticsearch.compute.data.PointVector;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.expression.function.Warnings;
+import org.elasticsearch.xpack.ql.tree.Source;
+
+/**
+ * {@link EvalOperator.ExpressionEvaluator} implementation for {@link Equals}.
+ * This class is generated. Do not edit it.
+ */
+public final class EqualsPointsEvaluator implements EvalOperator.ExpressionEvaluator {
+  private final Warnings warnings;
+
+  private final EvalOperator.ExpressionEvaluator lhs;
+
+  private final EvalOperator.ExpressionEvaluator rhs;
+
+  private final DriverContext driverContext;
+
+  public EqualsPointsEvaluator(Source source, EvalOperator.ExpressionEvaluator lhs,
+      EvalOperator.ExpressionEvaluator rhs, DriverContext driverContext) {
+    this.warnings = new Warnings(source);
+    this.lhs = lhs;
+    this.rhs = rhs;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (PointBlock lhsBlock = (PointBlock) lhs.eval(page)) {
+      try (PointBlock rhsBlock = (PointBlock) rhs.eval(page)) {
+        PointVector lhsVector = lhsBlock.asVector();
+        if (lhsVector == null) {
+          return eval(page.getPositionCount(), lhsBlock, rhsBlock);
+        }
+        PointVector rhsVector = rhsBlock.asVector();
+        if (rhsVector == null) {
+          return eval(page.getPositionCount(), lhsBlock, rhsBlock);
+        }
+        return eval(page.getPositionCount(), lhsVector, rhsVector).asBlock();
+      }
+    }
+  }
+
+  public BooleanBlock eval(int positionCount, PointBlock lhsBlock, PointBlock rhsBlock) {
+    try(BooleanBlock.Builder result = driverContext.blockFactory().newBooleanBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        if (lhsBlock.isNull(p)) {
+          result.appendNull();
+          continue position;
+        }
+        if (lhsBlock.getValueCount(p) != 1) {
+          if (lhsBlock.getValueCount(p) > 1) {
+            warnings.registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+          }
+          result.appendNull();
+          continue position;
+        }
+        if (rhsBlock.isNull(p)) {
+          result.appendNull();
+          continue position;
+        }
+        if (rhsBlock.getValueCount(p) != 1) {
+          if (rhsBlock.getValueCount(p) > 1) {
+            warnings.registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+          }
+          result.appendNull();
+          continue position;
+        }
+        result.appendBoolean(Equals.processPoints(lhsBlock.getPoint(lhsBlock.getFirstValueIndex(p)), rhsBlock.getPoint(rhsBlock.getFirstValueIndex(p))));
+      }
+      return result.build();
+    }
+  }
+
+  public BooleanVector eval(int positionCount, PointVector lhsVector, PointVector rhsVector) {
+    try(BooleanVector.Builder result = driverContext.blockFactory().newBooleanVectorBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        result.appendBoolean(Equals.processPoints(lhsVector.getPoint(p), rhsVector.getPoint(p)));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "EqualsPointsEvaluator[" + "lhs=" + lhs + ", rhs=" + rhs + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(lhs, rhs);
+  }
+
+  static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final EvalOperator.ExpressionEvaluator.Factory lhs;
+
+    private final EvalOperator.ExpressionEvaluator.Factory rhs;
+
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory lhs,
+        EvalOperator.ExpressionEvaluator.Factory rhs) {
+      this.source = source;
+      this.lhs = lhs;
+      this.rhs = rhs;
+    }
+
+    @Override
+    public EqualsPointsEvaluator get(DriverContext context) {
+      return new EqualsPointsEvaluator(source, lhs.get(context), rhs.get(context), context);
+    }
+
+    @Override
+    public String toString() {
+      return "EqualsPointsEvaluator[" + "lhs=" + lhs + ", rhs=" + rhs + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/evaluator/predicate/operator/comparison/NotEqualsPointsEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/evaluator/predicate/operator/comparison/NotEqualsPointsEvaluator.java
@@ -1,0 +1,134 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.evaluator.predicate.operator.comparison;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.BooleanVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.data.PointBlock;
+import org.elasticsearch.compute.data.PointVector;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.expression.function.Warnings;
+import org.elasticsearch.xpack.ql.tree.Source;
+
+/**
+ * {@link EvalOperator.ExpressionEvaluator} implementation for {@link NotEquals}.
+ * This class is generated. Do not edit it.
+ */
+public final class NotEqualsPointsEvaluator implements EvalOperator.ExpressionEvaluator {
+  private final Warnings warnings;
+
+  private final EvalOperator.ExpressionEvaluator lhs;
+
+  private final EvalOperator.ExpressionEvaluator rhs;
+
+  private final DriverContext driverContext;
+
+  public NotEqualsPointsEvaluator(Source source, EvalOperator.ExpressionEvaluator lhs,
+      EvalOperator.ExpressionEvaluator rhs, DriverContext driverContext) {
+    this.warnings = new Warnings(source);
+    this.lhs = lhs;
+    this.rhs = rhs;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (PointBlock lhsBlock = (PointBlock) lhs.eval(page)) {
+      try (PointBlock rhsBlock = (PointBlock) rhs.eval(page)) {
+        PointVector lhsVector = lhsBlock.asVector();
+        if (lhsVector == null) {
+          return eval(page.getPositionCount(), lhsBlock, rhsBlock);
+        }
+        PointVector rhsVector = rhsBlock.asVector();
+        if (rhsVector == null) {
+          return eval(page.getPositionCount(), lhsBlock, rhsBlock);
+        }
+        return eval(page.getPositionCount(), lhsVector, rhsVector).asBlock();
+      }
+    }
+  }
+
+  public BooleanBlock eval(int positionCount, PointBlock lhsBlock, PointBlock rhsBlock) {
+    try(BooleanBlock.Builder result = driverContext.blockFactory().newBooleanBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        if (lhsBlock.isNull(p)) {
+          result.appendNull();
+          continue position;
+        }
+        if (lhsBlock.getValueCount(p) != 1) {
+          if (lhsBlock.getValueCount(p) > 1) {
+            warnings.registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+          }
+          result.appendNull();
+          continue position;
+        }
+        if (rhsBlock.isNull(p)) {
+          result.appendNull();
+          continue position;
+        }
+        if (rhsBlock.getValueCount(p) != 1) {
+          if (rhsBlock.getValueCount(p) > 1) {
+            warnings.registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+          }
+          result.appendNull();
+          continue position;
+        }
+        result.appendBoolean(NotEquals.processPoints(lhsBlock.getPoint(lhsBlock.getFirstValueIndex(p)), rhsBlock.getPoint(rhsBlock.getFirstValueIndex(p))));
+      }
+      return result.build();
+    }
+  }
+
+  public BooleanVector eval(int positionCount, PointVector lhsVector, PointVector rhsVector) {
+    try(BooleanVector.Builder result = driverContext.blockFactory().newBooleanVectorBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        result.appendBoolean(NotEquals.processPoints(lhsVector.getPoint(p), rhsVector.getPoint(p)));
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "NotEqualsPointsEvaluator[" + "lhs=" + lhs + ", rhs=" + rhs + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(lhs, rhs);
+  }
+
+  static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final EvalOperator.ExpressionEvaluator.Factory lhs;
+
+    private final EvalOperator.ExpressionEvaluator.Factory rhs;
+
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory lhs,
+        EvalOperator.ExpressionEvaluator.Factory rhs) {
+      this.source = source;
+      this.lhs = lhs;
+      this.rhs = rhs;
+    }
+
+    @Override
+    public NotEqualsPointsEvaluator get(DriverContext context) {
+      return new NotEqualsPointsEvaluator(source, lhs.get(context), rhs.get(context), context);
+    }
+
+    @Override
+    public String toString() {
+      return "NotEqualsPointsEvaluator[" + "lhs=" + lhs + ", rhs=" + rhs + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToCartesianPointFromLongEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToCartesianPointFromLongEvaluator.java
@@ -1,0 +1,124 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.elasticsearch.common.geo.SpatialPoint;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.LongVector;
+import org.elasticsearch.compute.data.PointBlock;
+import org.elasticsearch.compute.data.Vector;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.xpack.ql.tree.Source;
+
+/**
+ * {@link EvalOperator.ExpressionEvaluator} implementation for {@link ToCartesianPoint}.
+ * This class is generated. Do not edit it.
+ */
+public final class ToCartesianPointFromLongEvaluator extends AbstractConvertFunction.AbstractEvaluator {
+  public ToCartesianPointFromLongEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+      DriverContext driverContext) {
+    super(driverContext, field, source);
+  }
+
+  @Override
+  public String name() {
+    return "ToCartesianPointFromLong";
+  }
+
+  @Override
+  public Block evalVector(Vector v) {
+    LongVector vector = (LongVector) v;
+    int positionCount = v.getPositionCount();
+    if (vector.isConstant()) {
+      try {
+        return driverContext.blockFactory().newConstantPointBlockWith(evalValue(vector, 0), positionCount);
+      } catch (IllegalArgumentException  e) {
+        registerException(e);
+        return driverContext.blockFactory().newConstantNullBlock(positionCount);
+      }
+    }
+    try (PointBlock.Builder builder = driverContext.blockFactory().newPointBlockBuilder(positionCount)) {
+      for (int p = 0; p < positionCount; p++) {
+        try {
+          builder.appendPoint(evalValue(vector, p));
+        } catch (IllegalArgumentException  e) {
+          registerException(e);
+          builder.appendNull();
+        }
+      }
+      return builder.build();
+    }
+  }
+
+  private static SpatialPoint evalValue(LongVector container, int index) {
+    long value = container.getLong(index);
+    return ToCartesianPoint.fromLong(value);
+  }
+
+  @Override
+  public Block evalBlock(Block b) {
+    LongBlock block = (LongBlock) b;
+    int positionCount = block.getPositionCount();
+    try (PointBlock.Builder builder = driverContext.blockFactory().newPointBlockBuilder(positionCount)) {
+      for (int p = 0; p < positionCount; p++) {
+        int valueCount = block.getValueCount(p);
+        int start = block.getFirstValueIndex(p);
+        int end = start + valueCount;
+        boolean positionOpened = false;
+        boolean valuesAppended = false;
+        for (int i = start; i < end; i++) {
+          try {
+            SpatialPoint value = evalValue(block, i);
+            if (positionOpened == false && valueCount > 1) {
+              builder.beginPositionEntry();
+              positionOpened = true;
+            }
+            builder.appendPoint(value);
+            valuesAppended = true;
+          } catch (IllegalArgumentException  e) {
+            registerException(e);
+          }
+        }
+        if (valuesAppended == false) {
+          builder.appendNull();
+        } else if (positionOpened) {
+          builder.endPositionEntry();
+        }
+      }
+      return builder.build();
+    }
+  }
+
+  private static SpatialPoint evalValue(LongBlock container, int index) {
+    long value = container.getLong(index);
+    return ToCartesianPoint.fromLong(value);
+  }
+
+  public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final EvalOperator.ExpressionEvaluator.Factory field;
+
+    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
+      this.field = field;
+      this.source = source;
+    }
+
+    @Override
+    public ToCartesianPointFromLongEvaluator get(DriverContext context) {
+      return new ToCartesianPointFromLongEvaluator(field.get(context), source, context);
+    }
+
+    @Override
+    public String toString() {
+      return "ToCartesianPointFromLongEvaluator[field=" + field + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToCartesianPointFromLongEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToCartesianPointFromLongEvaluator.java
@@ -38,7 +38,8 @@ public final class ToCartesianPointFromLongEvaluator extends AbstractConvertFunc
     int positionCount = v.getPositionCount();
     if (vector.isConstant()) {
       try {
-        return driverContext.blockFactory().newConstantPointBlockWith(evalValue(vector, 0), positionCount);
+        SpatialPoint point = evalValue(vector, 0);
+        return driverContext.blockFactory().newConstantPointBlockWith(point.getX(), point.getY(), positionCount);
       } catch (IllegalArgumentException  e) {
         registerException(e);
         return driverContext.blockFactory().newConstantNullBlock(positionCount);
@@ -47,7 +48,8 @@ public final class ToCartesianPointFromLongEvaluator extends AbstractConvertFunc
     try (PointBlock.Builder builder = driverContext.blockFactory().newPointBlockBuilder(positionCount)) {
       for (int p = 0; p < positionCount; p++) {
         try {
-          builder.appendPoint(evalValue(vector, p));
+          SpatialPoint point = evalValue(vector, p);
+          builder.appendPoint(point.getX(), point.getY());
         } catch (IllegalArgumentException  e) {
           registerException(e);
           builder.appendNull();
@@ -80,7 +82,7 @@ public final class ToCartesianPointFromLongEvaluator extends AbstractConvertFunc
               builder.beginPositionEntry();
               positionOpened = true;
             }
-            builder.appendPoint(value);
+            builder.appendPoint(value.getX(), value.getY());
             valuesAppended = true;
           } catch (IllegalArgumentException  e) {
             registerException(e);

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToCartesianPointFromStringEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToCartesianPointFromStringEvaluator.java
@@ -40,7 +40,8 @@ public final class ToCartesianPointFromStringEvaluator extends AbstractConvertFu
     BytesRef scratchPad = new BytesRef();
     if (vector.isConstant()) {
       try {
-        return driverContext.blockFactory().newConstantPointBlockWith(evalValue(vector, 0, scratchPad), positionCount);
+        SpatialPoint point = evalValue(vector, 0, scratchPad);
+        return driverContext.blockFactory().newConstantPointBlockWith(point.getX(), point.getY(), positionCount);
       } catch (IllegalArgumentException  e) {
         registerException(e);
         return driverContext.blockFactory().newConstantNullBlock(positionCount);
@@ -49,7 +50,8 @@ public final class ToCartesianPointFromStringEvaluator extends AbstractConvertFu
     try (PointBlock.Builder builder = driverContext.blockFactory().newPointBlockBuilder(positionCount)) {
       for (int p = 0; p < positionCount; p++) {
         try {
-          builder.appendPoint(evalValue(vector, p, scratchPad));
+          SpatialPoint point = evalValue(vector, p, scratchPad);
+          builder.appendPoint(point.getX(), point.getY());
         } catch (IllegalArgumentException  e) {
           registerException(e);
           builder.appendNull();
@@ -83,7 +85,7 @@ public final class ToCartesianPointFromStringEvaluator extends AbstractConvertFu
               builder.beginPositionEntry();
               positionOpened = true;
             }
-            builder.appendPoint(value);
+            builder.appendPoint(value.getX(), value.getY());
             valuesAppended = true;
           } catch (IllegalArgumentException  e) {
             registerException(e);

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToCartesianPointFromStringEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToCartesianPointFromStringEvaluator.java
@@ -8,10 +8,11 @@ import java.lang.IllegalArgumentException;
 import java.lang.Override;
 import java.lang.String;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
-import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.PointBlock;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
@@ -39,16 +40,16 @@ public final class ToCartesianPointFromStringEvaluator extends AbstractConvertFu
     BytesRef scratchPad = new BytesRef();
     if (vector.isConstant()) {
       try {
-        return driverContext.blockFactory().newConstantLongBlockWith(evalValue(vector, 0, scratchPad), positionCount);
+        return driverContext.blockFactory().newConstantPointBlockWith(evalValue(vector, 0, scratchPad), positionCount);
       } catch (IllegalArgumentException  e) {
         registerException(e);
         return driverContext.blockFactory().newConstantNullBlock(positionCount);
       }
     }
-    try (LongBlock.Builder builder = driverContext.blockFactory().newLongBlockBuilder(positionCount)) {
+    try (PointBlock.Builder builder = driverContext.blockFactory().newPointBlockBuilder(positionCount)) {
       for (int p = 0; p < positionCount; p++) {
         try {
-          builder.appendLong(evalValue(vector, p, scratchPad));
+          builder.appendPoint(evalValue(vector, p, scratchPad));
         } catch (IllegalArgumentException  e) {
           registerException(e);
           builder.appendNull();
@@ -58,7 +59,7 @@ public final class ToCartesianPointFromStringEvaluator extends AbstractConvertFu
     }
   }
 
-  private static long evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
+  private static SpatialPoint evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return ToCartesianPoint.fromKeyword(value);
   }
@@ -67,7 +68,7 @@ public final class ToCartesianPointFromStringEvaluator extends AbstractConvertFu
   public Block evalBlock(Block b) {
     BytesRefBlock block = (BytesRefBlock) b;
     int positionCount = block.getPositionCount();
-    try (LongBlock.Builder builder = driverContext.blockFactory().newLongBlockBuilder(positionCount)) {
+    try (PointBlock.Builder builder = driverContext.blockFactory().newPointBlockBuilder(positionCount)) {
       BytesRef scratchPad = new BytesRef();
       for (int p = 0; p < positionCount; p++) {
         int valueCount = block.getValueCount(p);
@@ -77,12 +78,12 @@ public final class ToCartesianPointFromStringEvaluator extends AbstractConvertFu
         boolean valuesAppended = false;
         for (int i = start; i < end; i++) {
           try {
-            long value = evalValue(block, i, scratchPad);
+            SpatialPoint value = evalValue(block, i, scratchPad);
             if (positionOpened == false && valueCount > 1) {
               builder.beginPositionEntry();
               positionOpened = true;
             }
-            builder.appendLong(value);
+            builder.appendPoint(value);
             valuesAppended = true;
           } catch (IllegalArgumentException  e) {
             registerException(e);
@@ -98,7 +99,7 @@ public final class ToCartesianPointFromStringEvaluator extends AbstractConvertFu
     }
   }
 
-  private static long evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
+  private static SpatialPoint evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return ToCartesianPoint.fromKeyword(value);
   }

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToGeoPointFromLongEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToGeoPointFromLongEvaluator.java
@@ -38,7 +38,8 @@ public final class ToGeoPointFromLongEvaluator extends AbstractConvertFunction.A
     int positionCount = v.getPositionCount();
     if (vector.isConstant()) {
       try {
-        return driverContext.blockFactory().newConstantPointBlockWith(evalValue(vector, 0), positionCount);
+        SpatialPoint point = evalValue(vector, 0);
+        return driverContext.blockFactory().newConstantPointBlockWith(point.getX(), point.getY(), positionCount);
       } catch (IllegalArgumentException  e) {
         registerException(e);
         return driverContext.blockFactory().newConstantNullBlock(positionCount);
@@ -47,7 +48,8 @@ public final class ToGeoPointFromLongEvaluator extends AbstractConvertFunction.A
     try (PointBlock.Builder builder = driverContext.blockFactory().newPointBlockBuilder(positionCount)) {
       for (int p = 0; p < positionCount; p++) {
         try {
-          builder.appendPoint(evalValue(vector, p));
+          SpatialPoint point = evalValue(vector, p);
+          builder.appendPoint(point.getX(), point.getY());
         } catch (IllegalArgumentException  e) {
           registerException(e);
           builder.appendNull();
@@ -80,7 +82,7 @@ public final class ToGeoPointFromLongEvaluator extends AbstractConvertFunction.A
               builder.beginPositionEntry();
               positionOpened = true;
             }
-            builder.appendPoint(value);
+            builder.appendPoint(value.getX(), value.getY());
             valuesAppended = true;
           } catch (IllegalArgumentException  e) {
             registerException(e);

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToGeoPointFromLongEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToGeoPointFromLongEvaluator.java
@@ -1,0 +1,124 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.elasticsearch.common.geo.SpatialPoint;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.LongVector;
+import org.elasticsearch.compute.data.PointBlock;
+import org.elasticsearch.compute.data.Vector;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.xpack.ql.tree.Source;
+
+/**
+ * {@link EvalOperator.ExpressionEvaluator} implementation for {@link ToGeoPoint}.
+ * This class is generated. Do not edit it.
+ */
+public final class ToGeoPointFromLongEvaluator extends AbstractConvertFunction.AbstractEvaluator {
+  public ToGeoPointFromLongEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+      DriverContext driverContext) {
+    super(driverContext, field, source);
+  }
+
+  @Override
+  public String name() {
+    return "ToGeoPointFromLong";
+  }
+
+  @Override
+  public Block evalVector(Vector v) {
+    LongVector vector = (LongVector) v;
+    int positionCount = v.getPositionCount();
+    if (vector.isConstant()) {
+      try {
+        return driverContext.blockFactory().newConstantPointBlockWith(evalValue(vector, 0), positionCount);
+      } catch (IllegalArgumentException  e) {
+        registerException(e);
+        return driverContext.blockFactory().newConstantNullBlock(positionCount);
+      }
+    }
+    try (PointBlock.Builder builder = driverContext.blockFactory().newPointBlockBuilder(positionCount)) {
+      for (int p = 0; p < positionCount; p++) {
+        try {
+          builder.appendPoint(evalValue(vector, p));
+        } catch (IllegalArgumentException  e) {
+          registerException(e);
+          builder.appendNull();
+        }
+      }
+      return builder.build();
+    }
+  }
+
+  private static SpatialPoint evalValue(LongVector container, int index) {
+    long value = container.getLong(index);
+    return ToGeoPoint.fromLong(value);
+  }
+
+  @Override
+  public Block evalBlock(Block b) {
+    LongBlock block = (LongBlock) b;
+    int positionCount = block.getPositionCount();
+    try (PointBlock.Builder builder = driverContext.blockFactory().newPointBlockBuilder(positionCount)) {
+      for (int p = 0; p < positionCount; p++) {
+        int valueCount = block.getValueCount(p);
+        int start = block.getFirstValueIndex(p);
+        int end = start + valueCount;
+        boolean positionOpened = false;
+        boolean valuesAppended = false;
+        for (int i = start; i < end; i++) {
+          try {
+            SpatialPoint value = evalValue(block, i);
+            if (positionOpened == false && valueCount > 1) {
+              builder.beginPositionEntry();
+              positionOpened = true;
+            }
+            builder.appendPoint(value);
+            valuesAppended = true;
+          } catch (IllegalArgumentException  e) {
+            registerException(e);
+          }
+        }
+        if (valuesAppended == false) {
+          builder.appendNull();
+        } else if (positionOpened) {
+          builder.endPositionEntry();
+        }
+      }
+      return builder.build();
+    }
+  }
+
+  private static SpatialPoint evalValue(LongBlock container, int index) {
+    long value = container.getLong(index);
+    return ToGeoPoint.fromLong(value);
+  }
+
+  public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final EvalOperator.ExpressionEvaluator.Factory field;
+
+    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
+      this.field = field;
+      this.source = source;
+    }
+
+    @Override
+    public ToGeoPointFromLongEvaluator get(DriverContext context) {
+      return new ToGeoPointFromLongEvaluator(field.get(context), source, context);
+    }
+
+    @Override
+    public String toString() {
+      return "ToGeoPointFromLongEvaluator[field=" + field + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToGeoPointFromStringEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToGeoPointFromStringEvaluator.java
@@ -40,7 +40,8 @@ public final class ToGeoPointFromStringEvaluator extends AbstractConvertFunction
     BytesRef scratchPad = new BytesRef();
     if (vector.isConstant()) {
       try {
-        return driverContext.blockFactory().newConstantPointBlockWith(evalValue(vector, 0, scratchPad), positionCount);
+        SpatialPoint point = evalValue(vector, 0, scratchPad);
+        return driverContext.blockFactory().newConstantPointBlockWith(point.getX(), point.getY(), positionCount);
       } catch (IllegalArgumentException  e) {
         registerException(e);
         return driverContext.blockFactory().newConstantNullBlock(positionCount);
@@ -49,7 +50,8 @@ public final class ToGeoPointFromStringEvaluator extends AbstractConvertFunction
     try (PointBlock.Builder builder = driverContext.blockFactory().newPointBlockBuilder(positionCount)) {
       for (int p = 0; p < positionCount; p++) {
         try {
-          builder.appendPoint(evalValue(vector, p, scratchPad));
+          SpatialPoint point = evalValue(vector, p, scratchPad);
+          builder.appendPoint(point.getX(), point.getY());
         } catch (IllegalArgumentException  e) {
           registerException(e);
           builder.appendNull();
@@ -83,7 +85,7 @@ public final class ToGeoPointFromStringEvaluator extends AbstractConvertFunction
               builder.beginPositionEntry();
               positionOpened = true;
             }
-            builder.appendPoint(value);
+            builder.appendPoint(value.getX(), value.getY());
             valuesAppended = true;
           } catch (IllegalArgumentException  e) {
             registerException(e);

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToGeoPointFromStringEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToGeoPointFromStringEvaluator.java
@@ -8,10 +8,11 @@ import java.lang.IllegalArgumentException;
 import java.lang.Override;
 import java.lang.String;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
-import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.PointBlock;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
@@ -39,16 +40,16 @@ public final class ToGeoPointFromStringEvaluator extends AbstractConvertFunction
     BytesRef scratchPad = new BytesRef();
     if (vector.isConstant()) {
       try {
-        return driverContext.blockFactory().newConstantLongBlockWith(evalValue(vector, 0, scratchPad), positionCount);
+        return driverContext.blockFactory().newConstantPointBlockWith(evalValue(vector, 0, scratchPad), positionCount);
       } catch (IllegalArgumentException  e) {
         registerException(e);
         return driverContext.blockFactory().newConstantNullBlock(positionCount);
       }
     }
-    try (LongBlock.Builder builder = driverContext.blockFactory().newLongBlockBuilder(positionCount)) {
+    try (PointBlock.Builder builder = driverContext.blockFactory().newPointBlockBuilder(positionCount)) {
       for (int p = 0; p < positionCount; p++) {
         try {
-          builder.appendLong(evalValue(vector, p, scratchPad));
+          builder.appendPoint(evalValue(vector, p, scratchPad));
         } catch (IllegalArgumentException  e) {
           registerException(e);
           builder.appendNull();
@@ -58,7 +59,7 @@ public final class ToGeoPointFromStringEvaluator extends AbstractConvertFunction
     }
   }
 
-  private static long evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
+  private static SpatialPoint evalValue(BytesRefVector container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return ToGeoPoint.fromKeyword(value);
   }
@@ -67,7 +68,7 @@ public final class ToGeoPointFromStringEvaluator extends AbstractConvertFunction
   public Block evalBlock(Block b) {
     BytesRefBlock block = (BytesRefBlock) b;
     int positionCount = block.getPositionCount();
-    try (LongBlock.Builder builder = driverContext.blockFactory().newLongBlockBuilder(positionCount)) {
+    try (PointBlock.Builder builder = driverContext.blockFactory().newPointBlockBuilder(positionCount)) {
       BytesRef scratchPad = new BytesRef();
       for (int p = 0; p < positionCount; p++) {
         int valueCount = block.getValueCount(p);
@@ -77,12 +78,12 @@ public final class ToGeoPointFromStringEvaluator extends AbstractConvertFunction
         boolean valuesAppended = false;
         for (int i = start; i < end; i++) {
           try {
-            long value = evalValue(block, i, scratchPad);
+            SpatialPoint value = evalValue(block, i, scratchPad);
             if (positionOpened == false && valueCount > 1) {
               builder.beginPositionEntry();
               positionOpened = true;
             }
-            builder.appendLong(value);
+            builder.appendPoint(value);
             valuesAppended = true;
           } catch (IllegalArgumentException  e) {
             registerException(e);
@@ -98,7 +99,7 @@ public final class ToGeoPointFromStringEvaluator extends AbstractConvertFunction
     }
   }
 
-  private static long evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
+  private static SpatialPoint evalValue(BytesRefBlock container, int index, BytesRef scratchPad) {
     BytesRef value = container.getBytesRef(index, scratchPad);
     return ToGeoPoint.fromKeyword(value);
   }

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLongFromCartesianPointEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLongFromCartesianPointEvaluator.java
@@ -47,7 +47,9 @@ public final class ToLongFromCartesianPointEvaluator extends AbstractConvertFunc
   }
 
   private static long evalValue(PointVector container, int index) {
-    SpatialPoint value = container.getPoint(index);
+    double x = container.getX(index);
+    double y = container.getY(index);
+    SpatialPoint value = new SpatialPoint(x, y);
     return ToLong.fromCartesianPoint(value);
   }
 
@@ -82,7 +84,9 @@ public final class ToLongFromCartesianPointEvaluator extends AbstractConvertFunc
   }
 
   private static long evalValue(PointBlock container, int index) {
-    SpatialPoint value = container.getPoint(index);
+    double x = container.getX(index);
+    double y = container.getY(index);
+    SpatialPoint value = new SpatialPoint(x, y);
     return ToLong.fromCartesianPoint(value);
   }
 

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLongFromCartesianPointEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLongFromCartesianPointEvaluator.java
@@ -1,0 +1,109 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
+
+import java.lang.Override;
+import java.lang.String;
+import org.elasticsearch.common.geo.SpatialPoint;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.PointBlock;
+import org.elasticsearch.compute.data.PointVector;
+import org.elasticsearch.compute.data.Vector;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.xpack.ql.tree.Source;
+
+/**
+ * {@link EvalOperator.ExpressionEvaluator} implementation for {@link ToLong}.
+ * This class is generated. Do not edit it.
+ */
+public final class ToLongFromCartesianPointEvaluator extends AbstractConvertFunction.AbstractEvaluator {
+  public ToLongFromCartesianPointEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+      DriverContext driverContext) {
+    super(driverContext, field, source);
+  }
+
+  @Override
+  public String name() {
+    return "ToLongFromCartesianPoint";
+  }
+
+  @Override
+  public Block evalVector(Vector v) {
+    PointVector vector = (PointVector) v;
+    int positionCount = v.getPositionCount();
+    if (vector.isConstant()) {
+      return driverContext.blockFactory().newConstantLongBlockWith(evalValue(vector, 0), positionCount);
+    }
+    try (LongBlock.Builder builder = driverContext.blockFactory().newLongBlockBuilder(positionCount)) {
+      for (int p = 0; p < positionCount; p++) {
+        builder.appendLong(evalValue(vector, p));
+      }
+      return builder.build();
+    }
+  }
+
+  private static long evalValue(PointVector container, int index) {
+    SpatialPoint value = container.getPoint(index);
+    return ToLong.fromCartesianPoint(value);
+  }
+
+  @Override
+  public Block evalBlock(Block b) {
+    PointBlock block = (PointBlock) b;
+    int positionCount = block.getPositionCount();
+    try (LongBlock.Builder builder = driverContext.blockFactory().newLongBlockBuilder(positionCount)) {
+      for (int p = 0; p < positionCount; p++) {
+        int valueCount = block.getValueCount(p);
+        int start = block.getFirstValueIndex(p);
+        int end = start + valueCount;
+        boolean positionOpened = false;
+        boolean valuesAppended = false;
+        for (int i = start; i < end; i++) {
+          long value = evalValue(block, i);
+          if (positionOpened == false && valueCount > 1) {
+            builder.beginPositionEntry();
+            positionOpened = true;
+          }
+          builder.appendLong(value);
+          valuesAppended = true;
+        }
+        if (valuesAppended == false) {
+          builder.appendNull();
+        } else if (positionOpened) {
+          builder.endPositionEntry();
+        }
+      }
+      return builder.build();
+    }
+  }
+
+  private static long evalValue(PointBlock container, int index) {
+    SpatialPoint value = container.getPoint(index);
+    return ToLong.fromCartesianPoint(value);
+  }
+
+  public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final EvalOperator.ExpressionEvaluator.Factory field;
+
+    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
+      this.field = field;
+      this.source = source;
+    }
+
+    @Override
+    public ToLongFromCartesianPointEvaluator get(DriverContext context) {
+      return new ToLongFromCartesianPointEvaluator(field.get(context), source, context);
+    }
+
+    @Override
+    public String toString() {
+      return "ToLongFromCartesianPointEvaluator[field=" + field + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLongFromGeoPointEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLongFromGeoPointEvaluator.java
@@ -1,0 +1,109 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
+
+import java.lang.Override;
+import java.lang.String;
+import org.elasticsearch.common.geo.SpatialPoint;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.PointBlock;
+import org.elasticsearch.compute.data.PointVector;
+import org.elasticsearch.compute.data.Vector;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.xpack.ql.tree.Source;
+
+/**
+ * {@link EvalOperator.ExpressionEvaluator} implementation for {@link ToLong}.
+ * This class is generated. Do not edit it.
+ */
+public final class ToLongFromGeoPointEvaluator extends AbstractConvertFunction.AbstractEvaluator {
+  public ToLongFromGeoPointEvaluator(EvalOperator.ExpressionEvaluator field, Source source,
+      DriverContext driverContext) {
+    super(driverContext, field, source);
+  }
+
+  @Override
+  public String name() {
+    return "ToLongFromGeoPoint";
+  }
+
+  @Override
+  public Block evalVector(Vector v) {
+    PointVector vector = (PointVector) v;
+    int positionCount = v.getPositionCount();
+    if (vector.isConstant()) {
+      return driverContext.blockFactory().newConstantLongBlockWith(evalValue(vector, 0), positionCount);
+    }
+    try (LongBlock.Builder builder = driverContext.blockFactory().newLongBlockBuilder(positionCount)) {
+      for (int p = 0; p < positionCount; p++) {
+        builder.appendLong(evalValue(vector, p));
+      }
+      return builder.build();
+    }
+  }
+
+  private static long evalValue(PointVector container, int index) {
+    SpatialPoint value = container.getPoint(index);
+    return ToLong.fromGeoPoint(value);
+  }
+
+  @Override
+  public Block evalBlock(Block b) {
+    PointBlock block = (PointBlock) b;
+    int positionCount = block.getPositionCount();
+    try (LongBlock.Builder builder = driverContext.blockFactory().newLongBlockBuilder(positionCount)) {
+      for (int p = 0; p < positionCount; p++) {
+        int valueCount = block.getValueCount(p);
+        int start = block.getFirstValueIndex(p);
+        int end = start + valueCount;
+        boolean positionOpened = false;
+        boolean valuesAppended = false;
+        for (int i = start; i < end; i++) {
+          long value = evalValue(block, i);
+          if (positionOpened == false && valueCount > 1) {
+            builder.beginPositionEntry();
+            positionOpened = true;
+          }
+          builder.appendLong(value);
+          valuesAppended = true;
+        }
+        if (valuesAppended == false) {
+          builder.appendNull();
+        } else if (positionOpened) {
+          builder.endPositionEntry();
+        }
+      }
+      return builder.build();
+    }
+  }
+
+  private static long evalValue(PointBlock container, int index) {
+    SpatialPoint value = container.getPoint(index);
+    return ToLong.fromGeoPoint(value);
+  }
+
+  public static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final EvalOperator.ExpressionEvaluator.Factory field;
+
+    public Factory(EvalOperator.ExpressionEvaluator.Factory field, Source source) {
+      this.field = field;
+      this.source = source;
+    }
+
+    @Override
+    public ToLongFromGeoPointEvaluator get(DriverContext context) {
+      return new ToLongFromGeoPointEvaluator(field.get(context), source, context);
+    }
+
+    @Override
+    public String toString() {
+      return "ToLongFromGeoPointEvaluator[field=" + field + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLongFromGeoPointEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLongFromGeoPointEvaluator.java
@@ -47,7 +47,9 @@ public final class ToLongFromGeoPointEvaluator extends AbstractConvertFunction.A
   }
 
   private static long evalValue(PointVector container, int index) {
-    SpatialPoint value = container.getPoint(index);
+    double x = container.getX(index);
+    double y = container.getY(index);
+    SpatialPoint value = new SpatialPoint(x, y);
     return ToLong.fromGeoPoint(value);
   }
 
@@ -82,7 +84,9 @@ public final class ToLongFromGeoPointEvaluator extends AbstractConvertFunction.A
   }
 
   private static long evalValue(PointBlock container, int index) {
-    SpatialPoint value = container.getPoint(index);
+    double x = container.getX(index);
+    double y = container.getY(index);
+    SpatialPoint value = new SpatialPoint(x, y);
     return ToLong.fromGeoPoint(value);
   }
 

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringFromCartesianPointEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringFromCartesianPointEvaluator.java
@@ -48,7 +48,9 @@ public final class ToStringFromCartesianPointEvaluator extends AbstractConvertFu
   }
 
   private static BytesRef evalValue(PointVector container, int index) {
-    SpatialPoint value = container.getPoint(index);
+    double x = container.getX(index);
+    double y = container.getY(index);
+    SpatialPoint value = new SpatialPoint(x, y);
     return ToString.fromCartesianPoint(value);
   }
 
@@ -83,7 +85,9 @@ public final class ToStringFromCartesianPointEvaluator extends AbstractConvertFu
   }
 
   private static BytesRef evalValue(PointBlock container, int index) {
-    SpatialPoint value = container.getPoint(index);
+    double x = container.getX(index);
+    double y = container.getY(index);
+    SpatialPoint value = new SpatialPoint(x, y);
     return ToString.fromCartesianPoint(value);
   }
 

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringFromCartesianPointEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringFromCartesianPointEvaluator.java
@@ -7,10 +7,11 @@ package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
 import java.lang.Override;
 import java.lang.String;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BytesRefBlock;
-import org.elasticsearch.compute.data.LongBlock;
-import org.elasticsearch.compute.data.LongVector;
+import org.elasticsearch.compute.data.PointBlock;
+import org.elasticsearch.compute.data.PointVector;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
@@ -33,7 +34,7 @@ public final class ToStringFromCartesianPointEvaluator extends AbstractConvertFu
 
   @Override
   public Block evalVector(Vector v) {
-    LongVector vector = (LongVector) v;
+    PointVector vector = (PointVector) v;
     int positionCount = v.getPositionCount();
     if (vector.isConstant()) {
       return driverContext.blockFactory().newConstantBytesRefBlockWith(evalValue(vector, 0), positionCount);
@@ -46,14 +47,14 @@ public final class ToStringFromCartesianPointEvaluator extends AbstractConvertFu
     }
   }
 
-  private static BytesRef evalValue(LongVector container, int index) {
-    long value = container.getLong(index);
+  private static BytesRef evalValue(PointVector container, int index) {
+    SpatialPoint value = container.getPoint(index);
     return ToString.fromCartesianPoint(value);
   }
 
   @Override
   public Block evalBlock(Block b) {
-    LongBlock block = (LongBlock) b;
+    PointBlock block = (PointBlock) b;
     int positionCount = block.getPositionCount();
     try (BytesRefBlock.Builder builder = driverContext.blockFactory().newBytesRefBlockBuilder(positionCount)) {
       for (int p = 0; p < positionCount; p++) {
@@ -81,8 +82,8 @@ public final class ToStringFromCartesianPointEvaluator extends AbstractConvertFu
     }
   }
 
-  private static BytesRef evalValue(LongBlock container, int index) {
-    long value = container.getLong(index);
+  private static BytesRef evalValue(PointBlock container, int index) {
+    SpatialPoint value = container.getPoint(index);
     return ToString.fromCartesianPoint(value);
   }
 

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringFromGeoPointEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringFromGeoPointEvaluator.java
@@ -48,7 +48,9 @@ public final class ToStringFromGeoPointEvaluator extends AbstractConvertFunction
   }
 
   private static BytesRef evalValue(PointVector container, int index) {
-    SpatialPoint value = container.getPoint(index);
+    double x = container.getX(index);
+    double y = container.getY(index);
+    SpatialPoint value = new SpatialPoint(x, y);
     return ToString.fromGeoPoint(value);
   }
 
@@ -83,7 +85,9 @@ public final class ToStringFromGeoPointEvaluator extends AbstractConvertFunction
   }
 
   private static BytesRef evalValue(PointBlock container, int index) {
-    SpatialPoint value = container.getPoint(index);
+    double x = container.getX(index);
+    double y = container.getY(index);
+    SpatialPoint value = new SpatialPoint(x, y);
     return ToString.fromGeoPoint(value);
   }
 

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringFromGeoPointEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringFromGeoPointEvaluator.java
@@ -7,10 +7,11 @@ package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
 import java.lang.Override;
 import java.lang.String;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BytesRefBlock;
-import org.elasticsearch.compute.data.LongBlock;
-import org.elasticsearch.compute.data.LongVector;
+import org.elasticsearch.compute.data.PointBlock;
+import org.elasticsearch.compute.data.PointVector;
 import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
@@ -33,7 +34,7 @@ public final class ToStringFromGeoPointEvaluator extends AbstractConvertFunction
 
   @Override
   public Block evalVector(Vector v) {
-    LongVector vector = (LongVector) v;
+    PointVector vector = (PointVector) v;
     int positionCount = v.getPositionCount();
     if (vector.isConstant()) {
       return driverContext.blockFactory().newConstantBytesRefBlockWith(evalValue(vector, 0), positionCount);
@@ -46,14 +47,14 @@ public final class ToStringFromGeoPointEvaluator extends AbstractConvertFunction
     }
   }
 
-  private static BytesRef evalValue(LongVector container, int index) {
-    long value = container.getLong(index);
+  private static BytesRef evalValue(PointVector container, int index) {
+    SpatialPoint value = container.getPoint(index);
     return ToString.fromGeoPoint(value);
   }
 
   @Override
   public Block evalBlock(Block b) {
-    LongBlock block = (LongBlock) b;
+    PointBlock block = (PointBlock) b;
     int positionCount = block.getPositionCount();
     try (BytesRefBlock.Builder builder = driverContext.blockFactory().newBytesRefBlockBuilder(positionCount)) {
       for (int p = 0; p < positionCount; p++) {
@@ -81,8 +82,8 @@ public final class ToStringFromGeoPointEvaluator extends AbstractConvertFunction
     }
   }
 
-  private static BytesRef evalValue(LongBlock container, int index) {
-    long value = container.getLong(index);
+  private static BytesRef evalValue(PointBlock container, int index) {
+    SpatialPoint value = container.getPoint(index);
     return ToString.fromGeoPoint(value);
   }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponse.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponse.java
@@ -318,7 +318,7 @@ public class EsqlQueryResponse extends ActionResponse implements ChunkedToXConte
         if (block instanceof LongBlock longBlock) {
             return spatial.longAsPoint(longBlock.getLong(offset));
         } else if (block instanceof PointBlock pointBlock) {
-            return pointBlock.getPoint(offset);
+            return spatial.pointAsPoint(pointBlock.getPoint(offset));
         } else {
             throw new IllegalArgumentException("Unsupported block type for " + dataType + ": " + block.getWriteableName());
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponse.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponse.java
@@ -318,7 +318,7 @@ public class EsqlQueryResponse extends ActionResponse implements ChunkedToXConte
         if (block instanceof LongBlock longBlock) {
             return spatial.longAsPoint(longBlock.getLong(offset));
         } else if (block instanceof PointBlock pointBlock) {
-            return spatial.pointAsPoint(pointBlock.getPoint(offset));
+            return spatial.pointAsPoint(pointBlock.getX(offset), pointBlock.getY(offset));
         } else {
             throw new IllegalArgumentException("Unsupported block type for " + dataType + ": " + block.getWriteableName());
         }
@@ -366,12 +366,13 @@ public class EsqlQueryResponse extends ActionResponse implements ChunkedToXConte
                         }
                     }
                     case "geo_point" -> {
+                        // TODO: check that we are not serializing/deserializing unnecessarily here
                         SpatialPoint pointVal = GEO.stringAsPoint(value.toString());
-                        ((PointBlock.Builder) builder).appendPoint(pointVal);
+                        ((PointBlock.Builder) builder).appendPoint(pointVal.getX(), pointVal.getY());
                     }
                     case "cartesian_point" -> {
                         SpatialPoint pointVal = CARTESIAN.stringAsPoint(value.toString());
-                        ((PointBlock.Builder) builder).appendPoint(pointVal);
+                        ((PointBlock.Builder) builder).appendPoint(pointVal.getX(), pointVal.getY());
                     }
                     default -> throw EsqlIllegalArgumentException.illegalDataType(dataTypes.get(c));
                 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponse.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponse.java
@@ -366,12 +366,12 @@ public class EsqlQueryResponse extends ActionResponse implements ChunkedToXConte
                         }
                     }
                     case "geo_point" -> {
-                        long longVal = GEO.pointAsLong(GEO.stringAsPoint(value.toString()));
-                        ((LongBlock.Builder) builder).appendLong(longVal);
+                        SpatialPoint pointVal = GEO.stringAsPoint(value.toString());
+                        ((PointBlock.Builder) builder).appendPoint(pointVal);
                     }
                     case "cartesian_point" -> {
-                        long longVal = CARTESIAN.pointAsLong(CARTESIAN.stringAsPoint(value.toString()));
-                        ((LongBlock.Builder) builder).appendLong(longVal);
+                        SpatialPoint pointVal = CARTESIAN.stringAsPoint(value.toString());
+                        ((PointBlock.Builder) builder).appendPoint(pointVal);
                     }
                     default -> throw EsqlIllegalArgumentException.illegalDataType(dataTypes.get(c));
                 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/EnrichLookupService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/EnrichLookupService.java
@@ -276,7 +276,8 @@ public class EnrichLookupService {
                 var loaders = BlockReaderFactories.loaders(
                     List.of(searchContext),
                     extractField instanceof Alias a ? ((NamedExpression) a.child()).name() : extractField.name(),
-                    EsqlDataTypes.isUnsupported(extractField.dataType())
+                    EsqlDataTypes.isUnsupported(extractField.dataType()),
+                    false
                 );
                 fields.add(new ValuesSourceReaderOperator.FieldInfo(extractField.name(), loaders));
             }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/QueryList.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/QueryList.java
@@ -15,6 +15,7 @@ import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.PointBlock;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.query.SearchExecutionContext;
@@ -95,6 +96,10 @@ abstract class QueryList {
             case LONG -> {
                 LongBlock longBlock = (LongBlock) block;
                 yield longBlock::getLong;
+            }
+            case POINT -> {
+                PointBlock pointBlock = (PointBlock) block;
+                yield pointBlock::getPoint;
             }
             case NULL -> offset -> null;
             case DOC -> throw new EsqlIllegalArgumentException("can't read values from [doc] block");

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/evaluator/predicate/operator/comparison/ComparisonMapper.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/evaluator/predicate/operator/comparison/ComparisonMapper.java
@@ -29,7 +29,8 @@ public abstract class ComparisonMapper<T extends BinaryComparison> extends Expre
         org.elasticsearch.xpack.esql.evaluator.predicate.operator.comparison.EqualsLongsEvaluator.Factory::new,
         org.elasticsearch.xpack.esql.evaluator.predicate.operator.comparison.EqualsDoublesEvaluator.Factory::new,
         org.elasticsearch.xpack.esql.evaluator.predicate.operator.comparison.EqualsKeywordsEvaluator.Factory::new,
-        org.elasticsearch.xpack.esql.evaluator.predicate.operator.comparison.EqualsBoolsEvaluator.Factory::new
+        org.elasticsearch.xpack.esql.evaluator.predicate.operator.comparison.EqualsBoolsEvaluator.Factory::new,
+        (s, l, r, t) -> new org.elasticsearch.xpack.esql.evaluator.predicate.operator.comparison.EqualsPointsEvaluator.Factory(s, l, r)
     ) {
     };
 
@@ -38,7 +39,8 @@ public abstract class ComparisonMapper<T extends BinaryComparison> extends Expre
         org.elasticsearch.xpack.esql.evaluator.predicate.operator.comparison.NotEqualsLongsEvaluator.Factory::new,
         org.elasticsearch.xpack.esql.evaluator.predicate.operator.comparison.NotEqualsDoublesEvaluator.Factory::new,
         org.elasticsearch.xpack.esql.evaluator.predicate.operator.comparison.NotEqualsKeywordsEvaluator.Factory::new,
-        org.elasticsearch.xpack.esql.evaluator.predicate.operator.comparison.NotEqualsBoolsEvaluator.Factory::new
+        org.elasticsearch.xpack.esql.evaluator.predicate.operator.comparison.NotEqualsBoolsEvaluator.Factory::new,
+        (s, l, r, t) -> new org.elasticsearch.xpack.esql.evaluator.predicate.operator.comparison.NotEqualsPointsEvaluator.Factory(s, l, r)
     ) {
     };
 
@@ -79,6 +81,28 @@ public abstract class ComparisonMapper<T extends BinaryComparison> extends Expre
     private final TriFunction<Source, ExpressionEvaluator.Factory, ExpressionEvaluator.Factory, ExpressionEvaluator.Factory> doubles;
     private final TriFunction<Source, ExpressionEvaluator.Factory, ExpressionEvaluator.Factory, ExpressionEvaluator.Factory> keywords;
     private final TriFunction<Source, ExpressionEvaluator.Factory, ExpressionEvaluator.Factory, ExpressionEvaluator.Factory> bools;
+    private final EvaluatorFunctionWithType<DataType> points;
+
+    @FunctionalInterface
+    private interface EvaluatorFunctionWithType<T extends DataType> {
+        ExpressionEvaluator.Factory apply(Source s, ExpressionEvaluator.Factory t, ExpressionEvaluator.Factory u, T dataType);
+    }
+
+    private ComparisonMapper(
+        TriFunction<Source, ExpressionEvaluator.Factory, ExpressionEvaluator.Factory, ExpressionEvaluator.Factory> ints,
+        TriFunction<Source, ExpressionEvaluator.Factory, ExpressionEvaluator.Factory, ExpressionEvaluator.Factory> longs,
+        TriFunction<Source, ExpressionEvaluator.Factory, ExpressionEvaluator.Factory, ExpressionEvaluator.Factory> doubles,
+        TriFunction<Source, ExpressionEvaluator.Factory, ExpressionEvaluator.Factory, ExpressionEvaluator.Factory> keywords,
+        TriFunction<Source, ExpressionEvaluator.Factory, ExpressionEvaluator.Factory, ExpressionEvaluator.Factory> bools,
+        EvaluatorFunctionWithType<DataType> points
+    ) {
+        this.ints = ints;
+        this.longs = longs;
+        this.doubles = doubles;
+        this.keywords = keywords;
+        this.bools = bools;
+        this.points = points;
+    }
 
     private ComparisonMapper(
         TriFunction<Source, ExpressionEvaluator.Factory, ExpressionEvaluator.Factory, ExpressionEvaluator.Factory> ints,
@@ -92,6 +116,7 @@ public abstract class ComparisonMapper<T extends BinaryComparison> extends Expre
         this.doubles = doubles;
         this.keywords = keywords;
         this.bools = bools;
+        this.points = (source, lhs, rhs, dataType) -> { throw EsqlIllegalArgumentException.illegalDataType(dataType); };
     }
 
     ComparisonMapper(
@@ -105,6 +130,7 @@ public abstract class ComparisonMapper<T extends BinaryComparison> extends Expre
         this.doubles = doubles;
         this.keywords = keywords;
         this.bools = (source, lhs, rhs) -> { throw EsqlIllegalArgumentException.illegalDataType(DataTypes.BOOLEAN); };
+        this.points = (source, lhs, rhs, dataType) -> { throw EsqlIllegalArgumentException.illegalDataType(dataType); };
     }
 
     @Override
@@ -138,11 +164,10 @@ public abstract class ComparisonMapper<T extends BinaryComparison> extends Expre
             return longs.apply(bc.source(), leftEval, rightEval);
         }
         if (leftType == EsqlDataTypes.GEO_POINT) {
-            return longs.apply(bc.source(), leftEval, rightEval);
+            return points.apply(bc.source(), leftEval, rightEval, leftType);
         }
-        // TODO: Perhaps neithger geo_point, not cartesian_point should support comparisons?
         if (leftType == EsqlDataTypes.CARTESIAN_POINT) {
-            return longs.apply(bc.source(), leftEval, rightEval);
+            return points.apply(bc.source(), leftEval, rightEval, leftType);
         }
         throw new EsqlIllegalArgumentException("resolved type for [" + bc + "] but didn't implement mapping");
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/evaluator/predicate/operator/comparison/Equals.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/evaluator/predicate/operator/comparison/Equals.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.esql.evaluator.predicate.operator.comparison;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.xpack.esql.expression.EsqlTypeResolutions;
 import org.elasticsearch.xpack.ql.expression.Expression;
@@ -76,5 +77,10 @@ public class Equals extends org.elasticsearch.xpack.ql.expression.predicate.oper
     @Evaluator(extraName = "Bools")
     static boolean processBools(boolean lhs, boolean rhs) {
         return lhs == rhs;
+    }
+
+    @Evaluator(extraName = "Points")
+    static boolean processPoints(SpatialPoint lhs, SpatialPoint rhs) {
+        return lhs.equals(rhs);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/evaluator/predicate/operator/comparison/NotEquals.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/evaluator/predicate/operator/comparison/NotEquals.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.esql.evaluator.predicate.operator.comparison;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.xpack.esql.expression.EsqlTypeResolutions;
 import org.elasticsearch.xpack.ql.expression.Expression;
@@ -72,5 +73,10 @@ public class NotEquals extends org.elasticsearch.xpack.ql.expression.predicate.o
     @Evaluator(extraName = "Bools")
     static boolean processBools(boolean lhs, boolean rhs) {
         return lhs != rhs;
+    }
+
+    @Evaluator(extraName = "Points")
+    static boolean processPoints(SpatialPoint lhs, SpatialPoint rhs) {
+        return false == lhs.equals(rhs);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToCartesianPoint.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToCartesianPoint.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.compute.ann.ConvertEvaluator;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.tree.NodeInfo;
@@ -28,8 +29,8 @@ public class ToCartesianPoint extends AbstractConvertFunction {
 
     private static final Map<DataType, BuildFactory> EVALUATORS = Map.ofEntries(
         Map.entry(CARTESIAN_POINT, (fieldEval, source) -> fieldEval),
-        Map.entry(LONG, (fieldEval, source) -> fieldEval),
-        Map.entry(UNSIGNED_LONG, (fieldEval, source) -> fieldEval),
+        Map.entry(LONG, ToCartesianPointFromLongEvaluator.Factory::new),
+        Map.entry(UNSIGNED_LONG, ToCartesianPointFromLongEvaluator.Factory::new),
         Map.entry(KEYWORD, ToCartesianPointFromStringEvaluator.Factory::new),
         Map.entry(TEXT, ToCartesianPointFromStringEvaluator.Factory::new)
     );
@@ -59,7 +60,12 @@ public class ToCartesianPoint extends AbstractConvertFunction {
     }
 
     @ConvertEvaluator(extraName = "FromString", warnExceptions = { IllegalArgumentException.class })
-    static long fromKeyword(BytesRef in) {
-        return CARTESIAN.pointAsLong(CARTESIAN.stringAsPoint(in.utf8ToString()));
+    static SpatialPoint fromKeyword(BytesRef in) {
+        return CARTESIAN.stringAsPoint(in.utf8ToString());
+    }
+
+    @ConvertEvaluator(extraName = "FromLong", warnExceptions = { IllegalArgumentException.class })
+    static SpatialPoint fromLong(long encoded) {
+        return CARTESIAN.longAsPoint(encoded);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToGeoPoint.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToGeoPoint.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.compute.ann.ConvertEvaluator;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.tree.NodeInfo;
@@ -28,8 +29,8 @@ public class ToGeoPoint extends AbstractConvertFunction {
 
     private static final Map<DataType, BuildFactory> EVALUATORS = Map.ofEntries(
         Map.entry(GEO_POINT, (fieldEval, source) -> fieldEval),
-        Map.entry(LONG, (fieldEval, source) -> fieldEval),
-        Map.entry(UNSIGNED_LONG, (fieldEval, source) -> fieldEval),
+        Map.entry(LONG, ToGeoPointFromLongEvaluator.Factory::new),
+        Map.entry(UNSIGNED_LONG, ToGeoPointFromLongEvaluator.Factory::new),
         Map.entry(KEYWORD, ToGeoPointFromStringEvaluator.Factory::new),
         Map.entry(TEXT, ToGeoPointFromStringEvaluator.Factory::new)
     );
@@ -59,7 +60,12 @@ public class ToGeoPoint extends AbstractConvertFunction {
     }
 
     @ConvertEvaluator(extraName = "FromString", warnExceptions = { IllegalArgumentException.class })
-    static long fromKeyword(BytesRef in) {
-        return GEO.pointAsLong(GEO.stringAsPoint(in.utf8ToString()));
+    static SpatialPoint fromKeyword(BytesRef in) {
+        return GEO.stringAsPoint(in.utf8ToString());
+    }
+
+    @ConvertEvaluator(extraName = "FromLong", warnExceptions = { IllegalArgumentException.class })
+    static SpatialPoint fromLong(long encoded) {
+        return GEO.longAsPoint(encoded);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLong.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLong.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.compute.ann.ConvertEvaluator;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
@@ -34,14 +35,16 @@ import static org.elasticsearch.xpack.ql.type.DataTypes.LONG;
 import static org.elasticsearch.xpack.ql.type.DataTypes.TEXT;
 import static org.elasticsearch.xpack.ql.type.DataTypes.UNSIGNED_LONG;
 import static org.elasticsearch.xpack.ql.util.NumericUtils.unsignedLongAsNumber;
+import static org.elasticsearch.xpack.ql.util.SpatialCoordinateTypes.CARTESIAN;
+import static org.elasticsearch.xpack.ql.util.SpatialCoordinateTypes.GEO;
 
 public class ToLong extends AbstractConvertFunction {
 
     private static final Map<DataType, BuildFactory> EVALUATORS = Map.ofEntries(
         Map.entry(LONG, (fieldEval, source) -> fieldEval),
         Map.entry(DATETIME, (fieldEval, source) -> fieldEval),
-        Map.entry(GEO_POINT, (fieldEval, source) -> fieldEval),
-        Map.entry(CARTESIAN_POINT, (fieldEval, source) -> fieldEval),
+        Map.entry(GEO_POINT, ToLongFromGeoPointEvaluator.Factory::new),
+        Map.entry(CARTESIAN_POINT, ToLongFromCartesianPointEvaluator.Factory::new),
         Map.entry(BOOLEAN, ToLongFromBooleanEvaluator.Factory::new),
         Map.entry(KEYWORD, ToLongFromStringEvaluator.Factory::new),
         Map.entry(TEXT, ToLongFromStringEvaluator.Factory::new),
@@ -113,5 +116,15 @@ public class ToLong extends AbstractConvertFunction {
     @ConvertEvaluator(extraName = "FromInt")
     static long fromInt(int i) {
         return i;
+    }
+
+    @ConvertEvaluator(extraName = "FromGeoPoint")
+    static long fromGeoPoint(SpatialPoint point) {
+        return GEO.pointAsLong(point);
+    }
+
+    @ConvertEvaluator(extraName = "FromCartesianPoint")
+    static long fromCartesianPoint(SpatialPoint point) {
+        return CARTESIAN.pointAsLong(point);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToString.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToString.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.expression.function.scalar.convert;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.compute.ann.ConvertEvaluator;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.xpack.esql.evaluator.mapper.EvaluatorMapper;
@@ -140,12 +141,12 @@ public class ToString extends AbstractConvertFunction implements EvaluatorMapper
     }
 
     @ConvertEvaluator(extraName = "FromGeoPoint")
-    static BytesRef fromGeoPoint(long point) {
-        return new BytesRef(GEO.pointAsString(GEO.longAsPoint(point)));
+    static BytesRef fromGeoPoint(SpatialPoint point) {
+        return new BytesRef(GEO.pointAsString(point));
     }
 
     @ConvertEvaluator(extraName = "FromCartesianPoint")
-    static BytesRef fromCartesianPoint(long point) {
-        return new BytesRef(CARTESIAN.pointAsString(CARTESIAN.longAsPoint(point)));
+    static BytesRef fromCartesianPoint(SpatialPoint point) {
+        return new BytesRef(CARTESIAN.pointAsString(point));
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/formatter/TextFormat.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/formatter/TextFormat.java
@@ -298,7 +298,8 @@ public enum TextFormat implements MediaType {
     private static String formatEsqlResultObject(Object obj) {
         // TODO: It would be nicer to override GeoPoint.toString() but that has consequences
         if (obj instanceof SpatialPoint point) {
-            return String.format(Locale.ROOT, "POINT (%.7f %.7f)", point.getX(), point.getY());
+            // TODO: For doc-values, it is better to display as (%.7f %.7f), so see if we can know if this comes from doc-values
+            return String.format(Locale.ROOT, "POINT (%f %f)", point.getX(), point.getY());
         }
         return Objects.toString(obj, StringUtils.EMPTY);
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/formatter/TextFormatter.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/formatter/TextFormatter.java
@@ -134,7 +134,8 @@ public class TextFormatter {
     private static String formatEsqlResultObject(Object obj) {
         // TODO: It would be nicer to override GeoPoint.toString() but that has consequences
         if (obj instanceof SpatialPoint point) {
-            return String.format(Locale.ROOT, "POINT (%.7f %.7f)", point.getX(), point.getY());
+            // TODO: For doc-values, it is better to display as (%.7f %.7f), so see if we can know if this comes from doc-values
+            return String.format(Locale.ROOT, "POINT (%f %f)", point.getX(), point.getY());
         }
         return Objects.toString(obj);
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypes.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypes.java
@@ -8,9 +8,13 @@
 package org.elasticsearch.xpack.esql.io.stream;
 
 import org.elasticsearch.common.TriFunction;
+import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.dissect.DissectParser;
+import org.elasticsearch.geometry.Point;
+import org.elasticsearch.geometry.utils.GeometryValidator;
+import org.elasticsearch.geometry.utils.WellKnownBinary;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.xpack.core.enrich.EnrichPolicy;
 import org.elasticsearch.xpack.esql.enrich.EnrichPolicyResolution;
@@ -172,6 +176,7 @@ import org.elasticsearch.xpack.ql.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.ql.plan.logical.OrderBy;
 import org.elasticsearch.xpack.ql.plan.logical.Project;
 import org.elasticsearch.xpack.ql.tree.Source;
+import org.elasticsearch.xpack.ql.type.DataType;
 import org.elasticsearch.xpack.ql.type.DateEsField;
 import org.elasticsearch.xpack.ql.type.EsField;
 import org.elasticsearch.xpack.ql.type.InvalidMappedField;
@@ -180,6 +185,7 @@ import org.elasticsearch.xpack.ql.type.TextEsField;
 import org.elasticsearch.xpack.ql.type.UnsupportedEsField;
 
 import java.io.IOException;
+import java.nio.ByteOrder;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -190,6 +196,8 @@ import static java.util.Map.entry;
 import static org.elasticsearch.xpack.esql.io.stream.PlanNameRegistry.Entry.of;
 import static org.elasticsearch.xpack.esql.io.stream.PlanNameRegistry.PlanReader.readerFromPlanReader;
 import static org.elasticsearch.xpack.esql.io.stream.PlanNameRegistry.PlanWriter.writerFromPlanWriter;
+import static org.elasticsearch.xpack.esql.type.EsqlDataTypes.CARTESIAN_POINT;
+import static org.elasticsearch.xpack.esql.type.EsqlDataTypes.GEO_POINT;
 
 /**
  * A utility class that consists solely of static methods that describe how to serialize and
@@ -1572,13 +1580,61 @@ public final class PlanNamedTypes {
     // -- Expressions (other)
 
     static Literal readLiteral(PlanStreamInput in) throws IOException {
-        return new Literal(in.readSource(), in.readGenericValue(), in.dataTypeFromTypeName(in.readString()));
+        return new Literal(
+            in.readSource(),
+            in.readGenericValue(),
+            in.dataTypeFromTypeName(in.readString()),
+            PlanNamedTypes::mapToLiteralValue
+        );
     }
 
     static void writeLiteral(PlanStreamOutput out, Literal literal) throws IOException {
         out.writeNoSource();
-        out.writeGenericValue(literal.value());
+        out.writeGenericValue(mapFromLiteralValue(literal));
         out.writeString(literal.dataType().typeName());
+    }
+
+    /**
+     * Not all literal values are currently supported in StreamInput/StreamOutput as generic values.
+     * This mapper allows for addition of new and interesting values without (yet) changing transport version.
+     * This only makes sense during the pre-GA version of ESQL. When we get near GA we want TransportVersion support.
+     * TODO: Implement TransportVersion checks before GA (eg. by adding to StreamInput/StreamOutput directly)
+     */
+    private static Object mapFromLiteralValue(Literal literal) {
+        if (literal.dataType() == GEO_POINT || literal.dataType() == CARTESIAN_POINT) {
+            if (literal.value() instanceof List<?> list) {
+                return list.stream().map(v -> pointAsWKB((SpatialPoint) v)).toList();
+            }
+            return pointAsWKB((SpatialPoint) literal.value());
+        }
+        return literal.value();
+    }
+
+    /**
+     * Not all literal values are currently supported in StreamInput/StreamOutput as generic values.
+     * This mapper allows for addition of new and interesting values without (yet) changing transport version.
+     * This only makes sense during the pre-GA version of ESQL. When we get near GA we want TransportVersion support.
+     * TODO: Implement TransportVersion checks before GA (eg. by adding to StreamInput/StreamOutput directly)
+     */
+    private static Object mapToLiteralValue(DataType dataType, Object value) {
+        if (value instanceof List<?> list) {
+            return list.stream().map(v -> mapToLiteralValue(dataType, v)).toList();
+        }
+        if (value instanceof byte[] bytes) {
+            if (dataType == GEO_POINT || dataType == CARTESIAN_POINT) {
+                return wkbAsPoint(bytes);
+            }
+        }
+        return value;
+    }
+
+    private static byte[] pointAsWKB(SpatialPoint point) {
+        return WellKnownBinary.toWKB(new Point(point.getX(), point.getY()), ByteOrder.LITTLE_ENDIAN);
+    }
+
+    private static SpatialPoint wkbAsPoint(byte[] bytes) {
+        Point point = (Point) WellKnownBinary.fromWKB(GeometryValidator.NOOP, false, bytes);
+        return new SpatialPoint(point.getX(), point.getY());
     }
 
     static Order readOrder(PlanStreamInput in) throws IOException {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EstimatesRowSize.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EstimatesRowSize.java
@@ -116,6 +116,7 @@ public interface EstimatesRowSize {
             case DOUBLE -> Double.BYTES;
             case INT -> Integer.BYTES;
             case LONG -> Long.BYTES;
+            case POINT -> 2 * Double.BYTES;
             case NULL -> 0;
             case UNKNOWN -> throw new EsqlIllegalArgumentException("[unknown] can't be the result of field extraction");
         };

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
@@ -78,7 +78,12 @@ public class EsPhysicalOperationProviders extends AbstractPhysicalOperationProvi
             layout.append(attr);
             DataType dataType = attr.dataType();
             String fieldName = attr.name();
-            List<BlockLoader> loaders = BlockReaderFactories.loaders(searchContexts, fieldName, EsqlDataTypes.isUnsupported(dataType));
+            List<BlockLoader> loaders = BlockReaderFactories.loaders(
+                searchContexts,
+                fieldName,
+                EsqlDataTypes.isUnsupported(dataType),
+                false
+            );
             fields.add(new ValuesSourceReaderOperator.FieldInfo(fieldName, loaders));
         }
         return source.with(new ValuesSourceReaderOperator.Factory(fields, readers, docChannel), layout.build());
@@ -169,7 +174,7 @@ public class EsPhysicalOperationProviders extends AbstractPhysicalOperationProvi
         // The grouping-by values are ready, let's group on them directly.
         // Costin: why are they ready and not already exposed in the layout?
         return new OrdinalsGroupingOperator.OrdinalsGroupingOperatorFactory(
-            BlockReaderFactories.loaders(searchContexts, attrSource.name(), EsqlDataTypes.isUnsupported(attrSource.dataType())),
+            BlockReaderFactories.loaders(searchContexts, attrSource.name(), EsqlDataTypes.isUnsupported(attrSource.dataType()), true),
             shardContexts,
             groupElementType,
             docChannel,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
@@ -61,6 +61,9 @@ public class EsPhysicalOperationProviders extends AbstractPhysicalOperationProvi
 
     @Override
     public final PhysicalOperation fieldExtractPhysicalOperation(FieldExtractExec fieldExtractExec, PhysicalOperation source) {
+        // TODO: see if we can get the FieldExtractExec to know if spatial types need to be read from source or doc values, and capture
+        // that information in the BlockReaderFactories.loaders method so it is passed in the BlockLoaderContext
+        // to GeoPointFieldMapper.blockLoader
         Layout.Builder layout = source.layout.builder();
         var sourceAttr = fieldExtractExec.sourceAttribute();
         List<ValuesSourceReaderOperator.ShardContext> readers = searchContexts.stream()

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -381,8 +381,8 @@ public class LocalExecutionPlanner {
                 case "text", "keyword" -> TopNEncoder.UTF8;
                 case "version" -> TopNEncoder.VERSION;
                 case "boolean", "null", "byte", "short", "integer", "long", "double", "float", "half_float", "datetime", "date_period",
-                    "time_duration", "object", "nested", "scaled_float", "unsigned_long", "_doc", "geo_point", "cartesian_point" ->
-                    TopNEncoder.DEFAULT_SORTABLE;
+                    "time_duration", "object", "nested", "scaled_float", "unsigned_long", "_doc" -> TopNEncoder.DEFAULT_SORTABLE;
+                case "geo_point", "cartesian_point" -> TopNEncoder.DEFAULT_SORTABLE; // TODO: Should this be unsortable?
                 // unsupported fields are encoded as BytesRef, we'll use the same encoder; all values should be null at this point
                 case "unsupported" -> TopNEncoder.UNSUPPORTED;
                 default -> throw new EsqlIllegalArgumentException("No TopN sorting encoder for type " + inverse.get(channel).type());

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
@@ -215,10 +215,10 @@ public class PlannerUtils {
             return ElementType.DOC;
         }
         if (dataType == EsqlDataTypes.GEO_POINT) {
-            return ElementType.LONG;
+            return ElementType.POINT;
         }
         if (dataType == EsqlDataTypes.CARTESIAN_POINT) {
-            return ElementType.LONG;
+            return ElementType.POINT;
         }
         throw EsqlIllegalArgumentException.illegalDataType(dataType);
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/type/EsqlDataTypes.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/type/EsqlDataTypes.java
@@ -7,6 +7,8 @@
 package org.elasticsearch.xpack.esql.type;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.geo.GeoPoint;
+import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.xpack.ql.type.DataType;
 import org.elasticsearch.xpack.ql.type.DataTypes;
 
@@ -121,6 +123,13 @@ public final class EsqlDataTypes {
         }
         if (value instanceof String || value instanceof Character || value instanceof BytesRef) {
             return KEYWORD;
+        }
+        if (value instanceof GeoPoint) {
+            return GEO_POINT;
+        }
+        if (value instanceof SpatialPoint) {
+            // TODO: we have no access to CartesianPoint, but since it implements SpatialPoint we can use that here for now
+            return CARTESIAN_POINT;
         }
 
         return null;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponseTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponseTests.java
@@ -28,6 +28,7 @@ import org.elasticsearch.compute.data.IntArrayVector;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.data.PointBlock;
 import org.elasticsearch.compute.lucene.UnsupportedValueSource;
 import org.elasticsearch.compute.operator.AbstractPageMappingOperator;
 import org.elasticsearch.compute.operator.DriverProfile;
@@ -51,8 +52,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
-import static org.elasticsearch.xpack.ql.util.SpatialCoordinateTypes.CARTESIAN;
-import static org.elasticsearch.xpack.ql.util.SpatialCoordinateTypes.GEO;
 import static org.hamcrest.Matchers.equalTo;
 
 public class EsqlQueryResponseTests extends AbstractChunkedSerializingTestCase<EsqlQueryResponse> {
@@ -130,8 +129,8 @@ public class EsqlQueryResponseTests extends AbstractChunkedSerializingTestCase<E
                     new BytesRef(UnsupportedValueSource.UNSUPPORTED_OUTPUT)
                 );
                 case "version" -> ((BytesRefBlock.Builder) builder).appendBytesRef(new Version(randomIdentifier()).toBytesRef());
-                case "geo_point" -> ((LongBlock.Builder) builder).appendLong(GEO.pointAsLong(randomGeoPoint()));
-                case "cartesian_point" -> ((LongBlock.Builder) builder).appendLong(CARTESIAN.pointAsLong(randomCartesianPoint()));
+                case "geo_point" -> ((PointBlock.Builder) builder).appendPoint(randomGeoPoint());
+                case "cartesian_point" -> ((PointBlock.Builder) builder).appendPoint(randomCartesianPoint());
                 case "null" -> builder.appendNull();
                 case "_source" -> {
                     try {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponseTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponseTests.java
@@ -12,6 +12,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.ByteSizeValue;
@@ -129,8 +130,8 @@ public class EsqlQueryResponseTests extends AbstractChunkedSerializingTestCase<E
                     new BytesRef(UnsupportedValueSource.UNSUPPORTED_OUTPUT)
                 );
                 case "version" -> ((BytesRefBlock.Builder) builder).appendBytesRef(new Version(randomIdentifier()).toBytesRef());
-                case "geo_point" -> ((PointBlock.Builder) builder).appendPoint(randomGeoPoint());
-                case "cartesian_point" -> ((PointBlock.Builder) builder).appendPoint(randomCartesianPoint());
+                case "geo_point" -> appendPoint((PointBlock.Builder) builder, randomGeoPoint());
+                case "cartesian_point" -> appendPoint((PointBlock.Builder) builder, randomCartesianPoint());
                 case "null" -> builder.appendNull();
                 case "_source" -> {
                     try {
@@ -150,6 +151,10 @@ public class EsqlQueryResponseTests extends AbstractChunkedSerializingTestCase<E
             }
             return builder.build();
         }).toArray(Block[]::new));
+    }
+
+    private void appendPoint(PointBlock.Builder builder, SpatialPoint point) {
+        builder.appendPoint(point.getX(), point.getY());
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractFunctionTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractFunctionTestCase.java
@@ -89,8 +89,6 @@ import java.util.stream.Stream;
 import static org.elasticsearch.compute.data.BlockUtils.toJavaObject;
 import static org.elasticsearch.xpack.esql.SerializationTestUtils.assertSerialization;
 import static org.elasticsearch.xpack.esql.type.EsqlDataTypes.isSpatial;
-import static org.elasticsearch.xpack.ql.util.SpatialCoordinateTypes.CARTESIAN;
-import static org.elasticsearch.xpack.ql.util.SpatialCoordinateTypes.GEO;
 import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
@@ -123,8 +121,8 @@ public abstract class AbstractFunctionTestCase extends ESTestCase {
             case "time_duration" -> Duration.ofMillis(randomLongBetween(-604800000L, 604800000L)); // plus/minus 7 days
             case "text" -> new BytesRef(randomAlphaOfLength(50));
             case "version" -> randomVersion().toBytesRef();
-            case "geo_point" -> GEO.pointAsLong(randomGeoPoint());
-            case "cartesian_point" -> CARTESIAN.pointAsLong(randomCartesianPoint());
+            case "geo_point" -> randomGeoPoint();
+            case "cartesian_point" -> randomCartesianPoint();
             case "null" -> null;
             case "_source" -> {
                 try {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/TestCaseSupplier.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/TestCaseSupplier.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.expression.function;
 
 import org.apache.lucene.document.InetAddressPoint;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
@@ -43,8 +44,6 @@ import java.util.stream.Collectors;
 
 import static org.elasticsearch.test.ESTestCase.randomCartesianPoint;
 import static org.elasticsearch.test.ESTestCase.randomGeoPoint;
-import static org.elasticsearch.xpack.ql.util.SpatialCoordinateTypes.CARTESIAN;
-import static org.elasticsearch.xpack.ql.util.SpatialCoordinateTypes.GEO;
 import static org.hamcrest.Matchers.equalTo;
 
 /**
@@ -559,17 +558,10 @@ public record TestCaseSupplier(String name, List<DataType> types, Supplier<TestC
         List<TestCaseSupplier> suppliers,
         String expectedEvaluatorToString,
         DataType expectedType,
-        Function<Long, Object> expectedValue,
+        Function<SpatialPoint, Object> expectedValue,
         List<String> warnings
     ) {
-        unaryNumeric(
-            suppliers,
-            expectedEvaluatorToString,
-            geoPointCases(),
-            expectedType,
-            n -> expectedValue.apply(n.longValue()),
-            warnings
-        );
+        unary(suppliers, expectedEvaluatorToString, geoPointCases(), expectedType, n -> expectedValue.apply((SpatialPoint) n), warnings);
     }
 
     /**
@@ -579,15 +571,15 @@ public record TestCaseSupplier(String name, List<DataType> types, Supplier<TestC
         List<TestCaseSupplier> suppliers,
         String expectedEvaluatorToString,
         DataType expectedType,
-        Function<Long, Object> expectedValue,
+        Function<SpatialPoint, Object> expectedValue,
         List<String> warnings
     ) {
-        unaryNumeric(
+        unary(
             suppliers,
             expectedEvaluatorToString,
             cartesianPointCases(),
             expectedType,
-            n -> expectedValue.apply(n.longValue()),
+            n -> expectedValue.apply((SpatialPoint) n),
             warnings
         );
     }
@@ -935,13 +927,11 @@ public record TestCaseSupplier(String name, List<DataType> types, Supplier<TestC
     }
 
     private static List<TypedDataSupplier> geoPointCases() {
-        return List.of(new TypedDataSupplier("<geo_point>", () -> GEO.pointAsLong(randomGeoPoint()), EsqlDataTypes.GEO_POINT));
+        return List.of(new TypedDataSupplier("<geo_point>", () -> randomGeoPoint(), EsqlDataTypes.GEO_POINT));
     }
 
     private static List<TypedDataSupplier> cartesianPointCases() {
-        return List.of(
-            new TypedDataSupplier("<cartesian_point>", () -> CARTESIAN.pointAsLong(randomCartesianPoint()), EsqlDataTypes.CARTESIAN_POINT)
-        );
+        return List.of(new TypedDataSupplier("<cartesian_point>", () -> randomCartesianPoint(), EsqlDataTypes.CARTESIAN_POINT));
     }
 
     public static List<TypedDataSupplier> ipCases() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLongTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLongTests.java
@@ -24,6 +24,9 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import static org.elasticsearch.xpack.ql.util.SpatialCoordinateTypes.CARTESIAN;
+import static org.elasticsearch.xpack.ql.util.SpatialCoordinateTypes.GEO;
+
 public class ToLongTests extends AbstractFunctionTestCase {
     public ToLongTests(@Name("TestCase") Supplier<TestCaseSupplier.TestCase> testCaseSupplier) {
         this.testCase = testCaseSupplier.get();
@@ -41,8 +44,14 @@ public class ToLongTests extends AbstractFunctionTestCase {
         TestCaseSupplier.forUnaryBoolean(suppliers, evaluatorName.apply("Boolean"), DataTypes.LONG, b -> b ? 1L : 0L, List.of());
 
         // geo types
-        TestCaseSupplier.forUnaryGeoPoint(suppliers, read, DataTypes.LONG, i -> i, List.of());
-        TestCaseSupplier.forUnaryCartesianPoint(suppliers, read, DataTypes.LONG, i -> i, List.of());
+        TestCaseSupplier.forUnaryGeoPoint(suppliers, evaluatorName.apply("GeoPoint"), DataTypes.LONG, GEO::pointAsLong, List.of());
+        TestCaseSupplier.forUnaryCartesianPoint(
+            suppliers,
+            evaluatorName.apply("CartesianPoint"),
+            DataTypes.LONG,
+            CARTESIAN::pointAsLong,
+            List.of()
+        );
         // datetimes
         TestCaseSupplier.forUnaryDatetime(suppliers, read, DataTypes.LONG, Instant::toEpochMilli, List.of());
         // random strings that don't look like a long

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToStringTests.java
@@ -91,14 +91,14 @@ public class ToStringTests extends AbstractFunctionTestCase {
             suppliers,
             "ToStringFromGeoPointEvaluator[field=" + read + "]",
             DataTypes.KEYWORD,
-            i -> new BytesRef(GEO.pointAsString(GEO.longAsPoint(i))),
+            i -> new BytesRef(GEO.pointAsString(i)),
             List.of()
         );
         TestCaseSupplier.forUnaryCartesianPoint(
             suppliers,
             "ToStringFromCartesianPointEvaluator[field=" + read + "]",
             DataTypes.KEYWORD,
-            i -> new BytesRef(CARTESIAN.pointAsString(CARTESIAN.longAsPoint(i))),
+            i -> new BytesRef(CARTESIAN.pointAsString(i)),
             List.of()
         );
         TestCaseSupplier.forUnaryIp(

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/AbstractBinaryComparisonTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/AbstractBinaryComparisonTestCase.java
@@ -21,6 +21,7 @@ import org.hamcrest.Matcher;
 import java.util.List;
 import java.util.Locale;
 
+import static org.elasticsearch.xpack.esql.type.EsqlDataTypes.isSpatial;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
@@ -68,7 +69,8 @@ public abstract class AbstractBinaryComparisonTestCase extends AbstractBinaryOpe
 
     @Override
     protected final boolean supportsType(DataType type) {
-        if (type == DataTypes.BOOLEAN) {
+        // Boolean and Spatial types do not support inequality operators
+        if (type == DataTypes.BOOLEAN || isSpatial(type)) {
             return isEquality();
         }
         return EsqlDataTypes.isRepresentable(type);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/formatter/TextFormatTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/formatter/TextFormatTests.java
@@ -264,11 +264,21 @@ public class TextFormatTests extends ESTestCase {
                     .build(),
                 new IntArrayVector(new int[] { 11 * 60 + 48, 4 * 60 + 40 }, 2).asBlock(),
                 new LongArrayVector(new long[] { GEO.pointAsLong(12, 56), GEO.pointAsLong(-97, 26) }, 2).asBlock(),
-                new PointArrayVector(new SpatialPoint[] { new SpatialPoint(1234, 5678), new SpatialPoint(-9753, 2611) }, 2).asBlock()
+                makePointArrayVector(new SpatialPoint(1234, 5678), new SpatialPoint(-9753, 2611)).asBlock()
             )
         );
 
         return new EsqlQueryResponse(headers, values, null, false);
+    }
+
+    static PointArrayVector makePointArrayVector(SpatialPoint... points) {
+        double[] x = new double[points.length];
+        double[] y = new double[points.length];
+        for (int i = 0; i < points.length; i++) {
+            x[i] = points[i].getX();
+            y[i] = points[i].getY();
+        }
+        return new PointArrayVector(x, y, points.length);
     }
 
     private static EsqlQueryResponse escapedData() {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/formatter/TextFormatterTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/formatter/TextFormatterTests.java
@@ -15,7 +15,6 @@ import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.DoubleArrayVector;
 import org.elasticsearch.compute.data.LongArrayVector;
 import org.elasticsearch.compute.data.Page;
-import org.elasticsearch.compute.data.PointArrayVector;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.action.ColumnInfo;
 import org.elasticsearch.xpack.esql.action.EsqlQueryResponse;
@@ -24,6 +23,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.elasticsearch.rest.RestResponseUtils.getTextBodyContent;
+import static org.elasticsearch.xpack.esql.formatter.TextFormatTests.makePointArrayVector;
 import static org.elasticsearch.xpack.ql.util.DateUtils.UTC_DATE_TIME_FORMATTER;
 import static org.elasticsearch.xpack.ql.util.SpatialCoordinateTypes.GEO;
 import static org.hamcrest.Matchers.arrayWithSize;
@@ -61,7 +61,7 @@ public class TextFormatterTests extends ESTestCase {
                     2
                 ).asBlock(),
                 new LongArrayVector(new long[] { GEO.pointAsLong(12, 56), GEO.pointAsLong(-97, 26) }, 2).asBlock(),
-                new PointArrayVector(new SpatialPoint[] { new SpatialPoint(1234, 5678), new SpatialPoint(-9753, 2611) }, 2).asBlock(),
+                makePointArrayVector(new SpatialPoint(1234, 5678), new SpatialPoint(-9753, 2611)).asBlock(),
                 Block.constantNullBlock(2)
             )
         ),
@@ -125,7 +125,7 @@ public class TextFormatterTests extends ESTestCase {
                         2
                     ).asBlock(),
                     new LongArrayVector(new long[] { GEO.pointAsLong(12, 56), GEO.pointAsLong(-97, 26) }, 2).asBlock(),
-                    new PointArrayVector(new SpatialPoint[] { new SpatialPoint(1234, 5678), new SpatialPoint(-9753, 2611) }, 2).asBlock(),
+                    makePointArrayVector(new SpatialPoint(1234, 5678), new SpatialPoint(-9753, 2611)).asBlock(),
                     Block.constantNullBlock(2)
                 )
             ),

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/formatter/TextFormatterTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/formatter/TextFormatterTests.java
@@ -9,11 +9,13 @@ package org.elasticsearch.xpack.esql.formatter;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.DoubleArrayVector;
 import org.elasticsearch.compute.data.LongArrayVector;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.data.PointArrayVector;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.action.ColumnInfo;
 import org.elasticsearch.xpack.esql.action.EsqlQueryResponse;
@@ -36,6 +38,7 @@ public class TextFormatterTests extends ESTestCase {
         new ColumnInfo("baz", "keyword"),
         new ColumnInfo("date", "date"),
         new ColumnInfo("location", "geo_point"),
+        new ColumnInfo("location2", "cartesian_point"),
         new ColumnInfo("null_field2", "keyword")
     );
     EsqlQueryResponse esqlResponse = new EsqlQueryResponse(
@@ -58,6 +61,7 @@ public class TextFormatterTests extends ESTestCase {
                     2
                 ).asBlock(),
                 new LongArrayVector(new long[] { GEO.pointAsLong(12, 56), GEO.pointAsLong(-97, 26) }, 2).asBlock(),
+                new PointArrayVector(new SpatialPoint[] { new SpatialPoint(1234, 5678), new SpatialPoint(-9753, 2611) }, 2).asBlock(),
                 Block.constantNullBlock(2)
             )
         ),
@@ -79,22 +83,22 @@ public class TextFormatterTests extends ESTestCase {
         assertThat(result, arrayWithSize(4));
         assertEquals(
             "      foo      |      bar      |15charwidename!|  null_field1  |superduperwidename!!!|      baz      |"
-                + "          date          |           location           |  null_field2  ",
+                + "          date          |          location          |           location2            |  null_field2  ",
             result[0]
         );
         assertEquals(
             "---------------+---------------+---------------+---------------+---------------------+---------------+"
-                + "------------------------+------------------------------+---------------",
+                + "------------------------+----------------------------+--------------------------------+---------------",
             result[1]
         );
         assertEquals(
             "15charwidedata!|1              |6.888          |null           |12.0                 |rabbit         |"
-                + "1953-09-02T00:00:00.000Z|POINT (12.0000000 56.0000000) |null           ",
+                + "1953-09-02T00:00:00.000Z|POINT (12.000000 56.000000) |POINT (1234.000000 5678.000000) |null           ",
             result[2]
         );
         assertEquals(
             "dog            |2              |123124.888     |null           |9912.0               |goat           |"
-                + "2000-03-15T21:34:37.443Z|POINT (-97.0000000 26.0000000)|null           ",
+                + "2000-03-15T21:34:37.443Z|POINT (-97.000000 26.000000)|POINT (-9753.000000 2611.000000)|null           ",
             result[3]
         );
     }
@@ -121,6 +125,7 @@ public class TextFormatterTests extends ESTestCase {
                         2
                     ).asBlock(),
                     new LongArrayVector(new long[] { GEO.pointAsLong(12, 56), GEO.pointAsLong(-97, 26) }, 2).asBlock(),
+                    new PointArrayVector(new SpatialPoint[] { new SpatialPoint(1234, 5678), new SpatialPoint(-9753, 2611) }, 2).asBlock(),
                     Block.constantNullBlock(2)
                 )
             ),
@@ -132,12 +137,12 @@ public class TextFormatterTests extends ESTestCase {
         assertThat(result, arrayWithSize(2));
         assertEquals(
             "doggie         |4              |1.0            |null           |77.0                 |wombat         |"
-                + "1955-01-21T01:02:03.342Z|POINT (12.0000000 56.0000000) |null           ",
+                + "1955-01-21T01:02:03.342Z|POINT (12.000000 56.000000) |POINT (1234.000000 5678.000000) |null           ",
             result[0]
         );
         assertEquals(
             "dog            |2              |123124.888     |null           |9912.0               |goat           |"
-                + "2231-12-31T23:59:59.999Z|POINT (-97.0000000 26.0000000)|null           ",
+                + "2231-12-31T23:59:59.999Z|POINT (-97.000000 26.000000)|POINT (-9753.000000 2611.000000)|null           ",
             result[1]
         );
     }

--- a/x-pack/plugin/mapper-constant-keyword/src/test/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapperTests.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/test/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapperTests.java
@@ -240,6 +240,11 @@ public class ConstantKeywordFieldMapperTests extends MapperTestCase {
             }
 
             @Override
+            public boolean forStats() {
+                return false;
+            }
+
+            @Override
             public SearchLookup lookup() {
                 throw new UnsupportedOperationException();
             }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/Literal.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/Literal.java
@@ -13,6 +13,7 @@ import org.elasticsearch.xpack.ql.type.DataType;
 import org.elasticsearch.xpack.ql.type.DataTypes;
 
 import java.util.Objects;
+import java.util.function.BiFunction;
 
 /**
  * SQL Literal or constant.
@@ -30,6 +31,10 @@ public class Literal extends LeafExpression {
         super(source);
         this.dataType = dataType;
         this.value = value;
+    }
+
+    public Literal(Source source, Object value, DataType dataType, BiFunction<DataType, Object, Object> valueMapper) {
+        this(source, valueMapper.apply(dataType, value), dataType);
     }
 
     @Override

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/util/SpatialCoordinateTypes.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/util/SpatialCoordinateTypes.java
@@ -90,4 +90,11 @@ public enum SpatialCoordinateTypes {
     public SpatialPoint pointAsPoint(SpatialPoint point) {
         return point;
     }
+
+    /**
+     * Convert point to the correct class for the upper column type. For example, create a GeoPoint from a cartesian point.
+     */
+    public SpatialPoint pointAsPoint(double x, double y) {
+        return pointAsPoint(new SpatialPoint(x, y));
+    }
 }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/util/SpatialCoordinateTypes.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/util/SpatialCoordinateTypes.java
@@ -78,7 +78,7 @@ public enum SpatialCoordinateTypes {
                 throw new IllegalArgumentException("Unsupported geometry type " + geometry.type());
             }
         } catch (Exception e) {
-            throw new RuntimeException("Failed to parse WKT: " + e.getMessage(), e);
+            throw new IllegalArgumentException("Failed to parse WKT: " + e.getMessage(), e);
         }
     }
 

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/util/SpatialCoordinateTypes.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/util/SpatialCoordinateTypes.java
@@ -34,6 +34,10 @@ public enum SpatialCoordinateTypes {
         public SpatialPoint pointAsPoint(Point point) {
             return new GeoPoint(point.getY(), point.getX());
         }
+
+        public SpatialPoint pointAsPoint(SpatialPoint point) {
+            return new GeoPoint(point);
+        }
     },
     CARTESIAN {
         public SpatialPoint longAsPoint(long encoded) {
@@ -79,4 +83,11 @@ public enum SpatialCoordinateTypes {
     }
 
     public abstract SpatialPoint pointAsPoint(Point point);
+
+    /**
+     * Convert point to the correct class for the upper column type. For example, create a GeoPoint from a cartesian point.
+     */
+    public SpatialPoint pointAsPoint(SpatialPoint point) {
+        return point;
+    }
 }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/util/SpatialCoordinateTypes.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/util/SpatialCoordinateTypes.java
@@ -16,8 +16,6 @@ import org.elasticsearch.geometry.Point;
 import org.elasticsearch.geometry.utils.GeometryValidator;
 import org.elasticsearch.geometry.utils.WellKnownText;
 
-import java.util.Locale;
-
 import static org.apache.lucene.geo.GeoEncodingUtils.encodeLatitude;
 import static org.apache.lucene.geo.GeoEncodingUtils.encodeLongitude;
 
@@ -41,7 +39,7 @@ public enum SpatialCoordinateTypes {
         public SpatialPoint longAsPoint(long encoded) {
             final double x = XYEncodingUtils.decode((int) (encoded >>> 32));
             final double y = XYEncodingUtils.decode((int) (encoded & 0xFFFFFFFF));
-            return makePoint(x, y);
+            return new SpatialPoint(x, y);
         }
 
         public long pointAsLong(double x, double y) {
@@ -51,42 +49,7 @@ public enum SpatialCoordinateTypes {
         }
 
         public SpatialPoint pointAsPoint(Point point) {
-            return makePoint(point.getX(), point.getY());
-        }
-
-        private SpatialPoint makePoint(double x, double y) {
-            return new SpatialPoint() {
-                @Override
-                public double getX() {
-                    return x;
-                }
-
-                @Override
-                public double getY() {
-                    return y;
-                }
-
-                @Override
-                public int hashCode() {
-                    return 31 * Double.hashCode(x) + Double.hashCode(y);
-                }
-
-                @Override
-                public boolean equals(Object obj) {
-                    if (obj == null) {
-                        return false;
-                    }
-                    if (obj instanceof SpatialPoint other) {
-                        return x == other.getX() && y == other.getY();
-                    }
-                    return false;
-                }
-
-                @Override
-                public String toString() {
-                    return String.format(Locale.ROOT, "POINT (%f %f)", x, y);
-                }
-            };
+            return new SpatialPoint(point.getX(), point.getY());
         }
     };
 

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/common/CartesianPoint.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/common/CartesianPoint.java
@@ -26,29 +26,26 @@ import org.elasticsearch.xpack.spatial.index.mapper.PointFieldMapper;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Locale;
-import java.util.Objects;
 
 /**
  * Represents a point in the cartesian space.
  */
-public class CartesianPoint implements SpatialPoint, ToXContentFragment {
+public class CartesianPoint extends SpatialPoint implements ToXContentFragment {
 
     private static final String X_FIELD = "x";
     private static final String Y_FIELD = "y";
     private static final String Z_FIELD = "z";
 
-    protected double x;
-    protected double y;
-
-    public CartesianPoint() {}
+    public CartesianPoint() {
+        super(0, 0);
+    }
 
     public CartesianPoint(double x, double y) {
-        this.x = x;
-        this.y = y;
+        super(x, y);
     }
 
     public CartesianPoint(SpatialPoint template) {
-        this(template.getX(), template.getY());
+        super(template);
     }
 
     public CartesianPoint reset(double x, double y) {
@@ -149,39 +146,6 @@ public class CartesianPoint implements SpatialPoint, ToXContentFragment {
     }
 
     @Override
-    public double getX() {
-        return this.x;
-    }
-
-    @Override
-    public double getY() {
-        return this.y;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        CartesianPoint point = (CartesianPoint) o;
-
-        if (Double.compare(point.x, x) != 0) return false;
-        if (Double.compare(point.y, y) != 0) return false;
-
-        return true;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(x, y);
-    }
-
-    @Override
-    public String toString() {
-        return x + ", " + y;
-    }
-
-    @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         return builder.startObject().field(X_FIELD, x).field(Y_FIELD, y).endObject();
     }
@@ -244,7 +208,7 @@ public class CartesianPoint implements SpatialPoint, ToXContentFragment {
         }
     }
 
-    private static GenericPointParser<CartesianPoint> cartesianPointParser = new GenericPointParser<>("point", "x", "y", false) {
+    private static final GenericPointParser<CartesianPoint> cartesianPointParser = new GenericPointParser<>("point", "x", "y", false) {
 
         @Override
         public void assertZValue(boolean ignoreZValue, double zValue) {

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldMapper.java
@@ -21,9 +21,6 @@ import org.elasticsearch.geometry.Point;
 import org.elasticsearch.index.fielddata.FieldDataContext;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.mapper.AbstractPointGeometryFieldMapper;
-import org.elasticsearch.index.mapper.BlockDocValuesReader;
-import org.elasticsearch.index.mapper.BlockLoader;
-import org.elasticsearch.index.mapper.BlockSourceReader;
 import org.elasticsearch.index.mapper.DocumentParserContext;
 import org.elasticsearch.index.mapper.FieldMapper;
 import org.elasticsearch.index.mapper.GeoShapeFieldMapper;
@@ -186,7 +183,6 @@ public class PointFieldMapper extends AbstractPointGeometryFieldMapper<Cartesian
     public static class PointFieldType extends AbstractGeometryFieldType<CartesianPoint> implements ShapeQueryable {
 
         private final ShapeQueryPointProcessor queryProcessor;
-        private final CartesianPoint nullValue;
 
         private PointFieldType(
             String name,
@@ -197,8 +193,7 @@ public class PointFieldMapper extends AbstractPointGeometryFieldMapper<Cartesian
             CartesianPoint nullValue,
             Map<String, String> meta
         ) {
-            super(name, indexed, stored, hasDocValues, parser, meta);
-            this.nullValue = nullValue;
+            super(name, indexed, stored, hasDocValues, parser, nullValue, meta);
             this.queryProcessor = new ShapeQueryPointProcessor();
         }
 
@@ -230,17 +225,6 @@ public class PointFieldMapper extends AbstractPointGeometryFieldMapper<Cartesian
         @Override
         protected Function<List<CartesianPoint>, List<Object>> getFormatter(String format) {
             return GeometryFormatterFactory.getFormatter(format, p -> new Point(p.getX(), p.getY()));
-        }
-
-        @Override
-        public BlockLoader blockLoader(BlockLoaderContext blContext) {
-            if (hasDocValues()) {
-                return new BlockDocValuesReader.LongsBlockLoader(name());
-            }
-            // TODO: Currently we use longs in the compute engine and render to WKT in ESQL
-            return new BlockSourceReader.LongsBlockLoader(
-                valueFetcher(blContext.sourcePaths(name()), nullValue, GeometryFormatterFactory.WKT)
-            );
         }
     }
 

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/30_types.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/30_types.yml
@@ -894,7 +894,7 @@ geo_point:
   - match: { columns.0.name: location }
   - match: { columns.0.type: geo_point }
   - length: { values: 1 }
-  - match: { values.0.0: "POINT (0.9999999403953552 -1.000000024214387)" }
+  - match: { values.0.0: "POINT (1.0 -1.0)" }
 
 ---
 cartesian_point:

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/30_types.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/30_types.yml
@@ -868,6 +868,9 @@ synthetic _source text with parent keyword:
 
 ---
 geo_point:
+  - skip:
+      version: " - 8.12.99"
+      reason: "geo_point precision changed in 8.13.0"
   - do:
       indices.create:
         index: test
@@ -898,6 +901,9 @@ geo_point:
 
 ---
 cartesian_point:
+  - skip:
+      version: " - 8.12.99"
+      reason: "cartesian_point precision changed in 8.13.0"
   - do:
       indices.create:
         index: test

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/40_unsupported_types.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/40_unsupported_types.yml
@@ -110,8 +110,8 @@ setup:
 ---
 unsupported:
   - skip:
-      version: " - 8.11.99"
-      reason: "Latest types supported in ESQL starting with 8.12.0"
+      version: " - 8.12.99"
+      reason: "Latest types supported in ESQL as of 8.13.0"
 
   - do:
       allowed_warnings_regex:
@@ -189,8 +189,8 @@ unsupported:
   - match: { values.0.5: null }
   - match: { values.0.6: null }
   - match: { values.0.7: null }
-  - match: { values.0.8: "POINT (9.999999990686774 11.999999997206032)" }
-  - match: { values.0.9: "POINT (9.999999990686774 11.999999997206032)" }
+  - match: { values.0.8: "POINT (10.0 12.0)" }
+  - match: { values.0.9: "POINT (10.0 12.0)" }
   - match: { values.0.10: null }
   - match: { values.0.11: null }
   - match: { values.0.12: null }
@@ -198,7 +198,7 @@ unsupported:
   - match: { values.0.14: null }
   - match: { values.0.15: "foo bar baz" }
   - match: { values.0.16: Alice }
-  - match: { values.0.17: "POINT (-97.15447235107422 25.996152877807617)" }
+  - match: { values.0.17: "POINT (-97.15447 25.9961525)" }
   - match: { values.0.18: null }
   - match: { values.0.19: null }
   - match: { values.0.20: null }
@@ -290,8 +290,8 @@ unsupported:
 ---
 unsupported with sort:
   - skip:
-      version: " - 8.11.99"
-      reason: "Latest types supported in ESQL starting with 8.12.0"
+      version: " - 8.12.99"
+      reason: "Latest types supported in ESQL as of 8.13.0"
 
   - do:
       allowed_warnings_regex:
@@ -369,8 +369,8 @@ unsupported with sort:
   - match: { values.0.5: null }
   - match: { values.0.6: null }
   - match: { values.0.7: null }
-  - match: { values.0.8: "POINT (9.999999990686774 11.999999997206032)" }
-  - match: { values.0.9: "POINT (9.999999990686774 11.999999997206032)" }
+  - match: { values.0.8: "POINT (10.0 12.0)" }
+  - match: { values.0.9: "POINT (10.0 12.0)" }
   - match: { values.0.10: null }
   - match: { values.0.11: null }
   - match: { values.0.12: null }
@@ -378,7 +378,7 @@ unsupported with sort:
   - match: { values.0.14: null }
   - match: { values.0.15: "foo bar baz" }
   - match: { values.0.16: Alice }
-  - match: { values.0.17: "POINT (-97.15447235107422 25.996152877807617)" }
+  - match: { values.0.17: "POINT (-97.15447 25.9961525)" }
   - match: { values.0.18: null }
   - match: { values.0.19: null }
   - match: { values.0.20: null }
@@ -390,6 +390,38 @@ unsupported with sort:
   - match: { values.0.26: xy }
   - match: { values.0.27: "foo bar" }
   - match: { values.0.28: 3 }
+
+---
+spatial types with different precision in 8.12.x:
+  - skip:
+      version: " - 8.11.99, 8.13.0 - "
+      reason: "Elasticsearch 8.12 supported geo_point and cartesian_point with doc-values only and precision differences"
+
+  - do:
+      allowed_warnings_regex:
+        - "Field \\[.*\\] cannot be retrieved, it is unsupported or not indexed; returning null"
+        - "No limit defined, adding default limit of \\[.*\\]"
+      esql.query:
+        body:
+          query: 'from test | keep geo_point, geo_point_alias, point, geo_shape, shape'
+
+  - match: { columns.0.name: geo_point }
+  - match: { columns.0.type: geo_point }
+  - match: { columns.1.name: geo_point_alias }
+  - match: { columns.1.type: geo_point }
+  - match: { columns.2.name: point }
+  - match: { columns.2.type: cartesian_point }
+  - match: { columns.3.name: geo_shape }
+  - match: { columns.3.type: unsupported }
+  - match: { columns.4.name: shape }
+  - match: { columns.4.type: unsupported }
+
+  - length: { values: 1 }
+  - match: { values.0.0: "POINT (9.999999990686774 11.999999997206032)" }
+  - match: { values.0.1: "POINT (9.999999990686774 11.999999997206032)" }
+  - match: { values.0.2: "POINT (-97.15447235107422 25.996152877807617)" }
+  - match: { values.0.3: null }
+  - match: { values.0.4: null }
 
 ---
 spatial types unsupported in 8.11:


### PR DESCRIPTION
This is based on https://github.com/elastic/elasticsearch/pull/102880, but tries to remove `SpatialPoint` as a type within the Block implementation, so instead of having `SpatialPoint[] values`, we would have `double[] xValues, yValues`. This might have performance and memory improvements, but it is not yet verified.