### PR TITLE
[8.12] [Connectors API] Add docs for set connector sync job stats API endpoint (#103469)

### DIFF
--- a/docs/reference/connector/apis/connector-apis.asciidoc
+++ b/docs/reference/connector/apis/connector-apis.asciidoc
@@ -41,6 +41,7 @@ Use the following APIs to manage sync jobs:
 * <<get-connector-sync-job-api>>
 * <<list-connector-sync-jobs-api>>
 * <<set-connector-sync-job-error-api>>
+* <<set-connector-sync-job-stats-api>>
 
 include::create-connector-api.asciidoc[]
 include::create-connector-sync-job-api.asciidoc[]
@@ -51,3 +52,4 @@ include::get-connector-sync-job-api.asciidoc[]
 include::list-connectors-api.asciidoc[]
 include::list-connector-sync-jobs-api.asciidoc[]
 include::set-connector-sync-job-error-api.asciidoc[]
+include::set-connector-sync-job-stats-api.asciidoc[]

--- a/docs/reference/connector/apis/set-connector-sync-job-stats-api.asciidoc
+++ b/docs/reference/connector/apis/set-connector-sync-job-stats-api.asciidoc
@@ -1,0 +1,77 @@
+[[set-connector-sync-job-stats-api]]
+=== Set connector sync job stats API
+++++
+<titleabbrev>Set connector sync job stats</titleabbrev>
+++++
+
+Sets connector sync job stats.
+
+[[set-connector-sync-job-stats-api-request]]
+==== {api-request-title}
+`PUT _connector/_sync_job/<connector_sync_job_id>/_stats`
+
+[[set-connector-sync-job-stats-api-prereqs]]
+==== {api-prereq-title}
+
+* To sync data using connectors, it's essential to have the Elastic connectors service running.
+* The `connector_sync_job_id` parameter should reference an existing connector sync job.
+
+[[set-connector-sync-job-stats-api-desc]]
+==== {api-description-title}
+
+Sets the stats for a connector sync job.
+Stats include: `deleted_document_count`, `indexed_document_count`, `indexed_document_volume` and `total_document_count`.
+`last_seen` can also be updated using this API.
+This API is mainly used by the connector service for updating sync job information.
+
+[[set-connector-sync-job-stats-api-path-params]]
+==== {api-path-parms-title}
+
+`<connector_sync_job_id>`::
+(Required, string)
+
+[role="child_attributes"]
+[[set-connector-sync-job-stats-api-request-body]]
+==== {api-request-body-title}
+
+`deleted_document_count`::
+(Required, int) The number of documents the sync job deleted.
+
+`indexed_document_count`::
+(Required, int) The number of documents the sync job indexed.
+
+`indexed_document_volume`::
+(Required, int) The total size of the data (in MiB) the sync job indexed.
+
+`total_document_count`::
+(Optional, int) The total number of documents in the target index after the sync job finished.
+
+`last_seen`::
+(Optional, instant) The timestamp to set the connector sync job's `last_seen` property.
+
+[[set-connector-sync-job-stats-api-response-codes]]
+==== {api-response-codes-title}
+
+`200`::
+Indicates that the connector sync job stats were successfully updated.
+
+`404`::
+No connector sync job matching `connector_sync_job_id` could be found.
+
+[[set-connector-sync-job-stats-api-example]]
+==== {api-examples-title}
+
+The following example sets all mandatory and optional stats for the connector sync job `my-connector-sync-job`:
+
+[source,console]
+----
+PUT _connector/_sync_job/my-connector-sync-job/_stats
+{
+    "deleted_document_count": 10,
+    "indexed_document_count": 20,
+    "indexed_document_volume": 1000,
+    "total_document_count": 2000,
+    "last_seen": "2023-01-02T10:00:00Z"
+}
+----
+// TEST[skip:there's no way to clean up after creating a connector sync job, as we don't know the id ahead of time. Therefore, skip this test.]


### PR DESCRIPTION
Backports the following commits to 8.12:
 - [Connectors API] Add docs for set connector sync job stats API endpoint (#103469)