### PR TITLE
Make sure to close XContentParser in more spots

### DIFF
--- a/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/PluginsConfig.java
+++ b/distribution/tools/plugin-cli/src/main/java/org/elasticsearch/plugins/cli/PluginsConfig.java
@@ -160,12 +160,11 @@ public class PluginsConfig {
         parser.declareStringOrNull(PluginsConfig::setProxy, new ParseField("proxy"));
         parser.declareObjectArrayOrNull(PluginsConfig::setPlugins, descriptorParser, new ParseField("plugins"));
 
-        final XContentParser yamlXContentParser = xContent.createParser(
-            XContentParserConfiguration.EMPTY,
-            Files.newInputStream(configPath)
-        );
-
-        return parser.parse(yamlXContentParser, null);
+        try (
+            XContentParser yamlXContentParser = xContent.createParser(XContentParserConfiguration.EMPTY, Files.newInputStream(configPath))
+        ) {
+            return parser.parse(yamlXContentParser, null);
+        }
     }
 
     /**

--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/MachineDependentHeap.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/MachineDependentHeap.java
@@ -86,8 +86,7 @@ public final class MachineDependentHeap {
         @SuppressWarnings("unchecked")
         public static MachineNodeRole parse(InputStream config) {
             final Settings settings;
-            try {
-                var parser = YamlXContent.yamlXContent.createParser(XContentParserConfiguration.EMPTY, config);
+            try (var parser = YamlXContent.yamlXContent.createParser(XContentParserConfiguration.EMPTY, config)) {
                 if (parser.currentToken() == null && parser.nextToken() == null) {
                     settings = null;
                 } else {

--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/FilterXContentParser.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/FilterXContentParser.java
@@ -236,7 +236,10 @@ public abstract class FilterXContentParser implements XContentParser {
 
     @Override
     public void close() throws IOException {
-        delegate().close();
+        var closeable = delegate();
+        if (closeable != null) {
+            closeable.close();
+        }
     }
 
     @Override

--- a/libs/x-content/src/test/java/org/elasticsearch/xcontent/ConstructingObjectParserTests.java
+++ b/libs/x-content/src/test/java/org/elasticsearch/xcontent/ConstructingObjectParserTests.java
@@ -102,22 +102,24 @@ public class ConstructingObjectParserTests extends ESTestCase {
     }
 
     public void testMissingAllConstructorArgs() throws IOException {
-        XContentParser parser = createParser(JsonXContent.jsonXContent, "{ \"mineral\": 1 }");
-        ConstructingObjectParser<HasCtorArguments, Void> objectParser = randomBoolean()
-            ? HasCtorArguments.PARSER
-            : HasCtorArguments.PARSER_VEGETABLE_OPTIONAL;
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> objectParser.apply(parser, null));
-        if (objectParser == HasCtorArguments.PARSER) {
-            assertEquals("Required [animal, vegetable]", e.getMessage());
-        } else {
-            assertEquals("Required [animal]", e.getMessage());
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, "{ \"mineral\": 1 }")) {
+            ConstructingObjectParser<HasCtorArguments, Void> objectParser = randomBoolean()
+                ? HasCtorArguments.PARSER
+                : HasCtorArguments.PARSER_VEGETABLE_OPTIONAL;
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> objectParser.apply(parser, null));
+            if (objectParser == HasCtorArguments.PARSER) {
+                assertEquals("Required [animal, vegetable]", e.getMessage());
+            } else {
+                assertEquals("Required [animal]", e.getMessage());
+            }
         }
     }
 
     public void testMissingAllConstructorArgsButNotRequired() throws IOException {
-        XContentParser parser = createParser(JsonXContent.jsonXContent, "{ \"mineral\": 1 }");
-        HasCtorArguments parsed = HasCtorArguments.PARSER_ALL_OPTIONAL.apply(parser, null);
-        assertEquals(1, parsed.mineral);
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, "{ \"mineral\": 1 }")) {
+            HasCtorArguments parsed = HasCtorArguments.PARSER_ALL_OPTIONAL.apply(parser, null);
+            assertEquals(1, parsed.mineral);
+        }
     }
 
     public void testMissingSecondConstructorArg() throws IOException {

--- a/modules/ingest-user-agent/src/main/java/org/elasticsearch/ingest/useragent/DeviceTypeParser.java
+++ b/modules/ingest-user-agent/src/main/java/org/elasticsearch/ingest/useragent/DeviceTypeParser.java
@@ -39,23 +39,24 @@ public class DeviceTypeParser {
     private final HashMap<String, ArrayList<DeviceTypeSubPattern>> deviceTypePatterns = new HashMap<>();
 
     public void init(InputStream regexStream) throws IOException {
-        XContentParser yamlParser = XContentFactory.xContent(XContentType.YAML)
-            .createParser(XContentParserConfiguration.EMPTY, regexStream);
+        try (
+            XContentParser yamlParser = XContentFactory.xContent(XContentType.YAML)
+                .createParser(XContentParserConfiguration.EMPTY, regexStream)
+        ) {
+            XContentParser.Token token = yamlParser.nextToken();
+            if (token == XContentParser.Token.START_OBJECT) {
+                token = yamlParser.nextToken();
 
-        XContentParser.Token token = yamlParser.nextToken();
-
-        if (token == XContentParser.Token.START_OBJECT) {
-            token = yamlParser.nextToken();
-
-            for (; token != null; token = yamlParser.nextToken()) {
-                String currentName = yamlParser.currentName();
-                if (token == XContentParser.Token.FIELD_NAME && patternListKeys.contains(currentName)) {
-                    List<Map<String, String>> parserConfigurations = readParserConfigurations(yamlParser);
-                    ArrayList<DeviceTypeSubPattern> subPatterns = new ArrayList<>();
-                    for (Map<String, String> map : parserConfigurations) {
-                        subPatterns.add(new DeviceTypeSubPattern(Pattern.compile((map.get("regex"))), map.get("replacement")));
+                for (; token != null; token = yamlParser.nextToken()) {
+                    String currentName = yamlParser.currentName();
+                    if (token == XContentParser.Token.FIELD_NAME && patternListKeys.contains(currentName)) {
+                        List<Map<String, String>> parserConfigurations = readParserConfigurations(yamlParser);
+                        ArrayList<DeviceTypeSubPattern> subPatterns = new ArrayList<>();
+                        for (Map<String, String> map : parserConfigurations) {
+                            subPatterns.add(new DeviceTypeSubPattern(Pattern.compile((map.get("regex"))), map.get("replacement")));
+                        }
+                        deviceTypePatterns.put(currentName, subPatterns);
                     }
-                    deviceTypePatterns.put(currentName, subPatterns);
                 }
             }
         }

--- a/modules/ingest-user-agent/src/main/java/org/elasticsearch/ingest/useragent/UserAgentParser.java
+++ b/modules/ingest-user-agent/src/main/java/org/elasticsearch/ingest/useragent/UserAgentParser.java
@@ -48,59 +48,62 @@ final class UserAgentParser {
 
     private void init(InputStream regexStream) throws IOException {
         // EMPTY is safe here because we don't use namedObject
-        XContentParser yamlParser = XContentFactory.xContent(XContentType.YAML)
-            .createParser(XContentParserConfiguration.EMPTY, regexStream);
+        try (
+            XContentParser yamlParser = XContentFactory.xContent(XContentType.YAML)
+                .createParser(XContentParserConfiguration.EMPTY, regexStream)
+        ) {
 
-        XContentParser.Token token = yamlParser.nextToken();
+            XContentParser.Token token = yamlParser.nextToken();
 
-        if (token == XContentParser.Token.START_OBJECT) {
-            token = yamlParser.nextToken();
+            if (token == XContentParser.Token.START_OBJECT) {
+                token = yamlParser.nextToken();
 
-            for (; token != null; token = yamlParser.nextToken()) {
-                if (token == XContentParser.Token.FIELD_NAME && yamlParser.currentName().equals("user_agent_parsers")) {
-                    List<Map<String, String>> parserConfigurations = readParserConfigurations(yamlParser);
+                for (; token != null; token = yamlParser.nextToken()) {
+                    if (token == XContentParser.Token.FIELD_NAME && yamlParser.currentName().equals("user_agent_parsers")) {
+                        List<Map<String, String>> parserConfigurations = readParserConfigurations(yamlParser);
 
-                    for (Map<String, String> map : parserConfigurations) {
-                        uaPatterns.add(
-                            new UserAgentSubpattern(
-                                compilePattern(map.get("regex"), map.get("regex_flag")),
-                                map.get("family_replacement"),
-                                map.get("v1_replacement"),
-                                map.get("v2_replacement"),
-                                map.get("v3_replacement"),
-                                map.get("v4_replacement")
-                            )
-                        );
-                    }
-                } else if (token == XContentParser.Token.FIELD_NAME && yamlParser.currentName().equals("os_parsers")) {
-                    List<Map<String, String>> parserConfigurations = readParserConfigurations(yamlParser);
+                        for (Map<String, String> map : parserConfigurations) {
+                            uaPatterns.add(
+                                new UserAgentSubpattern(
+                                    compilePattern(map.get("regex"), map.get("regex_flag")),
+                                    map.get("family_replacement"),
+                                    map.get("v1_replacement"),
+                                    map.get("v2_replacement"),
+                                    map.get("v3_replacement"),
+                                    map.get("v4_replacement")
+                                )
+                            );
+                        }
+                    } else if (token == XContentParser.Token.FIELD_NAME && yamlParser.currentName().equals("os_parsers")) {
+                        List<Map<String, String>> parserConfigurations = readParserConfigurations(yamlParser);
 
-                    for (Map<String, String> map : parserConfigurations) {
-                        osPatterns.add(
-                            new UserAgentSubpattern(
-                                compilePattern(map.get("regex"), map.get("regex_flag")),
-                                map.get("os_replacement"),
-                                map.get("os_v1_replacement"),
-                                map.get("os_v2_replacement"),
-                                map.get("os_v3_replacement"),
-                                map.get("os_v4_replacement")
-                            )
-                        );
-                    }
-                } else if (token == XContentParser.Token.FIELD_NAME && yamlParser.currentName().equals("device_parsers")) {
-                    List<Map<String, String>> parserConfigurations = readParserConfigurations(yamlParser);
+                        for (Map<String, String> map : parserConfigurations) {
+                            osPatterns.add(
+                                new UserAgentSubpattern(
+                                    compilePattern(map.get("regex"), map.get("regex_flag")),
+                                    map.get("os_replacement"),
+                                    map.get("os_v1_replacement"),
+                                    map.get("os_v2_replacement"),
+                                    map.get("os_v3_replacement"),
+                                    map.get("os_v4_replacement")
+                                )
+                            );
+                        }
+                    } else if (token == XContentParser.Token.FIELD_NAME && yamlParser.currentName().equals("device_parsers")) {
+                        List<Map<String, String>> parserConfigurations = readParserConfigurations(yamlParser);
 
-                    for (Map<String, String> map : parserConfigurations) {
-                        devicePatterns.add(
-                            new UserAgentSubpattern(
-                                compilePattern(map.get("regex"), map.get("regex_flag")),
-                                map.get("device_replacement"),
-                                null,
-                                null,
-                                null,
-                                null
-                            )
-                        );
+                        for (Map<String, String> map : parserConfigurations) {
+                            devicePatterns.add(
+                                new UserAgentSubpattern(
+                                    compilePattern(map.get("regex"), map.get("regex_flag")),
+                                    map.get("device_replacement"),
+                                    null,
+                                    null,
+                                    null,
+                                    null
+                                )
+                            );
+                        }
                     }
                 }
             }

--- a/modules/ingest-user-agent/src/test/java/org/elasticsearch/ingest/useragent/DeviceTypeParserTests.java
+++ b/modules/ingest-user-agent/src/test/java/org/elasticsearch/ingest/useragent/DeviceTypeParserTests.java
@@ -31,36 +31,39 @@ public class DeviceTypeParserTests extends ESTestCase {
     private static DeviceTypeParser deviceTypeParser;
 
     private ArrayList<HashMap<String, String>> readTestDevices(InputStream regexStream, String keyName) throws IOException {
-        XContentParser yamlParser = XContentFactory.xContent(XContentType.YAML)
-            .createParser(XContentParserConfiguration.EMPTY, regexStream);
+        try (
+            XContentParser yamlParser = XContentFactory.xContent(XContentType.YAML)
+                .createParser(XContentParserConfiguration.EMPTY, regexStream)
+        ) {
 
-        XContentParser.Token token = yamlParser.nextToken();
+            XContentParser.Token token = yamlParser.nextToken();
 
-        ArrayList<HashMap<String, String>> testDevices = new ArrayList<>();
+            ArrayList<HashMap<String, String>> testDevices = new ArrayList<>();
 
-        if (token == XContentParser.Token.START_OBJECT) {
-            token = yamlParser.nextToken();
+            if (token == XContentParser.Token.START_OBJECT) {
+                token = yamlParser.nextToken();
 
-            for (; token != null; token = yamlParser.nextToken()) {
-                String currentName = yamlParser.currentName();
-                if (token == XContentParser.Token.FIELD_NAME && currentName.equals(keyName)) {
-                    List<Map<String, String>> parserConfigurations = readParserConfigurations(yamlParser);
+                for (; token != null; token = yamlParser.nextToken()) {
+                    String currentName = yamlParser.currentName();
+                    if (token == XContentParser.Token.FIELD_NAME && currentName.equals(keyName)) {
+                        List<Map<String, String>> parserConfigurations = readParserConfigurations(yamlParser);
 
-                    for (Map<String, String> map : parserConfigurations) {
-                        HashMap<String, String> testDevice = new HashMap<>();
+                        for (Map<String, String> map : parserConfigurations) {
+                            HashMap<String, String> testDevice = new HashMap<>();
 
-                        testDevice.put("type", map.get("type"));
-                        testDevice.put("os", map.get("os"));
-                        testDevice.put("browser", map.get("browser"));
-                        testDevice.put("device", map.get("device"));
-                        testDevices.add(testDevice);
+                            testDevice.put("type", map.get("type"));
+                            testDevice.put("os", map.get("os"));
+                            testDevice.put("browser", map.get("browser"));
+                            testDevice.put("device", map.get("device"));
+                            testDevices.add(testDevice);
 
+                        }
                     }
                 }
             }
-        }
 
-        return testDevices;
+            return testDevices;
+        }
     }
 
     private static VersionedName getVersionName(String name) {

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/SearchTemplateResponse.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/SearchTemplateResponse.java
@@ -85,11 +85,12 @@ public class SearchTemplateResponse extends ActionResponse implements ToXContent
         } else {
             XContentType contentType = parser.contentType();
             XContentBuilder builder = XContentFactory.contentBuilder(contentType).map(contentAsMap);
-            XContentParser searchResponseParser = contentType.xContent()
-                .createParser(parser.getXContentRegistry(), parser.getDeprecationHandler(), BytesReference.bytes(builder).streamInput());
-
-            SearchResponse searchResponse = SearchResponse.fromXContent(searchResponseParser);
-            searchTemplateResponse.setResponse(searchResponse);
+            try (
+                XContentParser searchResponseParser = contentType.xContent()
+                    .createParser(parser.getXContentRegistry(), parser.getDeprecationHandler(), BytesReference.bytes(builder).streamInput())
+            ) {
+                searchTemplateResponse.setResponse(SearchResponse.fromXContent(searchResponseParser));
+            }
         }
         return searchTemplateResponse;
     }

--- a/modules/lang-painless/src/doc/java/org/elasticsearch/painless/ContextGeneratorCommon.java
+++ b/modules/lang-painless/src/doc/java/org/elasticsearch/painless/ContextGeneratorCommon.java
@@ -34,15 +34,21 @@ import java.util.stream.Collectors;
 
 public class ContextGeneratorCommon {
     @SuppressForbidden(reason = "retrieving data from an internal API not exposed as part of the REST client")
+    @SuppressWarnings("unchecked")
     public static List<PainlessContextInfo> getContextInfos() throws IOException {
         URLConnection getContextNames = new URL("http://" + System.getProperty("cluster.uri") + "/_scripts/painless/_context")
             .openConnection();
-        XContentParser parser = JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, getContextNames.getInputStream());
-        parser.nextToken();
-        parser.nextToken();
-        @SuppressWarnings("unchecked")
-        List<String> contextNames = (List<String>) (Object) parser.list();
-        parser.close();
+        List<String> contextNames;
+        try (
+            XContentParser parser = JsonXContent.jsonXContent.createParser(
+                XContentParserConfiguration.EMPTY,
+                getContextNames.getInputStream()
+            )
+        ) {
+            parser.nextToken();
+            parser.nextToken();
+            contextNames = (List<String>) (Object) parser.list();
+        }
         ((HttpURLConnection) getContextNames).disconnect();
 
         List<PainlessContextInfo> contextInfos = new ArrayList<>();
@@ -51,9 +57,10 @@ public class ContextGeneratorCommon {
             URLConnection getContextInfo = new URL(
                 "http://" + System.getProperty("cluster.uri") + "/_scripts/painless/_context?context=" + contextName
             ).openConnection();
-            parser = JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, getContextInfo.getInputStream());
-            contextInfos.add(PainlessContextInfo.fromXContent(parser));
-            ((HttpURLConnection) getContextInfo).disconnect();
+            try (var parser = JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, getContextInfo.getInputStream())) {
+                contextInfos.add(PainlessContextInfo.fromXContent(parser));
+                ((HttpURLConnection) getContextInfo).disconnect();
+            }
         }
 
         contextInfos.sort(Comparator.comparing(PainlessContextInfo::getName));

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/api/Json.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/api/Json.java
@@ -20,16 +20,16 @@ public class Json {
      * Load a string as the Java version of a JSON type, either List (JSON array), Map (JSON object), Number, Boolean or String
      */
     public static Object load(String json) throws IOException {
-        XContentParser parser = JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, json);
-
-        return switch (parser.nextToken()) {
-            case START_ARRAY -> parser.list();
-            case START_OBJECT -> parser.map();
-            case VALUE_NUMBER -> parser.numberValue();
-            case VALUE_BOOLEAN -> parser.booleanValue();
-            case VALUE_STRING -> parser.text();
-            default -> null;
-        };
+        try (XContentParser parser = JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, json)) {
+            return switch (parser.nextToken()) {
+                case START_ARRAY -> parser.list();
+                case START_OBJECT -> parser.map();
+                case VALUE_NUMBER -> parser.numberValue();
+                case VALUE_BOOLEAN -> parser.booleanValue();
+                case VALUE_STRING -> parser.text();
+                default -> null;
+            };
+        }
     }
 
     /**

--- a/modules/legacy-geo/src/test/java/org/elasticsearch/legacygeo/GeoJsonShapeParserTests.java
+++ b/modules/legacy-geo/src/test/java/org/elasticsearch/legacygeo/GeoJsonShapeParserTests.java
@@ -181,34 +181,37 @@ public class GeoJsonShapeParserTests extends BaseGeoParsingTestCase {
             .endArray()
             .endObject();
 
-        XContentParser parser = createParser(pointGeoJson);
-        parser.nextToken();
-        ElasticsearchGeoAssertions.assertValidException(parser, ElasticsearchParseException.class);
-        assertNull(parser.nextToken());
+        XContentBuilder lineGeoJson;
+        try (XContentParser parser = createParser(pointGeoJson)) {
+            parser.nextToken();
+            ElasticsearchGeoAssertions.assertValidException(parser, ElasticsearchParseException.class);
+            assertNull(parser.nextToken());
 
-        // multi dimension linestring
-        XContentBuilder lineGeoJson = XContentFactory.jsonBuilder()
-            .startObject()
-            .field("type", "LineString")
-            .startArray("coordinates")
-            .startArray()
-            .value(100.0)
-            .value(0.0)
-            .value(15.0)
-            .endArray()
-            .startArray()
-            .value(101.0)
-            .value(1.0)
-            .value(18.0)
-            .value(19.0)
-            .endArray()
-            .endArray()
-            .endObject();
+            // multi dimension linestring
+            lineGeoJson = XContentFactory.jsonBuilder()
+                .startObject()
+                .field("type", "LineString")
+                .startArray("coordinates")
+                .startArray()
+                .value(100.0)
+                .value(0.0)
+                .value(15.0)
+                .endArray()
+                .startArray()
+                .value(101.0)
+                .value(1.0)
+                .value(18.0)
+                .value(19.0)
+                .endArray()
+                .endArray()
+                .endObject();
+        }
 
-        parser = createParser(lineGeoJson);
-        parser.nextToken();
-        ElasticsearchGeoAssertions.assertValidException(parser, ElasticsearchParseException.class);
-        assertNull(parser.nextToken());
+        try (var parser = createParser(lineGeoJson)) {
+            parser.nextToken();
+            ElasticsearchGeoAssertions.assertValidException(parser, ElasticsearchParseException.class);
+            assertNull(parser.nextToken());
+        }
     }
 
     @Override

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/mapping/SimpleGetFieldMappingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/mapping/SimpleGetFieldMappingsIT.java
@@ -159,7 +159,9 @@ public class SimpleGetFieldMappingsIT extends ESIntegTestCase {
         String responseStrings = Strings.toString(responseBuilder);
 
         XContentBuilder prettyJsonBuilder = XContentFactory.jsonBuilder().prettyPrint();
-        prettyJsonBuilder.copyCurrentStructure(createParser(JsonXContent.jsonXContent, responseStrings));
+        try (var parser = createParser(JsonXContent.jsonXContent, responseStrings)) {
+            prettyJsonBuilder.copyCurrentStructure(parser);
+        }
         assertThat(responseStrings, equalTo(Strings.toString(prettyJsonBuilder)));
 
         params.put("pretty", "false");
@@ -170,7 +172,9 @@ public class SimpleGetFieldMappingsIT extends ESIntegTestCase {
         responseStrings = Strings.toString(responseBuilder);
 
         prettyJsonBuilder = XContentFactory.jsonBuilder().prettyPrint();
-        prettyJsonBuilder.copyCurrentStructure(createParser(JsonXContent.jsonXContent, responseStrings));
+        try (var parser = createParser(JsonXContent.jsonXContent, responseStrings)) {
+            prettyJsonBuilder.copyCurrentStructure(parser);
+        }
         assertThat(responseStrings, not(equalTo(Strings.toString(prettyJsonBuilder))));
 
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/ingest/IngestStatsNamesAndTypesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/ingest/IngestStatsNamesAndTypesIT.java
@@ -143,7 +143,10 @@ public class IngestStatsNamesAndTypesIT extends ESIntegTestCase {
             builder.startObject();
             response.toXContent(builder, new ToXContent.MapParams(Map.of()));
             builder.endObject();
-            Map<String, Object> stats = createParser(JsonXContent.jsonXContent, Strings.toString(builder)).map();
+            Map<String, Object> stats;
+            try (var parser = createParser(JsonXContent.jsonXContent, Strings.toString(builder))) {
+                stats = parser.map();
+            }
 
             int setProcessorCount = path(stats, "nodes.ingest.processor_stats.set.count");
             assertThat(setProcessorCount, equalTo(3));

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/pipeline/BucketScriptIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/pipeline/BucketScriptIT.java
@@ -657,10 +657,10 @@ public class BucketScriptIT extends ESIntegTestCase {
             .field("lang", CustomScriptPlugin.NAME)
             .endObject()
             .endObject();
-        BucketScriptPipelineAggregationBuilder bucketScriptAgg = BucketScriptPipelineAggregationBuilder.PARSER.parse(
-            createParser(content),
-            "seriesArithmetic"
-        );
+        BucketScriptPipelineAggregationBuilder bucketScriptAgg;
+        try (var parser = createParser(content)) {
+            bucketScriptAgg = BucketScriptPipelineAggregationBuilder.PARSER.parse(parser, "seriesArithmetic");
+        }
 
         assertNoFailuresAndResponse(
             prepareSearch("idx", "idx_unmapped").addAggregation(
@@ -703,10 +703,10 @@ public class BucketScriptIT extends ESIntegTestCase {
             .field("lang", CustomScriptPlugin.NAME)
             .endObject()
             .endObject();
-        BucketScriptPipelineAggregationBuilder bucketScriptAgg = BucketScriptPipelineAggregationBuilder.PARSER.parse(
-            createParser(content),
-            "seriesArithmetic"
-        );
+        BucketScriptPipelineAggregationBuilder bucketScriptAgg;
+        try (var parser = createParser(content)) {
+            bucketScriptAgg = BucketScriptPipelineAggregationBuilder.PARSER.parse(parser, "seriesArithmetic");
+        }
 
         assertNoFailuresAndResponse(
             prepareSearch("idx", "idx_unmapped").addAggregation(
@@ -761,10 +761,10 @@ public class BucketScriptIT extends ESIntegTestCase {
             .field("lang", CustomScriptPlugin.NAME)
             .endObject()
             .endObject();
-        BucketScriptPipelineAggregationBuilder bucketScriptAgg = BucketScriptPipelineAggregationBuilder.PARSER.parse(
-            createParser(content),
-            "seriesArithmetic"
-        );
+        BucketScriptPipelineAggregationBuilder bucketScriptAgg;
+        try (var parser = createParser(content)) {
+            bucketScriptAgg = BucketScriptPipelineAggregationBuilder.PARSER.parse(parser, "seriesArithmetic");
+        }
 
         assertNoFailuresAndResponse(
             prepareSearch("idx", "idx_unmapped").addAggregation(

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/simple/SimpleSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/simple/SimpleSearchIT.java
@@ -459,10 +459,11 @@ public class SimpleSearchIT extends ESIntegTestCase {
             .get();
 
         String queryJson = "{ \"field\" : { \"value\" : 80315953321748200608 } }";
-        XContentParser parser = createParser(JsonXContent.jsonXContent, queryJson);
-        parser.nextToken();
-        TermQueryBuilder query = TermQueryBuilder.fromXContent(parser);
-        assertHitCount(prepareSearch("idx").setQuery(query), 1);
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, queryJson)) {
+            parser.nextToken();
+            TermQueryBuilder query = TermQueryBuilder.fromXContent(parser);
+            assertHitCount(prepareSearch("idx").setQuery(query), 1);
+        }
     }
 
     public void testTooLongRegexInRegexpQuery() throws Exception {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/IndexRouting.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/IndexRouting.java
@@ -281,16 +281,14 @@ public abstract class IndexRouting {
 
         private Builder hashSource(XContentType sourceType, BytesReference source) {
             Builder b = builder();
-            try {
-                try (XContentParser parser = sourceType.xContent().createParser(parserConfig, source.streamInput())) {
-                    parser.nextToken(); // Move to first token
-                    if (parser.currentToken() == null) {
-                        throw new IllegalArgumentException("Error extracting routing: source didn't contain any routing fields");
-                    }
-                    parser.nextToken();
-                    b.extractObject(null, parser);
-                    ensureExpectedToken(null, parser.nextToken(), parser);
+            try (XContentParser parser = sourceType.xContent().createParser(parserConfig, source.streamInput())) {
+                parser.nextToken(); // Move to first token
+                if (parser.currentToken() == null) {
+                    throw new IllegalArgumentException("Error extracting routing: source didn't contain any routing fields");
                 }
+                parser.nextToken();
+                b.extractObject(null, parser);
+                ensureExpectedToken(null, parser.nextToken(), parser);
             } catch (IOException | ParsingException e) {
                 throw new IllegalArgumentException("Error extracting routing: " + e.getMessage(), e);
             }

--- a/server/src/main/java/org/elasticsearch/common/compress/CompressedXContent.java
+++ b/server/src/main/java/org/elasticsearch/common/compress/CompressedXContent.java
@@ -164,11 +164,9 @@ public final class CompressedXContent implements Writeable {
      * @return compressed x-content normalized to not contain any whitespaces
      */
     public static CompressedXContent fromJSON(String json) throws IOException {
-        return new CompressedXContent(
-            (ToXContentObject) (builder, params) -> builder.copyCurrentStructure(
-                JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, json)
-            )
-        );
+        try (var parser = JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, json)) {
+            return new CompressedXContent((ToXContentObject) (builder, params) -> builder.copyCurrentStructure(parser));
+        }
     }
 
     public CompressedXContent(String str) throws IOException {

--- a/server/src/main/java/org/elasticsearch/gateway/PersistedClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/gateway/PersistedClusterStateService.java
@@ -668,8 +668,7 @@ public class PersistedClusterStateService {
     }
 
     private <T> T readXContent(BytesReference bytes, CheckedFunction<XContentParser, T, IOException> reader) throws IOException {
-        final XContentParser parser = XContentFactory.xContent(XContentType.SMILE).createParser(parserConfig, bytes.streamInput());
-        try {
+        try (XContentParser parser = XContentFactory.xContent(XContentType.SMILE).createParser(parserConfig, bytes.streamInput())) {
             return reader.apply(parser);
         } catch (Exception e) {
             throw new CorruptStateException(e);

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestCloneSnapshotAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestCloneSnapshotAction.java
@@ -43,15 +43,17 @@ public class RestCloneSnapshotAction extends BaseRestHandler {
 
     @Override
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
-        final Map<String, Object> source = request.contentParser().map();
-        final CloneSnapshotRequest cloneSnapshotRequest = new CloneSnapshotRequest(
-            request.param("repository"),
-            request.param("snapshot"),
-            request.param("target_snapshot"),
-            XContentMapValues.nodeStringArrayValue(source.getOrDefault("indices", Collections.emptyList()))
-        );
-        cloneSnapshotRequest.masterNodeTimeout(request.paramAsTime("master_timeout", cloneSnapshotRequest.masterNodeTimeout()));
-        cloneSnapshotRequest.indicesOptions(IndicesOptions.fromMap(source, cloneSnapshotRequest.indicesOptions()));
-        return channel -> client.admin().cluster().cloneSnapshot(cloneSnapshotRequest, new RestToXContentListener<>(channel));
+        try (var parser = request.contentParser()) {
+            final Map<String, Object> source = parser.map();
+            final CloneSnapshotRequest cloneSnapshotRequest = new CloneSnapshotRequest(
+                request.param("repository"),
+                request.param("snapshot"),
+                request.param("target_snapshot"),
+                XContentMapValues.nodeStringArrayValue(source.getOrDefault("indices", Collections.emptyList()))
+            );
+            cloneSnapshotRequest.masterNodeTimeout(request.paramAsTime("master_timeout", cloneSnapshotRequest.masterNodeTimeout()));
+            cloneSnapshotRequest.indicesOptions(IndicesOptions.fromMap(source, cloneSnapshotRequest.indicesOptions()));
+            return channel -> client.admin().cluster().cloneSnapshot(cloneSnapshotRequest, new RestToXContentListener<>(channel));
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestPutComponentTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestPutComponentTemplateAction.java
@@ -43,7 +43,9 @@ public class RestPutComponentTemplateAction extends BaseRestHandler {
         putRequest.masterNodeTimeout(request.paramAsTime("master_timeout", putRequest.masterNodeTimeout()));
         putRequest.create(request.paramAsBoolean("create", false));
         putRequest.cause(request.param("cause", "api"));
-        putRequest.componentTemplate(ComponentTemplate.parse(request.contentParser()));
+        try (var parser = request.contentParser()) {
+            putRequest.componentTemplate(ComponentTemplate.parse(parser));
+        }
 
         return channel -> client.execute(PutComponentTemplateAction.INSTANCE, putRequest, new RestToXContentListener<>(channel));
     }

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestPutComposableIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestPutComposableIndexTemplateAction.java
@@ -43,7 +43,9 @@ public class RestPutComposableIndexTemplateAction extends BaseRestHandler {
         putRequest.masterNodeTimeout(request.paramAsTime("master_timeout", putRequest.masterNodeTimeout()));
         putRequest.create(request.paramAsBoolean("create", false));
         putRequest.cause(request.param("cause", "api"));
-        putRequest.indexTemplate(ComposableIndexTemplate.parse(request.contentParser()));
+        try (var parser = request.contentParser()) {
+            putRequest.indexTemplate(ComposableIndexTemplate.parse(parser));
+        }
 
         return channel -> client.execute(PutComposableIndexTemplateAction.INSTANCE, putRequest, new RestToXContentListener<>(channel));
     }

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestSimulateIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestSimulateIndexTemplateAction.java
@@ -48,7 +48,9 @@ public class RestSimulateIndexTemplateAction extends BaseRestHandler {
             PutComposableIndexTemplateAction.Request indexTemplateRequest = new PutComposableIndexTemplateAction.Request(
                 "simulating_template"
             );
-            indexTemplateRequest.indexTemplate(ComposableIndexTemplate.parse(request.contentParser()));
+            try (var parser = request.contentParser()) {
+                indexTemplateRequest.indexTemplate(ComposableIndexTemplate.parse(parser));
+            }
             indexTemplateRequest.create(request.paramAsBoolean("create", false));
             indexTemplateRequest.cause(request.param("cause", "api"));
 

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestSimulateTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestSimulateTemplateAction.java
@@ -44,7 +44,9 @@ public class RestSimulateTemplateAction extends BaseRestHandler {
             PutComposableIndexTemplateAction.Request indexTemplateRequest = new PutComposableIndexTemplateAction.Request(
                 "simulating_template"
             );
-            indexTemplateRequest.indexTemplate(ComposableIndexTemplate.parse(request.contentParser()));
+            try (var parser = request.contentParser()) {
+                indexTemplateRequest.indexTemplate(ComposableIndexTemplate.parse(parser));
+            }
             indexTemplateRequest.create(request.paramAsBoolean("create", false));
             indexTemplateRequest.cause(request.param("cause", "api"));
 

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestUpdateSettingsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestUpdateSettingsAction.java
@@ -47,7 +47,9 @@ public class RestUpdateSettingsAction extends BaseRestHandler {
         updateSettingsRequest.masterNodeTimeout(request.paramAsTime("master_timeout", updateSettingsRequest.masterNodeTimeout()));
         updateSettingsRequest.indicesOptions(IndicesOptions.fromRequest(request, updateSettingsRequest.indicesOptions()));
         updateSettingsRequest.reopen(request.paramAsBoolean("reopen", false));
-        updateSettingsRequest.fromXContent(request.contentParser());
+        try (var parser = request.contentParser()) {
+            updateSettingsRequest.fromXContent(parser);
+        }
 
         return channel -> client.admin().indices().updateSettings(updateSettingsRequest, new RestToXContentListener<>(channel));
     }

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestCatComponentTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestCatComponentTemplateAction.java
@@ -127,24 +127,27 @@ public class RestCatComponentTemplateAction extends AbstractCatAction {
         }
         int count = 0;
         XContentType xContentType = XContentType.JSON;
-        XContentParser parser = xContentType.xContent()
-            .createParser(XContentParserConfiguration.EMPTY, template.mappings().uncompressed().array());
-        XContentParser.Token token = parser.nextToken();
-        String currentFieldName = null;
-        while (token != XContentParser.Token.END_OBJECT) {
-            if (token == XContentParser.Token.FIELD_NAME) {
-                currentFieldName = parser.currentName();
-            } else if (token == XContentParser.Token.START_OBJECT) {
-                if ("_doc".equals(currentFieldName)) {
-                    List<Object> list = parser.mapOrdered().values().stream().toList();
-                    for (Object mapping : list) {
-                        count = count + countSubAttributes(mapping);
+        try (
+            XContentParser parser = xContentType.xContent()
+                .createParser(XContentParserConfiguration.EMPTY, template.mappings().uncompressed().array())
+        ) {
+            XContentParser.Token token = parser.nextToken();
+            String currentFieldName = null;
+            while (token != XContentParser.Token.END_OBJECT) {
+                if (token == XContentParser.Token.FIELD_NAME) {
+                    currentFieldName = parser.currentName();
+                } else if (token == XContentParser.Token.START_OBJECT) {
+                    if ("_doc".equals(currentFieldName)) {
+                        List<Object> list = parser.mapOrdered().values().stream().toList();
+                        for (Object mapping : list) {
+                            count = count + countSubAttributes(mapping);
+                        }
                     }
+                } else {
+                    parser.skipChildren();
                 }
-            } else {
-                parser.skipChildren();
+                token = parser.nextToken();
             }
-            token = parser.nextToken();
         }
         return count;
     }

--- a/server/src/main/java/org/elasticsearch/search/lookup/SourceFilter.java
+++ b/server/src/main/java/org/elasticsearch/search/lookup/SourceFilter.java
@@ -94,12 +94,13 @@ public final class SourceFilter {
                 BytesStreamOutput streamOutput = new BytesStreamOutput(1024);
                 XContent xContent = in.sourceContentType().xContent();
                 XContentBuilder builder = new XContentBuilder(xContent, streamOutput);
-                XContentParser parser = xContent.createParser(parserConfig, in.internalSourceRef().streamInput());
-                if ((parser.currentToken() == null) && (parser.nextToken() == null)) {
-                    return Source.empty(in.sourceContentType());
+                try (XContentParser parser = xContent.createParser(parserConfig, in.internalSourceRef().streamInput())) {
+                    if ((parser.currentToken() == null) && (parser.nextToken() == null)) {
+                        return Source.empty(in.sourceContentType());
+                    }
+                    builder.copyCurrentStructure(parser);
+                    return Source.fromBytes(BytesReference.bytes(builder));
                 }
-                builder.copyCurrentStructure(parser);
-                return Source.fromBytes(BytesReference.bytes(builder));
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/DesiredBalanceResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/DesiredBalanceResponseTests.java
@@ -179,9 +179,14 @@ public class DesiredBalanceResponseTests extends AbstractWireSerializingTestCase
             randomClusterInfo()
         );
 
-        Map<String, Object> json = createParser(
-            ChunkedToXContent.wrapAsToXContent(response).toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS)
-        ).map();
+        Map<String, Object> json;
+        try (
+            var parser = createParser(
+                ChunkedToXContent.wrapAsToXContent(response).toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS)
+            )
+        ) {
+            json = parser.map();
+        }
         assertThat(json.keySet(), containsInAnyOrder("stats", "cluster_balance_stats", "routing_table", "cluster_info"));
 
         // stats

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/settings/ClusterUpdateSettingsRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/settings/ClusterUpdateSettingsRequestTests.java
@@ -61,10 +61,11 @@ public class ClusterUpdateSettingsRequestTests extends ESTestCase {
                     () -> randomAlphaOfLengthBetween(3, 10)
                 )
             );
-            XContentParseException iae = expectThrows(
-                XContentParseException.class,
-                () -> ClusterUpdateSettingsRequest.fromXContent(createParser(xContentType.xContent(), mutated))
-            );
+            XContentParseException iae = expectThrows(XContentParseException.class, () -> {
+                try (var parser = createParser(xContentType.xContent(), mutated)) {
+                    ClusterUpdateSettingsRequest.fromXContent(parser);
+                }
+            });
             assertThat(iae.getMessage(), containsString("[cluster_update_settings_request] unknown field [" + unsupportedField + "]"));
         } else {
             try (XContentParser parser = createParser(xContentType.xContent(), originalBytes)) {

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequestTests.java
@@ -99,15 +99,18 @@ public class CreateSnapshotRequestTests extends ESTestCase {
         }
 
         XContentBuilder builder = original.toXContent(XContentFactory.jsonBuilder(), new MapParams(Collections.emptyMap()));
-        XContentParser parser = XContentType.JSON.xContent()
-            .createParser(NamedXContentRegistry.EMPTY, null, BytesReference.bytes(builder).streamInput());
-        Map<String, Object> map = parser.mapOrdered();
-        CreateSnapshotRequest processed = new CreateSnapshotRequest((String) map.get("repository"), (String) map.get("snapshot"));
-        processed.waitForCompletion(original.waitForCompletion());
-        processed.masterNodeTimeout(original.masterNodeTimeout());
-        processed.source(map);
+        try (
+            XContentParser parser = XContentType.JSON.xContent()
+                .createParser(NamedXContentRegistry.EMPTY, null, BytesReference.bytes(builder).streamInput())
+        ) {
+            Map<String, Object> map = parser.mapOrdered();
+            CreateSnapshotRequest processed = new CreateSnapshotRequest((String) map.get("repository"), (String) map.get("snapshot"));
+            processed.waitForCompletion(original.waitForCompletion());
+            processed.masterNodeTimeout(original.masterNodeTimeout());
+            processed.source(map);
 
-        assertEquals(original, processed);
+            assertEquals(original, processed);
+        }
     }
 
     public void testSizeCheck() {

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotRequestTests.java
@@ -130,9 +130,13 @@ public class RestoreSnapshotRequestTests extends AbstractWireSerializingTestCase
         original.snapshotUuid(null); // cannot be set via the REST API
         original.quiet(false); // cannot be set via the REST API
         XContentBuilder builder = original.toXContent(XContentFactory.jsonBuilder(), new ToXContent.MapParams(Collections.emptyMap()));
-        XContentParser parser = XContentType.JSON.xContent()
-            .createParser(NamedXContentRegistry.EMPTY, null, BytesReference.bytes(builder).streamInput());
-        Map<String, Object> map = parser.mapOrdered();
+        Map<String, Object> map;
+        try (
+            XContentParser parser = XContentType.JSON.xContent()
+                .createParser(NamedXContentRegistry.EMPTY, null, BytesReference.bytes(builder).streamInput())
+        ) {
+            map = parser.mapOrdered();
+        }
 
         // we will only restore properties from the map that are contained in the request body. All other
         // properties are restored from the original (in the actual REST action this is restored from the
@@ -174,8 +178,11 @@ public class RestoreSnapshotRequestTests extends AbstractWireSerializingTestCase
 
     private Map<String, Object> convertRequestToMap(RestoreSnapshotRequest request) throws IOException {
         XContentBuilder builder = request.toXContent(XContentFactory.jsonBuilder(), new ToXContent.MapParams(Collections.emptyMap()));
-        XContentParser parser = XContentType.JSON.xContent()
-            .createParser(NamedXContentRegistry.EMPTY, null, BytesReference.bytes(builder).streamInput());
-        return parser.mapOrdered();
+        try (
+            XContentParser parser = XContentType.JSON.xContent()
+                .createParser(NamedXContentRegistry.EMPTY, null, BytesReference.bytes(builder).streamInput())
+        ) {
+            return parser.mapOrdered();
+        }
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/RolloverRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/RolloverRequestTests.java
@@ -66,7 +66,9 @@ public class RolloverRequestTests extends ESTestCase {
             .field("min_primary_shard_docs", 10)
             .endObject()
             .endObject();
-        request.fromXContent(false, createParser(builder));
+        try (var parser = createParser(builder)) {
+            request.fromXContent(false, parser);
+        }
         Map<String, Condition<?>> conditions = request.getConditions().getConditions();
         assertThat(conditions.size(), equalTo(10));
         MaxAgeCondition maxAgeCondition = (MaxAgeCondition) conditions.get(MaxAgeCondition.NAME);
@@ -118,7 +120,9 @@ public class RolloverRequestTests extends ESTestCase {
             .endObject()
             .endObject()
             .endObject();
-        request.fromXContent(false, createParser(builder));
+        try (var parser = createParser(builder)) {
+            request.fromXContent(false, parser);
+        }
         Map<String, Condition<?>> conditions = request.getConditions().getConditions();
         assertThat(conditions.size(), equalTo(3));
         assertThat(request.getCreateIndexRequest().mappings(), containsString("not_analyzed"));
@@ -139,8 +143,9 @@ public class RolloverRequestTests extends ESTestCase {
             .endObject()
             .endObject();
 
-        request.fromXContent(false, createParser(builder));
-
+        try (var parser = createParser(builder)) {
+            request.fromXContent(false, parser);
+        }
         CreateIndexRequest createIndexRequest = request.getCreateIndexRequest();
         String mapping = createIndexRequest.mappings();
         assertNotNull(mapping);
@@ -198,7 +203,11 @@ public class RolloverRequestTests extends ESTestCase {
         }
         builder.endObject();
         BytesReference mutated = XContentTestUtils.insertRandomFields(xContentType, BytesReference.bytes(builder), null, random());
-        expectThrows(XContentParseException.class, () -> request.fromXContent(false, createParser(xContentType.xContent(), mutated)));
+        expectThrows(XContentParseException.class, () -> {
+            try (var parser = createParser(xContentType.xContent(), mutated)) {
+                request.fromXContent(false, parser);
+            }
+        });
     }
 
     public void testValidation() {

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesRequestTests.java
@@ -152,15 +152,15 @@ public class FieldCapabilitiesRequestTests extends AbstractWireSerializingTestCa
     }
 
     public void testFromXContent() throws IOException {
-        XContentParser parser = createParser(JsonXContent.jsonXContent, "{ \"fields\" : [\"FOO\"] }");
-        FieldCapabilitiesRequest request = new FieldCapabilitiesRequest();
-        ObjectParser<FieldCapabilitiesRequest, Void> PARSER = new ObjectParser<>("field_caps_request");
-        PARSER.declareStringArray(fromList(String.class, FieldCapabilitiesRequest::fields), new ParseField("fields"));
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, "{ \"fields\" : [\"FOO\"] }")) {
+            FieldCapabilitiesRequest request = new FieldCapabilitiesRequest();
+            ObjectParser<FieldCapabilitiesRequest, Void> PARSER = new ObjectParser<>("field_caps_request");
+            PARSER.declareStringArray(fromList(String.class, FieldCapabilitiesRequest::fields), new ParseField("fields"));
 
-        PARSER.parse(parser, request, null);
+            PARSER.parse(parser, request, null);
 
-        assertArrayEquals(request.fields(), new String[] { "FOO" });
-
+            assertArrayEquals(request.fields(), new String[] { "FOO" });
+        }
     }
 
     public void testValidation() {

--- a/server/src/test/java/org/elasticsearch/action/get/MultiGetRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/get/MultiGetRequestTests.java
@@ -80,24 +80,25 @@ public class MultiGetRequestTests extends ESTestCase {
     }
 
     public void testAddWithValidSourceValueIsAccepted() throws Exception {
-        XContentParser parser = createParser(
-            XContentFactory.jsonBuilder()
-                .startObject()
-                .startArray("docs")
-                .startObject()
-                .field("_source", randomFrom("false", "true"))
-                .endObject()
-                .startObject()
-                .field("_source", randomBoolean())
-                .endObject()
-                .endArray()
-                .endObject()
-        );
-
-        MultiGetRequest multiGetRequest = new MultiGetRequest();
-        multiGetRequest.add(randomAlphaOfLength(5), null, FetchSourceContext.FETCH_SOURCE, null, parser, true);
-
-        assertEquals(2, multiGetRequest.getItems().size());
+        try (
+            XContentParser parser = createParser(
+                XContentFactory.jsonBuilder()
+                    .startObject()
+                    .startArray("docs")
+                    .startObject()
+                    .field("_source", randomFrom("false", "true"))
+                    .endObject()
+                    .startObject()
+                    .field("_source", randomBoolean())
+                    .endObject()
+                    .endArray()
+                    .endObject()
+            )
+        ) {
+            MultiGetRequest multiGetRequest = new MultiGetRequest();
+            multiGetRequest.add(randomAlphaOfLength(5), null, FetchSourceContext.FETCH_SOURCE, null, parser, true);
+            assertEquals(2, multiGetRequest.getItems().size());
+        }
     }
 
     public void testXContentSerialization() throws IOException {

--- a/server/src/test/java/org/elasticsearch/action/ingest/GetPipelineResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/ingest/GetPipelineResponseTests.java
@@ -62,11 +62,15 @@ public class GetPipelineResponseTests extends AbstractXContentSerializingTestCas
         Map<String, PipelineConfiguration> pipelinesMap = createPipelineConfigMap();
         GetPipelineResponse response = new GetPipelineResponse(new ArrayList<>(pipelinesMap.values()));
         XContentBuilder builder = response.toXContent(getRandomXContentBuilder(), ToXContent.EMPTY_PARAMS);
-        XContentParser parser = builder.generator()
-            .contentType()
-            .xContent()
-            .createParser(xContentRegistry(), LoggingDeprecationHandler.INSTANCE, BytesReference.bytes(builder).streamInput());
-        GetPipelineResponse parsedResponse = GetPipelineResponse.fromXContent(parser);
+        GetPipelineResponse parsedResponse;
+        try (
+            XContentParser parser = builder.generator()
+                .contentType()
+                .xContent()
+                .createParser(xContentRegistry(), LoggingDeprecationHandler.INSTANCE, BytesReference.bytes(builder).streamInput())
+        ) {
+            parsedResponse = GetPipelineResponse.fromXContent(parser);
+        }
         List<PipelineConfiguration> actualPipelines = response.pipelines();
         List<PipelineConfiguration> parsedPipelines = parsedResponse.pipelines();
         assertEquals(actualPipelines.size(), parsedPipelines.size());

--- a/server/src/test/java/org/elasticsearch/action/termvectors/TermVectorsUnitTests.java
+++ b/server/src/test/java/org/elasticsearch/action/termvectors/TermVectorsUnitTests.java
@@ -294,17 +294,18 @@ public class TermVectorsUnitTests extends ESTestCase {
 
     public void testMultiParser() throws Exception {
         byte[] bytes = StreamsUtils.copyToBytesFromClasspath("/org/elasticsearch/action/termvectors/multiRequest1.json");
-        XContentParser data = createParser(JsonXContent.jsonXContent, bytes);
-        MultiTermVectorsRequest request = new MultiTermVectorsRequest();
-        request.add(new TermVectorsRequest(), data);
-        checkParsedParameters(request);
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, bytes)) {
+            MultiTermVectorsRequest request = new MultiTermVectorsRequest();
+            request.add(new TermVectorsRequest(), parser);
+            checkParsedParameters(request);
+        }
 
         bytes = StreamsUtils.copyToBytesFromClasspath("/org/elasticsearch/action/termvectors/multiRequest2.json");
-        data = createParser(JsonXContent.jsonXContent, new BytesArray(bytes));
-        request = new MultiTermVectorsRequest();
-        request.add(new TermVectorsRequest(), data);
-
-        checkParsedParameters(request);
+        try (var parser = createParser(JsonXContent.jsonXContent, new BytesArray(bytes))) {
+            MultiTermVectorsRequest request = new MultiTermVectorsRequest();
+            request.add(new TermVectorsRequest(), parser);
+            checkParsedParameters(request);
+        }
     }
 
     void checkParsedParameters(MultiTermVectorsRequest request) {

--- a/server/src/test/java/org/elasticsearch/action/update/UpdateRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/update/UpdateRequestTests.java
@@ -120,7 +120,9 @@ public class UpdateRequestTests extends ESTestCase {
     public void testFromXContent() throws Exception {
         UpdateRequest request = new UpdateRequest("test", "1");
         // simple script
-        request.fromXContent(createParser(XContentFactory.jsonBuilder().startObject().field("script", "script1").endObject()));
+        try (var parser = createParser(XContentFactory.jsonBuilder().startObject().field("script", "script1").endObject())) {
+            request.fromXContent(parser);
+        }
         Script script = request.script();
         assertThat(script, notNullValue());
         assertThat(script.getIdOrCode(), equalTo("script1"));
@@ -130,11 +132,13 @@ public class UpdateRequestTests extends ESTestCase {
         assertThat(params, equalTo(emptyMap()));
 
         // simple verbose script
-        request.fromXContent(
-            createParser(
+        try (
+            var parser = createParser(
                 XContentFactory.jsonBuilder().startObject().startObject("script").field("source", "script1").endObject().endObject()
             )
-        );
+        ) {
+            request.fromXContent(parser);
+        }
         script = request.script();
         assertThat(script, notNullValue());
         assertThat(script.getIdOrCode(), equalTo("script1"));
@@ -145,8 +149,8 @@ public class UpdateRequestTests extends ESTestCase {
 
         // script with params
         request = new UpdateRequest("test", "1");
-        request.fromXContent(
-            createParser(
+        try (
+            var parser = createParser(
                 XContentFactory.jsonBuilder()
                     .startObject()
                     .startObject("script")
@@ -157,7 +161,9 @@ public class UpdateRequestTests extends ESTestCase {
                     .endObject()
                     .endObject()
             )
-        );
+        ) {
+            request.fromXContent(parser);
+        }
         script = request.script();
         assertThat(script, notNullValue());
         assertThat(script.getIdOrCode(), equalTo("script1"));
@@ -169,8 +175,8 @@ public class UpdateRequestTests extends ESTestCase {
         assertThat(params.get("param1").toString(), equalTo("value1"));
 
         request = new UpdateRequest("test", "1");
-        request.fromXContent(
-            createParser(
+        try (
+            var parser = createParser(
                 XContentFactory.jsonBuilder()
                     .startObject()
                     .startObject("script")
@@ -181,7 +187,9 @@ public class UpdateRequestTests extends ESTestCase {
                     .endObject()
                     .endObject()
             )
-        );
+        ) {
+            request.fromXContent(parser);
+        }
         script = request.script();
         assertThat(script, notNullValue());
         assertThat(script.getIdOrCode(), equalTo("script1"));
@@ -194,8 +202,8 @@ public class UpdateRequestTests extends ESTestCase {
 
         // script with params and upsert
         request = new UpdateRequest("test", "1");
-        request.fromXContent(
-            createParser(
+        try (
+            var parser = createParser(
                 XContentFactory.jsonBuilder()
                     .startObject()
                     .startObject("script")
@@ -212,7 +220,9 @@ public class UpdateRequestTests extends ESTestCase {
                     .endObject()
                     .endObject()
             )
-        );
+        ) {
+            request.fromXContent(parser);
+        }
         script = request.script();
         assertThat(script, notNullValue());
         assertThat(script.getIdOrCode(), equalTo("script1"));
@@ -231,8 +241,8 @@ public class UpdateRequestTests extends ESTestCase {
         assertThat(((Map<String, Object>) upsertDoc.get("compound")).get("field2").toString(), equalTo("value2"));
 
         request = new UpdateRequest("test", "1");
-        request.fromXContent(
-            createParser(
+        try (
+            var parser = createParser(
                 XContentFactory.jsonBuilder()
                     .startObject()
                     .startObject("upsert")
@@ -249,7 +259,9 @@ public class UpdateRequestTests extends ESTestCase {
                     .endObject()
                     .endObject()
             )
-        );
+        ) {
+            request.fromXContent(parser);
+        }
         script = request.script();
         assertThat(script, notNullValue());
         assertThat(script.getIdOrCode(), equalTo("script1"));
@@ -265,8 +277,8 @@ public class UpdateRequestTests extends ESTestCase {
 
         // script with doc
         request = new UpdateRequest("test", "1");
-        request.fromXContent(
-            createParser(
+        try (
+            var parser = createParser(
                 XContentFactory.jsonBuilder()
                     .startObject()
                     .startObject("doc")
@@ -277,7 +289,9 @@ public class UpdateRequestTests extends ESTestCase {
                     .endObject()
                     .endObject()
             )
-        );
+        ) {
+            request.fromXContent(parser);
+        }
         Map<String, Object> doc = request.doc().sourceAsMap();
         assertThat(doc.get("field1").toString(), equalTo("value1"));
         assertThat(((Map<String, Object>) doc.get("compound")).get("field2").toString(), equalTo("value2"));
@@ -285,23 +299,30 @@ public class UpdateRequestTests extends ESTestCase {
 
     public void testUnknownFieldParsing() throws Exception {
         UpdateRequest request = new UpdateRequest("test", "1");
-        XContentParser contentParser = createParser(XContentFactory.jsonBuilder().startObject().field("unknown_field", "test").endObject());
-
-        XContentParseException ex = expectThrows(XContentParseException.class, () -> request.fromXContent(contentParser));
-        assertEquals("[1:2] [UpdateRequest] unknown field [unknown_field]", ex.getMessage());
+        try (
+            XContentParser contentParser = createParser(
+                XContentFactory.jsonBuilder().startObject().field("unknown_field", "test").endObject()
+            )
+        ) {
+            XContentParseException ex = expectThrows(XContentParseException.class, () -> request.fromXContent(contentParser));
+            assertEquals("[1:2] [UpdateRequest] unknown field [unknown_field]", ex.getMessage());
+        }
 
         UpdateRequest request2 = new UpdateRequest("test", "1");
-        XContentParser unknownObject = createParser(
-            XContentFactory.jsonBuilder()
-                .startObject()
-                .field("script", "ctx.op = ctx._source.views == params.count ? 'delete' : 'none'")
-                .startObject("params")
-                .field("count", 1)
-                .endObject()
-                .endObject()
-        );
-        ex = expectThrows(XContentParseException.class, () -> request2.fromXContent(unknownObject));
-        assertEquals("[1:76] [UpdateRequest] unknown field [params]", ex.getMessage());
+        try (
+            XContentParser unknownObject = createParser(
+                XContentFactory.jsonBuilder()
+                    .startObject()
+                    .field("script", "ctx.op = ctx._source.views == params.count ? 'delete' : 'none'")
+                    .startObject("params")
+                    .field("count", 1)
+                    .endObject()
+                    .endObject()
+            )
+        ) {
+            XContentParseException ex = expectThrows(XContentParseException.class, () -> request2.fromXContent(unknownObject));
+            assertEquals("[1:76] [UpdateRequest] unknown field [params]", ex.getMessage());
+        }
     }
 
     public void testFetchSourceParsing() throws Exception {
@@ -543,9 +564,10 @@ public class UpdateRequestTests extends ESTestCase {
         ShardId shardId = new ShardId("test", "", 0);
         GetResult getResult = new GetResult("test", "1", 0, 1, 0, true, new BytesArray("{\"body\": \"foo\"}"), null, null);
 
-        UpdateRequest request = new UpdateRequest("test", "1").fromXContent(
-            createParser(JsonXContent.jsonXContent, new BytesArray("{\"doc\": {\"body\": \"foo\"}}"))
-        );
+        UpdateRequest request;
+        try (var parser = createParser(JsonXContent.jsonXContent, new BytesArray("{\"doc\": {\"body\": \"foo\"}}"))) {
+            request = new UpdateRequest("test", "1").fromXContent(parser);
+        }
 
         UpdateHelper.Result result = UpdateHelper.prepareUpdateIndexRequest(shardId, request, getResult, true);
 
@@ -558,15 +580,15 @@ public class UpdateRequestTests extends ESTestCase {
         assertThat(result.getResponseResult(), equalTo(DocWriteResponse.Result.UPDATED));
         assertThat(result.updatedSourceAsMap().get("body").toString(), equalTo("foo"));
 
-        // Change the request to be a different doc
-        request = new UpdateRequest("test", "1").fromXContent(
-            createParser(JsonXContent.jsonXContent, new BytesArray("{\"doc\": {\"body\": \"bar\"}}"))
-        );
-        result = UpdateHelper.prepareUpdateIndexRequest(shardId, request, getResult, true);
+        try (var parser = createParser(JsonXContent.jsonXContent, new BytesArray("{\"doc\": {\"body\": \"bar\"}}"))) {
+            // Change the request to be a different doc
+            request = new UpdateRequest("test", "1").fromXContent(parser);
+            result = UpdateHelper.prepareUpdateIndexRequest(shardId, request, getResult, true);
 
-        assertThat(result.action(), instanceOf(IndexRequest.class));
-        assertThat(result.getResponseResult(), equalTo(DocWriteResponse.Result.UPDATED));
-        assertThat(result.updatedSourceAsMap().get("body").toString(), equalTo("bar"));
+            assertThat(result.action(), instanceOf(IndexRequest.class));
+            assertThat(result.getResponseResult(), equalTo(DocWriteResponse.Result.UPDATED));
+            assertThat(result.updatedSourceAsMap().get("body").toString(), equalTo("bar"));
+        }
 
     }
 
@@ -614,11 +636,11 @@ public class UpdateRequestTests extends ESTestCase {
         assertThat(request.toString(), equalTo("""
             update {[test][1], doc_as_upsert[false], script[Script{type=inline, lang='mock', idOrCode='ctx._source.body = "foo"', \
             options={}, params={}}], scripted_upsert[false], detect_noop[true]}"""));
-        request = new UpdateRequest("test", "1").fromXContent(
-            createParser(JsonXContent.jsonXContent, new BytesArray("{\"doc\": {\"body\": \"bar\"}}"))
-        );
-        assertThat(request.toString(), equalTo("""
-            update {[test][1], doc_as_upsert[false], doc[index {[null][null], source[{"body":"bar"}]}], \
-            scripted_upsert[false], detect_noop[true]}"""));
+        try (var parser = createParser(JsonXContent.jsonXContent, new BytesArray("{\"doc\": {\"body\": \"bar\"}}"))) {
+            request = new UpdateRequest("test", "1").fromXContent(parser);
+            assertThat(request.toString(), equalTo("""
+                update {[test][1], doc_as_upsert[false], doc[index {[null][null], source[{"body":"bar"}]}], \
+                scripted_upsert[false], detect_noop[true]}"""));
+        }
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/StableMasterHealthIndicatorServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/StableMasterHealthIndicatorServiceTests.java
@@ -312,8 +312,11 @@ public class StableMasterHealthIndicatorServiceTests extends AbstractCoordinator
     private Map<String, Object> xContentToMap(ToXContent xcontent) throws IOException {
         XContentBuilder builder = XContentFactory.jsonBuilder();
         xcontent.toXContent(builder, ToXContent.EMPTY_PARAMS);
-        XContentParser parser = XContentType.JSON.xContent()
-            .createParser(xContentRegistry(), LoggingDeprecationHandler.INSTANCE, BytesReference.bytes(builder).streamInput());
-        return parser.map();
+        try (
+            XContentParser parser = XContentType.JSON.xContent()
+                .createParser(xContentRegistry(), LoggingDeprecationHandler.INSTANCE, BytesReference.bytes(builder).streamInput())
+        ) {
+            return parser.map();
+        }
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexGraveyardTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexGraveyardTests.java
@@ -72,9 +72,10 @@ public class IndexGraveyardTests extends ESTestCase {
                 )
             );
         }
-        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder));
-        parser.nextToken(); // the beginning of the parser
-        assertThat(IndexGraveyard.fromXContent(parser), equalTo(graveyard));
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder))) {
+            parser.nextToken(); // the beginning of the parser
+            assertThat(IndexGraveyard.fromXContent(parser), equalTo(graveyard));
+        }
     }
 
     public void testChunking() {

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexMetadataTests.java
@@ -112,8 +112,10 @@ public class IndexMetadataTests extends ESTestCase {
         builder.startObject();
         IndexMetadata.FORMAT.toXContent(builder, metadata);
         builder.endObject();
-        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder));
-        final IndexMetadata fromXContentMeta = IndexMetadata.fromXContent(parser);
+        final IndexMetadata fromXContentMeta;
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder))) {
+            fromXContentMeta = IndexMetadata.fromXContent(parser);
+        }
         assertEquals(
             "expected: " + Strings.toString(metadata) + "\nactual  : " + Strings.toString(fromXContentMeta),
             metadata,

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/ReservedStateMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/ReservedStateMetadataTests.java
@@ -63,9 +63,10 @@ public class ReservedStateMetadataTests extends ESTestCase {
         builder.startObject();
         meta.toXContent(builder, ToXContent.EMPTY_PARAMS);
         builder.endObject();
-        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder));
-        parser.nextToken(); // the beginning of the object
-        assertThat(ReservedStateMetadata.fromXContent(parser), equalTo(meta));
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder))) {
+            parser.nextToken(); // the beginning of the object
+            assertThat(ReservedStateMetadata.fromXContent(parser), equalTo(meta));
+        }
     }
 
     public void testXContent() throws IOException {

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/ToAndFromJsonMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/ToAndFromJsonMetadataTests.java
@@ -138,7 +138,10 @@ public class ToAndFromJsonMetadataTests extends ESTestCase {
         Metadata.FORMAT.toXContent(builder, metadata);
         builder.endObject();
 
-        Metadata parsedMetadata = Metadata.Builder.fromXContent(createParser(builder));
+        Metadata parsedMetadata;
+        try (var parser = createParser(builder)) {
+            parsedMetadata = Metadata.Builder.fromXContent(parser);
+        }
 
         // templates
         assertThat(parsedMetadata.templates().get("foo").name(), is("foo"));

--- a/server/src/test/java/org/elasticsearch/cluster/routing/AllocationIdTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/AllocationIdTests.java
@@ -142,8 +142,10 @@ public class AllocationIdTests extends ESTestCase {
             allocationId = AllocationId.newRelocation(allocationId);
         }
         BytesReference bytes = BytesReference.bytes(allocationId.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS));
-        AllocationId parsedAllocationId = AllocationId.fromXContent(createParser(JsonXContent.jsonXContent, bytes));
-        assertEquals(allocationId, parsedAllocationId);
+        try (var parser = createParser(JsonXContent.jsonXContent, bytes)) {
+            AllocationId parsedAllocationId = AllocationId.fromXContent(parser);
+            assertEquals(allocationId, parsedAllocationId);
+        }
     }
 
     public void testEquals() {

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationCommandsTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationCommandsTests.java
@@ -811,23 +811,24 @@ public class AllocationCommandsTests extends ESAllocationTestCase {
                ]
              }
             """;
-        XContentParser parser = createParser(JsonXContent.jsonXContent, commands);
-        // move two tokens, parser expected to be "on" `commands` field
-        parser.nextToken();
-        parser.nextToken();
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, commands)) {
+            // move two tokens, parser expected to be "on" `commands` field
+            parser.nextToken();
+            parser.nextToken();
 
-        assertThat(
-            AllocationCommands.fromXContent(parser),
-            equalTo(
-                new AllocationCommands(
-                    new AllocateEmptyPrimaryAllocationCommand("test", 1, "node1", true),
-                    new AllocateStalePrimaryAllocationCommand("test", 2, "node1", true),
-                    new AllocateReplicaAllocationCommand("test", 2, "node1"),
-                    new MoveAllocationCommand("test", 3, "node2", "node3"),
-                    new CancelAllocationCommand("test", 4, "node5", true)
+            assertThat(
+                AllocationCommands.fromXContent(parser),
+                equalTo(
+                    new AllocationCommands(
+                        new AllocateEmptyPrimaryAllocationCommand("test", 1, "node1", true),
+                        new AllocateStalePrimaryAllocationCommand("test", 2, "node1", true),
+                        new AllocateReplicaAllocationCommand("test", 2, "node1"),
+                        new MoveAllocationCommand("test", 3, "node2", "node3"),
+                        new CancelAllocationCommand("test", 4, "node5", true)
+                    )
                 )
-            )
-        );
+            );
+        }
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/common/geo/GeoBoundingBoxTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/GeoBoundingBoxTests.java
@@ -29,10 +29,11 @@ public class GeoBoundingBoxTests extends ESTestCase {
 
     public void testInvalidParseInvalidWKT() throws IOException {
         XContentBuilder bboxBuilder = XContentFactory.jsonBuilder().startObject().field("wkt", "invalid").endObject();
-        XContentParser parser = createParser(bboxBuilder);
-        parser.nextToken();
-        ElasticsearchParseException e = expectThrows(ElasticsearchParseException.class, () -> GeoBoundingBox.parseBoundingBox(parser));
-        assertThat(e.getMessage(), equalTo("failed to parse WKT bounding box"));
+        try (XContentParser parser = createParser(bboxBuilder)) {
+            parser.nextToken();
+            ElasticsearchParseException e = expectThrows(ElasticsearchParseException.class, () -> GeoBoundingBox.parseBoundingBox(parser));
+            assertThat(e.getMessage(), equalTo("failed to parse WKT bounding box"));
+        }
     }
 
     public void testInvalidParsePoint() throws IOException {

--- a/server/src/test/java/org/elasticsearch/common/settings/SettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/SettingsTests.java
@@ -507,8 +507,10 @@ public class SettingsTests extends ESTestCase {
         builder.startObject();
         settings.toXContent(builder, new ToXContent.MapParams(Collections.singletonMap(Settings.FLAT_SETTINGS_PARAM, "" + flatSettings)));
         builder.endObject();
-        XContentParser parser = createParser(builder);
-        Settings build = Settings.fromXContent(parser);
+        Settings build;
+        try (XContentParser parser = createParser(builder)) {
+            build = Settings.fromXContent(parser);
+        }
         assertEquals(5, build.size());
         assertEquals(Arrays.asList("1", "2", "3"), build.getAsList("foo.bar.baz"));
         assertEquals(2, build.getAsInt("foo.foobar", 0).intValue());

--- a/server/src/test/java/org/elasticsearch/index/mapper/CompletionFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/CompletionFieldMapperTests.java
@@ -223,7 +223,10 @@ public class CompletionFieldMapperTests extends MapperTestCase {
         XContentBuilder builder = jsonBuilder().startObject();
         fieldMapper.toXContent(builder, new ToXContent.MapParams(Map.of("include_defaults", "true"))).endObject();
         builder.close();
-        Map<String, Object> serializedMap = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder)).map();
+        Map<String, Object> serializedMap;
+        try (var parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder))) {
+            serializedMap = parser.map();
+        }
         Map<String, Object> configMap = (Map<String, Object>) serializedMap.get("field");
         assertThat(configMap.get("analyzer").toString(), is("simple"));
         assertThat(configMap.get("search_analyzer").toString(), is("standard"));

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocCountFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocCountFieldMapperTests.java
@@ -104,8 +104,10 @@ public class DocCountFieldMapperTests extends MetadataMapperTestCase {
                 LeafStoredFieldLoader storedFieldLoader = StoredFieldLoader.empty().getLoader(leaf, docIds);
                 for (int docId : docIds) {
                     String source = sourceLoaderLeaf.source(storedFieldLoader, docId).internalSourceRef().utf8ToString();
-                    int doc = (int) JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, source).map().get("doc");
-                    assertThat("doc " + docId, source, equalTo("{\"_doc_count\":" + counts.get(doc) + ",\"doc\":" + doc + "}"));
+                    try (var parser = JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, source)) {
+                        int doc = (int) parser.map().get("doc");
+                        assertThat("doc " + docId, source, equalTo("{\"_doc_count\":" + counts.get(doc) + ",\"doc\":" + doc + "}"));
+                    }
                 }
             }
         });

--- a/server/src/test/java/org/elasticsearch/index/mapper/IgnoreMalformedStoredValuesTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IgnoreMalformedStoredValuesTests.java
@@ -148,13 +148,13 @@ public class IgnoreMalformedStoredValuesTests extends ESTestCase {
     private static StoredField ignoreMalformedStoredField(XContentType type, Object value) throws IOException {
         XContentBuilder b = XContentBuilder.builder(type.xContent());
         b.startObject().field("name", value).endObject();
-        XContentParser p = type.xContent().createParser(XContentParserConfiguration.EMPTY, BytesReference.bytes(b).streamInput());
-        assertThat(p.nextToken(), equalTo(XContentParser.Token.START_OBJECT));
-        assertThat(p.nextToken(), equalTo(XContentParser.Token.FIELD_NAME));
-        assertThat(p.currentName(), equalTo("name"));
-        p.nextToken();
-
-        return IgnoreMalformedStoredValues.storedField("foo.name", p);
+        try (XContentParser p = type.xContent().createParser(XContentParserConfiguration.EMPTY, BytesReference.bytes(b).streamInput())) {
+            assertThat(p.nextToken(), equalTo(XContentParser.Token.START_OBJECT));
+            assertThat(p.nextToken(), equalTo(XContentParser.Token.FIELD_NAME));
+            assertThat(p.currentName(), equalTo("name"));
+            p.nextToken();
+            return IgnoreMalformedStoredValues.storedField("foo.name", p);
+        }
     }
 
     private static XContentParser parserFrom(IgnoreMalformedStoredValues values, String fieldName) throws IOException {

--- a/server/src/test/java/org/elasticsearch/indices/TermsLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/TermsLookupTests.java
@@ -63,14 +63,15 @@ public class TermsLookupTests extends ESTestCase {
     }
 
     public void testXContentParsing() throws IOException {
-        XContentParser parser = createParser(JsonXContent.jsonXContent, """
-            { "index" : "index", "id" : "id", "path" : "path", "routing" : "routing" }""");
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, """
+            { "index" : "index", "id" : "id", "path" : "path", "routing" : "routing" }""")) {
 
-        TermsLookup tl = TermsLookup.parseTermsLookup(parser);
-        assertEquals("index", tl.index());
-        assertEquals("id", tl.id());
-        assertEquals("path", tl.path());
-        assertEquals("routing", tl.routing());
+            TermsLookup tl = TermsLookup.parseTermsLookup(parser);
+            assertEquals("index", tl.index());
+            assertEquals("id", tl.id());
+            assertEquals("path", tl.path());
+            assertEquals("routing", tl.routing());
+        }
     }
 
     public static TermsLookup randomTermsLookup() {

--- a/server/src/test/java/org/elasticsearch/repositories/IndexIdTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/IndexIdTests.java
@@ -48,17 +48,20 @@ public class IndexIdTests extends AbstractWireSerializingTestCase<IndexId> {
         IndexId indexId = new IndexId(randomAlphaOfLength(8), UUIDs.randomBase64UUID());
         XContentBuilder builder = JsonXContent.contentBuilder();
         indexId.toXContent(builder, ToXContent.EMPTY_PARAMS);
-        XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder));
-        assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
-        String name = null;
-        String id = null;
-        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
-            final String currentFieldName = parser.currentName();
-            parser.nextToken();
-            if (currentFieldName.equals(IndexId.NAME)) {
-                name = parser.text();
-            } else if (currentFieldName.equals(IndexId.ID)) {
-                id = parser.text();
+        String name;
+        String id;
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder))) {
+            assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
+            name = null;
+            id = null;
+            while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+                final String currentFieldName = parser.currentName();
+                parser.nextToken();
+                if (currentFieldName.equals(IndexId.NAME)) {
+                    name = parser.text();
+                } else if (currentFieldName.equals(IndexId.ID)) {
+                    id = parser.text();
+                }
             }
         }
         assertNotNull(name);

--- a/server/src/test/java/org/elasticsearch/search/suggest/completion/QueryContextTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/completion/QueryContextTestCase.java
@@ -34,11 +34,12 @@ public abstract class QueryContextTestCase<QC extends ToXContent> extends ESTest
             QC toXContent = createTestModel();
             XContentBuilder builder = XContentFactory.jsonBuilder();
             toXContent.toXContent(builder, ToXContent.EMPTY_PARAMS);
-            XContentParser parser = createParser(builder);
-            parser.nextToken();
-            QC fromXContext = fromXContent(parser);
-            assertEquals(toXContent, fromXContext);
-            assertEquals(toXContent.hashCode(), fromXContext.hashCode());
+            try (XContentParser parser = createParser(builder)) {
+                parser.nextToken();
+                QC fromXContext = fromXContent(parser);
+                assertEquals(toXContent, fromXContext);
+                assertEquals(toXContent.hashCode(), fromXContext.hashCode());
+            }
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/transport/TransportInfoTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportInfoTests.java
@@ -70,7 +70,10 @@ public class TransportInfoTests extends ESTestCase {
         httpInfo.toXContent(builder, ToXContent.EMPTY_PARAMS);
         builder.endObject();
 
-        Map<String, Object> transportMap = (Map<String, Object>) createParser(builder).map().get(TransportInfo.Fields.TRANSPORT);
+        Map<String, Object> transportMap;
+        try (var parser = createParser(builder)) {
+            transportMap = (Map<String, Object>) parser.map().get(TransportInfo.Fields.TRANSPORT);
+        }
         Map<String, Object> profilesMap = (Map<String, Object>) transportMap.get("profiles");
         assertEquals(expected, transportMap.get(TransportInfo.Fields.PUBLISH_ADDRESS));
         assertEquals(expected, ((Map<String, Object>) profilesMap.get("test_profile")).get(TransportInfo.Fields.PUBLISH_ADDRESS));

--- a/test/framework/src/main/java/org/elasticsearch/search/RandomSearchRequestGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/RandomSearchRequestGenerator.java
@@ -327,12 +327,15 @@ public class RandomSearchRequestGenerator {
                 }
                 jsonBuilder.endArray();
                 jsonBuilder.endObject();
-                XContentParser parser = XContentFactory.xContent(XContentType.JSON)
-                    .createParser(XContentParserConfiguration.EMPTY, BytesReference.bytes(jsonBuilder).streamInput());
-                parser.nextToken();
-                parser.nextToken();
-                parser.nextToken();
-                builder.searchAfter(SearchAfterBuilder.fromXContent(parser).getSortValues());
+                try (
+                    XContentParser parser = XContentFactory.xContent(XContentType.JSON)
+                        .createParser(XContentParserConfiguration.EMPTY, BytesReference.bytes(jsonBuilder).streamInput())
+                ) {
+                    parser.nextToken();
+                    parser.nextToken();
+                    parser.nextToken();
+                    builder.searchAfter(SearchAfterBuilder.fromXContent(parser).getSortValues());
+                }
             } catch (IOException e) {
                 throw new RuntimeException("Error building search_from", e);
             }

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/bucket/AbstractSignificanceHeuristicTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/bucket/AbstractSignificanceHeuristicTestCase.java
@@ -197,8 +197,10 @@ public abstract class AbstractSignificanceHeuristicTestCase extends ESTestCase {
         stBuilder.significanceHeuristic(significanceHeuristic).field("text").minDocCount(200);
         XContentBuilder stXContentBuilder = XContentFactory.jsonBuilder();
         stBuilder.internalXContent(stXContentBuilder, null);
-        XContentParser stParser = createParser(JsonXContent.jsonXContent, Strings.toString(stXContentBuilder));
-        SignificanceHeuristic parsedHeuristic = parseSignificanceHeuristic(stParser);
+        SignificanceHeuristic parsedHeuristic;
+        try (XContentParser stParser = createParser(JsonXContent.jsonXContent, Strings.toString(stXContentBuilder))) {
+            parsedHeuristic = parseSignificanceHeuristic(stParser);
+        }
         assertThat(significanceHeuristic, equalTo(parsedHeuristic));
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
@@ -405,24 +405,25 @@ public abstract class AbstractSnapshotIntegTestCase extends ESIntegTestCase {
             oldVersionString = currentVersionString.replace(",\"index_version\":" + IndexVersion.current(), "")
                 .replace(",\"version\":\"8.11.0\"", ",\"version\":\"" + Version.fromId(version.id()) + "\"");
         }
-        final RepositoryData downgradedRepoData = RepositoryData.snapshotsFromXContent(
-            JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, oldVersionString),
-            repositoryData.getGenId(),
-            randomBoolean()
-        );
+        final RepositoryData downgradedRepoData;
+        try (var parser = JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, oldVersionString)) {
+            downgradedRepoData = RepositoryData.snapshotsFromXContent(parser, repositoryData.getGenId(), randomBoolean());
+        }
         Files.write(
             repoPath.resolve(BlobStoreRepository.INDEX_FILE_PREFIX + repositoryData.getGenId()),
             BytesReference.toBytes(BytesReference.bytes(downgradedRepoData.snapshotsToXContent(XContentFactory.jsonBuilder(), version))),
             StandardOpenOption.TRUNCATE_EXISTING
         );
-        final SnapshotInfo downgradedSnapshotInfo = SnapshotInfo.fromXContentInternal(
-            repoName,
-            JsonXContent.jsonXContent.createParser(
+        final SnapshotInfo downgradedSnapshotInfo;
+        try (
+            var parser = JsonXContent.jsonXContent.createParser(
                 XContentParserConfiguration.EMPTY,
                 Strings.toString(snapshotInfo, ChecksumBlobStoreFormat.SNAPSHOT_ONLY_FORMAT_PARAMS)
                     .replace(IndexVersion.current().toString(), version.toString())
             )
-        );
+        ) {
+            downgradedSnapshotInfo = SnapshotInfo.fromXContentInternal(repoName, parser);
+        }
         final BlobStoreRepository blobStoreRepository = getRepositoryOnMaster(repoName);
         PlainActionFuture.get(
             f -> blobStoreRepository.threadPool()

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractQueryTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractQueryTestCase.java
@@ -152,10 +152,14 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
                 randomBoolean(),
                 shuffleProtectedFields()
             );
-            assertParsedQuery(createParser(xContentType.xContent(), shuffledXContent), testQuery);
+            try (var parser = createParser(xContentType.xContent(), shuffledXContent)) {
+                assertParsedQuery(parser, testQuery);
+            }
             for (Map.Entry<String, QB> alternateVersion : getAlternateVersions().entrySet()) {
                 String queryAsString = alternateVersion.getKey();
-                assertParsedQuery(createParser(JsonXContent.jsonXContent, queryAsString), alternateVersion.getValue());
+                try (var parser = createParser(JsonXContent.jsonXContent, queryAsString)) {
+                    assertParsedQuery(parser, alternateVersion.getValue());
+                }
             }
         }
     }
@@ -424,12 +428,15 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
 
     protected QueryBuilder parseQuery(AbstractQueryBuilder<?> builder) throws IOException {
         BytesReference bytes = XContentHelper.toXContent(builder, XContentType.JSON, false);
-        return parseQuery(createParser(JsonXContent.jsonXContent, bytes));
+        try (var parser = createParser(JsonXContent.jsonXContent, bytes)) {
+            return parseQuery(parser);
+        }
     }
 
     protected QueryBuilder parseQuery(String queryAsString) throws IOException {
-        XContentParser parser = createParser(JsonXContent.jsonXContent, queryAsString);
-        return parseQuery(parser);
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, queryAsString)) {
+            return parseQuery(parser);
+        }
     }
 
     protected QueryBuilder parseQuery(XContentParser parser) throws IOException {
@@ -651,9 +658,13 @@ public abstract class AbstractQueryTestCase<QB extends AbstractQueryBuilder<QB>>
             QB testQuery = createTestQueryBuilder();
             XContentType xContentType = XContentType.JSON;
             String toString = Strings.toString(testQuery);
-            assertParsedQuery(createParser(xContentType.xContent(), toString), testQuery);
+            try (var parser = createParser(xContentType.xContent(), toString)) {
+                assertParsedQuery(parser, testQuery);
+            }
             BytesReference bytes = XContentHelper.toXContent(testQuery, xContentType, false);
-            assertParsedQuery(createParser(xContentType.xContent(), bytes), testQuery);
+            try (var parser = createParser(xContentType.xContent(), bytes)) {
+                assertParsedQuery(parser, testQuery);
+            }
         }
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractXContentTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractXContentTestCase.java
@@ -154,8 +154,10 @@ public abstract class AbstractXContentTestCase<T extends ToXContent> extends EST
                         randomFieldsExcludeFilter,
                         createParser
                     );
-                    XContentParser parser = createParser.apply(XContentFactory.xContent(xContentType), shuffledContent);
-                    T parsed = fromXContent.apply(parser);
+                    final T parsed;
+                    try (XContentParser parser = createParser.apply(XContentFactory.xContent(xContentType), shuffledContent)) {
+                        parsed = fromXContent.apply(parser);
+                    }
                     try {
                         assertEqualsConsumer.accept(testInstance, parsed);
                         if (assertToXContentEquivalence) {
@@ -320,8 +322,9 @@ public abstract class AbstractXContentTestCase<T extends ToXContent> extends EST
         } else {
             withRandomFields = xContent;
         }
-        XContentParser parserWithRandomFields = createParserFunction.apply(XContentFactory.xContent(xContentType), withRandomFields);
-        return BytesReference.bytes(ESTestCase.shuffleXContent(parserWithRandomFields, false, shuffleFieldsExceptions));
+        try (XContentParser parserWithRandomFields = createParserFunction.apply(XContentFactory.xContent(xContentType), withRandomFields)) {
+            return BytesReference.bytes(ESTestCase.shuffleXContent(parserWithRandomFields, false, shuffleFieldsExceptions));
+        }
     }
 
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -1228,7 +1228,9 @@ public abstract class ESRestTestCase extends ESTestCase {
     protected static RefreshResponse refresh(RestClient client, String index) throws IOException {
         Request refreshRequest = new Request("POST", "/" + index + "/_refresh");
         Response response = client.performRequest(refreshRequest);
-        return RefreshResponse.fromXContent(responseAsParser(response));
+        try (var parser = responseAsParser(response)) {
+            return RefreshResponse.fromXContent(parser);
+        }
     }
 
     private static void waitForPendingRollupTasks() throws Exception {
@@ -1685,7 +1687,9 @@ public abstract class ESRestTestCase extends ESTestCase {
         entity += "}";
         request.setJsonEntity(entity);
         Response response = client.performRequest(request);
-        return CreateIndexResponse.fromXContent(responseAsParser(response));
+        try (var parser = responseAsParser(response)) {
+            return CreateIndexResponse.fromXContent(parser);
+        }
     }
 
     protected static AcknowledgedResponse deleteIndex(String name) throws IOException {
@@ -1695,7 +1699,9 @@ public abstract class ESRestTestCase extends ESTestCase {
     protected static AcknowledgedResponse deleteIndex(RestClient restClient, String name) throws IOException {
         Request request = new Request("DELETE", "/" + name);
         Response response = restClient.performRequest(request);
-        return AcknowledgedResponse.fromXContent(responseAsParser(response));
+        try (var parser = responseAsParser(response)) {
+            return AcknowledgedResponse.fromXContent(parser);
+        }
     }
 
     protected static void updateIndexSettings(String index, Settings.Builder settings) throws IOException {

--- a/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
+++ b/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
@@ -188,10 +188,16 @@ public class DoSection implements ExecutableSection {
                         } else if (token.isValue()) {
                             if ("body".equals(paramName)) {
                                 String body = parser.text();
-                                XContentParser bodyParser = JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, body);
-                                // multiple bodies are supported e.g. in case of bulk provided as a whole string
-                                while (bodyParser.nextToken() != null) {
-                                    apiCallSection.addBody(bodyParser.mapOrdered());
+                                try (
+                                    XContentParser bodyParser = JsonXContent.jsonXContent.createParser(
+                                        XContentParserConfiguration.EMPTY,
+                                        body
+                                    )
+                                ) {
+                                    // multiple bodies are supported e.g. in case of bulk provided as a whole string
+                                    while (bodyParser.nextToken() != null) {
+                                        apiCallSection.addBody(bodyParser.mapOrdered());
+                                    }
                                 }
                             } else {
                                 apiCallSection.addParam(paramName, parser.text());

--- a/x-pack/plugin/apm-data/src/main/java/org/elasticsearch/xpack/apmdata/APMIndexTemplateRegistry.java
+++ b/x-pack/plugin/apm-data/src/main/java/org/elasticsearch/xpack/apmdata/APMIndexTemplateRegistry.java
@@ -134,7 +134,9 @@ public class APMIndexTemplateRegistry extends IndexTemplateRegistry {
     private static ComponentTemplate loadComponentTemplate(String name, int version) {
         try {
             final byte[] content = loadVersionedResourceUTF8("/component-templates/" + name + ".yaml", version);
-            return ComponentTemplate.parse(YamlXContent.yamlXContent.createParser(XContentParserConfiguration.EMPTY, content));
+            try (var parser = YamlXContent.yamlXContent.createParser(XContentParserConfiguration.EMPTY, content)) {
+                return ComponentTemplate.parse(parser);
+            }
         } catch (Exception e) {
             throw new RuntimeException("failed to load APM Ingest plugin's component template: " + name, e);
         }
@@ -143,7 +145,9 @@ public class APMIndexTemplateRegistry extends IndexTemplateRegistry {
     private static ComposableIndexTemplate loadIndexTemplate(String name, int version) {
         try {
             final byte[] content = loadVersionedResourceUTF8("/index-templates/" + name + ".yaml", version);
-            return ComposableIndexTemplate.parse(YamlXContent.yamlXContent.createParser(XContentParserConfiguration.EMPTY, content));
+            try (var parser = YamlXContent.yamlXContent.createParser(XContentParserConfiguration.EMPTY, content)) {
+                return ComposableIndexTemplate.parse(parser);
+            }
         } catch (Exception e) {
             throw new RuntimeException("failed to load APM Ingest plugin's index template: " + name, e);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/notifications/AbstractAuditor.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/notifications/AbstractAuditor.java
@@ -67,11 +67,9 @@ public abstract class AbstractAuditor<T extends AbstractAuditMessage> {
     ) {
 
         this(client, auditIndex, templateConfig.getTemplateName(), () -> {
-            try {
+            try (var parser = JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, templateConfig.loadBytes())) {
                 return new PutComposableIndexTemplateAction.Request(templateConfig.getTemplateName()).indexTemplate(
-                    ComposableIndexTemplate.parse(
-                        JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, templateConfig.loadBytes())
-                    )
+                    ComposableIndexTemplate.parse(parser)
                 ).masterNodeTimeout(MASTER_TIMEOUT);
             } catch (IOException e) {
                 throw new ElasticsearchParseException("unable to parse composable template " + templateConfig.getTemplateName(), e);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/CategorizationAnalyzerConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/CategorizationAnalyzerConfig.java
@@ -294,11 +294,14 @@ public class CategorizationAnalyzerConfig implements ToXContentFragment, Writeab
      */
     public Map<String, Object> asMap(NamedXContentRegistry xContentRegistry) throws IOException {
         String strRep = Strings.toString(this);
-        XContentParser parser = JsonXContent.jsonXContent.createParser(
-            XContentParserConfiguration.EMPTY.withRegistry(xContentRegistry).withDeprecationHandler(LoggingDeprecationHandler.INSTANCE),
-            strRep
-        );
-        return parser.mapOrdered();
+        try (
+            XContentParser parser = JsonXContent.jsonXContent.createParser(
+                XContentParserConfiguration.EMPTY.withRegistry(xContentRegistry).withDeprecationHandler(LoggingDeprecationHandler.INSTANCE),
+                strRep
+            )
+        ) {
+            return parser.mapOrdered();
+        }
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAlias.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAlias.java
@@ -329,11 +329,9 @@ public final class MlIndexAndAlias {
         }
 
         PutComposableIndexTemplateAction.Request request;
-        try {
+        try (var parser = JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, templateConfig.loadBytes())) {
             request = new PutComposableIndexTemplateAction.Request(templateConfig.getTemplateName()).indexTemplate(
-                ComposableIndexTemplate.parse(
-                    JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, templateConfig.loadBytes())
-                )
+                ComposableIndexTemplate.parse(parser)
             ).masterNodeTimeout(masterTimeout);
         } catch (IOException e) {
             throw new ElasticsearchParseException("unable to parse composable template " + templateConfig.getTemplateName(), e);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/EnrollmentToken.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/EnrollmentToken.java
@@ -109,11 +109,14 @@ public class EnrollmentToken {
         if (Strings.isNullOrEmpty(encoded)) {
             throw new IOException("Cannot decode enrollment token from an empty string");
         }
-        final XContentParser jsonParser = JsonXContent.jsonXContent.createParser(
-            XContentParserConfiguration.EMPTY,
-            Base64.getDecoder().decode(encoded)
-        );
-        return EnrollmentToken.PARSER.parse(jsonParser, null);
+        try (
+            XContentParser jsonParser = JsonXContent.jsonXContent.createParser(
+                XContentParserConfiguration.EMPTY,
+                Base64.getDecoder().decode(encoded)
+            )
+        ) {
+            return EnrollmentToken.PARSER.parse(jsonParser, null);
+        }
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/CrossClusterApiKeyRoleDescriptorBuilder.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/CrossClusterApiKeyRoleDescriptorBuilder.java
@@ -91,10 +91,9 @@ public class CrossClusterApiKeyRoleDescriptorBuilder {
     }
 
     public static CrossClusterApiKeyRoleDescriptorBuilder parse(String access) throws IOException {
-        return CrossClusterApiKeyRoleDescriptorBuilder.PARSER.parse(
-            JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, access),
-            null
-        );
+        try (var parser = JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, access)) {
+            return CrossClusterApiKeyRoleDescriptorBuilder.PARSER.parse(parser, null);
+        }
     }
 
     static void validate(RoleDescriptor roleDescriptor) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/mapper/TemplateRoleName.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/mapper/TemplateRoleName.java
@@ -116,32 +116,35 @@ public class TemplateRoleName implements ToXContentObject, Writeable {
     }
 
     private static List<String> convertJsonToList(String evaluation) throws IOException {
-        final XContentParser parser = XContentFactory.xContent(XContentType.JSON)
-            .createParser(XContentParserConfiguration.EMPTY, evaluation);
-        XContentParser.Token token = parser.currentToken();
-        if (token == null) {
-            token = parser.nextToken();
-        }
-        if (token == XContentParser.Token.VALUE_STRING) {
-            return Collections.singletonList(parser.text());
-        } else if (token == XContentParser.Token.START_ARRAY) {
-            return parser.list().stream().filter(Objects::nonNull).map(o -> {
-                if (o instanceof String) {
-                    return (String) o;
-                } else {
-                    throw new XContentParseException(
-                        "Roles array may only contain strings but found [" + o.getClass().getName() + "] [" + o + "]"
-                    );
-                }
-            }).collect(Collectors.toList());
-        } else {
-            throw new XContentParseException("Roles template must generate a string or an array of strings, but found [" + token + "]");
+        try (
+            XContentParser parser = XContentFactory.xContent(XContentType.JSON).createParser(XContentParserConfiguration.EMPTY, evaluation)
+        ) {
+            XContentParser.Token token = parser.currentToken();
+            if (token == null) {
+                token = parser.nextToken();
+            }
+            if (token == XContentParser.Token.VALUE_STRING) {
+                return Collections.singletonList(parser.text());
+            } else if (token == XContentParser.Token.START_ARRAY) {
+                return parser.list().stream().filter(Objects::nonNull).map(o -> {
+                    if (o instanceof String) {
+                        return (String) o;
+                    } else {
+                        throw new XContentParseException(
+                            "Roles array may only contain strings but found [" + o.getClass().getName() + "] [" + o + "]"
+                        );
+                    }
+                }).collect(Collectors.toList());
+            } else {
+                throw new XContentParseException("Roles template must generate a string or an array of strings, but found [" + token + "]");
+            }
         }
     }
 
     private String parseTemplate(ScriptService scriptService, Map<String, Object> parameters) throws IOException {
-        final XContentParser parser = XContentHelper.createParser(XContentParserConfiguration.EMPTY, template, XContentType.JSON);
-        return MustacheTemplateEvaluator.evaluate(scriptService, parser, parameters);
+        try (XContentParser parser = XContentHelper.createParser(XContentParserConfiguration.EMPTY, template, XContentType.JSON)) {
+            return MustacheTemplateEvaluator.evaluate(scriptService, parser, parameters);
+        }
     }
 
     private static BytesReference extractTemplate(XContentParser parser, Void ignore) throws IOException {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/mapper/expressiondsl/ExpressionParser.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/mapper/expressiondsl/ExpressionParser.java
@@ -57,8 +57,8 @@ public final class ExpressionParser {
      * @param content The XContent (typically JSON) DSL representation of the expression
      */
     public RoleMapperExpression parse(String name, XContentSource content) throws IOException {
-        try (InputStream stream = content.getBytes().streamInput()) {
-            return parse(name, content.parser(NamedXContentRegistry.EMPTY, stream));
+        try (InputStream stream = content.getBytes().streamInput(); var parser = content.parser(NamedXContentRegistry.EMPTY, stream)) {
+            return parse(name, parser);
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/template/IndexTemplateRegistry.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/template/IndexTemplateRegistry.java
@@ -646,10 +646,8 @@ public abstract class IndexTemplateRegistry implements ClusterStateListener {
 
     protected static Map<String, ComposableIndexTemplate> parseComposableTemplates(IndexTemplateConfig... config) {
         return Arrays.stream(config).collect(Collectors.toUnmodifiableMap(IndexTemplateConfig::getTemplateName, indexTemplateConfig -> {
-            try {
-                return ComposableIndexTemplate.parse(
-                    JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, indexTemplateConfig.loadBytes())
-                );
+            try (var parser = JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, indexTemplateConfig.loadBytes())) {
+                return ComposableIndexTemplate.parse(parser);
             } catch (IOException e) {
                 throw new AssertionError(e);
             }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/QueryConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/QueryConfig.java
@@ -106,11 +106,14 @@ public class QueryConfig implements SimpleDiffable<QueryConfig>, Writeable, ToXC
         NamedXContentRegistry namedXContentRegistry,
         DeprecationHandler deprecationHandler
     ) throws IOException {
-        QueryBuilder query = null;
+        final QueryBuilder query;
         XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().map(source);
-        XContentParser sourceParser = XContentType.JSON.xContent()
-            .createParser(namedXContentRegistry, deprecationHandler, BytesReference.bytes(xContentBuilder).streamInput());
-        query = AbstractQueryBuilder.parseTopLevelQuery(sourceParser);
+        try (
+            XContentParser sourceParser = XContentType.JSON.xContent()
+                .createParser(namedXContentRegistry, deprecationHandler, BytesReference.bytes(xContentBuilder).streamInput())
+        ) {
+            query = AbstractQueryBuilder.parseTopLevelQuery(sourceParser);
+        }
 
         return query;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/pivot/AggregationConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/pivot/AggregationConfig.java
@@ -139,13 +139,15 @@ public class AggregationConfig implements Writeable, ToXContentObject {
         NamedXContentRegistry namedXContentRegistry,
         DeprecationHandler deprecationHandler
     ) throws IOException {
-        AggregatorFactories.Builder aggregations = null;
-
+        final AggregatorFactories.Builder aggregations;
         XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().map(source);
-        XContentParser sourceParser = XContentType.JSON.xContent()
-            .createParser(namedXContentRegistry, deprecationHandler, BytesReference.bytes(xContentBuilder).streamInput());
-        sourceParser.nextToken();
-        aggregations = AggregatorFactories.parseAggregators(sourceParser);
+        try (
+            XContentParser sourceParser = XContentType.JSON.xContent()
+                .createParser(namedXContentRegistry, deprecationHandler, BytesReference.bytes(xContentBuilder).streamInput())
+        ) {
+            sourceParser.nextToken();
+            aggregations = AggregatorFactories.parseAggregators(sourceParser);
+        }
 
         return aggregations;
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/JobTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/JobTests.java
@@ -108,12 +108,14 @@ public class JobTests extends AbstractXContentSerializingTestCase<Job> {
         ToXContent.MapParams params = new ToXContent.MapParams(Collections.singletonMap(ToXContentParams.FOR_INTERNAL_STORAGE, "true"));
 
         BytesReference serializedJob = XContentHelper.toXContent(config, XContentType.JSON, params, false);
-        XContentParser parser = XContentFactory.xContent(XContentType.JSON)
-            .createParser(XContentParserConfiguration.EMPTY.withRegistry(xContentRegistry()), serializedJob.streamInput());
-
-        Job parsedConfig = Job.LENIENT_PARSER.apply(parser, null).build();
-        // When we are writing for internal storage, we do not include the datafeed config
-        assertThat(parsedConfig.getDatafeedConfig().isPresent(), is(false));
+        try (
+            XContentParser parser = XContentFactory.xContent(XContentType.JSON)
+                .createParser(XContentParserConfiguration.EMPTY.withRegistry(xContentRegistry()), serializedJob.streamInput())
+        ) {
+            Job parsedConfig = Job.LENIENT_PARSER.apply(parser, null).build();
+            // When we are writing for internal storage, we do not include the datafeed config
+            assertThat(parsedConfig.getDatafeedConfig().isPresent(), is(false));
+        }
     }
 
     public void testFutureConfigParse() throws IOException {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappingsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappingsTests.java
@@ -362,10 +362,9 @@ public class ElasticsearchMappingsTests extends ESTestCase {
 
     private Set<String> collectFieldNames(String mapping) throws IOException {
         BufferedInputStream inputStream = new BufferedInputStream(new ByteArrayInputStream(mapping.getBytes(StandardCharsets.UTF_8)));
-        XContentParser parser = JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, inputStream);
         Set<String> fieldNames = new HashSet<>();
         boolean isAfterPropertiesStart = false;
-        try {
+        try (XContentParser parser = JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, inputStream)) {
             XContentParser.Token token = parser.nextToken();
             while (token != null) {
                 switch (token) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/RoleRestrictionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/RoleRestrictionTests.java
@@ -72,9 +72,10 @@ public class RoleRestrictionTests extends ESTestCase {
         final Restriction restriction = randomWorkflowsRestriction(1, 5);
         final XContentType xContentType = randomFrom(XContentType.values());
         final BytesReference xContentValue = toShuffledXContent(restriction, xContentType, ToXContent.EMPTY_PARAMS, false);
-        final XContentParser parser = xContentType.xContent().createParser(XContentParserConfiguration.EMPTY, xContentValue.streamInput());
-        final Restriction parsed = Restriction.parse(randomAlphaOfLengthBetween(3, 6), parser);
-        assertThat(parsed, equalTo(restriction));
+        try (XContentParser parser = xContentType.xContent().createParser(XContentParserConfiguration.EMPTY, xContentValue.streamInput())) {
+            final Restriction parsed = Restriction.parse(randomAlphaOfLengthBetween(3, 6), parser);
+            assertThat(parsed, equalTo(restriction));
+        }
     }
 
     public void testSerialization() throws IOException {

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/logging/DeprecationIndexingTemplateRegistry.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/logging/DeprecationIndexingTemplateRegistry.java
@@ -70,11 +70,8 @@ public class DeprecationIndexingTemplateRegistry extends IndexTemplateRegistry {
                 DEPRECATION_INDEXING_TEMPLATE_VERSION_VARIABLE
             )
         )) {
-            try {
-                componentTemplates.put(
-                    config.getTemplateName(),
-                    ComponentTemplate.parse(JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, config.loadBytes()))
-                );
+            try (var parser = JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, config.loadBytes())) {
+                componentTemplates.put(config.getTemplateName(), ComponentTemplate.parse(parser));
             } catch (IOException e) {
                 throw new AssertionError(e);
             }

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/RestDownsampleAction.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/RestDownsampleAction.java
@@ -35,7 +35,10 @@ public class RestDownsampleAction extends BaseRestHandler {
         String sourceIndex = restRequest.param("index");
         String targetIndex = restRequest.param("target_index");
         String timeout = restRequest.param("timeout");
-        DownsampleConfig config = DownsampleConfig.fromXContent(restRequest.contentParser());
+        DownsampleConfig config;
+        try (var parser = restRequest.contentParser()) {
+            config = DownsampleConfig.fromXContent(parser);
+        }
         DownsampleAction.Request request = new DownsampleAction.Request(
             sourceIndex,
             targetIndex,

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/AnalyticsTemplateRegistry.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/AnalyticsTemplateRegistry.java
@@ -65,11 +65,8 @@ public class AnalyticsTemplateRegistry extends IndexTemplateRegistry {
                 TEMPLATE_VERSION_VARIABLE
             )
         )) {
-            try {
-                componentTemplates.put(
-                    config.getTemplateName(),
-                    ComponentTemplate.parse(JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, config.loadBytes()))
-                );
+            try (var parser = JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, config.loadBytes())) {
+                componentTemplates.put(config.getTemplateName(), ComponentTemplate.parse(parser));
             } catch (IOException e) {
                 throw new AssertionError(e);
             }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorTemplateRegistry.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorTemplateRegistry.java
@@ -98,11 +98,8 @@ public class ConnectorTemplateRegistry extends IndexTemplateRegistry {
             )
         )) {
 
-            try {
-                componentTemplates.put(
-                    config.getTemplateName(),
-                    ComponentTemplate.parse(JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, config.loadBytes()))
-                );
+            try (var parser = JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, config.loadBytes())) {
+                componentTemplates.put(config.getTemplateName(), ComponentTemplate.parse(parser));
             } catch (IOException e) {
                 throw new AssertionError(e);
             }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/RestRenderSearchApplicationQueryAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/RestRenderSearchApplicationQueryAction.java
@@ -42,7 +42,9 @@ public class RestRenderSearchApplicationQueryAction extends EnterpriseSearchBase
         final String searchAppName = restRequest.param("name");
         SearchApplicationSearchRequest request;
         if (restRequest.hasContent()) {
-            request = SearchApplicationSearchRequest.fromXContent(searchAppName, restRequest.contentParser());
+            try (var parser = restRequest.contentParser()) {
+                request = SearchApplicationSearchRequest.fromXContent(searchAppName, parser);
+            }
         } else {
             request = new SearchApplicationSearchRequest(searchAppName);
         }

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/RestMigrateToDataTiersAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/RestMigrateToDataTiersAction.java
@@ -33,9 +33,14 @@ public class RestMigrateToDataTiersAction extends BaseRestHandler {
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
-        MigrateToDataTiersRequest migrateRequest = request.hasContent()
-            ? MigrateToDataTiersRequest.parse(request.contentParser())
-            : new MigrateToDataTiersRequest();
+        MigrateToDataTiersRequest migrateRequest;
+        if (request.hasContent()) {
+            try (var parser = request.contentParser()) {
+                migrateRequest = MigrateToDataTiersRequest.parse(parser);
+            }
+        } else {
+            migrateRequest = new MigrateToDataTiersRequest();
+        }
         migrateRequest.setDryRun(request.paramAsBoolean("dry_run", false));
         return channel -> client.execute(MigrateToDataTiersAction.INSTANCE, migrateRequest, new RestToXContentListener<>(channel));
     }

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/RestMoveToStepAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/RestMoveToStepAction.java
@@ -35,8 +35,10 @@ public class RestMoveToStepAction extends BaseRestHandler {
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
         String index = restRequest.param("name");
-        XContentParser parser = restRequest.contentParser();
-        MoveToStepAction.Request request = MoveToStepAction.Request.parseRequest(index, parser);
+        MoveToStepAction.Request request;
+        try (XContentParser parser = restRequest.contentParser()) {
+            request = MoveToStepAction.Request.parseRequest(index, parser);
+        }
         request.timeout(restRequest.paramAsTime("timeout", request.timeout()));
         request.masterNodeTimeout(restRequest.paramAsTime("master_timeout", request.masterNodeTimeout()));
         return channel -> client.execute(MoveToStepAction.INSTANCE, request, new RestToXContentListener<>(channel));

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rest/RestInferenceAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rest/RestInferenceAction.java
@@ -33,8 +33,9 @@ public class RestInferenceAction extends BaseRestHandler {
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
         String taskType = restRequest.param("task_type");
         String modelId = restRequest.param("model_id");
-        var request = InferenceAction.Request.parseRequest(modelId, taskType, restRequest.contentParser());
-
-        return channel -> client.execute(InferenceAction.INSTANCE, request, new RestToXContentListener<>(channel));
+        try (var parser = restRequest.contentParser()) {
+            var request = InferenceAction.Request.parseRequest(modelId, taskType, parser);
+            return channel -> client.execute(InferenceAction.INSTANCE, request, new RestToXContentListener<>(channel));
+        }
     }
 }

--- a/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/action/ModelLoaderUtils.java
+++ b/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/action/ModelLoaderUtils.java
@@ -130,9 +130,13 @@ final class ModelLoaderUtils {
 
     // visible for testing
     static VocabularyParts parseVocabParts(InputStream vocabInputStream) throws IOException {
-        XContentParser sourceParser = XContentType.JSON.xContent()
-            .createParser(XContentParserConfiguration.EMPTY, Streams.limitStream(vocabInputStream, VOCABULARY_SIZE_LIMIT.getBytes()));
-        Map<String, List<Object>> vocabParts = sourceParser.map(HashMap::new, XContentParser::list);
+        Map<String, List<Object>> vocabParts;
+        try (
+            XContentParser sourceParser = XContentType.JSON.xContent()
+                .createParser(XContentParserConfiguration.EMPTY, Streams.limitStream(vocabInputStream, VOCABULARY_SIZE_LIMIT.getBytes()))
+        ) {
+            vocabParts = sourceParser.map(HashMap::new, XContentParser::list);
+        }
 
         List<String> vocabulary = vocabParts.containsKey(VOCABULARY)
             ? vocabParts.get(VOCABULARY).stream().map(Object::toString).collect(Collectors.toList())

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutTrainedModelAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutTrainedModelAction.java
@@ -583,24 +583,27 @@ public class TransportPutTrainedModelAction extends TransportMasterNodeAction<Re
         NamedXContentRegistry namedXContentRegistry,
         DeprecationHandler deprecationHandler
     ) throws IOException {
-        XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().map(source);
-        XContentParser sourceParser = XContentType.JSON.xContent()
-            .createParser(
-                XContentParserConfiguration.EMPTY.withRegistry(namedXContentRegistry).withDeprecationHandler(deprecationHandler),
-                BytesReference.bytes(xContentBuilder).streamInput()
-            );
+        try (
+            XContentBuilder xContentBuilder = XContentFactory.jsonBuilder().map(source);
+            XContentParser sourceParser = XContentType.JSON.xContent()
+                .createParser(
+                    XContentParserConfiguration.EMPTY.withRegistry(namedXContentRegistry).withDeprecationHandler(deprecationHandler),
+                    BytesReference.bytes(xContentBuilder).streamInput()
+                )
+        ) {
 
-        XContentParser.Token token = sourceParser.nextToken();
-        assert token == XContentParser.Token.START_OBJECT;
-        token = sourceParser.nextToken();
-        assert token == XContentParser.Token.FIELD_NAME;
-        String currentName = sourceParser.currentName();
+            XContentParser.Token token = sourceParser.nextToken();
+            assert token == XContentParser.Token.START_OBJECT;
+            token = sourceParser.nextToken();
+            assert token == XContentParser.Token.FIELD_NAME;
+            String currentName = sourceParser.currentName();
 
-        InferenceConfig inferenceConfig = sourceParser.namedObject(LenientlyParsedInferenceConfig.class, currentName, null);
-        // consume the end object token
-        token = sourceParser.nextToken();
-        assert token == XContentParser.Token.END_OBJECT;
-        return inferenceConfig;
+            InferenceConfig inferenceConfig = sourceParser.namedObject(LenientlyParsedInferenceConfig.class, currentName, null);
+            // consume the end object token
+            token = sourceParser.nextToken();
+            assert token == XContentParser.Token.END_OBJECT;
+            return inferenceConfig;
+        }
     }
 
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/persistence/DataFrameAnalyticsConfigProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/persistence/DataFrameAnalyticsConfigProvider.java
@@ -176,14 +176,12 @@ public class DataFrameAnalyticsConfigProvider {
 
             // Parse the original config
             DataFrameAnalyticsConfig originalConfig;
-            try {
-                try (
-                    InputStream stream = getResponse.getSourceAsBytesRef().streamInput();
-                    XContentParser parser = XContentFactory.xContent(XContentType.JSON)
-                        .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, stream)
-                ) {
-                    originalConfig = DataFrameAnalyticsConfig.LENIENT_PARSER.apply(parser, null).build();
-                }
+            try (
+                InputStream stream = getResponse.getSourceAsBytesRef().streamInput();
+                XContentParser parser = XContentFactory.xContent(XContentType.JSON)
+                    .createParser(xContentRegistry, LoggingDeprecationHandler.INSTANCE, stream)
+            ) {
+                originalConfig = DataFrameAnalyticsConfig.LENIENT_PARSER.apply(parser, null).build();
             } catch (IOException e) {
                 listener.onFailure(new ElasticsearchParseException("Failed to parse data frame analytics configuration [" + id + "]", e));
                 return;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ltr/LearningToRankService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ltr/LearningToRankService.java
@@ -189,13 +189,13 @@ public class LearningToRankService {
         try {
             Script script = new Script(ScriptType.INLINE, DEFAULT_TEMPLATE_LANG, templateSource, SCRIPT_OPTIONS, Collections.emptyMap());
             String parsedTemplate = scriptService.compile(script, TemplateScript.CONTEXT).newInstance(params).execute();
-            XContentParser parser = XContentType.JSON.xContent().createParser(parserConfiguration, parsedTemplate);
-
-            return new QueryExtractorBuilder(
-                queryExtractorBuilder.featureName(),
-                QueryProvider.fromXContent(parser, false, INFERENCE_CONFIG_QUERY_BAD_FORMAT),
-                queryExtractorBuilder.defaultScore()
-            );
+            try (XContentParser parser = XContentType.JSON.xContent().createParser(parserConfiguration, parsedTemplate)) {
+                return new QueryExtractorBuilder(
+                    queryExtractorBuilder.featureName(),
+                    QueryProvider.fromXContent(parser, false, INFERENCE_CONFIG_QUERY_BAD_FORMAT),
+                    queryExtractorBuilder.defaultScore()
+                );
+            }
         } catch (GeneralScriptException e) {
             if (e.getRootCause().getClass().getName().equals(MustacheInvalidParameterException.class.getName())) {
                 // Can't use instanceof since it return unexpected result.

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/ProcessResultsParser.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/ProcessResultsParser.java
@@ -40,9 +40,10 @@ public class ProcessResultsParser<T> {
     }
 
     public Iterator<T> parseResults(InputStream in) throws ElasticsearchParseException {
-        try {
+        try (
             XContentParser parser = XContentFactory.xContent(XContentType.JSON)
-                .createParser(namedXContentRegistry, LoggingDeprecationHandler.INSTANCE, in);
+                .createParser(namedXContentRegistry, LoggingDeprecationHandler.INSTANCE, in)
+        ) {
             XContentParser.Token token = parser.nextToken();
             // if start of an array ignore it, we expect an array of results
             if (token != XContentParser.Token.START_ARRAY) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/ProcessResultsParser.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/ProcessResultsParser.java
@@ -40,10 +40,9 @@ public class ProcessResultsParser<T> {
     }
 
     public Iterator<T> parseResults(InputStream in) throws ElasticsearchParseException {
-        try (
+        try {
             XContentParser parser = XContentFactory.xContent(XContentType.JSON)
-                .createParser(namedXContentRegistry, LoggingDeprecationHandler.INSTANCE, in)
-        ) {
+                .createParser(namedXContentRegistry, LoggingDeprecationHandler.INSTANCE, in);
             XContentParser.Token token = parser.nextToken();
             // if start of an array ignore it, we expect an array of results
             if (token != XContentParser.Token.START_ARRAY) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/RestDeleteExpiredDataAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/RestDeleteExpiredDataAction.java
@@ -49,7 +49,9 @@ public class RestDeleteExpiredDataAction extends BaseRestHandler {
 
         DeleteExpiredDataAction.Request request;
         if (restRequest.hasContent()) {
-            request = DeleteExpiredDataAction.Request.parseRequest(jobId, restRequest.contentParser());
+            try (var parser = restRequest.contentParser()) {
+                request = DeleteExpiredDataAction.Request.parseRequest(jobId, parser);
+            }
         } else {
             request = new DeleteExpiredDataAction.Request();
             request.setJobId(jobId);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/datafeeds/RestPutDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/datafeeds/RestPutDatafeedAction.java
@@ -47,8 +47,10 @@ public class RestPutDatafeedAction extends BaseRestHandler {
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
         String datafeedId = restRequest.param(DatafeedConfig.ID.getPreferredName());
         IndicesOptions indicesOptions = IndicesOptions.fromRequest(restRequest, SearchRequest.DEFAULT_INDICES_OPTIONS);
-        XContentParser parser = restRequest.contentParser();
-        PutDatafeedAction.Request putDatafeedRequest = PutDatafeedAction.Request.parseRequest(datafeedId, indicesOptions, parser);
+        PutDatafeedAction.Request putDatafeedRequest;
+        try (XContentParser parser = restRequest.contentParser()) {
+            putDatafeedRequest = PutDatafeedAction.Request.parseRequest(datafeedId, indicesOptions, parser);
+        }
         putDatafeedRequest.timeout(restRequest.paramAsTime("timeout", putDatafeedRequest.timeout()));
         putDatafeedRequest.masterNodeTimeout(restRequest.paramAsTime("master_timeout", putDatafeedRequest.masterNodeTimeout()));
         return channel -> client.execute(PutDatafeedAction.INSTANCE, putDatafeedRequest, new RestToXContentListener<>(channel));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/datafeeds/RestUpdateDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/datafeeds/RestUpdateDatafeedAction.java
@@ -53,8 +53,10 @@ public class RestUpdateDatafeedAction extends BaseRestHandler {
             || restRequest.hasParam("ignore_throttled")) {
             indicesOptions = IndicesOptions.fromRequest(restRequest, SearchRequest.DEFAULT_INDICES_OPTIONS);
         }
-        XContentParser parser = restRequest.contentParser();
-        UpdateDatafeedAction.Request updateDatafeedRequest = UpdateDatafeedAction.Request.parseRequest(datafeedId, indicesOptions, parser);
+        UpdateDatafeedAction.Request updateDatafeedRequest;
+        try (XContentParser parser = restRequest.contentParser()) {
+            updateDatafeedRequest = UpdateDatafeedAction.Request.parseRequest(datafeedId, indicesOptions, parser);
+        }
         updateDatafeedRequest.timeout(restRequest.paramAsTime("timeout", updateDatafeedRequest.timeout()));
         updateDatafeedRequest.masterNodeTimeout(restRequest.paramAsTime("master_timeout", updateDatafeedRequest.masterNodeTimeout()));
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/dataframe/RestPostDataFrameAnalyticsUpdateAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/dataframe/RestPostDataFrameAnalyticsUpdateAction.java
@@ -48,8 +48,10 @@ public class RestPostDataFrameAnalyticsUpdateAction extends BaseRestHandler {
         }
 
         String id = restRequest.param(DataFrameAnalyticsConfig.ID.getPreferredName());
-        XContentParser parser = restRequest.contentParser();
-        UpdateDataFrameAnalyticsAction.Request updateRequest = UpdateDataFrameAnalyticsAction.Request.parseRequest(id, parser);
+        UpdateDataFrameAnalyticsAction.Request updateRequest;
+        try (XContentParser parser = restRequest.contentParser()) {
+            updateRequest = UpdateDataFrameAnalyticsAction.Request.parseRequest(id, parser);
+        }
         updateRequest.timeout(restRequest.paramAsTime("timeout", updateRequest.timeout()));
 
         return channel -> client.execute(UpdateDataFrameAnalyticsAction.INSTANCE, updateRequest, new RestToXContentListener<>(channel));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/dataframe/RestPutDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/dataframe/RestPutDataFrameAnalyticsAction.java
@@ -57,8 +57,10 @@ public class RestPutDataFrameAnalyticsAction extends BaseRestHandler {
         }
 
         String id = restRequest.param(DataFrameAnalyticsConfig.ID.getPreferredName());
-        XContentParser parser = restRequest.contentParser();
-        PutDataFrameAnalyticsAction.Request putRequest = PutDataFrameAnalyticsAction.Request.parseRequest(id, parser);
+        PutDataFrameAnalyticsAction.Request putRequest;
+        try (XContentParser parser = restRequest.contentParser()) {
+            putRequest = PutDataFrameAnalyticsAction.Request.parseRequest(id, parser);
+        }
         putRequest.timeout(restRequest.paramAsTime("timeout", putRequest.timeout()));
 
         return channel -> client.execute(PutDataFrameAnalyticsAction.INSTANCE, putRequest, new RestToXContentListener<>(channel));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/inference/RestInferTrainedModelAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/inference/RestInferTrainedModelAction.java
@@ -47,7 +47,10 @@ public class RestInferTrainedModelAction extends BaseRestHandler {
         if (restRequest.hasContent() == false) {
             throw ExceptionsHelper.badRequestException("requires body");
         }
-        InferModelAction.Request.Builder request = InferModelAction.Request.parseRequest(modelId, restRequest.contentParser());
+        InferModelAction.Request.Builder request;
+        try (var parser = restRequest.contentParser()) {
+            request = InferModelAction.Request.parseRequest(modelId, parser);
+        }
 
         if (restRequest.hasParam(InferModelAction.Request.TIMEOUT.getPreferredName())) {
             TimeValue inferTimeout = restRequest.paramAsTime(

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/ProfilingIndexTemplateRegistry.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/ProfilingIndexTemplateRegistry.java
@@ -174,11 +174,8 @@ public class ProfilingIndexTemplateRegistry extends IndexTemplateRegistry {
                 indexVersion("symbols", PROFILING_SYMBOLS_VERSION)
             )
         )) {
-            try {
-                componentTemplates.put(
-                    config.getTemplateName(),
-                    ComponentTemplate.parse(JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, config.loadBytes()))
-                );
+            try (var parser = JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, config.loadBytes())) {
+                componentTemplates.put(config.getTemplateName(), ComponentTemplate.parse(parser));
             } catch (IOException e) {
                 throw new AssertionError(e);
             }

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestPutRollupJobAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestPutRollupJobAction.java
@@ -29,7 +29,10 @@ public class RestPutRollupJobAction extends BaseRestHandler {
     @Override
     protected RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
         final String id = request.param("id");
-        final PutRollupJobAction.Request putRollupJobRequest = PutRollupJobAction.Request.fromXContent(request.contentParser(), id);
+        final PutRollupJobAction.Request putRollupJobRequest;
+        try (var parser = request.contentParser()) {
+            putRollupJobRequest = PutRollupJobAction.Request.fromXContent(parser, id);
+        }
         return channel -> client.execute(PutRollupJobAction.INSTANCE, putRollupJobRequest, new RestToXContentListener<>(channel));
     }
 

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/AbstractRemoteClusterSecurityDlsAndFlsRestIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/AbstractRemoteClusterSecurityDlsAndFlsRestIT.java
@@ -170,9 +170,9 @@ public abstract class AbstractRemoteClusterSecurityDlsAndFlsRestIT extends Abstr
         String[] expectedRemoteIndices,
         String[] expectedFields
     ) {
-        try {
+        try (var parser = responseAsParser(searchResponse)) {
             assertOK(searchResponse);
-            final var searchResult = Arrays.stream(SearchResponse.fromXContent(responseAsParser(searchResponse)).getHits().getHits())
+            final var searchResult = Arrays.stream(SearchResponse.fromXContent(parser).getHits().getHits())
                 .collect(Collectors.toMap(SearchHit::getIndex, SearchHit::getSourceAsMap));
 
             assertThat(searchResult.keySet(), containsInAnyOrder(expectedRemoteIndices));
@@ -193,9 +193,9 @@ public abstract class AbstractRemoteClusterSecurityDlsAndFlsRestIT extends Abstr
         Response searchResponse,
         Map<String, Set<String>> expectedRemoteIndicesAndFields
     ) {
-        try {
+        try (var parser = responseAsParser(searchResponse)) {
             assertOK(searchResponse);
-            final var searchResult = Arrays.stream(SearchResponse.fromXContent(responseAsParser(searchResponse)).getHits().getHits())
+            final var searchResult = Arrays.stream(SearchResponse.fromXContent(parser).getHits().getHits())
                 .collect(Collectors.toMap(SearchHit::getIndex, SearchHit::getSourceAsMap));
 
             assertThat(searchResult.keySet(), equalTo(expectedRemoteIndicesAndFields.keySet()));
@@ -209,9 +209,9 @@ public abstract class AbstractRemoteClusterSecurityDlsAndFlsRestIT extends Abstr
     }
 
     protected void assertSearchResponseContainsEmptyResult(Response response) {
-        try {
+        try (var parser = responseAsParser(response)) {
             assertOK(response);
-            SearchResponse searchResponse = SearchResponse.fromXContent(responseAsParser(response));
+            SearchResponse searchResponse = SearchResponse.fromXContent(parser);
             try {
                 assertThat(searchResponse.getHits().getTotalHits().value, equalTo(0L));
             } finally {

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/AbstractRemoteClusterSecurityWithMultipleRemotesRestIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/AbstractRemoteClusterSecurityWithMultipleRemotesRestIT.java
@@ -214,7 +214,10 @@ public abstract class AbstractRemoteClusterSecurityWithMultipleRemotesRestIT ext
     static void searchAndAssertIndicesFound(String searchPath, String... expectedIndices) throws IOException {
         final Response response = performRequestWithRemoteSearchUser(new Request("GET", searchPath));
         assertOK(response);
-        final SearchResponse searchResponse = SearchResponse.fromXContent(responseAsParser(response));
+        final SearchResponse searchResponse;
+        try (var parser = responseAsParser(response)) {
+            searchResponse = SearchResponse.fromXContent(parser);
+        }
         try {
             final List<String> actualIndices = Arrays.stream(searchResponse.getHits().getHits())
                 .map(SearchHit::getIndex)

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityApiKeyRestIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityApiKeyRestIT.java
@@ -183,7 +183,10 @@ public class RemoteClusterSecurityApiKeyRestIT extends AbstractRemoteClusterSecu
             );
             final Response response = performRequestWithApiKey(searchRequest, apiKeyEncoded);
             assertOK(response);
-            final SearchResponse searchResponse = SearchResponse.fromXContent(responseAsParser(response));
+            final SearchResponse searchResponse;
+            try (var parser = responseAsParser(response)) {
+                searchResponse = SearchResponse.fromXContent(parser);
+            }
             try {
                 final List<String> actualIndices = Arrays.stream(searchResponse.getHits().getHits())
                     .map(SearchHit::getIndex)

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityBwcRestIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityBwcRestIT.java
@@ -189,7 +189,10 @@ public class RemoteClusterSecurityBwcRestIT extends AbstractRemoteClusterSecurit
                 ? performRequestWithRemoteAccessUser(searchRequest)
                 : performRequestWithApiKey(searchRequest, apiKeyEncoded);
             assertOK(response);
-            final SearchResponse searchResponse = SearchResponse.fromXContent(responseAsParser(response));
+            final SearchResponse searchResponse;
+            try (var parser = responseAsParser(response)) {
+                searchResponse = SearchResponse.fromXContent(parser);
+            }
             try {
                 final List<String> actualIndices = Arrays.stream(searchResponse.getHits().getHits())
                     .map(SearchHit::getIndex)

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityCcrIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityCcrIT.java
@@ -276,7 +276,10 @@ public class RemoteClusterSecurityCcrIT extends AbstractRemoteClusterSecurityTes
                 throw new AssertionError(e);
             }
             assertOK(response);
-            final SearchResponse searchResponse = SearchResponse.fromXContent(responseAsParser(response));
+            final SearchResponse searchResponse;
+            try (var parser = responseAsParser(response)) {
+                searchResponse = SearchResponse.fromXContent(parser);
+            }
             try {
                 assertThat(searchResponse.getHits().getTotalHits().value, equalTo(numberOfDocs));
                 assertThat(

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
@@ -803,7 +803,7 @@ public class ApiKeyService {
         final Authentication authentication,
         final BaseUpdateApiKeyRequest request,
         final Set<RoleDescriptor> userRoleDescriptors
-    ) {
+    ) throws IOException {
         if (apiKeyDoc.version != targetDocVersion.id) {
             return false;
         }
@@ -824,12 +824,11 @@ public class ApiKeyService {
                 return false;
             }
             @SuppressWarnings("unchecked")
-            final var currentRealmDomain = RealmDomain.fromXContent(
-                XContentHelper.mapToXContentParser(
-                    XContentParserConfiguration.EMPTY,
-                    (Map<String, Object>) currentCreator.get("realm_domain")
-                )
-            );
+            var m = (Map<String, Object>) currentCreator.get("realm_domain");
+            final RealmDomain currentRealmDomain;
+            try (var parser = XContentHelper.mapToXContentParser(XContentParserConfiguration.EMPTY, m)) {
+                currentRealmDomain = RealmDomain.fromXContent(parser);
+            }
             if (sourceRealm.getDomain().equals(currentRealmDomain) == false) {
                 return false;
             }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/FileRolesStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/FileRolesStore.java
@@ -280,8 +280,7 @@ public class FileRolesStore implements BiConsumer<Set<String>, ActionListener<Ro
         String roleName = null;
         XContentParserConfiguration parserConfig = XContentParserConfiguration.EMPTY.withRegistry(xContentRegistry)
             .withDeprecationHandler(LoggingDeprecationHandler.INSTANCE);
-        try {
-            XContentParser parser = YamlXContent.yamlXContent.createParser(parserConfig, segment);
+        try (XContentParser parser = YamlXContent.yamlXContent.createParser(parserConfig, segment)) {
             XContentParser.Token token = parser.nextToken();
             if (token == XContentParser.Token.START_OBJECT) {
                 token = parser.nextToken();

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/profile/RestUpdateProfileDataAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/profile/RestUpdateProfileDataAction.java
@@ -63,7 +63,10 @@ public class RestUpdateProfileDataAction extends SecurityBaseRestHandler {
         final long ifPrimaryTerm = request.paramAsLong("if_primary_term", -1);
         final long ifSeqNo = request.paramAsLong("if_seq_no", -1);
         final RefreshPolicy refreshPolicy = RefreshPolicy.parse(request.param("refresh", "wait_for"));
-        final Payload payload = PARSER.parse(request.contentParser(), null);
+        final Payload payload;
+        try (var parser = request.contentParser()) {
+            payload = PARSER.parse(parser, null);
+        }
 
         final UpdateProfileDataRequest updateProfileDataRequest = new UpdateProfileDataRequest(
             uid,

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/settings/RestUpdateSecuritySettingsAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/settings/RestUpdateSecuritySettingsAction.java
@@ -36,7 +36,10 @@ public class RestUpdateSecuritySettingsAction extends SecurityBaseRestHandler {
 
     @Override
     protected RestChannelConsumer innerPrepareRequest(RestRequest request, NodeClient client) throws IOException {
-        UpdateSecuritySettingsAction.Request req = UpdateSecuritySettingsAction.Request.parse(request.contentParser());
+        UpdateSecuritySettingsAction.Request req;
+        try (var parser = request.contentParser()) {
+            req = UpdateSecuritySettingsAction.Request.parse(parser);
+        }
         return restChannel -> client.execute(UpdateSecuritySettingsAction.INSTANCE, req, new RestToXContentListener<>(restChannel));
     }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
@@ -2243,13 +2243,11 @@ public class ApiKeyServiceTests extends ESTestCase {
             assertEquals(realm.getType(), updatedApiKeyDoc.creator.get("realm_type"));
             if (realm.getDomain() != null) {
                 @SuppressWarnings("unchecked")
-                final var actualRealmDomain = RealmDomain.fromXContent(
-                    XContentHelper.mapToXContentParser(
-                        XContentParserConfiguration.EMPTY,
-                        (Map<String, Object>) updatedApiKeyDoc.creator.get("realm_domain")
-                    )
-                );
-                assertEquals(realm.getDomain(), actualRealmDomain);
+                var m = (Map<String, Object>) updatedApiKeyDoc.creator.get("realm_domain");
+                try (var p = XContentHelper.mapToXContentParser(XContentParserConfiguration.EMPTY, m)) {
+                    final var actualRealmDomain = RealmDomain.fromXContent(p);
+                    assertEquals(realm.getDomain(), actualRealmDomain);
+                }
             } else {
                 assertFalse(updatedApiKeyDoc.creator.containsKey("realm_domain"));
             }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/SecurityRestFilterTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/SecurityRestFilterTests.java
@@ -230,13 +230,17 @@ public class SecurityRestFilterTests extends ESTestCase {
 
         assertEquals(restRequest, handlerRequest.get());
         assertEquals(restRequest.content(), handlerRequest.get().content());
-        Map<String, Object> original = XContentType.JSON.xContent()
-            .createParser(
-                NamedXContentRegistry.EMPTY,
-                DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
-                handlerRequest.get().content().streamInput()
-            )
-            .map();
+        Map<String, Object> original;
+        try (
+            var parser = XContentType.JSON.xContent()
+                .createParser(
+                    NamedXContentRegistry.EMPTY,
+                    DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                    handlerRequest.get().content().streamInput()
+                )
+        ) {
+            original = parser.map();
+        }
         assertEquals(2, original.size());
         assertEquals(SecuritySettingsSourceField.TEST_PASSWORD, original.get("password"));
         assertEquals("bar", original.get("foo"));
@@ -244,13 +248,17 @@ public class SecurityRestFilterTests extends ESTestCase {
         assertNotEquals(restRequest, auditTrailRequest.get());
         assertNotEquals(restRequest.content(), auditTrailRequest.get().content());
 
-        Map<String, Object> map = XContentType.JSON.xContent()
-            .createParser(
-                NamedXContentRegistry.EMPTY,
-                DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
-                auditTrailRequest.get().content().streamInput()
-            )
-            .map();
+        Map<String, Object> map;
+        try (
+            var parser = XContentType.JSON.xContent()
+                .createParser(
+                    NamedXContentRegistry.EMPTY,
+                    DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                    auditTrailRequest.get().content().streamInput()
+                )
+        ) {
+            map = parser.map();
+        }
         assertEquals(1, map.size());
         assertEquals("bar", map.get("foo"));
     }

--- a/x-pack/plugin/sql/sql-action/src/test/java/org/elasticsearch/xpack/sql/action/SqlTestUtils.java
+++ b/x-pack/plugin/sql/sql-action/src/test/java/org/elasticsearch/xpack/sql/action/SqlTestUtils.java
@@ -103,10 +103,13 @@ public final class SqlTestUtils {
             objectGenerator.accept(generator);
             generator.close();
             // System.out.println(out.toString(StandardCharsets.UTF_8));
-            XContentParser parser = builder.contentType()
-                .xContent()
-                .createParser(XContentParserConfiguration.EMPTY, new ByteArrayInputStream(out.toByteArray()));
-            builder.copyCurrentStructure(parser);
+            try (
+                XContentParser parser = builder.contentType()
+                    .xContent()
+                    .createParser(XContentParserConfiguration.EMPTY, new ByteArrayInputStream(out.toByteArray()))
+            ) {
+                builder.copyCurrentStructure(parser);
+            }
             builder.flush();
             ByteArrayOutputStream stream = (ByteArrayOutputStream) builder.getOutputStream();
             assertEquals("serialized objects differ", out.toString(StandardCharsets.UTF_8), stream.toString(StandardCharsets.UTF_8));

--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/NdJsonTextStructureFinder.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/NdJsonTextStructureFinder.java
@@ -44,9 +44,10 @@ public class NdJsonTextStructureFinder implements TextStructureFinder {
 
         List<String> sampleMessages = Arrays.asList(sample.split("\n"));
         for (String sampleMessage : sampleMessages) {
-            XContentParser parser = jsonXContent.createParser(XContentParserConfiguration.EMPTY, sampleMessage);
-            sampleRecords.add(parser.mapOrdered());
-            timeoutChecker.check("NDJSON parsing");
+            try (XContentParser parser = jsonXContent.createParser(XContentParserConfiguration.EMPTY, sampleMessage)) {
+                sampleRecords.add(parser.mapOrdered());
+                timeoutChecker.check("NDJSON parsing");
+            }
         }
 
         TextStructure.Builder structureBuilder = new TextStructure.Builder(TextStructure.Format.NDJSON).setCharset(charsetName)

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/Pivot.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/Pivot.java
@@ -209,11 +209,18 @@ public class Pivot extends AbstractCompositeAggFunction {
 
             builder.endArray();
             builder.endObject(); // sources
-            XContentParser parser = builder.generator()
-                .contentType()
-                .xContent()
-                .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, BytesReference.bytes(builder).streamInput());
-            compositeAggregation = CompositeAggregationBuilder.PARSER.parse(parser, COMPOSITE_AGGREGATION_NAME);
+            try (
+                XContentParser parser = builder.generator()
+                    .contentType()
+                    .xContent()
+                    .createParser(
+                        NamedXContentRegistry.EMPTY,
+                        LoggingDeprecationHandler.INSTANCE,
+                        BytesReference.bytes(builder).streamInput()
+                    )
+            ) {
+                compositeAggregation = CompositeAggregationBuilder.PARSER.parse(parser, COMPOSITE_AGGREGATION_NAME);
+            }
         } catch (IOException e) {
             throw new RuntimeException(
                 TransformMessages.getMessage(TransformMessages.TRANSFORM_FAILED_TO_CREATE_COMPOSITE_AGGREGATION, "pivot"),


### PR DESCRIPTION
We're leaking quite a few of these parsers. That doesn't seem to be much of a problem but results in some memory inefficiencies in Jackson here and there. This PR bulk fixes a bunch of instances that I could easily automatically fix but is not exhaustive by any means. It covers most of the production spots that were left though.