### PR TITLE
[Connectors API] Fix ClassCastException when creating a new sync job

### DIFF
--- a/docs/changelog/103508.yaml
+++ b/docs/changelog/103508.yaml
@@ -1,0 +1,5 @@
+pr: 103508
+summary: "[Connectors API] Fix `ClassCastException` when creating a new sync job"
+area: Application
+type: bug
+issues: []

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/400_connector_sync_job_post.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/400_connector_sync_job_post.yml
@@ -41,8 +41,68 @@ setup:
   - exists: created_at
   - exists: last_seen
 
+---
+'Create connector sync job with complex connector document':
+
+  - do:
+      connector.update_pipeline:
+        connector_id: test-connector
+        body:
+          pipeline:
+            extract_binary_content: true
+            name: test-pipeline
+            reduce_whitespace: true
+            run_ml_inference: false
+
+  - match: { result: updated }
+
+  - do:
+      connector.update_configuration:
+        connector_id: test-connector
+        body:
+          configuration:
+            some_field:
+              default_value: null
+              depends_on:
+                - field: some_field
+                  value: 31
+              display: numeric
+              label: Very important field
+              options: [ ]
+              order: 4
+              required: true
+              sensitive: false
+              tooltip: Wow, this tooltip is useful.
+              type: str
+              ui_restrictions: [ ]
+              validations:
+                - constraint: 0
+                  type: greater_than
+              value: 456
+
+  - match: { result: updated }
+
+  - do:
+      connector_sync_job.post:
+        body:
+          id: test-connector
+          job_type: full
+          trigger_method: on_demand
+
+  - set:  { id: id }
+
+  - match: { id: $id }
+
+  - do:
+      connector_sync_job.get:
+        connector_sync_job_id: $id
+
+  - match: { connector.id: test-connector }
+  - match: { connector.configuration.some_field.value: 456 }
+  - match: { connector.pipeline.name: test-pipeline }
 
 ---
+
 'Create connector sync job with missing job type - expect job type full as default':
   - do:
       connector_sync_job.post:

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobTests.java
@@ -400,7 +400,7 @@ public class ConnectorSyncJobTests extends ESTestCase {
             }
             """);
 
-        Connector connector = ConnectorSyncJob.syncJobConnectorFromXContentBytes(new BytesArray(content), XContentType.JSON);
+        Connector connector = ConnectorSyncJob.syncJobConnectorFromXContentBytes(new BytesArray(content), null, XContentType.JSON);
 
         assertThat(connector.getConnectorId(), equalTo("connector-id"));
         assertThat(connector.getFiltering().size(), equalTo(1));
@@ -474,7 +474,7 @@ public class ConnectorSyncJobTests extends ESTestCase {
             }
             """);
 
-        ConnectorSyncJob.syncJobConnectorFromXContentBytes(new BytesArray(content), XContentType.JSON);
+        ConnectorSyncJob.syncJobConnectorFromXContentBytes(new BytesArray(content), null, XContentType.JSON);
     }
 
     private void assertTransportSerialization(ConnectorSyncJob testInstance) throws IOException {


### PR DESCRIPTION
## Bug description


When calling `POST /_connector/_sync_job` for an existing Connector, sync job is not created and an error is returned. This occurs for all job types and trigger methods. 

### To Reproduce
Steps to reproduce the behavior:
1. Create a connector via API
2. Assign it an index
3. Try to create a sync job via API `POST /_connector/_sync_job`
4. Observe returned error


## Changes to address the bug
- Instead of casting the get response `source` to Connector classes, use `syncJobConnectorFromXContentBytes` to process the response and create a `Connector` object
- Adapt the `ConstructingObjectParser` to accept `connector_id` from context when available to build a Connector object 