### PR TITLE
ESQL: Update ToDoubleTests's random string conversion checks (#103462)

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDoubleTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToDoubleTests.java
@@ -54,17 +54,13 @@ public class ToDoubleTests extends AbstractFunctionTestCase {
             List.of()
         );
         // random strings that don't look like a double
-        TestCaseSupplier.forUnaryStrings(
-            suppliers,
-            evaluatorName.apply("String"),
-            DataTypes.DOUBLE,
-            bytesRef -> null,
-            bytesRef -> List.of(
+        TestCaseSupplier.forUnaryStrings(suppliers, evaluatorName.apply("String"), DataTypes.DOUBLE, bytesRef -> null, bytesRef -> {
+            var exception = expectThrows(NumberFormatException.class, () -> Double.parseDouble(bytesRef.utf8ToString()));
+            return List.of(
                 "Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.",
-                "Line -1:-1: java.lang.NumberFormatException: "
-                    + (bytesRef.utf8ToString().isEmpty() ? "empty String" : ("For input string: \"" + bytesRef.utf8ToString() + "\""))
-            )
-        );
+                "Line -1:-1: " + exception
+            );
+        });
         TestCaseSupplier.forUnaryUnsignedLong(
             suppliers,
             evaluatorName.apply("UnsignedLong"),


### PR DESCRIPTION
This updates the checks for warnings triggered by parsing random strings. Besides some UTF8 issues, there are more ways the parsing can fail than tested before.

Fixes #103127

(cherry picked from commit db0f5f54672365c10db4074e834d17d1379fd0af)
