### PR TITLE
[8.12] [Connectors API] Add cancel connector sync job docs (#103446)

### DIFF
--- a/docs/reference/connector/apis/cancel-connector-sync-job-api.asciidoc
+++ b/docs/reference/connector/apis/cancel-connector-sync-job-api.asciidoc
@@ -1,0 +1,50 @@
+[[cancel-connector-sync-job-api]]
+=== Cancel connector sync job API
+++++
+<titleabbrev>Cancel connector sync job</titleabbrev>
+++++
+
+Cancels a connector sync job.
+
+[[cancel-connector-sync-job-api-request]]
+==== {api-request-title}
+`PUT _connector/_sync_job/<connector_sync_job_id>/_cancel`
+
+[[cancel-connector-sync-job-api-prereqs]]
+==== {api-prereq-title}
+
+* To sync data using connectors, it's essential to have the Elastic connectors service running.
+* The `connector_sync_job_id` parameter should reference an existing connector sync job.
+
+[[cancel-connector-sync-job-api-desc]]
+==== {api-description-title}
+
+Cancels a connector sync job, which sets the `status` to `cancelling` and updates `cancellation_requested_at` to the current time.
+The connector service is then responsible for setting the `status` of connector sync jobs to `cancelled`.
+
+[[cancel-connector-sync-job-api-path-params]]
+==== {api-path-parms-title}
+
+`connector_sync_job_id`::
+(Required, string)
+
+[[cancel-connector-sync-job-api-response-codes]]
+==== {api-response-codes-title}
+
+`200`::
+Connector sync job cancellation was successfully requested.
+
+`404`::
+No connector sync job matching `connector_sync_job_id` could be found.
+
+[[cancel-connector-sync-job-api-example]]
+==== {api-examples-title}
+
+The following example cancels the connector sync job with ID `my-connector-sync-job-id`:
+
+[source,console]
+----
+PUT _connector/_sync_job/my-connector-sync-job-id/_cancel
+----
+// TEST[skip:there's no way to clean up after creating a connector sync job, as we don't know the id ahead of time. Therefore, skip this test.]
+

--- a/docs/reference/connector/apis/connector-apis.asciidoc
+++ b/docs/reference/connector/apis/connector-apis.asciidoc
@@ -36,6 +36,7 @@ You can use these APIs to create, cancel, delete and update sync jobs.
 
 Use the following APIs to manage sync jobs:
 
+* <<cancel-connector-sync-job-api>>
 * <<create-connector-sync-job-api>>
 * <<delete-connector-sync-job-api>>
 * <<get-connector-sync-job-api>>
@@ -43,6 +44,8 @@ Use the following APIs to manage sync jobs:
 * <<set-connector-sync-job-error-api>>
 * <<set-connector-sync-job-stats-api>>
 
+
+include::cancel-connector-sync-job-api.asciidoc[]
 include::create-connector-api.asciidoc[]
 include::create-connector-sync-job-api.asciidoc[]
 include::delete-connector-api.asciidoc[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.12`:
 - [[Connectors API] Add cancel connector sync job docs (#103446)](https://github.com/elastic/elasticsearch/pull/103446)

<!--- Backport version: 8.9.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)