### PR TITLE
[8.12] [Connectors API] Add check in connector sync job docs (#103426)

### DIFF
--- a/docs/reference/connector/apis/check-in-connector-sync-job-api.asciidoc
+++ b/docs/reference/connector/apis/check-in-connector-sync-job-api.asciidoc
@@ -1,0 +1,48 @@
+[[check-in-connector-sync-job-api]]
+=== Check in connector sync job API
+++++
+<titleabbrev>Check in connector sync job</titleabbrev>
+++++
+
+Checks in a connector sync job (updates `last_seen` to the current time).
+
+[[check-in-connector-sync-job-api-request]]
+==== {api-request-title}
+`PUT _connector/_sync_job/<connector_sync_job_id>/_check_in/`
+
+[[check-in-connector-sync-job-api-prereqs]]
+==== {api-prereq-title}
+
+* To sync data using connectors, it's essential to have the Elastic connectors service running.
+* The `connector_sync_job_id` parameter should reference an existing connector sync job.
+
+[[check-in-connector-sync-job-api-desc]]
+==== {api-description-title}
+
+Checks in a connector sync job and sets `last_seen` to the time right before updating it in the internal index.
+
+[[check-in-connector-sync-job-path-params]]
+==== {api-path-parms-title}
+
+`<connector_sync_job_id>`::
+(Required, string)
+
+[[check-in-connector-sync-job-api-response-codes]]
+==== {api-response-codes-title}
+
+`200`::
+Connector sync job was successfully checked in.
+
+`404`::
+No connector sync job matching `connector_sync_job_id` could be found.
+
+[[check-in-connector-sync-job-api-example]]
+==== {api-examples-title}
+
+The following example checks in the connector sync job `my-connector-sync-job`:
+
+[source,console]
+----
+PUT _connector/_sync_job/my-connector-sync-job/_check_in
+----
+// TEST[skip:there's no way to clean up after creating a connector sync job, as we don't know the id ahead of time. Therefore, skip this test.]

--- a/docs/reference/connector/apis/connector-apis.asciidoc
+++ b/docs/reference/connector/apis/connector-apis.asciidoc
@@ -36,7 +36,9 @@ You can use these APIs to create, cancel, delete and update sync jobs.
 
 Use the following APIs to manage sync jobs:
 
+
 * <<cancel-connector-sync-job-api>>
+* <<check-in-connector-sync-job-api>>
 * <<create-connector-sync-job-api>>
 * <<delete-connector-sync-job-api>>
 * <<get-connector-sync-job-api>>
@@ -46,6 +48,7 @@ Use the following APIs to manage sync jobs:
 
 
 include::cancel-connector-sync-job-api.asciidoc[]
+include::check-in-connector-sync-job-api.asciidoc[]
 include::create-connector-api.asciidoc[]
 include::create-connector-sync-job-api.asciidoc[]
 include::delete-connector-api.asciidoc[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.12`:
 - [[Connectors API] Add check in connector sync job docs (#103426)](https://github.com/elastic/elasticsearch/pull/103426)

<!--- Backport version: 8.9.4 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)