### PR TITLE
[8.12] [Connector API][Docs] Document update pipeline, scheduling and check-in (#103450)

### DIFF
--- a/docs/reference/connector/apis/check-in-connector-api.asciidoc
+++ b/docs/reference/connector/apis/check-in-connector-api.asciidoc
@@ -1,34 +1,37 @@
-[[delete-connector-api]]
-=== Delete connector API
+[[check-in-connector-api]]
+=== Check in connector API
 
 preview::[]
 
 ++++
-<titleabbrev>Delete connector</titleabbrev>
+<titleabbrev>Check in a connector</titleabbrev>
 ++++
 
-Removes a connector and its associated data.
-This is a destructive action that is not recoverable.
+Updates the `last_seen` field of a connector with current timestamp.
 
-[[delete-connector-api-request]]
+[[check-in-connector-api-request]]
 ==== {api-request-title}
 
-`DELETE _connector/<connector_id>`
+`PUT _connector/<connector_id>/_check_in`
 
-[[delete-connector-api-prereq]]
+[[check-in-connector-api-prereq]]
 ==== {api-prereq-title}
 
 * To sync data using connectors, it's essential to have the Elastic connectors service running.
 * The `connector_id` parameter should reference an existing connector.
 
-[[delete-connector-api-path-params]]
+[[check-in-connector-api-path-params]]
 ==== {api-path-parms-title}
 
 `<connector_id>`::
 (Required, string)
 
-[[delete-connector-api-response-codes]]
+
+[[check-in-connector-api-response-codes]]
 ==== {api-response-codes-title}
+
+`200`::
+Connector `last_seen` field was successfully updated with a current timestamp.
 
 `400`::
 The `connector_id` was not provided.
@@ -36,10 +39,10 @@ The `connector_id` was not provided.
 `404` (Missing resources)::
 No connector matching `connector_id` could be found.
 
-[[delete-connector-api-example]]
+[[check-in-connector-api-example]]
 ==== {api-examples-title}
 
-The following example deletes the connector with ID `my-connector`:
+The following example updates the `last_seen` property with current timestamp for the connector with ID `my-connector`:
 
 ////
 [source, console]
@@ -52,16 +55,22 @@ PUT _connector/my-connector
 }
 --------------------------------------------------
 // TESTSETUP
+
+[source,console]
+--------------------------------------------------
+DELETE _connector/my-connector
+--------------------------------------------------
+// TEARDOWN
 ////
 
 [source,console]
 ----
-DELETE _connector/my-connector
+PUT _connector/my-connector/_check_in
 ----
 
 [source,console-result]
 ----
 {
-    "acknowledged": true
+    "result": "updated"
 }
 ----

--- a/docs/reference/connector/apis/connector-apis.asciidoc
+++ b/docs/reference/connector/apis/connector-apis.asciidoc
@@ -26,6 +26,9 @@ Use the following APIs to manage connectors:
 * <<delete-connector-api>>
 * <<get-connector-api>>
 * <<list-connector-api>>
+* <<check-in-connector-api>>
+* <<update-connector-pipeline-api>>
+* <<update-connector-scheduling-api>>
 
 
 [discrete]
@@ -48,6 +51,7 @@ Use the following APIs to manage sync jobs:
 
 
 include::cancel-connector-sync-job-api.asciidoc[]
+include::check-in-connector-api.asciidoc[]
 include::check-in-connector-sync-job-api.asciidoc[]
 include::create-connector-api.asciidoc[]
 include::create-connector-sync-job-api.asciidoc[]
@@ -57,5 +61,7 @@ include::get-connector-api.asciidoc[]
 include::get-connector-sync-job-api.asciidoc[]
 include::list-connectors-api.asciidoc[]
 include::list-connector-sync-jobs-api.asciidoc[]
+include::update-connector-pipeline-api.asciidoc[]
+include::update-connector-scheduling-api.asciidoc[]
 include::set-connector-sync-job-error-api.asciidoc[]
 include::set-connector-sync-job-stats-api.asciidoc[]

--- a/docs/reference/connector/apis/update-connector-pipeline-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-pipeline-api.asciidoc
@@ -1,0 +1,103 @@
+[[update-connector-pipeline-api]]
+=== Update connector pipeline API
+
+preview::[]
+
+++++
+<titleabbrev>Update connector pipeline</titleabbrev>
+++++
+
+Updates the `pipeline` configuration of a connector.
+
+When you create a new connector, the configuration of an <<ingest-pipeline-search-details-generic-reference, ingest pipeline>> is populated with default settings.
+
+[[update-connector-pipeline-api-request]]
+==== {api-request-title}
+
+`PUT _connector/<connector_id>/_pipeline`
+
+[[update-connector-pipeline-api-prereq]]
+==== {api-prereq-title}
+
+* To sync data using connectors, it's essential to have the Elastic connectors service running.
+* The `connector_id` parameter should reference an existing connector.
+
+[[update-connector-pipeline-api-path-params]]
+==== {api-path-parms-title}
+
+`<connector_id>`::
+(Required, string)
+
+[role="child_attributes"]
+[[update-connector-pipeline-api-request-body]]
+==== {api-request-body-title}
+
+`pipeline`::
+(Required, object) The pipeline configuration of the connector. The pipeline determines how data is processed during ingestion into Elasticsearch.
+
+Pipeline configuration must include the following attributes:
+
+- `extract_binary_content` (Required, boolean) A flag indicating whether to extract binary content during ingestion.
+
+- `name` (Required, string) The name of the ingest pipeline.
+
+- `reduce_whitespace` (Required, boolean) A flag indicating whether to reduce extra whitespace in the ingested content.
+
+- `run_ml_inference` (Required, boolean) A flag indicating whether to run machine learning inference on the ingested content.
+
+
+[[update-connector-pipeline-api-response-codes]]
+==== {api-response-codes-title}
+
+`200`::
+Connector `pipeline` field was successfully updated.
+
+`400`::
+The `connector_id` was not provided or the request payload was malformed.
+
+`404` (Missing resources)::
+No connector matching `connector_id` could be found.
+
+[[update-connector-pipeline-api-example]]
+==== {api-examples-title}
+
+The following example updates the `pipeline` property for the connector with ID `my-connector`:
+
+////
+[source, console]
+--------------------------------------------------
+PUT _connector/my-connector
+{
+  "index_name": "search-google-drive",
+  "name": "My Connector",
+  "service_type": "google_drive"
+}
+--------------------------------------------------
+// TESTSETUP
+
+[source,console]
+--------------------------------------------------
+DELETE _connector/my-connector
+--------------------------------------------------
+// TEARDOWN
+////
+
+[source,console]
+----
+PUT _connector/my-connector/_pipeline
+{
+    "pipeline": {
+        "extract_binary_content": true,
+        "name": "my-connector-pipeline",
+        "reduce_whitespace": true,
+        "run_ml_inference": true
+    }
+}
+----
+
+[source,console-result]
+----
+{
+    "result": "updated"
+}
+----

--- a/docs/reference/connector/apis/update-connector-scheduling-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-scheduling-api.asciidoc
@@ -1,0 +1,113 @@
+[[update-connector-scheduling-api]]
+=== Update connector scheduling API
+
+preview::[]
+
+++++
+<titleabbrev>Update connector scheduling</titleabbrev>
+++++
+
+Updates the `scheduling` configuration of a connector.
+
+[[update-connector-scheduling-api-request]]
+==== {api-request-title}
+
+`PUT _connector/<connector_id>/_scheduling`
+
+[[update-connector-scheduling-api-prereq]]
+==== {api-prereq-title}
+
+* To sync data using connectors, it's essential to have the Elastic connectors service running.
+* The `connector_id` parameter should reference an existing connector.
+
+[[update-connector-scheduling-api-path-params]]
+==== {api-path-parms-title}
+
+`<connector_id>`::
+(Required, string)
+
+[role="child_attributes"]
+[[update-connector-scheduling-api-request-body]]
+==== {api-request-body-title}
+
+`scheduling`::
+(Required, object) The scheduling configuration for the connector. This configuration determines frequency of synchronization operations for the connector.
+
+The scheduling configuration includes the following attributes, each represented as a `ScheduleConfig` object:
+
+- `access_control` (Required, `ScheduleConfig` object) Defines the schedule for synchronizing access control settings of the connector.
+
+- `full` (Required, `ScheduleConfig` object) Defines the schedule for a full content syncs.
+
+- `incremental` (Required, `ScheduleConfig` object) Defines the schedule for incremental content syncs.
+
+Each `ScheduleConfig` object includes the following sub-attributes:
+
+  - `enabled` (Required, boolean) A flag that enables or disables the scheduling.
+
+  - `interval` (Required, string) A CRON expression representing the sync schedule. This expression defines the grequency at which the sync operations should occur. It must be provided in a valid CRON format.
+
+
+[[update-connector-scheduling-api-response-codes]]
+==== {api-response-codes-title}
+
+`200`::
+Connector `scheduling` field was successfully updated.
+
+`400`::
+The `connector_id` was not provided or the request payload was malformed.
+
+`404` (Missing resources)::
+No connector matching `connector_id` could be found.
+
+[[update-connector-scheduling-api-example]]
+==== {api-examples-title}
+
+The following example updates the `scheduling` property for the connector with ID `my-connector`:
+
+////
+[source, console]
+--------------------------------------------------
+PUT _connector/my-connector
+{
+  "index_name": "search-google-drive",
+  "name": "My Connector",
+  "service_type": "google_drive"
+}
+--------------------------------------------------
+// TESTSETUP
+
+[source,console]
+--------------------------------------------------
+DELETE _connector/my-connector
+--------------------------------------------------
+// TEARDOWN
+////
+
+[source,console]
+----
+PUT _connector/my-connector/_scheduling
+{
+    "scheduling": {
+        "access_control": {
+            "enabled": true,
+            "interval": "0 10 0 * * ?"
+        },
+        "full": {
+            "enabled": true,
+            "interval": "0 20 0 * * ?"
+        },
+        "incremental": {
+            "enabled": false,
+            "interval": "0 30 0 * * ?"
+        }
+    }
+}
+----
+
+[source,console-result]
+----
+{
+    "result": "updated"
+}
+----


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.12`:
 - [[Connector API][Docs] Document update pipeline, scheduling and check-in (#103450)](https://github.com/elastic/elasticsearch/pull/103450)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)