### PR TITLE
[8.12] [Connector API][Docs] Document update error, last sync, name actions (#103503)

### DIFF
--- a/docs/reference/connector/apis/connector-apis.asciidoc
+++ b/docs/reference/connector/apis/connector-apis.asciidoc
@@ -27,6 +27,9 @@ Use the following APIs to manage connectors:
 * <<get-connector-api>>
 * <<list-connector-api>>
 * <<check-in-connector-api>>
+* <<update-connector-error-api>>
+* <<update-connector-last-sync-api>>
+* <<update-connector-name-description-api>>
 * <<update-connector-pipeline-api>>
 * <<update-connector-scheduling-api>>
 
@@ -61,7 +64,10 @@ include::get-connector-api.asciidoc[]
 include::get-connector-sync-job-api.asciidoc[]
 include::list-connectors-api.asciidoc[]
 include::list-connector-sync-jobs-api.asciidoc[]
-include::update-connector-pipeline-api.asciidoc[]
-include::update-connector-scheduling-api.asciidoc[]
 include::set-connector-sync-job-error-api.asciidoc[]
 include::set-connector-sync-job-stats-api.asciidoc[]
+include::update-connector-error-api.asciidoc[]
+include::update-connector-last-sync-api.asciidoc[]
+include::update-connector-name-description-api.asciidoc[]
+include::update-connector-pipeline-api.asciidoc[]
+include::update-connector-scheduling-api.asciidoc[]

--- a/docs/reference/connector/apis/update-connector-error-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-error-api.asciidoc
@@ -1,0 +1,86 @@
+[[update-connector-error-api]]
+=== Update connector error API
+
+preview::[]
+
+++++
+<titleabbrev>Update connector error</titleabbrev>
+++++
+
+Updates the `error` field of a connector.
+
+[[update-connector-error-api-request]]
+==== {api-request-title}
+
+`PUT _connector/<connector_id>/_error`
+
+[[update-connector-error-api-prereq]]
+==== {api-prereq-title}
+
+* To sync data using connectors, it's essential to have the Elastic connectors service running.
+* The `connector_id` parameter should reference an existing connector.
+
+[[update-connector-error-api-path-params]]
+==== {api-path-parms-title}
+
+`<connector_id>`::
+(Required, string)
+
+[role="child_attributes"]
+[[update-connector-error-api-request-body]]
+==== {api-request-body-title}
+
+`error`::
+(Required, string) A messaged related to the last error encountered by the connector.
+
+
+[[update-connector-error-api-response-codes]]
+==== {api-response-codes-title}
+
+`200`::
+Connector `error` field was successfully updated.
+
+`400`::
+The `connector_id` was not provided or the request payload was malformed.
+
+`404` (Missing resources)::
+No connector matching `connector_id` could be found.
+
+[[update-connector-error-api-example]]
+==== {api-examples-title}
+
+The following example updates the `error` field for the connector with ID `my-connector`:
+
+////
+[source, console]
+--------------------------------------------------
+PUT _connector/my-connector
+{
+  "index_name": "search-google-drive",
+  "name": "My Connector",
+  "service_type": "google_drive"
+}
+--------------------------------------------------
+// TESTSETUP
+
+[source,console]
+--------------------------------------------------
+DELETE _connector/my-connector
+--------------------------------------------------
+// TEARDOWN
+////
+
+[source,console]
+----
+PUT _connector/my-connector/_error
+{
+    "error": "Houston, we have a problem!"
+}
+----
+
+[source,console-result]
+----
+{
+    "result": "updated"
+}
+----

--- a/docs/reference/connector/apis/update-connector-last-sync-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-last-sync-api.asciidoc
@@ -1,0 +1,135 @@
+[[update-connector-last-sync-api]]
+=== Update connector last sync stats API
+
+preview::[]
+
+++++
+<titleabbrev>Update connector last sync stats</titleabbrev>
+++++
+
+Updates the fields related to the last sync of a connector.
+
+This action is used for analytics and monitoring.
+
+[[update-connector-last-sync-api-request]]
+==== {api-request-title}
+
+`PUT _connector/<connector_id>/_last_sync`
+
+[[update-connector-last-sync-api-prereq]]
+==== {api-prereq-title}
+
+* To sync data using connectors, it's essential to have the Elastic connectors service running.
+* The `connector_id` parameter should reference an existing connector.
+
+[[update-connector-last-sync-api-path-params]]
+==== {api-path-parms-title}
+
+`<connector_id>`::
+(Required, string)
+
+[role="child_attributes"]
+[[update-connector-last-sync-api-request-body]]
+==== {api-request-body-title}
+
+`last_access_control_sync_error`::
+(Optional, string) The last error message related to access control sync, if any.
+
+`last_access_control_sync_scheduled_at`::
+(Optional, datetime) The datetime indicating when the last access control sync was scheduled.
+
+`last_access_control_sync_status`::
+(Optional, ConnectorSyncStatus) The status of the last access control sync.
+
+`last_deleted_document_count`::
+(Optional, long) The number of documents deleted in the last sync process.
+
+`last_incremental_sync_scheduled_at`::
+(Optional, datetime) The datetime when the last incremental sync was scheduled.
+
+`last_indexed_document_count`::
+(Optional, long) The number of documents indexed in the last sync.
+
+`last_sync_error`::
+(Optional, string) The last error message encountered during a sync process, if any.
+
+`last_sync_scheduled_at`::
+(Optional, datetime) The datetime when the last sync was scheduled.
+
+`last_sync_status`::
+(Optional, ConnectorSyncStatus) The status of the last sync.
+
+`last_synced`::
+(Optional, datetime) The datetime of the last successful synchronization.
+
+
+The value of `ConnectorSyncStatus` is one of the following lowercase strings representing different sync states:
+
+* `canceling`: The sync process is in the process of being canceled.
+* `canceled`: The sync process has been canceled.
+* `completed`: The sync process completed successfully.
+* `error`: An error occurred during the sync process.
+* `in_progress`: The sync process is currently underway.
+* `pending`: The sync is pending and has not yet started.
+* `suspended`: The sync process has been temporarily suspended.
+
+
+[[update-connector-last-sync-api-response-codes]]
+==== {api-response-codes-title}
+
+`200`::
+Connector last sync stats were successfully updated.
+
+`400`::
+The `connector_id` was not provided or the request payload was malformed.
+
+`404` (Missing resources)::
+No connector matching `connector_id` could be found.
+
+[[update-connector-last-sync-api-example]]
+==== {api-examples-title}
+
+The following example updates the last sync stats for the connector with ID `my-connector`:
+
+////
+[source, console]
+--------------------------------------------------
+PUT _connector/my-connector
+{
+  "index_name": "search-google-drive",
+  "name": "My Connector",
+  "service_type": "google_drive"
+}
+--------------------------------------------------
+// TESTSETUP
+
+[source,console]
+--------------------------------------------------
+DELETE _connector/my-connector
+--------------------------------------------------
+// TEARDOWN
+////
+
+[source,console]
+----
+PUT _connector/my-connector/_last_sync
+{
+    "last_access_control_sync_error": "Houston, we have a problem!",
+    "last_access_control_sync_scheduled_at": "2023-11-09T15:13:08.231Z",
+    "last_access_control_sync_status": "pending",
+    "last_deleted_document_count": 42,
+    "last_incremental_sync_scheduled_at": "2023-11-09T15:13:08.231Z",
+    "last_indexed_document_count": 42,
+    "last_sync_error": "Houston, we have a problem!",
+    "last_sync_scheduled_at": "2024-11-09T15:13:08.231Z",
+    "last_sync_status": "completed",
+    "last_synced": "2024-11-09T15:13:08.231Z"
+}
+----
+
+[source,console-result]
+----
+{
+    "result": "updated"
+}
+----

--- a/docs/reference/connector/apis/update-connector-name-description-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-name-description-api.asciidoc
@@ -1,0 +1,90 @@
+[[update-connector-name-description-api]]
+=== Update connector name and description API
+
+preview::[]
+
+++++
+<titleabbrev>Update connector name and description</titleabbrev>
+++++
+
+Updates the `name` and `description` fields of a connector.
+
+[[update-connector-name-description-api-request]]
+==== {api-request-title}
+
+`PUT _connector/<connector_id>/_name`
+
+[[update-connector-name-description-api-prereq]]
+==== {api-prereq-title}
+
+* To sync data using connectors, it's essential to have the Elastic connectors service running.
+* The `connector_id` parameter should reference an existing connector.
+
+[[update-connector-name-description-api-path-params]]
+==== {api-path-parms-title}
+
+`<connector_id>`::
+(Required, string)
+
+[role="child_attributes"]
+[[update-connector-name-description-api-request-body]]
+==== {api-request-body-title}
+
+`name`::
+(Required, string) Name of the connector.
+
+`description`::
+(Optional, string) Description of the connector.
+
+
+[[update-connector-name-description-api-response-codes]]
+==== {api-response-codes-title}
+
+`200`::
+Connector `name` and `description` fields were successfully updated.
+
+`400`::
+The `connector_id` was not provided or the request payload was malformed.
+
+`404` (Missing resources)::
+No connector matching `connector_id` could be found.
+
+[[update-connector-name-description-api-example]]
+==== {api-examples-title}
+
+The following example updates the `name` and `description` fields for the connector with ID `my-connector`:
+
+////
+[source, console]
+--------------------------------------------------
+PUT _connector/my-connector
+{
+  "index_name": "search-google-drive",
+  "name": "My Connector",
+  "service_type": "google_drive"
+}
+--------------------------------------------------
+// TESTSETUP
+
+[source,console]
+--------------------------------------------------
+DELETE _connector/my-connector
+--------------------------------------------------
+// TEARDOWN
+////
+
+[source,console]
+----
+PUT _connector/my-connector/_name
+{
+    "name": "Custom connector",
+    "description": "This is my customized connector"
+}
+----
+
+[source,console-result]
+----
+{
+    "result": "updated"
+}
+----


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.12`:
 - [[Connector API][Docs] Document update error, last sync, name actions (#103503)](https://github.com/elastic/elasticsearch/pull/103503)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)