### PR TITLE
[8.11] Mute HeapAttackIT (#103539)

### DIFF
--- a/x-pack/plugin/esql/qa/server/heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/heap_attack/HeapAttackIT.java
+++ b/x-pack/plugin/esql/qa/server/heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/heap_attack/HeapAttackIT.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.qa.heap_attack;
 
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.util.EntityUtils;
+import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
@@ -47,6 +48,7 @@ import static org.hamcrest.Matchers.hasSize;
  * Tests that run ESQL queries that have, in the past, used so much memory they
  * crash Elasticsearch.
  */
+@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/103527")
 public class HeapAttackIT extends ESRestTestCase {
     /**
      * This used to fail, but we've since compacted top n so it actually succeeds now.


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Mute HeapAttackIT (#103539)