### PR TITLE
[8.12] [Connectors API] Make nullable fields optional in the parser inside ConnectorSyncJob (#103262)

### DIFF
--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/Connector.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/Connector.java
@@ -153,7 +153,7 @@ public class Connector implements NamedWriteable, ToXContentObject {
         this.error = error;
         this.features = features;
         this.filtering = Objects.requireNonNull(filtering, "[filtering] cannot be null");
-        this.indexName = Objects.requireNonNull(indexName, "[index_name] cannot be null");
+        this.indexName = indexName;
         this.isNative = isNative;
         this.language = language;
         this.lastSeen = lastSeen;

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJob.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJob.java
@@ -31,6 +31,7 @@ import org.elasticsearch.xpack.application.connector.ConnectorSyncStatus;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -349,20 +350,19 @@ public class ConnectorSyncJob implements Writeable, ToXContentObject {
             (p, c) -> ConnectorFiltering.fromXContent(p),
             Connector.FILTERING_FIELD
         );
-        SYNC_JOB_CONNECTOR_PARSER.declareString(optionalConstructorArg(), Connector.INDEX_NAME_FIELD);
-        SYNC_JOB_CONNECTOR_PARSER.declareString(optionalConstructorArg(), Connector.LANGUAGE_FIELD);
-        SYNC_JOB_CONNECTOR_PARSER.declareField(
+        SYNC_JOB_CONNECTOR_PARSER.declareStringOrNull(optionalConstructorArg(), Connector.INDEX_NAME_FIELD);
+        SYNC_JOB_CONNECTOR_PARSER.declareStringOrNull(optionalConstructorArg(), Connector.LANGUAGE_FIELD);
+        SYNC_JOB_CONNECTOR_PARSER.declareObjectOrNull(
             optionalConstructorArg(),
             (p, c) -> ConnectorIngestPipeline.fromXContent(p),
-            Connector.PIPELINE_FIELD,
-            ObjectParser.ValueType.OBJECT
+            null,
+            Connector.PIPELINE_FIELD
         );
-        SYNC_JOB_CONNECTOR_PARSER.declareString(optionalConstructorArg(), Connector.SERVICE_TYPE_FIELD);
-        SYNC_JOB_CONNECTOR_PARSER.declareField(
+        SYNC_JOB_CONNECTOR_PARSER.declareStringOrNull(optionalConstructorArg(), Connector.SERVICE_TYPE_FIELD);
+        SYNC_JOB_CONNECTOR_PARSER.declareObject(
             optionalConstructorArg(),
-            (parser, context) -> parser.map(),
-            Connector.CONFIGURATION_FIELD,
-            ObjectParser.ValueType.OBJECT
+            (p, c) -> p.map(HashMap::new, ConnectorConfiguration::fromXContent),
+            Connector.CONFIGURATION_FIELD
         );
     }
 
@@ -376,6 +376,14 @@ public class ConnectorSyncJob implements Writeable, ToXContentObject {
 
     public static ConnectorSyncJob fromXContent(XContentParser parser) throws IOException {
         return PARSER.parse(parser, null);
+    }
+
+    public static Connector syncJobConnectorFromXContentBytes(BytesReference source, XContentType xContentType) {
+        try (XContentParser parser = XContentHelper.createParser(XContentParserConfiguration.EMPTY, source, xContentType)) {
+            return ConnectorSyncJob.syncJobConnectorFromXContent(parser);
+        } catch (IOException e) {
+            throw new ElasticsearchParseException("Failed to parse a connector document.", e);
+        }
     }
 
     public static Connector syncJobConnectorFromXContent(XContentParser parser) throws IOException {
@@ -470,7 +478,9 @@ public class ConnectorSyncJob implements Writeable, ToXContentObject {
 
             builder.startObject(CONNECTOR_FIELD.getPreferredName());
             {
-                builder.field(Connector.ID_FIELD.getPreferredName(), connector.getConnectorId());
+                if (connector.getConnectorId() != null) {
+                    builder.field(Connector.ID_FIELD.getPreferredName(), connector.getConnectorId());
+                }
                 if (connector.getFiltering() != null) {
                     builder.field(Connector.FILTERING_FIELD.getPreferredName(), connector.getFiltering());
                 }

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobTests.java
@@ -332,6 +332,151 @@ public class ConnectorSyncJobTests extends ESTestCase {
         ConnectorSyncJob.fromXContentBytes(new BytesArray(content), XContentType.JSON);
     }
 
+    public void testSyncJobConnectorFromXContent_WithAllFieldsSet() throws IOException {
+        String content = XContentHelper.stripWhitespace("""
+            {
+                "id": "connector-id",
+                "filtering": [
+                    {
+                        "active": {
+                            "advanced_snippet": {
+                                "created_at": "2023-12-01T14:18:37.397819Z",
+                                "updated_at": "2023-12-01T14:18:37.397819Z",
+                                "value": {}
+                            },
+                            "rules": [
+                                {
+                                    "created_at": "2023-12-01T14:18:37.397819Z",
+                                    "field": "_",
+                                    "id": "DEFAULT",
+                                    "order": 0,
+                                    "policy": "include",
+                                    "rule": "regex",
+                                    "updated_at": "2023-12-01T14:18:37.397819Z",
+                                    "value": ".*"
+                                }
+                            ],
+                            "validation": {
+                                "errors": [],
+                                "state": "valid"
+                            }
+                        },
+                        "domain": "DEFAULT",
+                        "draft": {
+                            "advanced_snippet": {
+                                "created_at": "2023-12-01T14:18:37.397819Z",
+                                "updated_at": "2023-12-01T14:18:37.397819Z",
+                                "value": {}
+                            },
+                            "rules": [
+                                {
+                                    "created_at": "2023-12-01T14:18:37.397819Z",
+                                    "field": "_",
+                                    "id": "DEFAULT",
+                                    "order": 0,
+                                    "policy": "include",
+                                    "rule": "regex",
+                                    "updated_at": "2023-12-01T14:18:37.397819Z",
+                                    "value": ".*"
+                                }
+                            ],
+                            "validation": {
+                                "errors": [],
+                                "state": "valid"
+                            }
+                        }
+                    }
+                ],
+                "index_name": "search-connector",
+                "language": "english",
+                "pipeline": {
+                    "extract_binary_content": true,
+                    "name": "ent-search-generic-ingestion",
+                    "reduce_whitespace": true,
+                    "run_ml_inference": false
+                },
+                "service_type": "service type",
+                "configuration": {}
+            }
+            """);
+
+        Connector connector = ConnectorSyncJob.syncJobConnectorFromXContentBytes(new BytesArray(content), XContentType.JSON);
+
+        assertThat(connector.getConnectorId(), equalTo("connector-id"));
+        assertThat(connector.getFiltering().size(), equalTo(1));
+        assertThat(connector.getIndexName(), equalTo("search-connector"));
+        assertThat(connector.getLanguage(), equalTo("english"));
+        assertThat(connector.getPipeline(), notNullValue());
+        assertThat(connector.getServiceType(), equalTo("service type"));
+        assertThat(connector.getConfiguration(), notNullValue());
+    }
+
+    public void testSyncJobConnectorFromXContent_WithAllNonOptionalFieldsSet_DoesNotThrow() throws IOException {
+        String content = XContentHelper.stripWhitespace("""
+            {
+                "id": "connector-id",
+                "filtering": [
+                    {
+                        "active": {
+                            "advanced_snippet": {
+                                "created_at": "2023-12-01T14:18:37.397819Z",
+                                "updated_at": "2023-12-01T14:18:37.397819Z",
+                                "value": {}
+                            },
+                            "rules": [
+                                {
+                                    "created_at": "2023-12-01T14:18:37.397819Z",
+                                    "field": "_",
+                                    "id": "DEFAULT",
+                                    "order": 0,
+                                    "policy": "include",
+                                    "rule": "regex",
+                                    "updated_at": "2023-12-01T14:18:37.397819Z",
+                                    "value": ".*"
+                                }
+                            ],
+                            "validation": {
+                                "errors": [],
+                                "state": "valid"
+                            }
+                        },
+                        "domain": "DEFAULT",
+                        "draft": {
+                            "advanced_snippet": {
+                                "created_at": "2023-12-01T14:18:37.397819Z",
+                                "updated_at": "2023-12-01T14:18:37.397819Z",
+                                "value": {}
+                            },
+                            "rules": [
+                                {
+                                    "created_at": "2023-12-01T14:18:37.397819Z",
+                                    "field": "_",
+                                    "id": "DEFAULT",
+                                    "order": 0,
+                                    "policy": "include",
+                                    "rule": "regex",
+                                    "updated_at": "2023-12-01T14:18:37.397819Z",
+                                    "value": ".*"
+                                }
+                            ],
+                            "validation": {
+                                "errors": [],
+                                "state": "valid"
+                            }
+                        }
+                    }
+                ],
+                "index_name": null,
+                "language": null,
+                "pipeline": null,
+                "service_type": null,
+                "configuration": {}
+            }
+            """);
+
+        ConnectorSyncJob.syncJobConnectorFromXContentBytes(new BytesArray(content), XContentType.JSON);
+    }
+
     private void assertTransportSerialization(ConnectorSyncJob testInstance) throws IOException {
         ConnectorSyncJob deserializedInstance = copyInstance(testInstance);
         assertNotSame(testInstance, deserializedInstance);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.12`:
 - [[Connectors API] Make nullable fields optional in the parser inside ConnectorSyncJob (#103262)](https://github.com/elastic/elasticsearch/pull/103262)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)