### PR TITLE
YAML test framework: adding cluster features filtering to `node_selector`

### DIFF
--- a/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestExecutionContext.java
+++ b/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/ClientYamlTestExecutionContext.java
@@ -241,4 +241,9 @@ public class ClientYamlTestExecutionContext {
     public boolean clusterHasFeature(String featureId) {
         return clientYamlTestClient.clusterHasFeature(featureId);
     }
+
+    public boolean nodeHasFeature(String nodeName, String featureId) {
+        // TODO: node features from TestFeatureService/ESRestTestCase
+        return true;
+    }
 }

--- a/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/ApiCallSection.java
+++ b/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/ApiCallSection.java
@@ -24,7 +24,7 @@ public class ApiCallSection {
     private final Map<String, String> params = new HashMap<>();
     private final Map<String, String> headers = new HashMap<>();
     private final List<Map<String, Object>> bodies = new ArrayList<>();
-    private ContextNodeSelector nodeSelector = ContextNodeSelector.ANY;
+    private ClientYamlNodeSelector nodeSelector = ClientYamlNodeSelector.ANY;
 
     public ApiCallSection(String api) {
         this.api = api;
@@ -70,14 +70,14 @@ public class ApiCallSection {
     /**
      * Selects the node on which to run this request.
      */
-    ContextNodeSelector getNodeSelector() {
+    ClientYamlNodeSelector getNodeSelector() {
         return nodeSelector;
     }
 
     /**
      * Set the selector that decides which node can run this request.
      */
-    void setNodeSelector(ContextNodeSelector nodeSelector) {
+    void setNodeSelector(ClientYamlNodeSelector nodeSelector) {
         this.nodeSelector = nodeSelector;
     }
 }

--- a/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/ApiCallSection.java
+++ b/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/ApiCallSection.java
@@ -7,8 +7,6 @@
  */
 package org.elasticsearch.test.rest.yaml.section;
 
-import org.elasticsearch.client.NodeSelector;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -26,7 +24,7 @@ public class ApiCallSection {
     private final Map<String, String> params = new HashMap<>();
     private final Map<String, String> headers = new HashMap<>();
     private final List<Map<String, Object>> bodies = new ArrayList<>();
-    private NodeSelector nodeSelector = NodeSelector.ANY;
+    private ContextNodeSelector nodeSelector = ContextNodeSelector.ANY;
 
     public ApiCallSection(String api) {
         this.api = api;
@@ -72,14 +70,14 @@ public class ApiCallSection {
     /**
      * Selects the node on which to run this request.
      */
-    public NodeSelector getNodeSelector() {
+    ContextNodeSelector getNodeSelector() {
         return nodeSelector;
     }
 
     /**
      * Set the selector that decides which node can run this request.
      */
-    public void setNodeSelector(NodeSelector nodeSelector) {
+    void setNodeSelector(ContextNodeSelector nodeSelector) {
         this.nodeSelector = nodeSelector;
     }
 }

--- a/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/ClientYamlTestSuite.java
+++ b/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/ClientYamlTestSuite.java
@@ -7,7 +7,6 @@
  */
 package org.elasticsearch.test.rest.yaml.section;
 
-import org.elasticsearch.client.NodeSelector;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.io.Channels;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
@@ -228,7 +227,7 @@ public class ClientYamlTestSuite {
             sections.stream()
                 .filter(section -> section instanceof DoSection)
                 .map(section -> (DoSection) section)
-                .filter(section -> NodeSelector.ANY != section.getApiCallSection().getNodeSelector())
+                .filter(section -> ContextNodeSelector.ANY != section.getApiCallSection().getNodeSelector())
                 .filter(section -> false == hasSkipFeature("node_selector", testSection, setupSection, teardownSection))
                 .map(section -> String.format(Locale.ROOT, """
                     attempted to add a [do] with a [node_selector] section without a corresponding \

--- a/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/ClientYamlTestSuite.java
+++ b/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/ClientYamlTestSuite.java
@@ -227,7 +227,7 @@ public class ClientYamlTestSuite {
             sections.stream()
                 .filter(section -> section instanceof DoSection)
                 .map(section -> (DoSection) section)
-                .filter(section -> ContextNodeSelector.ANY != section.getApiCallSection().getNodeSelector())
+                .filter(section -> ClientYamlNodeSelector.ANY != section.getApiCallSection().getNodeSelector())
                 .filter(section -> false == hasSkipFeature("node_selector", testSection, setupSection, teardownSection))
                 .map(section -> String.format(Locale.ROOT, """
                     attempted to add a [do] with a [node_selector] section without a corresponding \

--- a/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/ContextNodeSelector.java
+++ b/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/ContextNodeSelector.java
@@ -12,17 +12,86 @@ import org.elasticsearch.client.Node;
 import org.elasticsearch.client.NodeSelector;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestExecutionContext;
 
+import java.util.Objects;
+
 interface ContextNodeSelector {
+
+    interface NodeSelectorWithContext {
+        void select(Iterable<Node> nodes, ClientYamlTestExecutionContext context);
+    }
+
+    static ContextNodeSelector withoutContext(String selectorDescription, NodeSelector nodeSelector) {
+        return new NoContextNodeSelector(nodeSelector, selectorDescription);
+    }
+
+    static ContextNodeSelector withoutContext(NodeSelector nodeSelector) {
+        return new NoContextNodeSelector(nodeSelector, nodeSelector.toString());
+    }
+
+    static ContextNodeSelector withContext(String selectorDescription, NodeSelectorWithContext nodeSelector) {
+        return new ContextNodeSelector() {
+            @Override
+            public void select(Iterable<Node> nodes, ClientYamlTestExecutionContext context) {
+                nodeSelector.select(nodes, context);
+            }
+
+            @Override
+            public NodeSelector bind(ClientYamlTestExecutionContext executionContext) {
+                return nodes -> nodeSelector.select(nodes, executionContext);
+            }
+
+            @Override
+            public String toString() {
+                return selectorDescription;
+            }
+        };
+    }
+
+    /**
+     * Selector that composes two selectors, running the "right" most selector
+     * first and then running the "left" selector on the results of the "right"
+     * selector.
+     */
+    static ContextNodeSelector compose(ContextNodeSelector lhs, ContextNodeSelector rhs) {
+        Objects.requireNonNull(lhs, "lhs is required");
+        Objects.requireNonNull(rhs, "rhs is required");
+
+        // . as in haskell's "compose" operator
+        var description = lhs + "." + rhs;
+        return withContext(description, (nodes, context) -> {
+            rhs.select(nodes, context);
+            lhs.select(nodes, context);
+        });
+    }
+
+    class NoContextNodeSelector implements ContextNodeSelector {
+        private final NodeSelector nodeSelector;
+        private final String nodeSelectorString;
+
+        NoContextNodeSelector(NodeSelector nodeSelector, String nodeSelectorString) {
+            this.nodeSelector = nodeSelector;
+            this.nodeSelectorString = nodeSelectorString;
+        }
+
+        @Override
+        public void select(Iterable<Node> nodes, ClientYamlTestExecutionContext context) {
+            nodeSelector.select(nodes);
+        }
+
+        @Override
+        public NodeSelector bind(ClientYamlTestExecutionContext executionContext) {
+            return nodeSelector;
+        }
+
+        @Override
+        public String toString() {
+            return nodeSelectorString;
+        }
+    }
+
+    ContextNodeSelector ANY = withoutContext(NodeSelector.ANY);
+
     void select(Iterable<Node> nodes, ClientYamlTestExecutionContext context);
 
-    ContextNodeSelector ANY = (nodes, context) -> {};
-
-    default NodeSelector bind(ClientYamlTestExecutionContext executionContext) {
-        var me = this;
-        return nodes -> me.select(nodes, executionContext);
-    }
-
-    static ContextNodeSelector wrap(NodeSelector nodeSelector) {
-        return (nodes, context) -> nodeSelector.select(nodes);
-    }
+    NodeSelector bind(ClientYamlTestExecutionContext executionContext);
 }

--- a/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/ContextNodeSelector.java
+++ b/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/ContextNodeSelector.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.test.rest.yaml.section;
+
+import org.elasticsearch.client.Node;
+import org.elasticsearch.client.NodeSelector;
+import org.elasticsearch.test.rest.yaml.ClientYamlTestExecutionContext;
+
+interface ContextNodeSelector {
+    void select(Iterable<Node> nodes, ClientYamlTestExecutionContext context);
+
+    ContextNodeSelector ANY = (nodes, context) -> {};
+
+    default NodeSelector bind(ClientYamlTestExecutionContext executionContext) {
+        var me = this;
+        return nodes -> me.select(nodes, executionContext);
+    }
+
+    static ContextNodeSelector wrap(NodeSelector nodeSelector) {
+        return (nodes, context) -> nodeSelector.select(nodes);
+    }
+}

--- a/test/yaml-rest-runner/src/test/java/org/elasticsearch/test/rest/yaml/section/ClientYamlTestSuiteTests.java
+++ b/test/yaml-rest-runner/src/test/java/org/elasticsearch/test/rest/yaml/section/ClientYamlTestSuiteTests.java
@@ -571,7 +571,7 @@ public class ClientYamlTestSuiteTests extends AbstractClientYamlTestFragmentPars
         int lineNumber = between(1, 10000);
         DoSection doSection = new DoSection(new XContentLocation(lineNumber, 0));
         ApiCallSection apiCall = new ApiCallSection("test");
-        apiCall.setNodeSelector(NodeSelector.SKIP_DEDICATED_MASTERS);
+        apiCall.setNodeSelector(ContextNodeSelector.wrap(NodeSelector.SKIP_DEDICATED_MASTERS));
         doSection.setApiCallSection(apiCall);
         ClientYamlTestSuite testSuite = createTestSuite(SkipSection.EMPTY, doSection);
         Exception e = expectThrows(IllegalArgumentException.class, testSuite::validate);
@@ -628,7 +628,7 @@ public class ClientYamlTestSuiteTests extends AbstractClientYamlTestFragmentPars
         {
             DoSection doSection = new DoSection(new XContentLocation(thirdLineNumber, 0));
             ApiCallSection apiCall = new ApiCallSection("test");
-            apiCall.setNodeSelector(NodeSelector.SKIP_DEDICATED_MASTERS);
+            apiCall.setNodeSelector(ContextNodeSelector.wrap(NodeSelector.SKIP_DEDICATED_MASTERS));
             doSection.setApiCallSection(apiCall);
             doSections.add(doSection);
         }
@@ -678,7 +678,7 @@ public class ClientYamlTestSuiteTests extends AbstractClientYamlTestFragmentPars
         SkipSection skipSection = new SkipSection(null, singletonList("node_selector"), emptyList(), null);
         DoSection doSection = new DoSection(new XContentLocation(lineNumber, 0));
         ApiCallSection apiCall = new ApiCallSection("test");
-        apiCall.setNodeSelector(NodeSelector.SKIP_DEDICATED_MASTERS);
+        apiCall.setNodeSelector(ContextNodeSelector.wrap(NodeSelector.SKIP_DEDICATED_MASTERS));
         doSection.setApiCallSection(apiCall);
         createTestSuite(skipSection, doSection).validate();
     }

--- a/test/yaml-rest-runner/src/test/java/org/elasticsearch/test/rest/yaml/section/ClientYamlTestSuiteTests.java
+++ b/test/yaml-rest-runner/src/test/java/org/elasticsearch/test/rest/yaml/section/ClientYamlTestSuiteTests.java
@@ -571,7 +571,7 @@ public class ClientYamlTestSuiteTests extends AbstractClientYamlTestFragmentPars
         int lineNumber = between(1, 10000);
         DoSection doSection = new DoSection(new XContentLocation(lineNumber, 0));
         ApiCallSection apiCall = new ApiCallSection("test");
-        apiCall.setNodeSelector(ContextNodeSelector.wrap(NodeSelector.SKIP_DEDICATED_MASTERS));
+        apiCall.setNodeSelector(ContextNodeSelector.withoutContext(NodeSelector.SKIP_DEDICATED_MASTERS));
         doSection.setApiCallSection(apiCall);
         ClientYamlTestSuite testSuite = createTestSuite(SkipSection.EMPTY, doSection);
         Exception e = expectThrows(IllegalArgumentException.class, testSuite::validate);
@@ -628,7 +628,7 @@ public class ClientYamlTestSuiteTests extends AbstractClientYamlTestFragmentPars
         {
             DoSection doSection = new DoSection(new XContentLocation(thirdLineNumber, 0));
             ApiCallSection apiCall = new ApiCallSection("test");
-            apiCall.setNodeSelector(ContextNodeSelector.wrap(NodeSelector.SKIP_DEDICATED_MASTERS));
+            apiCall.setNodeSelector(ContextNodeSelector.withoutContext(NodeSelector.SKIP_DEDICATED_MASTERS));
             doSection.setApiCallSection(apiCall);
             doSections.add(doSection);
         }
@@ -678,7 +678,7 @@ public class ClientYamlTestSuiteTests extends AbstractClientYamlTestFragmentPars
         SkipSection skipSection = new SkipSection(null, singletonList("node_selector"), emptyList(), null);
         DoSection doSection = new DoSection(new XContentLocation(lineNumber, 0));
         ApiCallSection apiCall = new ApiCallSection("test");
-        apiCall.setNodeSelector(ContextNodeSelector.wrap(NodeSelector.SKIP_DEDICATED_MASTERS));
+        apiCall.setNodeSelector(ContextNodeSelector.withoutContext(NodeSelector.SKIP_DEDICATED_MASTERS));
         doSection.setApiCallSection(apiCall);
         createTestSuite(skipSection, doSection).validate();
     }

--- a/test/yaml-rest-runner/src/test/java/org/elasticsearch/test/rest/yaml/section/ClientYamlTestSuiteTests.java
+++ b/test/yaml-rest-runner/src/test/java/org/elasticsearch/test/rest/yaml/section/ClientYamlTestSuiteTests.java
@@ -571,7 +571,7 @@ public class ClientYamlTestSuiteTests extends AbstractClientYamlTestFragmentPars
         int lineNumber = between(1, 10000);
         DoSection doSection = new DoSection(new XContentLocation(lineNumber, 0));
         ApiCallSection apiCall = new ApiCallSection("test");
-        apiCall.setNodeSelector(ContextNodeSelector.withoutContext(NodeSelector.SKIP_DEDICATED_MASTERS));
+        apiCall.setNodeSelector(ClientYamlNodeSelector.withoutContext(NodeSelector.SKIP_DEDICATED_MASTERS));
         doSection.setApiCallSection(apiCall);
         ClientYamlTestSuite testSuite = createTestSuite(SkipSection.EMPTY, doSection);
         Exception e = expectThrows(IllegalArgumentException.class, testSuite::validate);
@@ -628,7 +628,7 @@ public class ClientYamlTestSuiteTests extends AbstractClientYamlTestFragmentPars
         {
             DoSection doSection = new DoSection(new XContentLocation(thirdLineNumber, 0));
             ApiCallSection apiCall = new ApiCallSection("test");
-            apiCall.setNodeSelector(ContextNodeSelector.withoutContext(NodeSelector.SKIP_DEDICATED_MASTERS));
+            apiCall.setNodeSelector(ClientYamlNodeSelector.withoutContext(NodeSelector.SKIP_DEDICATED_MASTERS));
             doSection.setApiCallSection(apiCall);
             doSections.add(doSection);
         }
@@ -678,7 +678,7 @@ public class ClientYamlTestSuiteTests extends AbstractClientYamlTestFragmentPars
         SkipSection skipSection = new SkipSection(null, singletonList("node_selector"), emptyList(), null);
         DoSection doSection = new DoSection(new XContentLocation(lineNumber, 0));
         ApiCallSection apiCall = new ApiCallSection("test");
-        apiCall.setNodeSelector(ContextNodeSelector.withoutContext(NodeSelector.SKIP_DEDICATED_MASTERS));
+        apiCall.setNodeSelector(ClientYamlNodeSelector.withoutContext(NodeSelector.SKIP_DEDICATED_MASTERS));
         doSection.setApiCallSection(apiCall);
         createTestSuite(skipSection, doSection).validate();
     }

--- a/test/yaml-rest-runner/src/test/java/org/elasticsearch/test/rest/yaml/section/DoSectionTests.java
+++ b/test/yaml-rest-runner/src/test/java/org/elasticsearch/test/rest/yaml/section/DoSectionTests.java
@@ -587,7 +587,7 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
 
         DoSection doSection = DoSection.parse(parser);
         ClientYamlTestExecutionContext context = mock(ClientYamlTestExecutionContext.class);
-        assertNotSame(ContextNodeSelector.ANY, doSection.getApiCallSection().getNodeSelector());
+        assertNotSame(ClientYamlNodeSelector.ANY, doSection.getApiCallSection().getNodeSelector());
         Node v170 = nodeWithVersion("1.7.0");
         Node v521 = nodeWithVersion("5.2.1");
         Node v550 = nodeWithVersion("5.5.0");
@@ -639,7 +639,7 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
                 index: test_index""");
 
         DoSection doSection = DoSection.parse(parser);
-        assertNotSame(ContextNodeSelector.ANY, doSection.getApiCallSection().getNodeSelector());
+        assertNotSame(ClientYamlNodeSelector.ANY, doSection.getApiCallSection().getNodeSelector());
         Node nonSemantic = nodeWithVersion("abddef");
         List<Node> nodes = new ArrayList<>();
 
@@ -661,7 +661,7 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
                 index: test_index""");
 
         DoSection doSection = DoSection.parse(parser);
-        assertNotSame(ContextNodeSelector.ANY, doSection.getApiCallSection().getNodeSelector());
+        assertNotSame(ClientYamlNodeSelector.ANY, doSection.getApiCallSection().getNodeSelector());
         Node v170 = nodeWithVersion("1.7.0");
         Node v521 = nodeWithVersion("5.2.1");
         Node v550 = nodeWithVersion("5.5.0");
@@ -690,7 +690,7 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
                 index: test_index""");
 
         DoSection doSection = DoSection.parse(parser);
-        assertNotSame(ContextNodeSelector.ANY, doSection.getApiCallSection().getNodeSelector());
+        assertNotSame(ClientYamlNodeSelector.ANY, doSection.getApiCallSection().getNodeSelector());
         Node hasAttr = nodeWithAttributes(singletonMap("attr", singletonList("val")));
         Node hasAttrWrongValue = nodeWithAttributes(singletonMap("attr", singletonList("notval")));
         Node notHasAttr = nodeWithAttributes(singletonMap("notattr", singletonList("val")));
@@ -721,7 +721,7 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
                 index: test_index""");
 
         DoSection doSectionWithTwoAttributes = DoSection.parse(parser);
-        assertNotSame(ContextNodeSelector.ANY, doSection.getApiCallSection().getNodeSelector());
+        assertNotSame(ClientYamlNodeSelector.ANY, doSection.getApiCallSection().getNodeSelector());
         Node hasAttr2 = nodeWithAttributes(singletonMap("attr2", singletonList("val2")));
         Map<String, List<String>> bothAttributes = new HashMap<>();
         bothAttributes.put("attr", singletonList("val"));
@@ -753,7 +753,7 @@ public class DoSectionTests extends AbstractClientYamlTestFragmentParserTestCase
                 index: test_index""");
 
         DoSection doSection = DoSection.parse(parser);
-        assertNotSame(ContextNodeSelector.ANY, doSection.getApiCallSection().getNodeSelector());
+        assertNotSame(ClientYamlNodeSelector.ANY, doSection.getApiCallSection().getNodeSelector());
         Node both = nodeWithVersionAndAttributes("5.2.1", singletonMap("attr", singletonList("val")));
         Node badVersion = nodeWithVersionAndAttributes("5.1.1", singletonMap("attr", singletonList("val")));
         Node badAttr = nodeWithVersionAndAttributes("5.2.1", singletonMap("notattr", singletonList("val")));


### PR DESCRIPTION
Selection based on cluster/node features needs context to work; introducing `ContextNodeSelector` that allows to access context (`ClientYamlTestExecutionContext`) in the `select` method. 
`ContextNodeSelector` is later adapted to a `NodeSelector` by binding to a context.

TODO: 
- Modify `TestFeatureService` to expose _nodes_ features. This is not something we usually want to do; features are cluster wide. However, mixed cluster tests, upgrade tests and so on rely on filtering nodes based on a finer granularity (nodes) - currently done by filtering by version. For test only (it's `TestFeatureService` after all) we want to expose features supported by a single node.
- Wire `TestFeatureService`/ESRestTest method to `ClientYamlTestExecutionContext` (similarly to what already in place for cluster features).