### PR TITLE
[8.12] [Connectors API] Fix ClassCastException when creating a new sync job (#103508)

### DIFF
--- a/docs/changelog/103508.yaml
+++ b/docs/changelog/103508.yaml
@@ -1,0 +1,5 @@
+pr: 103508
+summary: "[Connectors API] Fix `ClassCastException` when creating a new sync job"
+area: Application
+type: bug
+issues: []

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/400_connector_sync_job_post.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/400_connector_sync_job_post.yml
@@ -23,8 +23,85 @@ setup:
   - set:  { id: id }
   - match: { id: $id }
 
+  - do:
+      connector_sync_job.get:
+        connector_sync_job_id: $id
+
+  - match: { connector.id: test-connector}
+  - match: { job_type: full }
+  - match: { trigger_method: on_demand }
+  - match: { status: pending }
+  - match: { total_document_count: 0 }
+  - match: { indexed_document_count: 0 }
+  - match: { indexed_document_volume: 0 }
+  - match: { deleted_document_count: 0 }
+  - match: { id: $id }
+  - exists: created_at
+  - exists: last_seen
+
 ---
-'Create connector sync job with missing job type':
+'Create connector sync job with complex connector document':
+
+  - do:
+      connector.update_pipeline:
+        connector_id: test-connector
+        body:
+          pipeline:
+            extract_binary_content: true
+            name: test-pipeline
+            reduce_whitespace: true
+            run_ml_inference: false
+
+  - match: { result: updated }
+
+  - do:
+      connector.update_configuration:
+        connector_id: test-connector
+        body:
+          configuration:
+            some_field:
+              default_value: null
+              depends_on:
+                - field: some_field
+                  value: 31
+              display: numeric
+              label: Very important field
+              options: [ ]
+              order: 4
+              required: true
+              sensitive: false
+              tooltip: Wow, this tooltip is useful.
+              type: str
+              ui_restrictions: [ ]
+              validations:
+                - constraint: 0
+                  type: greater_than
+              value: 456
+
+  - match: { result: updated }
+
+  - do:
+      connector_sync_job.post:
+        body:
+          id: test-connector
+          job_type: full
+          trigger_method: on_demand
+
+  - set:  { id: id }
+
+  - match: { id: $id }
+
+  - do:
+      connector_sync_job.get:
+        connector_sync_job_id: $id
+
+  - match: { connector.id: test-connector }
+  - match: { connector.configuration.some_field.value: 456 }
+  - match: { connector.pipeline.name: test-pipeline }
+
+---
+
+'Create connector sync job with missing job type - expect job type full as default':
   - do:
       connector_sync_job.post:
         body:

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobTests.java
@@ -400,7 +400,7 @@ public class ConnectorSyncJobTests extends ESTestCase {
             }
             """);
 
-        Connector connector = ConnectorSyncJob.syncJobConnectorFromXContentBytes(new BytesArray(content), XContentType.JSON);
+        Connector connector = ConnectorSyncJob.syncJobConnectorFromXContentBytes(new BytesArray(content), null, XContentType.JSON);
 
         assertThat(connector.getConnectorId(), equalTo("connector-id"));
         assertThat(connector.getFiltering().size(), equalTo(1));
@@ -474,7 +474,7 @@ public class ConnectorSyncJobTests extends ESTestCase {
             }
             """);
 
-        ConnectorSyncJob.syncJobConnectorFromXContentBytes(new BytesArray(content), XContentType.JSON);
+        ConnectorSyncJob.syncJobConnectorFromXContentBytes(new BytesArray(content), null, XContentType.JSON);
     }
 
     private void assertTransportSerialization(ConnectorSyncJob testInstance) throws IOException {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.12`:
 - [[Connectors API] Fix ClassCastException when creating a new sync job (#103508)](https://github.com/elastic/elasticsearch/pull/103508)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)