### PR TITLE
Update IndexVersion constants for 8.13

### DIFF
--- a/plugins/analysis-nori/src/main/java/org/elasticsearch/plugin/analysis/nori/NoriTokenizerFactory.java
+++ b/plugins/analysis-nori/src/main/java/org/elasticsearch/plugin/analysis/nori/NoriTokenizerFactory.java
@@ -83,6 +83,8 @@ public class NoriTokenizerFactory extends AbstractTokenizerFactory {
      */
     private static boolean isSupportDuplicateCheck(IndexSettings indexSettings) {
         var idxVersion = indexSettings.getIndexVersionCreated();
+        // Explicitly exclude the range of versions greater than NORI_DUPLICATES, that
+        // are also in 8.12. The only version in this range is UPGRADE_LUCENE_9_9_1.
         return idxVersion.onOrAfter(IndexVersions.NORI_DUPLICATES) && idxVersion != UPGRADE_LUCENE_9_9_1;
     }
 

--- a/plugins/analysis-nori/src/main/java/org/elasticsearch/plugin/analysis/nori/NoriTokenizerFactory.java
+++ b/plugins/analysis-nori/src/main/java/org/elasticsearch/plugin/analysis/nori/NoriTokenizerFactory.java
@@ -80,7 +80,7 @@ public class NoriTokenizerFactory extends AbstractTokenizerFactory {
      * that the duplicate check feature is supported.
      */
     private static boolean isSupportDuplicateCheck(IndexSettings indexSettings) {
-        return indexSettings.getIndexVersionCreated().onOrAfter(IndexVersions.ES_VERSION_8_13);
+        return indexSettings.getIndexVersionCreated().onOrAfter(IndexVersions.ES_VERSION_8_13); // HERE
     }
 
     public static KoreanTokenizer.DecompoundMode getMode(Settings settings) {

--- a/plugins/analysis-nori/src/main/java/org/elasticsearch/plugin/analysis/nori/NoriTokenizerFactory.java
+++ b/plugins/analysis-nori/src/main/java/org/elasticsearch/plugin/analysis/nori/NoriTokenizerFactory.java
@@ -25,6 +25,8 @@ import java.io.StringReader;
 import java.util.List;
 import java.util.Locale;
 
+import static org.elasticsearch.index.IndexVersions.UPGRADE_LUCENE_9_9_1;
+
 public class NoriTokenizerFactory extends AbstractTokenizerFactory {
     private static final String USER_DICT_PATH_OPTION = "user_dictionary";
     private static final String USER_DICT_RULES_OPTION = "user_dictionary_rules";
@@ -80,7 +82,8 @@ public class NoriTokenizerFactory extends AbstractTokenizerFactory {
      * that the duplicate check feature is supported.
      */
     private static boolean isSupportDuplicateCheck(IndexSettings indexSettings) {
-        return indexSettings.getIndexVersionCreated().onOrAfter(IndexVersions.ES_VERSION_8_13); // HERE
+        var idxVersion = indexSettings.getIndexVersionCreated();
+        return idxVersion.onOrAfter(IndexVersions.NORI_DUPLICATES) && idxVersion != UPGRADE_LUCENE_9_9_1;
     }
 
     public static KoreanTokenizer.DecompoundMode getMode(Settings settings) {

--- a/plugins/analysis-nori/src/test/java/org/elasticsearch/plugin/analysis/nori/NoriAnalysisTests.java
+++ b/plugins/analysis-nori/src/test/java/org/elasticsearch/plugin/analysis/nori/NoriAnalysisTests.java
@@ -121,7 +121,7 @@ public class NoriAnalysisTests extends ESTokenStreamTestCase {
     public void testNoriAnalyzerDuplicateUserDictRule() throws Exception {
         Settings settings = Settings.builder()
             .put("index.analysis.analyzer.my_analyzer.type", "nori")
-            .put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersions.ES_VERSION_8_13) // HERE
+            .put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersions.NORI_DUPLICATES)
             .putList("index.analysis.analyzer.my_analyzer.user_dictionary_rules", "c++", "C쁠쁠", "세종", "세종", "세종시 세종 시")
             .build();
 

--- a/plugins/analysis-nori/src/test/java/org/elasticsearch/plugin/analysis/nori/NoriAnalysisTests.java
+++ b/plugins/analysis-nori/src/test/java/org/elasticsearch/plugin/analysis/nori/NoriAnalysisTests.java
@@ -121,7 +121,7 @@ public class NoriAnalysisTests extends ESTokenStreamTestCase {
     public void testNoriAnalyzerDuplicateUserDictRule() throws Exception {
         Settings settings = Settings.builder()
             .put("index.analysis.analyzer.my_analyzer.type", "nori")
-            .put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersions.ES_VERSION_8_13)
+            .put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersions.ES_VERSION_8_13) // HERE
             .putList("index.analysis.analyzer.my_analyzer.user_dictionary_rules", "c++", "C쁠쁠", "세종", "세종", "세종시 세종 시")
             .build();
 

--- a/server/src/main/java/org/elasticsearch/index/IndexVersions.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersions.java
@@ -92,8 +92,10 @@ public class IndexVersions {
     public static final IndexVersion ES_VERSION_8_12 = def(8_500_004, Version.LUCENE_9_8_0);
     public static final IndexVersion NORMALIZED_VECTOR_COSINE = def(8_500_005, Version.LUCENE_9_8_0);
     public static final IndexVersion UPGRADE_LUCENE_9_9 = def(8_500_006, Version.LUCENE_9_9_0);
-    public static final IndexVersion ES_VERSION_8_13 = def(8_500_007, Version.LUCENE_9_9_0);
+    public static final IndexVersion ES_VERSION_TRANSIENT = def(8_500_007, Version.LUCENE_9_9_0);
     public static final IndexVersion UPGRADE_LUCENE_9_9_1 = def(8_500_008, Version.LUCENE_9_9_1);
+    public static final IndexVersion ES_VERSION_8_13 = def(8_500_009, Version.LUCENE_9_9_1);
+
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/index/IndexVersions.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersions.java
@@ -92,10 +92,9 @@ public class IndexVersions {
     public static final IndexVersion ES_VERSION_8_12 = def(8_500_004, Version.LUCENE_9_8_0);
     public static final IndexVersion NORMALIZED_VECTOR_COSINE = def(8_500_005, Version.LUCENE_9_8_0);
     public static final IndexVersion UPGRADE_LUCENE_9_9 = def(8_500_006, Version.LUCENE_9_9_0);
-    public static final IndexVersion ES_VERSION_TRANSIENT = def(8_500_007, Version.LUCENE_9_9_0);
+    public static final IndexVersion NORI_DUPLICATES = def(8_500_007, Version.LUCENE_9_9_0);
     public static final IndexVersion UPGRADE_LUCENE_9_9_1 = def(8_500_008, Version.LUCENE_9_9_1);
     public static final IndexVersion ES_VERSION_8_13 = def(8_500_009, Version.LUCENE_9_9_1);
-
 
     /*
      * STOP! READ THIS FIRST! No, really,


### PR DESCRIPTION
This commit adds a new IndexVersion so that 8.13. can be determined over 8.12, since 8.12 is having it's IndexVersion's updated as per #103549.