### PR TITLE
[Connectors API][Docs] Update stubbed doc links for actions

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector.check_in.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector.check_in.json
@@ -1,7 +1,7 @@
 {
   "connector.check_in": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/enterprise-search/current/connectors.html",
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/check-in-connector-api.html",
       "description": "Updates the last_seen timestamp in the connector document."
     },
     "stability": "experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector.delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector.delete.json
@@ -1,7 +1,7 @@
 {
   "connector.delete": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/enterprise-search/current/connectors.html",
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-connector-api.html",
       "description": "Deletes a connector."
     },
     "stability": "experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector.get.json
@@ -1,7 +1,7 @@
 {
   "connector.get": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/enterprise-search/current/connectors.html",
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/get-connector-api.html",
       "description": "Returns the details about a connector."
     },
     "stability": "experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector.last_sync.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector.last_sync.json
@@ -1,7 +1,7 @@
 {
   "connector.last_sync": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/enterprise-search/current/connectors.html",
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/update-connector-last-sync-api.html",
       "description": "Updates the stats of last sync in the connector document."
     },
     "stability": "experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector.list.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector.list.json
@@ -1,7 +1,7 @@
 {
   "connector.list": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/enterprise-search/current/connectors.html",
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/list-connector-api.html",
       "description": "Lists all connectors."
     },
     "stability": "experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector.post.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector.post.json
@@ -1,7 +1,7 @@
 {
   "connector.post": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/enterprise-search/current/connectors.html",
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/create-connector-api.html",
       "description": "Creates a connector."
     },
     "stability": "experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector.put.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector.put.json
@@ -1,7 +1,7 @@
 {
   "connector.put": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/enterprise-search/current/connectors.html",
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/create-connector-api.html",
       "description": "Creates or updates a connector."
     },
     "stability": "experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector.update_configuration.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector.update_configuration.json
@@ -1,7 +1,7 @@
 {
   "connector.update_configuration": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/enterprise-search/current/connectors.html",
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/update-connector-configuration-api.html",
       "description": "Updates the connector configuration."
     },
     "stability": "experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector.update_error.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector.update_error.json
@@ -1,7 +1,7 @@
 {
   "connector.update_error": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/enterprise-search/current/connectors.html",
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/update-connector-error-api.html",
       "description": "Updates the error field in the connector document."
     },
     "stability": "experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector.update_filtering.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector.update_filtering.json
@@ -1,7 +1,7 @@
 {
   "connector.update_filtering": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/enterprise-search/current/connectors.html",
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/update-connector-filtering-api.html",
       "description": "Updates the filtering field in the connector document."
     },
     "stability": "experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector.update_name.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector.update_name.json
@@ -1,7 +1,7 @@
 {
   "connector.update_name": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/enterprise-search/current/connectors.html",
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/update-connector-name-description-api.html",
       "description": "Updates the name and/or description fields in the connector document."
     },
     "stability": "experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector.update_pipeline.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector.update_pipeline.json
@@ -1,7 +1,7 @@
 {
   "connector.update_pipeline": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/enterprise-search/current/connectors.html",
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/update-connector-pipeline-api.html",
       "description": "Updates the pipeline field in the connector document."
     },
     "stability": "experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector.update_scheduling.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector.update_scheduling.json
@@ -1,7 +1,7 @@
 {
   "connector.update_scheduling": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/enterprise-search/current/connectors.html",
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/update-connector-scheduling-api.html",
       "description": "Updates the scheduling field in the connector document."
     },
     "stability": "experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector_sync_job.cancel.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector_sync_job.cancel.json
@@ -1,7 +1,7 @@
 {
   "connector_sync_job.cancel": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/enterprise-search/current/connectors.html",
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/cancel-connector-sync-job-api.html",
       "description": "Cancels a connector sync job."
     },
     "stability": "experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector_sync_job.check_in.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector_sync_job.check_in.json
@@ -1,7 +1,7 @@
 {
   "connector_sync_job.check_in": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/enterprise-search/current/connectors.html",
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/check-in-connector-sync-job-api.html",
       "description": "Checks in a connector sync job (refreshes 'last_seen')."
     },
     "stability": "experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector_sync_job.delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector_sync_job.delete.json
@@ -1,7 +1,7 @@
 {
   "connector_sync_job.delete": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/enterprise-search/current/connectors.html",
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-connector-sync-job-api.html",
       "description": "Deletes a connector sync job."
     },
     "stability": "experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector_sync_job.error.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector_sync_job.error.json
@@ -1,7 +1,7 @@
 {
   "connector_sync_job.error": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/enterprise-search/current/connectors.html",
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/set-connector-sync-job-error-api.html",
       "description": "Sets an error for a connector sync job."
     },
     "stability": "experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector_sync_job.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector_sync_job.get.json
@@ -1,7 +1,7 @@
 {
   "connector_sync_job.get": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/enterprise-search/current/connectors.html",
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/get-connector-sync-job-api.html",
       "description": "Returns the details about a connector sync job."
     },
     "stability": "experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector_sync_job.list.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector_sync_job.list.json
@@ -1,7 +1,7 @@
 {
   "connector_sync_job.list": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/enterprise-search/current/connectors.html",
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/list-connector-sync-jobs-api.html",
       "description": "Lists all connector sync jobs."
     },
     "stability": "experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector_sync_job.post.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector_sync_job.post.json
@@ -1,7 +1,7 @@
 {
   "connector_sync_job.post": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/enterprise-search/current/connectors.html",
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/create-connector-sync-job-api.html",
       "description": "Creates a connector sync job."
     },
     "stability": "experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector_sync_job.update_stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector_sync_job.update_stats.json
@@ -1,7 +1,7 @@
 {
   "connector_sync_job.update_stats": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/enterprise-search/current/connectors.html",
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/set-connector-sync-job-stats-api.html",
       "description": "Updates the stats fields in the connector sync job document."
     },
     "stability": "experimental",


### PR DESCRIPTION
Change stubbed doc links for actions related to Connectors and Sync Jobs API. 

All added doc pages were backported to 8.12 as well.