### PR TITLE
Match and match_phrase not rewriting to term query

### DIFF
--- a/docs/changelog/103572.yaml
+++ b/docs/changelog/103572.yaml
@@ -1,0 +1,5 @@
+pr: 103572
+summary: Match and `match_phrase` not rewriting to term query
+area: Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/query/MatchPhraseQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/MatchPhraseQueryBuilder.java
@@ -163,8 +163,9 @@ public class MatchPhraseQueryBuilder extends AbstractQueryBuilder<MatchPhraseQue
         // and possibly shortcut
         // If we're using a keyword analyzer then we can rewrite this to a TermQueryBuilder
         // and possibly shortcut
+        // If no analyzer is set then we can rewrite this to a TermQueryBuilder and possibly shortcut
         NamedAnalyzer configuredAnalyzer = configuredAnalyzer(context);
-        if (configuredAnalyzer != null && configuredAnalyzer.analyzer() instanceof KeywordAnalyzer) {
+        if (configuredAnalyzer == null || configuredAnalyzer.analyzer() instanceof KeywordAnalyzer) {
             TermQueryBuilder termQueryBuilder = new TermQueryBuilder(fieldName, value);
             return termQueryBuilder.rewrite(context);
         } else {

--- a/server/src/main/java/org/elasticsearch/index/query/MatchQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/MatchQueryBuilder.java
@@ -374,10 +374,10 @@ public class MatchQueryBuilder extends AbstractQueryBuilder<MatchQueryBuilder> {
             // Term queries can be neither fuzzy nor lenient, so don't rewrite under these conditions
             return this;
         }
-        // If we're using a keyword analyzer then we can rewrite this to a TermQueryBuilder
-        // and possibly shortcut
+        // If we're using a keyword analyzer then we can rewrite this to a TermQueryBuilder and possibly shortcut
+        // If no analyzer is set then we can rewrite this to a TermQueryBuilder and possibly shortcut
         NamedAnalyzer configuredAnalyzer = configuredAnalyzer(context);
-        if (configuredAnalyzer != null && configuredAnalyzer.analyzer() instanceof KeywordAnalyzer) {
+        if (configuredAnalyzer == null || configuredAnalyzer.analyzer() instanceof KeywordAnalyzer) {
             TermQueryBuilder termQueryBuilder = new TermQueryBuilder(fieldName, value);
             return termQueryBuilder.rewrite(context);
         }

--- a/server/src/test/java/org/elasticsearch/index/query/MatchPhraseQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/MatchPhraseQueryBuilderTests.java
@@ -213,6 +213,14 @@ public class MatchPhraseQueryBuilderTests extends AbstractQueryTestCase<MatchPhr
         }
     }
 
+    public void testRewriteUnmappedFieldToMatchNone() throws IOException {
+        MatchPhraseQueryBuilder queryBuilder = new MatchPhraseQueryBuilder(UNMAPPED_FIELD_NAME, "value");
+        for (QueryRewriteContext context : new QueryRewriteContext[] { createSearchExecutionContext(), createQueryRewriteContext() }) {
+            QueryBuilder rewritten = queryBuilder.rewrite(context);
+            assertThat(rewritten, instanceOf(MatchNoneQueryBuilder.class));
+        }
+    }
+
     public void testRewriteIndexQueryToMatchNone() throws IOException {
         QueryBuilder query = new MatchPhraseQueryBuilder("_index", "does_not_exist");
         for (QueryRewriteContext context : new QueryRewriteContext[] { createSearchExecutionContext(), createQueryRewriteContext() }) {

--- a/server/src/test/java/org/elasticsearch/index/query/MatchQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/MatchQueryBuilderTests.java
@@ -628,6 +628,14 @@ public class MatchQueryBuilderTests extends AbstractQueryTestCase<MatchQueryBuil
         }
     }
 
+    public void testRewriteUnmappedFieldToMatchNone() throws IOException {
+        MatchQueryBuilder queryBuilder = new MatchQueryBuilder(UNMAPPED_FIELD_NAME, "value");
+        for (QueryRewriteContext context : new QueryRewriteContext[] { createSearchExecutionContext(), createQueryRewriteContext() }) {
+            QueryBuilder rewritten = queryBuilder.rewrite(context);
+            assertThat(rewritten, instanceOf(MatchNoneQueryBuilder.class));
+        }
+    }
+
     public void testRewriteWithFuzziness() throws IOException {
         // If we've configured fuzziness then we can't rewrite to a term query
         MatchQueryBuilder queryBuilder = new MatchQueryBuilder(KEYWORD_FIELD_NAME, "value");

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
@@ -127,6 +127,7 @@ public abstract class AbstractBuilderTestCase extends ESTestCase {
     protected static final String GEO_POINT_ALIAS_FIELD_NAME = "mapped_geo_point_alias";
     // we don't include the binary field in the arrays below as it is not searchable
     protected static final String BINARY_FIELD_NAME = "mapped_binary";
+    protected static final String UNMAPPED_FIELD_NAME = "unmapped_field";
     protected static final String[] MAPPED_FIELD_NAMES = new String[] {
         TEXT_FIELD_NAME,
         TEXT_ALIAS_FIELD_NAME,


### PR DESCRIPTION
When doing a match or match_phrase query against an unmapped field in an index the query 
was not rewritten to TermQuery (and therefore possibly shortcut to MatchNone/MatchAll) because 
unmapped fields doesn't have an analyzer.
Now if the analyzer is not found we do rewrite to TermQuery.