### PR TITLE
Filter out all `ForkJoinPool.commonPool-worker` threads

### DIFF
--- a/test/fixtures/testcontainer-utils/src/main/java/org/elasticsearch/test/fixtures/testcontainers/TestContainersThreadFilter.java
+++ b/test/fixtures/testcontainer-utils/src/main/java/org/elasticsearch/test/fixtures/testcontainers/TestContainersThreadFilter.java
@@ -19,6 +19,6 @@ public class TestContainersThreadFilter implements ThreadFilter {
     public boolean reject(Thread t) {
         return t.getName().startsWith("testcontainers-")
             || t.getName().startsWith("ducttape")
-            || t.getName().startsWith("ForkJoinPool.commonPool-worker-1");
+            || t.getName().startsWith("ForkJoinPool.commonPool-worker-");
     }
 }


### PR DESCRIPTION
This is a temporary fix for a known issue which we need to ignore for now, see [this comment](https://github.com/elastic/elasticsearch/pull/103320/files#r1424129050) for more info.

In this case the failure reported leakage of `ForkJoinPool.commonPool-worker-2` thread.
This PR changes the filter to ignore all threads which start with `ForkJoinPool.commonPool-worker-`.

Closes https://github.com/elastic/elasticsearch/issues/103525