### PR TITLE
[ML] Wait for the model results on graceful shutdown

### DIFF
--- a/docs/changelog/103591.yaml
+++ b/docs/changelog/103591.yaml
@@ -1,0 +1,6 @@
+pr: 103591
+summary: Wait for the model results on graceful shutdown
+area: Machine Learning
+type: bug
+issues:
+ - 103414

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -1051,7 +1051,7 @@ public class MachineLearning extends Plugin
             normalizerProcessFactory = (jobId, quantilesState, bucketSpan, executorService) -> new MultiplyingNormalizerProcess(1.0);
             analyticsProcessFactory = (jobId, analyticsProcessConfig, hasState, executorService, onProcessCrash) -> null;
             memoryEstimationProcessFactory = (jobId, analyticsProcessConfig, hasState, executorService, onProcessCrash) -> null;
-            pyTorchProcessFactory = (task, executorService, onProcessCrash) -> new BlackHolePyTorchProcess();
+            pyTorchProcessFactory = (task, executorService, afterInputStreamClose, onProcessCrash) -> new BlackHolePyTorchProcess();
         }
         NormalizerFactory normalizerFactory = new NormalizerFactory(
             normalizerProcessFactory,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
@@ -496,7 +496,14 @@ public class DeploymentManager {
             }
 
             logger.debug("[{}] start and load", task.getDeploymentId());
-            process.set(pyTorchProcessFactory.createProcess(task, executorServiceForProcess, this::onProcessCrash));
+            process.set(
+                pyTorchProcessFactory.createProcess(
+                    task,
+                    executorServiceForProcess,
+                    () -> resultProcessor.awaitCompletion(COMPLETION_TIMEOUT.getMinutes(), TimeUnit.MINUTES),
+                    this::onProcessCrash
+                )
+            );
             startTime = Instant.now();
             logger.debug("[{}] process started", task.getDeploymentId());
             try {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/process/NativePyTorchProcessFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/process/NativePyTorchProcessFactory.java
@@ -56,6 +56,7 @@ public class NativePyTorchProcessFactory implements PyTorchProcessFactory {
     public NativePyTorchProcess createProcess(
         TrainedModelDeploymentTask task,
         ExecutorService executorService,
+        TimeoutRunnable afterInStreamClose,
         Consumer<String> onProcessCrash
     ) {
         ProcessPipes processPipes = new ProcessPipes(
@@ -80,6 +81,7 @@ public class NativePyTorchProcessFactory implements PyTorchProcessFactory {
             processPipes,
             0,
             Collections.emptyList(),
+            afterInStreamClose,
             onProcessCrash
         );
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/process/PyTorchProcessFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/process/PyTorchProcessFactory.java
@@ -10,9 +10,19 @@ package org.elasticsearch.xpack.ml.inference.pytorch.process;
 import org.elasticsearch.xpack.ml.inference.deployment.TrainedModelDeploymentTask;
 
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 
 public interface PyTorchProcessFactory {
 
-    PyTorchProcess createProcess(TrainedModelDeploymentTask task, ExecutorService executorService, Consumer<String> onProcessCrash);
+    interface TimeoutRunnable {
+        void run() throws TimeoutException;
+    }
+
+    PyTorchProcess createProcess(
+        TrainedModelDeploymentTask task,
+        ExecutorService executorService,
+        TimeoutRunnable afterInStreamClose,
+        Consumer<String> onProcessCrash
+    );
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/AbstractNativeProcess.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/AbstractNativeProcess.java
@@ -223,7 +223,7 @@ public abstract class AbstractNativeProcess implements NativeProcess {
      * Implementations can override this if they need to perform extra processing
      * immediately after the native process's input stream is closed.
      */
-    protected void afterProcessInStreamClose() {
+    protected void afterProcessInStreamClose() throws TimeoutException {
         // no-op by default
     }
 


### PR DESCRIPTION
#103414 shows a timeout exception when the pytorch_inference process is gracefully shutdown. The timeout occurs waiting for the log stream to close but that will not happen until the process has finished processing the queued requests. 

This change waits for that work to complete after closing the input stream but before waiting on the log stream to close.

The error in #103414 does not mean that the process has not stopped properly rather it is a short timeout as at that point it was expected that all the work is complete but this was not the case. The process would continue to shutdown properly. 

Closes #103414