### PR TITLE
Remove deprecated Block APIs

### DIFF
--- a/docs/changelog/103592.yaml
+++ b/docs/changelog/103592.yaml
@@ -1,0 +1,5 @@
+pr: 103592
+summary: Remove deprecated Block APIs
+area: ES|QL
+type: enhancement
+issues: []

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayBlock.java
@@ -16,17 +16,13 @@ import java.util.BitSet;
  * Block implementation that stores an array of boolean.
  * This class is generated. Do not edit it.
  */
-public final class BooleanArrayBlock extends AbstractArrayBlock implements BooleanBlock {
+final class BooleanArrayBlock extends AbstractArrayBlock implements BooleanBlock {
 
     private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(BooleanArrayBlock.class);
 
     private final boolean[] values;
 
-    public BooleanArrayBlock(boolean[] values, int positionCount, int[] firstValueIndexes, BitSet nulls, MvOrdering mvOrdering) {
-        this(values, positionCount, firstValueIndexes, nulls, mvOrdering, BlockFactory.getNonBreakingInstance());
-    }
-
-    public BooleanArrayBlock(
+    BooleanArrayBlock(
         boolean[] values,
         int positionCount,
         int[] firstValueIndexes,

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayBlock.java
@@ -18,17 +18,13 @@ import java.util.BitSet;
  * Block implementation that stores an array of BytesRef.
  * This class is generated. Do not edit it.
  */
-public final class BytesRefArrayBlock extends AbstractArrayBlock implements BytesRefBlock {
+final class BytesRefArrayBlock extends AbstractArrayBlock implements BytesRefBlock {
 
     private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(BytesRefArrayBlock.class);
 
     private final BytesRefArray values;
 
-    public BytesRefArrayBlock(BytesRefArray values, int positionCount, int[] firstValueIndexes, BitSet nulls, MvOrdering mvOrdering) {
-        this(values, positionCount, firstValueIndexes, nulls, mvOrdering, BlockFactory.getNonBreakingInstance());
-    }
-
-    public BytesRefArrayBlock(
+    BytesRefArrayBlock(
         BytesRefArray values,
         int positionCount,
         int[] firstValueIndexes,

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayBlock.java
@@ -16,17 +16,13 @@ import java.util.BitSet;
  * Block implementation that stores an array of double.
  * This class is generated. Do not edit it.
  */
-public final class DoubleArrayBlock extends AbstractArrayBlock implements DoubleBlock {
+final class DoubleArrayBlock extends AbstractArrayBlock implements DoubleBlock {
 
     private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(DoubleArrayBlock.class);
 
     private final double[] values;
 
-    public DoubleArrayBlock(double[] values, int positionCount, int[] firstValueIndexes, BitSet nulls, MvOrdering mvOrdering) {
-        this(values, positionCount, firstValueIndexes, nulls, mvOrdering, BlockFactory.getNonBreakingInstance());
-    }
-
-    public DoubleArrayBlock(
+    DoubleArrayBlock(
         double[] values,
         int positionCount,
         int[] firstValueIndexes,

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayBlock.java
@@ -16,17 +16,13 @@ import java.util.BitSet;
  * Block implementation that stores an array of int.
  * This class is generated. Do not edit it.
  */
-public final class IntArrayBlock extends AbstractArrayBlock implements IntBlock {
+final class IntArrayBlock extends AbstractArrayBlock implements IntBlock {
 
     private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(IntArrayBlock.class);
 
     private final int[] values;
 
-    public IntArrayBlock(int[] values, int positionCount, int[] firstValueIndexes, BitSet nulls, MvOrdering mvOrdering) {
-        this(values, positionCount, firstValueIndexes, nulls, mvOrdering, BlockFactory.getNonBreakingInstance());
-    }
-
-    public IntArrayBlock(
+    IntArrayBlock(
         int[] values,
         int positionCount,
         int[] firstValueIndexes,

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayBlock.java
@@ -16,17 +16,13 @@ import java.util.BitSet;
  * Block implementation that stores an array of long.
  * This class is generated. Do not edit it.
  */
-public final class LongArrayBlock extends AbstractArrayBlock implements LongBlock {
+final class LongArrayBlock extends AbstractArrayBlock implements LongBlock {
 
     private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(LongArrayBlock.class);
 
     private final long[] values;
 
-    public LongArrayBlock(long[] values, int positionCount, int[] firstValueIndexes, BitSet nulls, MvOrdering mvOrdering) {
-        this(values, positionCount, firstValueIndexes, nulls, mvOrdering, BlockFactory.getNonBreakingInstance());
-    }
-
-    public LongArrayBlock(
+    LongArrayBlock(
         long[] values,
         int positionCount,
         int[] firstValueIndexes,

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
@@ -24,7 +24,7 @@ import java.util.BitSet;
  * Block implementation that stores an array of $type$.
  * This class is generated. Do not edit it.
  */
-public final class $Type$ArrayBlock extends AbstractArrayBlock implements $Type$Block {
+final class $Type$ArrayBlock extends AbstractArrayBlock implements $Type$Block {
 
     private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance($Type$ArrayBlock.class);
 
@@ -35,11 +35,7 @@ $else$
     private final $type$[] values;
 $endif$
 
-    public $Type$ArrayBlock($if(BytesRef)$BytesRefArray$else$$type$[]$endif$ values, int positionCount, int[] firstValueIndexes, BitSet nulls, MvOrdering mvOrdering) {
-        this(values, positionCount, firstValueIndexes, nulls, mvOrdering, BlockFactory.getNonBreakingInstance());
-    }
-
-    public $Type$ArrayBlock(
+    $Type$ArrayBlock(
         $if(BytesRef)$BytesRefArray$else$$type$[]$endif$ values,
         int positionCount,
         int[] firstValueIndexes,

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BooleanBlockEqualityTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BooleanBlockEqualityTests.java
@@ -7,12 +7,12 @@
 
 package org.elasticsearch.compute.data;
 
-import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.compute.operator.ComputeTestCase;
 
 import java.util.BitSet;
 import java.util.List;
 
-public class BooleanBlockEqualityTests extends ESTestCase {
+public class BooleanBlockEqualityTests extends ComputeTestCase {
 
     public void testEmptyVector() {
         // all these "empty" vectors should be equivalent
@@ -28,6 +28,7 @@ public class BooleanBlockEqualityTests extends ESTestCase {
     }
 
     public void testEmptyBlock() {
+        BlockFactory blockFactory = blockFactory();
         // all these "empty" vectors should be equivalent
         List<BooleanBlock> blocks = List.of(
             new BooleanArrayBlock(
@@ -35,14 +36,16 @@ public class BooleanBlockEqualityTests extends ESTestCase {
                 0,
                 new int[] {},
                 BitSet.valueOf(new byte[] { 0b00 }),
-                randomFrom(Block.MvOrdering.values())
+                randomFrom(Block.MvOrdering.values()),
+                blockFactory
             ),
             new BooleanArrayBlock(
                 new boolean[] { randomBoolean() },
                 0,
                 new int[] {},
                 BitSet.valueOf(new byte[] { 0b00 }),
-                randomFrom(Block.MvOrdering.values())
+                randomFrom(Block.MvOrdering.values()),
+                blockFactory
             ),
             BooleanBlock.newConstantBlockWith(randomBoolean(), 0),
             BooleanBlock.newBlockBuilder(0).build(),
@@ -116,6 +119,7 @@ public class BooleanBlockEqualityTests extends ESTestCase {
     }
 
     public void testBlockEquality() {
+        BlockFactory blockFactory = blockFactory();
         // all these blocks should be equivalent
         List<BooleanBlock> blocks = List.of(
             new BooleanArrayVector(new boolean[] { true, false, true }, 3).asBlock(),
@@ -124,14 +128,16 @@ public class BooleanBlockEqualityTests extends ESTestCase {
                 3,
                 new int[] { 0, 1, 2, 3 },
                 BitSet.valueOf(new byte[] { 0b000 }),
-                randomFrom(Block.MvOrdering.values())
+                randomFrom(Block.MvOrdering.values()),
+                blockFactory
             ),
             new BooleanArrayBlock(
                 new boolean[] { true, false, true, false },
                 3,
                 new int[] { 0, 1, 2, 3 },
                 BitSet.valueOf(new byte[] { 0b1000 }),
-                randomFrom(Block.MvOrdering.values())
+                randomFrom(Block.MvOrdering.values()),
+                blockFactory
             ),
             new BooleanArrayVector(new boolean[] { true, false, true }, 3).filter(0, 1, 2).asBlock(),
             new BooleanArrayVector(new boolean[] { true, false, true, false }, 3).filter(0, 1, 2).asBlock(),
@@ -164,14 +170,16 @@ public class BooleanBlockEqualityTests extends ESTestCase {
                 2,
                 new int[] { 0, 1, 2 },
                 BitSet.valueOf(new byte[] { 0b000 }),
-                randomFrom(Block.MvOrdering.values())
+                randomFrom(Block.MvOrdering.values()),
+                blockFactory
             ),
             new BooleanArrayBlock(
                 new boolean[] { true, true, false },
                 2,
                 new int[] { 0, 1, 2 },
                 BitSet.valueOf(new byte[] { 0b100 }),
-                randomFrom(Block.MvOrdering.values())
+                randomFrom(Block.MvOrdering.values()),
+                blockFactory
             ),
             new BooleanArrayVector(new boolean[] { true, true }, 2).filter(0, 1).asBlock(),
             new BooleanArrayVector(new boolean[] { true, true, false }, 2).filter(0, 1).asBlock(),

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BytesRefBlockEqualityTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BytesRefBlockEqualityTests.java
@@ -10,18 +10,23 @@ package org.elasticsearch.compute.data;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BytesRefArray;
-import org.elasticsearch.common.util.MockBigArrays;
-import org.elasticsearch.common.util.PageCacheRecycler;
-import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
-import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.compute.operator.ComputeTestCase;
+import org.junit.Before;
 
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.List;
 
-public class BytesRefBlockEqualityTests extends ESTestCase {
+public class BytesRefBlockEqualityTests extends ComputeTestCase {
 
-    final BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, new NoneCircuitBreakerService());
+    private BigArrays bigArrays;
+    private BlockFactory blockFactory;
+
+    @Before
+    public void setupBlockFactory() {
+        blockFactory = blockFactory();
+        bigArrays = blockFactory.bigArrays();
+    }
 
     public void testEmptyVector() {
         // all these "empty" vectors should be equivalent
@@ -47,14 +52,16 @@ public class BytesRefBlockEqualityTests extends ESTestCase {
                     0,
                     new int[] {},
                     BitSet.valueOf(new byte[] { 0b00 }),
-                    randomFrom(Block.MvOrdering.values())
+                    randomFrom(Block.MvOrdering.values()),
+                    blockFactory
                 ),
                 new BytesRefArrayBlock(
                     bytesRefArray2,
                     0,
                     new int[] {},
                     BitSet.valueOf(new byte[] { 0b00 }),
-                    randomFrom(Block.MvOrdering.values())
+                    randomFrom(Block.MvOrdering.values()),
+                    blockFactory
                 ),
                 BytesRefBlock.newConstantBlockWith(new BytesRef(), 0),
                 BytesRefBlock.newBlockBuilder(0).build(),
@@ -160,14 +167,16 @@ public class BytesRefBlockEqualityTests extends ESTestCase {
                     3,
                     new int[] { 0, 1, 2, 3 },
                     BitSet.valueOf(new byte[] { 0b000 }),
-                    randomFrom(Block.MvOrdering.values())
+                    randomFrom(Block.MvOrdering.values()),
+                    blockFactory
                 ),
                 new BytesRefArrayBlock(
                     bytesRefArray2,
                     3,
                     new int[] { 0, 1, 2, 3 },
                     BitSet.valueOf(new byte[] { 0b1000 }),
-                    randomFrom(Block.MvOrdering.values())
+                    randomFrom(Block.MvOrdering.values()),
+                    blockFactory
                 ),
                 new BytesRefArrayVector(bytesRefArray1, 3).filter(0, 1, 2).asBlock(),
                 new BytesRefArrayVector(bytesRefArray2, 3).filter(0, 1, 2).asBlock(),
@@ -210,14 +219,16 @@ public class BytesRefBlockEqualityTests extends ESTestCase {
                     2,
                     new int[] { 0, 1, 2 },
                     BitSet.valueOf(new byte[] { 0b000 }),
-                    randomFrom(Block.MvOrdering.values())
+                    randomFrom(Block.MvOrdering.values()),
+                    blockFactory
                 ),
                 new BytesRefArrayBlock(
                     bytesRefArray2,
                     2,
                     new int[] { 0, 1, 2 },
                     BitSet.valueOf(new byte[] { 0b100 }),
-                    randomFrom(Block.MvOrdering.values())
+                    randomFrom(Block.MvOrdering.values()),
+                    blockFactory
                 ),
                 new BytesRefArrayVector(bytesRefArray1, 2).filter(0, 1).asBlock(),
                 new BytesRefArrayVector(bytesRefArray2, 2).filter(0, 1).asBlock(),

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/DoubleBlockEqualityTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/DoubleBlockEqualityTests.java
@@ -7,12 +7,12 @@
 
 package org.elasticsearch.compute.data;
 
-import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.compute.operator.ComputeTestCase;
 
 import java.util.BitSet;
 import java.util.List;
 
-public class DoubleBlockEqualityTests extends ESTestCase {
+public class DoubleBlockEqualityTests extends ComputeTestCase {
 
     public void testEmptyVector() {
         // all these "empty" vectors should be equivalent
@@ -28,6 +28,7 @@ public class DoubleBlockEqualityTests extends ESTestCase {
     }
 
     public void testEmptyBlock() {
+        BlockFactory blockFactory = blockFactory();
         // all these "empty" vectors should be equivalent
         List<DoubleBlock> blocks = List.of(
             new DoubleArrayBlock(
@@ -35,14 +36,16 @@ public class DoubleBlockEqualityTests extends ESTestCase {
                 0,
                 new int[] {},
                 BitSet.valueOf(new byte[] { 0b00 }),
-                randomFrom(Block.MvOrdering.values())
+                randomFrom(Block.MvOrdering.values()),
+                blockFactory
             ),
             new DoubleArrayBlock(
                 new double[] { 0 },
                 0,
                 new int[] {},
                 BitSet.valueOf(new byte[] { 0b00 }),
-                randomFrom(Block.MvOrdering.values())
+                randomFrom(Block.MvOrdering.values()),
+                blockFactory
             ),
             DoubleBlock.newConstantBlockWith(0, 0),
             DoubleBlock.newBlockBuilder(0).build(),
@@ -116,6 +119,7 @@ public class DoubleBlockEqualityTests extends ESTestCase {
     }
 
     public void testBlockEquality() {
+        BlockFactory blockFactory = blockFactory();
         // all these blocks should be equivalent
         List<DoubleBlock> blocks = List.of(
             new DoubleArrayVector(new double[] { 1, 2, 3 }, 3).asBlock(),
@@ -124,14 +128,16 @@ public class DoubleBlockEqualityTests extends ESTestCase {
                 3,
                 new int[] { 0, 1, 2, 3 },
                 BitSet.valueOf(new byte[] { 0b000 }),
-                randomFrom(Block.MvOrdering.values())
+                randomFrom(Block.MvOrdering.values()),
+                blockFactory
             ),
             new DoubleArrayBlock(
                 new double[] { 1, 2, 3, 4 },
                 3,
                 new int[] { 0, 1, 2, 3 },
                 BitSet.valueOf(new byte[] { 0b1000 }),
-                randomFrom(Block.MvOrdering.values())
+                randomFrom(Block.MvOrdering.values()),
+                blockFactory
             ),
             new DoubleArrayVector(new double[] { 1, 2, 3 }, 3).filter(0, 1, 2).asBlock(),
             new DoubleArrayVector(new double[] { 1, 2, 3, 4 }, 3).filter(0, 1, 2).asBlock(),
@@ -152,14 +158,16 @@ public class DoubleBlockEqualityTests extends ESTestCase {
                 2,
                 new int[] { 0, 1, 2 },
                 BitSet.valueOf(new byte[] { 0b000 }),
-                randomFrom(Block.MvOrdering.values())
+                randomFrom(Block.MvOrdering.values()),
+                blockFactory
             ),
             new DoubleArrayBlock(
                 new double[] { 9, 9, 4 },
                 2,
                 new int[] { 0, 1, 2 },
                 BitSet.valueOf(new byte[] { 0b100 }),
-                randomFrom(Block.MvOrdering.values())
+                randomFrom(Block.MvOrdering.values()),
+                blockFactory
             ),
             new DoubleArrayVector(new double[] { 9, 9 }, 2).filter(0, 1).asBlock(),
             new DoubleArrayVector(new double[] { 9, 9, 4 }, 2).filter(0, 1).asBlock(),

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/FilteredBlockTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/FilteredBlockTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BytesRefArray;
 import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.common.util.PageCacheRecycler;
+import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.test.ESTestCase;
@@ -202,49 +203,69 @@ public class FilteredBlockTests extends ESTestCase {
             4,
             null,
             nulls,
-            randomFrom(Block.MvOrdering.values())
+            randomFrom(Block.MvOrdering.values()),
+            blockFactory
         );
-        for (Object obj : List.of(boolVector.filter(0, 2), boolVector.asBlock().filter(0, 2), boolBlock.filter(0, 2))) {
+        for (Releasable obj : List.of(boolVector.filter(0, 2), boolVector.asBlock().filter(0, 2), boolBlock.filter(0, 2))) {
             String s = obj.toString();
             assertThat(s, containsString("[true, false]"));
             assertThat(s, containsString("positions=2"));
+            Releasables.close(obj);
         }
 
         var intVector = new IntArrayVector(new int[] { 10, 20, 30, 40 }, 4);
-        var intBlock = new IntArrayBlock(new int[] { 10, 20, 30, 40 }, 4, null, nulls, randomFrom(Block.MvOrdering.values()));
-        for (Object obj : List.of(intVector.filter(0, 2), intVector.asBlock().filter(0, 2), intBlock.filter(0, 2))) {
+        var intBlock = new IntArrayBlock(new int[] { 10, 20, 30, 40 }, 4, null, nulls, randomFrom(Block.MvOrdering.values()), blockFactory);
+        for (Releasable obj : List.of(intVector.filter(0, 2), intVector.asBlock().filter(0, 2), intBlock.filter(0, 2))) {
             String s = obj.toString();
             assertThat(s, containsString("[10, 30]"));
             assertThat(s, containsString("positions=2"));
+            Releasables.close(obj);
         }
 
         var longVector = new LongArrayVector(new long[] { 100L, 200L, 300L, 400L }, 4);
-        var longBlock = new LongArrayBlock(new long[] { 100L, 200L, 300L, 400L }, 4, null, nulls, randomFrom(Block.MvOrdering.values()));
-        for (Object obj : List.of(longVector.filter(0, 2), longVector.asBlock().filter(0, 2), longBlock.filter(0, 2))) {
+        var longBlock = new LongArrayBlock(
+            new long[] { 100L, 200L, 300L, 400L },
+            4,
+            null,
+            nulls,
+            randomFrom(Block.MvOrdering.values()),
+            blockFactory
+        );
+        for (Releasable obj : List.of(longVector.filter(0, 2), longVector.asBlock().filter(0, 2), longBlock.filter(0, 2))) {
             String s = obj.toString();
             assertThat(s, containsString("[100, 300]"));
             assertThat(s, containsString("positions=2"));
+            Releasables.close(obj);
         }
 
         var doubleVector = new DoubleArrayVector(new double[] { 1.1, 2.2, 3.3, 4.4 }, 4);
-        var doubleBlock = new DoubleArrayBlock(new double[] { 1.1, 2.2, 3.3, 4.4 }, 4, null, nulls, randomFrom(Block.MvOrdering.values()));
-        for (Object obj : List.of(doubleVector.filter(0, 2), doubleVector.asBlock().filter(0, 2), doubleBlock.filter(0, 2))) {
+        var doubleBlock = new DoubleArrayBlock(
+            new double[] { 1.1, 2.2, 3.3, 4.4 },
+            4,
+            null,
+            nulls,
+            randomFrom(Block.MvOrdering.values()),
+            blockFactory
+        );
+        for (Releasable obj : List.of(doubleVector.filter(0, 2), doubleVector.asBlock().filter(0, 2), doubleBlock.filter(0, 2))) {
             String s = obj.toString();
             assertThat(s, containsString("[1.1, 3.3]"));
             assertThat(s, containsString("positions=2"));
+            Releasables.close(obj);
         }
 
         assert new BytesRef("1a").toString().equals("[31 61]") && new BytesRef("3c").toString().equals("[33 63]");
         try (var bytesRefArray = arrayOf("1a", "2b", "3c", "4d")) {
             var bytesRefVector = new BytesRefArrayVector(bytesRefArray, 4);
-            var bytesRefBlock = new BytesRefArrayBlock(bytesRefArray, 4, null, nulls, randomFrom(Block.MvOrdering.values()));
-            for (Object obj : List.of(bytesRefVector.filter(0, 2), bytesRefVector.asBlock().filter(0, 2), bytesRefBlock.filter(0, 2))) {
+            var bytesRefBlock = new BytesRefArrayBlock(bytesRefArray, 4, null, nulls, randomFrom(Block.MvOrdering.values()), blockFactory);
+            for (Releasable obj : List.of(bytesRefVector.filter(0, 2), bytesRefVector.asBlock().filter(0, 2), bytesRefBlock.filter(0, 2))) {
                 assertThat(
                     obj.toString(),
                     either(equalTo("BytesRefArrayVector[positions=2]")).or(
                         equalTo("BytesRefVectorBlock[vector=BytesRefArrayVector[positions=2]]")
                     )
                 );
+                Releasables.close(obj);
             }
         }
     }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/IntBlockEqualityTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/IntBlockEqualityTests.java
@@ -7,12 +7,12 @@
 
 package org.elasticsearch.compute.data;
 
-import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.compute.operator.ComputeTestCase;
 
 import java.util.BitSet;
 import java.util.List;
 
-public class IntBlockEqualityTests extends ESTestCase {
+public class IntBlockEqualityTests extends ComputeTestCase {
 
     public void testEmptyVector() {
         // all these "empty" vectors should be equivalent
@@ -28,10 +28,25 @@ public class IntBlockEqualityTests extends ESTestCase {
     }
 
     public void testEmptyBlock() {
+        BlockFactory blockFactory = blockFactory();
         // all these "empty" vectors should be equivalent
         List<IntBlock> blocks = List.of(
-            new IntArrayBlock(new int[] {}, 0, new int[] {}, BitSet.valueOf(new byte[] { 0b00 }), randomFrom(Block.MvOrdering.values())),
-            new IntArrayBlock(new int[] { 0 }, 0, new int[] {}, BitSet.valueOf(new byte[] { 0b00 }), randomFrom(Block.MvOrdering.values())),
+            new IntArrayBlock(
+                new int[] {},
+                0,
+                new int[] {},
+                BitSet.valueOf(new byte[] { 0b00 }),
+                randomFrom(Block.MvOrdering.values()),
+                blockFactory
+            ),
+            new IntArrayBlock(
+                new int[] { 0 },
+                0,
+                new int[] {},
+                BitSet.valueOf(new byte[] { 0b00 }),
+                randomFrom(Block.MvOrdering.values()),
+                blockFactory
+            ),
             IntBlock.newConstantBlockWith(0, 0),
             IntBlock.newBlockBuilder(0).build(),
             IntBlock.newBlockBuilder(0).appendInt(1).build().filter(),
@@ -76,6 +91,7 @@ public class IntBlockEqualityTests extends ESTestCase {
     }
 
     public void testBlockEquality() {
+        BlockFactory blockFactory = blockFactory();
         // all these blocks should be equivalent
         List<IntBlock> blocks = List.of(
             new IntArrayVector(new int[] { 1, 2, 3 }, 3).asBlock(),
@@ -84,14 +100,16 @@ public class IntBlockEqualityTests extends ESTestCase {
                 3,
                 new int[] { 0, 1, 2, 3 },
                 BitSet.valueOf(new byte[] { 0b000 }),
-                randomFrom(Block.MvOrdering.values())
+                randomFrom(Block.MvOrdering.values()),
+                blockFactory
             ),
             new IntArrayBlock(
                 new int[] { 1, 2, 3, 4 },
                 3,
                 new int[] { 0, 1, 2, 3 },
                 BitSet.valueOf(new byte[] { 0b1000 }),
-                randomFrom(Block.MvOrdering.values())
+                randomFrom(Block.MvOrdering.values()),
+                blockFactory
             ),
             new IntArrayVector(new int[] { 1, 2, 3 }, 3).filter(0, 1, 2).asBlock(),
             new IntArrayVector(new int[] { 1, 2, 3, 4 }, 3).filter(0, 1, 2).asBlock(),
@@ -112,14 +130,16 @@ public class IntBlockEqualityTests extends ESTestCase {
                 2,
                 new int[] { 0, 1, 2 },
                 BitSet.valueOf(new byte[] { 0b000 }),
-                randomFrom(Block.MvOrdering.values())
+                randomFrom(Block.MvOrdering.values()),
+                blockFactory
             ),
             new IntArrayBlock(
                 new int[] { 9, 9, 4 },
                 2,
                 new int[] { 0, 1, 2 },
                 BitSet.valueOf(new byte[] { 0b100 }),
-                randomFrom(Block.MvOrdering.values())
+                randomFrom(Block.MvOrdering.values()),
+                blockFactory
             ),
             new IntArrayVector(new int[] { 9, 9 }, 2).filter(0, 1).asBlock(),
             new IntArrayVector(new int[] { 9, 9, 4 }, 2).filter(0, 1).asBlock(),

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/LongBlockEqualityTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/LongBlockEqualityTests.java
@@ -7,12 +7,12 @@
 
 package org.elasticsearch.compute.data;
 
-import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.compute.operator.ComputeTestCase;
 
 import java.util.BitSet;
 import java.util.List;
 
-public class LongBlockEqualityTests extends ESTestCase {
+public class LongBlockEqualityTests extends ComputeTestCase {
 
     public void testEmptyVector() {
         // all these "empty" vectors should be equivalent
@@ -28,15 +28,24 @@ public class LongBlockEqualityTests extends ESTestCase {
     }
 
     public void testEmptyBlock() {
+        BlockFactory blockFactory = blockFactory();
         // all these "empty" vectors should be equivalent
         List<LongBlock> blocks = List.of(
-            new LongArrayBlock(new long[] {}, 0, new int[] {}, BitSet.valueOf(new byte[] { 0b00 }), randomFrom(Block.MvOrdering.values())),
+            new LongArrayBlock(
+                new long[] {},
+                0,
+                new int[] {},
+                BitSet.valueOf(new byte[] { 0b00 }),
+                randomFrom(Block.MvOrdering.values()),
+                blockFactory
+            ),
             new LongArrayBlock(
                 new long[] { 0 },
                 0,
                 new int[] {},
                 BitSet.valueOf(new byte[] { 0b00 }),
-                randomFrom(Block.MvOrdering.values())
+                randomFrom(Block.MvOrdering.values()),
+                blockFactory
             ),
             LongBlock.newConstantBlockWith(0, 0),
             LongBlock.newBlockBuilder(0).build(),
@@ -82,6 +91,7 @@ public class LongBlockEqualityTests extends ESTestCase {
     }
 
     public void testBlockEquality() {
+        BlockFactory blockFactory = blockFactory();
         // all these blocks should be equivalent
         List<LongBlock> blocks = List.of(
             new LongArrayVector(new long[] { 1, 2, 3 }, 3).asBlock(),
@@ -90,14 +100,16 @@ public class LongBlockEqualityTests extends ESTestCase {
                 3,
                 new int[] { 0, 1, 2, 3 },
                 BitSet.valueOf(new byte[] { 0b000 }),
-                randomFrom(Block.MvOrdering.values())
+                randomFrom(Block.MvOrdering.values()),
+                blockFactory
             ),
             new LongArrayBlock(
                 new long[] { 1, 2, 3, 4 },
                 3,
                 new int[] { 0, 1, 2, 3 },
                 BitSet.valueOf(new byte[] { 0b1000 }),
-                randomFrom(Block.MvOrdering.values())
+                randomFrom(Block.MvOrdering.values()),
+                blockFactory
             ),
             new LongArrayVector(new long[] { 1, 2, 3 }, 3).filter(0, 1, 2).asBlock(),
             new LongArrayVector(new long[] { 1, 2, 3, 4 }, 3).filter(0, 1, 2).asBlock(),
@@ -118,14 +130,16 @@ public class LongBlockEqualityTests extends ESTestCase {
                 2,
                 new int[] { 0, 1, 2 },
                 BitSet.valueOf(new byte[] { 0b000 }),
-                randomFrom(Block.MvOrdering.values())
+                randomFrom(Block.MvOrdering.values()),
+                blockFactory
             ),
             new LongArrayBlock(
                 new long[] { 9, 9, 4 },
                 2,
                 new int[] { 0, 1, 2 },
                 BitSet.valueOf(new byte[] { 0b100 }),
-                randomFrom(Block.MvOrdering.values())
+                randomFrom(Block.MvOrdering.values()),
+                blockFactory
             ),
             new LongArrayVector(new long[] { 9, 9 }, 2).filter(0, 1).asBlock(),
             new LongArrayVector(new long[] { 9, 9, 4 }, 2).filter(0, 1).asBlock(),

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/AnyOperatorTestCase.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/AnyOperatorTestCase.java
@@ -7,22 +7,9 @@
 
 package org.elasticsearch.compute.operator;
 
-import org.elasticsearch.common.breaker.CircuitBreaker;
-import org.elasticsearch.common.breaker.CircuitBreakingException;
-import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.common.util.MockBigArrays;
-import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
 import org.elasticsearch.compute.data.BlockFactory;
-import org.elasticsearch.compute.data.MockBlockFactory;
-import org.elasticsearch.indices.CrankyCircuitBreakerService;
-import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
-import org.elasticsearch.test.ESTestCase;
-import org.junit.After;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.matchesPattern;
@@ -30,7 +17,7 @@ import static org.hamcrest.Matchers.matchesPattern;
 /**
  * Superclass for testing any {@link Operator}, including {@link SourceOperator}s.
  */
-public abstract class AnyOperatorTestCase extends ESTestCase {
+public abstract class AnyOperatorTestCase extends ComputeTestCase {
     /**
      * The operator configured a "simple" or basic way, used for smoke testing
      * descriptions and {@link BigArrays} and scatter/gather.
@@ -88,57 +75,15 @@ public abstract class AnyOperatorTestCase extends ESTestCase {
     }
 
     /**
-     * A {@link BigArrays} that won't throw {@link CircuitBreakingException}.
-     * <p>
-     *     Rather than using the {@link NoneCircuitBreakerService} we use a
-     *     very large limit so tests can call {@link CircuitBreaker#getUsed()}.
-     * </p>
-     */
-    protected final BigArrays nonBreakingBigArrays() {
-        return new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, ByteSizeValue.ofBytes(Integer.MAX_VALUE)).withCircuitBreaking();
-    }
-
-    /**
      * A {@link DriverContext} with a nonBreakingBigArrays.
      */
     protected DriverContext driverContext() { // TODO make this final once all operators support memory tracking
-        BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, ByteSizeValue.ofGb(1)).withCircuitBreaking();
-        CircuitBreaker breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
-        breakers.add(breaker);
-        BlockFactory factory = new MockBlockFactory(breaker, bigArrays);
-        blockFactories.add(factory);
-        return new DriverContext(bigArrays, factory);
+        BlockFactory blockFactory = blockFactory();
+        return new DriverContext(blockFactory.bigArrays(), blockFactory);
     }
-
-    protected final DriverContext nonBreakingDriverContext() { // TODO drop this once the driverContext method isn't overrideable
-        return new DriverContext(nonBreakingBigArrays(), BlockFactory.getNonBreakingInstance());
-    }
-
-    private final List<CircuitBreaker> breakers = new ArrayList<>();
-    private final List<BlockFactory> blockFactories = new ArrayList<>();
 
     protected final DriverContext crankyDriverContext() {
-        CrankyCircuitBreakerService cranky = new CrankyCircuitBreakerService();
-        BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, cranky).withCircuitBreaking();
-        CircuitBreaker breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
-        breakers.add(breaker);
-        BlockFactory blockFactory = new MockBlockFactory(breaker, bigArrays);
-        blockFactories.add(blockFactory);
-        return new DriverContext(bigArrays, blockFactory);
-    }
-
-    @After
-    public void allBreakersEmpty() throws Exception {
-        // first check that all big arrays are released, which can affect breakers
-        MockBigArrays.ensureAllArraysAreReleased();
-
-        for (CircuitBreaker breaker : breakers) {
-            for (var factory : blockFactories) {
-                if (factory instanceof MockBlockFactory mockBlockFactory) {
-                    mockBlockFactory.ensureAllBlocksAreReleased();
-                }
-            }
-            assertThat("Unexpected used in breaker: " + breaker, breaker.getUsed(), equalTo(0L));
-        }
+        BlockFactory blockFactory = crankyBlockFactory();
+        return new DriverContext(blockFactory.bigArrays(), blockFactory);
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/ComputeTestCase.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/ComputeTestCase.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.operator;
+
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.MockBigArrays;
+import org.elasticsearch.common.util.PageCacheRecycler;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.MockBlockFactory;
+import org.elasticsearch.indices.CrankyCircuitBreakerService;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.After;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Superclass for testing with blocks and operators
+ */
+public abstract class ComputeTestCase extends ESTestCase {
+
+    private final List<CircuitBreaker> breakers = new ArrayList<>();
+    private final List<BlockFactory> blockFactories = new ArrayList<>();
+
+    /**
+     * A {@link BigArrays} that won't throw {@link CircuitBreakingException}.
+     * <p>
+     * Rather than using the {@link NoneCircuitBreakerService} we use a
+     * very large limit so tests can call {@link CircuitBreaker#getUsed()}.
+     * </p>
+     */
+    protected final BigArrays nonBreakingBigArrays() {
+        return new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, ByteSizeValue.ofBytes(Integer.MAX_VALUE)).withCircuitBreaking();
+    }
+
+    protected BlockFactory blockFactory() {
+        BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, ByteSizeValue.ofGb(1)).withCircuitBreaking();
+        CircuitBreaker breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
+        breakers.add(breaker);
+        BlockFactory factory = new MockBlockFactory(breaker, bigArrays);
+        blockFactories.add(factory);
+        return factory;
+    }
+
+    protected BlockFactory crankyBlockFactory() {
+        CrankyCircuitBreakerService cranky = new CrankyCircuitBreakerService();
+        BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, cranky).withCircuitBreaking();
+        CircuitBreaker breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
+        breakers.add(breaker);
+        BlockFactory blockFactory = new MockBlockFactory(breaker, bigArrays);
+        blockFactories.add(blockFactory);
+        return blockFactory;
+    }
+
+    @After
+    public void allBreakersEmpty() throws Exception {
+        // first check that all big arrays are released, which can affect breakers
+        MockBigArrays.ensureAllArraysAreReleased();
+
+        for (CircuitBreaker breaker : breakers) {
+            for (var factory : blockFactories) {
+                if (factory instanceof MockBlockFactory mockBlockFactory) {
+                    mockBlockFactory.ensureAllBlocksAreReleased();
+                }
+            }
+            assertThat("Unexpected used in breaker: " + breaker, breaker.getUsed(), equalTo(0L));
+        }
+    }
+}

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/ComputeTestCase.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/ComputeTestCase.java
@@ -67,13 +67,12 @@ public abstract class ComputeTestCase extends ESTestCase {
     public void allBreakersEmpty() throws Exception {
         // first check that all big arrays are released, which can affect breakers
         MockBigArrays.ensureAllArraysAreReleased();
-
-        for (CircuitBreaker breaker : breakers) {
-            for (var factory : blockFactories) {
-                if (factory instanceof MockBlockFactory mockBlockFactory) {
-                    mockBlockFactory.ensureAllBlocksAreReleased();
-                }
+        for (var factory : blockFactories) {
+            if (factory instanceof MockBlockFactory mockBlockFactory) {
+                mockBlockFactory.ensureAllBlocksAreReleased();
             }
+        }
+        for (CircuitBreaker breaker : breakers) {
             assertThat("Unexpected used in breaker: " + breaker, breaker.getUsed(), equalTo(0L));
         }
     }


### PR DESCRIPTION
This PR removes deprecated block APIs that use on-breaking block factories. It also changes the Block implementation to the package level to ensure that callers create Blocks via BlockFactory.

More follow-ups are coming.