### PR TITLE
Remove non breaking Vectors API

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/BlockBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/BlockBenchmark.java
@@ -17,30 +17,20 @@ import org.elasticsearch.common.util.IntArray;
 import org.elasticsearch.common.util.LongArray;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
-import org.elasticsearch.compute.data.BooleanArrayVector;
 import org.elasticsearch.compute.data.BooleanBigArrayBlock;
 import org.elasticsearch.compute.data.BooleanBigArrayVector;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BooleanVector;
-import org.elasticsearch.compute.data.BytesRefArrayVector;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
-import org.elasticsearch.compute.data.ConstantBooleanVector;
-import org.elasticsearch.compute.data.ConstantBytesRefVector;
-import org.elasticsearch.compute.data.ConstantDoubleVector;
-import org.elasticsearch.compute.data.ConstantIntVector;
-import org.elasticsearch.compute.data.ConstantLongVector;
-import org.elasticsearch.compute.data.DoubleArrayVector;
 import org.elasticsearch.compute.data.DoubleBigArrayBlock;
 import org.elasticsearch.compute.data.DoubleBigArrayVector;
 import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.DoubleVector;
-import org.elasticsearch.compute.data.IntArrayVector;
 import org.elasticsearch.compute.data.IntBigArrayBlock;
 import org.elasticsearch.compute.data.IntBigArrayVector;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
-import org.elasticsearch.compute.data.LongArrayVector;
 import org.elasticsearch.compute.data.LongBigArrayBlock;
 import org.elasticsearch.compute.data.LongBigArrayVector;
 import org.elasticsearch.compute.data.LongBlock;
@@ -149,7 +139,7 @@ public class BlockBenchmark {
             case "boolean" -> {
                 for (int blockIndex = 0; blockIndex < NUM_BLOCKS_PER_ITERATION; blockIndex++) {
                     if (blockKind.equalsIgnoreCase("vector-const")) {
-                        BooleanVector vector = new ConstantBooleanVector(random.nextBoolean(), totalPositions);
+                        BooleanVector vector = blockFactory.newConstantBooleanVector(random.nextBoolean(), totalPositions);
                         blocks[blockIndex] = vector.asBlock();
                         continue;
                     }
@@ -203,7 +193,7 @@ public class BlockBenchmark {
                             );
                         }
                         case "vector" -> {
-                            BooleanVector vector = new BooleanArrayVector(values, totalPositions);
+                            BooleanVector vector = blockFactory.newBooleanArrayVector(values, totalPositions);
                             blocks[blockIndex] = vector.asBlock();
                         }
                         case "vector-big-array" -> {
@@ -213,7 +203,7 @@ public class BlockBenchmark {
                                     valuesBigArray.set(i);
                                 }
                             }
-                            BooleanVector vector = new BooleanBigArrayVector(valuesBigArray, totalPositions);
+                            BooleanVector vector = new BooleanBigArrayVector(valuesBigArray, totalPositions, blockFactory);
                             blocks[blockIndex] = vector.asBlock();
                         }
                         default -> {
@@ -233,7 +223,7 @@ public class BlockBenchmark {
                         byte[] bytes = new byte[random.nextInt(MAX_BYTES_REF_LENGTH)];
                         random.nextBytes(bytes);
 
-                        BytesRefVector vector = new ConstantBytesRefVector(new BytesRef(bytes), totalPositions);
+                        BytesRefVector vector = blockFactory.newConstantBytesRefVector(new BytesRef(bytes), totalPositions);
                         blocks[blockIndex] = vector.asBlock();
                         continue;
                     }
@@ -270,7 +260,7 @@ public class BlockBenchmark {
                             );
                         }
                         case "vector" -> {
-                            BytesRefVector vector = new BytesRefArrayVector(values, totalPositions);
+                            BytesRefVector vector = blockFactory.newBytesRefArrayVector(values, totalPositions);
                             blocks[blockIndex] = vector.asBlock();
                         }
                         default -> {
@@ -287,7 +277,7 @@ public class BlockBenchmark {
             case "double" -> {
                 for (int blockIndex = 0; blockIndex < NUM_BLOCKS_PER_ITERATION; blockIndex++) {
                     if (blockKind.equalsIgnoreCase("vector-const")) {
-                        DoubleVector vector = new ConstantDoubleVector(random.nextDouble() * 1000000.0, totalPositions);
+                        DoubleVector vector = blockFactory.newConstantDoubleVector(random.nextDouble() * 1000000.0, totalPositions);
                         blocks[blockIndex] = vector.asBlock();
                         continue;
                     }
@@ -341,7 +331,7 @@ public class BlockBenchmark {
                             );
                         }
                         case "vector" -> {
-                            DoubleVector vector = new DoubleArrayVector(values, totalPositions);
+                            DoubleVector vector = blockFactory.newDoubleArrayVector(values, totalPositions);
                             blocks[blockIndex] = vector.asBlock();
                         }
                         case "vector-big-array" -> {
@@ -351,7 +341,7 @@ public class BlockBenchmark {
                             for (int i = 0; i < values.length; i++) {
                                 valuesBigArray.set(i, values[i]);
                             }
-                            DoubleVector vector = new DoubleBigArrayVector(valuesBigArray, totalPositions);
+                            DoubleVector vector = new DoubleBigArrayVector(valuesBigArray, totalPositions, blockFactory);
                             blocks[blockIndex] = vector.asBlock();
                         }
                         default -> {
@@ -368,7 +358,7 @@ public class BlockBenchmark {
             case "int" -> {
                 for (int blockIndex = 0; blockIndex < NUM_BLOCKS_PER_ITERATION; blockIndex++) {
                     if (blockKind.equalsIgnoreCase("vector-const")) {
-                        IntVector vector = new ConstantIntVector(random.nextInt(), totalPositions);
+                        IntVector vector = blockFactory.newConstantIntVector(random.nextInt(), totalPositions);
                         blocks[blockIndex] = vector.asBlock();
                         continue;
                     }
@@ -420,7 +410,7 @@ public class BlockBenchmark {
                             );
                         }
                         case "vector" -> {
-                            IntVector vector = new IntArrayVector(values, totalPositions);
+                            IntVector vector = blockFactory.newIntArrayVector(values, totalPositions);
                             blocks[blockIndex] = vector.asBlock();
                         }
                         case "vector-big-array" -> {
@@ -428,7 +418,7 @@ public class BlockBenchmark {
                             for (int i = 0; i < values.length; i++) {
                                 valuesBigArray.set(i, values[i]);
                             }
-                            IntVector vector = new IntBigArrayVector(valuesBigArray, totalPositions);
+                            IntVector vector = new IntBigArrayVector(valuesBigArray, totalPositions, blockFactory);
                             blocks[blockIndex] = vector.asBlock();
                         }
                         default -> {
@@ -445,7 +435,7 @@ public class BlockBenchmark {
             case "long" -> {
                 for (int blockIndex = 0; blockIndex < NUM_BLOCKS_PER_ITERATION; blockIndex++) {
                     if (blockKind.equalsIgnoreCase("vector-const")) {
-                        LongVector vector = new ConstantLongVector(random.nextLong(), totalPositions);
+                        LongVector vector = blockFactory.newConstantLongVector(random.nextLong(), totalPositions);
                         blocks[blockIndex] = vector.asBlock();
                         continue;
                     }
@@ -499,7 +489,7 @@ public class BlockBenchmark {
                             );
                         }
                         case "vector" -> {
-                            LongVector vector = new LongArrayVector(values, totalPositions);
+                            LongVector vector = blockFactory.newLongArrayVector(values, totalPositions);
                             blocks[blockIndex] = vector.asBlock();
                         }
                         case "vector-big-array" -> {
@@ -509,7 +499,7 @@ public class BlockBenchmark {
                             for (int i = 0; i < values.length; i++) {
                                 valuesBigArray.set(i, values[i]);
                             }
-                            LongVector vector = new LongBigArrayVector(valuesBigArray, totalPositions);
+                            LongVector vector = new LongBigArrayVector(valuesBigArray, totalPositions, blockFactory);
                             blocks[blockIndex] = vector.asBlock();
                         }
                         default -> {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayVector.java
@@ -15,7 +15,7 @@ import java.util.Arrays;
  * Vector implementation that stores an array of boolean values.
  * This class is generated. Do not edit it.
  */
-public final class BooleanArrayVector extends AbstractVector implements BooleanVector {
+final class BooleanArrayVector extends AbstractVector implements BooleanVector {
 
     static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(BooleanArrayVector.class);
 
@@ -23,11 +23,7 @@ public final class BooleanArrayVector extends AbstractVector implements BooleanV
 
     private final BooleanBlock block;
 
-    public BooleanArrayVector(boolean[] values, int positionCount) {
-        this(values, positionCount, BlockFactory.getNonBreakingInstance());
-    }
-
-    public BooleanArrayVector(boolean[] values, int positionCount, BlockFactory blockFactory) {
+    BooleanArrayVector(boolean[] values, int positionCount, BlockFactory blockFactory) {
         super(positionCount, blockFactory);
         this.values = values;
         this.block = new BooleanVectorBlock(this);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBigArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBigArrayVector.java
@@ -23,10 +23,6 @@ public final class BooleanBigArrayVector extends AbstractVector implements Boole
 
     private final BooleanBlock block;
 
-    public BooleanBigArrayVector(BitArray values, int positionCount) {
-        this(values, positionCount, BlockFactory.getNonBreakingInstance());
-    }
-
     public BooleanBigArrayVector(BitArray values, int positionCount, BlockFactory blockFactory) {
         super(positionCount, blockFactory);
         this.values = values;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayVector.java
@@ -16,7 +16,7 @@ import org.elasticsearch.core.Releasables;
  * Vector implementation that stores an array of BytesRef values.
  * This class is generated. Do not edit it.
  */
-public final class BytesRefArrayVector extends AbstractVector implements BytesRefVector {
+final class BytesRefArrayVector extends AbstractVector implements BytesRefVector {
 
     static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(BytesRefArrayVector.class);
 
@@ -24,11 +24,7 @@ public final class BytesRefArrayVector extends AbstractVector implements BytesRe
 
     private final BytesRefBlock block;
 
-    public BytesRefArrayVector(BytesRefArray values, int positionCount) {
-        this(values, positionCount, BlockFactory.getNonBreakingInstance());
-    }
-
-    public BytesRefArrayVector(BytesRefArray values, int positionCount, BlockFactory blockFactory) {
+    BytesRefArrayVector(BytesRefArray values, int positionCount, BlockFactory blockFactory) {
         super(positionCount, blockFactory);
         this.values = values;
         this.block = new BytesRefVectorBlock(this);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantBooleanVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantBooleanVector.java
@@ -13,7 +13,7 @@ import org.apache.lucene.util.RamUsageEstimator;
  * Vector implementation that stores a constant boolean value.
  * This class is generated. Do not edit it.
  */
-public final class ConstantBooleanVector extends AbstractVector implements BooleanVector {
+final class ConstantBooleanVector extends AbstractVector implements BooleanVector {
 
     static final long RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(ConstantBooleanVector.class);
 
@@ -21,11 +21,7 @@ public final class ConstantBooleanVector extends AbstractVector implements Boole
 
     private final BooleanBlock block;
 
-    public ConstantBooleanVector(boolean value, int positionCount) {
-        this(value, positionCount, BlockFactory.getNonBreakingInstance());
-    }
-
-    public ConstantBooleanVector(boolean value, int positionCount, BlockFactory blockFactory) {
+    ConstantBooleanVector(boolean value, int positionCount, BlockFactory blockFactory) {
         super(positionCount, blockFactory);
         this.value = value;
         this.block = new BooleanVectorBlock(this);
@@ -43,7 +39,7 @@ public final class ConstantBooleanVector extends AbstractVector implements Boole
 
     @Override
     public BooleanVector filter(int... positions) {
-        return new ConstantBooleanVector(value, positions.length);
+        return blockFactory().newConstantBooleanVector(value, positions.length);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantBytesRefVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantBytesRefVector.java
@@ -14,7 +14,7 @@ import org.apache.lucene.util.RamUsageEstimator;
  * Vector implementation that stores a constant BytesRef value.
  * This class is generated. Do not edit it.
  */
-public final class ConstantBytesRefVector extends AbstractVector implements BytesRefVector {
+final class ConstantBytesRefVector extends AbstractVector implements BytesRefVector {
 
     static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(ConstantBytesRefVector.class) + RamUsageEstimator
         .shallowSizeOfInstance(BytesRef.class);
@@ -22,11 +22,7 @@ public final class ConstantBytesRefVector extends AbstractVector implements Byte
 
     private final BytesRefBlock block;
 
-    public ConstantBytesRefVector(BytesRef value, int positionCount) {
-        this(value, positionCount, BlockFactory.getNonBreakingInstance());
-    }
-
-    public ConstantBytesRefVector(BytesRef value, int positionCount, BlockFactory blockFactory) {
+    ConstantBytesRefVector(BytesRef value, int positionCount, BlockFactory blockFactory) {
         super(positionCount, blockFactory);
         this.value = value;
         this.block = new BytesRefVectorBlock(this);
@@ -44,7 +40,7 @@ public final class ConstantBytesRefVector extends AbstractVector implements Byte
 
     @Override
     public BytesRefVector filter(int... positions) {
-        return new ConstantBytesRefVector(value, positions.length);
+        return blockFactory().newConstantBytesRefVector(value, positions.length);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantDoubleVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantDoubleVector.java
@@ -13,7 +13,7 @@ import org.apache.lucene.util.RamUsageEstimator;
  * Vector implementation that stores a constant double value.
  * This class is generated. Do not edit it.
  */
-public final class ConstantDoubleVector extends AbstractVector implements DoubleVector {
+final class ConstantDoubleVector extends AbstractVector implements DoubleVector {
 
     static final long RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(ConstantDoubleVector.class);
 
@@ -21,11 +21,7 @@ public final class ConstantDoubleVector extends AbstractVector implements Double
 
     private final DoubleBlock block;
 
-    public ConstantDoubleVector(double value, int positionCount) {
-        this(value, positionCount, BlockFactory.getNonBreakingInstance());
-    }
-
-    public ConstantDoubleVector(double value, int positionCount, BlockFactory blockFactory) {
+    ConstantDoubleVector(double value, int positionCount, BlockFactory blockFactory) {
         super(positionCount, blockFactory);
         this.value = value;
         this.block = new DoubleVectorBlock(this);
@@ -43,7 +39,7 @@ public final class ConstantDoubleVector extends AbstractVector implements Double
 
     @Override
     public DoubleVector filter(int... positions) {
-        return new ConstantDoubleVector(value, positions.length);
+        return blockFactory().newConstantDoubleVector(value, positions.length);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantIntVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantIntVector.java
@@ -13,7 +13,7 @@ import org.apache.lucene.util.RamUsageEstimator;
  * Vector implementation that stores a constant int value.
  * This class is generated. Do not edit it.
  */
-public final class ConstantIntVector extends AbstractVector implements IntVector {
+final class ConstantIntVector extends AbstractVector implements IntVector {
 
     static final long RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(ConstantIntVector.class);
 
@@ -21,11 +21,7 @@ public final class ConstantIntVector extends AbstractVector implements IntVector
 
     private final IntBlock block;
 
-    public ConstantIntVector(int value, int positionCount) {
-        this(value, positionCount, BlockFactory.getNonBreakingInstance());
-    }
-
-    public ConstantIntVector(int value, int positionCount, BlockFactory blockFactory) {
+    ConstantIntVector(int value, int positionCount, BlockFactory blockFactory) {
         super(positionCount, blockFactory);
         this.value = value;
         this.block = new IntVectorBlock(this);
@@ -43,7 +39,7 @@ public final class ConstantIntVector extends AbstractVector implements IntVector
 
     @Override
     public IntVector filter(int... positions) {
-        return new ConstantIntVector(value, positions.length);
+        return blockFactory().newConstantIntVector(value, positions.length);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantLongVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantLongVector.java
@@ -13,7 +13,7 @@ import org.apache.lucene.util.RamUsageEstimator;
  * Vector implementation that stores a constant long value.
  * This class is generated. Do not edit it.
  */
-public final class ConstantLongVector extends AbstractVector implements LongVector {
+final class ConstantLongVector extends AbstractVector implements LongVector {
 
     static final long RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(ConstantLongVector.class);
 
@@ -21,11 +21,7 @@ public final class ConstantLongVector extends AbstractVector implements LongVect
 
     private final LongBlock block;
 
-    public ConstantLongVector(long value, int positionCount) {
-        this(value, positionCount, BlockFactory.getNonBreakingInstance());
-    }
-
-    public ConstantLongVector(long value, int positionCount, BlockFactory blockFactory) {
+    ConstantLongVector(long value, int positionCount, BlockFactory blockFactory) {
         super(positionCount, blockFactory);
         this.value = value;
         this.block = new LongVectorBlock(this);
@@ -43,7 +39,7 @@ public final class ConstantLongVector extends AbstractVector implements LongVect
 
     @Override
     public LongVector filter(int... positions) {
-        return new ConstantLongVector(value, positions.length);
+        return blockFactory().newConstantLongVector(value, positions.length);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayVector.java
@@ -15,7 +15,7 @@ import java.util.Arrays;
  * Vector implementation that stores an array of double values.
  * This class is generated. Do not edit it.
  */
-public final class DoubleArrayVector extends AbstractVector implements DoubleVector {
+final class DoubleArrayVector extends AbstractVector implements DoubleVector {
 
     static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(DoubleArrayVector.class);
 
@@ -23,11 +23,7 @@ public final class DoubleArrayVector extends AbstractVector implements DoubleVec
 
     private final DoubleBlock block;
 
-    public DoubleArrayVector(double[] values, int positionCount) {
-        this(values, positionCount, BlockFactory.getNonBreakingInstance());
-    }
-
-    public DoubleArrayVector(double[] values, int positionCount, BlockFactory blockFactory) {
+    DoubleArrayVector(double[] values, int positionCount, BlockFactory blockFactory) {
         super(positionCount, blockFactory);
         this.values = values;
         this.block = new DoubleVectorBlock(this);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBigArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBigArrayVector.java
@@ -23,10 +23,6 @@ public final class DoubleBigArrayVector extends AbstractVector implements Double
 
     private final DoubleBlock block;
 
-    public DoubleBigArrayVector(DoubleArray values, int positionCount) {
-        this(values, positionCount, BlockFactory.getNonBreakingInstance());
-    }
-
     public DoubleBigArrayVector(DoubleArray values, int positionCount, BlockFactory blockFactory) {
         super(positionCount, blockFactory);
         this.values = values;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayVector.java
@@ -15,7 +15,7 @@ import java.util.Arrays;
  * Vector implementation that stores an array of int values.
  * This class is generated. Do not edit it.
  */
-public final class IntArrayVector extends AbstractVector implements IntVector {
+final class IntArrayVector extends AbstractVector implements IntVector {
 
     static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(IntArrayVector.class);
 
@@ -23,11 +23,7 @@ public final class IntArrayVector extends AbstractVector implements IntVector {
 
     private final IntBlock block;
 
-    public IntArrayVector(int[] values, int positionCount) {
-        this(values, positionCount, BlockFactory.getNonBreakingInstance());
-    }
-
-    public IntArrayVector(int[] values, int positionCount, BlockFactory blockFactory) {
+    IntArrayVector(int[] values, int positionCount, BlockFactory blockFactory) {
         super(positionCount, blockFactory);
         this.values = values;
         this.block = new IntVectorBlock(this);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBigArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBigArrayVector.java
@@ -23,10 +23,6 @@ public final class IntBigArrayVector extends AbstractVector implements IntVector
 
     private final IntBlock block;
 
-    public IntBigArrayVector(IntArray values, int positionCount) {
-        this(values, positionCount, BlockFactory.getNonBreakingInstance());
-    }
-
     public IntBigArrayVector(IntArray values, int positionCount, BlockFactory blockFactory) {
         super(positionCount, blockFactory);
         this.values = values;

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayVector.java
@@ -15,7 +15,7 @@ import java.util.Arrays;
  * Vector implementation that stores an array of long values.
  * This class is generated. Do not edit it.
  */
-public final class LongArrayVector extends AbstractVector implements LongVector {
+final class LongArrayVector extends AbstractVector implements LongVector {
 
     static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(LongArrayVector.class);
 
@@ -23,11 +23,7 @@ public final class LongArrayVector extends AbstractVector implements LongVector 
 
     private final LongBlock block;
 
-    public LongArrayVector(long[] values, int positionCount) {
-        this(values, positionCount, BlockFactory.getNonBreakingInstance());
-    }
-
-    public LongArrayVector(long[] values, int positionCount, BlockFactory blockFactory) {
+    LongArrayVector(long[] values, int positionCount, BlockFactory blockFactory) {
         super(positionCount, blockFactory);
         this.values = values;
         this.block = new LongVectorBlock(this);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBigArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBigArrayVector.java
@@ -23,10 +23,6 @@ public final class LongBigArrayVector extends AbstractVector implements LongVect
 
     private final LongBlock block;
 
-    public LongBigArrayVector(LongArray values, int positionCount) {
-        this(values, positionCount, BlockFactory.getNonBreakingInstance());
-    }
-
     public LongBigArrayVector(LongArray values, int positionCount, BlockFactory blockFactory) {
         super(positionCount, blockFactory);
         this.values = values;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayVector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayVector.java.st
@@ -23,7 +23,7 @@ $endif$
  * Vector implementation that stores an array of $type$ values.
  * This class is generated. Do not edit it.
  */
-public final class $Type$ArrayVector extends AbstractVector implements $Type$Vector {
+final class $Type$ArrayVector extends AbstractVector implements $Type$Vector {
 
     static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance($Type$ArrayVector.class);
 
@@ -36,11 +36,7 @@ $endif$
 
     private final $Type$Block block;
 
-    public $Type$ArrayVector($if(BytesRef)$BytesRefArray$else$$type$[]$endif$ values, int positionCount) {
-        this(values, positionCount, BlockFactory.getNonBreakingInstance());
-    }
-
-    public $Type$ArrayVector($if(BytesRef)$BytesRefArray$else$$type$[]$endif$ values, int positionCount, BlockFactory blockFactory) {
+    $Type$ArrayVector($if(BytesRef)$BytesRefArray$else$$type$[]$endif$ values, int positionCount, BlockFactory blockFactory) {
         super(positionCount, blockFactory);
         this.values = values;
         this.block = new $Type$VectorBlock(this);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BigArrayVector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BigArrayVector.java.st
@@ -23,10 +23,6 @@ public final class $Type$BigArrayVector extends AbstractVector implements $Type$
 
     private final $Type$Block block;
 
-    public $Type$BigArrayVector($if(boolean)$Bit$else$$Type$$endif$Array values, int positionCount) {
-        this(values, positionCount, BlockFactory.getNonBreakingInstance());
-    }
-
     public $Type$BigArrayVector($if(boolean)$Bit$else$$Type$$endif$Array values, int positionCount, BlockFactory blockFactory) {
         super(positionCount, blockFactory);
         this.values = values;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ConstantVector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ConstantVector.java.st
@@ -16,7 +16,7 @@ import org.apache.lucene.util.RamUsageEstimator;
  * Vector implementation that stores a constant $type$ value.
  * This class is generated. Do not edit it.
  */
-public final class Constant$Type$Vector extends AbstractVector implements $Type$Vector {
+final class Constant$Type$Vector extends AbstractVector implements $Type$Vector {
 
 $if(BytesRef)$
     static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(ConstantBytesRefVector.class) + RamUsageEstimator
@@ -29,11 +29,7 @@ $endif$
 
     private final $Type$Block block;
 
-    public Constant$Type$Vector($type$ value, int positionCount) {
-        this(value, positionCount, BlockFactory.getNonBreakingInstance());
-    }
-
-    public Constant$Type$Vector($type$ value, int positionCount, BlockFactory blockFactory) {
+    Constant$Type$Vector($type$ value, int positionCount, BlockFactory blockFactory) {
         super(positionCount, blockFactory);
         this.value = value;
         this.block = new $Type$VectorBlock(this);
@@ -55,7 +51,7 @@ $endif$
 
     @Override
     public $Type$Vector filter(int... positions) {
-        return new Constant$Type$Vector(value, positions.length);
+        return blockFactory().newConstant$Type$Vector(value, positions.length);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicPageTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicPageTests.java
@@ -41,41 +41,72 @@ public class BasicPageTests extends SerializationTestCase {
     }
 
     public void testEqualityAndHashCodeSmallInput() {
+        Page in = new Page(0);
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(
-            new Page(0, new Block[] {}),
-            page -> new Page(0, new Block[] {}),
-            page -> new Page(1, IntBlock.newConstantBlockWith(1, 1))
+            in,
+            page -> new Page(0),
+            page -> new Page(1, IntBlock.newConstantBlockWith(1, 1)),
+            Page::releaseBlocks
         );
+        in.releaseBlocks();
+
+        in = new Page(blockFactory.newIntArrayVector(new int[] {}, 0).asBlock());
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(
-            new Page(new IntArrayVector(new int[] {}, 0).asBlock()),
-            page -> new Page(new IntArrayVector(new int[] {}, 0).asBlock()),
-            page -> new Page(new IntArrayVector(new int[] { 1 }, 1).asBlock())
+            in,
+            page -> new Page(blockFactory.newIntArrayVector(new int[] {}, 0).asBlock()),
+            page -> new Page(blockFactory.newIntArrayVector(new int[] { 1 }, 1).asBlock()),
+            Page::releaseBlocks
         );
+        in.releaseBlocks();
+
+        in = new Page(blockFactory.newIntArrayVector(new int[] { 1 }, 0).asBlock());
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(
-            new Page(new IntArrayVector(new int[] { 1 }, 0).asBlock()),
-            page -> new Page(new IntArrayVector(new int[] { 1 }, 0).asBlock()),
-            page -> new Page(new IntArrayVector(new int[] { 1 }, 1).asBlock())
+            in,
+            page -> new Page(blockFactory.newIntArrayVector(new int[] { 1 }, 0).asBlock()),
+            page -> new Page(blockFactory.newIntArrayVector(new int[] { 1 }, 1).asBlock()),
+            Page::releaseBlocks
         );
+        in.releaseBlocks();
+
+        in = new Page(blockFactory.newIntArrayVector(new int[] { 1, 1, 1 }, 3).asBlock());
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(
-            new Page(new IntArrayVector(new int[] { 1, 1, 1 }, 3).asBlock()),
+            in,
             page -> new Page(IntBlock.newConstantBlockWith(1, 3)),
-            page -> new Page(IntBlock.newConstantBlockWith(1, 2))
+            page -> new Page(IntBlock.newConstantBlockWith(1, 2)),
+            Page::releaseBlocks
         );
+        in.releaseBlocks();
+
+        in = new Page(blockFactory.newIntArrayVector(IntStream.range(0, 10).toArray(), 10).asBlock());
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(
-            new Page(new IntArrayVector(IntStream.range(0, 10).toArray(), 10).asBlock()),
-            page -> new Page(new IntArrayVector(IntStream.range(0, 10).toArray(), 10).asBlock()),
-            page -> new Page(new IntArrayVector(IntStream.range(0, 10).toArray(), 9).asBlock())
+            in,
+            page -> new Page(blockFactory.newIntArrayVector(IntStream.range(0, 10).toArray(), 10).asBlock()),
+            page -> new Page(blockFactory.newIntArrayVector(IntStream.range(0, 10).toArray(), 9).asBlock()),
+            Page::releaseBlocks
         );
+        in.releaseBlocks();
+
+        in = new Page(blockFactory.newIntArrayVector(IntStream.range(0, 100).toArray(), 100).asBlock());
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(
-            new Page(new IntArrayVector(IntStream.range(0, 100).toArray(), 100).asBlock()),
-            page -> new Page(new IntArrayVector(IntStream.range(0, 100).toArray(), 100).asBlock()),
-            page -> new Page(new LongArrayVector(LongStream.range(0, 100).toArray(), 100).asBlock())
+            in,
+            page -> new Page(blockFactory.newIntArrayVector(IntStream.range(0, 100).toArray(), 100).asBlock()),
+            page -> new Page(blockFactory.newLongArrayVector(LongStream.range(0, 100).toArray(), 100).asBlock()),
+            Page::releaseBlocks
         );
-        EqualsHashCodeTestUtils.checkEqualsAndHashCode(
-            new Page(new IntArrayVector(new int[] { 1 }, 1).asBlock()),
-            page -> new Page(1, page.getBlock(0)),
-            page -> new Page(new IntArrayVector(new int[] { 1 }, 1).asBlock(), new IntArrayVector(new int[] { 1 }, 1).asBlock())
+        in.releaseBlocks();
+
+        in = new Page(blockFactory.newIntArrayVector(new int[] { 1 }, 1).asBlock());
+        EqualsHashCodeTestUtils.checkEqualsAndHashCode(in, page -> {
+            page.getBlock(0).incRef();
+            return new Page(1, page.getBlock(0));
+        },
+            page -> new Page(
+                blockFactory.newIntArrayVector(new int[] { 1 }, 1).asBlock(),
+                blockFactory.newIntArrayVector(new int[] { 1 }, 1).asBlock()
+            ),
+            Page::releaseBlocks
         );
+        in.releaseBlocks();
     }
 
     public void testEqualityAndHashCode() throws IOException {
@@ -103,9 +134,9 @@ public class BasicPageTests extends SerializationTestCase {
         Block[] blocks = new Block[blockCount];
         for (int blockIndex = 0; blockIndex < blockCount; blockIndex++) {
             blocks[blockIndex] = switch (randomInt(6)) {
-                case 0 -> new IntArrayVector(randomInts(positions).toArray(), positions).asBlock();
-                case 1 -> new LongArrayVector(randomLongs(positions).toArray(), positions).asBlock();
-                case 2 -> new DoubleArrayVector(randomDoubles(positions).toArray(), positions).asBlock();
+                case 0 -> blockFactory.newIntArrayVector(randomInts(positions).toArray(), positions).asBlock();
+                case 1 -> blockFactory.newLongArrayVector(randomLongs(positions).toArray(), positions).asBlock();
+                case 2 -> blockFactory.newDoubleArrayVector(randomDoubles(positions).toArray(), positions).asBlock();
                 case 3 -> IntBlock.newConstantBlockWith(randomInt(), positions);
                 case 4 -> LongBlock.newConstantBlockWith(randomLong(), positions);
                 case 5 -> DoubleBlock.newConstantBlockWith(randomDouble(), positions);
@@ -125,36 +156,40 @@ public class BasicPageTests extends SerializationTestCase {
 
     public void testBasic() {
         int positions = randomInt(1024);
-        Page page = new Page(new IntArrayVector(IntStream.range(0, positions).toArray(), positions).asBlock());
+        Page page = new Page(blockFactory.newIntArrayVector(IntStream.range(0, positions).toArray(), positions).asBlock());
         assertThat(1, is(page.getBlockCount()));
         assertThat(positions, is(page.getPositionCount()));
         IntBlock block = page.getBlock(0);
         IntStream.range(0, positions).forEach(i -> assertThat(i, is(block.getInt(i))));
+        page.releaseBlocks();
     }
 
     public void testAppend() {
-        Page page1 = new Page(new IntArrayVector(IntStream.range(0, 10).toArray(), 10).asBlock());
-        Page page2 = page1.appendBlock(new LongArrayVector(LongStream.range(0, 10).toArray(), 10).asBlock());
+        Page page1 = new Page(blockFactory.newIntArrayVector(IntStream.range(0, 10).toArray(), 10).asBlock());
+        Page page2 = page1.appendBlock(blockFactory.newLongArrayVector(LongStream.range(0, 10).toArray(), 10).asBlock());
         assertThat(1, is(page1.getBlockCount()));
         assertThat(2, is(page2.getBlockCount()));
         IntBlock block1 = page2.getBlock(0);
         IntStream.range(0, 10).forEach(i -> assertThat(i, is(block1.getInt(i))));
         LongBlock block2 = page2.getBlock(1);
         IntStream.range(0, 10).forEach(i -> assertThat((long) i, is(block2.getLong(i))));
+        page2.releaseBlocks();
     }
 
     public void testPageSerializationSimple() throws IOException {
+        IntVector toFilter = blockFactory.newIntArrayVector(IntStream.range(0, 20).toArray(), 20);
         Page origPage = new Page(
-            new IntArrayVector(IntStream.range(0, 10).toArray(), 10).asBlock(),
-            new LongArrayVector(LongStream.range(10, 20).toArray(), 10).asBlock(),
-            new DoubleArrayVector(LongStream.range(30, 40).mapToDouble(i -> i).toArray(), 10).asBlock(),
-            new BytesRefArrayVector(bytesRefArrayOf("0a", "1b", "2c", "3d", "4e", "5f", "6g", "7h", "8i", "9j"), 10).asBlock(),
+            blockFactory.newIntArrayVector(IntStream.range(0, 10).toArray(), 10).asBlock(),
+            blockFactory.newLongArrayVector(LongStream.range(10, 20).toArray(), 10).asBlock(),
+            blockFactory.newDoubleArrayVector(LongStream.range(30, 40).mapToDouble(i -> i).toArray(), 10).asBlock(),
+            blockFactory.newBytesRefArrayVector(bytesRefArrayOf("0a", "1b", "2c", "3d", "4e", "5f", "6g", "7h", "8i", "9j"), 10).asBlock(),
             IntBlock.newConstantBlockWith(randomInt(), 10),
             LongBlock.newConstantBlockWith(randomInt(), 10),
             DoubleBlock.newConstantBlockWith(randomInt(), 10),
             BytesRefBlock.newConstantBlockWith(new BytesRef(Integer.toHexString(randomInt())), 10),
-            new IntArrayVector(IntStream.range(0, 20).toArray(), 20).filter(5, 6, 7, 8, 9, 10, 11, 12, 13, 14).asBlock()
+            toFilter.filter(5, 6, 7, 8, 9, 10, 11, 12, 13, 14).asBlock()
         );
+        toFilter.close();
         try {
             Page deserPage = serializeDeserializePage(origPage);
             try {
@@ -177,9 +212,9 @@ public class BasicPageTests extends SerializationTestCase {
     public void testSerializationListPages() throws IOException {
         final int positions = randomIntBetween(1, 64);
         List<Page> origPages = List.of(
-            new Page(new IntArrayVector(randomInts(positions).toArray(), positions).asBlock()),
+            new Page(blockFactory.newIntArrayVector(randomInts(positions).toArray(), positions).asBlock()),
             new Page(
-                new LongArrayVector(randomLongs(positions).toArray(), positions).asBlock(),
+                blockFactory.newLongArrayVector(randomLongs(positions).toArray(), positions).asBlock(),
                 DoubleBlock.newConstantBlockWith(randomInt(), positions)
             ),
             new Page(BytesRefBlock.newConstantBlockWith(new BytesRef("Hello World"), positions))
@@ -198,7 +233,7 @@ public class BasicPageTests extends SerializationTestCase {
 
     public void testPageMultiRelease() {
         int positions = randomInt(1024);
-        var block = new IntArrayVector(IntStream.range(0, positions).toArray(), positions).asBlock();
+        var block = blockFactory.newIntArrayVector(IntStream.range(0, positions).toArray(), positions).asBlock();
         Page page = new Page(block);
         page.releaseBlocks();
         assertThat(block.isReleased(), is(true));

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockAccountingTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockAccountingTests.java
@@ -39,87 +39,96 @@ public class BlockAccountingTests extends ComputeTestCase {
 
     // Array Vectors
     public void testBooleanVector() {
-        Vector empty = new BooleanArrayVector(new boolean[] {}, 0);
+        BlockFactory blockFactory = blockFactory();
+        Vector empty = blockFactory.newBooleanArrayVector(new boolean[] {}, 0);
         long expectedEmptyUsed = RamUsageTester.ramUsed(empty, RAM_USAGE_ACCUMULATOR);
         assertThat(empty.ramBytesUsed(), is(expectedEmptyUsed));
 
-        Vector emptyPlusOne = new BooleanArrayVector(new boolean[] { randomBoolean() }, 1);
+        Vector emptyPlusOne = blockFactory.newBooleanArrayVector(new boolean[] { randomBoolean() }, 1);
         assertThat(emptyPlusOne.ramBytesUsed(), is(alignObjectSize(empty.ramBytesUsed() + 1)));
 
         boolean[] randomData = new boolean[randomIntBetween(2, 1024)];
-        Vector emptyPlusSome = new BooleanArrayVector(randomData, randomData.length);
+        Vector emptyPlusSome = blockFactory.newBooleanArrayVector(randomData, randomData.length);
         assertThat(emptyPlusSome.ramBytesUsed(), is(alignObjectSize(empty.ramBytesUsed() + randomData.length)));
 
         Vector filterVector = emptyPlusSome.filter(1);
         assertThat(filterVector.ramBytesUsed(), lessThan(emptyPlusSome.ramBytesUsed()));
+        Releasables.close(empty, emptyPlusOne, emptyPlusSome, filterVector);
     }
 
     public void testIntVector() {
-        Vector empty = new IntArrayVector(new int[] {}, 0);
+        BlockFactory blockFactory = blockFactory();
+        Vector empty = blockFactory.newIntArrayVector(new int[] {}, 0);
         long expectedEmptyUsed = RamUsageTester.ramUsed(empty, RAM_USAGE_ACCUMULATOR);
         assertThat(empty.ramBytesUsed(), is(expectedEmptyUsed));
 
-        Vector emptyPlusOne = new IntArrayVector(new int[] { randomInt() }, 1);
+        Vector emptyPlusOne = blockFactory.newIntArrayVector(new int[] { randomInt() }, 1);
         assertThat(emptyPlusOne.ramBytesUsed(), is(alignObjectSize(empty.ramBytesUsed() + Integer.BYTES)));
 
         int[] randomData = new int[randomIntBetween(2, 1024)];
-        Vector emptyPlusSome = new IntArrayVector(randomData, randomData.length);
+        Vector emptyPlusSome = blockFactory.newIntArrayVector(randomData, randomData.length);
         assertThat(emptyPlusSome.ramBytesUsed(), is(alignObjectSize(empty.ramBytesUsed() + (long) Integer.BYTES * randomData.length)));
 
         Vector filterVector = emptyPlusSome.filter(1);
         assertThat(filterVector.ramBytesUsed(), lessThan(emptyPlusSome.ramBytesUsed()));
+        Releasables.close(empty, emptyPlusOne, emptyPlusSome, filterVector);
     }
 
     public void testLongVector() {
-        Vector empty = new LongArrayVector(new long[] {}, 0);
+        BlockFactory blockFactory = blockFactory();
+        Vector empty = blockFactory.newLongArrayVector(new long[] {}, 0);
         long expectedEmptyUsed = RamUsageTester.ramUsed(empty, RAM_USAGE_ACCUMULATOR);
         assertThat(empty.ramBytesUsed(), is(expectedEmptyUsed));
 
-        Vector emptyPlusOne = new LongArrayVector(new long[] { randomLong() }, 1);
+        Vector emptyPlusOne = blockFactory.newLongArrayVector(new long[] { randomLong() }, 1);
         assertThat(emptyPlusOne.ramBytesUsed(), is(empty.ramBytesUsed() + Long.BYTES));
 
         long[] randomData = new long[randomIntBetween(2, 1024)];
-        Vector emptyPlusSome = new LongArrayVector(randomData, randomData.length);
+        Vector emptyPlusSome = blockFactory.newLongArrayVector(randomData, randomData.length);
         assertThat(emptyPlusSome.ramBytesUsed(), is(empty.ramBytesUsed() + (long) Long.BYTES * randomData.length));
 
         Vector filterVector = emptyPlusSome.filter(1);
         assertThat(filterVector.ramBytesUsed(), lessThan(emptyPlusSome.ramBytesUsed()));
+
+        Releasables.close(empty, emptyPlusOne, emptyPlusSome, filterVector);
     }
 
     public void testDoubleVector() {
-        Vector empty = new DoubleArrayVector(new double[] {}, 0);
+        BlockFactory blockFactory = blockFactory();
+        Vector empty = blockFactory.newDoubleArrayVector(new double[] {}, 0);
         long expectedEmptyUsed = RamUsageTester.ramUsed(empty, RAM_USAGE_ACCUMULATOR);
         assertThat(empty.ramBytesUsed(), is(expectedEmptyUsed));
 
-        Vector emptyPlusOne = new DoubleArrayVector(new double[] { randomDouble() }, 1);
+        Vector emptyPlusOne = blockFactory.newDoubleArrayVector(new double[] { randomDouble() }, 1);
         assertThat(emptyPlusOne.ramBytesUsed(), is(empty.ramBytesUsed() + Double.BYTES));
 
         double[] randomData = new double[randomIntBetween(2, 1024)];
-        Vector emptyPlusSome = new DoubleArrayVector(randomData, randomData.length);
+        Vector emptyPlusSome = blockFactory.newDoubleArrayVector(randomData, randomData.length);
         assertThat(emptyPlusSome.ramBytesUsed(), is(empty.ramBytesUsed() + (long) Double.BYTES * randomData.length));
 
         // a filter becomes responsible for it's enclosing data, both in terms of accountancy and releasability
         Vector filterVector = emptyPlusSome.filter(1);
         assertThat(filterVector.ramBytesUsed(), lessThan(emptyPlusSome.ramBytesUsed()));
+
+        Releasables.close(empty, emptyPlusOne, emptyPlusSome, filterVector);
     }
 
     public void testBytesRefVector() {
-        try (
-            var emptyArray = new BytesRefArray(0, BigArrays.NON_RECYCLING_INSTANCE);
-            var arrayWithOne = new BytesRefArray(0, BigArrays.NON_RECYCLING_INSTANCE)
-        ) {
-            Vector emptyVector = new BytesRefArrayVector(emptyArray, 0);
-            long expectedEmptyVectorUsed = RamUsageTester.ramUsed(emptyVector, RAM_USAGE_ACCUMULATOR);
-            assertThat(emptyVector.ramBytesUsed(), is(expectedEmptyVectorUsed));
+        BlockFactory blockFactory = blockFactory();
+        var emptyArray = new BytesRefArray(0, blockFactory.bigArrays());
+        var arrayWithOne = new BytesRefArray(0, blockFactory.bigArrays());
+        Vector emptyVector = blockFactory.newBytesRefArrayVector(emptyArray, 0);
+        long expectedEmptyVectorUsed = RamUsageTester.ramUsed(emptyVector, RAM_USAGE_ACCUMULATOR);
+        assertThat(emptyVector.ramBytesUsed(), is(expectedEmptyVectorUsed));
 
-            var bytesRef = new BytesRef(randomAlphaOfLengthBetween(1, 16));
-            arrayWithOne.append(bytesRef);
-            Vector emptyPlusOne = new BytesRefArrayVector(arrayWithOne, 1);
-            assertThat(emptyPlusOne.ramBytesUsed(), between(emptyVector.ramBytesUsed() + bytesRef.length, UPPER_BOUND));
+        var bytesRef = new BytesRef(randomAlphaOfLengthBetween(1, 16));
+        arrayWithOne.append(bytesRef);
+        Vector emptyPlusOne = blockFactory.newBytesRefArrayVector(arrayWithOne, 1);
+        assertThat(emptyPlusOne.ramBytesUsed(), between(emptyVector.ramBytesUsed() + bytesRef.length, UPPER_BOUND));
 
-            Vector filterVector = emptyPlusOne.filter(0);
-            assertThat(filterVector.ramBytesUsed(), lessThan(emptyPlusOne.ramBytesUsed()));
-        }
+        Vector filterVector = emptyPlusOne.filter(0);
+        assertThat(filterVector.ramBytesUsed(), lessThan(emptyPlusOne.ramBytesUsed()));
+        Releasables.close(emptyVector, emptyPlusOne, filterVector);
     }
 
     // Array Blocks

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BooleanBlockEqualityTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BooleanBlockEqualityTests.java
@@ -7,18 +7,20 @@
 
 package org.elasticsearch.compute.data;
 
-import org.elasticsearch.compute.operator.ComputeTestCase;
+import org.elasticsearch.test.ESTestCase;
 
 import java.util.BitSet;
 import java.util.List;
 
-public class BooleanBlockEqualityTests extends ComputeTestCase {
+public class BooleanBlockEqualityTests extends ESTestCase {
+
+    static final BlockFactory blockFactory = BlockFactory.getNonBreakingInstance();
 
     public void testEmptyVector() {
         // all these "empty" vectors should be equivalent
         List<BooleanVector> vectors = List.of(
-            new BooleanArrayVector(new boolean[] {}, 0),
-            new BooleanArrayVector(new boolean[] { randomBoolean() }, 0),
+            blockFactory.newBooleanArrayVector(new boolean[] {}, 0),
+            blockFactory.newBooleanArrayVector(new boolean[] { randomBoolean() }, 0),
             BooleanBlock.newConstantBlockWith(randomBoolean(), 0).asVector(),
             BooleanBlock.newConstantBlockWith(randomBoolean(), 0).filter().asVector(),
             BooleanBlock.newBlockBuilder(0).build().asVector(),
@@ -28,7 +30,6 @@ public class BooleanBlockEqualityTests extends ComputeTestCase {
     }
 
     public void testEmptyBlock() {
-        BlockFactory blockFactory = blockFactory();
         // all these "empty" vectors should be equivalent
         List<BooleanBlock> blocks = List.of(
             new BooleanArrayBlock(
@@ -58,13 +59,13 @@ public class BooleanBlockEqualityTests extends ComputeTestCase {
     public void testVectorEquality() {
         // all these vectors should be equivalent
         List<BooleanVector> vectors = List.of(
-            new BooleanArrayVector(new boolean[] { true, false, true }, 3),
-            new BooleanArrayVector(new boolean[] { true, false, true }, 3).asBlock().asVector(),
-            new BooleanArrayVector(new boolean[] { true, false, true, false }, 3),
-            new BooleanArrayVector(new boolean[] { true, false, true }, 3).filter(0, 1, 2),
-            new BooleanArrayVector(new boolean[] { true, false, true, false }, 4).filter(0, 1, 2),
-            new BooleanArrayVector(new boolean[] { false, true, false, true }, 4).filter(1, 2, 3),
-            new BooleanArrayVector(new boolean[] { true, true, false, true }, 4).filter(0, 2, 3),
+            blockFactory.newBooleanArrayVector(new boolean[] { true, false, true }, 3),
+            blockFactory.newBooleanArrayVector(new boolean[] { true, false, true }, 3).asBlock().asVector(),
+            blockFactory.newBooleanArrayVector(new boolean[] { true, false, true, false }, 3),
+            blockFactory.newBooleanArrayVector(new boolean[] { true, false, true }, 3).filter(0, 1, 2),
+            blockFactory.newBooleanArrayVector(new boolean[] { true, false, true, false }, 4).filter(0, 1, 2),
+            blockFactory.newBooleanArrayVector(new boolean[] { false, true, false, true }, 4).filter(1, 2, 3),
+            blockFactory.newBooleanArrayVector(new boolean[] { true, true, false, true }, 4).filter(0, 2, 3),
             BooleanBlock.newBlockBuilder(3).appendBoolean(true).appendBoolean(false).appendBoolean(true).build().asVector(),
             BooleanBlock.newBlockBuilder(3).appendBoolean(true).appendBoolean(false).appendBoolean(true).build().asVector().filter(0, 1, 2),
             BooleanBlock.newBlockBuilder(3)
@@ -88,13 +89,13 @@ public class BooleanBlockEqualityTests extends ComputeTestCase {
 
         // all these constant-like vectors should be equivalent
         List<BooleanVector> moreVectors = List.of(
-            new BooleanArrayVector(new boolean[] { true, true, true }, 3),
-            new BooleanArrayVector(new boolean[] { true, true, true }, 3).asBlock().asVector(),
-            new BooleanArrayVector(new boolean[] { true, true, true, true }, 3),
-            new BooleanArrayVector(new boolean[] { true, true, true }, 3).filter(0, 1, 2),
-            new BooleanArrayVector(new boolean[] { true, true, true, false }, 4).filter(0, 1, 2),
-            new BooleanArrayVector(new boolean[] { false, true, true, true }, 4).filter(1, 2, 3),
-            new BooleanArrayVector(new boolean[] { true, false, true, true }, 4).filter(0, 2, 3),
+            blockFactory.newBooleanArrayVector(new boolean[] { true, true, true }, 3),
+            blockFactory.newBooleanArrayVector(new boolean[] { true, true, true }, 3).asBlock().asVector(),
+            blockFactory.newBooleanArrayVector(new boolean[] { true, true, true, true }, 3),
+            blockFactory.newBooleanArrayVector(new boolean[] { true, true, true }, 3).filter(0, 1, 2),
+            blockFactory.newBooleanArrayVector(new boolean[] { true, true, true, false }, 4).filter(0, 1, 2),
+            blockFactory.newBooleanArrayVector(new boolean[] { false, true, true, true }, 4).filter(1, 2, 3),
+            blockFactory.newBooleanArrayVector(new boolean[] { true, false, true, true }, 4).filter(0, 2, 3),
             BooleanBlock.newConstantBlockWith(true, 3).asVector(),
             BooleanBlock.newBlockBuilder(3).appendBoolean(true).appendBoolean(true).appendBoolean(true).build().asVector(),
             BooleanBlock.newBlockBuilder(3).appendBoolean(true).appendBoolean(true).appendBoolean(true).build().asVector().filter(0, 1, 2),
@@ -119,10 +120,9 @@ public class BooleanBlockEqualityTests extends ComputeTestCase {
     }
 
     public void testBlockEquality() {
-        BlockFactory blockFactory = blockFactory();
         // all these blocks should be equivalent
         List<BooleanBlock> blocks = List.of(
-            new BooleanArrayVector(new boolean[] { true, false, true }, 3).asBlock(),
+            blockFactory.newBooleanArrayVector(new boolean[] { true, false, true }, 3).asBlock(),
             new BooleanArrayBlock(
                 new boolean[] { true, false, true },
                 3,
@@ -139,10 +139,10 @@ public class BooleanBlockEqualityTests extends ComputeTestCase {
                 randomFrom(Block.MvOrdering.values()),
                 blockFactory
             ),
-            new BooleanArrayVector(new boolean[] { true, false, true }, 3).filter(0, 1, 2).asBlock(),
-            new BooleanArrayVector(new boolean[] { true, false, true, false }, 3).filter(0, 1, 2).asBlock(),
-            new BooleanArrayVector(new boolean[] { true, false, true, false }, 4).filter(0, 1, 2).asBlock(),
-            new BooleanArrayVector(new boolean[] { true, false, false, true }, 4).filter(0, 1, 3).asBlock(),
+            blockFactory.newBooleanArrayVector(new boolean[] { true, false, true }, 3).filter(0, 1, 2).asBlock(),
+            blockFactory.newBooleanArrayVector(new boolean[] { true, false, true, false }, 3).filter(0, 1, 2).asBlock(),
+            blockFactory.newBooleanArrayVector(new boolean[] { true, false, true, false }, 4).filter(0, 1, 2).asBlock(),
+            blockFactory.newBooleanArrayVector(new boolean[] { true, false, false, true }, 4).filter(0, 1, 3).asBlock(),
             BooleanBlock.newBlockBuilder(3).appendBoolean(true).appendBoolean(false).appendBoolean(true).build(),
             BooleanBlock.newBlockBuilder(3).appendBoolean(true).appendBoolean(false).appendBoolean(true).build().filter(0, 1, 2),
             BooleanBlock.newBlockBuilder(3)
@@ -164,7 +164,7 @@ public class BooleanBlockEqualityTests extends ComputeTestCase {
 
         // all these constant-like blocks should be equivalent
         List<BooleanBlock> moreBlocks = List.of(
-            new BooleanArrayVector(new boolean[] { true, true }, 2).asBlock(),
+            blockFactory.newBooleanArrayVector(new boolean[] { true, true }, 2).asBlock(),
             new BooleanArrayBlock(
                 new boolean[] { true, true },
                 2,
@@ -181,10 +181,10 @@ public class BooleanBlockEqualityTests extends ComputeTestCase {
                 randomFrom(Block.MvOrdering.values()),
                 blockFactory
             ),
-            new BooleanArrayVector(new boolean[] { true, true }, 2).filter(0, 1).asBlock(),
-            new BooleanArrayVector(new boolean[] { true, true, false }, 2).filter(0, 1).asBlock(),
-            new BooleanArrayVector(new boolean[] { true, true, false }, 3).filter(0, 1).asBlock(),
-            new BooleanArrayVector(new boolean[] { true, false, true }, 3).filter(0, 2).asBlock(),
+            blockFactory.newBooleanArrayVector(new boolean[] { true, true }, 2).filter(0, 1).asBlock(),
+            blockFactory.newBooleanArrayVector(new boolean[] { true, true, false }, 2).filter(0, 1).asBlock(),
+            blockFactory.newBooleanArrayVector(new boolean[] { true, true, false }, 3).filter(0, 1).asBlock(),
+            blockFactory.newBooleanArrayVector(new boolean[] { true, false, true }, 3).filter(0, 2).asBlock(),
             BooleanBlock.newConstantBlockWith(true, 2),
             BooleanBlock.newBlockBuilder(2).appendBoolean(true).appendBoolean(true).build(),
             BooleanBlock.newBlockBuilder(2).appendBoolean(true).appendBoolean(true).build().filter(0, 1),
@@ -197,11 +197,11 @@ public class BooleanBlockEqualityTests extends ComputeTestCase {
     public void testVectorInequality() {
         // all these vectors should NOT be equivalent
         List<BooleanVector> notEqualVectors = List.of(
-            new BooleanArrayVector(new boolean[] { true }, 1),
-            new BooleanArrayVector(new boolean[] { false }, 1),
-            new BooleanArrayVector(new boolean[] { true, false }, 2),
-            new BooleanArrayVector(new boolean[] { true, false, true }, 3),
-            new BooleanArrayVector(new boolean[] { false, true, false }, 3),
+            blockFactory.newBooleanArrayVector(new boolean[] { true }, 1),
+            blockFactory.newBooleanArrayVector(new boolean[] { false }, 1),
+            blockFactory.newBooleanArrayVector(new boolean[] { true, false }, 2),
+            blockFactory.newBooleanArrayVector(new boolean[] { true, false, true }, 3),
+            blockFactory.newBooleanArrayVector(new boolean[] { false, true, false }, 3),
             BooleanBlock.newConstantBlockWith(true, 2).asVector(),
             BooleanBlock.newBlockBuilder(2).appendBoolean(false).appendBoolean(true).build().asVector(),
             BooleanBlock.newBlockBuilder(3).appendBoolean(false).appendBoolean(false).appendBoolean(true).build().asVector(),
@@ -219,11 +219,11 @@ public class BooleanBlockEqualityTests extends ComputeTestCase {
     public void testBlockInequality() {
         // all these blocks should NOT be equivalent
         List<BooleanBlock> notEqualBlocks = List.of(
-            new BooleanArrayVector(new boolean[] { false }, 1).asBlock(),
-            new BooleanArrayVector(new boolean[] { true }, 1).asBlock(),
-            new BooleanArrayVector(new boolean[] { false, true }, 2).asBlock(),
-            new BooleanArrayVector(new boolean[] { false, true, false }, 3).asBlock(),
-            new BooleanArrayVector(new boolean[] { false, false, true }, 3).asBlock(),
+            blockFactory.newBooleanArrayVector(new boolean[] { false }, 1).asBlock(),
+            blockFactory.newBooleanArrayVector(new boolean[] { true }, 1).asBlock(),
+            blockFactory.newBooleanArrayVector(new boolean[] { false, true }, 2).asBlock(),
+            blockFactory.newBooleanArrayVector(new boolean[] { false, true, false }, 3).asBlock(),
+            blockFactory.newBooleanArrayVector(new boolean[] { false, false, true }, 3).asBlock(),
             BooleanBlock.newConstantBlockWith(true, 2),
             BooleanBlock.newBlockBuilder(3).appendBoolean(true).appendBoolean(false).appendBoolean(false).build(),
             BooleanBlock.newBlockBuilder(1).appendBoolean(true).appendBoolean(false).appendBoolean(true).appendBoolean(false).build(),

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BytesRefBlockEqualityTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BytesRefBlockEqualityTests.java
@@ -10,8 +10,10 @@ package org.elasticsearch.compute.data;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BytesRefArray;
+import org.elasticsearch.common.util.MockBigArrays;
+import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.compute.operator.ComputeTestCase;
-import org.junit.Before;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 
 import java.util.Arrays;
 import java.util.BitSet;
@@ -19,21 +21,15 @@ import java.util.List;
 
 public class BytesRefBlockEqualityTests extends ComputeTestCase {
 
-    private BigArrays bigArrays;
-    private BlockFactory blockFactory;
-
-    @Before
-    public void setupBlockFactory() {
-        blockFactory = blockFactory();
-        bigArrays = blockFactory.bigArrays();
-    }
+    final BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, new NoneCircuitBreakerService());
+    final BlockFactory blockFactory = BlockFactory.getNonBreakingInstance();
 
     public void testEmptyVector() {
         // all these "empty" vectors should be equivalent
         try (var bytesRefArray1 = new BytesRefArray(0, bigArrays); var bytesRefArray2 = new BytesRefArray(1, bigArrays)) {
             List<BytesRefVector> vectors = List.of(
-                new BytesRefArrayVector(bytesRefArray1, 0),
-                new BytesRefArrayVector(bytesRefArray2, 0),
+                new BytesRefArrayVector(bytesRefArray1, 0, blockFactory),
+                new BytesRefArrayVector(bytesRefArray2, 0, blockFactory),
                 BytesRefBlock.newConstantBlockWith(new BytesRef(), 0).asVector(),
                 BytesRefBlock.newConstantBlockWith(new BytesRef(), 0).filter().asVector(),
                 BytesRefBlock.newBlockBuilder(0).build().asVector(),
@@ -76,11 +72,11 @@ public class BytesRefBlockEqualityTests extends ComputeTestCase {
         // all these vectors should be equivalent
         try (var bytesRefArray1 = arrayOf("1", "2", "3"); var bytesRefArray2 = arrayOf("1", "2", "3", "4")) {
             List<BytesRefVector> vectors = List.of(
-                new BytesRefArrayVector(bytesRefArray1, 3),
-                new BytesRefArrayVector(bytesRefArray1, 3).asBlock().asVector(),
-                new BytesRefArrayVector(bytesRefArray2, 3),
-                new BytesRefArrayVector(bytesRefArray1, 3).filter(0, 1, 2),
-                new BytesRefArrayVector(bytesRefArray2, 4).filter(0, 1, 2),
+                new BytesRefArrayVector(bytesRefArray1, 3, blockFactory),
+                new BytesRefArrayVector(bytesRefArray1, 3, blockFactory).asBlock().asVector(),
+                new BytesRefArrayVector(bytesRefArray2, 3, blockFactory),
+                new BytesRefArrayVector(bytesRefArray1, 3, blockFactory).filter(0, 1, 2),
+                new BytesRefArrayVector(bytesRefArray2, 4, blockFactory).filter(0, 1, 2),
                 BytesRefBlock.newBlockBuilder(3)
                     .appendBytesRef(new BytesRef("1"))
                     .appendBytesRef(new BytesRef("2"))
@@ -117,11 +113,11 @@ public class BytesRefBlockEqualityTests extends ComputeTestCase {
         // all these constant-like vectors should be equivalent
         try (var bytesRefArray1 = arrayOf("1", "1", "1"); var bytesRefArray2 = arrayOf("1", "1", "1", "4")) {
             List<BytesRefVector> moreVectors = List.of(
-                new BytesRefArrayVector(bytesRefArray1, 3),
-                new BytesRefArrayVector(bytesRefArray1, 3).asBlock().asVector(),
-                new BytesRefArrayVector(bytesRefArray2, 3),
-                new BytesRefArrayVector(bytesRefArray1, 3).filter(0, 1, 2),
-                new BytesRefArrayVector(bytesRefArray2, 4).filter(0, 1, 2),
+                new BytesRefArrayVector(bytesRefArray1, 3, blockFactory),
+                new BytesRefArrayVector(bytesRefArray1, 3, blockFactory).asBlock().asVector(),
+                new BytesRefArrayVector(bytesRefArray2, 3, blockFactory),
+                new BytesRefArrayVector(bytesRefArray1, 3, blockFactory).filter(0, 1, 2),
+                new BytesRefArrayVector(bytesRefArray2, 4, blockFactory).filter(0, 1, 2),
                 BytesRefBlock.newConstantBlockWith(new BytesRef("1"), 3).asVector(),
                 BytesRefBlock.newBlockBuilder(3)
                     .appendBytesRef(new BytesRef("1"))
@@ -161,7 +157,7 @@ public class BytesRefBlockEqualityTests extends ComputeTestCase {
         // all these blocks should be equivalent
         try (var bytesRefArray1 = arrayOf("1", "2", "3"); var bytesRefArray2 = arrayOf("1", "2", "3", "4")) {
             List<BytesRefBlock> blocks = List.of(
-                new BytesRefArrayVector(bytesRefArray1, 3).asBlock(),
+                new BytesRefArrayVector(bytesRefArray1, 3, blockFactory).asBlock(),
                 new BytesRefArrayBlock(
                     bytesRefArray1,
                     3,
@@ -178,9 +174,9 @@ public class BytesRefBlockEqualityTests extends ComputeTestCase {
                     randomFrom(Block.MvOrdering.values()),
                     blockFactory
                 ),
-                new BytesRefArrayVector(bytesRefArray1, 3).filter(0, 1, 2).asBlock(),
-                new BytesRefArrayVector(bytesRefArray2, 3).filter(0, 1, 2).asBlock(),
-                new BytesRefArrayVector(bytesRefArray2, 4).filter(0, 1, 2).asBlock(),
+                new BytesRefArrayVector(bytesRefArray1, 3, blockFactory).filter(0, 1, 2).asBlock(),
+                new BytesRefArrayVector(bytesRefArray2, 3, blockFactory).filter(0, 1, 2).asBlock(),
+                new BytesRefArrayVector(bytesRefArray2, 4, blockFactory).filter(0, 1, 2).asBlock(),
                 BytesRefBlock.newBlockBuilder(3)
                     .appendBytesRef(new BytesRef("1"))
                     .appendBytesRef(new BytesRef("2"))
@@ -213,7 +209,7 @@ public class BytesRefBlockEqualityTests extends ComputeTestCase {
         // all these constant-like blocks should be equivalent
         try (var bytesRefArray1 = arrayOf("9", "9"); var bytesRefArray2 = arrayOf("9", "9", "4")) {
             List<BytesRefBlock> moreBlocks = List.of(
-                new BytesRefArrayVector(bytesRefArray1, 2).asBlock(),
+                new BytesRefArrayVector(bytesRefArray1, 2, blockFactory).asBlock(),
                 new BytesRefArrayBlock(
                     bytesRefArray1,
                     2,
@@ -230,9 +226,9 @@ public class BytesRefBlockEqualityTests extends ComputeTestCase {
                     randomFrom(Block.MvOrdering.values()),
                     blockFactory
                 ),
-                new BytesRefArrayVector(bytesRefArray1, 2).filter(0, 1).asBlock(),
-                new BytesRefArrayVector(bytesRefArray2, 2).filter(0, 1).asBlock(),
-                new BytesRefArrayVector(bytesRefArray2, 3).filter(0, 1).asBlock(),
+                new BytesRefArrayVector(bytesRefArray1, 2, blockFactory).filter(0, 1).asBlock(),
+                new BytesRefArrayVector(bytesRefArray2, 2, blockFactory).filter(0, 1).asBlock(),
+                new BytesRefArrayVector(bytesRefArray2, 3, blockFactory).filter(0, 1).asBlock(),
                 BytesRefBlock.newConstantBlockWith(new BytesRef("9"), 2),
                 BytesRefBlock.newBlockBuilder(2).appendBytesRef(new BytesRef("9")).appendBytesRef(new BytesRef("9")).build(),
                 BytesRefBlock.newBlockBuilder(2).appendBytesRef(new BytesRef("9")).appendBytesRef(new BytesRef("9")).build().filter(0, 1),
@@ -263,11 +259,11 @@ public class BytesRefBlockEqualityTests extends ComputeTestCase {
             var bytesRefArray5 = arrayOf("1", "2", "4")
         ) {
             List<BytesRefVector> notEqualVectors = List.of(
-                new BytesRefArrayVector(bytesRefArray1, 1),
-                new BytesRefArrayVector(bytesRefArray2, 1),
-                new BytesRefArrayVector(bytesRefArray3, 2),
-                new BytesRefArrayVector(bytesRefArray4, 3),
-                new BytesRefArrayVector(bytesRefArray5, 3),
+                new BytesRefArrayVector(bytesRefArray1, 1, blockFactory),
+                new BytesRefArrayVector(bytesRefArray2, 1, blockFactory),
+                new BytesRefArrayVector(bytesRefArray3, 2, blockFactory),
+                new BytesRefArrayVector(bytesRefArray4, 3, blockFactory),
+                new BytesRefArrayVector(bytesRefArray5, 3, blockFactory),
                 BytesRefBlock.newConstantBlockWith(new BytesRef("9"), 2).asVector(),
                 BytesRefBlock.newBlockBuilder(2)
                     .appendBytesRef(new BytesRef("1"))
@@ -303,11 +299,11 @@ public class BytesRefBlockEqualityTests extends ComputeTestCase {
             var bytesRefArray5 = arrayOf("1", "2", "4")
         ) {
             List<BytesRefBlock> notEqualBlocks = List.of(
-                new BytesRefArrayVector(bytesRefArray1, 1).asBlock(),
-                new BytesRefArrayVector(bytesRefArray2, 1).asBlock(),
-                new BytesRefArrayVector(bytesRefArray3, 2).asBlock(),
-                new BytesRefArrayVector(bytesRefArray4, 3).asBlock(),
-                new BytesRefArrayVector(bytesRefArray5, 3).asBlock(),
+                new BytesRefArrayVector(bytesRefArray1, 1, blockFactory).asBlock(),
+                new BytesRefArrayVector(bytesRefArray2, 1, blockFactory).asBlock(),
+                new BytesRefArrayVector(bytesRefArray3, 2, blockFactory).asBlock(),
+                new BytesRefArrayVector(bytesRefArray4, 3, blockFactory).asBlock(),
+                new BytesRefArrayVector(bytesRefArray5, 3, blockFactory).asBlock(),
                 BytesRefBlock.newConstantBlockWith(new BytesRef("9"), 2),
                 BytesRefBlock.newBlockBuilder(2).appendBytesRef(new BytesRef("1")).appendBytesRef(new BytesRef("2")).build().filter(1),
                 BytesRefBlock.newBlockBuilder(3)

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/DocVectorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/DocVectorTests.java
@@ -9,8 +9,8 @@ package org.elasticsearch.compute.data;
 
 import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.compute.operator.ComputeTestCase;
 import org.elasticsearch.core.Releasables;
-import org.elasticsearch.test.ESTestCase;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -21,7 +21,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
-public class DocVectorTests extends ESTestCase {
+public class DocVectorTests extends ComputeTestCase {
     public void testNonDecreasingSetTrue() {
         int length = between(1, 100);
         DocVector docs = new DocVector(intRange(0, length), intRange(0, length), intRange(0, length), true);
@@ -29,8 +29,10 @@ public class DocVectorTests extends ESTestCase {
     }
 
     public void testNonDecreasingSetFalse() {
-        DocVector docs = new DocVector(intRange(0, 2), intRange(0, 2), new IntArrayVector(new int[] { 1, 0 }, 2), false);
+        BlockFactory blockFactory = blockFactory();
+        DocVector docs = new DocVector(intRange(0, 2), intRange(0, 2), blockFactory.newIntArrayVector(new int[] { 1, 0 }, 2), false);
         assertFalse(docs.singleSegmentNonDecreasing());
+        docs.close();
     }
 
     public void testNonDecreasingNonConstantShard() {
@@ -44,13 +46,15 @@ public class DocVectorTests extends ESTestCase {
     }
 
     public void testNonDecreasingDescendingDocs() {
+        BlockFactory blockFactory = blockFactory();
         DocVector docs = new DocVector(
             IntBlock.newConstantBlockWith(0, 2).asVector(),
             IntBlock.newConstantBlockWith(0, 2).asVector(),
-            new IntArrayVector(new int[] { 1, 0 }, 2),
+            blockFactory.newIntArrayVector(new int[] { 1, 0 }, 2),
             null
         );
         assertFalse(docs.singleSegmentNonDecreasing());
+        docs.close();
     }
 
     public void testShardSegmentDocMap() {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/DoubleBlockEqualityTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/DoubleBlockEqualityTests.java
@@ -14,11 +14,13 @@ import java.util.List;
 
 public class DoubleBlockEqualityTests extends ComputeTestCase {
 
+    static final BlockFactory blockFactory = BlockFactory.getNonBreakingInstance();
+
     public void testEmptyVector() {
         // all these "empty" vectors should be equivalent
         List<DoubleVector> vectors = List.of(
-            new DoubleArrayVector(new double[] {}, 0),
-            new DoubleArrayVector(new double[] { 0 }, 0),
+            blockFactory.newDoubleArrayVector(new double[] {}, 0),
+            blockFactory.newDoubleArrayVector(new double[] { 0 }, 0),
             DoubleBlock.newConstantBlockWith(0, 0).asVector(),
             DoubleBlock.newConstantBlockWith(0, 0).filter().asVector(),
             DoubleBlock.newBlockBuilder(0).build().asVector(),
@@ -58,13 +60,13 @@ public class DoubleBlockEqualityTests extends ComputeTestCase {
     public void testVectorEquality() {
         // all these vectors should be equivalent
         List<DoubleVector> vectors = List.of(
-            new DoubleArrayVector(new double[] { 1, 2, 3 }, 3),
-            new DoubleArrayVector(new double[] { 1, 2, 3 }, 3).asBlock().asVector(),
-            new DoubleArrayVector(new double[] { 1, 2, 3, 4 }, 3),
-            new DoubleArrayVector(new double[] { 1, 2, 3 }, 3).filter(0, 1, 2),
-            new DoubleArrayVector(new double[] { 1, 2, 3, 4 }, 4).filter(0, 1, 2),
-            new DoubleArrayVector(new double[] { 0, 1, 2, 3 }, 4).filter(1, 2, 3),
-            new DoubleArrayVector(new double[] { 1, 4, 2, 3 }, 4).filter(0, 2, 3),
+            blockFactory.newDoubleArrayVector(new double[] { 1, 2, 3 }, 3),
+            blockFactory.newDoubleArrayVector(new double[] { 1, 2, 3 }, 3).asBlock().asVector(),
+            blockFactory.newDoubleArrayVector(new double[] { 1, 2, 3, 4 }, 3),
+            blockFactory.newDoubleArrayVector(new double[] { 1, 2, 3 }, 3).filter(0, 1, 2),
+            blockFactory.newDoubleArrayVector(new double[] { 1, 2, 3, 4 }, 4).filter(0, 1, 2),
+            blockFactory.newDoubleArrayVector(new double[] { 0, 1, 2, 3 }, 4).filter(1, 2, 3),
+            blockFactory.newDoubleArrayVector(new double[] { 1, 4, 2, 3 }, 4).filter(0, 2, 3),
             DoubleBlock.newBlockBuilder(3).appendDouble(1).appendDouble(2).appendDouble(3).build().asVector(),
             DoubleBlock.newBlockBuilder(3).appendDouble(1).appendDouble(2).appendDouble(3).build().asVector().filter(0, 1, 2),
             DoubleBlock.newBlockBuilder(3)
@@ -88,13 +90,13 @@ public class DoubleBlockEqualityTests extends ComputeTestCase {
 
         // all these constant-like vectors should be equivalent
         List<DoubleVector> moreVectors = List.of(
-            new DoubleArrayVector(new double[] { 1, 1, 1 }, 3),
-            new DoubleArrayVector(new double[] { 1, 1, 1 }, 3).asBlock().asVector(),
-            new DoubleArrayVector(new double[] { 1, 1, 1, 1 }, 3),
-            new DoubleArrayVector(new double[] { 1, 1, 1 }, 3).filter(0, 1, 2),
-            new DoubleArrayVector(new double[] { 1, 1, 1, 4 }, 4).filter(0, 1, 2),
-            new DoubleArrayVector(new double[] { 3, 1, 1, 1 }, 4).filter(1, 2, 3),
-            new DoubleArrayVector(new double[] { 1, 4, 1, 1 }, 4).filter(0, 2, 3),
+            blockFactory.newDoubleArrayVector(new double[] { 1, 1, 1 }, 3),
+            blockFactory.newDoubleArrayVector(new double[] { 1, 1, 1 }, 3).asBlock().asVector(),
+            blockFactory.newDoubleArrayVector(new double[] { 1, 1, 1, 1 }, 3),
+            blockFactory.newDoubleArrayVector(new double[] { 1, 1, 1 }, 3).filter(0, 1, 2),
+            blockFactory.newDoubleArrayVector(new double[] { 1, 1, 1, 4 }, 4).filter(0, 1, 2),
+            blockFactory.newDoubleArrayVector(new double[] { 3, 1, 1, 1 }, 4).filter(1, 2, 3),
+            blockFactory.newDoubleArrayVector(new double[] { 1, 4, 1, 1 }, 4).filter(0, 2, 3),
             DoubleBlock.newConstantBlockWith(1, 3).asVector(),
             DoubleBlock.newBlockBuilder(3).appendDouble(1).appendDouble(1).appendDouble(1).build().asVector(),
             DoubleBlock.newBlockBuilder(3).appendDouble(1).appendDouble(1).appendDouble(1).build().asVector().filter(0, 1, 2),
@@ -119,10 +121,9 @@ public class DoubleBlockEqualityTests extends ComputeTestCase {
     }
 
     public void testBlockEquality() {
-        BlockFactory blockFactory = blockFactory();
         // all these blocks should be equivalent
         List<DoubleBlock> blocks = List.of(
-            new DoubleArrayVector(new double[] { 1, 2, 3 }, 3).asBlock(),
+            blockFactory.newDoubleArrayVector(new double[] { 1, 2, 3 }, 3).asBlock(),
             new DoubleArrayBlock(
                 new double[] { 1, 2, 3 },
                 3,
@@ -139,10 +140,10 @@ public class DoubleBlockEqualityTests extends ComputeTestCase {
                 randomFrom(Block.MvOrdering.values()),
                 blockFactory
             ),
-            new DoubleArrayVector(new double[] { 1, 2, 3 }, 3).filter(0, 1, 2).asBlock(),
-            new DoubleArrayVector(new double[] { 1, 2, 3, 4 }, 3).filter(0, 1, 2).asBlock(),
-            new DoubleArrayVector(new double[] { 1, 2, 3, 4 }, 4).filter(0, 1, 2).asBlock(),
-            new DoubleArrayVector(new double[] { 1, 2, 4, 3 }, 4).filter(0, 1, 3).asBlock(),
+            blockFactory.newDoubleArrayVector(new double[] { 1, 2, 3 }, 3).filter(0, 1, 2).asBlock(),
+            blockFactory.newDoubleArrayVector(new double[] { 1, 2, 3, 4 }, 3).filter(0, 1, 2).asBlock(),
+            blockFactory.newDoubleArrayVector(new double[] { 1, 2, 3, 4 }, 4).filter(0, 1, 2).asBlock(),
+            blockFactory.newDoubleArrayVector(new double[] { 1, 2, 4, 3 }, 4).filter(0, 1, 3).asBlock(),
             DoubleBlock.newBlockBuilder(3).appendDouble(1).appendDouble(2).appendDouble(3).build(),
             DoubleBlock.newBlockBuilder(3).appendDouble(1).appendDouble(2).appendDouble(3).build().filter(0, 1, 2),
             DoubleBlock.newBlockBuilder(3).appendDouble(1).appendDouble(4).appendDouble(2).appendDouble(3).build().filter(0, 2, 3),
@@ -152,7 +153,7 @@ public class DoubleBlockEqualityTests extends ComputeTestCase {
 
         // all these constant-like blocks should be equivalent
         List<DoubleBlock> moreBlocks = List.of(
-            new DoubleArrayVector(new double[] { 9, 9 }, 2).asBlock(),
+            blockFactory.newDoubleArrayVector(new double[] { 9, 9 }, 2).asBlock(),
             new DoubleArrayBlock(
                 new double[] { 9, 9 },
                 2,
@@ -169,10 +170,10 @@ public class DoubleBlockEqualityTests extends ComputeTestCase {
                 randomFrom(Block.MvOrdering.values()),
                 blockFactory
             ),
-            new DoubleArrayVector(new double[] { 9, 9 }, 2).filter(0, 1).asBlock(),
-            new DoubleArrayVector(new double[] { 9, 9, 4 }, 2).filter(0, 1).asBlock(),
-            new DoubleArrayVector(new double[] { 9, 9, 4 }, 3).filter(0, 1).asBlock(),
-            new DoubleArrayVector(new double[] { 9, 4, 9 }, 3).filter(0, 2).asBlock(),
+            blockFactory.newDoubleArrayVector(new double[] { 9, 9 }, 2).filter(0, 1).asBlock(),
+            blockFactory.newDoubleArrayVector(new double[] { 9, 9, 4 }, 2).filter(0, 1).asBlock(),
+            blockFactory.newDoubleArrayVector(new double[] { 9, 9, 4 }, 3).filter(0, 1).asBlock(),
+            blockFactory.newDoubleArrayVector(new double[] { 9, 4, 9 }, 3).filter(0, 2).asBlock(),
             DoubleBlock.newConstantBlockWith(9, 2),
             DoubleBlock.newBlockBuilder(2).appendDouble(9).appendDouble(9).build(),
             DoubleBlock.newBlockBuilder(2).appendDouble(9).appendDouble(9).build().filter(0, 1),
@@ -185,11 +186,11 @@ public class DoubleBlockEqualityTests extends ComputeTestCase {
     public void testVectorInequality() {
         // all these vectors should NOT be equivalent
         List<DoubleVector> notEqualVectors = List.of(
-            new DoubleArrayVector(new double[] { 1 }, 1),
-            new DoubleArrayVector(new double[] { 9 }, 1),
-            new DoubleArrayVector(new double[] { 1, 2 }, 2),
-            new DoubleArrayVector(new double[] { 1, 2, 3 }, 3),
-            new DoubleArrayVector(new double[] { 1, 2, 4 }, 3),
+            blockFactory.newDoubleArrayVector(new double[] { 1 }, 1),
+            blockFactory.newDoubleArrayVector(new double[] { 9 }, 1),
+            blockFactory.newDoubleArrayVector(new double[] { 1, 2 }, 2),
+            blockFactory.newDoubleArrayVector(new double[] { 1, 2, 3 }, 3),
+            blockFactory.newDoubleArrayVector(new double[] { 1, 2, 4 }, 3),
             DoubleBlock.newConstantBlockWith(9, 2).asVector(),
             DoubleBlock.newBlockBuilder(2).appendDouble(1).appendDouble(2).build().asVector().filter(1),
             DoubleBlock.newBlockBuilder(3).appendDouble(1).appendDouble(2).appendDouble(5).build().asVector(),
@@ -201,11 +202,11 @@ public class DoubleBlockEqualityTests extends ComputeTestCase {
     public void testBlockInequality() {
         // all these blocks should NOT be equivalent
         List<DoubleBlock> notEqualBlocks = List.of(
-            new DoubleArrayVector(new double[] { 1 }, 1).asBlock(),
-            new DoubleArrayVector(new double[] { 9 }, 1).asBlock(),
-            new DoubleArrayVector(new double[] { 1, 2 }, 2).asBlock(),
-            new DoubleArrayVector(new double[] { 1, 2, 3 }, 3).asBlock(),
-            new DoubleArrayVector(new double[] { 1, 2, 4 }, 3).asBlock(),
+            blockFactory.newDoubleArrayVector(new double[] { 1 }, 1).asBlock(),
+            blockFactory.newDoubleArrayVector(new double[] { 9 }, 1).asBlock(),
+            blockFactory.newDoubleArrayVector(new double[] { 1, 2 }, 2).asBlock(),
+            blockFactory.newDoubleArrayVector(new double[] { 1, 2, 3 }, 3).asBlock(),
+            blockFactory.newDoubleArrayVector(new double[] { 1, 2, 4 }, 3).asBlock(),
             DoubleBlock.newConstantBlockWith(9, 2),
             DoubleBlock.newBlockBuilder(2).appendDouble(1).appendDouble(2).build().filter(1),
             DoubleBlock.newBlockBuilder(3).appendDouble(1).appendDouble(2).appendDouble(5).build(),

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/FilteredBlockTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/FilteredBlockTests.java
@@ -197,14 +197,13 @@ public class FilteredBlockTests extends ESTestCase {
     public void testFilterToStringSimple() {
         BitSet nulls = BitSet.valueOf(new byte[] { 0x08 });  // any non-empty bitset, that does not affect the filter, should suffice
 
-        var boolVector = new BooleanArrayVector(new boolean[] { true, false, false, true }, 4);
-        var boolBlock = new BooleanArrayBlock(
+        var boolVector = blockFactory.newBooleanArrayVector(new boolean[] { true, false, false, true }, 4);
+        var boolBlock = blockFactory.newBooleanArrayBlock(
             new boolean[] { true, false, false, true },
             4,
             null,
             nulls,
-            randomFrom(Block.MvOrdering.values()),
-            blockFactory
+            randomFrom(Block.MvOrdering.values())
         );
         for (Releasable obj : List.of(boolVector.filter(0, 2), boolVector.asBlock().filter(0, 2), boolBlock.filter(0, 2))) {
             String s = obj.toString();
@@ -212,24 +211,25 @@ public class FilteredBlockTests extends ESTestCase {
             assertThat(s, containsString("positions=2"));
             Releasables.close(obj);
         }
+        Releasables.close(boolVector, boolBlock);
 
-        var intVector = new IntArrayVector(new int[] { 10, 20, 30, 40 }, 4);
-        var intBlock = new IntArrayBlock(new int[] { 10, 20, 30, 40 }, 4, null, nulls, randomFrom(Block.MvOrdering.values()), blockFactory);
+        var intVector = blockFactory.newIntArrayVector(new int[] { 10, 20, 30, 40 }, 4);
+        var intBlock = blockFactory.newIntArrayBlock(new int[] { 10, 20, 30, 40 }, 4, null, nulls, randomFrom(Block.MvOrdering.values()));
         for (Releasable obj : List.of(intVector.filter(0, 2), intVector.asBlock().filter(0, 2), intBlock.filter(0, 2))) {
             String s = obj.toString();
             assertThat(s, containsString("[10, 30]"));
             assertThat(s, containsString("positions=2"));
             Releasables.close(obj);
         }
+        Releasables.close(intVector, intBlock);
 
-        var longVector = new LongArrayVector(new long[] { 100L, 200L, 300L, 400L }, 4);
-        var longBlock = new LongArrayBlock(
+        var longVector = blockFactory.newLongArrayVector(new long[] { 100L, 200L, 300L, 400L }, 4);
+        var longBlock = blockFactory.newLongArrayBlock(
             new long[] { 100L, 200L, 300L, 400L },
             4,
             null,
             nulls,
-            randomFrom(Block.MvOrdering.values()),
-            blockFactory
+            randomFrom(Block.MvOrdering.values())
         );
         for (Releasable obj : List.of(longVector.filter(0, 2), longVector.asBlock().filter(0, 2), longBlock.filter(0, 2))) {
             String s = obj.toString();
@@ -238,14 +238,15 @@ public class FilteredBlockTests extends ESTestCase {
             Releasables.close(obj);
         }
 
-        var doubleVector = new DoubleArrayVector(new double[] { 1.1, 2.2, 3.3, 4.4 }, 4);
-        var doubleBlock = new DoubleArrayBlock(
+        Releasables.close(longVector, longBlock);
+
+        var doubleVector = blockFactory.newDoubleArrayVector(new double[] { 1.1, 2.2, 3.3, 4.4 }, 4);
+        var doubleBlock = blockFactory.newDoubleArrayBlock(
             new double[] { 1.1, 2.2, 3.3, 4.4 },
             4,
             null,
             nulls,
-            randomFrom(Block.MvOrdering.values()),
-            blockFactory
+            randomFrom(Block.MvOrdering.values())
         );
         for (Releasable obj : List.of(doubleVector.filter(0, 2), doubleVector.asBlock().filter(0, 2), doubleBlock.filter(0, 2))) {
             String s = obj.toString();
@@ -254,20 +255,27 @@ public class FilteredBlockTests extends ESTestCase {
             Releasables.close(obj);
         }
 
+        Releasables.close(doubleVector, doubleBlock);
+
         assert new BytesRef("1a").toString().equals("[31 61]") && new BytesRef("3c").toString().equals("[33 63]");
-        try (var bytesRefArray = arrayOf("1a", "2b", "3c", "4d")) {
-            var bytesRefVector = new BytesRefArrayVector(bytesRefArray, 4);
-            var bytesRefBlock = new BytesRefArrayBlock(bytesRefArray, 4, null, nulls, randomFrom(Block.MvOrdering.values()), blockFactory);
-            for (Releasable obj : List.of(bytesRefVector.filter(0, 2), bytesRefVector.asBlock().filter(0, 2), bytesRefBlock.filter(0, 2))) {
-                assertThat(
-                    obj.toString(),
-                    either(equalTo("BytesRefArrayVector[positions=2]")).or(
-                        equalTo("BytesRefVectorBlock[vector=BytesRefArrayVector[positions=2]]")
-                    )
-                );
-                Releasables.close(obj);
-            }
+        var bytesRefVector = blockFactory.newBytesRefArrayVector(arrayOf("1a", "2b", "3c", "4d"), 4);
+        var bytesRefBlock = blockFactory.newBytesRefArrayBlock(
+            arrayOf("1a", "2b", "3c", "4d"),
+            4,
+            null,
+            nulls,
+            randomFrom(Block.MvOrdering.values())
+        );
+        for (Releasable obj : List.of(bytesRefVector.filter(0, 2), bytesRefVector.asBlock().filter(0, 2), bytesRefBlock.filter(0, 2))) {
+            assertThat(
+                obj.toString(),
+                either(equalTo("BytesRefArrayVector[positions=2]")).or(
+                    equalTo("BytesRefVectorBlock[vector=BytesRefArrayVector[positions=2]]")
+                )
+            );
+            Releasables.close(obj);
         }
+        Releasables.close(bytesRefVector, bytesRefBlock);
     }
 
     public void testFilterToStringMultiValue() {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/IntBlockEqualityTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/IntBlockEqualityTests.java
@@ -14,11 +14,13 @@ import java.util.List;
 
 public class IntBlockEqualityTests extends ComputeTestCase {
 
+    static final BlockFactory blockFactory = BlockFactory.getNonBreakingInstance();
+
     public void testEmptyVector() {
         // all these "empty" vectors should be equivalent
         List<IntVector> vectors = List.of(
-            new IntArrayVector(new int[] {}, 0),
-            new IntArrayVector(new int[] { 0 }, 0),
+            blockFactory.newIntArrayVector(new int[] {}, 0),
+            blockFactory.newIntArrayVector(new int[] { 0 }, 0),
             IntBlock.newConstantBlockWith(0, 0).asVector(),
             IntBlock.newConstantBlockWith(0, 0).filter().asVector(),
             IntBlock.newBlockBuilder(0).build().asVector(),
@@ -28,24 +30,21 @@ public class IntBlockEqualityTests extends ComputeTestCase {
     }
 
     public void testEmptyBlock() {
-        BlockFactory blockFactory = blockFactory();
         // all these "empty" vectors should be equivalent
         List<IntBlock> blocks = List.of(
-            new IntArrayBlock(
+            blockFactory.newIntArrayBlock(
                 new int[] {},
                 0,
                 new int[] {},
                 BitSet.valueOf(new byte[] { 0b00 }),
-                randomFrom(Block.MvOrdering.values()),
-                blockFactory
+                randomFrom(Block.MvOrdering.values())
             ),
-            new IntArrayBlock(
+            blockFactory.newIntArrayBlock(
                 new int[] { 0 },
                 0,
                 new int[] {},
                 BitSet.valueOf(new byte[] { 0b00 }),
-                randomFrom(Block.MvOrdering.values()),
-                blockFactory
+                randomFrom(Block.MvOrdering.values())
             ),
             IntBlock.newConstantBlockWith(0, 0),
             IntBlock.newBlockBuilder(0).build(),
@@ -58,13 +57,13 @@ public class IntBlockEqualityTests extends ComputeTestCase {
     public void testVectorEquality() {
         // all these vectors should be equivalent
         List<IntVector> vectors = List.of(
-            new IntArrayVector(new int[] { 1, 2, 3 }, 3),
-            new IntArrayVector(new int[] { 1, 2, 3 }, 3).asBlock().asVector(),
-            new IntArrayVector(new int[] { 1, 2, 3, 4 }, 3),
-            new IntArrayVector(new int[] { 1, 2, 3 }, 3).filter(0, 1, 2),
-            new IntArrayVector(new int[] { 1, 2, 3, 4 }, 4).filter(0, 1, 2),
-            new IntArrayVector(new int[] { 0, 1, 2, 3 }, 4).filter(1, 2, 3),
-            new IntArrayVector(new int[] { 1, 4, 2, 3 }, 4).filter(0, 2, 3),
+            blockFactory.newIntArrayVector(new int[] { 1, 2, 3 }, 3),
+            blockFactory.newIntArrayVector(new int[] { 1, 2, 3 }, 3).asBlock().asVector(),
+            blockFactory.newIntArrayVector(new int[] { 1, 2, 3, 4 }, 3),
+            blockFactory.newIntArrayVector(new int[] { 1, 2, 3 }, 3).filter(0, 1, 2),
+            blockFactory.newIntArrayVector(new int[] { 1, 2, 3, 4 }, 4).filter(0, 1, 2),
+            blockFactory.newIntArrayVector(new int[] { 0, 1, 2, 3 }, 4).filter(1, 2, 3),
+            blockFactory.newIntArrayVector(new int[] { 1, 4, 2, 3 }, 4).filter(0, 2, 3),
             IntBlock.newBlockBuilder(3).appendInt(1).appendInt(2).appendInt(3).build().asVector(),
             IntBlock.newBlockBuilder(3).appendInt(1).appendInt(2).appendInt(3).build().asVector().filter(0, 1, 2),
             IntBlock.newBlockBuilder(3).appendInt(1).appendInt(4).appendInt(2).appendInt(3).build().filter(0, 2, 3).asVector(),
@@ -74,13 +73,13 @@ public class IntBlockEqualityTests extends ComputeTestCase {
 
         // all these constant-like vectors should be equivalent
         List<IntVector> moreVectors = List.of(
-            new IntArrayVector(new int[] { 1, 1, 1 }, 3),
-            new IntArrayVector(new int[] { 1, 1, 1 }, 3).asBlock().asVector(),
-            new IntArrayVector(new int[] { 1, 1, 1, 1 }, 3),
-            new IntArrayVector(new int[] { 1, 1, 1 }, 3).filter(0, 1, 2),
-            new IntArrayVector(new int[] { 1, 1, 1, 4 }, 4).filter(0, 1, 2),
-            new IntArrayVector(new int[] { 3, 1, 1, 1 }, 4).filter(1, 2, 3),
-            new IntArrayVector(new int[] { 1, 4, 1, 1 }, 4).filter(0, 2, 3),
+            blockFactory.newIntArrayVector(new int[] { 1, 1, 1 }, 3),
+            blockFactory.newIntArrayVector(new int[] { 1, 1, 1 }, 3).asBlock().asVector(),
+            blockFactory.newIntArrayVector(new int[] { 1, 1, 1, 1 }, 3),
+            blockFactory.newIntArrayVector(new int[] { 1, 1, 1 }, 3).filter(0, 1, 2),
+            blockFactory.newIntArrayVector(new int[] { 1, 1, 1, 4 }, 4).filter(0, 1, 2),
+            blockFactory.newIntArrayVector(new int[] { 3, 1, 1, 1 }, 4).filter(1, 2, 3),
+            blockFactory.newIntArrayVector(new int[] { 1, 4, 1, 1 }, 4).filter(0, 2, 3),
             IntBlock.newConstantBlockWith(1, 3).asVector(),
             IntBlock.newBlockBuilder(3).appendInt(1).appendInt(1).appendInt(1).build().asVector(),
             IntBlock.newBlockBuilder(3).appendInt(1).appendInt(1).appendInt(1).build().asVector().filter(0, 1, 2),
@@ -91,10 +90,9 @@ public class IntBlockEqualityTests extends ComputeTestCase {
     }
 
     public void testBlockEquality() {
-        BlockFactory blockFactory = blockFactory();
         // all these blocks should be equivalent
         List<IntBlock> blocks = List.of(
-            new IntArrayVector(new int[] { 1, 2, 3 }, 3).asBlock(),
+            new IntArrayVector(new int[] { 1, 2, 3 }, 3, blockFactory).asBlock(),
             new IntArrayBlock(
                 new int[] { 1, 2, 3 },
                 3,
@@ -111,10 +109,10 @@ public class IntBlockEqualityTests extends ComputeTestCase {
                 randomFrom(Block.MvOrdering.values()),
                 blockFactory
             ),
-            new IntArrayVector(new int[] { 1, 2, 3 }, 3).filter(0, 1, 2).asBlock(),
-            new IntArrayVector(new int[] { 1, 2, 3, 4 }, 3).filter(0, 1, 2).asBlock(),
-            new IntArrayVector(new int[] { 1, 2, 3, 4 }, 4).filter(0, 1, 2).asBlock(),
-            new IntArrayVector(new int[] { 1, 2, 4, 3 }, 4).filter(0, 1, 3).asBlock(),
+            new IntArrayVector(new int[] { 1, 2, 3 }, 3, blockFactory).filter(0, 1, 2).asBlock(),
+            new IntArrayVector(new int[] { 1, 2, 3, 4 }, 3, blockFactory).filter(0, 1, 2).asBlock(),
+            new IntArrayVector(new int[] { 1, 2, 3, 4 }, 4, blockFactory).filter(0, 1, 2).asBlock(),
+            new IntArrayVector(new int[] { 1, 2, 4, 3 }, 4, blockFactory).filter(0, 1, 3).asBlock(),
             IntBlock.newBlockBuilder(3).appendInt(1).appendInt(2).appendInt(3).build(),
             IntBlock.newBlockBuilder(3).appendInt(1).appendInt(2).appendInt(3).build().filter(0, 1, 2),
             IntBlock.newBlockBuilder(3).appendInt(1).appendInt(4).appendInt(2).appendInt(3).build().filter(0, 2, 3),
@@ -124,27 +122,25 @@ public class IntBlockEqualityTests extends ComputeTestCase {
 
         // all these constant-like blocks should be equivalent
         List<IntBlock> moreBlocks = List.of(
-            new IntArrayVector(new int[] { 9, 9 }, 2).asBlock(),
-            new IntArrayBlock(
+            blockFactory.newIntArrayVector(new int[] { 9, 9 }, 2).asBlock(),
+            blockFactory.newIntArrayBlock(
                 new int[] { 9, 9 },
                 2,
                 new int[] { 0, 1, 2 },
                 BitSet.valueOf(new byte[] { 0b000 }),
-                randomFrom(Block.MvOrdering.values()),
-                blockFactory
+                randomFrom(Block.MvOrdering.values())
             ),
-            new IntArrayBlock(
+            blockFactory.newIntArrayBlock(
                 new int[] { 9, 9, 4 },
                 2,
                 new int[] { 0, 1, 2 },
                 BitSet.valueOf(new byte[] { 0b100 }),
-                randomFrom(Block.MvOrdering.values()),
-                blockFactory
+                randomFrom(Block.MvOrdering.values())
             ),
-            new IntArrayVector(new int[] { 9, 9 }, 2).filter(0, 1).asBlock(),
-            new IntArrayVector(new int[] { 9, 9, 4 }, 2).filter(0, 1).asBlock(),
-            new IntArrayVector(new int[] { 9, 9, 4 }, 3).filter(0, 1).asBlock(),
-            new IntArrayVector(new int[] { 9, 4, 9 }, 3).filter(0, 2).asBlock(),
+            blockFactory.newIntArrayVector(new int[] { 9, 9 }, 2).filter(0, 1).asBlock(),
+            blockFactory.newIntArrayVector(new int[] { 9, 9, 4 }, 2).filter(0, 1).asBlock(),
+            blockFactory.newIntArrayVector(new int[] { 9, 9, 4 }, 3).filter(0, 1).asBlock(),
+            blockFactory.newIntArrayVector(new int[] { 9, 4, 9 }, 3).filter(0, 2).asBlock(),
             IntBlock.newConstantBlockWith(9, 2),
             IntBlock.newBlockBuilder(2).appendInt(9).appendInt(9).build(),
             IntBlock.newBlockBuilder(2).appendInt(9).appendInt(9).build().filter(0, 1),
@@ -157,11 +153,11 @@ public class IntBlockEqualityTests extends ComputeTestCase {
     public void testVectorInequality() {
         // all these vectors should NOT be equivalent
         List<IntVector> notEqualVectors = List.of(
-            new IntArrayVector(new int[] { 1 }, 1),
-            new IntArrayVector(new int[] { 9 }, 1),
-            new IntArrayVector(new int[] { 1, 2 }, 2),
-            new IntArrayVector(new int[] { 1, 2, 3 }, 3),
-            new IntArrayVector(new int[] { 1, 2, 4 }, 3),
+            blockFactory.newIntArrayVector(new int[] { 1 }, 1),
+            blockFactory.newIntArrayVector(new int[] { 9 }, 1),
+            blockFactory.newIntArrayVector(new int[] { 1, 2 }, 2),
+            blockFactory.newIntArrayVector(new int[] { 1, 2, 3 }, 3),
+            blockFactory.newIntArrayVector(new int[] { 1, 2, 4 }, 3),
             IntBlock.newConstantBlockWith(9, 2).asVector(),
             IntBlock.newBlockBuilder(2).appendInt(1).appendInt(2).build().asVector().filter(1),
             IntBlock.newBlockBuilder(3).appendInt(1).appendInt(2).appendInt(5).build().asVector(),
@@ -173,11 +169,11 @@ public class IntBlockEqualityTests extends ComputeTestCase {
     public void testBlockInequality() {
         // all these blocks should NOT be equivalent
         List<IntBlock> notEqualBlocks = List.of(
-            new IntArrayVector(new int[] { 1 }, 1).asBlock(),
-            new IntArrayVector(new int[] { 9 }, 1).asBlock(),
-            new IntArrayVector(new int[] { 1, 2 }, 2).asBlock(),
-            new IntArrayVector(new int[] { 1, 2, 3 }, 3).asBlock(),
-            new IntArrayVector(new int[] { 1, 2, 4 }, 3).asBlock(),
+            blockFactory.newIntArrayVector(new int[] { 1 }, 1).asBlock(),
+            blockFactory.newIntArrayVector(new int[] { 9 }, 1).asBlock(),
+            blockFactory.newIntArrayVector(new int[] { 1, 2 }, 2).asBlock(),
+            blockFactory.newIntArrayVector(new int[] { 1, 2, 3 }, 3).asBlock(),
+            blockFactory.newIntArrayVector(new int[] { 1, 2, 4 }, 3).asBlock(),
             IntBlock.newConstantBlockWith(9, 2),
             IntBlock.newBlockBuilder(2).appendInt(1).appendInt(2).build().filter(1),
             IntBlock.newBlockBuilder(3).appendInt(1).appendInt(2).appendInt(5).build(),

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/LongBlockEqualityTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/LongBlockEqualityTests.java
@@ -14,11 +14,13 @@ import java.util.List;
 
 public class LongBlockEqualityTests extends ComputeTestCase {
 
+    static final BlockFactory blockFactory = BlockFactory.getNonBreakingInstance();
+
     public void testEmptyVector() {
         // all these "empty" vectors should be equivalent
         List<LongVector> vectors = List.of(
-            new LongArrayVector(new long[] {}, 0),
-            new LongArrayVector(new long[] { 0 }, 0),
+            blockFactory.newLongArrayVector(new long[] {}, 0),
+            blockFactory.newLongArrayVector(new long[] { 0 }, 0),
             LongBlock.newConstantBlockWith(0, 0).asVector(),
             LongBlock.newConstantBlockWith(0, 0).filter().asVector(),
             LongBlock.newBlockBuilder(0).build().asVector(),
@@ -28,24 +30,21 @@ public class LongBlockEqualityTests extends ComputeTestCase {
     }
 
     public void testEmptyBlock() {
-        BlockFactory blockFactory = blockFactory();
         // all these "empty" vectors should be equivalent
         List<LongBlock> blocks = List.of(
-            new LongArrayBlock(
+            blockFactory.newLongArrayBlock(
                 new long[] {},
                 0,
                 new int[] {},
                 BitSet.valueOf(new byte[] { 0b00 }),
-                randomFrom(Block.MvOrdering.values()),
-                blockFactory
+                randomFrom(Block.MvOrdering.values())
             ),
-            new LongArrayBlock(
+            blockFactory.newLongArrayBlock(
                 new long[] { 0 },
                 0,
                 new int[] {},
                 BitSet.valueOf(new byte[] { 0b00 }),
-                randomFrom(Block.MvOrdering.values()),
-                blockFactory
+                randomFrom(Block.MvOrdering.values())
             ),
             LongBlock.newConstantBlockWith(0, 0),
             LongBlock.newBlockBuilder(0).build(),
@@ -58,13 +57,13 @@ public class LongBlockEqualityTests extends ComputeTestCase {
     public void testVectorEquality() {
         // all these vectors should be equivalent
         List<LongVector> vectors = List.of(
-            new LongArrayVector(new long[] { 1, 2, 3 }, 3),
-            new LongArrayVector(new long[] { 1, 2, 3 }, 3).asBlock().asVector(),
-            new LongArrayVector(new long[] { 1, 2, 3, 4 }, 3),
-            new LongArrayVector(new long[] { 1, 2, 3 }, 3).filter(0, 1, 2),
-            new LongArrayVector(new long[] { 1, 2, 3, 4 }, 4).filter(0, 1, 2),
-            new LongArrayVector(new long[] { 0, 1, 2, 3 }, 4).filter(1, 2, 3),
-            new LongArrayVector(new long[] { 1, 4, 2, 3 }, 4).filter(0, 2, 3),
+            blockFactory.newLongArrayVector(new long[] { 1, 2, 3 }, 3),
+            blockFactory.newLongArrayVector(new long[] { 1, 2, 3 }, 3).asBlock().asVector(),
+            blockFactory.newLongArrayVector(new long[] { 1, 2, 3, 4 }, 3),
+            blockFactory.newLongArrayVector(new long[] { 1, 2, 3 }, 3).filter(0, 1, 2),
+            blockFactory.newLongArrayVector(new long[] { 1, 2, 3, 4 }, 4).filter(0, 1, 2),
+            blockFactory.newLongArrayVector(new long[] { 0, 1, 2, 3 }, 4).filter(1, 2, 3),
+            blockFactory.newLongArrayVector(new long[] { 1, 4, 2, 3 }, 4).filter(0, 2, 3),
             LongBlock.newBlockBuilder(3).appendLong(1).appendLong(2).appendLong(3).build().asVector(),
             LongBlock.newBlockBuilder(3).appendLong(1).appendLong(2).appendLong(3).build().asVector().filter(0, 1, 2),
             LongBlock.newBlockBuilder(3).appendLong(1).appendLong(4).appendLong(2).appendLong(3).build().filter(0, 2, 3).asVector(),
@@ -74,13 +73,13 @@ public class LongBlockEqualityTests extends ComputeTestCase {
 
         // all these constant-like vectors should be equivalent
         List<LongVector> moreVectors = List.of(
-            new LongArrayVector(new long[] { 1, 1, 1 }, 3),
-            new LongArrayVector(new long[] { 1, 1, 1 }, 3).asBlock().asVector(),
-            new LongArrayVector(new long[] { 1, 1, 1, 1 }, 3),
-            new LongArrayVector(new long[] { 1, 1, 1 }, 3).filter(0, 1, 2),
-            new LongArrayVector(new long[] { 1, 1, 1, 4 }, 4).filter(0, 1, 2),
-            new LongArrayVector(new long[] { 3, 1, 1, 1 }, 4).filter(1, 2, 3),
-            new LongArrayVector(new long[] { 1, 4, 1, 1 }, 4).filter(0, 2, 3),
+            blockFactory.newLongArrayVector(new long[] { 1, 1, 1 }, 3),
+            blockFactory.newLongArrayVector(new long[] { 1, 1, 1 }, 3).asBlock().asVector(),
+            blockFactory.newLongArrayVector(new long[] { 1, 1, 1, 1 }, 3),
+            blockFactory.newLongArrayVector(new long[] { 1, 1, 1 }, 3).filter(0, 1, 2),
+            blockFactory.newLongArrayVector(new long[] { 1, 1, 1, 4 }, 4).filter(0, 1, 2),
+            blockFactory.newLongArrayVector(new long[] { 3, 1, 1, 1 }, 4).filter(1, 2, 3),
+            blockFactory.newLongArrayVector(new long[] { 1, 4, 1, 1 }, 4).filter(0, 2, 3),
             LongBlock.newConstantBlockWith(1, 3).asVector(),
             LongBlock.newBlockBuilder(3).appendLong(1).appendLong(1).appendLong(1).build().asVector(),
             LongBlock.newBlockBuilder(3).appendLong(1).appendLong(1).appendLong(1).build().asVector().filter(0, 1, 2),
@@ -91,30 +90,27 @@ public class LongBlockEqualityTests extends ComputeTestCase {
     }
 
     public void testBlockEquality() {
-        BlockFactory blockFactory = blockFactory();
         // all these blocks should be equivalent
         List<LongBlock> blocks = List.of(
-            new LongArrayVector(new long[] { 1, 2, 3 }, 3).asBlock(),
-            new LongArrayBlock(
+            blockFactory.newLongArrayVector(new long[] { 1, 2, 3 }, 3).asBlock(),
+            blockFactory.newLongArrayBlock(
                 new long[] { 1, 2, 3 },
                 3,
                 new int[] { 0, 1, 2, 3 },
                 BitSet.valueOf(new byte[] { 0b000 }),
-                randomFrom(Block.MvOrdering.values()),
-                blockFactory
+                randomFrom(Block.MvOrdering.values())
             ),
-            new LongArrayBlock(
+            blockFactory.newLongArrayBlock(
                 new long[] { 1, 2, 3, 4 },
                 3,
                 new int[] { 0, 1, 2, 3 },
                 BitSet.valueOf(new byte[] { 0b1000 }),
-                randomFrom(Block.MvOrdering.values()),
-                blockFactory
+                randomFrom(Block.MvOrdering.values())
             ),
-            new LongArrayVector(new long[] { 1, 2, 3 }, 3).filter(0, 1, 2).asBlock(),
-            new LongArrayVector(new long[] { 1, 2, 3, 4 }, 3).filter(0, 1, 2).asBlock(),
-            new LongArrayVector(new long[] { 1, 2, 3, 4 }, 4).filter(0, 1, 2).asBlock(),
-            new LongArrayVector(new long[] { 1, 2, 4, 3 }, 4).filter(0, 1, 3).asBlock(),
+            blockFactory.newLongArrayVector(new long[] { 1, 2, 3 }, 3).filter(0, 1, 2).asBlock(),
+            blockFactory.newLongArrayVector(new long[] { 1, 2, 3, 4 }, 3).filter(0, 1, 2).asBlock(),
+            blockFactory.newLongArrayVector(new long[] { 1, 2, 3, 4 }, 4).filter(0, 1, 2).asBlock(),
+            blockFactory.newLongArrayVector(new long[] { 1, 2, 4, 3 }, 4).filter(0, 1, 3).asBlock(),
             LongBlock.newBlockBuilder(3).appendLong(1).appendLong(2).appendLong(3).build(),
             LongBlock.newBlockBuilder(3).appendLong(1).appendLong(2).appendLong(3).build().filter(0, 1, 2),
             LongBlock.newBlockBuilder(3).appendLong(1).appendLong(4).appendLong(2).appendLong(3).build().filter(0, 2, 3),
@@ -124,27 +120,25 @@ public class LongBlockEqualityTests extends ComputeTestCase {
 
         // all these constant-like blocks should be equivalent
         List<LongBlock> moreBlocks = List.of(
-            new LongArrayVector(new long[] { 9, 9 }, 2).asBlock(),
-            new LongArrayBlock(
+            blockFactory.newLongArrayVector(new long[] { 9, 9 }, 2).asBlock(),
+            blockFactory.newLongArrayBlock(
                 new long[] { 9, 9 },
                 2,
                 new int[] { 0, 1, 2 },
                 BitSet.valueOf(new byte[] { 0b000 }),
-                randomFrom(Block.MvOrdering.values()),
-                blockFactory
+                randomFrom(Block.MvOrdering.values())
             ),
-            new LongArrayBlock(
+            blockFactory.newLongArrayBlock(
                 new long[] { 9, 9, 4 },
                 2,
                 new int[] { 0, 1, 2 },
                 BitSet.valueOf(new byte[] { 0b100 }),
-                randomFrom(Block.MvOrdering.values()),
-                blockFactory
+                randomFrom(Block.MvOrdering.values())
             ),
-            new LongArrayVector(new long[] { 9, 9 }, 2).filter(0, 1).asBlock(),
-            new LongArrayVector(new long[] { 9, 9, 4 }, 2).filter(0, 1).asBlock(),
-            new LongArrayVector(new long[] { 9, 9, 4 }, 3).filter(0, 1).asBlock(),
-            new LongArrayVector(new long[] { 9, 4, 9 }, 3).filter(0, 2).asBlock(),
+            blockFactory.newLongArrayVector(new long[] { 9, 9 }, 2).filter(0, 1).asBlock(),
+            blockFactory.newLongArrayVector(new long[] { 9, 9, 4 }, 2).filter(0, 1).asBlock(),
+            blockFactory.newLongArrayVector(new long[] { 9, 9, 4 }, 3).filter(0, 1).asBlock(),
+            blockFactory.newLongArrayVector(new long[] { 9, 4, 9 }, 3).filter(0, 2).asBlock(),
             LongBlock.newConstantBlockWith(9, 2),
             LongBlock.newBlockBuilder(2).appendLong(9).appendLong(9).build(),
             LongBlock.newBlockBuilder(2).appendLong(9).appendLong(9).build().filter(0, 1),
@@ -157,11 +151,11 @@ public class LongBlockEqualityTests extends ComputeTestCase {
     public void testVectorInequality() {
         // all these vectors should NOT be equivalent
         List<LongVector> notEqualVectors = List.of(
-            new LongArrayVector(new long[] { 1 }, 1),
-            new LongArrayVector(new long[] { 9 }, 1),
-            new LongArrayVector(new long[] { 1, 2 }, 2),
-            new LongArrayVector(new long[] { 1, 2, 3 }, 3),
-            new LongArrayVector(new long[] { 1, 2, 4 }, 3),
+            blockFactory.newLongArrayVector(new long[] { 1 }, 1),
+            blockFactory.newLongArrayVector(new long[] { 9 }, 1),
+            blockFactory.newLongArrayVector(new long[] { 1, 2 }, 2),
+            blockFactory.newLongArrayVector(new long[] { 1, 2, 3 }, 3),
+            blockFactory.newLongArrayVector(new long[] { 1, 2, 4 }, 3),
             LongBlock.newConstantBlockWith(9, 2).asVector(),
             LongBlock.newBlockBuilder(2).appendLong(1).appendLong(2).build().asVector().filter(1),
             LongBlock.newBlockBuilder(3).appendLong(1).appendLong(2).appendLong(5).build().asVector(),
@@ -173,11 +167,11 @@ public class LongBlockEqualityTests extends ComputeTestCase {
     public void testBlockInequality() {
         // all these blocks should NOT be equivalent
         List<LongBlock> notEqualBlocks = List.of(
-            new LongArrayVector(new long[] { 1 }, 1).asBlock(),
-            new LongArrayVector(new long[] { 9 }, 1).asBlock(),
-            new LongArrayVector(new long[] { 1, 2 }, 2).asBlock(),
-            new LongArrayVector(new long[] { 1, 2, 3 }, 3).asBlock(),
-            new LongArrayVector(new long[] { 1, 2, 4 }, 3).asBlock(),
+            blockFactory.newLongArrayVector(new long[] { 1 }, 1).asBlock(),
+            blockFactory.newLongArrayVector(new long[] { 9 }, 1).asBlock(),
+            blockFactory.newLongArrayVector(new long[] { 1, 2 }, 2).asBlock(),
+            blockFactory.newLongArrayVector(new long[] { 1, 2, 3 }, 3).asBlock(),
+            blockFactory.newLongArrayVector(new long[] { 1, 2, 4 }, 3).asBlock(),
             LongBlock.newConstantBlockWith(9, 2),
             LongBlock.newBlockBuilder(2).appendLong(1).appendLong(2).build().filter(1),
             LongBlock.newBlockBuilder(3).appendLong(1).appendLong(2).appendLong(5).build(),

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/TopNOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/TopNOperatorTests.java
@@ -22,7 +22,6 @@ import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.ElementType;
-import org.elasticsearch.compute.data.IntArrayVector;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.Page;
@@ -1386,7 +1385,7 @@ public class TopNOperatorTests extends OperatorTestCase {
                 randomPageSize()
             )
         ) {
-            op.addInput(new Page(new IntArrayVector(new int[] { 1 }, 1).asBlock()));
+            op.addInput(new Page(blockFactory().newIntArrayVector(new int[] { 1 }, 1).asBlock()));
         }
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/evaluator/predicate/operator/comparison/InMapper.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/evaluator/predicate/operator/comparison/InMapper.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.esql.evaluator.predicate.operator.comparison;
 
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
-import org.elasticsearch.compute.data.BooleanArrayVector;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.Page;
@@ -98,7 +97,7 @@ public class InMapper extends ExpressionMapper<In> {
 
         private static Block evalWithNulls(BlockFactory blockFactory, boolean[] values, BitSet nulls, boolean nullInValues) {
             if (nulls.isEmpty() && nullInValues == false) {
-                return new BooleanArrayVector(values, values.length).asBlock();
+                return blockFactory.newBooleanArrayVector(values, values.length).asBlock();
             } else {
                 // 3VL: true trumps null; null trumps false.
                 for (int i = 0; i < values.length; i++) {
@@ -110,7 +109,7 @@ public class InMapper extends ExpressionMapper<In> {
                 }
                 if (nulls.isEmpty()) {
                     // no nulls and no multi-values means we must use a Vector
-                    return new BooleanArrayVector(values, values.length).asBlock();
+                    return blockFactory.newBooleanArrayVector(values, values.length).asBlock();
                 } else {
                     return blockFactory.newBooleanArrayBlock(values, values.length, null, nulls, Block.MvOrdering.UNORDERED);
                 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponseTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponseTests.java
@@ -24,7 +24,6 @@ import org.elasticsearch.compute.data.BlockUtils;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.DoubleBlock;
-import org.elasticsearch.compute.data.IntArrayVector;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.Page;
@@ -292,7 +291,7 @@ public class EsqlQueryResponseTests extends AbstractChunkedSerializingTestCase<E
         try (
             EsqlQueryResponse response = new EsqlQueryResponse(
                 List.of(new ColumnInfo("foo", "integer")),
-                List.of(new Page(new IntArrayVector(new int[] { 40, 80 }, 2).asBlock())),
+                List.of(new Page(blockFactory.newIntArrayVector(new int[] { 40, 80 }, 2).asBlock())),
                 null,
                 false,
                 "id-123",
@@ -312,7 +311,7 @@ public class EsqlQueryResponseTests extends AbstractChunkedSerializingTestCase<E
     private EsqlQueryResponse simple(boolean columnar, boolean async) {
         return new EsqlQueryResponse(
             List.of(new ColumnInfo("foo", "integer")),
-            List.of(new Page(new IntArrayVector(new int[] { 40, 80 }, 2).asBlock())),
+            List.of(new Page(blockFactory.newIntArrayVector(new int[] { 40, 80 }, 2).asBlock())),
             null,
             columnar,
             async
@@ -323,7 +322,7 @@ public class EsqlQueryResponseTests extends AbstractChunkedSerializingTestCase<E
         try (
             EsqlQueryResponse response = new EsqlQueryResponse(
                 List.of(new ColumnInfo("foo", "integer")),
-                List.of(new Page(new IntArrayVector(new int[] { 40, 80 }, 2).asBlock())),
+                List.of(new Page(blockFactory.newIntArrayVector(new int[] { 40, 80 }, 2).asBlock())),
                 new EsqlQueryResponse.Profile(
                     List.of(new DriverProfile(List.of(new DriverStatus.OperatorStatus("asdf", new AbstractPageMappingOperator.Status(10)))))
                 ),

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/formatter/TextFormatTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/formatter/TextFormatTests.java
@@ -8,9 +8,8 @@
 package org.elasticsearch.xpack.esql.formatter;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BytesRefBlock;
-import org.elasticsearch.compute.data.IntArrayVector;
-import org.elasticsearch.compute.data.LongArrayVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.test.ESTestCase;
@@ -240,6 +239,7 @@ public class TextFormatTests extends ESTestCase {
     }
 
     private static EsqlQueryResponse regularData() {
+        BlockFactory blockFactory = BlockFactory.getNonBreakingInstance();
         // headers
         List<ColumnInfo> headers = asList(
             new ColumnInfo("string", "keyword"),
@@ -254,8 +254,8 @@ public class TextFormatTests extends ESTestCase {
                     .appendBytesRef(new BytesRef("Along The River Bank"))
                     .appendBytesRef(new BytesRef("Mind Train"))
                     .build(),
-                new IntArrayVector(new int[] { 11 * 60 + 48, 4 * 60 + 40 }, 2).asBlock(),
-                new LongArrayVector(new long[] { GEO.pointAsLong(12, 56), GEO.pointAsLong(-97, 26) }, 2).asBlock()
+                blockFactory.newIntArrayVector(new int[] { 11 * 60 + 48, 4 * 60 + 40 }, 2).asBlock(),
+                blockFactory.newLongArrayVector(new long[] { GEO.pointAsLong(12, 56), GEO.pointAsLong(-97, 26) }, 2).asBlock()
             )
         );
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/formatter/TextFormatterTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/formatter/TextFormatterTests.java
@@ -10,9 +10,8 @@ package org.elasticsearch.xpack.esql.formatter;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BytesRefBlock;
-import org.elasticsearch.compute.data.DoubleArrayVector;
-import org.elasticsearch.compute.data.LongArrayVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.action.ColumnInfo;
@@ -27,6 +26,9 @@ import static org.elasticsearch.xpack.ql.util.SpatialCoordinateTypes.GEO;
 import static org.hamcrest.Matchers.arrayWithSize;
 
 public class TextFormatterTests extends ESTestCase {
+
+    static BlockFactory blockFactory = BlockFactory.getNonBreakingInstance();
+
     private final List<ColumnInfo> columns = Arrays.asList(
         new ColumnInfo("foo", "keyword"),
         new ColumnInfo("bar", "long"),
@@ -46,18 +48,18 @@ public class TextFormatterTests extends ESTestCase {
                     .appendBytesRef(new BytesRef("15charwidedata!"))
                     .appendBytesRef(new BytesRef("dog"))
                     .build(),
-                new LongArrayVector(new long[] { 1, 2 }, 2).asBlock(),
-                new DoubleArrayVector(new double[] { 6.888, 123124.888 }, 2).asBlock(),
+                blockFactory.newLongArrayVector(new long[] { 1, 2 }, 2).asBlock(),
+                blockFactory.newDoubleArrayVector(new double[] { 6.888, 123124.888 }, 2).asBlock(),
                 Block.constantNullBlock(2),
-                new DoubleArrayVector(new double[] { 12, 9912 }, 2).asBlock(),
+                blockFactory.newDoubleArrayVector(new double[] { 12, 9912 }, 2).asBlock(),
                 BytesRefBlock.newBlockBuilder(2).appendBytesRef(new BytesRef("rabbit")).appendBytesRef(new BytesRef("goat")).build(),
-                new LongArrayVector(
+                blockFactory.newLongArrayVector(
                     new long[] {
                         UTC_DATE_TIME_FORMATTER.parseMillis("1953-09-02T00:00:00.000Z"),
                         UTC_DATE_TIME_FORMATTER.parseMillis("2000-03-15T21:34:37.443Z") },
                     2
                 ).asBlock(),
-                new LongArrayVector(new long[] { GEO.pointAsLong(12, 56), GEO.pointAsLong(-97, 26) }, 2).asBlock(),
+                blockFactory.newLongArrayVector(new long[] { GEO.pointAsLong(12, 56), GEO.pointAsLong(-97, 26) }, 2).asBlock(),
                 Block.constantNullBlock(2)
             )
         ),
@@ -110,18 +112,18 @@ public class TextFormatterTests extends ESTestCase {
             List.of(
                 new Page(
                     BytesRefBlock.newBlockBuilder(2).appendBytesRef(new BytesRef("doggie")).appendBytesRef(new BytesRef("dog")).build(),
-                    new LongArrayVector(new long[] { 4, 2 }, 2).asBlock(),
-                    new DoubleArrayVector(new double[] { 1, 123124.888 }, 2).asBlock(),
+                    blockFactory.newLongArrayVector(new long[] { 4, 2 }, 2).asBlock(),
+                    blockFactory.newDoubleArrayVector(new double[] { 1, 123124.888 }, 2).asBlock(),
                     Block.constantNullBlock(2),
-                    new DoubleArrayVector(new double[] { 77.0, 9912.0 }, 2).asBlock(),
+                    blockFactory.newDoubleArrayVector(new double[] { 77.0, 9912.0 }, 2).asBlock(),
                     BytesRefBlock.newBlockBuilder(2).appendBytesRef(new BytesRef("wombat")).appendBytesRef(new BytesRef("goat")).build(),
-                    new LongArrayVector(
+                    blockFactory.newLongArrayVector(
                         new long[] {
                             UTC_DATE_TIME_FORMATTER.parseMillis("1955-01-21T01:02:03.342Z"),
                             UTC_DATE_TIME_FORMATTER.parseMillis("2231-12-31T23:59:59.999Z") },
                         2
                     ).asBlock(),
-                    new LongArrayVector(new long[] { GEO.pointAsLong(12, 56), GEO.pointAsLong(-97, 26) }, 2).asBlock(),
+                    blockFactory.newLongArrayVector(new long[] { GEO.pointAsLong(12, 56), GEO.pointAsLong(-97, 26) }, 2).asBlock(),
                     Block.constantNullBlock(2)
                 )
             ),

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/TestPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/TestPhysicalOperationProviders.java
@@ -13,11 +13,10 @@ import org.elasticsearch.compute.Describable;
 import org.elasticsearch.compute.aggregation.GroupingAggregator;
 import org.elasticsearch.compute.aggregation.blockhash.BlockHash;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.DocBlock;
 import org.elasticsearch.compute.data.DocVector;
 import org.elasticsearch.compute.data.ElementType;
-import org.elasticsearch.compute.data.IntArrayVector;
-import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.DriverContext;
@@ -92,6 +91,11 @@ public class TestPhysicalOperationProviders extends AbstractPhysicalOperationPro
     private class TestSourceOperator extends SourceOperator {
 
         boolean finished = false;
+        private final DriverContext driverContext;
+
+        TestSourceOperator(DriverContext driverContext) {
+            this.driverContext = driverContext;
+        }
 
         @Override
         public Page getOutput() {
@@ -99,15 +103,14 @@ public class TestPhysicalOperationProviders extends AbstractPhysicalOperationPro
                 finish();
             }
 
-            return new Page(
-                new Block[] {
-                    new DocVector(
-                        IntBlock.newConstantBlockWith(0, testData.getPositionCount()).asVector(),
-                        IntBlock.newConstantBlockWith(0, testData.getPositionCount()).asVector(),
-                        new IntArrayVector(IntStream.range(0, testData.getPositionCount()).toArray(), testData.getPositionCount()),
-                        true
-                    ).asBlock() }
+            BlockFactory blockFactory = driverContext.blockFactory();
+            DocVector docVector = new DocVector(
+                blockFactory.newConstantIntVector(0, testData.getPositionCount()),
+                blockFactory.newConstantIntVector(0, testData.getPositionCount()),
+                blockFactory.newIntArrayVector(IntStream.range(0, testData.getPositionCount()).toArray(), testData.getPositionCount()),
+                true
             );
+            return new Page(docVector.asBlock());
         }
 
         @Override
@@ -128,11 +131,9 @@ public class TestPhysicalOperationProviders extends AbstractPhysicalOperationPro
 
     private class TestSourceOperatorFactory implements SourceOperatorFactory {
 
-        SourceOperator op = new TestSourceOperator();
-
         @Override
         public SourceOperator get(DriverContext driverContext) {
-            return op;
+            return new TestSourceOperator(driverContext);
         }
 
         @Override


### PR DESCRIPTION
This PR removes APIs in Vectors that use the non-breaking block factory. Some tests now explicitly use the non-breaking factory. The goal of this PR, along with some follow-ups, is to phase out the non-breaking block factory in production. We can gradually remove its usage in tests later