### PR TITLE
Mute cranky eval tests for convert functions

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractFunctionTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractFunctionTestCase.java
@@ -32,6 +32,7 @@ import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.evaluator.EvalMapper;
 import org.elasticsearch.xpack.esql.expression.function.scalar.conditional.Greatest;
+import org.elasticsearch.xpack.esql.expression.function.scalar.convert.AbstractConvertFunction;
 import org.elasticsearch.xpack.esql.expression.function.scalar.nulls.Coalesce;
 import org.elasticsearch.xpack.esql.optimizer.FoldNull;
 import org.elasticsearch.xpack.esql.planner.Layout;
@@ -279,6 +280,11 @@ public abstract class AbstractFunctionTestCase extends ESTestCase {
      */
     public final void testCrankyEvaluateBlockWithoutNulls() {
         assumeTrue("sometimes the cranky breaker silences warnings, just skip these cases", testCase.getExpectedWarnings() == null);
+        // See https://github.com/elastic/elasticsearch/issues/102996#issuecomment-1860198434
+        assumeTrue(
+            "Convert functions catch CircuitBreakerExceptions in evalVector and emit null instead. Fixed in 8.12",
+            (buildFieldExpression(testCase) instanceof AbstractConvertFunction) == false
+        );
         try {
             testEvaluateBlock(driverContext().blockFactory(), crankyContext(), false, false);
         } catch (CircuitBreakingException ex) {
@@ -297,6 +303,11 @@ public abstract class AbstractFunctionTestCase extends ESTestCase {
      */
     public final void testCrankyEvaluateBlockWithoutNullsFloating() {
         assumeTrue("sometimes the cranky breaker silences warnings, just skip these cases", testCase.getExpectedWarnings() == null);
+        // See https://github.com/elastic/elasticsearch/issues/102996#issuecomment-1860198434
+        assumeTrue(
+            "Convert functions catch CircuitBreakerExceptions in evalVector and emit null instead. Fixed in 8.12",
+            (buildFieldExpression(testCase) instanceof AbstractConvertFunction) == false
+        );
         try {
             testEvaluateBlock(driverContext().blockFactory(), crankyContext(), false, true);
         } catch (CircuitBreakingException ex) {


### PR DESCRIPTION
Fix https://github.com/elastic/elasticsearch/issues/102996

The `evalVector` method on convert functions catches exceptions, including `CircuitBreakerException`, and emits nulls instead. This was fixed in 8.12. (link to [fixing PR](https://github.com/elastic/elasticsearch/pull/101788)) but is still present in 8.11, leading to test failures.

Mute the corresponding tests for convert functions.