### PR TITLE
Fix NPE on missing event queries

### DIFF
--- a/docs/changelog/103611.yaml
+++ b/docs/changelog/103611.yaml
@@ -1,0 +1,6 @@
+pr: 103611
+summary: Fix NPE on missing event queries
+area: EQL
+type: bug
+issues:
+ - 103608

--- a/x-pack/plugin/eql/qa/common/src/main/resources/test_missing_events.toml
+++ b/x-pack/plugin/eql/qa/common/src/main/resources/test_missing_events.toml
@@ -385,3 +385,16 @@ join_keys = ["foo", "foo",
              "foo", "foo",
              "baz", "baz"]
 
+[[queries]]
+name = "interleaved_3_missing"
+query = '''
+  sequence with maxspan=1h
+   ![ test1 where tag == "foobar" ]
+    [ test1 where tag == "normal" ]
+   ![ test1 where tag == "foobar" ]
+    [ test1 where tag == "normal" ]
+   ![ test1 where tag == "foobar" ]
+'''
+expected_event_ids = [-1, 1, -1, 2, -1,
+                      -1, 2, -1, 4, -1]
+

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/Sequence.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/Sequence.java
@@ -32,14 +32,17 @@ public class Sequence implements Comparable<Sequence>, Accountable {
 
     private final SequenceKey key;
     private final Match[] matches;
+    private int firstStage;
     private int currentStage = 0;
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    public Sequence(SequenceKey key, int stages, Ordinal ordinal, HitReference firstHit) {
+    public Sequence(SequenceKey key, int stages, int firstStage, Ordinal ordinal, HitReference firstHit) {
         Check.isTrue(stages >= 2, "A sequence requires at least 2 criteria, given [{}]", stages);
         this.key = key;
         this.matches = new Match[stages];
-        this.matches[0] = new Match(ordinal, firstHit);
+        this.matches[firstStage] = new Match(ordinal, firstHit);
+        this.firstStage = firstStage;
+        this.currentStage = firstStage;
     }
 
     public void putMatch(int stage, Ordinal ordinal, HitReference hit) {
@@ -56,7 +59,7 @@ public class Sequence implements Comparable<Sequence>, Accountable {
     }
 
     public Ordinal startOrdinal() {
-        return matches[0].ordinal();
+        return matches[firstStage].ordinal();
     }
 
     public List<HitReference> hits() {

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/SequenceMatcher.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/SequenceMatcher.java
@@ -168,7 +168,7 @@ public class SequenceMatcher {
 
             if (isFirstPositiveStage(stage)) {
                 log.trace("Matching hit {}  - track sequence", ko.ordinal);
-                Sequence seq = new Sequence(ko.key, numberOfStages, ko.ordinal, hit);
+                Sequence seq = new Sequence(ko.key, numberOfStages, stage, ko.ordinal, hit);
                 if (lastPositiveStage == stage) {
                     tryComplete(seq);
                 } else {


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/103608

In queries with missing events like

```
sequence by x with maxspan=90m
![ authentication where ... ]
[ authentication where ...]
![ authentication where ... ]
[ authentication where ... ]
![ authentication where ... ]
```

the first positive event was wrongly stored in the position `0` of the sequence match, instead of `1`.
This resulted in a NullPointerException when trying to retrieve the ordinal of the event to build the query to check the first missing event.