### PR TITLE
Fix SearchResponse leaks in GeoIP plugin

### DIFF
--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/DatabaseNodeServiceTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/DatabaseNodeServiceTests.java
@@ -38,6 +38,8 @@ import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.core.CheckedRunnable;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.Strings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.Index;
@@ -57,6 +59,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.junit.After;
 import org.junit.Before;
 import org.mockito.ArgumentCaptor;
+import org.mockito.stubbing.Answer;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -68,11 +71,13 @@ import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -109,6 +114,8 @@ public class DatabaseNodeServiceTests extends ESTestCase {
     private IngestService ingestService;
     private ClusterService clusterService;
 
+    private final Collection<Releasable> toRelease = new CopyOnWriteArrayList<>();
+
     @Before
     public void setup() throws IOException {
         final Path geoIpConfigDir = createTempDir();
@@ -133,6 +140,8 @@ public class DatabaseNodeServiceTests extends ESTestCase {
     public void cleanup() {
         resourceWatcherService.close();
         threadPool.shutdownNow();
+        Releasables.close(toRelease);
+        toRelease.clear();
     }
 
     public void testCheckDatabases() throws Exception {
@@ -331,9 +340,13 @@ public class DatabaseNodeServiceTests extends ESTestCase {
                 null,
                 null
             );
+            toRelease.add(searchResponse::decRef);
             @SuppressWarnings("unchecked")
             ActionFuture<SearchResponse> actionFuture = mock(ActionFuture.class);
-            when(actionFuture.actionGet()).thenReturn(searchResponse);
+            when(actionFuture.actionGet()).thenAnswer((Answer<SearchResponse>) invocation -> {
+                searchResponse.incRef();
+                return searchResponse;
+            });
             requestMap.put(databaseName + "_" + i, actionFuture);
         }
         when(client.search(any())).thenAnswer(invocationOnMock -> {


### PR DESCRIPTION
Fixing the production and test use of `SearchResponse` in the GeoIP plugin.

part of #102030 