### PR TITLE
Rework APMIndexTemplateRegistryTests.testIngestPipelines (#102797)

### DIFF
--- a/x-pack/plugin/apm-data/src/test/java/org/elasticsearch/xpack/apmdata/APMIndexTemplateRegistryTests.java
+++ b/x-pack/plugin/apm-data/src/test/java/org/elasticsearch/xpack/apmdata/APMIndexTemplateRegistryTests.java
@@ -51,13 +51,14 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.xpack.core.XPackSettings.APM_DATA_ENABLED;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -137,31 +138,30 @@ public class APMIndexTemplateRegistryTests extends ESTestCase {
         assertThat(actualInstalledIndexTemplates.get(), equalTo(0));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/102797")
-    public void testIngestPipelines() {
+    public void testIngestPipelines() throws Exception {
         DiscoveryNode node = DiscoveryNodeUtils.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
 
         final List<IngestPipelineConfig> pipelineConfigs = apmIndexTemplateRegistry.getIngestPipelines();
         assertThat(pipelineConfigs, is(not(empty())));
 
-        pipelineConfigs.forEach(ingestPipelineConfig -> {
-            AtomicInteger putPipelineRequestsLocal = new AtomicInteger(0);
-            client.setVerifier((a, r, l) -> {
-                if (r instanceof PutPipelineRequest && ingestPipelineConfig.getId().equals(((PutPipelineRequest) r).getId())) {
-                    putPipelineRequestsLocal.incrementAndGet();
+        final Set<String> expectedPipelines = apmIndexTemplateRegistry.getIngestPipelines()
+            .stream()
+            .map(IngestPipelineConfig::getId)
+            .collect(Collectors.toSet());
+        final Set<String> installedPipelines = ConcurrentHashMap.newKeySet(pipelineConfigs.size());
+        client.setVerifier((a, r, l) -> {
+            if (r instanceof PutPipelineRequest putPipelineRequest) {
+                if (expectedPipelines.contains(putPipelineRequest.getId())) {
+                    installedPipelines.add(putPipelineRequest.getId());
                 }
-                return AcknowledgedResponse.TRUE;
-            });
-
-            apmIndexTemplateRegistry.clusterChanged(
-                createClusterChangedEvent(Map.of(), Map.of(), ingestPipelineConfig.getPipelineDependencies(), nodes)
-            );
-            try {
-                assertBusy(() -> assertThat(putPipelineRequestsLocal.get(), greaterThanOrEqualTo(1)));
-            } catch (Exception e) {
-                throw new RuntimeException(e);
             }
+            return AcknowledgedResponse.TRUE;
+        });
+
+        assertBusy(() -> {
+            apmIndexTemplateRegistry.clusterChanged(createClusterChangedEvent(Map.of(), Map.of(), List.copyOf(installedPipelines), nodes));
+            assertThat(installedPipelines, equalTo(expectedPipelines));
         });
     }
 
@@ -310,7 +310,7 @@ public class APMIndexTemplateRegistryTests extends ESTestCase {
     private ClusterChangedEvent createClusterChangedEvent(
         Map<String, Integer> existingComponentTemplates,
         Map<String, Integer> existingComposableTemplates,
-        List<String> ingestPipelines,
+        List<String> existingIngestPipelines,
         Map<String, LifecyclePolicy> existingPolicies,
         DiscoveryNodes nodes
     ) {
@@ -318,7 +318,7 @@ public class APMIndexTemplateRegistryTests extends ESTestCase {
             Settings.EMPTY,
             existingComponentTemplates,
             existingComposableTemplates,
-            ingestPipelines,
+            existingIngestPipelines,
             existingPolicies,
             nodes
         );


### PR DESCRIPTION
In this PR we rework the `APMIndexTemplateRegistryTests.testIngestPipelines` to fix a race in the test.

The previous version of the test has the following race : 
```
# First cluster change is triggered and it will try to insert as many pipelines as possible. 
# Namely `apm@default-pipeline` and `apm@pipeline` because they have no dependencies
[First round] adding ingest pipeline apm@default-pipeline 
# The code sees that the pipeline was added so it kick starts the second cluster change
[Second round] adding ingest pipeline apm@default-pipeline
# The first cluster change continues on adding the second pipeline and holds the creation 
# flag blocking other threads from creating it.
[First round] adding ingest pipeline apm@pipeline
# Second round fails to create the `apm@pipeline` because the creation flag was held by the first round.
```

This PR proposes the following approach:
 
We create a concurrent set in which we keep track of the installed pipelines. We trigger a cluster state change and provide the installed pipelines as input. We wait until all the expected pipelines have been installed.

Fixes #102797