### PR TITLE
Add the ability to check for single-node features to TestFeatureService

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/TestFeatureService.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/TestFeatureService.java
@@ -23,9 +23,10 @@ import java.util.function.Predicate;
 public class TestFeatureService {
     private final Predicate<String> historicalFeaturesPredicate;
     private final Set<String> clusterStateFeatures;
-    private final Map<String, Version> nodeVersions;
+    private final Map<String, Version> nodesVersions;
     private final Map<String, Set<String>> nodesFeatures;
     private final NavigableMap<Version, Set<String>> historicalFeatures;
+    private final String errorMessage;
 
     TestFeatureService(
         boolean hasHistoricalFeaturesInformation,
@@ -33,44 +34,61 @@ public class TestFeatureService {
         Map<String, Version> nodesVersion,
         Map<String, Set<String>> nodesFeatures
     ) {
-        this.nodeVersions = nodesVersion;
+        this.nodesVersions = nodesVersion;
         this.nodesFeatures = nodesFeatures;
 
         var minNodeVersion = nodesVersion.values().stream().min(Version::compareTo);
         var featureData = FeatureData.createFromSpecifications(specs);
         this.historicalFeatures = featureData.getHistoricalFeatures();
-        var allHistoricalFeatures = getAllHistoricalFeatures();
 
-        var errorMessage = hasHistoricalFeaturesInformation
+        this.errorMessage = hasHistoricalFeaturesInformation
             ? "Check the feature has been added to the correct FeatureSpecification in the relevant module or, if this is a "
                 + "legacy feature used only in tests, to a test-only FeatureSpecification"
             : "This test is running on the legacy test framework; historical features from production code will not be available."
                 + " You need to port the test to the new test plugins in order to use historical features from production code."
                 + " If this is a legacy feature used only in tests, you can add it to a test-only FeatureSpecification";
-        this.historicalFeaturesPredicate = minNodeVersion.<Predicate<String>>map(v -> featureId -> {
-            assert allHistoricalFeatures.contains(featureId) : Strings.format("Unknown historical feature %s: %s", featureId, errorMessage);
-            return hasHistoricalFeature(historicalFeatures, v, featureId);
-        }).orElse(featureId -> {
-            // We can safely assume that new non-semantic versions (serverless) support all historical features
-            assert allHistoricalFeatures.contains(featureId) : Strings.format("Unknown historical feature %s: %s", featureId, errorMessage);
-            return true;
-        });
+        this.historicalFeaturesPredicate = minNodeVersion.<Predicate<String>>map(
+            v -> featureId -> hasHistoricalFeatureWithVersion(v, featureId)
+        ).orElse(this::hasHistoricalFeatureWithoutVersion);
         this.clusterStateFeatures = ClusterFeatures.calculateAllNodeFeatures(nodesFeatures.values());
+    }
+
+    private boolean hasHistoricalFeatureWithVersion(Version v, String featureId) {
+        assert getAllHistoricalFeatures().contains(featureId)
+            : Strings.format("Unknown historical feature %s: %s", featureId, errorMessage);
+        var features = historicalFeatures.floorEntry(v);
+        return features != null && features.getValue().contains(featureId);
+    }
+
+    private boolean hasHistoricalFeatureWithoutVersion(String featureId) {
+        // We can safely assume that new non-semantic versions (serverless) support all historical features
+        assert getAllHistoricalFeatures().contains(featureId)
+            : Strings.format("Unknown historical feature %s: %s", featureId, errorMessage);
+        return true;
     }
 
     private Set<String> getAllHistoricalFeatures() {
         return historicalFeatures.lastEntry() == null ? Set.of() : historicalFeatures.lastEntry().getValue();
     }
 
-    private static boolean hasHistoricalFeature(NavigableMap<Version, Set<String>> historicalFeatures, Version version, String featureId) {
-        var features = historicalFeatures.floorEntry(version);
-        return features != null && features.getValue().contains(featureId);
-    }
-
-    boolean clusterHasFeature(String featureId) {
+    public boolean clusterHasFeature(String featureId) {
         if (clusterStateFeatures.contains(featureId)) {
             return true;
         }
         return historicalFeaturesPredicate.test(featureId);
+    }
+
+    public boolean nodeHasFeature(String nodeId, String featureId) {
+        var nodeFeatures = nodesFeatures.get(nodeId);
+        if (nodeFeatures != null && nodeFeatures.contains(featureId)) {
+            return true;
+        }
+
+        if (nodesVersions.isEmpty()) {
+            return hasHistoricalFeatureWithoutVersion(featureId);
+        }
+
+        var nodeVersion = nodesVersions.get(nodeId);
+        return nodeVersion != null && hasHistoricalFeatureWithVersion(nodeVersion, featureId);
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/TestFeatureService.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/TestFeatureService.java
@@ -9,12 +9,13 @@
 package org.elasticsearch.test.rest;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterFeatures;
 import org.elasticsearch.core.Strings;
 import org.elasticsearch.features.FeatureData;
 import org.elasticsearch.features.FeatureSpecification;
 
-import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -22,17 +23,23 @@ import java.util.function.Predicate;
 public class TestFeatureService {
     private final Predicate<String> historicalFeaturesPredicate;
     private final Set<String> clusterStateFeatures;
+    private final Map<String, Version> nodeVersions;
+    private final Map<String, Set<String>> nodesFeatures;
+    private final NavigableMap<Version, Set<String>> historicalFeatures;
 
     TestFeatureService(
         boolean hasHistoricalFeaturesInformation,
         List<? extends FeatureSpecification> specs,
-        Collection<Version> nodeVersions,
-        Set<String> clusterStateFeatures
+        Map<String, Version> nodesVersion,
+        Map<String, Set<String>> nodesFeatures
     ) {
-        var minNodeVersion = nodeVersions.stream().min(Version::compareTo);
+        this.nodeVersions = nodesVersion;
+        this.nodesFeatures = nodesFeatures;
+
+        var minNodeVersion = nodesVersion.values().stream().min(Version::compareTo);
         var featureData = FeatureData.createFromSpecifications(specs);
-        var historicalFeatures = featureData.getHistoricalFeatures();
-        var allHistoricalFeatures = historicalFeatures.lastEntry() == null ? Set.of() : historicalFeatures.lastEntry().getValue();
+        this.historicalFeatures = featureData.getHistoricalFeatures();
+        var allHistoricalFeatures = getAllHistoricalFeatures();
 
         var errorMessage = hasHistoricalFeaturesInformation
             ? "Check the feature has been added to the correct FeatureSpecification in the relevant module or, if this is a "
@@ -48,7 +55,11 @@ public class TestFeatureService {
             assert allHistoricalFeatures.contains(featureId) : Strings.format("Unknown historical feature %s: %s", featureId, errorMessage);
             return true;
         });
-        this.clusterStateFeatures = clusterStateFeatures;
+        this.clusterStateFeatures = ClusterFeatures.calculateAllNodeFeatures(nodesFeatures.values());
+    }
+
+    private Set<String> getAllHistoricalFeatures() {
+        return historicalFeatures.lastEntry() == null ? Set.of() : historicalFeatures.lastEntry().getValue();
     }
 
     private static boolean hasHistoricalFeature(NavigableMap<Version, Set<String>> historicalFeatures, Version version, String featureId) {


### PR DESCRIPTION
Features should not be checked per-node, but per-cluster. However, in the test framework we can currently select nodes (via `node_selector`) based on version. The purpose is to act on a subset of nodes in mixed cluster/partial upgrade BwC tests, when we know a feature may not be available on a node based on its version. This would be the replacement based on features.

From a real test case: suppose we start from a 7.x cluster, and upgrade (part of it) to 8.13 (current). 
We want to probe some nodes via rest, but only if they are > 8.0.0. In this case a `node_selector: current` would be enough; but if the same test starts from a 8.1.0 cluster, "current" would be just the 8.13 nodes, while we'd like to probe all of them. 

This looks like a misuse of `node_selector`; an alternative could be to duplicate the test and have different tests for > or < 8.0.0 (which will be: skip based on not based on starting cluster version - a related problem we are already investigating and have ideas how to solve), and just have `node_selector: current` or nothing.

Should we correct `node_selector` misues? Try to remove all version-based selectors completely, and rely only on `current` and `old` (which is compatible with serverless too).
Or should we proceed with a `node_selector` based on features?

TODO: tests - there are none ATM