### PR TITLE
Update s3 latency metric to use micros

### DIFF
--- a/docs/changelog/103633.yaml
+++ b/docs/changelog/103633.yaml
@@ -1,0 +1,5 @@
+pr: 103633
+summary: Update s3 latency metric to use micros
+area: Search
+type: enhancement
+issues: []

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/BlobCacheMetrics.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/BlobCacheMetrics.java
@@ -20,17 +20,17 @@ public class BlobCacheMetrics {
     public BlobCacheMetrics(MeterRegistry meterRegistry) {
         this(
             meterRegistry.registerLongCounter(
-                "elasticsearch.blob_cache.miss_that_triggered_read",
+                "es.blob_cache.miss_that_triggered_read",
                 "The number of times there was a cache miss that triggered a read from the blob store",
                 "count"
             ),
             meterRegistry.registerLongCounter(
-                "elasticsearch.blob_cache.count_of_evicted_used_regions",
+                "es.blob_cache.count_of_evicted_used_regions",
                 "The number of times a cache entry was evicted where the frequency was not zero",
                 "entries"
             ),
             meterRegistry.registerLongHistogram(
-                "elasticsearch.blob_cache.cache_miss_load_times",
+                "es.blob_cache.cache_miss_load_times",
                 "The time in microseconds for populating entries in the blob store resulting from a cache miss, expressed as a histogram.",
                 "micros"
             )

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/BlobCacheMetrics.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/BlobCacheMetrics.java
@@ -31,8 +31,8 @@ public class BlobCacheMetrics {
             ),
             meterRegistry.registerLongHistogram(
                 "elasticsearch.blob_cache.cache_miss_load_times",
-                "The timing data for populating entries in the blob store resulting from a cache miss.",
-                "count"
+                "The time in microseconds for populating entries in the blob store resulting from a cache miss, expressed as a histogram.",
+                "micros"
             )
         );
     }

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/BlobCacheMetrics.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/BlobCacheMetrics.java
@@ -20,17 +20,17 @@ public class BlobCacheMetrics {
     public BlobCacheMetrics(MeterRegistry meterRegistry) {
         this(
             meterRegistry.registerLongCounter(
-                "es.blob_cache.miss_that_triggered_read",
+                "es.blob_cache.miss_that_triggered_read.total",
                 "The number of times there was a cache miss that triggered a read from the blob store",
                 "count"
             ),
             meterRegistry.registerLongCounter(
-                "es.blob_cache.count_of_evicted_used_regions",
+                "es.blob_cache.count_of_evicted_used_regions.total",
                 "The number of times a cache entry was evicted where the frequency was not zero",
                 "entries"
             ),
             meterRegistry.registerLongHistogram(
-                "es.blob_cache.cache_miss_load_times",
+                "es.blob_cache.cache_miss_load_times.histogram",
                 "The time in microseconds for populating entries in the blob store resulting from a cache miss, expressed as a histogram.",
                 "micros"
             )

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
@@ -55,6 +55,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.IntConsumer;
@@ -815,7 +816,7 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
         ) throws Exception {
             // We are interested in the total time that the system spends when fetching a result (including time spent queuing), so we start
             // our measurement here.
-            final long startTime = threadPool.relativeTimeInMillis();
+            final long startTime = threadPool.relativeTimeInNanos();
             RangeMissingHandler writerInstrumentationDecorator = (
                 SharedBytes.IO channel,
                 int channelPos,
@@ -823,7 +824,7 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
                 int length,
                 IntConsumer progressUpdater) -> {
                 writer.fillCacheRange(channel, channelPos, relativePos, length, progressUpdater);
-                var elapsedTime = threadPool.relativeTimeInMillis() - startTime;
+                var elapsedTime = TimeUnit.NANOSECONDS.toMicros(threadPool.relativeTimeInNanos() - startTime);
                 SharedBlobCacheService.this.blobCacheMetrics.getCacheMissLoadTimes().record(elapsedTime);
                 SharedBlobCacheService.this.blobCacheMetrics.getCacheMissCounter().increment();
             };


### PR DESCRIPTION
This PR updates the metric `"elasticsearch.blob_cache.cache_miss_load_times"` so as to be directly comparable with other repository metrics.