### PR TITLE
Add missing SuppressWarning to RemoteClusterCredentialsManager

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterCredentialsManager.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterCredentialsManager.java
@@ -25,6 +25,7 @@ public class RemoteClusterCredentialsManager {
 
     private volatile Map<String, SecureString> clusterCredentials;
 
+    @SuppressWarnings("this-escape")
     public RemoteClusterCredentialsManager(Settings settings) {
         updateClusterCredentials(settings);
     }


### PR DESCRIPTION
Adding this warning suppression, this caused some Intellij Idea Gradle operations to fail for me, though weirdly enough they kept working fine from the commandline.
