### PR TITLE
Make SearchTemplateResponse ref counted properly

### DIFF
--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/TransportMultiSearchTemplateAction.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/TransportMultiSearchTemplateAction.java
@@ -80,6 +80,7 @@ public class TransportMultiSearchTemplateAction extends HandledTransportAction<M
             try {
                 searchRequest = convert(searchTemplateRequest, searchTemplateResponse, scriptService, xContentRegistry, searchUsageHolder);
             } catch (Exception e) {
+                searchTemplateResponse.decRef();
                 items[i] = new MultiSearchTemplateResponse.Item(null, e);
                 if (ExceptionsHelper.status(e).getStatus() >= 500 && ExceptionsHelper.isNodeOrShardUnavailableTypeException(e) == false) {
                     logger.warn("MultiSearchTemplate convert failure", e);
@@ -98,12 +99,17 @@ public class TransportMultiSearchTemplateAction extends HandledTransportAction<M
                 MultiSearchResponse.Item item = r.getResponses()[i];
                 int originalSlot = originalSlots.get(i);
                 if (item.isFailure()) {
+                    var existing = items[originalSlot];
+                    if (existing.getResponse() != null) {
+                        existing.getResponse().decRef();
+                    }
                     items[originalSlot] = new MultiSearchTemplateResponse.Item(null, item.getFailure());
                 } else {
                     items[originalSlot].getResponse().setResponse(item.getResponse());
+                    item.getResponse().incRef();
                 }
             }
-            l.onResponse(new MultiSearchTemplateResponse(items, r.getTook().millis()));
+            ActionListener.respondAndRelease(l, new MultiSearchTemplateResponse(items, r.getTook().millis()));
         }));
     }
 }

--- a/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/MultiSearchTemplateResponseTests.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/MultiSearchTemplateResponseTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.core.RefCounted;
 import org.elasticsearch.search.SearchResponseUtils;
 import org.elasticsearch.test.AbstractXContentTestCase;
 import org.elasticsearch.xcontent.ToXContent;
@@ -146,7 +147,13 @@ public class MultiSearchTemplateResponseTests extends AbstractXContentTestCase<M
             this::doParseInstance,
             this::assertEqualInstances,
             assertToXContentEquivalence,
-            ToXContent.EMPTY_PARAMS
+            ToXContent.EMPTY_PARAMS,
+            RefCounted::decRef
         );
+    }
+
+    @Override
+    protected void dispose(MultiSearchTemplateResponse instance) {
+        instance.decRef();
     }
 }

--- a/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/SearchTemplateResponseTests.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/SearchTemplateResponseTests.java
@@ -125,33 +125,36 @@ public class SearchTemplateResponseTests extends AbstractXContentTestCase<Search
 
     public void testSourceToXContent() throws IOException {
         SearchTemplateResponse response = new SearchTemplateResponse();
+        try {
+            XContentBuilder source = XContentFactory.jsonBuilder()
+                .startObject()
+                .startObject("query")
+                .startObject("terms")
+                .field("status", new String[] { "pending", "published" })
+                .endObject()
+                .endObject()
+                .endObject();
+            response.setSource(BytesReference.bytes(source));
 
-        XContentBuilder source = XContentFactory.jsonBuilder()
-            .startObject()
-            .startObject("query")
-            .startObject("terms")
-            .field("status", new String[] { "pending", "published" })
-            .endObject()
-            .endObject()
-            .endObject();
-        response.setSource(BytesReference.bytes(source));
+            XContentType contentType = randomFrom(XContentType.values());
+            XContentBuilder expectedResponse = XContentFactory.contentBuilder(contentType)
+                .startObject()
+                .startObject("template_output")
+                .startObject("query")
+                .startObject("terms")
+                .field("status", new String[] { "pending", "published" })
+                .endObject()
+                .endObject()
+                .endObject()
+                .endObject();
 
-        XContentType contentType = randomFrom(XContentType.values());
-        XContentBuilder expectedResponse = XContentFactory.contentBuilder(contentType)
-            .startObject()
-            .startObject("template_output")
-            .startObject("query")
-            .startObject("terms")
-            .field("status", new String[] { "pending", "published" })
-            .endObject()
-            .endObject()
-            .endObject()
-            .endObject();
+            XContentBuilder actualResponse = XContentFactory.contentBuilder(contentType);
+            response.toXContent(actualResponse, ToXContent.EMPTY_PARAMS);
 
-        XContentBuilder actualResponse = XContentFactory.contentBuilder(contentType);
-        response.toXContent(actualResponse, ToXContent.EMPTY_PARAMS);
-
-        assertToXContentEquivalent(BytesReference.bytes(expectedResponse), BytesReference.bytes(actualResponse), contentType);
+            assertToXContentEquivalent(BytesReference.bytes(expectedResponse), BytesReference.bytes(actualResponse), contentType);
+        } finally {
+            response.decRef();
+        }
     }
 
     public void testSearchResponseToXContent() throws IOException {
@@ -177,37 +180,46 @@ public class SearchTemplateResponseTests extends AbstractXContentTestCase<Search
         );
 
         SearchTemplateResponse response = new SearchTemplateResponse();
-        response.setResponse(searchResponse);
+        try {
+            response.setResponse(searchResponse);
 
-        XContentType contentType = randomFrom(XContentType.values());
-        XContentBuilder expectedResponse = XContentFactory.contentBuilder(contentType)
-            .startObject()
-            .field("took", 0)
-            .field("timed_out", false)
-            .startObject("_shards")
-            .field("total", 0)
-            .field("successful", 0)
-            .field("skipped", 0)
-            .field("failed", 0)
-            .endObject()
-            .startObject("hits")
-            .startObject("total")
-            .field("value", 100)
-            .field("relation", "eq")
-            .endObject()
-            .field("max_score", 1.5F)
-            .startArray("hits")
-            .startObject()
-            .field("_id", "id")
-            .field("_score", 2.0F)
-            .endObject()
-            .endArray()
-            .endObject()
-            .endObject();
+            XContentType contentType = randomFrom(XContentType.values());
+            XContentBuilder expectedResponse = XContentFactory.contentBuilder(contentType)
+                .startObject()
+                .field("took", 0)
+                .field("timed_out", false)
+                .startObject("_shards")
+                .field("total", 0)
+                .field("successful", 0)
+                .field("skipped", 0)
+                .field("failed", 0)
+                .endObject()
+                .startObject("hits")
+                .startObject("total")
+                .field("value", 100)
+                .field("relation", "eq")
+                .endObject()
+                .field("max_score", 1.5F)
+                .startArray("hits")
+                .startObject()
+                .field("_id", "id")
+                .field("_score", 2.0F)
+                .endObject()
+                .endArray()
+                .endObject()
+                .endObject();
 
-        XContentBuilder actualResponse = XContentFactory.contentBuilder(contentType);
-        response.toXContent(actualResponse, ToXContent.EMPTY_PARAMS);
+            XContentBuilder actualResponse = XContentFactory.contentBuilder(contentType);
+            response.toXContent(actualResponse, ToXContent.EMPTY_PARAMS);
 
-        assertToXContentEquivalent(BytesReference.bytes(expectedResponse), BytesReference.bytes(actualResponse), contentType);
+            assertToXContentEquivalent(BytesReference.bytes(expectedResponse), BytesReference.bytes(actualResponse), contentType);
+        } finally {
+            response.decRef();
+        }
+    }
+
+    @Override
+    protected void dispose(SearchTemplateResponse instance) {
+        instance.decRef();
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractXContentTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractXContentTestCase.java
@@ -224,12 +224,41 @@ public abstract class AbstractXContentTestCase<T extends ToXContent> extends EST
         boolean assertToXContentEquivalence,
         ToXContent.Params toXContentParams
     ) throws IOException {
+        testFromXContent(
+            numberOfTestRuns,
+            instanceSupplier,
+            supportsUnknownFields,
+            shuffleFieldsExceptions,
+            randomFieldsExcludeFilter,
+            createParserFunction,
+            fromXContent,
+            assertEqualsConsumer,
+            assertToXContentEquivalence,
+            toXContentParams,
+            t -> {}
+        );
+    }
+
+    public static <T extends ToXContent> void testFromXContent(
+        int numberOfTestRuns,
+        Supplier<T> instanceSupplier,
+        boolean supportsUnknownFields,
+        String[] shuffleFieldsExceptions,
+        Predicate<String> randomFieldsExcludeFilter,
+        CheckedBiFunction<XContent, BytesReference, XContentParser, IOException> createParserFunction,
+        CheckedFunction<XContentParser, T, IOException> fromXContent,
+        BiConsumer<T, T> assertEqualsConsumer,
+        boolean assertToXContentEquivalence,
+        ToXContent.Params toXContentParams,
+        Consumer<T> dispose
+    ) throws IOException {
         xContentTester(createParserFunction, instanceSupplier, toXContentParams, fromXContent).numberOfTestRuns(numberOfTestRuns)
             .supportsUnknownFields(supportsUnknownFields)
             .shuffleFieldsExceptions(shuffleFieldsExceptions)
             .randomFieldsExcludeFilter(randomFieldsExcludeFilter)
             .assertEqualsConsumer(assertEqualsConsumer)
             .assertToXContentEquivalence(assertToXContentEquivalence)
+            .dispose(dispose)
             .test();
     }
 
@@ -248,9 +277,16 @@ public abstract class AbstractXContentTestCase<T extends ToXContent> extends EST
             this::parseInstance,
             this::assertEqualInstances,
             assertToXContentEquivalence(),
-            getToXContentParams()
+            getToXContentParams(),
+            this::dispose
         );
     }
+
+    /**
+     * Callback invoked after a test instance is no longer needed that can be overridden to release resources associated with the instance.
+     * @param instance test instance that is no longer used
+     */
+    protected void dispose(T instance) {}
 
     /**
      * Creates a random test instance to use in the tests. This method will be


### PR DESCRIPTION
This is required to make the SearchResponse instances that the template classes refer to ref-counted.
Enhances the AbstractXContentTestCase with a generic way of disposing instances. Exactly the same way this has been implemented for the multi-search-response.

part of #102030 