### PR TITLE
Remove non-breaking block builders

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/AggregatorBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/AggregatorBenchmark.java
@@ -65,6 +65,10 @@ public class AggregatorBenchmark {
     private static final int GROUPS = 5;
 
     private static final BigArrays BIG_ARRAYS = BigArrays.NON_RECYCLING_INSTANCE;  // TODO real big arrays?
+    private static final BlockFactory blockFactory = BlockFactory.getInstance(
+        new NoopCircuitBreaker("noop"),
+        BigArrays.NON_RECYCLING_INSTANCE
+    );
 
     private static final String LONGS = "longs";
     private static final String INTS = "ints";
@@ -446,7 +450,7 @@ public class AggregatorBenchmark {
                 BLOCK_LENGTH
             ).asBlock();
             case MULTIVALUED_LONGS -> {
-                var builder = LongBlock.newBlockBuilder(BLOCK_LENGTH);
+                var builder = blockFactory.newLongBlockBuilder(BLOCK_LENGTH);
                 builder.beginPositionEntry();
                 for (int i = 0; i < BLOCK_LENGTH; i++) {
                     builder.appendLong(i);
@@ -459,7 +463,7 @@ public class AggregatorBenchmark {
                 yield builder.build();
             }
             case HALF_NULL_LONGS -> {
-                var builder = LongBlock.newBlockBuilder(BLOCK_LENGTH);
+                var builder = blockFactory.newLongBlockBuilder(BLOCK_LENGTH);
                 for (int i = 0; i < BLOCK_LENGTH; i++) {
                     builder.appendLong(i);
                     builder.appendNull();
@@ -467,7 +471,7 @@ public class AggregatorBenchmark {
                 yield builder.build();
             }
             case HALF_NULL_DOUBLES -> {
-                var builder = DoubleBlock.newBlockBuilder(BLOCK_LENGTH);
+                var builder = blockFactory.newDoubleBlockBuilder(BLOCK_LENGTH);
                 for (int i = 0; i < BLOCK_LENGTH; i++) {
                     builder.appendDouble(i);
                     builder.appendNull();
@@ -499,7 +503,7 @@ public class AggregatorBenchmark {
         };
         return switch (grouping) {
             case LONGS -> {
-                var builder = LongBlock.newBlockBuilder(BLOCK_LENGTH);
+                var builder = blockFactory.newLongBlockBuilder(BLOCK_LENGTH);
                 for (int i = 0; i < BLOCK_LENGTH; i++) {
                     for (int v = 0; v < valuesPerGroup; v++) {
                         builder.appendLong(i % GROUPS);
@@ -508,7 +512,7 @@ public class AggregatorBenchmark {
                 yield builder.build();
             }
             case INTS -> {
-                var builder = IntBlock.newBlockBuilder(BLOCK_LENGTH);
+                var builder = blockFactory.newIntBlockBuilder(BLOCK_LENGTH);
                 for (int i = 0; i < BLOCK_LENGTH; i++) {
                     for (int v = 0; v < valuesPerGroup; v++) {
                         builder.appendInt(i % GROUPS);
@@ -517,7 +521,7 @@ public class AggregatorBenchmark {
                 yield builder.build();
             }
             case DOUBLES -> {
-                var builder = DoubleBlock.newBlockBuilder(BLOCK_LENGTH);
+                var builder = blockFactory.newDoubleBlockBuilder(BLOCK_LENGTH);
                 for (int i = 0; i < BLOCK_LENGTH; i++) {
                     for (int v = 0; v < valuesPerGroup; v++) {
                         builder.appendDouble(i % GROUPS);
@@ -526,7 +530,7 @@ public class AggregatorBenchmark {
                 yield builder.build();
             }
             case BOOLEANS -> {
-                BooleanBlock.Builder builder = BooleanBlock.newBlockBuilder(BLOCK_LENGTH);
+                BooleanBlock.Builder builder = blockFactory.newBooleanBlockBuilder(BLOCK_LENGTH);
                 for (int i = 0; i < BLOCK_LENGTH; i++) {
                     for (int v = 0; v < valuesPerGroup; v++) {
                         builder.appendBoolean(i % 2 == 1);
@@ -535,7 +539,7 @@ public class AggregatorBenchmark {
                 yield builder.build();
             }
             case BYTES_REFS -> {
-                BytesRefBlock.Builder builder = BytesRefBlock.newBlockBuilder(BLOCK_LENGTH);
+                BytesRefBlock.Builder builder = blockFactory.newBytesRefBlockBuilder(BLOCK_LENGTH);
                 for (int i = 0; i < BLOCK_LENGTH; i++) {
                     for (int v = 0; v < valuesPerGroup; v++) {
                         builder.appendBytesRef(bytesGroup(i % GROUPS));
@@ -582,9 +586,6 @@ public class AggregatorBenchmark {
     }
 
     static DriverContext driverContext() {
-        return new DriverContext(
-            BigArrays.NON_RECYCLING_INSTANCE,
-            BlockFactory.getInstance(new NoopCircuitBreaker("noop"), BigArrays.NON_RECYCLING_INSTANCE)
-        );
+        return new DriverContext(BigArrays.NON_RECYCLING_INSTANCE, blockFactory);
     }
 }

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/MultivalueDedupeBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/MultivalueDedupeBenchmark.java
@@ -10,6 +10,8 @@ package org.elasticsearch.benchmark.compute.operator;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Randomness;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BooleanBlock;
@@ -43,6 +45,12 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Thread)
 @Fork(1)
 public class MultivalueDedupeBenchmark {
+    private static final BigArrays BIG_ARRAYS = BigArrays.NON_RECYCLING_INSTANCE;  // TODO real big arrays?
+    private static final BlockFactory blockFactory = BlockFactory.getInstance(
+        new NoopCircuitBreaker("noop"),
+        BigArrays.NON_RECYCLING_INSTANCE
+    );
+
     @Param({ "BOOLEAN", "BYTES_REF", "DOUBLE", "INT", "LONG" })
     private ElementType elementType;
 
@@ -58,7 +66,7 @@ public class MultivalueDedupeBenchmark {
     public void setup() {
         this.block = switch (elementType) {
             case BOOLEAN -> {
-                BooleanBlock.Builder builder = BooleanBlock.newBlockBuilder(AggregatorBenchmark.BLOCK_LENGTH * (size + repeats));
+                BooleanBlock.Builder builder = blockFactory.newBooleanBlockBuilder(AggregatorBenchmark.BLOCK_LENGTH * (size + repeats));
                 for (int p = 0; p < AggregatorBenchmark.BLOCK_LENGTH; p++) {
                     List<Boolean> values = new ArrayList<>();
                     for (int i = 0; i < size; i++) {
@@ -77,7 +85,7 @@ public class MultivalueDedupeBenchmark {
                 yield builder.build();
             }
             case BYTES_REF -> {
-                BytesRefBlock.Builder builder = BytesRefBlock.newBlockBuilder(AggregatorBenchmark.BLOCK_LENGTH * (size + repeats));
+                BytesRefBlock.Builder builder = blockFactory.newBytesRefBlockBuilder(AggregatorBenchmark.BLOCK_LENGTH * (size + repeats));
                 for (int p = 0; p < AggregatorBenchmark.BLOCK_LENGTH; p++) {
                     List<BytesRef> values = new ArrayList<>();
                     for (int i = 0; i < size; i++) {
@@ -96,7 +104,7 @@ public class MultivalueDedupeBenchmark {
                 yield builder.build();
             }
             case DOUBLE -> {
-                DoubleBlock.Builder builder = DoubleBlock.newBlockBuilder(AggregatorBenchmark.BLOCK_LENGTH * (size + repeats));
+                DoubleBlock.Builder builder = blockFactory.newDoubleBlockBuilder(AggregatorBenchmark.BLOCK_LENGTH * (size + repeats));
                 for (int p = 0; p < AggregatorBenchmark.BLOCK_LENGTH; p++) {
                     List<Double> values = new ArrayList<>();
                     for (int i = 0; i < size; i++) {
@@ -115,7 +123,7 @@ public class MultivalueDedupeBenchmark {
                 yield builder.build();
             }
             case INT -> {
-                IntBlock.Builder builder = IntBlock.newBlockBuilder(AggregatorBenchmark.BLOCK_LENGTH * (size + repeats));
+                IntBlock.Builder builder = blockFactory.newIntBlockBuilder(AggregatorBenchmark.BLOCK_LENGTH * (size + repeats));
                 for (int p = 0; p < AggregatorBenchmark.BLOCK_LENGTH; p++) {
                     List<Integer> values = new ArrayList<>();
                     for (int i = 0; i < size; i++) {
@@ -134,7 +142,7 @@ public class MultivalueDedupeBenchmark {
                 yield builder.build();
             }
             case LONG -> {
-                LongBlock.Builder builder = LongBlock.newBlockBuilder(AggregatorBenchmark.BLOCK_LENGTH * (size + repeats));
+                LongBlock.Builder builder = blockFactory.newLongBlockBuilder(AggregatorBenchmark.BLOCK_LENGTH * (size + repeats));
                 for (int p = 0; p < AggregatorBenchmark.BLOCK_LENGTH; p++) {
                     List<Long> values = new ArrayList<>();
                     for (long i = 0; i < size; i++) {

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/TopNBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/TopNBenchmark.java
@@ -10,16 +10,15 @@ package org.elasticsearch.benchmark.compute.operator;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BytesRefBlock;
-import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.ElementType;
-import org.elasticsearch.compute.data.IntBlock;
-import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.Operator;
 import org.elasticsearch.compute.operator.topn.TopNEncoder;
@@ -51,6 +50,12 @@ import java.util.stream.IntStream;
 @State(Scope.Thread)
 @Fork(1)
 public class TopNBenchmark {
+    private static final BigArrays BIG_ARRAYS = BigArrays.NON_RECYCLING_INSTANCE;  // TODO real big arrays?
+    private static final BlockFactory blockFactory = BlockFactory.getInstance(
+        new NoopCircuitBreaker("noop"),
+        BigArrays.NON_RECYCLING_INSTANCE
+    );
+
     private static final int BLOCK_LENGTH = 8 * 1024;
 
     private static final String LONGS = "longs";
@@ -137,35 +142,35 @@ public class TopNBenchmark {
     private static Block block(String data) {
         return switch (data) {
             case LONGS -> {
-                var builder = LongBlock.newBlockBuilder(BLOCK_LENGTH);
+                var builder = blockFactory.newLongBlockBuilder(BLOCK_LENGTH);
                 for (int i = 0; i < BLOCK_LENGTH; i++) {
                     builder.appendLong(i);
                 }
                 yield builder.build();
             }
             case INTS -> {
-                var builder = IntBlock.newBlockBuilder(BLOCK_LENGTH);
+                var builder = blockFactory.newIntBlockBuilder(BLOCK_LENGTH);
                 for (int i = 0; i < BLOCK_LENGTH; i++) {
                     builder.appendInt(i);
                 }
                 yield builder.build();
             }
             case DOUBLES -> {
-                var builder = DoubleBlock.newBlockBuilder(BLOCK_LENGTH);
+                var builder = blockFactory.newDoubleBlockBuilder(BLOCK_LENGTH);
                 for (int i = 0; i < BLOCK_LENGTH; i++) {
                     builder.appendDouble(i);
                 }
                 yield builder.build();
             }
             case BOOLEANS -> {
-                BooleanBlock.Builder builder = BooleanBlock.newBlockBuilder(BLOCK_LENGTH);
+                BooleanBlock.Builder builder = blockFactory.newBooleanBlockBuilder(BLOCK_LENGTH);
                 for (int i = 0; i < BLOCK_LENGTH; i++) {
                     builder.appendBoolean(i % 2 == 1);
                 }
                 yield builder.build();
             }
             case BYTES_REFS -> {
-                BytesRefBlock.Builder builder = BytesRefBlock.newBlockBuilder(BLOCK_LENGTH);
+                BytesRefBlock.Builder builder = blockFactory.newBytesRefBlockBuilder(BLOCK_LENGTH);
                 for (int i = 0; i < BLOCK_LENGTH; i++) {
                     builder.appendBytesRef(new BytesRef(Integer.toString(i)));
                 }

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/ValuesSourceReaderBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/ValuesSourceReaderBenchmark.java
@@ -381,7 +381,7 @@ public class ValuesSourceReaderBenchmark {
         pages = new ArrayList<>();
         switch (layout) {
             case "in_order" -> {
-                IntVector.Builder docs = IntVector.newVectorBuilder(BLOCK_LENGTH);
+                IntVector.Builder docs = blockFactory.newIntVectorBuilder(BLOCK_LENGTH);
                 for (LeafReaderContext ctx : reader.leaves()) {
                     int begin = 0;
                     while (begin < ctx.reader().maxDoc()) {
@@ -399,7 +399,7 @@ public class ValuesSourceReaderBenchmark {
                                 ).asBlock()
                             )
                         );
-                        docs = IntVector.newVectorBuilder(BLOCK_LENGTH);
+                        docs = blockFactory.newIntVectorBuilder(BLOCK_LENGTH);
                         begin = end;
                     }
                 }
@@ -410,8 +410,8 @@ public class ValuesSourceReaderBenchmark {
                 for (LeafReaderContext ctx : reader.leaves()) {
                     docItrs.add(new ItrAndOrd(IntStream.range(0, ctx.reader().maxDoc()).iterator(), ctx.ord));
                 }
-                IntVector.Builder docs = IntVector.newVectorBuilder(BLOCK_LENGTH);
-                IntVector.Builder leafs = IntVector.newVectorBuilder(BLOCK_LENGTH);
+                IntVector.Builder docs = blockFactory.newIntVectorBuilder(BLOCK_LENGTH);
+                IntVector.Builder leafs = blockFactory.newIntVectorBuilder(BLOCK_LENGTH);
                 int size = 0;
                 while (docItrs.isEmpty() == false) {
                     Iterator<ItrAndOrd> itrItr = docItrs.iterator();
@@ -430,8 +430,8 @@ public class ValuesSourceReaderBenchmark {
                                     new DocVector(blockFactory.newConstantIntVector(0, size), leafs.build(), docs.build(), null).asBlock()
                                 )
                             );
-                            docs = IntVector.newVectorBuilder(BLOCK_LENGTH);
-                            leafs = IntVector.newVectorBuilder(BLOCK_LENGTH);
+                            docs = blockFactory.newIntVectorBuilder(BLOCK_LENGTH);
+                            leafs = blockFactory.newIntVectorBuilder(BLOCK_LENGTH);
                             size = 0;
                         }
                     }

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/ValuesSourceReaderBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/ValuesSourceReaderBenchmark.java
@@ -22,7 +22,9 @@ import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.NumericUtils;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.lucene.Lucene;
+import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
@@ -78,6 +80,11 @@ public class ValuesSourceReaderBenchmark {
     private static final int BLOCK_LENGTH = 16 * 1024;
     private static final int INDEX_SIZE = 10 * BLOCK_LENGTH;
     private static final int COMMIT_INTERVAL = 500;
+    private static final BigArrays BIG_ARRAYS = BigArrays.NON_RECYCLING_INSTANCE;
+    private static final BlockFactory blockFactory = BlockFactory.getInstance(
+        new NoopCircuitBreaker("noop"),
+        BigArrays.NON_RECYCLING_INSTANCE
+    );
 
     static {
         // Smoke test all the expected values and force loading subclasses more like prod
@@ -385,8 +392,8 @@ public class ValuesSourceReaderBenchmark {
                         pages.add(
                             new Page(
                                 new DocVector(
-                                    IntBlock.newConstantBlockWith(0, end - begin).asVector(),
-                                    IntBlock.newConstantBlockWith(ctx.ord, end - begin).asVector(),
+                                    blockFactory.newConstantIntBlockWith(0, end - begin).asVector(),
+                                    blockFactory.newConstantIntBlockWith(ctx.ord, end - begin).asVector(),
                                     docs.build(),
                                     true
                                 ).asBlock()
@@ -420,8 +427,7 @@ public class ValuesSourceReaderBenchmark {
                         if (size >= BLOCK_LENGTH) {
                             pages.add(
                                 new Page(
-                                    new DocVector(IntBlock.newConstantBlockWith(0, size).asVector(), leafs.build(), docs.build(), null)
-                                        .asBlock()
+                                    new DocVector(blockFactory.newConstantIntVector(0, size), leafs.build(), docs.build(), null).asBlock()
                                 )
                             );
                             docs = IntVector.newVectorBuilder(BLOCK_LENGTH);
@@ -434,7 +440,7 @@ public class ValuesSourceReaderBenchmark {
                     pages.add(
                         new Page(
                             new DocVector(
-                                IntBlock.newConstantBlockWith(0, size).asVector(),
+                                blockFactory.newConstantIntBlockWith(0, size).asVector(),
                                 leafs.build().asBlock().asVector(),
                                 docs.build(),
                                 null
@@ -460,9 +466,9 @@ public class ValuesSourceReaderBenchmark {
                         pages.add(
                             new Page(
                                 new DocVector(
-                                    IntBlock.newConstantBlockWith(0, 1).asVector(),
-                                    IntBlock.newConstantBlockWith(next.ord, 1).asVector(),
-                                    IntBlock.newConstantBlockWith(next.itr.nextInt(), 1).asVector(),
+                                    blockFactory.newConstantIntVector(0, 1),
+                                    blockFactory.newConstantIntVector(next.ord, 1),
+                                    blockFactory.newConstantIntVector(next.itr.nextInt(), 1),
                                     true
                                 ).asBlock()
                             )

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBlock.java
@@ -167,32 +167,12 @@ public sealed interface BooleanBlock extends Block permits BooleanArrayBlock, Bo
     }
 
     /**
-     * Returns a builder using the {@link BlockFactory#getNonBreakingInstance non-breaking block factory}.
-     * @deprecated use {@link BlockFactory#newBooleanBlockBuilder}
-     */
-    // Eventually, we want to remove this entirely, always passing an explicit BlockFactory
-    @Deprecated
-    static Builder newBlockBuilder(int estimatedSize) {
-        return newBlockBuilder(estimatedSize, BlockFactory.getNonBreakingInstance());
-    }
-
-    /**
      * Returns a builder.
      * @deprecated use {@link BlockFactory#newBooleanBlockBuilder}
      */
     @Deprecated
     static Builder newBlockBuilder(int estimatedSize, BlockFactory blockFactory) {
         return blockFactory.newBooleanBlockBuilder(estimatedSize);
-    }
-
-    /**
-     * Returns a constant block built by the {@link BlockFactory#getNonBreakingInstance non-breaking block factory}.
-     * @deprecated use {@link BlockFactory#newConstantBooleanBlockWith}
-     */
-    // Eventually, we want to remove this entirely, always passing an explicit BlockFactory
-    @Deprecated
-    static BooleanBlock newConstantBlockWith(boolean value, int positions) {
-        return newConstantBlockWith(value, positions, BlockFactory.getNonBreakingInstance());
     }
 
     /**

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVector.java
@@ -102,16 +102,6 @@ public sealed interface BooleanVector extends Vector permits ConstantBooleanVect
     }
 
     /**
-     * Returns a builder using the {@link BlockFactory#getNonBreakingInstance nonbreaking block factory}.
-     * @deprecated use {@link BlockFactory#newBooleanVectorBuilder}
-     */
-    // Eventually, we want to remove this entirely, always passing an explicit BlockFactory
-    @Deprecated
-    static Builder newVectorBuilder(int estimatedSize) {
-        return newVectorBuilder(estimatedSize, BlockFactory.getNonBreakingInstance());
-    }
-
-    /**
      * Creates a builder that grows as needed. Prefer {@link #newVectorFixedBuilder}
      * if you know the size up front because it's faster.
      * @deprecated use {@link BlockFactory#newBooleanVectorBuilder}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefBlock.java
@@ -172,32 +172,12 @@ public sealed interface BytesRefBlock extends Block permits BytesRefArrayBlock, 
     }
 
     /**
-     * Returns a builder using the {@link BlockFactory#getNonBreakingInstance non-breaking block factory}.
-     * @deprecated use {@link BlockFactory#newBytesRefBlockBuilder}
-     */
-    // Eventually, we want to remove this entirely, always passing an explicit BlockFactory
-    @Deprecated
-    static Builder newBlockBuilder(int estimatedSize) {
-        return newBlockBuilder(estimatedSize, BlockFactory.getNonBreakingInstance());
-    }
-
-    /**
      * Returns a builder.
      * @deprecated use {@link BlockFactory#newBytesRefBlockBuilder}
      */
     @Deprecated
     static Builder newBlockBuilder(int estimatedSize, BlockFactory blockFactory) {
         return blockFactory.newBytesRefBlockBuilder(estimatedSize);
-    }
-
-    /**
-     * Returns a constant block built by the {@link BlockFactory#getNonBreakingInstance non-breaking block factory}.
-     * @deprecated use {@link BlockFactory#newConstantBytesRefBlockWith}
-     */
-    // Eventually, we want to remove this entirely, always passing an explicit BlockFactory
-    @Deprecated
-    static BytesRefBlock newConstantBlockWith(BytesRef value, int positions) {
-        return newConstantBlockWith(value, positions, BlockFactory.getNonBreakingInstance());
     }
 
     /**

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVector.java
@@ -102,16 +102,6 @@ public sealed interface BytesRefVector extends Vector permits ConstantBytesRefVe
     }
 
     /**
-     * Returns a builder using the {@link BlockFactory#getNonBreakingInstance nonbreaking block factory}.
-     * @deprecated use {@link BlockFactory#newBytesRefVectorBuilder}
-     */
-    // Eventually, we want to remove this entirely, always passing an explicit BlockFactory
-    @Deprecated
-    static Builder newVectorBuilder(int estimatedSize) {
-        return newVectorBuilder(estimatedSize, BlockFactory.getNonBreakingInstance());
-    }
-
-    /**
      * Creates a builder that grows as needed.
      * @deprecated use {@link BlockFactory#newBytesRefVectorBuilder}
      */

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBlock.java
@@ -168,32 +168,12 @@ public sealed interface DoubleBlock extends Block permits DoubleArrayBlock, Doub
     }
 
     /**
-     * Returns a builder using the {@link BlockFactory#getNonBreakingInstance non-breaking block factory}.
-     * @deprecated use {@link BlockFactory#newDoubleBlockBuilder}
-     */
-    // Eventually, we want to remove this entirely, always passing an explicit BlockFactory
-    @Deprecated
-    static Builder newBlockBuilder(int estimatedSize) {
-        return newBlockBuilder(estimatedSize, BlockFactory.getNonBreakingInstance());
-    }
-
-    /**
      * Returns a builder.
      * @deprecated use {@link BlockFactory#newDoubleBlockBuilder}
      */
     @Deprecated
     static Builder newBlockBuilder(int estimatedSize, BlockFactory blockFactory) {
         return blockFactory.newDoubleBlockBuilder(estimatedSize);
-    }
-
-    /**
-     * Returns a constant block built by the {@link BlockFactory#getNonBreakingInstance non-breaking block factory}.
-     * @deprecated use {@link BlockFactory#newConstantDoubleBlockWith}
-     */
-    // Eventually, we want to remove this entirely, always passing an explicit BlockFactory
-    @Deprecated
-    static DoubleBlock newConstantBlockWith(double value, int positions) {
-        return newConstantBlockWith(value, positions, BlockFactory.getNonBreakingInstance());
     }
 
     /**

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleVector.java
@@ -103,16 +103,6 @@ public sealed interface DoubleVector extends Vector permits ConstantDoubleVector
     }
 
     /**
-     * Returns a builder using the {@link BlockFactory#getNonBreakingInstance nonbreaking block factory}.
-     * @deprecated use {@link BlockFactory#newDoubleVectorBuilder}
-     */
-    // Eventually, we want to remove this entirely, always passing an explicit BlockFactory
-    @Deprecated
-    static Builder newVectorBuilder(int estimatedSize) {
-        return newVectorBuilder(estimatedSize, BlockFactory.getNonBreakingInstance());
-    }
-
-    /**
      * Creates a builder that grows as needed. Prefer {@link #newVectorFixedBuilder}
      * if you know the size up front because it's faster.
      * @deprecated use {@link BlockFactory#newDoubleVectorBuilder}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBlock.java
@@ -167,32 +167,12 @@ public sealed interface IntBlock extends Block permits IntArrayBlock, IntVectorB
     }
 
     /**
-     * Returns a builder using the {@link BlockFactory#getNonBreakingInstance non-breaking block factory}.
-     * @deprecated use {@link BlockFactory#newIntBlockBuilder}
-     */
-    // Eventually, we want to remove this entirely, always passing an explicit BlockFactory
-    @Deprecated
-    static Builder newBlockBuilder(int estimatedSize) {
-        return newBlockBuilder(estimatedSize, BlockFactory.getNonBreakingInstance());
-    }
-
-    /**
      * Returns a builder.
      * @deprecated use {@link BlockFactory#newIntBlockBuilder}
      */
     @Deprecated
     static Builder newBlockBuilder(int estimatedSize, BlockFactory blockFactory) {
         return blockFactory.newIntBlockBuilder(estimatedSize);
-    }
-
-    /**
-     * Returns a constant block built by the {@link BlockFactory#getNonBreakingInstance non-breaking block factory}.
-     * @deprecated use {@link BlockFactory#newConstantIntBlockWith}
-     */
-    // Eventually, we want to remove this entirely, always passing an explicit BlockFactory
-    @Deprecated
-    static IntBlock newConstantBlockWith(int value, int positions) {
-        return newConstantBlockWith(value, positions, BlockFactory.getNonBreakingInstance());
     }
 
     /**

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVector.java
@@ -102,16 +102,6 @@ public sealed interface IntVector extends Vector permits ConstantIntVector, IntA
     }
 
     /**
-     * Returns a builder using the {@link BlockFactory#getNonBreakingInstance nonbreaking block factory}.
-     * @deprecated use {@link BlockFactory#newIntVectorBuilder}
-     */
-    // Eventually, we want to remove this entirely, always passing an explicit BlockFactory
-    @Deprecated
-    static Builder newVectorBuilder(int estimatedSize) {
-        return newVectorBuilder(estimatedSize, BlockFactory.getNonBreakingInstance());
-    }
-
-    /**
      * Creates a builder that grows as needed. Prefer {@link #newVectorFixedBuilder}
      * if you know the size up front because it's faster.
      * @deprecated use {@link BlockFactory#newIntVectorBuilder}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBlock.java
@@ -168,32 +168,12 @@ public sealed interface LongBlock extends Block permits LongArrayBlock, LongVect
     }
 
     /**
-     * Returns a builder using the {@link BlockFactory#getNonBreakingInstance non-breaking block factory}.
-     * @deprecated use {@link BlockFactory#newLongBlockBuilder}
-     */
-    // Eventually, we want to remove this entirely, always passing an explicit BlockFactory
-    @Deprecated
-    static Builder newBlockBuilder(int estimatedSize) {
-        return newBlockBuilder(estimatedSize, BlockFactory.getNonBreakingInstance());
-    }
-
-    /**
      * Returns a builder.
      * @deprecated use {@link BlockFactory#newLongBlockBuilder}
      */
     @Deprecated
     static Builder newBlockBuilder(int estimatedSize, BlockFactory blockFactory) {
         return blockFactory.newLongBlockBuilder(estimatedSize);
-    }
-
-    /**
-     * Returns a constant block built by the {@link BlockFactory#getNonBreakingInstance non-breaking block factory}.
-     * @deprecated use {@link BlockFactory#newConstantLongBlockWith}
-     */
-    // Eventually, we want to remove this entirely, always passing an explicit BlockFactory
-    @Deprecated
-    static LongBlock newConstantBlockWith(long value, int positions) {
-        return newConstantBlockWith(value, positions, BlockFactory.getNonBreakingInstance());
     }
 
     /**

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVector.java
@@ -103,16 +103,6 @@ public sealed interface LongVector extends Vector permits ConstantLongVector, Lo
     }
 
     /**
-     * Returns a builder using the {@link BlockFactory#getNonBreakingInstance nonbreaking block factory}.
-     * @deprecated use {@link BlockFactory#newLongVectorBuilder}
-     */
-    // Eventually, we want to remove this entirely, always passing an explicit BlockFactory
-    @Deprecated
-    static Builder newVectorBuilder(int estimatedSize) {
-        return newVectorBuilder(estimatedSize, BlockFactory.getNonBreakingInstance());
-    }
-
-    /**
      * Creates a builder that grows as needed. Prefer {@link #newVectorFixedBuilder}
      * if you know the size up front because it's faster.
      * @deprecated use {@link BlockFactory#newLongVectorBuilder}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Block.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Block.java
@@ -160,16 +160,6 @@ public interface Block extends Accountable, BlockLoader.Block, NamedWriteable, R
     Block expand();
 
     /**
-     * {@return a constant null block with the given number of positions, using the non-breaking block factory}.
-     * @deprecated use {@link BlockFactory#newConstantNullBlock}
-     */
-    // Eventually, this should use the GLOBAL breaking instance
-    @Deprecated
-    static Block constantNullBlock(int positions) {
-        return constantNullBlock(positions, BlockFactory.getNonBreakingInstance());
-    }
-
-    /**
      * {@return a constant null block with the given number of positions}.
      * @deprecated use {@link BlockFactory#newConstantNullBlock}
      */

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockUtils.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockUtils.java
@@ -216,7 +216,7 @@ public final class BlockUtils {
 
     public static Block constantBlock(BlockFactory blockFactory, Object val, int size) {
         if (val == null) {
-            return Block.constantNullBlock(size);
+            return blockFactory.newConstantNullBlock(size);
         }
         return constantBlock(blockFactory, fromJava(val.getClass()), val, size);
     }
@@ -224,7 +224,7 @@ public final class BlockUtils {
     // TODO: allow null values
     private static Block constantBlock(BlockFactory blockFactory, ElementType type, Object val, int size) {
         return switch (type) {
-            case NULL -> Block.constantNullBlock(size);
+            case NULL -> blockFactory.newConstantNullBlock(size);
             case LONG -> LongBlock.newConstantBlockWith((long) val, size, blockFactory);
             case INT -> IntBlock.newConstantBlockWith((int) val, size, blockFactory);
             case BYTES_REF -> BytesRefBlock.newConstantBlockWith(toBytesRef(val), size, blockFactory);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ConstantNullBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ConstantNullBlock.java
@@ -19,14 +19,9 @@ import java.util.Objects;
 /**
  * Block implementation representing a constant null value.
  */
-public final class ConstantNullBlock extends AbstractBlock implements BooleanBlock, IntBlock, LongBlock, DoubleBlock, BytesRefBlock {
+final class ConstantNullBlock extends AbstractBlock implements BooleanBlock, IntBlock, LongBlock, DoubleBlock, BytesRefBlock {
 
     private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(ConstantNullBlock.class);
-
-    // Eventually, this should use the GLOBAL breaking instance
-    ConstantNullBlock(int positionCount) {
-        this(positionCount, BlockFactory.getNonBreakingInstance());
-    }
 
     ConstantNullBlock(int positionCount, BlockFactory blockFactory) {
         super(positionCount, blockFactory);
@@ -83,8 +78,9 @@ public final class ConstantNullBlock extends AbstractBlock implements BooleanBlo
         return "ConstantNullBlock";
     }
 
-    static ConstantNullBlock of(StreamInput in) throws IOException {
-        return new ConstantNullBlock(in.readVInt());
+    static Block of(StreamInput in) throws IOException {
+        BlockFactory blockFactory = ((BlockStreamInput) in).blockFactory();
+        return blockFactory.newConstantNullBlock(in.readVInt());
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Block.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Block.java.st
@@ -204,32 +204,12 @@ $endif$
     }
 
     /**
-     * Returns a builder using the {@link BlockFactory#getNonBreakingInstance non-breaking block factory}.
-     * @deprecated use {@link BlockFactory#new$Type$BlockBuilder}
-     */
-    // Eventually, we want to remove this entirely, always passing an explicit BlockFactory
-    @Deprecated
-    static Builder newBlockBuilder(int estimatedSize) {
-        return newBlockBuilder(estimatedSize, BlockFactory.getNonBreakingInstance());
-    }
-
-    /**
      * Returns a builder.
      * @deprecated use {@link BlockFactory#new$Type$BlockBuilder}
      */
     @Deprecated
     static Builder newBlockBuilder(int estimatedSize, BlockFactory blockFactory) {
         return blockFactory.new$Type$BlockBuilder(estimatedSize);
-    }
-
-    /**
-     * Returns a constant block built by the {@link BlockFactory#getNonBreakingInstance non-breaking block factory}.
-     * @deprecated use {@link BlockFactory#newConstant$Type$BlockWith}
-     */
-    // Eventually, we want to remove this entirely, always passing an explicit BlockFactory
-    @Deprecated
-    static $Type$Block newConstantBlockWith($type$ value, int positions) {
-        return newConstantBlockWith(value, positions, BlockFactory.getNonBreakingInstance());
     }
 
     /**

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Vector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Vector.java.st
@@ -143,16 +143,6 @@ $endif$
         }
     }
 
-    /**
-     * Returns a builder using the {@link BlockFactory#getNonBreakingInstance nonbreaking block factory}.
-     * @deprecated use {@link BlockFactory#new$Type$VectorBuilder}
-     */
-    // Eventually, we want to remove this entirely, always passing an explicit BlockFactory
-    @Deprecated
-    static Builder newVectorBuilder(int estimatedSize) {
-        return newVectorBuilder(estimatedSize, BlockFactory.getNonBreakingInstance());
-    }
-
 $if(BytesRef)$
     /**
      * Creates a builder that grows as needed.

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/EvalOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/EvalOperator.java
@@ -75,27 +75,22 @@ public class EvalOperator extends AbstractPageMappingOperator {
     public static final ExpressionEvaluator.Factory CONSTANT_NULL_FACTORY = new ExpressionEvaluator.Factory() {
         @Override
         public ExpressionEvaluator get(DriverContext driverContext) {
-            return CONSTANT_NULL;
-        }
+            return new ExpressionEvaluator() {
+                @Override
+                public Block eval(Page page) {
+                    return driverContext.blockFactory().newConstantNullBlock(page.getPositionCount());
+                }
 
-        @Override
-        public String toString() {
-            return CONSTANT_NULL.toString();
-        }
-    };
+                @Override
+                public void close() {
 
-    public static final ExpressionEvaluator CONSTANT_NULL = new ExpressionEvaluator() {
-        @Override
-        public Block eval(Page page) {
-            return Block.constantNullBlock(page.getPositionCount());
+                }
+            };
         }
 
         @Override
         public String toString() {
             return "ConstantNull";
         }
-
-        @Override
-        public void close() {}
     };
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/OperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/OperatorTests.java
@@ -41,7 +41,6 @@ import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.DocBlock;
 import org.elasticsearch.compute.data.DocVector;
 import org.elasticsearch.compute.data.ElementType;
-import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.Page;
@@ -222,7 +221,7 @@ public class OperatorTests extends MapperServiceTestCase {
                     List.of(shuffleDocsOperator, new AbstractPageMappingOperator() {
                         @Override
                         protected Page process(Page page) {
-                            return page.appendBlock(IntBlock.newConstantBlockWith(1, page.getPositionCount()));
+                            return page.appendBlock(driverContext.blockFactory().newConstantIntBlockWith(1, page.getPositionCount()));
                         }
 
                         @Override

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/OperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/OperatorTests.java
@@ -172,7 +172,7 @@ public class OperatorTests extends MapperServiceTestCase {
                     int positionCount = docVector.getPositionCount();
                     IntVector shards = docVector.shards();
                     if (randomBoolean()) {
-                        try (IntVector.Builder builder = IntVector.newVectorBuilder(positionCount)) {
+                        try (IntVector.Builder builder = blockFactory.newIntVectorBuilder(positionCount)) {
                             for (int i = 0; i < positionCount; i++) {
                                 builder.appendInt(shards.getInt(i));
                             }
@@ -182,7 +182,7 @@ public class OperatorTests extends MapperServiceTestCase {
                     }
                     IntVector segments = docVector.segments();
                     if (randomBoolean()) {
-                        try (IntVector.Builder builder = IntVector.newVectorBuilder(positionCount)) {
+                        try (IntVector.Builder builder = blockFactory.newIntVectorBuilder(positionCount)) {
                             for (int i = 0; i < positionCount; i++) {
                                 builder.appendInt(segments.getInt(i));
                             }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashTests.java
@@ -498,12 +498,12 @@ public class BlockHashTests extends ESTestCase {
                 assertThat(ordsAndKeys.description, startsWith("PackedValuesBlockHash{groups=[0:BOOLEAN], entries=1, size="));
                 assertOrds(ordsAndKeys.ords, 0, 0, 0, 0);
                 assertKeys(ordsAndKeys.keys, true);
-                assertThat(ordsAndKeys.nonEmpty, equalTo(IntVector.newVectorBuilder(1).appendInt(0).build()));
+                assertThat(ordsAndKeys.nonEmpty, equalTo(BlockFactory.getNonBreakingInstance().newConstantIntVector(0, 1)));
             } else {
                 assertThat(ordsAndKeys.description, equalTo("BooleanBlockHash{channel=0, seenFalse=false, seenTrue=true, seenNull=false}"));
                 assertOrds(ordsAndKeys.ords, 2, 2, 2, 2);
                 assertKeys(ordsAndKeys.keys, true);
-                assertThat(ordsAndKeys.nonEmpty, equalTo(IntVector.newVectorBuilder(1).appendInt(2).build()));
+                assertThat(ordsAndKeys.nonEmpty, equalTo(BlockFactory.getNonBreakingInstance().newConstantIntVector(2, 1)));
             }
         }, blockFactory.newBooleanArrayVector(values, values.length).asBlock());
     }
@@ -514,11 +514,11 @@ public class BlockHashTests extends ESTestCase {
             if (forcePackedHash) {
                 assertThat(ordsAndKeys.description, startsWith("PackedValuesBlockHash{groups=[0:BOOLEAN], entries=1, size="));
                 assertOrds(ordsAndKeys.ords, 0, 0, 0, 0);
-                assertThat(ordsAndKeys.nonEmpty, equalTo(IntVector.newVectorBuilder(1).appendInt(0).build()));
+                assertThat(ordsAndKeys.nonEmpty, equalTo(BlockFactory.getNonBreakingInstance().newConstantIntVector(0, 1)));
             } else {
                 assertThat(ordsAndKeys.description, equalTo("BooleanBlockHash{channel=0, seenFalse=true, seenTrue=false, seenNull=false}"));
                 assertOrds(ordsAndKeys.ords, 1, 1, 1, 1);
-                assertThat(ordsAndKeys.nonEmpty, equalTo(IntVector.newVectorBuilder(1).appendInt(1).build()));
+                assertThat(ordsAndKeys.nonEmpty, equalTo(BlockFactory.getNonBreakingInstance().newConstantIntVector(1, 1)));
             }
             assertKeys(ordsAndKeys.keys, false);
         }, blockFactory.newBooleanArrayVector(values, values.length).asBlock());

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicBlockTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicBlockTests.java
@@ -798,7 +798,7 @@ public class BasicBlockTests extends ESTestCase {
 
         try (
             var longBlock = blockFactory.newLongBlockBuilder(estimatedSize).appendLong(10L).appendLong(20L).build();
-            var longVector = LongVector.newVectorBuilder(estimatedSize).appendLong(10L).appendLong(20L).build()
+            var longVector = blockFactory.newLongVectorBuilder(estimatedSize).appendLong(10L).appendLong(20L).build()
         ) {
             for (Object obj : List.of(longVector, longBlock, longBlock.asVector())) {
                 String s = obj.toString();
@@ -809,7 +809,7 @@ public class BasicBlockTests extends ESTestCase {
 
         try (
             var doubleBlock = blockFactory.newDoubleBlockBuilder(estimatedSize).appendDouble(3.3).appendDouble(4.4).build();
-            var doubleVector = DoubleVector.newVectorBuilder(estimatedSize).appendDouble(3.3).appendDouble(4.4).build()
+            var doubleVector = blockFactory.newDoubleVectorBuilder(estimatedSize).appendDouble(3.3).appendDouble(4.4).build()
         ) {
             for (Object obj : List.of(doubleVector, doubleBlock, doubleBlock.asVector())) {
                 String s = obj.toString();

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicPageTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicPageTests.java
@@ -45,7 +45,7 @@ public class BasicPageTests extends SerializationTestCase {
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(
             in,
             page -> new Page(0),
-            page -> new Page(1, IntBlock.newConstantBlockWith(1, 1)),
+            page -> new Page(1, blockFactory.newConstantIntBlockWith(1, 1)),
             Page::releaseBlocks
         );
         in.releaseBlocks();
@@ -71,8 +71,8 @@ public class BasicPageTests extends SerializationTestCase {
         in = new Page(blockFactory.newIntArrayVector(new int[] { 1, 1, 1 }, 3).asBlock());
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(
             in,
-            page -> new Page(IntBlock.newConstantBlockWith(1, 3)),
-            page -> new Page(IntBlock.newConstantBlockWith(1, 2)),
+            page -> new Page(blockFactory.newConstantIntBlockWith(1, 3)),
+            page -> new Page(blockFactory.newConstantIntBlockWith(1, 2)),
             Page::releaseBlocks
         );
         in.releaseBlocks();
@@ -137,10 +137,10 @@ public class BasicPageTests extends SerializationTestCase {
                 case 0 -> blockFactory.newIntArrayVector(randomInts(positions).toArray(), positions).asBlock();
                 case 1 -> blockFactory.newLongArrayVector(randomLongs(positions).toArray(), positions).asBlock();
                 case 2 -> blockFactory.newDoubleArrayVector(randomDoubles(positions).toArray(), positions).asBlock();
-                case 3 -> IntBlock.newConstantBlockWith(randomInt(), positions);
-                case 4 -> LongBlock.newConstantBlockWith(randomLong(), positions);
-                case 5 -> DoubleBlock.newConstantBlockWith(randomDouble(), positions);
-                case 6 -> BytesRefBlock.newConstantBlockWith(new BytesRef(Integer.toHexString(randomInt())), positions);
+                case 3 -> blockFactory.newConstantIntBlockWith(randomInt(), positions);
+                case 4 -> blockFactory.newConstantLongBlockWith(randomLong(), positions);
+                case 5 -> blockFactory.newConstantDoubleBlockWith(randomDouble(), positions);
+                case 6 -> blockFactory.newConstantBytesRefBlockWith(new BytesRef(Integer.toHexString(randomInt())), positions);
                 default -> throw new AssertionError();
             };
         }
@@ -183,10 +183,10 @@ public class BasicPageTests extends SerializationTestCase {
             blockFactory.newLongArrayVector(LongStream.range(10, 20).toArray(), 10).asBlock(),
             blockFactory.newDoubleArrayVector(LongStream.range(30, 40).mapToDouble(i -> i).toArray(), 10).asBlock(),
             blockFactory.newBytesRefArrayVector(bytesRefArrayOf("0a", "1b", "2c", "3d", "4e", "5f", "6g", "7h", "8i", "9j"), 10).asBlock(),
-            IntBlock.newConstantBlockWith(randomInt(), 10),
-            LongBlock.newConstantBlockWith(randomInt(), 10),
-            DoubleBlock.newConstantBlockWith(randomInt(), 10),
-            BytesRefBlock.newConstantBlockWith(new BytesRef(Integer.toHexString(randomInt())), 10),
+            blockFactory.newConstantIntBlockWith(randomInt(), 10),
+            blockFactory.newConstantLongBlockWith(randomLong(), 10),
+            blockFactory.newConstantDoubleBlockWith(randomDouble(), 10),
+            blockFactory.newConstantBytesRefBlockWith(new BytesRef(Integer.toHexString(randomInt())), 10),
             toFilter.filter(5, 6, 7, 8, 9, 10, 11, 12, 13, 14).asBlock()
         );
         toFilter.close();
@@ -215,9 +215,9 @@ public class BasicPageTests extends SerializationTestCase {
             new Page(blockFactory.newIntArrayVector(randomInts(positions).toArray(), positions).asBlock()),
             new Page(
                 blockFactory.newLongArrayVector(randomLongs(positions).toArray(), positions).asBlock(),
-                DoubleBlock.newConstantBlockWith(randomInt(), positions)
+                blockFactory.newConstantDoubleBlockWith(randomInt(), positions)
             ),
-            new Page(BytesRefBlock.newConstantBlockWith(new BytesRef("Hello World"), positions))
+            new Page(blockFactory.newConstantBytesRefBlockWith(new BytesRef("Hello World"), positions))
         );
         try {
             EqualsHashCodeTestUtils.checkEqualsAndHashCode(origPages, page -> {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockBuilderAppendBlockTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockBuilderAppendBlockTests.java
@@ -7,17 +7,19 @@
 
 package org.elasticsearch.compute.data;
 
-import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.compute.operator.ComputeTestCase;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.hamcrest.Matchers.equalTo;
 
-public class BlockBuilderAppendBlockTests extends ESTestCase {
+public class BlockBuilderAppendBlockTests extends ComputeTestCase {
 
     public void testBasic() {
-        IntBlock src = new IntBlockBuilder(10, BlockFactory.getNonBreakingInstance()).appendInt(1)
+        BlockFactory blockFactory = blockFactory();
+        IntBlock src = blockFactory.newIntBlockBuilder(10)
+            .appendInt(1)
             .appendNull()
             .beginPositionEntry()
             .appendInt(4)
@@ -32,40 +34,48 @@ public class BlockBuilderAppendBlockTests extends ESTestCase {
             .endPositionEntry()
             .build();
         // copy position by position
-        {
-            IntBlock.Builder dst = IntBlock.newBlockBuilder(randomIntBetween(1, 20));
+        try (IntBlock.Builder dst = blockFactory.newIntBlockBuilder(randomIntBetween(1, 20))) {
             for (int i = 0; i < src.getPositionCount(); i++) {
-                dst.appendAllValuesToCurrentPosition(src.filter(i));
+                try (IntBlock filter = src.filter(i)) {
+                    dst.appendAllValuesToCurrentPosition(filter);
+                }
             }
-            assertThat(dst.build(), equalTo(src));
+            try (IntBlock block = dst.build()) {
+                assertThat(block, equalTo(src));
+            }
         }
         // copy all block
-        {
-            IntBlock.Builder dst = IntBlock.newBlockBuilder(randomIntBetween(1, 20));
-            IntBlock block = dst.appendAllValuesToCurrentPosition(src).build();
-            assertThat(block.getPositionCount(), equalTo(1));
-            assertThat(BlockUtils.toJavaObject(block, 0), equalTo(List.of(1, 4, 6, 10, 20, 30, 1)));
+        try (IntBlock.Builder dst = blockFactory.newIntBlockBuilder(randomIntBetween(1, 20))) {
+            try (IntBlock block = dst.appendAllValuesToCurrentPosition(src).build()) {
+                assertThat(block.getPositionCount(), equalTo(1));
+                assertThat(BlockUtils.toJavaObject(block, 0), equalTo(List.of(1, 4, 6, 10, 20, 30, 1)));
+            }
         }
-        {
-            Block dst = randomlyDivideAndMerge(src);
+        try (Block dst = randomlyDivideAndMerge(src)) {
             assertThat(dst.getPositionCount(), equalTo(1));
             assertThat(BlockUtils.toJavaObject(dst, 0), equalTo(List.of(1, 4, 6, 10, 20, 30, 1)));
         }
     }
 
     public void testRandomNullBlock() {
-        IntBlock.Builder src = IntBlock.newBlockBuilder(10);
-        src.appendAllValuesToCurrentPosition(new ConstantNullBlock(between(1, 100)));
+        BlockFactory blockFactory = blockFactory();
+        IntBlock.Builder src = blockFactory.newIntBlockBuilder(10);
+        try (var nullBlock = blockFactory.newConstantNullBlock(between(1, 100))) {
+            src.appendAllValuesToCurrentPosition(nullBlock);
+        }
         src.appendInt(101);
-        src.appendAllValuesToCurrentPosition(new ConstantNullBlock(between(1, 100)));
+        try (var nullBlock = blockFactory.newConstantNullBlock(between(1, 100))) {
+            src.appendAllValuesToCurrentPosition(nullBlock);
+        }
         IntBlock block = src.build();
         assertThat(block.getPositionCount(), equalTo(3));
         assertTrue(block.isNull(0));
         assertThat(block.getInt(1), equalTo(101));
         assertTrue(block.isNull(2));
-        Block flatten = randomlyDivideAndMerge(block);
-        assertThat(flatten.getPositionCount(), equalTo(1));
-        assertThat(BlockUtils.toJavaObject(flatten, 0), equalTo(101));
+        try (Block flatten = randomlyDivideAndMerge(block)) {
+            assertThat(flatten.getPositionCount(), equalTo(1));
+            assertThat(BlockUtils.toJavaObject(flatten, 0), equalTo(101));
+        }
     }
 
     public void testRandom() {
@@ -79,10 +89,13 @@ public class BlockBuilderAppendBlockTests extends ESTestCase {
             0,
             between(0, 16)
         ).block();
-        randomlyDivideAndMerge(block);
+
+        block = randomlyDivideAndMerge(block);
+        block.close();
     }
 
     private Block randomlyDivideAndMerge(Block block) {
+        assertFalse(block.isReleased());
         while (block.getPositionCount() > 1 || randomBoolean()) {
             int positionCount = block.getPositionCount();
             int offset = 0;
@@ -95,11 +108,14 @@ public class BlockBuilderAppendBlockTests extends ESTestCase {
                     positions[i] = offset + i;
                 }
                 offset += length;
-                Block sub = block.filter(positions);
-                expected.add(extractAndFlattenBlockValues(sub));
-                builder.appendAllValuesToCurrentPosition(sub);
+                try (Block sub = block.filter(positions)) {
+                    expected.add(extractAndFlattenBlockValues(sub));
+                    builder.appendAllValuesToCurrentPosition(sub);
+                }
             }
+            block.close();
             block = builder.build();
+            assertFalse(block.isReleased());
             assertThat(block.getPositionCount(), equalTo(expected.size()));
             for (int i = 0; i < block.getPositionCount(); i++) {
                 assertThat(BlockUtils.toJavaObject(block, i), equalTo(expected.get(i)));

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockBuilderAppendBlockTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockBuilderAppendBlockTests.java
@@ -95,7 +95,6 @@ public class BlockBuilderAppendBlockTests extends ComputeTestCase {
     }
 
     private Block randomlyDivideAndMerge(Block block) {
-        assertFalse(block.isReleased());
         while (block.getPositionCount() > 1 || randomBoolean()) {
             int positionCount = block.getPositionCount();
             int offset = 0;
@@ -108,14 +107,13 @@ public class BlockBuilderAppendBlockTests extends ComputeTestCase {
                     positions[i] = offset + i;
                 }
                 offset += length;
-                try (Block sub = block.filter(positions)) {
-                    expected.add(extractAndFlattenBlockValues(sub));
-                    builder.appendAllValuesToCurrentPosition(sub);
-                }
+                Block sub = block.filter(positions);
+                expected.add(extractAndFlattenBlockValues(sub));
+                builder.appendAllValuesToCurrentPosition(sub);
+                sub.close();
             }
             block.close();
             block = builder.build();
-            assertFalse(block.isReleased());
             assertThat(block.getPositionCount(), equalTo(expected.size()));
             for (int i = 0; i < block.getPositionCount(); i++) {
                 assertThat(BlockUtils.toJavaObject(block, i), equalTo(expected.get(i)));

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockBuilderCopyFromTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockBuilderCopyFromTests.java
@@ -69,11 +69,11 @@ public class BlockBuilderCopyFromTests extends ESTestCase {
     }
 
     public void testSmallAllNull() {
-        assertSmall(Block.constantNullBlock(10));
+        assertSmall(BlockFactory.getNonBreakingInstance().newConstantNullBlock(10));
     }
 
     public void testEvensAllNull() {
-        assertEvens(Block.constantNullBlock(10));
+        assertEvens(BlockFactory.getNonBreakingInstance().newConstantNullBlock(10));
     }
 
     private void assertSmall(Block block) {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockSerializationTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockSerializationTests.java
@@ -30,122 +30,172 @@ import static org.hamcrest.Matchers.is;
 public class BlockSerializationTests extends SerializationTestCase {
 
     public void testConstantIntBlock() throws IOException {
-        assertConstantBlockImpl(IntBlock.newConstantBlockWith(randomInt(), randomIntBetween(1, 8192)));
+        assertConstantBlockImpl(blockFactory.newConstantIntBlockWith(randomInt(), randomIntBetween(1, 8192)));
     }
 
     public void testConstantLongBlockLong() throws IOException {
-        assertConstantBlockImpl(LongBlock.newConstantBlockWith(randomLong(), randomIntBetween(1, 8192)));
+        assertConstantBlockImpl(blockFactory.newConstantLongBlockWith(randomLong(), randomIntBetween(1, 8192)));
     }
 
     public void testConstantDoubleBlock() throws IOException {
-        assertConstantBlockImpl(DoubleBlock.newConstantBlockWith(randomDouble(), randomIntBetween(1, 8192)));
+        assertConstantBlockImpl(blockFactory.newConstantDoubleBlockWith(randomDouble(), randomIntBetween(1, 8192)));
     }
 
     public void testConstantBytesRefBlock() throws IOException {
-        Block block = BytesRefBlock.newConstantBlockWith(new BytesRef(((Integer) randomInt()).toString()), randomIntBetween(1, 8192));
+        Block block = blockFactory.newConstantBytesRefBlockWith(
+            new BytesRef(((Integer) randomInt()).toString()),
+            randomIntBetween(1, 8192)
+        );
         assertConstantBlockImpl(block);
     }
 
     private void assertConstantBlockImpl(Block origBlock) throws IOException {
         assertThat(origBlock.asVector().isConstant(), is(true));
-        try (Block deserBlock = serializeDeserializeBlock(origBlock)) {
+        try (origBlock; Block deserBlock = serializeDeserializeBlock(origBlock)) {
             EqualsHashCodeTestUtils.checkEqualsAndHashCode(origBlock, unused -> deserBlock);
             assertThat(deserBlock.asVector().isConstant(), is(true));
         }
     }
 
     public void testEmptyIntBlock() throws IOException {
-        assertEmptyBlock(IntBlock.newBlockBuilder(0).build());
-        assertEmptyBlock(IntBlock.newBlockBuilder(0).appendNull().build().filter());
-        assertEmptyBlock(IntVector.newVectorBuilder(0).build().asBlock());
-        assertEmptyBlock(IntVector.newVectorBuilder(0).appendInt(randomInt()).build().filter().asBlock());
+        assertEmptyBlock(blockFactory.newIntBlockBuilder(0).build());
+        try (IntBlock toFilter = blockFactory.newIntBlockBuilder(0).appendNull().build()) {
+            assertEmptyBlock(toFilter.filter());
+        }
+        assertEmptyBlock(blockFactory.newIntVectorBuilder(0).build().asBlock());
+        try (IntVector toFilter = blockFactory.newIntVectorBuilder(0).appendInt(randomInt()).build()) {
+            assertEmptyBlock(toFilter.filter().asBlock());
+        }
     }
 
     public void testEmptyLongBlock() throws IOException {
-        assertEmptyBlock(LongBlock.newBlockBuilder(0).build());
-        assertEmptyBlock(LongBlock.newBlockBuilder(0).appendNull().build().filter());
-        assertEmptyBlock(LongVector.newVectorBuilder(0).build().asBlock());
-        assertEmptyBlock(LongVector.newVectorBuilder(0).appendLong(randomLong()).build().filter().asBlock());
+        assertEmptyBlock(blockFactory.newLongBlockBuilder(0).build());
+        try (LongBlock toFilter = blockFactory.newLongBlockBuilder(0).appendNull().build()) {
+            assertEmptyBlock(toFilter.filter());
+        }
+        assertEmptyBlock(blockFactory.newLongVectorBuilder(0).build().asBlock());
+        try (LongVector toFilter = blockFactory.newLongVectorBuilder(0).appendLong(randomLong()).build()) {
+            assertEmptyBlock(toFilter.filter().asBlock());
+        }
     }
 
     public void testEmptyDoubleBlock() throws IOException {
-        assertEmptyBlock(DoubleBlock.newBlockBuilder(0).build());
-        assertEmptyBlock(DoubleBlock.newBlockBuilder(0).appendNull().build().filter());
-        assertEmptyBlock(DoubleVector.newVectorBuilder(0).build().asBlock());
-        assertEmptyBlock(DoubleVector.newVectorBuilder(0).appendDouble(randomDouble()).build().filter().asBlock());
+        assertEmptyBlock(blockFactory.newDoubleBlockBuilder(0).build());
+        try (DoubleBlock toFilter = blockFactory.newDoubleBlockBuilder(0).appendNull().build()) {
+            assertEmptyBlock(toFilter.filter());
+        }
+        assertEmptyBlock(blockFactory.newDoubleVectorBuilder(0).build().asBlock());
+        try (DoubleVector toFilter = blockFactory.newDoubleVectorBuilder(0).appendDouble(randomDouble()).build()) {
+            assertEmptyBlock(toFilter.filter().asBlock());
+        }
     }
 
     public void testEmptyBytesRefBlock() throws IOException {
-        assertEmptyBlock(BytesRefBlock.newBlockBuilder(0).build());
-        assertEmptyBlock(BytesRefBlock.newBlockBuilder(0).appendNull().build().filter());
-        assertEmptyBlock(BytesRefVector.newVectorBuilder(0).build().asBlock());
-        assertEmptyBlock(BytesRefVector.newVectorBuilder(0).appendBytesRef(randomBytesRef()).build().filter().asBlock());
+        assertEmptyBlock(blockFactory.newBytesRefBlockBuilder(0).build());
+        try (BytesRefBlock toFilter = blockFactory.newBytesRefBlockBuilder(0).appendNull().build()) {
+            assertEmptyBlock(toFilter.filter());
+        }
+        assertEmptyBlock(blockFactory.newBytesRefVectorBuilder(0).build().asBlock());
+        try (BytesRefVector toFilter = blockFactory.newBytesRefVectorBuilder(0).appendBytesRef(randomBytesRef()).build()) {
+            assertEmptyBlock(toFilter.filter().asBlock());
+        }
     }
 
     private void assertEmptyBlock(Block origBlock) throws IOException {
         assertThat(origBlock.getPositionCount(), is(0));
-        try (Block deserBlock = serializeDeserializeBlock(origBlock)) {
+        try (origBlock; Block deserBlock = serializeDeserializeBlock(origBlock)) {
             EqualsHashCodeTestUtils.checkEqualsAndHashCode(origBlock, unused -> deserBlock);
         }
     }
 
     public void testFilterIntBlock() throws IOException {
-        assertFilterBlock(IntBlock.newBlockBuilder(0).appendInt(1).appendInt(2).build().filter(1));
-        assertFilterBlock(IntBlock.newBlockBuilder(1).appendInt(randomInt()).appendNull().build().filter(0));
-        assertFilterBlock(IntVector.newVectorBuilder(1).appendInt(randomInt()).build().filter(0).asBlock());
-        assertFilterBlock(IntVector.newVectorBuilder(1).appendInt(randomInt()).appendInt(randomInt()).build().filter(0).asBlock());
+        try (IntBlock toFilter = blockFactory.newIntBlockBuilder(0).appendInt(1).appendInt(2).build()) {
+            assertFilterBlock(toFilter.filter(1));
+        }
+        try (IntBlock toFilter = blockFactory.newIntBlockBuilder(1).appendInt(randomInt()).appendNull().build()) {
+            assertFilterBlock(toFilter.filter(0));
+        }
+        try (IntVector toFilter = blockFactory.newIntVectorBuilder(1).appendInt(randomInt()).build()) {
+            assertFilterBlock(toFilter.filter(0).asBlock());
+        }
+        try (IntVector toFilter = blockFactory.newIntVectorBuilder(1).appendInt(randomInt()).appendInt(randomInt()).build()) {
+            assertFilterBlock(toFilter.filter(0).asBlock());
+        }
     }
 
     public void testFilterLongBlock() throws IOException {
-        assertFilterBlock(LongBlock.newBlockBuilder(0).appendLong(1).appendLong(2).build().filter(1));
-        assertFilterBlock(LongBlock.newBlockBuilder(1).appendLong(randomLong()).appendNull().build().filter(0));
-        assertFilterBlock(LongVector.newVectorBuilder(1).appendLong(randomLong()).build().filter(0).asBlock());
-        assertFilterBlock(LongVector.newVectorBuilder(1).appendLong(randomLong()).appendLong(randomLong()).build().filter(0).asBlock());
+        try (LongBlock toFilter = blockFactory.newLongBlockBuilder(0).appendLong(1).appendLong(2).build()) {
+            assertFilterBlock(toFilter.filter(1));
+        }
+        try (LongBlock toFilter = blockFactory.newLongBlockBuilder(1).appendLong(randomLong()).appendNull().build()) {
+            assertFilterBlock(toFilter.filter(0));
+        }
+        try (LongVector toFilter = blockFactory.newLongVectorBuilder(1).appendLong(randomLong()).build()) {
+            assertFilterBlock(toFilter.filter(0).asBlock());
+        }
+        try (LongVector toFilter = blockFactory.newLongVectorBuilder(1).appendLong(randomLong()).appendLong(randomLong()).build()) {
+            assertFilterBlock(toFilter.filter(0).asBlock());
+        }
     }
 
     public void testFilterDoubleBlock() throws IOException {
-        assertFilterBlock(DoubleBlock.newBlockBuilder(0).appendDouble(1).appendDouble(2).build().filter(1));
-        assertFilterBlock(DoubleBlock.newBlockBuilder(1).appendDouble(randomDouble()).appendNull().build().filter(0));
-        assertFilterBlock(DoubleVector.newVectorBuilder(1).appendDouble(randomDouble()).build().filter(0).asBlock());
-        assertFilterBlock(
-            DoubleVector.newVectorBuilder(1).appendDouble(randomDouble()).appendDouble(randomDouble()).build().filter(0).asBlock()
-        );
+        try (DoubleBlock toFilter = blockFactory.newDoubleBlockBuilder(0).appendDouble(1).appendDouble(2).build()) {
+            assertFilterBlock(toFilter.filter(1));
+        }
+        try (DoubleBlock toFilter = blockFactory.newDoubleBlockBuilder(1).appendDouble(randomDouble()).appendNull().build()) {
+            assertFilterBlock(toFilter.filter(0));
+        }
+        try (DoubleVector toFilter = blockFactory.newDoubleVectorBuilder(1).appendDouble(randomDouble()).build()) {
+            assertFilterBlock(toFilter.filter(0).asBlock());
+
+        }
+        try (
+            DoubleVector toFilter = blockFactory.newDoubleVectorBuilder(1).appendDouble(randomDouble()).appendDouble(randomDouble()).build()
+        ) {
+            assertFilterBlock(toFilter.filter(0).asBlock());
+        }
     }
 
     public void testFilterBytesRefBlock() throws IOException {
-        assertFilterBlock(
-            BytesRefBlock.newBlockBuilder(0)
+        try (
+            BytesRefBlock toFilter = blockFactory.newBytesRefBlockBuilder(0)
                 .appendBytesRef(randomBytesRef())
                 .appendBytesRef(randomBytesRef())
                 .build()
-                .filter(randomIntBetween(0, 1))
-        );
-        assertFilterBlock(
-            BytesRefBlock.newBlockBuilder(0).appendBytesRef(randomBytesRef()).appendNull().build().filter(randomIntBetween(0, 1))
-        );
-        assertFilterBlock(BytesRefVector.newVectorBuilder(0).appendBytesRef(randomBytesRef()).build().asBlock().filter(0));
-        assertFilterBlock(
-            BytesRefVector.newVectorBuilder(0)
+        ) {
+            assertFilterBlock(toFilter.filter(randomIntBetween(0, 1)));
+        }
+
+        try (BytesRefBlock toFilter = blockFactory.newBytesRefBlockBuilder(0).appendBytesRef(randomBytesRef()).appendNull().build()) {
+            assertFilterBlock(toFilter.filter(randomIntBetween(0, 1)));
+        }
+
+        try (BytesRefVector toFilter = blockFactory.newBytesRefVectorBuilder(0).appendBytesRef(randomBytesRef()).build()) {
+            assertFilterBlock(toFilter.asBlock().filter(0));
+        }
+        try (
+            BytesRefVector toFilter = blockFactory.newBytesRefVectorBuilder(0)
                 .appendBytesRef(randomBytesRef())
                 .appendBytesRef(randomBytesRef())
                 .build()
-                .asBlock()
-                .filter(randomIntBetween(0, 1))
-        );
+        ) {
+            assertFilterBlock(toFilter.asBlock().filter(randomIntBetween(0, 1)));
+        }
     }
 
     private void assertFilterBlock(Block origBlock) throws IOException {
         assertThat(origBlock.getPositionCount(), is(1));
-        try (Block deserBlock = serializeDeserializeBlock(origBlock)) {
+        try (origBlock; Block deserBlock = serializeDeserializeBlock(origBlock)) {
             EqualsHashCodeTestUtils.checkEqualsAndHashCode(origBlock, unused -> deserBlock);
             assertThat(deserBlock.getPositionCount(), is(1));
         }
     }
 
     public void testConstantNullBlock() throws IOException {
-        Block origBlock = new ConstantNullBlock(randomIntBetween(1, 8192));
-        try (Block deserBlock = serializeDeserializeBlock(origBlock)) {
-            EqualsHashCodeTestUtils.checkEqualsAndHashCode(origBlock, unused -> deserBlock);
+        try (Block origBlock = blockFactory.newConstantNullBlock(randomIntBetween(1, 8192))) {
+            try (Block deserBlock = serializeDeserializeBlock(origBlock)) {
+                EqualsHashCodeTestUtils.checkEqualsAndHashCode(origBlock, unused -> deserBlock);
+            }
         }
     }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BooleanBlockEqualityTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BooleanBlockEqualityTests.java
@@ -21,10 +21,10 @@ public class BooleanBlockEqualityTests extends ESTestCase {
         List<BooleanVector> vectors = List.of(
             blockFactory.newBooleanArrayVector(new boolean[] {}, 0),
             blockFactory.newBooleanArrayVector(new boolean[] { randomBoolean() }, 0),
-            BooleanBlock.newConstantBlockWith(randomBoolean(), 0).asVector(),
-            BooleanBlock.newConstantBlockWith(randomBoolean(), 0).filter().asVector(),
-            BooleanBlock.newBlockBuilder(0).build().asVector(),
-            BooleanBlock.newBlockBuilder(0).appendBoolean(randomBoolean()).build().asVector().filter()
+            blockFactory.newConstantBooleanBlockWith(randomBoolean(), 0).asVector(),
+            blockFactory.newConstantBooleanBlockWith(randomBoolean(), 0).filter().asVector(),
+            blockFactory.newBooleanBlockBuilder(0).build().asVector(),
+            blockFactory.newBooleanBlockBuilder(0).appendBoolean(randomBoolean()).build().asVector().filter()
         );
         assertAllEquals(vectors);
     }
@@ -48,10 +48,10 @@ public class BooleanBlockEqualityTests extends ESTestCase {
                 randomFrom(Block.MvOrdering.values()),
                 blockFactory
             ),
-            BooleanBlock.newConstantBlockWith(randomBoolean(), 0),
-            BooleanBlock.newBlockBuilder(0).build(),
-            BooleanBlock.newBlockBuilder(0).appendBoolean(randomBoolean()).build().filter(),
-            BooleanBlock.newBlockBuilder(0).appendNull().build().filter()
+            blockFactory.newConstantBooleanBlockWith(randomBoolean(), 0),
+            blockFactory.newBooleanBlockBuilder(0).build(),
+            blockFactory.newBooleanBlockBuilder(0).appendBoolean(randomBoolean()).build().filter(),
+            blockFactory.newBooleanBlockBuilder(0).appendNull().build().filter()
         );
         assertAllEquals(blocks);
     }
@@ -66,9 +66,9 @@ public class BooleanBlockEqualityTests extends ESTestCase {
             blockFactory.newBooleanArrayVector(new boolean[] { true, false, true, false }, 4).filter(0, 1, 2),
             blockFactory.newBooleanArrayVector(new boolean[] { false, true, false, true }, 4).filter(1, 2, 3),
             blockFactory.newBooleanArrayVector(new boolean[] { true, true, false, true }, 4).filter(0, 2, 3),
-            BooleanBlock.newBlockBuilder(3).appendBoolean(true).appendBoolean(false).appendBoolean(true).build().asVector(),
-            BooleanBlock.newBlockBuilder(3).appendBoolean(true).appendBoolean(false).appendBoolean(true).build().asVector().filter(0, 1, 2),
-            BooleanBlock.newBlockBuilder(3)
+            blockFactory.newBooleanVectorBuilder(3).appendBoolean(true).appendBoolean(false).appendBoolean(true).build(),
+            blockFactory.newBooleanVectorBuilder(3).appendBoolean(true).appendBoolean(false).appendBoolean(true).build().filter(0, 1, 2),
+            blockFactory.newBooleanBlockBuilder(3)
                 .appendBoolean(true)
                 .appendBoolean(true)
                 .appendBoolean(false)
@@ -76,7 +76,7 @@ public class BooleanBlockEqualityTests extends ESTestCase {
                 .build()
                 .filter(0, 2, 3)
                 .asVector(),
-            BooleanBlock.newBlockBuilder(3)
+            blockFactory.newBooleanBlockBuilder(3)
                 .appendBoolean(true)
                 .appendBoolean(true)
                 .appendBoolean(false)
@@ -96,10 +96,16 @@ public class BooleanBlockEqualityTests extends ESTestCase {
             blockFactory.newBooleanArrayVector(new boolean[] { true, true, true, false }, 4).filter(0, 1, 2),
             blockFactory.newBooleanArrayVector(new boolean[] { false, true, true, true }, 4).filter(1, 2, 3),
             blockFactory.newBooleanArrayVector(new boolean[] { true, false, true, true }, 4).filter(0, 2, 3),
-            BooleanBlock.newConstantBlockWith(true, 3).asVector(),
-            BooleanBlock.newBlockBuilder(3).appendBoolean(true).appendBoolean(true).appendBoolean(true).build().asVector(),
-            BooleanBlock.newBlockBuilder(3).appendBoolean(true).appendBoolean(true).appendBoolean(true).build().asVector().filter(0, 1, 2),
-            BooleanBlock.newBlockBuilder(3)
+            blockFactory.newConstantBooleanBlockWith(true, 3).asVector(),
+            blockFactory.newBooleanBlockBuilder(3).appendBoolean(true).appendBoolean(true).appendBoolean(true).build().asVector(),
+            blockFactory.newBooleanBlockBuilder(3)
+                .appendBoolean(true)
+                .appendBoolean(true)
+                .appendBoolean(true)
+                .build()
+                .asVector()
+                .filter(0, 1, 2),
+            blockFactory.newBooleanBlockBuilder(3)
                 .appendBoolean(true)
                 .appendBoolean(false)
                 .appendBoolean(true)
@@ -107,7 +113,7 @@ public class BooleanBlockEqualityTests extends ESTestCase {
                 .build()
                 .filter(0, 2, 3)
                 .asVector(),
-            BooleanBlock.newBlockBuilder(3)
+            blockFactory.newBooleanBlockBuilder(3)
                 .appendBoolean(true)
                 .appendBoolean(false)
                 .appendBoolean(true)
@@ -143,16 +149,16 @@ public class BooleanBlockEqualityTests extends ESTestCase {
             blockFactory.newBooleanArrayVector(new boolean[] { true, false, true, false }, 3).filter(0, 1, 2).asBlock(),
             blockFactory.newBooleanArrayVector(new boolean[] { true, false, true, false }, 4).filter(0, 1, 2).asBlock(),
             blockFactory.newBooleanArrayVector(new boolean[] { true, false, false, true }, 4).filter(0, 1, 3).asBlock(),
-            BooleanBlock.newBlockBuilder(3).appendBoolean(true).appendBoolean(false).appendBoolean(true).build(),
-            BooleanBlock.newBlockBuilder(3).appendBoolean(true).appendBoolean(false).appendBoolean(true).build().filter(0, 1, 2),
-            BooleanBlock.newBlockBuilder(3)
+            blockFactory.newBooleanBlockBuilder(3).appendBoolean(true).appendBoolean(false).appendBoolean(true).build(),
+            blockFactory.newBooleanBlockBuilder(3).appendBoolean(true).appendBoolean(false).appendBoolean(true).build().filter(0, 1, 2),
+            blockFactory.newBooleanBlockBuilder(3)
                 .appendBoolean(true)
                 .appendBoolean(true)
                 .appendBoolean(false)
                 .appendBoolean(true)
                 .build()
                 .filter(0, 2, 3),
-            BooleanBlock.newBlockBuilder(3)
+            blockFactory.newBooleanBlockBuilder(3)
                 .appendBoolean(true)
                 .appendNull()
                 .appendBoolean(false)
@@ -185,11 +191,11 @@ public class BooleanBlockEqualityTests extends ESTestCase {
             blockFactory.newBooleanArrayVector(new boolean[] { true, true, false }, 2).filter(0, 1).asBlock(),
             blockFactory.newBooleanArrayVector(new boolean[] { true, true, false }, 3).filter(0, 1).asBlock(),
             blockFactory.newBooleanArrayVector(new boolean[] { true, false, true }, 3).filter(0, 2).asBlock(),
-            BooleanBlock.newConstantBlockWith(true, 2),
-            BooleanBlock.newBlockBuilder(2).appendBoolean(true).appendBoolean(true).build(),
-            BooleanBlock.newBlockBuilder(2).appendBoolean(true).appendBoolean(true).build().filter(0, 1),
-            BooleanBlock.newBlockBuilder(2).appendBoolean(true).appendBoolean(true).appendBoolean(true).build().filter(0, 2),
-            BooleanBlock.newBlockBuilder(2).appendBoolean(true).appendNull().appendBoolean(true).build().filter(0, 2)
+            blockFactory.newConstantBooleanBlockWith(true, 2),
+            blockFactory.newBooleanBlockBuilder(2).appendBoolean(true).appendBoolean(true).build(),
+            blockFactory.newBooleanBlockBuilder(2).appendBoolean(true).appendBoolean(true).build().filter(0, 1),
+            blockFactory.newBooleanBlockBuilder(2).appendBoolean(true).appendBoolean(true).appendBoolean(true).build().filter(0, 2),
+            blockFactory.newBooleanBlockBuilder(2).appendBoolean(true).appendNull().appendBoolean(true).build().filter(0, 2)
         );
         assertAllEquals(moreBlocks);
     }
@@ -202,10 +208,10 @@ public class BooleanBlockEqualityTests extends ESTestCase {
             blockFactory.newBooleanArrayVector(new boolean[] { true, false }, 2),
             blockFactory.newBooleanArrayVector(new boolean[] { true, false, true }, 3),
             blockFactory.newBooleanArrayVector(new boolean[] { false, true, false }, 3),
-            BooleanBlock.newConstantBlockWith(true, 2).asVector(),
-            BooleanBlock.newBlockBuilder(2).appendBoolean(false).appendBoolean(true).build().asVector(),
-            BooleanBlock.newBlockBuilder(3).appendBoolean(false).appendBoolean(false).appendBoolean(true).build().asVector(),
-            BooleanBlock.newBlockBuilder(1)
+            blockFactory.newConstantBooleanBlockWith(true, 2).asVector(),
+            blockFactory.newBooleanBlockBuilder(2).appendBoolean(false).appendBoolean(true).build().asVector(),
+            blockFactory.newBooleanBlockBuilder(3).appendBoolean(false).appendBoolean(false).appendBoolean(true).build().asVector(),
+            blockFactory.newBooleanBlockBuilder(1)
                 .appendBoolean(false)
                 .appendBoolean(false)
                 .appendBoolean(false)
@@ -224,13 +230,23 @@ public class BooleanBlockEqualityTests extends ESTestCase {
             blockFactory.newBooleanArrayVector(new boolean[] { false, true }, 2).asBlock(),
             blockFactory.newBooleanArrayVector(new boolean[] { false, true, false }, 3).asBlock(),
             blockFactory.newBooleanArrayVector(new boolean[] { false, false, true }, 3).asBlock(),
-            BooleanBlock.newConstantBlockWith(true, 2),
-            BooleanBlock.newBlockBuilder(3).appendBoolean(true).appendBoolean(false).appendBoolean(false).build(),
-            BooleanBlock.newBlockBuilder(1).appendBoolean(true).appendBoolean(false).appendBoolean(true).appendBoolean(false).build(),
-            BooleanBlock.newBlockBuilder(1).appendBoolean(true).appendNull().build(),
-            BooleanBlock.newBlockBuilder(1).appendBoolean(true).appendNull().appendBoolean(false).build(),
-            BooleanBlock.newBlockBuilder(1).appendBoolean(true).appendBoolean(false).build(),
-            BooleanBlock.newBlockBuilder(3).appendBoolean(true).beginPositionEntry().appendBoolean(false).appendBoolean(false).build()
+            blockFactory.newConstantBooleanBlockWith(true, 2),
+            blockFactory.newBooleanBlockBuilder(3).appendBoolean(true).appendBoolean(false).appendBoolean(false).build(),
+            blockFactory.newBooleanBlockBuilder(1)
+                .appendBoolean(true)
+                .appendBoolean(false)
+                .appendBoolean(true)
+                .appendBoolean(false)
+                .build(),
+            blockFactory.newBooleanBlockBuilder(1).appendBoolean(true).appendNull().build(),
+            blockFactory.newBooleanBlockBuilder(1).appendBoolean(true).appendNull().appendBoolean(false).build(),
+            blockFactory.newBooleanBlockBuilder(1).appendBoolean(true).appendBoolean(false).build(),
+            blockFactory.newBooleanBlockBuilder(3)
+                .appendBoolean(true)
+                .beginPositionEntry()
+                .appendBoolean(false)
+                .appendBoolean(false)
+                .build()
         );
         assertAllNotEquals(notEqualBlocks);
     }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BytesRefBlockEqualityTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BytesRefBlockEqualityTests.java
@@ -30,10 +30,10 @@ public class BytesRefBlockEqualityTests extends ComputeTestCase {
             List<BytesRefVector> vectors = List.of(
                 new BytesRefArrayVector(bytesRefArray1, 0, blockFactory),
                 new BytesRefArrayVector(bytesRefArray2, 0, blockFactory),
-                BytesRefBlock.newConstantBlockWith(new BytesRef(), 0).asVector(),
-                BytesRefBlock.newConstantBlockWith(new BytesRef(), 0).filter().asVector(),
-                BytesRefBlock.newBlockBuilder(0).build().asVector(),
-                BytesRefBlock.newBlockBuilder(0).appendBytesRef(new BytesRef()).build().asVector().filter()
+                blockFactory.newConstantBytesRefBlockWith(new BytesRef(), 0).asVector(),
+                blockFactory.newConstantBytesRefBlockWith(new BytesRef(), 0).filter().asVector(),
+                blockFactory.newBytesRefBlockBuilder(0).build().asVector(),
+                blockFactory.newBytesRefBlockBuilder(0).appendBytesRef(new BytesRef()).build().asVector().filter()
             );
             assertAllEquals(vectors);
         }
@@ -59,10 +59,10 @@ public class BytesRefBlockEqualityTests extends ComputeTestCase {
                     randomFrom(Block.MvOrdering.values()),
                     blockFactory
                 ),
-                BytesRefBlock.newConstantBlockWith(new BytesRef(), 0),
-                BytesRefBlock.newBlockBuilder(0).build(),
-                BytesRefBlock.newBlockBuilder(0).appendBytesRef(new BytesRef()).build().filter(),
-                BytesRefBlock.newBlockBuilder(0).appendNull().build().filter()
+                blockFactory.newConstantBytesRefBlockWith(new BytesRef(), 0),
+                blockFactory.newBytesRefBlockBuilder(0).build(),
+                blockFactory.newBytesRefBlockBuilder(0).appendBytesRef(new BytesRef()).build().filter(),
+                blockFactory.newBytesRefBlockBuilder(0).appendNull().build().filter()
             );
             assertAllEquals(blocks);
         }
@@ -77,20 +77,20 @@ public class BytesRefBlockEqualityTests extends ComputeTestCase {
                 new BytesRefArrayVector(bytesRefArray2, 3, blockFactory),
                 new BytesRefArrayVector(bytesRefArray1, 3, blockFactory).filter(0, 1, 2),
                 new BytesRefArrayVector(bytesRefArray2, 4, blockFactory).filter(0, 1, 2),
-                BytesRefBlock.newBlockBuilder(3)
+                blockFactory.newBytesRefBlockBuilder(3)
                     .appendBytesRef(new BytesRef("1"))
                     .appendBytesRef(new BytesRef("2"))
                     .appendBytesRef(new BytesRef("3"))
                     .build()
                     .asVector(),
-                BytesRefBlock.newBlockBuilder(3)
+                blockFactory.newBytesRefBlockBuilder(3)
                     .appendBytesRef(new BytesRef("1"))
                     .appendBytesRef(new BytesRef("2"))
                     .appendBytesRef(new BytesRef("3"))
                     .build()
                     .asVector()
                     .filter(0, 1, 2),
-                BytesRefBlock.newBlockBuilder(3)
+                blockFactory.newBytesRefBlockBuilder(3)
                     .appendBytesRef(new BytesRef("1"))
                     .appendBytesRef(new BytesRef("4"))
                     .appendBytesRef(new BytesRef("2"))
@@ -98,7 +98,7 @@ public class BytesRefBlockEqualityTests extends ComputeTestCase {
                     .build()
                     .filter(0, 2, 3)
                     .asVector(),
-                BytesRefBlock.newBlockBuilder(3)
+                blockFactory.newBytesRefBlockBuilder(3)
                     .appendBytesRef(new BytesRef("1"))
                     .appendBytesRef(new BytesRef("4"))
                     .appendBytesRef(new BytesRef("2"))
@@ -118,21 +118,21 @@ public class BytesRefBlockEqualityTests extends ComputeTestCase {
                 new BytesRefArrayVector(bytesRefArray2, 3, blockFactory),
                 new BytesRefArrayVector(bytesRefArray1, 3, blockFactory).filter(0, 1, 2),
                 new BytesRefArrayVector(bytesRefArray2, 4, blockFactory).filter(0, 1, 2),
-                BytesRefBlock.newConstantBlockWith(new BytesRef("1"), 3).asVector(),
-                BytesRefBlock.newBlockBuilder(3)
+                blockFactory.newConstantBytesRefBlockWith(new BytesRef("1"), 3).asVector(),
+                blockFactory.newBytesRefBlockBuilder(3)
                     .appendBytesRef(new BytesRef("1"))
                     .appendBytesRef(new BytesRef("1"))
                     .appendBytesRef(new BytesRef("1"))
                     .build()
                     .asVector(),
-                BytesRefBlock.newBlockBuilder(3)
+                blockFactory.newBytesRefBlockBuilder(3)
                     .appendBytesRef(new BytesRef("1"))
                     .appendBytesRef(new BytesRef("1"))
                     .appendBytesRef(new BytesRef("1"))
                     .build()
                     .asVector()
                     .filter(0, 1, 2),
-                BytesRefBlock.newBlockBuilder(3)
+                blockFactory.newBytesRefBlockBuilder(3)
                     .appendBytesRef(new BytesRef("1"))
                     .appendBytesRef(new BytesRef("4"))
                     .appendBytesRef(new BytesRef("1"))
@@ -140,7 +140,7 @@ public class BytesRefBlockEqualityTests extends ComputeTestCase {
                     .build()
                     .filter(0, 2, 3)
                     .asVector(),
-                BytesRefBlock.newBlockBuilder(3)
+                blockFactory.newBytesRefBlockBuilder(3)
                     .appendBytesRef(new BytesRef("1"))
                     .appendBytesRef(new BytesRef("4"))
                     .appendBytesRef(new BytesRef("1"))
@@ -177,25 +177,25 @@ public class BytesRefBlockEqualityTests extends ComputeTestCase {
                 new BytesRefArrayVector(bytesRefArray1, 3, blockFactory).filter(0, 1, 2).asBlock(),
                 new BytesRefArrayVector(bytesRefArray2, 3, blockFactory).filter(0, 1, 2).asBlock(),
                 new BytesRefArrayVector(bytesRefArray2, 4, blockFactory).filter(0, 1, 2).asBlock(),
-                BytesRefBlock.newBlockBuilder(3)
+                blockFactory.newBytesRefBlockBuilder(3)
                     .appendBytesRef(new BytesRef("1"))
                     .appendBytesRef(new BytesRef("2"))
                     .appendBytesRef(new BytesRef("3"))
                     .build(),
-                BytesRefBlock.newBlockBuilder(3)
+                blockFactory.newBytesRefBlockBuilder(3)
                     .appendBytesRef(new BytesRef("1"))
                     .appendBytesRef(new BytesRef("2"))
                     .appendBytesRef(new BytesRef("3"))
                     .build()
                     .filter(0, 1, 2),
-                BytesRefBlock.newBlockBuilder(3)
+                blockFactory.newBytesRefBlockBuilder(3)
                     .appendBytesRef(new BytesRef("1"))
                     .appendBytesRef(new BytesRef("4"))
                     .appendBytesRef(new BytesRef("2"))
                     .appendBytesRef(new BytesRef("3"))
                     .build()
                     .filter(0, 2, 3),
-                BytesRefBlock.newBlockBuilder(3)
+                blockFactory.newBytesRefBlockBuilder(3)
                     .appendBytesRef(new BytesRef("1"))
                     .appendNull()
                     .appendBytesRef(new BytesRef("2"))
@@ -229,16 +229,20 @@ public class BytesRefBlockEqualityTests extends ComputeTestCase {
                 new BytesRefArrayVector(bytesRefArray1, 2, blockFactory).filter(0, 1).asBlock(),
                 new BytesRefArrayVector(bytesRefArray2, 2, blockFactory).filter(0, 1).asBlock(),
                 new BytesRefArrayVector(bytesRefArray2, 3, blockFactory).filter(0, 1).asBlock(),
-                BytesRefBlock.newConstantBlockWith(new BytesRef("9"), 2),
-                BytesRefBlock.newBlockBuilder(2).appendBytesRef(new BytesRef("9")).appendBytesRef(new BytesRef("9")).build(),
-                BytesRefBlock.newBlockBuilder(2).appendBytesRef(new BytesRef("9")).appendBytesRef(new BytesRef("9")).build().filter(0, 1),
-                BytesRefBlock.newBlockBuilder(2)
+                blockFactory.newConstantBytesRefBlockWith(new BytesRef("9"), 2),
+                blockFactory.newBytesRefBlockBuilder(2).appendBytesRef(new BytesRef("9")).appendBytesRef(new BytesRef("9")).build(),
+                blockFactory.newBytesRefBlockBuilder(2)
+                    .appendBytesRef(new BytesRef("9"))
+                    .appendBytesRef(new BytesRef("9"))
+                    .build()
+                    .filter(0, 1),
+                blockFactory.newBytesRefBlockBuilder(2)
                     .appendBytesRef(new BytesRef("9"))
                     .appendBytesRef(new BytesRef("4"))
                     .appendBytesRef(new BytesRef("9"))
                     .build()
                     .filter(0, 2),
-                BytesRefBlock.newBlockBuilder(2)
+                blockFactory.newBytesRefBlockBuilder(2)
                     .appendBytesRef(new BytesRef("9"))
                     .appendNull()
                     .appendBytesRef(new BytesRef("9"))
@@ -264,20 +268,20 @@ public class BytesRefBlockEqualityTests extends ComputeTestCase {
                 new BytesRefArrayVector(bytesRefArray3, 2, blockFactory),
                 new BytesRefArrayVector(bytesRefArray4, 3, blockFactory),
                 new BytesRefArrayVector(bytesRefArray5, 3, blockFactory),
-                BytesRefBlock.newConstantBlockWith(new BytesRef("9"), 2).asVector(),
-                BytesRefBlock.newBlockBuilder(2)
+                blockFactory.newConstantBytesRefBlockWith(new BytesRef("9"), 2).asVector(),
+                blockFactory.newBytesRefBlockBuilder(2)
                     .appendBytesRef(new BytesRef("1"))
                     .appendBytesRef(new BytesRef("2"))
                     .build()
                     .asVector()
                     .filter(1),
-                BytesRefBlock.newBlockBuilder(3)
+                blockFactory.newBytesRefBlockBuilder(3)
                     .appendBytesRef(new BytesRef("1"))
                     .appendBytesRef(new BytesRef("2"))
                     .appendBytesRef(new BytesRef("5"))
                     .build()
                     .asVector(),
-                BytesRefBlock.newBlockBuilder(1)
+                blockFactory.newBytesRefBlockBuilder(1)
                     .appendBytesRef(new BytesRef("1"))
                     .appendBytesRef(new BytesRef("2"))
                     .appendBytesRef(new BytesRef("3"))
@@ -304,22 +308,30 @@ public class BytesRefBlockEqualityTests extends ComputeTestCase {
                 new BytesRefArrayVector(bytesRefArray3, 2, blockFactory).asBlock(),
                 new BytesRefArrayVector(bytesRefArray4, 3, blockFactory).asBlock(),
                 new BytesRefArrayVector(bytesRefArray5, 3, blockFactory).asBlock(),
-                BytesRefBlock.newConstantBlockWith(new BytesRef("9"), 2),
-                BytesRefBlock.newBlockBuilder(2).appendBytesRef(new BytesRef("1")).appendBytesRef(new BytesRef("2")).build().filter(1),
-                BytesRefBlock.newBlockBuilder(3)
+                blockFactory.newConstantBytesRefBlockWith(new BytesRef("9"), 2),
+                blockFactory.newBytesRefBlockBuilder(2)
+                    .appendBytesRef(new BytesRef("1"))
+                    .appendBytesRef(new BytesRef("2"))
+                    .build()
+                    .filter(1),
+                blockFactory.newBytesRefBlockBuilder(3)
                     .appendBytesRef(new BytesRef("1"))
                     .appendBytesRef(new BytesRef("2"))
                     .appendBytesRef(new BytesRef("5"))
                     .build(),
-                BytesRefBlock.newBlockBuilder(1)
+                blockFactory.newBytesRefBlockBuilder(1)
                     .appendBytesRef(new BytesRef("1"))
                     .appendBytesRef(new BytesRef("2"))
                     .appendBytesRef(new BytesRef("3"))
                     .appendBytesRef(new BytesRef("4"))
                     .build(),
-                BytesRefBlock.newBlockBuilder(1).appendBytesRef(new BytesRef("1")).appendNull().build(),
-                BytesRefBlock.newBlockBuilder(1).appendBytesRef(new BytesRef("1")).appendNull().appendBytesRef(new BytesRef("3")).build(),
-                BytesRefBlock.newBlockBuilder(1).appendBytesRef(new BytesRef("1")).appendBytesRef(new BytesRef("3")).build()
+                blockFactory.newBytesRefBlockBuilder(1).appendBytesRef(new BytesRef("1")).appendNull().build(),
+                blockFactory.newBytesRefBlockBuilder(1)
+                    .appendBytesRef(new BytesRef("1"))
+                    .appendNull()
+                    .appendBytesRef(new BytesRef("3"))
+                    .build(),
+                blockFactory.newBytesRefBlockBuilder(1).appendBytesRef(new BytesRef("1")).appendBytesRef(new BytesRef("3")).build()
             );
             assertAllNotEquals(notEqualBlocks);
         }
@@ -327,8 +339,12 @@ public class BytesRefBlockEqualityTests extends ComputeTestCase {
 
     public void testSimpleBlockWithSingleNull() {
         List<BytesRefBlock> blocks = List.of(
-            BytesRefBlock.newBlockBuilder(3).appendBytesRef(new BytesRef("1")).appendNull().appendBytesRef(new BytesRef("3")).build(),
-            BytesRefBlock.newBlockBuilder(3).appendBytesRef(new BytesRef("1")).appendNull().appendBytesRef(new BytesRef("3")).build()
+            blockFactory.newBytesRefBlockBuilder(3)
+                .appendBytesRef(new BytesRef("1"))
+                .appendNull()
+                .appendBytesRef(new BytesRef("3"))
+                .build(),
+            blockFactory.newBytesRefBlockBuilder(3).appendBytesRef(new BytesRef("1")).appendNull().appendBytesRef(new BytesRef("3")).build()
         );
         assertEquals(3, blocks.get(0).getPositionCount());
         assertTrue(blocks.get(0).isNull(1));
@@ -338,8 +354,8 @@ public class BytesRefBlockEqualityTests extends ComputeTestCase {
     public void testSimpleBlockWithManyNulls() {
         int positions = randomIntBetween(1, 256);
         boolean grow = randomBoolean();
-        BytesRefBlock.Builder builder1 = BytesRefBlock.newBlockBuilder(grow ? 0 : positions);
-        BytesRefBlock.Builder builder2 = BytesRefBlock.newBlockBuilder(grow ? 0 : positions);
+        BytesRefBlock.Builder builder1 = blockFactory.newBytesRefBlockBuilder(grow ? 0 : positions);
+        BytesRefBlock.Builder builder2 = blockFactory.newBytesRefBlockBuilder(grow ? 0 : positions);
         for (int p = 0; p < positions; p++) {
             builder1.appendNull();
             builder2.appendNull();
@@ -356,12 +372,12 @@ public class BytesRefBlockEqualityTests extends ComputeTestCase {
 
     public void testSimpleBlockWithSingleMultiValue() {
         List<BytesRefBlock> blocks = List.of(
-            BytesRefBlock.newBlockBuilder(1)
+            blockFactory.newBytesRefBlockBuilder(1)
                 .beginPositionEntry()
                 .appendBytesRef(new BytesRef("1a"))
                 .appendBytesRef(new BytesRef("2b"))
                 .build(),
-            BytesRefBlock.newBlockBuilder(1)
+            blockFactory.newBytesRefBlockBuilder(1)
                 .beginPositionEntry()
                 .appendBytesRef(new BytesRef("1a"))
                 .appendBytesRef(new BytesRef("2b"))
@@ -375,9 +391,9 @@ public class BytesRefBlockEqualityTests extends ComputeTestCase {
     public void testSimpleBlockWithManyMultiValues() {
         int positions = randomIntBetween(1, 256);
         boolean grow = randomBoolean();
-        BytesRefBlock.Builder builder1 = BytesRefBlock.newBlockBuilder(grow ? 0 : positions);
-        BytesRefBlock.Builder builder2 = BytesRefBlock.newBlockBuilder(grow ? 0 : positions);
-        BytesRefBlock.Builder builder3 = BytesRefBlock.newBlockBuilder(grow ? 0 : positions);
+        BytesRefBlock.Builder builder1 = blockFactory.newBytesRefBlockBuilder(grow ? 0 : positions);
+        BytesRefBlock.Builder builder2 = blockFactory.newBytesRefBlockBuilder(grow ? 0 : positions);
+        BytesRefBlock.Builder builder3 = blockFactory.newBytesRefBlockBuilder(grow ? 0 : positions);
         for (int pos = 0; pos < positions; pos++) {
             builder1.beginPositionEntry();
             builder2.beginPositionEntry();

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/DocVectorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/DocVectorTests.java
@@ -36,20 +36,24 @@ public class DocVectorTests extends ComputeTestCase {
     }
 
     public void testNonDecreasingNonConstantShard() {
-        DocVector docs = new DocVector(intRange(0, 2), IntBlock.newConstantBlockWith(0, 2).asVector(), intRange(0, 2), null);
+        BlockFactory blockFactory = blockFactory();
+        DocVector docs = new DocVector(intRange(0, 2), blockFactory.newConstantIntVector(0, 2), intRange(0, 2), null);
         assertFalse(docs.singleSegmentNonDecreasing());
+        docs.close();
     }
 
     public void testNonDecreasingNonConstantSegment() {
-        DocVector docs = new DocVector(IntBlock.newConstantBlockWith(0, 2).asVector(), intRange(0, 2), intRange(0, 2), null);
+        BlockFactory blockFactory = blockFactory();
+        DocVector docs = new DocVector(blockFactory.newConstantIntVector(0, 2), intRange(0, 2), intRange(0, 2), null);
         assertFalse(docs.singleSegmentNonDecreasing());
+        docs.close();
     }
 
     public void testNonDecreasingDescendingDocs() {
         BlockFactory blockFactory = blockFactory();
         DocVector docs = new DocVector(
-            IntBlock.newConstantBlockWith(0, 2).asVector(),
-            IntBlock.newConstantBlockWith(0, 2).asVector(),
+            blockFactory.newConstantIntVector(0, 2),
+            blockFactory.newConstantIntVector(0, 2),
             blockFactory.newIntArrayVector(new int[] { 1, 0 }, 2),
             null
         );
@@ -137,7 +141,8 @@ public class DocVectorTests extends ComputeTestCase {
     }
 
     public void testCannotDoubleRelease() {
-        var block = new DocVector(intRange(0, 2), IntBlock.newConstantBlockWith(0, 2).asVector(), intRange(0, 2), null).asBlock();
+        BlockFactory blockFactory = blockFactory();
+        var block = new DocVector(intRange(0, 2), blockFactory.newConstantIntBlockWith(0, 2).asVector(), intRange(0, 2), null).asBlock();
         assertThat(block.isReleased(), is(false));
         Page page = new Page(block);
 
@@ -155,14 +160,16 @@ public class DocVectorTests extends ComputeTestCase {
     }
 
     public void testRamBytesUsedWithout() {
+        BlockFactory blockFactory = blockFactory();
         DocVector docs = new DocVector(
-            IntBlock.newConstantBlockWith(0, 1).asVector(),
-            IntBlock.newConstantBlockWith(0, 1).asVector(),
-            IntBlock.newConstantBlockWith(0, 1).asVector(),
+            blockFactory.newConstantIntBlockWith(0, 1).asVector(),
+            blockFactory.newConstantIntBlockWith(0, 1).asVector(),
+            blockFactory.newConstantIntBlockWith(0, 1).asVector(),
             false
         );
         assertThat(docs.singleSegmentNonDecreasing(), is(false));
         docs.ramBytesUsed(); // ensure non-singleSegmentNonDecreasing handles nulls in ramByteUsed
+        docs.close();
     }
 
     IntVector intRange(int startInclusive, int endExclusive) {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/DoubleBlockEqualityTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/DoubleBlockEqualityTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.compute.data;
 
 import org.elasticsearch.compute.operator.ComputeTestCase;
+import org.elasticsearch.core.Releasables;
 
 import java.util.BitSet;
 import java.util.List;
@@ -21,40 +22,38 @@ public class DoubleBlockEqualityTests extends ComputeTestCase {
         List<DoubleVector> vectors = List.of(
             blockFactory.newDoubleArrayVector(new double[] {}, 0),
             blockFactory.newDoubleArrayVector(new double[] { 0 }, 0),
-            DoubleBlock.newConstantBlockWith(0, 0).asVector(),
-            DoubleBlock.newConstantBlockWith(0, 0).filter().asVector(),
-            DoubleBlock.newBlockBuilder(0).build().asVector(),
-            DoubleBlock.newBlockBuilder(0).appendDouble(1).build().asVector().filter()
+            blockFactory.newConstantDoubleVector(0, 0),
+            blockFactory.newConstantDoubleBlockWith(0, 0).filter().asVector(),
+            blockFactory.newDoubleBlockBuilder(0).build().asVector(),
+            blockFactory.newDoubleBlockBuilder(0).appendDouble(1).build().asVector().filter()
         );
         assertAllEquals(vectors);
     }
 
     public void testEmptyBlock() {
-        BlockFactory blockFactory = blockFactory();
         // all these "empty" vectors should be equivalent
         List<DoubleBlock> blocks = List.of(
-            new DoubleArrayBlock(
+            blockFactory.newDoubleArrayBlock(
                 new double[] {},
                 0,
                 new int[] {},
                 BitSet.valueOf(new byte[] { 0b00 }),
-                randomFrom(Block.MvOrdering.values()),
-                blockFactory
+                randomFrom(Block.MvOrdering.values())
             ),
-            new DoubleArrayBlock(
+            blockFactory.newDoubleArrayBlock(
                 new double[] { 0 },
                 0,
                 new int[] {},
                 BitSet.valueOf(new byte[] { 0b00 }),
-                randomFrom(Block.MvOrdering.values()),
-                blockFactory
+                randomFrom(Block.MvOrdering.values())
             ),
-            DoubleBlock.newConstantBlockWith(0, 0),
-            DoubleBlock.newBlockBuilder(0).build(),
-            DoubleBlock.newBlockBuilder(0).appendDouble(1).build().filter(),
-            DoubleBlock.newBlockBuilder(0).appendNull().build().filter()
+            blockFactory.newConstantDoubleBlockWith(0, 0),
+            blockFactory.newDoubleBlockBuilder(0).build(),
+            blockFactory.newDoubleBlockBuilder(0).appendDouble(1).build().filter(),
+            blockFactory.newDoubleBlockBuilder(0).appendNull().build().filter()
         );
         assertAllEquals(blocks);
+        Releasables.close(blocks);
     }
 
     public void testVectorEquality() {
@@ -67,9 +66,9 @@ public class DoubleBlockEqualityTests extends ComputeTestCase {
             blockFactory.newDoubleArrayVector(new double[] { 1, 2, 3, 4 }, 4).filter(0, 1, 2),
             blockFactory.newDoubleArrayVector(new double[] { 0, 1, 2, 3 }, 4).filter(1, 2, 3),
             blockFactory.newDoubleArrayVector(new double[] { 1, 4, 2, 3 }, 4).filter(0, 2, 3),
-            DoubleBlock.newBlockBuilder(3).appendDouble(1).appendDouble(2).appendDouble(3).build().asVector(),
-            DoubleBlock.newBlockBuilder(3).appendDouble(1).appendDouble(2).appendDouble(3).build().asVector().filter(0, 1, 2),
-            DoubleBlock.newBlockBuilder(3)
+            blockFactory.newDoubleBlockBuilder(3).appendDouble(1).appendDouble(2).appendDouble(3).build().asVector(),
+            blockFactory.newDoubleBlockBuilder(3).appendDouble(1).appendDouble(2).appendDouble(3).build().asVector().filter(0, 1, 2),
+            blockFactory.newDoubleBlockBuilder(3)
                 .appendDouble(1)
                 .appendDouble(4)
                 .appendDouble(2)
@@ -77,7 +76,7 @@ public class DoubleBlockEqualityTests extends ComputeTestCase {
                 .build()
                 .filter(0, 2, 3)
                 .asVector(),
-            DoubleBlock.newBlockBuilder(3)
+            blockFactory.newDoubleBlockBuilder(3)
                 .appendDouble(1)
                 .appendDouble(4)
                 .appendDouble(2)
@@ -97,10 +96,10 @@ public class DoubleBlockEqualityTests extends ComputeTestCase {
             blockFactory.newDoubleArrayVector(new double[] { 1, 1, 1, 4 }, 4).filter(0, 1, 2),
             blockFactory.newDoubleArrayVector(new double[] { 3, 1, 1, 1 }, 4).filter(1, 2, 3),
             blockFactory.newDoubleArrayVector(new double[] { 1, 4, 1, 1 }, 4).filter(0, 2, 3),
-            DoubleBlock.newConstantBlockWith(1, 3).asVector(),
-            DoubleBlock.newBlockBuilder(3).appendDouble(1).appendDouble(1).appendDouble(1).build().asVector(),
-            DoubleBlock.newBlockBuilder(3).appendDouble(1).appendDouble(1).appendDouble(1).build().asVector().filter(0, 1, 2),
-            DoubleBlock.newBlockBuilder(3)
+            blockFactory.newConstantDoubleBlockWith(1, 3).asVector(),
+            blockFactory.newDoubleBlockBuilder(3).appendDouble(1).appendDouble(1).appendDouble(1).build().asVector(),
+            blockFactory.newDoubleBlockBuilder(3).appendDouble(1).appendDouble(1).appendDouble(1).build().asVector().filter(0, 1, 2),
+            blockFactory.newDoubleBlockBuilder(3)
                 .appendDouble(1)
                 .appendDouble(4)
                 .appendDouble(1)
@@ -108,7 +107,7 @@ public class DoubleBlockEqualityTests extends ComputeTestCase {
                 .build()
                 .filter(0, 2, 3)
                 .asVector(),
-            DoubleBlock.newBlockBuilder(3)
+            blockFactory.newDoubleBlockBuilder(3)
                 .appendDouble(1)
                 .appendDouble(4)
                 .appendDouble(1)
@@ -144,10 +143,10 @@ public class DoubleBlockEqualityTests extends ComputeTestCase {
             blockFactory.newDoubleArrayVector(new double[] { 1, 2, 3, 4 }, 3).filter(0, 1, 2).asBlock(),
             blockFactory.newDoubleArrayVector(new double[] { 1, 2, 3, 4 }, 4).filter(0, 1, 2).asBlock(),
             blockFactory.newDoubleArrayVector(new double[] { 1, 2, 4, 3 }, 4).filter(0, 1, 3).asBlock(),
-            DoubleBlock.newBlockBuilder(3).appendDouble(1).appendDouble(2).appendDouble(3).build(),
-            DoubleBlock.newBlockBuilder(3).appendDouble(1).appendDouble(2).appendDouble(3).build().filter(0, 1, 2),
-            DoubleBlock.newBlockBuilder(3).appendDouble(1).appendDouble(4).appendDouble(2).appendDouble(3).build().filter(0, 2, 3),
-            DoubleBlock.newBlockBuilder(3).appendDouble(1).appendNull().appendDouble(2).appendDouble(3).build().filter(0, 2, 3)
+            blockFactory.newDoubleBlockBuilder(3).appendDouble(1).appendDouble(2).appendDouble(3).build(),
+            blockFactory.newDoubleBlockBuilder(3).appendDouble(1).appendDouble(2).appendDouble(3).build().filter(0, 1, 2),
+            blockFactory.newDoubleBlockBuilder(3).appendDouble(1).appendDouble(4).appendDouble(2).appendDouble(3).build().filter(0, 2, 3),
+            blockFactory.newDoubleBlockBuilder(3).appendDouble(1).appendNull().appendDouble(2).appendDouble(3).build().filter(0, 2, 3)
         );
         assertAllEquals(blocks);
 
@@ -174,11 +173,11 @@ public class DoubleBlockEqualityTests extends ComputeTestCase {
             blockFactory.newDoubleArrayVector(new double[] { 9, 9, 4 }, 2).filter(0, 1).asBlock(),
             blockFactory.newDoubleArrayVector(new double[] { 9, 9, 4 }, 3).filter(0, 1).asBlock(),
             blockFactory.newDoubleArrayVector(new double[] { 9, 4, 9 }, 3).filter(0, 2).asBlock(),
-            DoubleBlock.newConstantBlockWith(9, 2),
-            DoubleBlock.newBlockBuilder(2).appendDouble(9).appendDouble(9).build(),
-            DoubleBlock.newBlockBuilder(2).appendDouble(9).appendDouble(9).build().filter(0, 1),
-            DoubleBlock.newBlockBuilder(2).appendDouble(9).appendDouble(4).appendDouble(9).build().filter(0, 2),
-            DoubleBlock.newBlockBuilder(2).appendDouble(9).appendNull().appendDouble(9).build().filter(0, 2)
+            blockFactory.newConstantDoubleBlockWith(9, 2),
+            blockFactory.newDoubleBlockBuilder(2).appendDouble(9).appendDouble(9).build(),
+            blockFactory.newDoubleBlockBuilder(2).appendDouble(9).appendDouble(9).build().filter(0, 1),
+            blockFactory.newDoubleBlockBuilder(2).appendDouble(9).appendDouble(4).appendDouble(9).build().filter(0, 2),
+            blockFactory.newDoubleBlockBuilder(2).appendDouble(9).appendNull().appendDouble(9).build().filter(0, 2)
         );
         assertAllEquals(moreBlocks);
     }
@@ -191,10 +190,10 @@ public class DoubleBlockEqualityTests extends ComputeTestCase {
             blockFactory.newDoubleArrayVector(new double[] { 1, 2 }, 2),
             blockFactory.newDoubleArrayVector(new double[] { 1, 2, 3 }, 3),
             blockFactory.newDoubleArrayVector(new double[] { 1, 2, 4 }, 3),
-            DoubleBlock.newConstantBlockWith(9, 2).asVector(),
-            DoubleBlock.newBlockBuilder(2).appendDouble(1).appendDouble(2).build().asVector().filter(1),
-            DoubleBlock.newBlockBuilder(3).appendDouble(1).appendDouble(2).appendDouble(5).build().asVector(),
-            DoubleBlock.newBlockBuilder(1).appendDouble(1).appendDouble(2).appendDouble(3).appendDouble(4).build().asVector()
+            blockFactory.newConstantDoubleBlockWith(9, 2).asVector(),
+            blockFactory.newDoubleBlockBuilder(2).appendDouble(1).appendDouble(2).build().asVector().filter(1),
+            blockFactory.newDoubleBlockBuilder(3).appendDouble(1).appendDouble(2).appendDouble(5).build().asVector(),
+            blockFactory.newDoubleBlockBuilder(1).appendDouble(1).appendDouble(2).appendDouble(3).appendDouble(4).build().asVector()
         );
         assertAllNotEquals(notEqualVectors);
     }
@@ -207,22 +206,22 @@ public class DoubleBlockEqualityTests extends ComputeTestCase {
             blockFactory.newDoubleArrayVector(new double[] { 1, 2 }, 2).asBlock(),
             blockFactory.newDoubleArrayVector(new double[] { 1, 2, 3 }, 3).asBlock(),
             blockFactory.newDoubleArrayVector(new double[] { 1, 2, 4 }, 3).asBlock(),
-            DoubleBlock.newConstantBlockWith(9, 2),
-            DoubleBlock.newBlockBuilder(2).appendDouble(1).appendDouble(2).build().filter(1),
-            DoubleBlock.newBlockBuilder(3).appendDouble(1).appendDouble(2).appendDouble(5).build(),
-            DoubleBlock.newBlockBuilder(1).appendDouble(1).appendDouble(2).appendDouble(3).appendDouble(4).build(),
-            DoubleBlock.newBlockBuilder(1).appendDouble(1).appendNull().build(),
-            DoubleBlock.newBlockBuilder(1).appendDouble(1).appendNull().appendDouble(3).build(),
-            DoubleBlock.newBlockBuilder(1).appendDouble(1).appendDouble(3).build(),
-            DoubleBlock.newBlockBuilder(3).appendDouble(1).beginPositionEntry().appendDouble(2).appendDouble(3).build()
+            blockFactory.newConstantDoubleBlockWith(9, 2),
+            blockFactory.newDoubleBlockBuilder(2).appendDouble(1).appendDouble(2).build().filter(1),
+            blockFactory.newDoubleBlockBuilder(3).appendDouble(1).appendDouble(2).appendDouble(5).build(),
+            blockFactory.newDoubleBlockBuilder(1).appendDouble(1).appendDouble(2).appendDouble(3).appendDouble(4).build(),
+            blockFactory.newDoubleBlockBuilder(1).appendDouble(1).appendNull().build(),
+            blockFactory.newDoubleBlockBuilder(1).appendDouble(1).appendNull().appendDouble(3).build(),
+            blockFactory.newDoubleBlockBuilder(1).appendDouble(1).appendDouble(3).build(),
+            blockFactory.newDoubleBlockBuilder(3).appendDouble(1).beginPositionEntry().appendDouble(2).appendDouble(3).build()
         );
         assertAllNotEquals(notEqualBlocks);
     }
 
     public void testSimpleBlockWithSingleNull() {
         List<DoubleBlock> blocks = List.of(
-            DoubleBlock.newBlockBuilder(3).appendDouble(1.1).appendNull().appendDouble(3.1).build(),
-            DoubleBlock.newBlockBuilder(3).appendDouble(1.1).appendNull().appendDouble(3.1).build()
+            blockFactory.newDoubleBlockBuilder(3).appendDouble(1.1).appendNull().appendDouble(3.1).build(),
+            blockFactory.newDoubleBlockBuilder(3).appendDouble(1.1).appendNull().appendDouble(3.1).build()
         );
         assertEquals(3, blocks.get(0).getPositionCount());
         assertTrue(blocks.get(0).isNull(1));
@@ -232,8 +231,8 @@ public class DoubleBlockEqualityTests extends ComputeTestCase {
     public void testSimpleBlockWithManyNulls() {
         int positions = randomIntBetween(1, 256);
         boolean grow = randomBoolean();
-        DoubleBlock.Builder builder1 = DoubleBlock.newBlockBuilder(grow ? 0 : positions);
-        DoubleBlock.Builder builder2 = DoubleBlock.newBlockBuilder(grow ? 0 : positions);
+        DoubleBlock.Builder builder1 = blockFactory.newDoubleBlockBuilder(grow ? 0 : positions);
+        DoubleBlock.Builder builder2 = blockFactory.newDoubleBlockBuilder(grow ? 0 : positions);
         for (int p = 0; p < positions; p++) {
             builder1.appendNull();
             builder2.appendNull();
@@ -250,8 +249,8 @@ public class DoubleBlockEqualityTests extends ComputeTestCase {
 
     public void testSimpleBlockWithSingleMultiValue() {
         List<DoubleBlock> blocks = List.of(
-            DoubleBlock.newBlockBuilder(1).beginPositionEntry().appendDouble(1.1).appendDouble(2.2).build(),
-            DoubleBlock.newBlockBuilder(1).beginPositionEntry().appendDouble(1.1).appendDouble(2.2).build()
+            blockFactory.newDoubleBlockBuilder(1).beginPositionEntry().appendDouble(1.1).appendDouble(2.2).build(),
+            blockFactory.newDoubleBlockBuilder(1).beginPositionEntry().appendDouble(1.1).appendDouble(2.2).build()
         );
         assert blocks.get(0).getPositionCount() == 1 && blocks.get(0).getValueCount(0) == 2;
         assertAllEquals(blocks);
@@ -260,9 +259,9 @@ public class DoubleBlockEqualityTests extends ComputeTestCase {
     public void testSimpleBlockWithManyMultiValues() {
         int positions = randomIntBetween(1, 256);
         boolean grow = randomBoolean();
-        DoubleBlock.Builder builder1 = DoubleBlock.newBlockBuilder(grow ? 0 : positions);
-        DoubleBlock.Builder builder2 = DoubleBlock.newBlockBuilder(grow ? 0 : positions);
-        DoubleBlock.Builder builder3 = DoubleBlock.newBlockBuilder(grow ? 0 : positions);
+        DoubleBlock.Builder builder1 = blockFactory.newDoubleBlockBuilder(grow ? 0 : positions);
+        DoubleBlock.Builder builder2 = blockFactory.newDoubleBlockBuilder(grow ? 0 : positions);
+        DoubleBlock.Builder builder3 = blockFactory.newDoubleBlockBuilder(grow ? 0 : positions);
         for (int pos = 0; pos < positions; pos++) {
             builder1.beginPositionEntry();
             builder2.beginPositionEntry();

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/IntBlockEqualityTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/IntBlockEqualityTests.java
@@ -21,10 +21,10 @@ public class IntBlockEqualityTests extends ComputeTestCase {
         List<IntVector> vectors = List.of(
             blockFactory.newIntArrayVector(new int[] {}, 0),
             blockFactory.newIntArrayVector(new int[] { 0 }, 0),
-            IntBlock.newConstantBlockWith(0, 0).asVector(),
-            IntBlock.newConstantBlockWith(0, 0).filter().asVector(),
-            IntBlock.newBlockBuilder(0).build().asVector(),
-            IntBlock.newBlockBuilder(0).appendInt(1).build().asVector().filter()
+            blockFactory.newConstantIntVector(0, 0),
+            blockFactory.newConstantIntVector(0, 0).filter(),
+            blockFactory.newIntBlockBuilder(0).build().asVector(),
+            blockFactory.newIntBlockBuilder(0).appendInt(1).build().asVector().filter()
         );
         assertAllEquals(vectors);
     }
@@ -46,10 +46,10 @@ public class IntBlockEqualityTests extends ComputeTestCase {
                 BitSet.valueOf(new byte[] { 0b00 }),
                 randomFrom(Block.MvOrdering.values())
             ),
-            IntBlock.newConstantBlockWith(0, 0),
-            IntBlock.newBlockBuilder(0).build(),
-            IntBlock.newBlockBuilder(0).appendInt(1).build().filter(),
-            IntBlock.newBlockBuilder(0).appendNull().build().filter()
+            blockFactory.newConstantIntBlockWith(0, 0),
+            blockFactory.newIntBlockBuilder(0).build(),
+            blockFactory.newIntBlockBuilder(0).appendInt(1).build().filter(),
+            blockFactory.newIntBlockBuilder(0).appendNull().build().filter()
         );
         assertAllEquals(blocks);
     }
@@ -64,10 +64,10 @@ public class IntBlockEqualityTests extends ComputeTestCase {
             blockFactory.newIntArrayVector(new int[] { 1, 2, 3, 4 }, 4).filter(0, 1, 2),
             blockFactory.newIntArrayVector(new int[] { 0, 1, 2, 3 }, 4).filter(1, 2, 3),
             blockFactory.newIntArrayVector(new int[] { 1, 4, 2, 3 }, 4).filter(0, 2, 3),
-            IntBlock.newBlockBuilder(3).appendInt(1).appendInt(2).appendInt(3).build().asVector(),
-            IntBlock.newBlockBuilder(3).appendInt(1).appendInt(2).appendInt(3).build().asVector().filter(0, 1, 2),
-            IntBlock.newBlockBuilder(3).appendInt(1).appendInt(4).appendInt(2).appendInt(3).build().filter(0, 2, 3).asVector(),
-            IntBlock.newBlockBuilder(3).appendInt(1).appendInt(4).appendInt(2).appendInt(3).build().asVector().filter(0, 2, 3)
+            blockFactory.newIntBlockBuilder(3).appendInt(1).appendInt(2).appendInt(3).build().asVector(),
+            blockFactory.newIntBlockBuilder(3).appendInt(1).appendInt(2).appendInt(3).build().asVector().filter(0, 1, 2),
+            blockFactory.newIntBlockBuilder(3).appendInt(1).appendInt(4).appendInt(2).appendInt(3).build().filter(0, 2, 3).asVector(),
+            blockFactory.newIntBlockBuilder(3).appendInt(1).appendInt(4).appendInt(2).appendInt(3).build().asVector().filter(0, 2, 3)
         );
         assertAllEquals(vectors);
 
@@ -80,11 +80,11 @@ public class IntBlockEqualityTests extends ComputeTestCase {
             blockFactory.newIntArrayVector(new int[] { 1, 1, 1, 4 }, 4).filter(0, 1, 2),
             blockFactory.newIntArrayVector(new int[] { 3, 1, 1, 1 }, 4).filter(1, 2, 3),
             blockFactory.newIntArrayVector(new int[] { 1, 4, 1, 1 }, 4).filter(0, 2, 3),
-            IntBlock.newConstantBlockWith(1, 3).asVector(),
-            IntBlock.newBlockBuilder(3).appendInt(1).appendInt(1).appendInt(1).build().asVector(),
-            IntBlock.newBlockBuilder(3).appendInt(1).appendInt(1).appendInt(1).build().asVector().filter(0, 1, 2),
-            IntBlock.newBlockBuilder(3).appendInt(1).appendInt(4).appendInt(1).appendInt(1).build().filter(0, 2, 3).asVector(),
-            IntBlock.newBlockBuilder(3).appendInt(1).appendInt(4).appendInt(1).appendInt(1).build().asVector().filter(0, 2, 3)
+            blockFactory.newConstantIntBlockWith(1, 3).asVector(),
+            blockFactory.newIntBlockBuilder(3).appendInt(1).appendInt(1).appendInt(1).build().asVector(),
+            blockFactory.newIntBlockBuilder(3).appendInt(1).appendInt(1).appendInt(1).build().asVector().filter(0, 1, 2),
+            blockFactory.newIntBlockBuilder(3).appendInt(1).appendInt(4).appendInt(1).appendInt(1).build().filter(0, 2, 3).asVector(),
+            blockFactory.newIntBlockBuilder(3).appendInt(1).appendInt(4).appendInt(1).appendInt(1).build().asVector().filter(0, 2, 3)
         );
         assertAllEquals(moreVectors);
     }
@@ -113,10 +113,10 @@ public class IntBlockEqualityTests extends ComputeTestCase {
             new IntArrayVector(new int[] { 1, 2, 3, 4 }, 3, blockFactory).filter(0, 1, 2).asBlock(),
             new IntArrayVector(new int[] { 1, 2, 3, 4 }, 4, blockFactory).filter(0, 1, 2).asBlock(),
             new IntArrayVector(new int[] { 1, 2, 4, 3 }, 4, blockFactory).filter(0, 1, 3).asBlock(),
-            IntBlock.newBlockBuilder(3).appendInt(1).appendInt(2).appendInt(3).build(),
-            IntBlock.newBlockBuilder(3).appendInt(1).appendInt(2).appendInt(3).build().filter(0, 1, 2),
-            IntBlock.newBlockBuilder(3).appendInt(1).appendInt(4).appendInt(2).appendInt(3).build().filter(0, 2, 3),
-            IntBlock.newBlockBuilder(3).appendInt(1).appendNull().appendInt(2).appendInt(3).build().filter(0, 2, 3)
+            blockFactory.newIntBlockBuilder(3).appendInt(1).appendInt(2).appendInt(3).build(),
+            blockFactory.newIntBlockBuilder(3).appendInt(1).appendInt(2).appendInt(3).build().filter(0, 1, 2),
+            blockFactory.newIntBlockBuilder(3).appendInt(1).appendInt(4).appendInt(2).appendInt(3).build().filter(0, 2, 3),
+            blockFactory.newIntBlockBuilder(3).appendInt(1).appendNull().appendInt(2).appendInt(3).build().filter(0, 2, 3)
         );
         assertAllEquals(blocks);
 
@@ -141,11 +141,11 @@ public class IntBlockEqualityTests extends ComputeTestCase {
             blockFactory.newIntArrayVector(new int[] { 9, 9, 4 }, 2).filter(0, 1).asBlock(),
             blockFactory.newIntArrayVector(new int[] { 9, 9, 4 }, 3).filter(0, 1).asBlock(),
             blockFactory.newIntArrayVector(new int[] { 9, 4, 9 }, 3).filter(0, 2).asBlock(),
-            IntBlock.newConstantBlockWith(9, 2),
-            IntBlock.newBlockBuilder(2).appendInt(9).appendInt(9).build(),
-            IntBlock.newBlockBuilder(2).appendInt(9).appendInt(9).build().filter(0, 1),
-            IntBlock.newBlockBuilder(2).appendInt(9).appendInt(4).appendInt(9).build().filter(0, 2),
-            IntBlock.newBlockBuilder(2).appendInt(9).appendNull().appendInt(9).build().filter(0, 2)
+            blockFactory.newConstantIntBlockWith(9, 2),
+            blockFactory.newIntBlockBuilder(2).appendInt(9).appendInt(9).build(),
+            blockFactory.newIntBlockBuilder(2).appendInt(9).appendInt(9).build().filter(0, 1),
+            blockFactory.newIntBlockBuilder(2).appendInt(9).appendInt(4).appendInt(9).build().filter(0, 2),
+            blockFactory.newIntBlockBuilder(2).appendInt(9).appendNull().appendInt(9).build().filter(0, 2)
         );
         assertAllEquals(moreBlocks);
     }
@@ -158,10 +158,10 @@ public class IntBlockEqualityTests extends ComputeTestCase {
             blockFactory.newIntArrayVector(new int[] { 1, 2 }, 2),
             blockFactory.newIntArrayVector(new int[] { 1, 2, 3 }, 3),
             blockFactory.newIntArrayVector(new int[] { 1, 2, 4 }, 3),
-            IntBlock.newConstantBlockWith(9, 2).asVector(),
-            IntBlock.newBlockBuilder(2).appendInt(1).appendInt(2).build().asVector().filter(1),
-            IntBlock.newBlockBuilder(3).appendInt(1).appendInt(2).appendInt(5).build().asVector(),
-            IntBlock.newBlockBuilder(1).appendInt(1).appendInt(2).appendInt(3).appendInt(4).build().asVector()
+            blockFactory.newConstantIntBlockWith(9, 2).asVector(),
+            blockFactory.newIntBlockBuilder(2).appendInt(1).appendInt(2).build().asVector().filter(1),
+            blockFactory.newIntBlockBuilder(3).appendInt(1).appendInt(2).appendInt(5).build().asVector(),
+            blockFactory.newIntBlockBuilder(1).appendInt(1).appendInt(2).appendInt(3).appendInt(4).build().asVector()
         );
         assertAllNotEquals(notEqualVectors);
     }
@@ -174,22 +174,22 @@ public class IntBlockEqualityTests extends ComputeTestCase {
             blockFactory.newIntArrayVector(new int[] { 1, 2 }, 2).asBlock(),
             blockFactory.newIntArrayVector(new int[] { 1, 2, 3 }, 3).asBlock(),
             blockFactory.newIntArrayVector(new int[] { 1, 2, 4 }, 3).asBlock(),
-            IntBlock.newConstantBlockWith(9, 2),
-            IntBlock.newBlockBuilder(2).appendInt(1).appendInt(2).build().filter(1),
-            IntBlock.newBlockBuilder(3).appendInt(1).appendInt(2).appendInt(5).build(),
-            IntBlock.newBlockBuilder(1).appendInt(1).appendInt(2).appendInt(3).appendInt(4).build(),
-            IntBlock.newBlockBuilder(1).appendInt(1).appendNull().build(),
-            IntBlock.newBlockBuilder(1).appendInt(1).appendNull().appendInt(3).build(),
-            IntBlock.newBlockBuilder(1).appendInt(1).appendInt(3).build(),
-            IntBlock.newBlockBuilder(3).appendInt(1).beginPositionEntry().appendInt(2).appendInt(3).build()
+            blockFactory.newConstantIntBlockWith(9, 2),
+            blockFactory.newIntBlockBuilder(2).appendInt(1).appendInt(2).build().filter(1),
+            blockFactory.newIntBlockBuilder(3).appendInt(1).appendInt(2).appendInt(5).build(),
+            blockFactory.newIntBlockBuilder(1).appendInt(1).appendInt(2).appendInt(3).appendInt(4).build(),
+            blockFactory.newIntBlockBuilder(1).appendInt(1).appendNull().build(),
+            blockFactory.newIntBlockBuilder(1).appendInt(1).appendNull().appendInt(3).build(),
+            blockFactory.newIntBlockBuilder(1).appendInt(1).appendInt(3).build(),
+            blockFactory.newIntBlockBuilder(3).appendInt(1).beginPositionEntry().appendInt(2).appendInt(3).build()
         );
         assertAllNotEquals(notEqualBlocks);
     }
 
     public void testSimpleBlockWithSingleNull() {
         List<IntBlock> blocks = List.of(
-            IntBlock.newBlockBuilder(1).appendInt(1).appendNull().appendInt(3).build(),
-            IntBlock.newBlockBuilder(1).appendInt(1).appendNull().appendInt(3).build()
+            blockFactory.newIntBlockBuilder(1).appendInt(1).appendNull().appendInt(3).build(),
+            blockFactory.newIntBlockBuilder(1).appendInt(1).appendNull().appendInt(3).build()
         );
         assertEquals(3, blocks.get(0).getPositionCount());
         assertTrue(blocks.get(0).isNull(1));
@@ -200,8 +200,8 @@ public class IntBlockEqualityTests extends ComputeTestCase {
     public void testSimpleBlockWithManyNulls() {
         int positions = randomIntBetween(1, 256);
         boolean grow = randomBoolean();
-        IntBlock.Builder builder1 = IntBlock.newBlockBuilder(grow ? 0 : positions);
-        IntBlock.Builder builder2 = IntBlock.newBlockBuilder(grow ? 0 : positions);
+        IntBlock.Builder builder1 = blockFactory.newIntBlockBuilder(grow ? 0 : positions);
+        IntBlock.Builder builder2 = blockFactory.newIntBlockBuilder(grow ? 0 : positions);
         for (int p = 0; p < positions; p++) {
             builder1.appendNull();
             builder2.appendNull();
@@ -218,8 +218,8 @@ public class IntBlockEqualityTests extends ComputeTestCase {
 
     public void testSimpleBlockWithSingleMultiValue() {
         List<IntBlock> blocks = List.of(
-            IntBlock.newBlockBuilder(1).beginPositionEntry().appendInt(1).appendInt(2).build(),
-            IntBlock.newBlockBuilder(1).beginPositionEntry().appendInt(1).appendInt(2).build()
+            blockFactory.newIntBlockBuilder(1).beginPositionEntry().appendInt(1).appendInt(2).build(),
+            blockFactory.newIntBlockBuilder(1).beginPositionEntry().appendInt(1).appendInt(2).build()
         );
         assertEquals(1, blocks.get(0).getPositionCount());
         assertEquals(2, blocks.get(0).getValueCount(0));
@@ -229,9 +229,9 @@ public class IntBlockEqualityTests extends ComputeTestCase {
     public void testSimpleBlockWithManyMultiValues() {
         int positions = randomIntBetween(1, 256);
         boolean grow = randomBoolean();
-        IntBlock.Builder builder1 = IntBlock.newBlockBuilder(grow ? 0 : positions);
-        IntBlock.Builder builder2 = IntBlock.newBlockBuilder(grow ? 0 : positions);
-        IntBlock.Builder builder3 = IntBlock.newBlockBuilder(grow ? 0 : positions);
+        IntBlock.Builder builder1 = blockFactory.newIntBlockBuilder(grow ? 0 : positions);
+        IntBlock.Builder builder2 = blockFactory.newIntBlockBuilder(grow ? 0 : positions);
+        IntBlock.Builder builder3 = blockFactory.newIntBlockBuilder(grow ? 0 : positions);
         for (int pos = 0; pos < positions; pos++) {
             builder1.beginPositionEntry();
             builder2.beginPositionEntry();

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/LongBlockEqualityTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/LongBlockEqualityTests.java
@@ -21,10 +21,10 @@ public class LongBlockEqualityTests extends ComputeTestCase {
         List<LongVector> vectors = List.of(
             blockFactory.newLongArrayVector(new long[] {}, 0),
             blockFactory.newLongArrayVector(new long[] { 0 }, 0),
-            LongBlock.newConstantBlockWith(0, 0).asVector(),
-            LongBlock.newConstantBlockWith(0, 0).filter().asVector(),
-            LongBlock.newBlockBuilder(0).build().asVector(),
-            LongBlock.newBlockBuilder(0).appendLong(1).build().asVector().filter()
+            blockFactory.newConstantLongBlockWith(0, 0).asVector(),
+            blockFactory.newConstantLongBlockWith(0, 0).filter().asVector(),
+            blockFactory.newLongBlockBuilder(0).build().asVector(),
+            blockFactory.newLongBlockBuilder(0).appendLong(1).build().asVector().filter()
         );
         assertAllEquals(vectors);
     }
@@ -46,10 +46,10 @@ public class LongBlockEqualityTests extends ComputeTestCase {
                 BitSet.valueOf(new byte[] { 0b00 }),
                 randomFrom(Block.MvOrdering.values())
             ),
-            LongBlock.newConstantBlockWith(0, 0),
-            LongBlock.newBlockBuilder(0).build(),
-            LongBlock.newBlockBuilder(0).appendLong(1).build().filter(),
-            LongBlock.newBlockBuilder(0).appendNull().build().filter()
+            blockFactory.newConstantLongBlockWith(0, 0),
+            blockFactory.newLongBlockBuilder(0).build(),
+            blockFactory.newLongBlockBuilder(0).appendLong(1).build().filter(),
+            blockFactory.newLongBlockBuilder(0).appendNull().build().filter()
         );
         assertAllEquals(blocks);
     }
@@ -64,10 +64,10 @@ public class LongBlockEqualityTests extends ComputeTestCase {
             blockFactory.newLongArrayVector(new long[] { 1, 2, 3, 4 }, 4).filter(0, 1, 2),
             blockFactory.newLongArrayVector(new long[] { 0, 1, 2, 3 }, 4).filter(1, 2, 3),
             blockFactory.newLongArrayVector(new long[] { 1, 4, 2, 3 }, 4).filter(0, 2, 3),
-            LongBlock.newBlockBuilder(3).appendLong(1).appendLong(2).appendLong(3).build().asVector(),
-            LongBlock.newBlockBuilder(3).appendLong(1).appendLong(2).appendLong(3).build().asVector().filter(0, 1, 2),
-            LongBlock.newBlockBuilder(3).appendLong(1).appendLong(4).appendLong(2).appendLong(3).build().filter(0, 2, 3).asVector(),
-            LongBlock.newBlockBuilder(3).appendLong(1).appendLong(4).appendLong(2).appendLong(3).build().asVector().filter(0, 2, 3)
+            blockFactory.newLongBlockBuilder(3).appendLong(1).appendLong(2).appendLong(3).build().asVector(),
+            blockFactory.newLongBlockBuilder(3).appendLong(1).appendLong(2).appendLong(3).build().asVector().filter(0, 1, 2),
+            blockFactory.newLongBlockBuilder(3).appendLong(1).appendLong(4).appendLong(2).appendLong(3).build().filter(0, 2, 3).asVector(),
+            blockFactory.newLongBlockBuilder(3).appendLong(1).appendLong(4).appendLong(2).appendLong(3).build().asVector().filter(0, 2, 3)
         );
         assertAllEquals(vectors);
 
@@ -80,11 +80,11 @@ public class LongBlockEqualityTests extends ComputeTestCase {
             blockFactory.newLongArrayVector(new long[] { 1, 1, 1, 4 }, 4).filter(0, 1, 2),
             blockFactory.newLongArrayVector(new long[] { 3, 1, 1, 1 }, 4).filter(1, 2, 3),
             blockFactory.newLongArrayVector(new long[] { 1, 4, 1, 1 }, 4).filter(0, 2, 3),
-            LongBlock.newConstantBlockWith(1, 3).asVector(),
-            LongBlock.newBlockBuilder(3).appendLong(1).appendLong(1).appendLong(1).build().asVector(),
-            LongBlock.newBlockBuilder(3).appendLong(1).appendLong(1).appendLong(1).build().asVector().filter(0, 1, 2),
-            LongBlock.newBlockBuilder(3).appendLong(1).appendLong(4).appendLong(1).appendLong(1).build().filter(0, 2, 3).asVector(),
-            LongBlock.newBlockBuilder(3).appendLong(1).appendLong(4).appendLong(1).appendLong(1).build().asVector().filter(0, 2, 3)
+            blockFactory.newConstantLongBlockWith(1, 3).asVector(),
+            blockFactory.newLongBlockBuilder(3).appendLong(1).appendLong(1).appendLong(1).build().asVector(),
+            blockFactory.newLongBlockBuilder(3).appendLong(1).appendLong(1).appendLong(1).build().asVector().filter(0, 1, 2),
+            blockFactory.newLongBlockBuilder(3).appendLong(1).appendLong(4).appendLong(1).appendLong(1).build().filter(0, 2, 3).asVector(),
+            blockFactory.newLongBlockBuilder(3).appendLong(1).appendLong(4).appendLong(1).appendLong(1).build().asVector().filter(0, 2, 3)
         );
         assertAllEquals(moreVectors);
     }
@@ -111,10 +111,10 @@ public class LongBlockEqualityTests extends ComputeTestCase {
             blockFactory.newLongArrayVector(new long[] { 1, 2, 3, 4 }, 3).filter(0, 1, 2).asBlock(),
             blockFactory.newLongArrayVector(new long[] { 1, 2, 3, 4 }, 4).filter(0, 1, 2).asBlock(),
             blockFactory.newLongArrayVector(new long[] { 1, 2, 4, 3 }, 4).filter(0, 1, 3).asBlock(),
-            LongBlock.newBlockBuilder(3).appendLong(1).appendLong(2).appendLong(3).build(),
-            LongBlock.newBlockBuilder(3).appendLong(1).appendLong(2).appendLong(3).build().filter(0, 1, 2),
-            LongBlock.newBlockBuilder(3).appendLong(1).appendLong(4).appendLong(2).appendLong(3).build().filter(0, 2, 3),
-            LongBlock.newBlockBuilder(3).appendLong(1).appendNull().appendLong(2).appendLong(3).build().filter(0, 2, 3)
+            blockFactory.newLongBlockBuilder(3).appendLong(1).appendLong(2).appendLong(3).build(),
+            blockFactory.newLongBlockBuilder(3).appendLong(1).appendLong(2).appendLong(3).build().filter(0, 1, 2),
+            blockFactory.newLongBlockBuilder(3).appendLong(1).appendLong(4).appendLong(2).appendLong(3).build().filter(0, 2, 3),
+            blockFactory.newLongBlockBuilder(3).appendLong(1).appendNull().appendLong(2).appendLong(3).build().filter(0, 2, 3)
         );
         assertAllEquals(blocks);
 
@@ -139,11 +139,11 @@ public class LongBlockEqualityTests extends ComputeTestCase {
             blockFactory.newLongArrayVector(new long[] { 9, 9, 4 }, 2).filter(0, 1).asBlock(),
             blockFactory.newLongArrayVector(new long[] { 9, 9, 4 }, 3).filter(0, 1).asBlock(),
             blockFactory.newLongArrayVector(new long[] { 9, 4, 9 }, 3).filter(0, 2).asBlock(),
-            LongBlock.newConstantBlockWith(9, 2),
-            LongBlock.newBlockBuilder(2).appendLong(9).appendLong(9).build(),
-            LongBlock.newBlockBuilder(2).appendLong(9).appendLong(9).build().filter(0, 1),
-            LongBlock.newBlockBuilder(2).appendLong(9).appendLong(4).appendLong(9).build().filter(0, 2),
-            LongBlock.newBlockBuilder(2).appendLong(9).appendNull().appendLong(9).build().filter(0, 2)
+            blockFactory.newConstantLongBlockWith(9, 2),
+            blockFactory.newLongBlockBuilder(2).appendLong(9).appendLong(9).build(),
+            blockFactory.newLongBlockBuilder(2).appendLong(9).appendLong(9).build().filter(0, 1),
+            blockFactory.newLongBlockBuilder(2).appendLong(9).appendLong(4).appendLong(9).build().filter(0, 2),
+            blockFactory.newLongBlockBuilder(2).appendLong(9).appendNull().appendLong(9).build().filter(0, 2)
         );
         assertAllEquals(moreBlocks);
     }
@@ -156,10 +156,10 @@ public class LongBlockEqualityTests extends ComputeTestCase {
             blockFactory.newLongArrayVector(new long[] { 1, 2 }, 2),
             blockFactory.newLongArrayVector(new long[] { 1, 2, 3 }, 3),
             blockFactory.newLongArrayVector(new long[] { 1, 2, 4 }, 3),
-            LongBlock.newConstantBlockWith(9, 2).asVector(),
-            LongBlock.newBlockBuilder(2).appendLong(1).appendLong(2).build().asVector().filter(1),
-            LongBlock.newBlockBuilder(3).appendLong(1).appendLong(2).appendLong(5).build().asVector(),
-            LongBlock.newBlockBuilder(1).appendLong(1).appendLong(2).appendLong(3).appendLong(4).build().asVector()
+            blockFactory.newConstantLongBlockWith(9, 2).asVector(),
+            blockFactory.newLongBlockBuilder(2).appendLong(1).appendLong(2).build().asVector().filter(1),
+            blockFactory.newLongBlockBuilder(3).appendLong(1).appendLong(2).appendLong(5).build().asVector(),
+            blockFactory.newLongBlockBuilder(1).appendLong(1).appendLong(2).appendLong(3).appendLong(4).build().asVector()
         );
         assertAllNotEquals(notEqualVectors);
     }
@@ -172,22 +172,22 @@ public class LongBlockEqualityTests extends ComputeTestCase {
             blockFactory.newLongArrayVector(new long[] { 1, 2 }, 2).asBlock(),
             blockFactory.newLongArrayVector(new long[] { 1, 2, 3 }, 3).asBlock(),
             blockFactory.newLongArrayVector(new long[] { 1, 2, 4 }, 3).asBlock(),
-            LongBlock.newConstantBlockWith(9, 2),
-            LongBlock.newBlockBuilder(2).appendLong(1).appendLong(2).build().filter(1),
-            LongBlock.newBlockBuilder(3).appendLong(1).appendLong(2).appendLong(5).build(),
-            LongBlock.newBlockBuilder(1).appendLong(1).appendLong(2).appendLong(3).appendLong(4).build(),
-            LongBlock.newBlockBuilder(1).appendLong(1).appendNull().build(),
-            LongBlock.newBlockBuilder(1).appendLong(1).appendNull().appendLong(3).build(),
-            LongBlock.newBlockBuilder(1).appendLong(1).appendLong(3).build(),
-            LongBlock.newBlockBuilder(3).appendLong(1).beginPositionEntry().appendLong(2).appendLong(3).build()
+            blockFactory.newConstantLongBlockWith(9, 2),
+            blockFactory.newLongBlockBuilder(2).appendLong(1).appendLong(2).build().filter(1),
+            blockFactory.newLongBlockBuilder(3).appendLong(1).appendLong(2).appendLong(5).build(),
+            blockFactory.newLongBlockBuilder(1).appendLong(1).appendLong(2).appendLong(3).appendLong(4).build(),
+            blockFactory.newLongBlockBuilder(1).appendLong(1).appendNull().build(),
+            blockFactory.newLongBlockBuilder(1).appendLong(1).appendNull().appendLong(3).build(),
+            blockFactory.newLongBlockBuilder(1).appendLong(1).appendLong(3).build(),
+            blockFactory.newLongBlockBuilder(3).appendLong(1).beginPositionEntry().appendLong(2).appendLong(3).build()
         );
         assertAllNotEquals(notEqualBlocks);
     }
 
     public void testSimpleBlockWithSingleNull() {
         List<LongBlock> blocks = List.of(
-            LongBlock.newBlockBuilder(1).appendLong(1).appendNull().appendLong(3).build(),
-            LongBlock.newBlockBuilder(1).appendLong(1).appendNull().appendLong(3).build()
+            blockFactory.newLongBlockBuilder(1).appendLong(1).appendNull().appendLong(3).build(),
+            blockFactory.newLongBlockBuilder(1).appendLong(1).appendNull().appendLong(3).build()
         );
         assertEquals(3, blocks.get(0).getPositionCount());
         assertTrue(blocks.get(0).isNull(1));
@@ -198,8 +198,8 @@ public class LongBlockEqualityTests extends ComputeTestCase {
     public void testSimpleBlockWithManyNulls() {
         int positions = randomIntBetween(1, 256);
         boolean grow = randomBoolean();
-        LongBlock.Builder builder1 = LongBlock.newBlockBuilder(grow ? 0 : positions);
-        LongBlock.Builder builder2 = LongBlock.newBlockBuilder(grow ? 0 : positions);
+        LongBlock.Builder builder1 = blockFactory.newLongBlockBuilder(grow ? 0 : positions);
+        LongBlock.Builder builder2 = blockFactory.newLongBlockBuilder(grow ? 0 : positions);
         for (int p = 0; p < positions; p++) {
             builder1.appendNull();
             builder2.appendNull();
@@ -216,8 +216,8 @@ public class LongBlockEqualityTests extends ComputeTestCase {
 
     public void testSimpleBlockWithSingleMultiValue() {
         List<LongBlock> blocks = List.of(
-            LongBlock.newBlockBuilder(1).beginPositionEntry().appendLong(1).appendLong(2).build(),
-            LongBlock.newBlockBuilder(1).beginPositionEntry().appendLong(1).appendLong(2).build()
+            blockFactory.newLongBlockBuilder(1).beginPositionEntry().appendLong(1).appendLong(2).build(),
+            blockFactory.newLongBlockBuilder(1).beginPositionEntry().appendLong(1).appendLong(2).build()
         );
         assertEquals(1, blocks.get(0).getPositionCount());
         assertEquals(2, blocks.get(0).getValueCount(0));
@@ -227,9 +227,9 @@ public class LongBlockEqualityTests extends ComputeTestCase {
     public void testSimpleBlockWithManyMultiValues() {
         int positions = randomIntBetween(1, 256);
         boolean grow = randomBoolean();
-        LongBlock.Builder builder1 = LongBlock.newBlockBuilder(grow ? 0 : positions);
-        LongBlock.Builder builder2 = LongBlock.newBlockBuilder(grow ? 0 : positions);
-        LongBlock.Builder builder3 = LongBlock.newBlockBuilder(grow ? 0 : positions);
+        LongBlock.Builder builder1 = blockFactory.newLongBlockBuilder(grow ? 0 : positions);
+        LongBlock.Builder builder2 = blockFactory.newLongBlockBuilder(grow ? 0 : positions);
+        LongBlock.Builder builder3 = blockFactory.newLongBlockBuilder(grow ? 0 : positions);
         for (int pos = 0; pos < positions; pos++) {
             builder1.beginPositionEntry();
             builder2.beginPositionEntry();

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/MultiValueBlockTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/MultiValueBlockTests.java
@@ -23,7 +23,7 @@ import static org.hamcrest.Matchers.nullValue;
 public class MultiValueBlockTests extends SerializationTestCase {
 
     public void testIntBlockTrivial1() {
-        var blockBuilder = IntBlock.newBlockBuilder(4);
+        var blockBuilder = blockFactory.newIntBlockBuilder(4);
         blockBuilder.appendInt(10);
         blockBuilder.beginPositionEntry();
         blockBuilder.appendInt(21);
@@ -54,10 +54,11 @@ public class MultiValueBlockTests extends SerializationTestCase {
         // cannot get a Vector view
         assertNull(block.asVector());
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(block, this::serializeDeserializeBlock, null, Releasable::close);
+        block.close();
     }
 
     public void testIntBlockTrivial() {
-        var blockBuilder = IntBlock.newBlockBuilder(10);
+        var blockBuilder = blockFactory.newIntBlockBuilder(10);
         blockBuilder.appendInt(1);
         blockBuilder.beginPositionEntry();
         blockBuilder.appendInt(21);
@@ -79,57 +80,66 @@ public class MultiValueBlockTests extends SerializationTestCase {
         assertThat(block.getInt(block.getFirstValueIndex(0)), is(1));
         assertNull(block.asVector());
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(block, this::serializeDeserializeBlock, null, Releasable::close);
+        block.close();
     }
 
     public void testEmpty() {
         for (int initialSize : new int[] { 0, 10, 100, randomInt(512) }) {
-            IntBlock intBlock = IntBlock.newBlockBuilder(initialSize).build();
+            IntBlock intBlock = blockFactory.newIntBlockBuilder(initialSize).build();
             assertThat(intBlock.getPositionCount(), is(0));
             assertThat(intBlock.asVector(), is(notNullValue()));
             EqualsHashCodeTestUtils.checkEqualsAndHashCode(intBlock, this::serializeDeserializeBlock, null, Releasable::close);
+            intBlock.close();
 
-            LongBlock longBlock = LongBlock.newBlockBuilder(initialSize).build();
+            LongBlock longBlock = blockFactory.newLongBlockBuilder(initialSize).build();
             assertThat(longBlock.getPositionCount(), is(0));
             assertThat(longBlock.asVector(), is(notNullValue()));
             EqualsHashCodeTestUtils.checkEqualsAndHashCode(longBlock, this::serializeDeserializeBlock, null, Releasable::close);
+            longBlock.close();
 
-            DoubleBlock doubleBlock = DoubleBlock.newBlockBuilder(initialSize).build();
+            DoubleBlock doubleBlock = blockFactory.newDoubleBlockBuilder(initialSize).build();
             assertThat(doubleBlock.getPositionCount(), is(0));
             assertThat(doubleBlock.asVector(), is(notNullValue()));
             EqualsHashCodeTestUtils.checkEqualsAndHashCode(doubleBlock, this::serializeDeserializeBlock, null, Releasable::close);
+            doubleBlock.close();
 
-            BytesRefBlock bytesRefBlock = BytesRefBlock.newBlockBuilder(initialSize).build();
+            BytesRefBlock bytesRefBlock = blockFactory.newBytesRefBlockBuilder(initialSize).build();
             assertThat(bytesRefBlock.getPositionCount(), is(0));
             assertThat(bytesRefBlock.asVector(), is(notNullValue()));
             EqualsHashCodeTestUtils.checkEqualsAndHashCode(bytesRefBlock, this::serializeDeserializeBlock, null, Releasable::close);
+            bytesRefBlock.close();
         }
     }
 
     public void testNullOnly() throws IOException {
         for (int initialSize : new int[] { 0, 10, 100, randomInt(512) }) {
-            IntBlock intBlock = IntBlock.newBlockBuilder(initialSize).appendNull().build();
+            IntBlock intBlock = blockFactory.newIntBlockBuilder(initialSize).appendNull().build();
             assertThat(intBlock.getPositionCount(), is(1));
             assertThat(intBlock.getValueCount(0), is(0));
             assertNull(intBlock.asVector());
             EqualsHashCodeTestUtils.checkEqualsAndHashCode(intBlock, this::serializeDeserializeBlock, null, Releasable::close);
+            intBlock.close();
 
-            LongBlock longBlock = LongBlock.newBlockBuilder(initialSize).appendNull().build();
+            LongBlock longBlock = blockFactory.newLongBlockBuilder(initialSize).appendNull().build();
             assertThat(longBlock.getPositionCount(), is(1));
             assertThat(longBlock.getValueCount(0), is(0));
             assertNull(longBlock.asVector());
             EqualsHashCodeTestUtils.checkEqualsAndHashCode(longBlock, this::serializeDeserializeBlock, null, Releasable::close);
+            longBlock.close();
 
-            DoubleBlock doubleBlock = DoubleBlock.newBlockBuilder(initialSize).appendNull().build();
+            DoubleBlock doubleBlock = blockFactory.newDoubleBlockBuilder(initialSize).appendNull().build();
             assertThat(doubleBlock.getPositionCount(), is(1));
             assertThat(doubleBlock.getValueCount(0), is(0));
             assertNull(doubleBlock.asVector());
             EqualsHashCodeTestUtils.checkEqualsAndHashCode(doubleBlock, this::serializeDeserializeBlock, null, Releasable::close);
+            doubleBlock.close();
 
-            BytesRefBlock bytesRefBlock = BytesRefBlock.newBlockBuilder(initialSize).appendNull().build();
+            BytesRefBlock bytesRefBlock = blockFactory.newBytesRefBlockBuilder(initialSize).appendNull().build();
             assertThat(bytesRefBlock.getPositionCount(), is(1));
             assertThat(bytesRefBlock.getValueCount(0), is(0));
             assertNull(bytesRefBlock.asVector());
             EqualsHashCodeTestUtils.checkEqualsAndHashCode(bytesRefBlock, this::serializeDeserializeBlock, null, Releasable::close);
+            bytesRefBlock.close();
         }
     }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/TestBlockBuilder.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/TestBlockBuilder.java
@@ -29,7 +29,7 @@ public abstract class TestBlockBuilder implements Block.Builder {
     public abstract TestBlockBuilder endPositionEntry();
 
     public static Block blockFromValues(List<List<Object>> blockValues, ElementType elementType) {
-        TestBlockBuilder builder = builderOf(elementType);
+        TestBlockBuilder builder = builderOf(BlockFactory.getNonBreakingInstance(), elementType);
         for (List<Object> rowValues : blockValues) {
             if (rowValues.isEmpty()) {
                 builder.appendNull();
@@ -47,7 +47,7 @@ public abstract class TestBlockBuilder implements Block.Builder {
     // Builds a block of single values. Each value can be null or non-null.
     // Differs from blockFromValues, as it does not use begin/endPositionEntry
     public static Block blockFromSingleValues(List<Object> blockValues, ElementType elementType) {
-        TestBlockBuilder builder = builderOf(elementType);
+        TestBlockBuilder builder = builderOf(BlockFactory.getNonBreakingInstance(), elementType);
         for (Object rowValue : blockValues) {
             if (rowValue == null) {
                 builder.appendNull();
@@ -58,39 +58,23 @@ public abstract class TestBlockBuilder implements Block.Builder {
         return builder.build();
     }
 
-    static TestBlockBuilder builderOf(ElementType type) {
+    static TestBlockBuilder builderOf(BlockFactory blockFactory, ElementType type) {
         return switch (type) {
-            case INT -> new TestIntBlockBuilder(0);
-            case LONG -> new TestLongBlockBuilder(0);
-            case DOUBLE -> new TestDoubleBlockBuilder(0);
-            case BYTES_REF -> new TestBytesRefBlockBuilder(0);
-            case BOOLEAN -> new TestBooleanBlockBuilder(0);
+            case INT -> new TestIntBlockBuilder(blockFactory, 0);
+            case LONG -> new TestLongBlockBuilder(blockFactory, 0);
+            case DOUBLE -> new TestDoubleBlockBuilder(blockFactory, 0);
+            case BYTES_REF -> new TestBytesRefBlockBuilder(blockFactory, 0);
+            case BOOLEAN -> new TestBooleanBlockBuilder(blockFactory, 0);
             default -> throw new AssertionError(type);
         };
-    }
-
-    static TestBlockBuilder ofInt(int estimatedSize) {
-        return new TestIntBlockBuilder(estimatedSize);
-    }
-
-    static TestBlockBuilder ofLong(int estimatedSize) {
-        return new TestLongBlockBuilder(estimatedSize);
-    }
-
-    static TestBlockBuilder ofDouble(int estimatedSize) {
-        return new TestDoubleBlockBuilder(estimatedSize);
-    }
-
-    static TestBlockBuilder ofBytesRef(int estimatedSize) {
-        return new TestBytesRefBlockBuilder(estimatedSize);
     }
 
     private static class TestIntBlockBuilder extends TestBlockBuilder {
 
         private final IntBlock.Builder builder;
 
-        TestIntBlockBuilder(int estimatedSize) {
-            builder = IntBlock.newBlockBuilder(estimatedSize);
+        TestIntBlockBuilder(BlockFactory blockFactory, int estimatedSize) {
+            builder = blockFactory.newIntBlockBuilder(estimatedSize);
         }
 
         @Override
@@ -150,8 +134,8 @@ public abstract class TestBlockBuilder implements Block.Builder {
 
         private final LongBlock.Builder builder;
 
-        TestLongBlockBuilder(int estimatedSize) {
-            builder = LongBlock.newBlockBuilder(estimatedSize);
+        TestLongBlockBuilder(BlockFactory blockFactory, int estimatedSize) {
+            builder = blockFactory.newLongBlockBuilder(estimatedSize);
         }
 
         @Override
@@ -211,8 +195,8 @@ public abstract class TestBlockBuilder implements Block.Builder {
 
         private final DoubleBlock.Builder builder;
 
-        TestDoubleBlockBuilder(int estimatedSize) {
-            builder = DoubleBlock.newBlockBuilder(estimatedSize);
+        TestDoubleBlockBuilder(BlockFactory blockFactory, int estimatedSize) {
+            builder = blockFactory.newDoubleBlockBuilder(estimatedSize);
         }
 
         @Override
@@ -272,8 +256,8 @@ public abstract class TestBlockBuilder implements Block.Builder {
 
         private final BytesRefBlock.Builder builder;
 
-        TestBytesRefBlockBuilder(int estimatedSize) {
-            builder = BytesRefBlock.newBlockBuilder(estimatedSize);
+        TestBytesRefBlockBuilder(BlockFactory blockFactory, int estimatedSize) {
+            builder = blockFactory.newBytesRefBlockBuilder(estimatedSize);
         }
 
         @Override
@@ -333,8 +317,8 @@ public abstract class TestBlockBuilder implements Block.Builder {
 
         private final BooleanBlock.Builder builder;
 
-        TestBooleanBlockBuilder(int estimatedSize) {
-            builder = BooleanBlock.newBlockBuilder(estimatedSize);
+        TestBooleanBlockBuilder(BlockFactory blockFactory, int estimatedSize) {
+            builder = blockFactory.newBooleanBlockBuilder(estimatedSize);
         }
 
         @Override

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/MvExpandOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/MvExpandOperatorTests.java
@@ -12,7 +12,6 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.ElementType;
-import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.Page;
 
 import java.util.Iterator;
@@ -207,10 +206,11 @@ public class MvExpandOperatorTests extends OperatorTestCase {
     }
 
     public void testNoopStatus() {
+        BlockFactory blockFactory = blockFactory();
         MvExpandOperator op = new MvExpandOperator(0, randomIntBetween(1, 1000));
         List<Page> result = drive(
             op,
-            List.of(new Page(IntVector.newVectorBuilder(2).appendInt(1).appendInt(2).build().asBlock())).iterator(),
+            List.of(new Page(blockFactory.newIntVectorBuilder(2).appendInt(1).appendInt(2).build().asBlock())).iterator(),
             driverContext()
         );
         assertThat(result, hasSize(1));

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/MvExpandOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/MvExpandOperatorTests.java
@@ -12,7 +12,6 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.ElementType;
-import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.Page;
 
@@ -224,7 +223,8 @@ public class MvExpandOperatorTests extends OperatorTestCase {
 
     public void testExpandStatus() {
         MvExpandOperator op = new MvExpandOperator(0, randomIntBetween(1, 1));
-        var builder = IntBlock.newBlockBuilder(2).beginPositionEntry().appendInt(1).appendInt(2).endPositionEntry();
+        BlockFactory blockFactory = blockFactory();
+        var builder = blockFactory.newIntBlockBuilder(2).beginPositionEntry().appendInt(1).appendInt(2).endPositionEntry();
         List<Page> result = drive(op, List.of(new Page(builder.build())).iterator(), driverContext());
         assertThat(result, hasSize(1));
         assertThat(valuesAtPositions(result.get(0).getBlock(0), 0, 2), equalTo(List.of(List.of(1), List.of(2))));
@@ -232,6 +232,7 @@ public class MvExpandOperatorTests extends OperatorTestCase {
         assertThat(status.pagesIn(), equalTo(1));
         assertThat(status.pagesOut(), equalTo(1));
         assertThat(status.noops(), equalTo(0));
+        result.forEach(Page::releaseBlocks);
     }
 
     public void testExpandWithBytesRefs() {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/StringExtractOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/StringExtractOperatorTests.java
@@ -103,8 +103,9 @@ public class StringExtractOperatorTests extends OperatorTestCase {
             public void close() {}
         }, new FirstWord("test"), driverContext());
 
-        Page result = null;
-        try (BytesRefBlock.Builder builder = BytesRefBlock.newBlockBuilder(1)) {
+        BlockFactory blockFactory = blockFactory();
+        final Page result;
+        try (BytesRefBlock.Builder builder = blockFactory.newBytesRefBlockBuilder(1)) {
             builder.beginPositionEntry();
             builder.appendBytesRef(new BytesRef("foo1 bar1"));
             builder.appendBytesRef(new BytesRef("foo2 bar2"));

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/exchange/ExchangeServiceTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/exchange/ExchangeServiceTests.java
@@ -183,7 +183,7 @@ public class ExchangeServiceTests extends ESTestCase {
                         return null;
                     }
                     int size = randomIntBetween(1, 10);
-                    IntBlock.Builder builder = IntBlock.newBlockBuilder(size);
+                    IntBlock.Builder builder = driverContext.blockFactory().newIntBlockBuilder(size);
                     for (int i = 0; i < size; i++) {
                         int seqNo = nextSeqNo.incrementAndGet();
                         if (seqNo < maxInputSeqNo) {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/exchange/ExchangeServiceTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/exchange/ExchangeServiceTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.MockBlockFactory;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.Driver;
 import org.elasticsearch.compute.operator.DriverContext;
@@ -183,14 +184,15 @@ public class ExchangeServiceTests extends ESTestCase {
                         return null;
                     }
                     int size = randomIntBetween(1, 10);
-                    IntBlock.Builder builder = driverContext.blockFactory().newIntBlockBuilder(size);
-                    for (int i = 0; i < size; i++) {
-                        int seqNo = nextSeqNo.incrementAndGet();
-                        if (seqNo < maxInputSeqNo) {
-                            builder.appendInt(seqNo);
+                    try (IntBlock.Builder builder = driverContext.blockFactory().newIntBlockBuilder(size)) {
+                        for (int i = 0; i < size; i++) {
+                            int seqNo = nextSeqNo.incrementAndGet();
+                            if (seqNo < maxInputSeqNo) {
+                                builder.appendInt(seqNo);
+                            }
                         }
+                        return new Page(builder.build());
                     }
-                    return new Page(builder.build());
                 }
 
                 @Override
@@ -390,8 +392,8 @@ public class ExchangeServiceTests extends ESTestCase {
         ExchangeService exchange1 = new ExchangeService(settings, threadPool, ESQL_TEST_EXECUTOR, blockFactory());
         exchange1.registerTransportHandler(node1);
         AbstractSimpleTransportTestCase.connectToNode(node0, node1.getLocalNode());
-        final int maxSeqNo = randomIntBetween(1000, 5000);
-        final int disconnectOnSeqNo = randomIntBetween(100, 500);
+        final int maxSeqNo = randomIntBetween(10, 50);
+        final int disconnectOnSeqNo = randomIntBetween(10, 20);
         node1.addRequestHandlingBehavior(ExchangeService.EXCHANGE_ACTION_NAME, new StubbableTransport.RequestHandlingBehavior<>() {
             @Override
             public void messageReceived(
@@ -414,8 +416,8 @@ public class ExchangeServiceTests extends ESTestCase {
                                 }
                             }
                         }
-                        ExchangeResponse newResp = new ExchangeResponse(page, origResp.finished());
                         origResp.decRef();
+                        ExchangeResponse newResp = new ExchangeResponse(page, origResp.finished());
                         super.sendResponse(newResp);
                     }
                 };
@@ -435,6 +437,7 @@ public class ExchangeServiceTests extends ESTestCase {
             Throwable cause = ExceptionsHelper.unwrap(err, IOException.class);
             assertNotNull(cause);
             assertThat(cause.getMessage(), equalTo("page is too large"));
+            sinkHandler.onFailure(new RuntimeException(cause));
         }
     }
 
@@ -499,11 +502,18 @@ public class ExchangeServiceTests extends ESTestCase {
         MockBigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, ByteSizeValue.ofGb(1));
         CircuitBreaker breaker = bigArrays.breakerService().getBreaker(CircuitBreaker.REQUEST);
         breakers.add(breaker);
-        return new BlockFactory(breaker, bigArrays);
+        MockBlockFactory factory = new MockBlockFactory(breaker, bigArrays);
+        blockFactories.add(factory);
+        return factory;
     }
+
+    private final List<MockBlockFactory> blockFactories = new ArrayList<>();
 
     @After
     public void allMemoryReleased() {
+        for (MockBlockFactory blockFactory : blockFactories) {
+            blockFactory.ensureAllBlocksAreReleased();
+        }
         for (CircuitBreaker breaker : breakers) {
             assertThat(breaker.getUsed(), equalTo(0L));
         }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/ExtractorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/ExtractorTests.java
@@ -19,7 +19,6 @@ import org.elasticsearch.compute.data.BlockTestUtils;
 import org.elasticsearch.compute.data.BlockUtils;
 import org.elasticsearch.compute.data.DocVector;
 import org.elasticsearch.compute.data.ElementType;
-import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
 import org.elasticsearch.test.ESTestCase;
 
@@ -34,6 +33,7 @@ import static org.hamcrest.Matchers.greaterThan;
 public class ExtractorTests extends ESTestCase {
     @ParametersFactory
     public static Iterable<Object[]> parameters() {
+        BlockFactory blockFactory = BlockFactory.getNonBreakingInstance();
         List<Object[]> cases = new ArrayList<>();
         for (ElementType e : ElementType.values()) {
             switch (e) {
@@ -79,9 +79,9 @@ public class ExtractorTests extends ESTestCase {
                             e,
                             TopNEncoder.DEFAULT_UNSORTABLE,
                             () -> new DocVector(
-                                IntBlock.newConstantBlockWith(randomInt(), 1).asVector(),
-                                IntBlock.newConstantBlockWith(randomInt(), 1).asVector(),
-                                IntBlock.newConstantBlockWith(randomInt(), 1).asVector(),
+                                blockFactory.newConstantIntBlockWith(randomInt(), 1).asVector(),
+                                blockFactory.newConstantIntBlockWith(randomInt(), 1).asVector(),
+                                blockFactory.newConstantIntBlockWith(randomInt(), 1).asVector(),
                                 randomBoolean() ? null : randomBoolean()
                             ).asBlock()
                         ) }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/TopNOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/TopNOperatorTests.java
@@ -18,9 +18,6 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
-import org.elasticsearch.compute.data.BooleanBlock;
-import org.elasticsearch.compute.data.BytesRefBlock;
-import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
@@ -304,14 +301,14 @@ public class TopNOperatorTests extends OperatorTestCase {
     }
 
     public void testCompareInts() {
+        BlockFactory blockFactory = blockFactory();
         testCompare(
             new Page(
-                new Block[] {
-                    IntBlock.newBlockBuilder(2).appendInt(Integer.MIN_VALUE).appendInt(randomIntBetween(-1000, -1)).build(),
-                    IntBlock.newBlockBuilder(2).appendInt(randomIntBetween(-1000, -1)).appendInt(0).build(),
-                    IntBlock.newBlockBuilder(2).appendInt(0).appendInt(randomIntBetween(1, 1000)).build(),
-                    IntBlock.newBlockBuilder(2).appendInt(randomIntBetween(1, 1000)).appendInt(Integer.MAX_VALUE).build(),
-                    IntBlock.newBlockBuilder(2).appendInt(0).appendInt(Integer.MAX_VALUE).build() }
+                blockFactory.newIntBlockBuilder(2).appendInt(Integer.MIN_VALUE).appendInt(randomIntBetween(-1000, -1)).build(),
+                blockFactory.newIntBlockBuilder(2).appendInt(randomIntBetween(-1000, -1)).appendInt(0).build(),
+                blockFactory.newIntBlockBuilder(2).appendInt(0).appendInt(randomIntBetween(1, 1000)).build(),
+                blockFactory.newIntBlockBuilder(2).appendInt(randomIntBetween(1, 1000)).appendInt(Integer.MAX_VALUE).build(),
+                blockFactory.newIntBlockBuilder(2).appendInt(0).appendInt(Integer.MAX_VALUE).build()
             ),
             INT,
             DEFAULT_SORTABLE
@@ -319,14 +316,14 @@ public class TopNOperatorTests extends OperatorTestCase {
     }
 
     public void testCompareLongs() {
+        BlockFactory blockFactory = blockFactory();
         testCompare(
             new Page(
-                new Block[] {
-                    LongBlock.newBlockBuilder(2).appendLong(Long.MIN_VALUE).appendLong(randomLongBetween(-1000, -1)).build(),
-                    LongBlock.newBlockBuilder(2).appendLong(randomLongBetween(-1000, -1)).appendLong(0).build(),
-                    LongBlock.newBlockBuilder(2).appendLong(0).appendLong(randomLongBetween(1, 1000)).build(),
-                    LongBlock.newBlockBuilder(2).appendLong(randomLongBetween(1, 1000)).appendLong(Long.MAX_VALUE).build(),
-                    LongBlock.newBlockBuilder(2).appendLong(0).appendLong(Long.MAX_VALUE).build() }
+                blockFactory.newLongBlockBuilder(2).appendLong(Long.MIN_VALUE).appendLong(randomLongBetween(-1000, -1)).build(),
+                blockFactory.newLongBlockBuilder(2).appendLong(randomLongBetween(-1000, -1)).appendLong(0).build(),
+                blockFactory.newLongBlockBuilder(2).appendLong(0).appendLong(randomLongBetween(1, 1000)).build(),
+                blockFactory.newLongBlockBuilder(2).appendLong(randomLongBetween(1, 1000)).appendLong(Long.MAX_VALUE).build(),
+                blockFactory.newLongBlockBuilder(2).appendLong(0).appendLong(Long.MAX_VALUE).build()
             ),
             LONG,
             DEFAULT_SORTABLE
@@ -334,17 +331,17 @@ public class TopNOperatorTests extends OperatorTestCase {
     }
 
     public void testCompareDoubles() {
+        BlockFactory blockFactory = blockFactory();
         testCompare(
             new Page(
-                new Block[] {
-                    DoubleBlock.newBlockBuilder(2)
-                        .appendDouble(-Double.MAX_VALUE)
-                        .appendDouble(randomDoubleBetween(-1000, -1, true))
-                        .build(),
-                    DoubleBlock.newBlockBuilder(2).appendDouble(randomDoubleBetween(-1000, -1, true)).appendDouble(0.0).build(),
-                    DoubleBlock.newBlockBuilder(2).appendDouble(0).appendDouble(randomDoubleBetween(1, 1000, true)).build(),
-                    DoubleBlock.newBlockBuilder(2).appendDouble(randomLongBetween(1, 1000)).appendDouble(Double.MAX_VALUE).build(),
-                    DoubleBlock.newBlockBuilder(2).appendDouble(0.0).appendDouble(Double.MAX_VALUE).build() }
+                blockFactory.newDoubleBlockBuilder(2)
+                    .appendDouble(-Double.MAX_VALUE)
+                    .appendDouble(randomDoubleBetween(-1000, -1, true))
+                    .build(),
+                blockFactory.newDoubleBlockBuilder(2).appendDouble(randomDoubleBetween(-1000, -1, true)).appendDouble(0.0).build(),
+                blockFactory.newDoubleBlockBuilder(2).appendDouble(0).appendDouble(randomDoubleBetween(1, 1000, true)).build(),
+                blockFactory.newDoubleBlockBuilder(2).appendDouble(randomLongBetween(1, 1000)).appendDouble(Double.MAX_VALUE).build(),
+                blockFactory.newDoubleBlockBuilder(2).appendDouble(0.0).appendDouble(Double.MAX_VALUE).build()
             ),
             DOUBLE,
             DEFAULT_SORTABLE
@@ -352,10 +349,10 @@ public class TopNOperatorTests extends OperatorTestCase {
     }
 
     public void testCompareUtf8() {
+        BlockFactory blockFactory = blockFactory();
         testCompare(
             new Page(
-                new Block[] {
-                    BytesRefBlock.newBlockBuilder(2).appendBytesRef(new BytesRef("bye")).appendBytesRef(new BytesRef("hello")).build() }
+                blockFactory.newBytesRefBlockBuilder(2).appendBytesRef(new BytesRef("bye")).appendBytesRef(new BytesRef("hello")).build()
             ),
             BYTES_REF,
             UTF8
@@ -363,15 +360,16 @@ public class TopNOperatorTests extends OperatorTestCase {
     }
 
     public void testCompareBooleans() {
+        BlockFactory blockFactory = blockFactory();
         testCompare(
-            new Page(new Block[] { BooleanBlock.newBlockBuilder(2).appendBoolean(false).appendBoolean(true).build() }),
+            new Page(blockFactory.newBooleanBlockBuilder(2).appendBoolean(false).appendBoolean(true).build()),
             BOOLEAN,
             DEFAULT_SORTABLE
         );
     }
 
     private void testCompare(Page page, ElementType elementType, TopNEncoder encoder) {
-        Block nullBlock = Block.constantNullBlock(1);
+        Block nullBlock = BlockFactory.getNonBreakingInstance().newConstantNullBlock(1);
         Page nullPage = new Page(new Block[] { nullBlock, nullBlock, nullBlock, nullBlock, nullBlock });
 
         for (int b = 0; b < page.getBlockCount(); b++) {
@@ -422,6 +420,7 @@ public class TopNOperatorTests extends OperatorTestCase {
                 assertThat(TopNOperator.compareRows(r2, r1), greaterThan(0));
             }
         }
+        page.releaseBlocks();
     }
 
     private TopNOperator.Row row(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvSum.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvSum.java
@@ -45,7 +45,7 @@ public class MvSum extends AbstractMultivalueFunction {
             case LONG -> field().dataType() == DataTypes.UNSIGNED_LONG
                 ? new MvSumUnsignedLongEvaluator.Factory(source(), fieldEval)
                 : new MvSumLongEvaluator.Factory(source(), fieldEval);
-            case NULL -> dvrCtx -> EvalOperator.CONSTANT_NULL;
+            case NULL -> EvalOperator.CONSTANT_NULL_FACTORY;
 
             default -> throw EsqlIllegalArgumentException.illegalDataType(field.dataType());
         };

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/SplitTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/SplitTests.java
@@ -12,8 +12,9 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.data.Block;
-import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
 import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
 import org.elasticsearch.xpack.esql.expression.function.scalar.AbstractScalarFunctionTestCase;
@@ -84,10 +85,11 @@ public class SplitTests extends AbstractScalarFunctionTestCase {
     }
 
     public void testConstantDelimiter() {
+        DriverContext driverContext = driverContext();
         try (
             EvalOperator.ExpressionEvaluator eval = evaluator(
                 new Split(Source.EMPTY, field("str", DataTypes.KEYWORD), new Literal(Source.EMPTY, new BytesRef(":"), DataTypes.KEYWORD))
-            ).get(driverContext())
+            ).get(driverContext)
         ) {
             /*
              * 58 is ascii for : and appears in the toString below. We don't convert the delimiter to a
@@ -96,8 +98,12 @@ public class SplitTests extends AbstractScalarFunctionTestCase {
              */
             assert ':' == 58;
             assertThat(eval.toString(), equalTo("SplitSingleByteEvaluator[str=Attribute[channel=0], delim=58]"));
-            try (Block block = eval.eval(new Page(BytesRefBlock.newConstantBlockWith(new BytesRef("foo:bar"), 1)))) {
+            BlockFactory blockFactory = driverContext.blockFactory();
+            Page page = new Page(blockFactory.newConstantBytesRefBlockWith(new BytesRef("foo:bar"), 1));
+            try (Block block = eval.eval(page)) {
                 assertThat(toJavaObject(block, 0), equalTo(List.of(new BytesRef("foo"), new BytesRef("bar"))));
+            } finally {
+                page.releaseBlocks();
             }
         }
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/formatter/TextFormatTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/formatter/TextFormatTests.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.esql.formatter;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.data.BlockFactory;
-import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.test.ESTestCase;
@@ -37,6 +36,8 @@ import static org.elasticsearch.xpack.esql.formatter.TextFormat.TSV;
 import static org.elasticsearch.xpack.ql.util.SpatialCoordinateTypes.GEO;
 
 public class TextFormatTests extends ESTestCase {
+
+    static final BlockFactory blockFactory = BlockFactory.getNonBreakingInstance();
 
     public void testCsvContentType() {
         assertEquals("text/csv; charset=utf-8; header=present", CSV.contentType(req()));
@@ -250,7 +251,7 @@ public class TextFormatTests extends ESTestCase {
         // values
         List<Page> values = List.of(
             new Page(
-                BytesRefBlock.newBlockBuilder(2)
+                blockFactory.newBytesRefBlockBuilder(2)
                     .appendBytesRef(new BytesRef("Along The River Bank"))
                     .appendBytesRef(new BytesRef("Mind Train"))
                     .build(),
@@ -269,8 +270,11 @@ public class TextFormatTests extends ESTestCase {
         // values
         List<Page> values = List.of(
             new Page(
-                BytesRefBlock.newBlockBuilder(2).appendBytesRef(new BytesRef("normal")).appendBytesRef(new BytesRef("commas")).build(),
-                BytesRefBlock.newBlockBuilder(2)
+                blockFactory.newBytesRefBlockBuilder(2)
+                    .appendBytesRef(new BytesRef("normal"))
+                    .appendBytesRef(new BytesRef("commas"))
+                    .build(),
+                blockFactory.newBytesRefBlockBuilder(2)
                     .appendBytesRef(new BytesRef("\"quo\"ted\",\n"))
                     .appendBytesRef(new BytesRef("a,b,c,\n,d,e,\t\n"))
                     .build()

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/formatter/TextFormatterTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/formatter/TextFormatterTests.java
@@ -9,9 +9,7 @@ package org.elasticsearch.xpack.esql.formatter;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
-import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.action.ColumnInfo;
@@ -44,15 +42,15 @@ public class TextFormatterTests extends ESTestCase {
         columns,
         List.of(
             new Page(
-                BytesRefBlock.newBlockBuilder(2)
+                blockFactory.newBytesRefBlockBuilder(2)
                     .appendBytesRef(new BytesRef("15charwidedata!"))
                     .appendBytesRef(new BytesRef("dog"))
                     .build(),
                 blockFactory.newLongArrayVector(new long[] { 1, 2 }, 2).asBlock(),
                 blockFactory.newDoubleArrayVector(new double[] { 6.888, 123124.888 }, 2).asBlock(),
-                Block.constantNullBlock(2),
+                blockFactory.newConstantNullBlock(2),
                 blockFactory.newDoubleArrayVector(new double[] { 12, 9912 }, 2).asBlock(),
-                BytesRefBlock.newBlockBuilder(2).appendBytesRef(new BytesRef("rabbit")).appendBytesRef(new BytesRef("goat")).build(),
+                blockFactory.newBytesRefBlockBuilder(2).appendBytesRef(new BytesRef("rabbit")).appendBytesRef(new BytesRef("goat")).build(),
                 blockFactory.newLongArrayVector(
                     new long[] {
                         UTC_DATE_TIME_FORMATTER.parseMillis("1953-09-02T00:00:00.000Z"),
@@ -60,7 +58,7 @@ public class TextFormatterTests extends ESTestCase {
                     2
                 ).asBlock(),
                 blockFactory.newLongArrayVector(new long[] { GEO.pointAsLong(12, 56), GEO.pointAsLong(-97, 26) }, 2).asBlock(),
-                Block.constantNullBlock(2)
+                blockFactory.newConstantNullBlock(2)
             )
         ),
         null,
@@ -111,12 +109,18 @@ public class TextFormatterTests extends ESTestCase {
             columns,
             List.of(
                 new Page(
-                    BytesRefBlock.newBlockBuilder(2).appendBytesRef(new BytesRef("doggie")).appendBytesRef(new BytesRef("dog")).build(),
+                    blockFactory.newBytesRefBlockBuilder(2)
+                        .appendBytesRef(new BytesRef("doggie"))
+                        .appendBytesRef(new BytesRef("dog"))
+                        .build(),
                     blockFactory.newLongArrayVector(new long[] { 4, 2 }, 2).asBlock(),
                     blockFactory.newDoubleArrayVector(new double[] { 1, 123124.888 }, 2).asBlock(),
-                    Block.constantNullBlock(2),
+                    blockFactory.newConstantNullBlock(2),
                     blockFactory.newDoubleArrayVector(new double[] { 77.0, 9912.0 }, 2).asBlock(),
-                    BytesRefBlock.newBlockBuilder(2).appendBytesRef(new BytesRef("wombat")).appendBytesRef(new BytesRef("goat")).build(),
+                    blockFactory.newBytesRefBlockBuilder(2)
+                        .appendBytesRef(new BytesRef("wombat"))
+                        .appendBytesRef(new BytesRef("goat"))
+                        .build(),
                     blockFactory.newLongArrayVector(
                         new long[] {
                             UTC_DATE_TIME_FORMATTER.parseMillis("1955-01-21T01:02:03.342Z"),
@@ -124,7 +128,7 @@ public class TextFormatterTests extends ESTestCase {
                         2
                     ).asBlock(),
                     blockFactory.newLongArrayVector(new long[] { GEO.pointAsLong(12, 56), GEO.pointAsLong(-97, 26) }, 2).asBlock(),
-                    Block.constantNullBlock(2)
+                    blockFactory.newConstantNullBlock(2)
                 )
             ),
             null,
@@ -161,7 +165,7 @@ public class TextFormatterTests extends ESTestCase {
                         List.of(new ColumnInfo("foo", "keyword")),
                         List.of(
                             new Page(
-                                BytesRefBlock.newBlockBuilder(2)
+                                blockFactory.newBytesRefBlockBuilder(2)
                                     .appendBytesRef(new BytesRef(smallFieldContent))
                                     .appendBytesRef(new BytesRef(largeFieldContent))
                                     .build()

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/GrokEvaluatorExtracterTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/GrokEvaluatorExtracterTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.esql.planner;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.DoubleBlock;
@@ -26,6 +27,8 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
 public class GrokEvaluatorExtracterTests extends ESTestCase {
+    final BlockFactory blockFactory = BlockFactory.getNonBreakingInstance();
+
     final Map<String, Integer> KEY_TO_BLOCK = Map.of("a", 0, "b", 1, "c", 2, "d", 3, "e", 4, "f", 5);
     final Map<String, ElementType> TYPES = Map.of(
         "a",
@@ -196,7 +199,7 @@ public class GrokEvaluatorExtracterTests extends ESTestCase {
 
     private BytesRefBlock buildInputBlock(int[] mvSize, String... input) {
         int nextString = 0;
-        BytesRefBlock.Builder inputBuilder = BytesRefBlock.newBlockBuilder(input.length);
+        BytesRefBlock.Builder inputBuilder = blockFactory.newBytesRefBlockBuilder(input.length);
         for (int i = 0; i < mvSize.length; i++) {
             if (mvSize[i] == 0) {
                 inputBuilder.appendNull();
@@ -222,12 +225,12 @@ public class GrokEvaluatorExtracterTests extends ESTestCase {
 
     private Block.Builder[] buidDefaultTargetBlocks(int estimatedSize) {
         return new Block.Builder[] {
-            BytesRefBlock.newBlockBuilder(estimatedSize),
-            IntBlock.newBlockBuilder(estimatedSize),
-            LongBlock.newBlockBuilder(estimatedSize),
-            DoubleBlock.newBlockBuilder(estimatedSize),
-            DoubleBlock.newBlockBuilder(estimatedSize),
-            BooleanBlock.newBlockBuilder(estimatedSize) };
+            blockFactory.newBytesRefBlockBuilder(estimatedSize),
+            blockFactory.newIntBlockBuilder(estimatedSize),
+            blockFactory.newLongBlockBuilder(estimatedSize),
+            blockFactory.newDoubleBlockBuilder(estimatedSize),
+            blockFactory.newDoubleBlockBuilder(estimatedSize),
+            blockFactory.newBooleanBlockBuilder(estimatedSize) };
     }
 
     private GrokEvaluatorExtracter buildExtracter(String pattern, Map<String, Integer> keyToBlock, Map<String, ElementType> types) {


### PR DESCRIPTION
This PR removes Builder APIs that use the non-breaking block factory. Similar to the previous PRs, some tests now explicitly use the non-breaking block factory. The main goal of this PR is to remove the non-breaking block factory from the production code.