### PR TITLE
Remove usage of non-breaking block factory

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/OrdinalsGroupingOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/OrdinalsGroupingOperator.java
@@ -475,7 +475,7 @@ public class OrdinalsGroupingOperator implements Operator {
             DriverContext driverContext
         ) {
             this.extractor = new ValuesSourceReaderOperator(
-                BlockFactory.getNonBreakingInstance(),
+                driverContext.blockFactory(),
                 List.of(new ValuesSourceReaderOperator.FieldInfo(groupingField, blockLoaders)),
                 shardContexts,
                 docChannel

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/RowOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/RowOperator.java
@@ -22,8 +22,7 @@ public class RowOperator extends LocalSourceOperator {
 
         @Override
         public SourceOperator get(DriverContext driverContext) {
-            // We aren't yet ready to use the read block factory
-            return new RowOperator(BlockFactory.getNonBreakingInstance(), objects);
+            return new RowOperator(driverContext.blockFactory(), objects);
         }
 
         @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/ThrowingDriverContext.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/ThrowingDriverContext.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.compute.operator;
 
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.ByteArray;
 import org.elasticsearch.common.util.DoubleArray;
@@ -18,7 +19,7 @@ import org.elasticsearch.core.Releasable;
 
 public class ThrowingDriverContext extends DriverContext {
     public ThrowingDriverContext() {
-        super(new ThrowingBigArrays(), BlockFactory.getNonBreakingInstance());
+        super(new ThrowingBigArrays(), BlockFactory.getInstance(new NoopCircuitBreaker("throwing-context"), new ThrowingBigArrays()));
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -337,7 +337,7 @@ public class LocalExecutionPlanner {
                     for (int i = 0, s = output.size(); i < s; i++) {
                         var out = output.get(i);
                         if (out.dataType() == DataTypes.BOOLEAN) {
-                            blocks.add(i, BlockFactory.getNonBreakingInstance().newConstantBooleanBlockWith(true, 1));
+                            blocks.add(i, PlannerUtils.NON_BREAKING_BLOCK_FACTORY.newConstantBooleanBlockWith(true, 1));
                         }
                     }
                 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
@@ -8,6 +8,9 @@
 package org.elasticsearch.xpack.esql.planner;
 
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.query.QueryBuilder;
@@ -222,4 +225,14 @@ public class PlannerUtils {
         }
         throw EsqlIllegalArgumentException.illegalDataType(dataType);
     }
+
+    /**
+     * A non-breaking block factory used to create small pages during the planning
+     * TODO: Remove this
+     */
+    @Deprecated(forRemoval = true)
+    public static final BlockFactory NON_BREAKING_BLOCK_FACTORY = BlockFactory.getInstance(
+        new NoopCircuitBreaker("noop-esql-breaker"),
+        BigArrays.NON_RECYCLING_INSTANCE
+    );
 }


### PR DESCRIPTION
This should be the last PR before we can move the non-breaking block factory to tests. There are two instances where the planner can create small blocks. However, since their ownership is unclear, I've created a separate non-breaking factory for them. We can address these later.