### PR TITLE
[8.12] Enlarge jetty restart timeframe in idpfixture (#103616)

### DIFF
--- a/x-pack/test/idp-fixture/src/main/resources/idp/bin/run-jetty.sh
+++ b/x-pack/test/idp-fixture/src/main/resources/idp/bin/run-jetty.sh
@@ -20,7 +20,7 @@ exit_code=$?
 end_time=$(date +%s)
 
 duration=$((end_time - start_time))
-if [ $duration -lt 5 ]; then
+if [ $duration -lt 10 ]; then
   /opt/jetty-home/bin/jetty.sh run
   exit_code=$?
 fi


### PR DESCRIPTION
Backports the following commits to 8.12:
 - Enlarge jetty restart timeframe in idpfixture (#103616)