### PR TITLE
[Profiling] Use shard request cache consistently

### DIFF
--- a/docs/changelog/103643.yaml
+++ b/docs/changelog/103643.yaml
@@ -1,0 +1,5 @@
+pr: 103643
+summary: "[Profiling] Use shard request cache consistently"
+area: Application
+type: enhancement
+issues: []

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStackTracesAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStackTracesAction.java
@@ -221,6 +221,9 @@ public class TransportGetStackTracesAction extends TransportAction<GetStackTrace
         client.prepareSearch(request.indices())
             .setTrackTotalHits(false)
             .setSize(0)
+            // take advantage of request cache and keep a consistent order for the same request
+            .setRequestCache(true)
+            .setPreference(String.valueOf(request.hashCode()))
             .setQuery(request.getQuery())
             .addAggregation(new MinAggregationBuilder("min_time").field("@timestamp"))
             .addAggregation(new MaxAggregationBuilder("max_time").field("@timestamp"))
@@ -269,6 +272,9 @@ public class TransportGetStackTracesAction extends TransportAction<GetStackTrace
         client.prepareSearch(eventsIndex.getName())
             .setTrackTotalHits(false)
             .setSize(0)
+            // take advantage of request cache and keep a consistent order for the same request
+            .setRequestCache(true)
+            .setPreference(String.valueOf(request.hashCode()))
             .setQuery(request.getQuery())
             .addAggregation(new MinAggregationBuilder("min_time").field("@timestamp"))
             .addAggregation(new MaxAggregationBuilder("max_time").field("@timestamp"))


### PR DESCRIPTION
With this commit we enforce a consistent shard preference internally for the same request where it makes sense (i.e. for aggregations). The default behavior is to use adaptive replica selection so by enforcing a consistent order we will take advantage of the shard request cache after the first request. For the native UI the response times are rather low anyway (~10ms) but when profiling is integrated into other contexts (e.g. APM), then response time of the internal aggregation may vary more (initial response times of several hundred ms are possible) so it makes sense to take advantage of the shard request cache consistently to speed up subsequent requests. For consistency we have changed both code paths.
