### PR TITLE
[8.12] Add `active_only` flag to Get API Key REST spec (#103621)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/security.get_api_key.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/security.get_api_key.json
@@ -45,6 +45,11 @@
         "type":"boolean",
         "default":false,
         "description": "flag to show the limited-by role descriptors of API Keys"
+      },
+      "active_only":{
+        "type":"boolean",
+        "default":false,
+        "description": "flag to limit response to only active (not invalidated or expired) API keys"
       }
     }
   }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/api_key/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/api_key/10_basic.yml
@@ -191,6 +191,7 @@ teardown:
         Authorization: "Basic YXBpX2tleV91c2VyOngtcGFjay10ZXN0LXBhc3N3b3Jk" # api_key_user
       security.get_api_key:
         owner: true
+        active_only: true
   - length: { "api_keys" : 1 }
   - match: { "api_keys.0.username": "api_key_user" }
   - match: { "api_keys.0.invalidated": false }


### PR DESCRIPTION
Backports the following commits to 8.12:
 - Add `active_only` flag to Get API Key REST spec (#103621)