### PR TITLE
Exists query also works with only doc_values

### DIFF
--- a/docs/reference/query-dsl/exists-query.asciidoc
+++ b/docs/reference/query-dsl/exists-query.asciidoc
@@ -9,7 +9,7 @@ Returns documents that contain an indexed value for a field.
 An indexed value may not exist for a document's field due to a variety of reasons:
 
 * The field in the source JSON is `null` or `[]`
-* The field has `"index" : false` set in the mapping
+* The field has `"index" : false` and `"doc_values" : false` set in the mapping
 * The length of the field value exceeded an `ignore_above` setting in the mapping
 * The field value was malformed and `ignore_malformed` was defined in the mapping
 


### PR DESCRIPTION
With this commit we amend the docs for the `exists` query to clarify that it works with either `index` *or* `doc_values` set to `true` in the mapping. Only if both are disabled, the `exists` query won't work.