### PR TITLE
ESQL: Clean aggs slightly

### DIFF
--- a/x-pack/plugin/esql/compute/ann/src/main/java/org/elasticsearch/compute/ann/Aggregator.java
+++ b/x-pack/plugin/esql/compute/ann/src/main/java/org/elasticsearch/compute/ann/Aggregator.java
@@ -42,7 +42,7 @@ import java.lang.annotation.Target;
  *     not need this after we convert AVG into a composite operation.
  * </p>
  * <p>
- *     The generation code also looks for the optional methods {@code combineStates}
+ *     The generation code also looks for the optional methods {@code combineIntermediate}
  *     and {@code evaluateFinal} which are used to combine intermediate states and
  *     produce the final output. If the first is missing then the generated code will
  *     call the {@code combine} method to combine intermediate states. If the second

--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/AggregatorImplementer.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/AggregatorImplementer.java
@@ -69,7 +69,6 @@ public class AggregatorImplementer {
     private final ExecutableElement init;
     private final ExecutableElement combine;
     private final ExecutableElement combineValueCount;
-    private final ExecutableElement combineStates;
     private final ExecutableElement combineIntermediate;
     private final ExecutableElement evaluateFinal;
     private final ClassName implementation;
@@ -95,7 +94,6 @@ public class AggregatorImplementer {
             return firstParamType.isPrimitive() || firstParamType.toString().equals(stateType.toString());
         });
         this.combineValueCount = findMethod(declarationType, "combineValueCount");
-        this.combineStates = findMethod(declarationType, "combineStates");
         this.combineIntermediate = findMethod(declarationType, "combineIntermediate");
         this.evaluateFinal = findMethod(declarationType, "evaluateFinal");
 
@@ -399,34 +397,30 @@ public class AggregatorImplementer {
         builder.addAnnotation(Override.class).addModifiers(Modifier.PUBLIC).addParameter(PAGE, "page");
         builder.addStatement("assert channels.size() == intermediateBlockCount()");
         builder.addStatement("assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size()");
-        builder.addStatement("Block uncastBlock = page.getBlock(channels.get(0))");
-        builder.beginControlFlow("if (uncastBlock.areAllValuesNull())");
-        {
-            builder.addStatement("return");
-            builder.endControlFlow();
-        }
-        int count = 0;
-        for (var interState : intermediateState) {
+        for (int i = 0; i < intermediateState.size(); i++) {
+            var interState = intermediateState.get(i);
+            ClassName blockType = blockType(interState.elementType());
+            builder.addStatement("Block $L = page.getBlock(channels.get($L))", interState.name + "Uncast", i);
+            builder.beginControlFlow("if ($L.areAllValuesNull())", interState.name + "Uncast");
+            {
+                builder.addStatement("return");
+                builder.endControlFlow();
+            }
             builder.addStatement(
-                "$T " + interState.name() + " = page.<$T>getBlock(channels.get(" + count + ")).asVector()",
+                "$T $L = (($T) $L).asVector()",
                 vectorType(interState.elementType()),
-                blockType(interState.elementType())
+                interState.name(),
+                blockType,
+                interState.name() + "Uncast"
             );
-            count++;
+            builder.addStatement("assert $L.getPositionCount() == 1", interState.name());
         }
-        final String first = intermediateState.get(0).name();
-        builder.addStatement("assert " + first + ".getPositionCount() == 1");
-        if (intermediateState.size() > 1) {
-            builder.addStatement(
-                "assert "
-                    + intermediateState.stream()
-                        .map(IntermediateStateDesc::name)
-                        .skip(1)
-                        .map(s -> first + ".getPositionCount() == " + s + ".getPositionCount()")
-                        .collect(joining(" && "))
-            );
-        }
-        if (hasPrimitiveState()) {
+        if (combineIntermediate != null) {
+            if (intermediateState.stream().map(IntermediateStateDesc::elementType).anyMatch(n -> n.equals("BYTES_REF"))) {
+                builder.addStatement("$T scratch = new $T()", BYTES_REF, BYTES_REF);
+            }
+            builder.addStatement("$T.combineIntermediate(state, " + intermediateStateRowAccess() + ")", declarationType);
+        } else if (hasPrimitiveState()) {
             assert intermediateState.size() == 2;
             assert intermediateState.get(1).name().equals("seen");
             builder.beginControlFlow("if (seen.getBoolean(0))");
@@ -438,10 +432,7 @@ public class AggregatorImplementer {
                 builder.endControlFlow();
             }
         } else {
-            if (intermediateState.stream().map(IntermediateStateDesc::elementType).anyMatch(n -> n.equals("BYTES_REF"))) {
-                builder.addStatement("$T scratch = new $T()", BYTES_REF, BYTES_REF);
-            }
-            builder.addStatement("$T.combineIntermediate(state, " + intermediateStateRowAccess() + ")", declarationType);
+            throw new IllegalArgumentException("Don't know how to combine intermediate input. Define combineIntermediate");
         }
         return builder.build();
     }
@@ -468,7 +459,7 @@ public class AggregatorImplementer {
                 return "doubleValue";
             default:
                 throw new IllegalArgumentException(
-                    "don't know how to fetch primitive values from " + stateType + ". define combineStates."
+                    "don't know how to fetch primitive values from " + stateType + ". define combineIntermediate."
                 );
         }
     }

--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/Methods.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/Methods.java
@@ -194,7 +194,7 @@ public class Methods {
             case "DOUBLE" -> "getDouble";
             case "BYTES_REF" -> "getBytesRef";
             default -> throw new IllegalArgumentException(
-                "don't know how to fetch primitive values from " + elementTypeName + ". define combineStates."
+                "don't know how to fetch primitive values from " + elementTypeName + ". define combineIntermediate."
             );
         };
     }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBooleanAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBooleanAggregatorFunction.java
@@ -86,14 +86,18 @@ public final class CountDistinctBooleanAggregatorFunction implements AggregatorF
   public void addIntermediateInput(Page page) {
     assert channels.size() == intermediateBlockCount();
     assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
-    Block uncastBlock = page.getBlock(channels.get(0));
-    if (uncastBlock.areAllValuesNull()) {
+    Block fbitUncast = page.getBlock(channels.get(0));
+    if (fbitUncast.areAllValuesNull()) {
       return;
     }
-    BooleanVector fbit = page.<BooleanBlock>getBlock(channels.get(0)).asVector();
-    BooleanVector tbit = page.<BooleanBlock>getBlock(channels.get(1)).asVector();
+    BooleanVector fbit = ((BooleanBlock) fbitUncast).asVector();
     assert fbit.getPositionCount() == 1;
-    assert fbit.getPositionCount() == tbit.getPositionCount();
+    Block tbitUncast = page.getBlock(channels.get(1));
+    if (tbitUncast.areAllValuesNull()) {
+      return;
+    }
+    BooleanVector tbit = ((BooleanBlock) tbitUncast).asVector();
+    assert tbit.getPositionCount() == 1;
     CountDistinctBooleanAggregator.combineIntermediate(state, fbit.getBoolean(0), tbit.getBoolean(0));
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBytesRefAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBytesRefAggregatorFunction.java
@@ -95,11 +95,11 @@ public final class CountDistinctBytesRefAggregatorFunction implements Aggregator
   public void addIntermediateInput(Page page) {
     assert channels.size() == intermediateBlockCount();
     assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
-    Block uncastBlock = page.getBlock(channels.get(0));
-    if (uncastBlock.areAllValuesNull()) {
+    Block hllUncast = page.getBlock(channels.get(0));
+    if (hllUncast.areAllValuesNull()) {
       return;
     }
-    BytesRefVector hll = page.<BytesRefBlock>getBlock(channels.get(0)).asVector();
+    BytesRefVector hll = ((BytesRefBlock) hllUncast).asVector();
     assert hll.getPositionCount() == 1;
     BytesRef scratch = new BytesRef();
     CountDistinctBytesRefAggregator.combineIntermediate(state, hll.getBytesRef(0, scratch));

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctDoubleAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctDoubleAggregatorFunction.java
@@ -95,11 +95,11 @@ public final class CountDistinctDoubleAggregatorFunction implements AggregatorFu
   public void addIntermediateInput(Page page) {
     assert channels.size() == intermediateBlockCount();
     assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
-    Block uncastBlock = page.getBlock(channels.get(0));
-    if (uncastBlock.areAllValuesNull()) {
+    Block hllUncast = page.getBlock(channels.get(0));
+    if (hllUncast.areAllValuesNull()) {
       return;
     }
-    BytesRefVector hll = page.<BytesRefBlock>getBlock(channels.get(0)).asVector();
+    BytesRefVector hll = ((BytesRefBlock) hllUncast).asVector();
     assert hll.getPositionCount() == 1;
     BytesRef scratch = new BytesRef();
     CountDistinctDoubleAggregator.combineIntermediate(state, hll.getBytesRef(0, scratch));

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctIntAggregatorFunction.java
@@ -95,11 +95,11 @@ public final class CountDistinctIntAggregatorFunction implements AggregatorFunct
   public void addIntermediateInput(Page page) {
     assert channels.size() == intermediateBlockCount();
     assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
-    Block uncastBlock = page.getBlock(channels.get(0));
-    if (uncastBlock.areAllValuesNull()) {
+    Block hllUncast = page.getBlock(channels.get(0));
+    if (hllUncast.areAllValuesNull()) {
       return;
     }
-    BytesRefVector hll = page.<BytesRefBlock>getBlock(channels.get(0)).asVector();
+    BytesRefVector hll = ((BytesRefBlock) hllUncast).asVector();
     assert hll.getPositionCount() == 1;
     BytesRef scratch = new BytesRef();
     CountDistinctIntAggregator.combineIntermediate(state, hll.getBytesRef(0, scratch));

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctLongAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctLongAggregatorFunction.java
@@ -95,11 +95,11 @@ public final class CountDistinctLongAggregatorFunction implements AggregatorFunc
   public void addIntermediateInput(Page page) {
     assert channels.size() == intermediateBlockCount();
     assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
-    Block uncastBlock = page.getBlock(channels.get(0));
-    if (uncastBlock.areAllValuesNull()) {
+    Block hllUncast = page.getBlock(channels.get(0));
+    if (hllUncast.areAllValuesNull()) {
       return;
     }
-    BytesRefVector hll = page.<BytesRefBlock>getBlock(channels.get(0)).asVector();
+    BytesRefVector hll = ((BytesRefBlock) hllUncast).asVector();
     assert hll.getPositionCount() == 1;
     BytesRef scratch = new BytesRef();
     CountDistinctLongAggregator.combineIntermediate(state, hll.getBytesRef(0, scratch));

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxDoubleAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxDoubleAggregatorFunction.java
@@ -90,14 +90,18 @@ public final class MaxDoubleAggregatorFunction implements AggregatorFunction {
   public void addIntermediateInput(Page page) {
     assert channels.size() == intermediateBlockCount();
     assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
-    Block uncastBlock = page.getBlock(channels.get(0));
-    if (uncastBlock.areAllValuesNull()) {
+    Block maxUncast = page.getBlock(channels.get(0));
+    if (maxUncast.areAllValuesNull()) {
       return;
     }
-    DoubleVector max = page.<DoubleBlock>getBlock(channels.get(0)).asVector();
-    BooleanVector seen = page.<BooleanBlock>getBlock(channels.get(1)).asVector();
+    DoubleVector max = ((DoubleBlock) maxUncast).asVector();
     assert max.getPositionCount() == 1;
-    assert max.getPositionCount() == seen.getPositionCount();
+    Block seenUncast = page.getBlock(channels.get(1));
+    if (seenUncast.areAllValuesNull()) {
+      return;
+    }
+    BooleanVector seen = ((BooleanBlock) seenUncast).asVector();
+    assert seen.getPositionCount() == 1;
     if (seen.getBoolean(0)) {
       state.doubleValue(MaxDoubleAggregator.combine(state.doubleValue(), max.getDouble(0)));
       state.seen(true);

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxIntAggregatorFunction.java
@@ -90,14 +90,18 @@ public final class MaxIntAggregatorFunction implements AggregatorFunction {
   public void addIntermediateInput(Page page) {
     assert channels.size() == intermediateBlockCount();
     assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
-    Block uncastBlock = page.getBlock(channels.get(0));
-    if (uncastBlock.areAllValuesNull()) {
+    Block maxUncast = page.getBlock(channels.get(0));
+    if (maxUncast.areAllValuesNull()) {
       return;
     }
-    IntVector max = page.<IntBlock>getBlock(channels.get(0)).asVector();
-    BooleanVector seen = page.<BooleanBlock>getBlock(channels.get(1)).asVector();
+    IntVector max = ((IntBlock) maxUncast).asVector();
     assert max.getPositionCount() == 1;
-    assert max.getPositionCount() == seen.getPositionCount();
+    Block seenUncast = page.getBlock(channels.get(1));
+    if (seenUncast.areAllValuesNull()) {
+      return;
+    }
+    BooleanVector seen = ((BooleanBlock) seenUncast).asVector();
+    assert seen.getPositionCount() == 1;
     if (seen.getBoolean(0)) {
       state.intValue(MaxIntAggregator.combine(state.intValue(), max.getInt(0)));
       state.seen(true);

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxLongAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxLongAggregatorFunction.java
@@ -90,14 +90,18 @@ public final class MaxLongAggregatorFunction implements AggregatorFunction {
   public void addIntermediateInput(Page page) {
     assert channels.size() == intermediateBlockCount();
     assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
-    Block uncastBlock = page.getBlock(channels.get(0));
-    if (uncastBlock.areAllValuesNull()) {
+    Block maxUncast = page.getBlock(channels.get(0));
+    if (maxUncast.areAllValuesNull()) {
       return;
     }
-    LongVector max = page.<LongBlock>getBlock(channels.get(0)).asVector();
-    BooleanVector seen = page.<BooleanBlock>getBlock(channels.get(1)).asVector();
+    LongVector max = ((LongBlock) maxUncast).asVector();
     assert max.getPositionCount() == 1;
-    assert max.getPositionCount() == seen.getPositionCount();
+    Block seenUncast = page.getBlock(channels.get(1));
+    if (seenUncast.areAllValuesNull()) {
+      return;
+    }
+    BooleanVector seen = ((BooleanBlock) seenUncast).asVector();
+    assert seen.getPositionCount() == 1;
     if (seen.getBoolean(0)) {
       state.longValue(MaxLongAggregator.combine(state.longValue(), max.getLong(0)));
       state.seen(true);

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleAggregatorFunction.java
@@ -88,11 +88,11 @@ public final class MedianAbsoluteDeviationDoubleAggregatorFunction implements Ag
   public void addIntermediateInput(Page page) {
     assert channels.size() == intermediateBlockCount();
     assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
-    Block uncastBlock = page.getBlock(channels.get(0));
-    if (uncastBlock.areAllValuesNull()) {
+    Block quartUncast = page.getBlock(channels.get(0));
+    if (quartUncast.areAllValuesNull()) {
       return;
     }
-    BytesRefVector quart = page.<BytesRefBlock>getBlock(channels.get(0)).asVector();
+    BytesRefVector quart = ((BytesRefBlock) quartUncast).asVector();
     assert quart.getPositionCount() == 1;
     BytesRef scratch = new BytesRef();
     MedianAbsoluteDeviationDoubleAggregator.combineIntermediate(state, quart.getBytesRef(0, scratch));

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationIntAggregatorFunction.java
@@ -88,11 +88,11 @@ public final class MedianAbsoluteDeviationIntAggregatorFunction implements Aggre
   public void addIntermediateInput(Page page) {
     assert channels.size() == intermediateBlockCount();
     assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
-    Block uncastBlock = page.getBlock(channels.get(0));
-    if (uncastBlock.areAllValuesNull()) {
+    Block quartUncast = page.getBlock(channels.get(0));
+    if (quartUncast.areAllValuesNull()) {
       return;
     }
-    BytesRefVector quart = page.<BytesRefBlock>getBlock(channels.get(0)).asVector();
+    BytesRefVector quart = ((BytesRefBlock) quartUncast).asVector();
     assert quart.getPositionCount() == 1;
     BytesRef scratch = new BytesRef();
     MedianAbsoluteDeviationIntAggregator.combineIntermediate(state, quart.getBytesRef(0, scratch));

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationLongAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationLongAggregatorFunction.java
@@ -88,11 +88,11 @@ public final class MedianAbsoluteDeviationLongAggregatorFunction implements Aggr
   public void addIntermediateInput(Page page) {
     assert channels.size() == intermediateBlockCount();
     assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
-    Block uncastBlock = page.getBlock(channels.get(0));
-    if (uncastBlock.areAllValuesNull()) {
+    Block quartUncast = page.getBlock(channels.get(0));
+    if (quartUncast.areAllValuesNull()) {
       return;
     }
-    BytesRefVector quart = page.<BytesRefBlock>getBlock(channels.get(0)).asVector();
+    BytesRefVector quart = ((BytesRefBlock) quartUncast).asVector();
     assert quart.getPositionCount() == 1;
     BytesRef scratch = new BytesRef();
     MedianAbsoluteDeviationLongAggregator.combineIntermediate(state, quart.getBytesRef(0, scratch));

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinIntAggregatorFunction.java
@@ -90,14 +90,18 @@ public final class MinIntAggregatorFunction implements AggregatorFunction {
   public void addIntermediateInput(Page page) {
     assert channels.size() == intermediateBlockCount();
     assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
-    Block uncastBlock = page.getBlock(channels.get(0));
-    if (uncastBlock.areAllValuesNull()) {
+    Block minUncast = page.getBlock(channels.get(0));
+    if (minUncast.areAllValuesNull()) {
       return;
     }
-    IntVector min = page.<IntBlock>getBlock(channels.get(0)).asVector();
-    BooleanVector seen = page.<BooleanBlock>getBlock(channels.get(1)).asVector();
+    IntVector min = ((IntBlock) minUncast).asVector();
     assert min.getPositionCount() == 1;
-    assert min.getPositionCount() == seen.getPositionCount();
+    Block seenUncast = page.getBlock(channels.get(1));
+    if (seenUncast.areAllValuesNull()) {
+      return;
+    }
+    BooleanVector seen = ((BooleanBlock) seenUncast).asVector();
+    assert seen.getPositionCount() == 1;
     if (seen.getBoolean(0)) {
       state.intValue(MinIntAggregator.combine(state.intValue(), min.getInt(0)));
       state.seen(true);

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinLongAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinLongAggregatorFunction.java
@@ -90,14 +90,18 @@ public final class MinLongAggregatorFunction implements AggregatorFunction {
   public void addIntermediateInput(Page page) {
     assert channels.size() == intermediateBlockCount();
     assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
-    Block uncastBlock = page.getBlock(channels.get(0));
-    if (uncastBlock.areAllValuesNull()) {
+    Block minUncast = page.getBlock(channels.get(0));
+    if (minUncast.areAllValuesNull()) {
       return;
     }
-    LongVector min = page.<LongBlock>getBlock(channels.get(0)).asVector();
-    BooleanVector seen = page.<BooleanBlock>getBlock(channels.get(1)).asVector();
+    LongVector min = ((LongBlock) minUncast).asVector();
     assert min.getPositionCount() == 1;
-    assert min.getPositionCount() == seen.getPositionCount();
+    Block seenUncast = page.getBlock(channels.get(1));
+    if (seenUncast.areAllValuesNull()) {
+      return;
+    }
+    BooleanVector seen = ((BooleanBlock) seenUncast).asVector();
+    assert seen.getPositionCount() == 1;
     if (seen.getBoolean(0)) {
       state.longValue(MinLongAggregator.combine(state.longValue(), min.getLong(0)));
       state.seen(true);

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileDoubleAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileDoubleAggregatorFunction.java
@@ -91,11 +91,11 @@ public final class PercentileDoubleAggregatorFunction implements AggregatorFunct
   public void addIntermediateInput(Page page) {
     assert channels.size() == intermediateBlockCount();
     assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
-    Block uncastBlock = page.getBlock(channels.get(0));
-    if (uncastBlock.areAllValuesNull()) {
+    Block quartUncast = page.getBlock(channels.get(0));
+    if (quartUncast.areAllValuesNull()) {
       return;
     }
-    BytesRefVector quart = page.<BytesRefBlock>getBlock(channels.get(0)).asVector();
+    BytesRefVector quart = ((BytesRefBlock) quartUncast).asVector();
     assert quart.getPositionCount() == 1;
     BytesRef scratch = new BytesRef();
     PercentileDoubleAggregator.combineIntermediate(state, quart.getBytesRef(0, scratch));

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileIntAggregatorFunction.java
@@ -91,11 +91,11 @@ public final class PercentileIntAggregatorFunction implements AggregatorFunction
   public void addIntermediateInput(Page page) {
     assert channels.size() == intermediateBlockCount();
     assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
-    Block uncastBlock = page.getBlock(channels.get(0));
-    if (uncastBlock.areAllValuesNull()) {
+    Block quartUncast = page.getBlock(channels.get(0));
+    if (quartUncast.areAllValuesNull()) {
       return;
     }
-    BytesRefVector quart = page.<BytesRefBlock>getBlock(channels.get(0)).asVector();
+    BytesRefVector quart = ((BytesRefBlock) quartUncast).asVector();
     assert quart.getPositionCount() == 1;
     BytesRef scratch = new BytesRef();
     PercentileIntAggregator.combineIntermediate(state, quart.getBytesRef(0, scratch));

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileLongAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileLongAggregatorFunction.java
@@ -91,11 +91,11 @@ public final class PercentileLongAggregatorFunction implements AggregatorFunctio
   public void addIntermediateInput(Page page) {
     assert channels.size() == intermediateBlockCount();
     assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
-    Block uncastBlock = page.getBlock(channels.get(0));
-    if (uncastBlock.areAllValuesNull()) {
+    Block quartUncast = page.getBlock(channels.get(0));
+    if (quartUncast.areAllValuesNull()) {
       return;
     }
-    BytesRefVector quart = page.<BytesRefBlock>getBlock(channels.get(0)).asVector();
+    BytesRefVector quart = ((BytesRefBlock) quartUncast).asVector();
     assert quart.getPositionCount() == 1;
     BytesRef scratch = new BytesRef();
     PercentileLongAggregator.combineIntermediate(state, quart.getBytesRef(0, scratch));

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumDoubleAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumDoubleAggregatorFunction.java
@@ -91,15 +91,24 @@ public final class SumDoubleAggregatorFunction implements AggregatorFunction {
   public void addIntermediateInput(Page page) {
     assert channels.size() == intermediateBlockCount();
     assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
-    Block uncastBlock = page.getBlock(channels.get(0));
-    if (uncastBlock.areAllValuesNull()) {
+    Block valueUncast = page.getBlock(channels.get(0));
+    if (valueUncast.areAllValuesNull()) {
       return;
     }
-    DoubleVector value = page.<DoubleBlock>getBlock(channels.get(0)).asVector();
-    DoubleVector delta = page.<DoubleBlock>getBlock(channels.get(1)).asVector();
-    BooleanVector seen = page.<BooleanBlock>getBlock(channels.get(2)).asVector();
+    DoubleVector value = ((DoubleBlock) valueUncast).asVector();
     assert value.getPositionCount() == 1;
-    assert value.getPositionCount() == delta.getPositionCount() && value.getPositionCount() == seen.getPositionCount();
+    Block deltaUncast = page.getBlock(channels.get(1));
+    if (deltaUncast.areAllValuesNull()) {
+      return;
+    }
+    DoubleVector delta = ((DoubleBlock) deltaUncast).asVector();
+    assert delta.getPositionCount() == 1;
+    Block seenUncast = page.getBlock(channels.get(2));
+    if (seenUncast.areAllValuesNull()) {
+      return;
+    }
+    BooleanVector seen = ((BooleanBlock) seenUncast).asVector();
+    assert seen.getPositionCount() == 1;
     SumDoubleAggregator.combineIntermediate(state, value.getDouble(0), delta.getDouble(0), seen.getBoolean(0));
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumIntAggregatorFunction.java
@@ -92,14 +92,18 @@ public final class SumIntAggregatorFunction implements AggregatorFunction {
   public void addIntermediateInput(Page page) {
     assert channels.size() == intermediateBlockCount();
     assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
-    Block uncastBlock = page.getBlock(channels.get(0));
-    if (uncastBlock.areAllValuesNull()) {
+    Block sumUncast = page.getBlock(channels.get(0));
+    if (sumUncast.areAllValuesNull()) {
       return;
     }
-    LongVector sum = page.<LongBlock>getBlock(channels.get(0)).asVector();
-    BooleanVector seen = page.<BooleanBlock>getBlock(channels.get(1)).asVector();
+    LongVector sum = ((LongBlock) sumUncast).asVector();
     assert sum.getPositionCount() == 1;
-    assert sum.getPositionCount() == seen.getPositionCount();
+    Block seenUncast = page.getBlock(channels.get(1));
+    if (seenUncast.areAllValuesNull()) {
+      return;
+    }
+    BooleanVector seen = ((BooleanBlock) seenUncast).asVector();
+    assert seen.getPositionCount() == 1;
     if (seen.getBoolean(0)) {
       state.longValue(SumIntAggregator.combine(state.longValue(), sum.getLong(0)));
       state.seen(true);

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumLongAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumLongAggregatorFunction.java
@@ -90,14 +90,18 @@ public final class SumLongAggregatorFunction implements AggregatorFunction {
   public void addIntermediateInput(Page page) {
     assert channels.size() == intermediateBlockCount();
     assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
-    Block uncastBlock = page.getBlock(channels.get(0));
-    if (uncastBlock.areAllValuesNull()) {
+    Block sumUncast = page.getBlock(channels.get(0));
+    if (sumUncast.areAllValuesNull()) {
       return;
     }
-    LongVector sum = page.<LongBlock>getBlock(channels.get(0)).asVector();
-    BooleanVector seen = page.<BooleanBlock>getBlock(channels.get(1)).asVector();
+    LongVector sum = ((LongBlock) sumUncast).asVector();
     assert sum.getPositionCount() == 1;
-    assert sum.getPositionCount() == seen.getPositionCount();
+    Block seenUncast = page.getBlock(channels.get(1));
+    if (seenUncast.areAllValuesNull()) {
+      return;
+    }
+    BooleanVector seen = ((BooleanBlock) seenUncast).asVector();
+    assert seen.getPositionCount() == 1;
     if (seen.getBoolean(0)) {
       state.longValue(SumLongAggregator.combine(state.longValue(), sum.getLong(0)));
       state.seen(true);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountDistinctBooleanAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountDistinctBooleanAggregator.java
@@ -33,10 +33,6 @@ public class CountDistinctBooleanAggregator {
         current.bits |= v ? BIT_TRUE : BIT_FALSE;
     }
 
-    public static void combineStates(SingleState current, SingleState state) {
-        current.bits |= state.bits;
-    }
-
     public static void combineIntermediate(SingleState current, boolean fbit, boolean tbit) {
         if (fbit) current.bits |= BIT_FALSE;
         if (tbit) current.bits |= BIT_TRUE;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountDistinctBytesRefAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountDistinctBytesRefAggregator.java
@@ -29,10 +29,6 @@ public class CountDistinctBytesRefAggregator {
         current.collect(v);
     }
 
-    public static void combineStates(HllStates.SingleState current, HllStates.SingleState state) {
-        current.merge(0, state.hll, 0);
-    }
-
     public static void combineIntermediate(HllStates.SingleState current, BytesRef inValue) {
         current.merge(0, inValue, 0);
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountDistinctDoubleAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountDistinctDoubleAggregator.java
@@ -29,10 +29,6 @@ public class CountDistinctDoubleAggregator {
         current.collect(v);
     }
 
-    public static void combineStates(HllStates.SingleState current, HllStates.SingleState state) {
-        current.merge(0, state.hll, 0);
-    }
-
     public static void combineIntermediate(HllStates.SingleState current, BytesRef inValue) {
         current.merge(0, inValue, 0);
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountDistinctIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountDistinctIntAggregator.java
@@ -29,10 +29,6 @@ public class CountDistinctIntAggregator {
         current.collect(v);
     }
 
-    public static void combineStates(HllStates.SingleState current, HllStates.SingleState state) {
-        current.merge(0, state.hll, 0);
-    }
-
     public static void combineIntermediate(HllStates.SingleState current, BytesRef inValue) {
         current.merge(0, inValue, 0);
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountDistinctLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountDistinctLongAggregator.java
@@ -29,10 +29,6 @@ public class CountDistinctLongAggregator {
         current.collect(v);
     }
 
-    public static void combineStates(HllStates.SingleState current, HllStates.SingleState state) {
-        current.merge(0, state.hll, 0);
-    }
-
     public static void combineIntermediate(HllStates.SingleState current, BytesRef inValue) {
         current.merge(0, inValue, 0);
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleAggregator.java
@@ -28,10 +28,6 @@ class MedianAbsoluteDeviationDoubleAggregator {
         current.add(v);
     }
 
-    public static void combineStates(QuantileStates.SingleState current, QuantileStates.SingleState state) {
-        current.add(state);
-    }
-
     public static void combineIntermediate(QuantileStates.SingleState state, BytesRef inValue) {
         state.add(inValue);
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationIntAggregator.java
@@ -28,10 +28,6 @@ class MedianAbsoluteDeviationIntAggregator {
         current.add(v);
     }
 
-    public static void combineStates(QuantileStates.SingleState current, QuantileStates.SingleState state) {
-        current.add(state);
-    }
-
     public static void combineIntermediate(QuantileStates.SingleState state, BytesRef inValue) {
         state.add(inValue);
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationLongAggregator.java
@@ -32,10 +32,6 @@ class MedianAbsoluteDeviationLongAggregator {
         state.add(inValue);
     }
 
-    public static void combineStates(QuantileStates.SingleState current, QuantileStates.SingleState state) {
-        current.add(state);
-    }
-
     public static Block evaluateFinal(QuantileStates.SingleState state, DriverContext driverContext) {
         return state.evaluateMedianAbsoluteDeviation(driverContext);
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/PercentileDoubleAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/PercentileDoubleAggregator.java
@@ -28,10 +28,6 @@ class PercentileDoubleAggregator {
         current.add(v);
     }
 
-    public static void combineStates(QuantileStates.SingleState current, QuantileStates.SingleState state) {
-        current.add(state);
-    }
-
     public static void combineIntermediate(QuantileStates.SingleState state, BytesRef inValue) {
         state.add(inValue);
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/PercentileIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/PercentileIntAggregator.java
@@ -28,10 +28,6 @@ class PercentileIntAggregator {
         current.add(v);
     }
 
-    public static void combineStates(QuantileStates.SingleState current, QuantileStates.SingleState state) {
-        current.add(state);
-    }
-
     public static void combineIntermediate(QuantileStates.SingleState state, BytesRef inValue) {
         state.add(inValue);
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/PercentileLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/PercentileLongAggregator.java
@@ -28,10 +28,6 @@ class PercentileLongAggregator {
         current.add(v);
     }
 
-    public static void combineStates(QuantileStates.SingleState current, QuantileStates.SingleState state) {
-        current.add(state);
-    }
-
     public static void combineIntermediate(QuantileStates.SingleState state, BytesRef inValue) {
         state.add(inValue);
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/QuantileStates.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/QuantileStates.java
@@ -72,10 +72,6 @@ public final class QuantileStates {
             digest.add(v);
         }
 
-        void add(SingleState other) {
-            digest.add(other.digest);
-        }
-
         void add(BytesRef other) {
             digest.add(deserializeDigest(other));
         }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/SumDoubleAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/SumDoubleAggregator.java
@@ -42,10 +42,6 @@ class SumDoubleAggregator {
         current.add(value, delta);
     }
 
-    public static void combineStates(SumState current, SumState state) {
-        current.add(state.value(), state.delta());
-    }
-
     public static void combineIntermediate(SumState state, double inValue, double inDelta, boolean seen) {
         if (seen) {
             combine(state, inValue, inDelta);


### PR DESCRIPTION
This removes an unused method from every agg - the `combineStates` variant for ungrouped aggs. Usually `combineStates` is used to implement ordinals grouping. But ungrouped aggs aren't grouped at all. So we don't need the method.

This also cleans how we perform null checking on multi-valued intermediate states. We were only checking for entirely null valued intermediate states on the first state rather than each. Now we check on all states. In practice only the first state is likely to have any nulls at all, but this feels more clean.
