### PR TITLE
Updated public method to final to avoid warning

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterCredentialsManager.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterCredentialsManager.java
@@ -29,7 +29,7 @@ public class RemoteClusterCredentialsManager {
         updateClusterCredentials(settings);
     }
 
-    public void updateClusterCredentials(Settings settings) {
+    public final void updateClusterCredentials(Settings settings) {
         clusterCredentials = REMOTE_CLUSTER_CREDENTIALS.getAsMap(settings);
         logger.debug(
             () -> Strings.format(


### PR DESCRIPTION
when building I would get the following warning which caused my build to fail:
```
> Task :server:compileJava
/Users/mh/workplace/elasticsearch/server/src/main/java/org/elasticsearch/transport/RemoteClusterCredentialsManager.java:29: warning: [this-escape] possible 'this' escape before subclass is fully initialized
        updateClusterCredentials(settings);
                                ^
error: warnings found and -Werror specified
```

To fix this warning I made updateClusterCredentials final.
