### PR TITLE
[Failure Store] Make the XContent resilient to the enabling and disabling of the failure store feature flag.

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestPutComposableIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestPutComposableIndexTemplateAction.java
@@ -44,7 +44,7 @@ public class RestPutComposableIndexTemplateAction extends BaseRestHandler {
         putRequest.create(request.paramAsBoolean("create", false));
         putRequest.cause(request.param("cause", "api"));
         try (var parser = request.contentParser()) {
-            putRequest.indexTemplate(ComposableIndexTemplate.parse(parser));
+            putRequest.indexTemplate(ComposableIndexTemplate.parseUserInput(parser));
         }
 
         return channel -> client.execute(PutComposableIndexTemplateAction.INSTANCE, putRequest, new RestToXContentListener<>(channel));

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestSimulateIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestSimulateIndexTemplateAction.java
@@ -49,7 +49,7 @@ public class RestSimulateIndexTemplateAction extends BaseRestHandler {
                 "simulating_template"
             );
             try (var parser = request.contentParser()) {
-                indexTemplateRequest.indexTemplate(ComposableIndexTemplate.parse(parser));
+                indexTemplateRequest.indexTemplate(ComposableIndexTemplate.parseUserInput(parser));
             }
             indexTemplateRequest.create(request.paramAsBoolean("create", false));
             indexTemplateRequest.cause(request.param("cause", "api"));

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestSimulateTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestSimulateTemplateAction.java
@@ -45,7 +45,7 @@ public class RestSimulateTemplateAction extends BaseRestHandler {
                 "simulating_template"
             );
             try (var parser = request.contentParser()) {
-                indexTemplateRequest.indexTemplate(ComposableIndexTemplate.parse(parser));
+                indexTemplateRequest.indexTemplate(ComposableIndexTemplate.parseUserInput(parser));
             }
             indexTemplateRequest.create(request.paramAsBoolean("create", false));
             indexTemplateRequest.cause(request.param("cause", "api"));

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplateUserInputTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplateUserInputTests.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.cluster.metadata;
+
+import org.elasticsearch.action.admin.indices.rollover.RolloverConfiguration;
+import org.elasticsearch.action.admin.indices.rollover.RolloverConfigurationTests;
+import org.elasticsearch.cluster.Diff;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.SimpleDiffableSerializationTestCase;
+import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentType;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.cluster.metadata.DataStream.TIMESTAMP_FIELD_NAME;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+public class ComposableIndexTemplateUserInputTests extends SimpleDiffableSerializationTestCase<ComposableIndexTemplate> {
+    @Override
+    protected ComposableIndexTemplate makeTestChanges(ComposableIndexTemplate testInstance) {
+        return mutateInstance(testInstance);
+    }
+
+    @Override
+    protected Writeable.Reader<Diff<ComposableIndexTemplate>> diffReader() {
+        return ComposableIndexTemplate::readITV2DiffFrom;
+    }
+
+    @Override
+    protected ComposableIndexTemplate doParseInstance(XContentParser parser) throws IOException {
+        return ComposableIndexTemplate.parseUserInput(parser);
+    }
+
+    @Override
+    protected Writeable.Reader<ComposableIndexTemplate> instanceReader() {
+        return ComposableIndexTemplate::new;
+    }
+
+    @Override
+    protected ComposableIndexTemplate createTestInstance() {
+        return randomInstance();
+    }
+
+    public static ComposableIndexTemplate randomInstance() {
+        Settings settings = null;
+        CompressedXContent mappings = null;
+        Map<String, AliasMetadata> aliases = null;
+        Template template = null;
+        ComposableIndexTemplate.DataStreamTemplate dataStreamTemplate = randomDataStreamTemplate();
+
+        if (dataStreamTemplate != null || randomBoolean()) {
+            if (randomBoolean()) {
+                settings = randomSettings();
+            }
+            if (dataStreamTemplate != null || randomBoolean()) {
+                mappings = randomMappings(dataStreamTemplate);
+            }
+            if (dataStreamTemplate == null && randomBoolean()) {
+                aliases = randomAliases();
+            }
+            template = new Template(settings, mappings, aliases);
+        }
+
+        Map<String, Object> meta = null;
+        if (randomBoolean()) {
+            meta = randomMeta();
+        }
+
+        List<String> indexPatterns = randomList(1, 4, () -> randomAlphaOfLength(4));
+        List<String> ignoreMissingComponentTemplates = randomList(0, 4, () -> randomAlphaOfLength(4));
+        return ComposableIndexTemplate.builder()
+            .indexPatterns(indexPatterns)
+            .template(template)
+            .componentTemplates(randomBoolean() ? null : randomList(0, 10, () -> randomAlphaOfLength(5)))
+            .priority(randomBoolean() ? null : randomNonNegativeLong())
+            .version(randomBoolean() ? null : randomNonNegativeLong())
+            .metadata(meta)
+            .dataStreamTemplate(dataStreamTemplate)
+            .allowAutoCreate(randomOptionalBoolean())
+            .ignoreMissingComponentTemplates(ignoreMissingComponentTemplates)
+            .deprecated(randomOptionalBoolean())
+            .build();
+    }
+
+    private static Map<String, AliasMetadata> randomAliases() {
+        String aliasName = randomAlphaOfLength(5);
+        AliasMetadata aliasMeta = AliasMetadata.builder(aliasName)
+            .filter("{\"term\":{\"year\":" + randomIntBetween(1, 3000) + "}}")
+            .routing(randomBoolean() ? null : randomAlphaOfLength(3))
+            .isHidden(randomBoolean() ? null : randomBoolean())
+            .writeIndex(randomBoolean() ? null : randomBoolean())
+            .build();
+        return Collections.singletonMap(aliasName, aliasMeta);
+    }
+
+    private static DataStreamLifecycle randomLifecycle() {
+        return DataStreamLifecycle.newBuilder().dataRetention(randomMillisUpToYear9999()).build();
+    }
+
+    private static CompressedXContent randomMappings(ComposableIndexTemplate.DataStreamTemplate dataStreamTemplate) {
+        try {
+            if (dataStreamTemplate != null) {
+                return new CompressedXContent("{\"properties\":{\"" + TIMESTAMP_FIELD_NAME + "\":{\"type\":\"date\"}}}");
+            } else {
+                return new CompressedXContent("{\"properties\":{\"" + randomAlphaOfLength(5) + "\":{\"type\":\"keyword\"}}}");
+            }
+        } catch (IOException e) {
+            fail("got an IO exception creating fake mappings: " + e);
+            return null;
+        }
+    }
+
+    private static Settings randomSettings() {
+        return indexSettings(randomIntBetween(1, 10), randomIntBetween(0, 5)).put(IndexMetadata.SETTING_BLOCKS_READ, randomBoolean())
+            .put(IndexMetadata.SETTING_BLOCKS_WRITE, randomBoolean())
+            .put(IndexMetadata.SETTING_BLOCKS_WRITE, randomBoolean())
+            .put(IndexMetadata.SETTING_PRIORITY, randomIntBetween(0, 100000))
+            .build();
+    }
+
+    private static Map<String, Object> randomMeta() {
+        if (randomBoolean()) {
+            return Collections.singletonMap(randomAlphaOfLength(4), randomAlphaOfLength(4));
+        } else {
+            return Collections.singletonMap(
+                randomAlphaOfLength(5),
+                Collections.singletonMap(randomAlphaOfLength(4), randomAlphaOfLength(4))
+            );
+        }
+    }
+
+    private static ComposableIndexTemplate.DataStreamTemplate randomDataStreamTemplate() {
+        if (randomBoolean()) {
+            return null;
+        } else {
+            return DataStreamTemplateTests.randomInstance();
+        }
+    }
+
+    @Override
+    protected ComposableIndexTemplate mutateInstance(ComposableIndexTemplate orig) {
+        return mutateTemplate(orig);
+    }
+
+    public static ComposableIndexTemplate mutateTemplate(ComposableIndexTemplate orig) {
+        switch (randomIntBetween(0, 8)) {
+            case 0:
+                List<String> newIndexPatterns = randomValueOtherThan(
+                    orig.indexPatterns(),
+                    () -> randomList(1, 4, () -> randomAlphaOfLength(4))
+                );
+                return orig.toBuilder().indexPatterns(newIndexPatterns).build();
+            case 1:
+                return orig.toBuilder()
+                    .template(
+                        randomValueOtherThan(
+                            orig.template(),
+                            () -> new Template(randomSettings(), randomMappings(orig.getDataStreamTemplate()), randomAliases())
+                        )
+                    )
+                    .build();
+            case 2:
+                List<String> newComposedOf = randomValueOtherThan(orig.composedOf(), () -> randomList(0, 10, () -> randomAlphaOfLength(5)));
+                return orig.toBuilder().componentTemplates(newComposedOf).build();
+            case 3:
+                return orig.toBuilder().priority(randomValueOtherThan(orig.priority(), ESTestCase::randomNonNegativeLong)).build();
+            case 4:
+                return orig.toBuilder().version(randomValueOtherThan(orig.version(), ESTestCase::randomNonNegativeLong)).build();
+            case 5:
+                return orig.toBuilder()
+                    .metadata(randomValueOtherThan(orig.metadata(), ComposableIndexTemplateUserInputTests::randomMeta))
+                    .build();
+            case 6:
+                return orig.toBuilder()
+                    .dataStreamTemplate(
+                        randomValueOtherThan(orig.getDataStreamTemplate(), ComposableIndexTemplateUserInputTests::randomDataStreamTemplate)
+                    )
+                    .build();
+            case 7:
+                List<String> ignoreMissingComponentTemplates = randomValueOtherThan(
+                    orig.getIgnoreMissingComponentTemplates(),
+                    () -> randomList(1, 4, () -> randomAlphaOfLength(4))
+                );
+                return orig.toBuilder().ignoreMissingComponentTemplates(ignoreMissingComponentTemplates).build();
+            case 8:
+                return orig.toBuilder().deprecated(orig.isDeprecated() ? randomFrom(false, null) : true).build();
+            default:
+                throw new IllegalStateException("illegal randomization branch");
+        }
+    }
+
+    public void testComponentTemplatesEquals() {
+        assertThat(ComposableIndexTemplate.componentTemplatesEquals(null, null), equalTo(true));
+        assertThat(ComposableIndexTemplate.componentTemplatesEquals(null, List.of()), equalTo(true));
+        assertThat(ComposableIndexTemplate.componentTemplatesEquals(List.of(), null), equalTo(true));
+        assertThat(ComposableIndexTemplate.componentTemplatesEquals(List.of(), List.of()), equalTo(true));
+        assertThat(ComposableIndexTemplate.componentTemplatesEquals(List.of(randomAlphaOfLength(5)), List.of()), equalTo(false));
+        assertThat(ComposableIndexTemplate.componentTemplatesEquals(List.of(), List.of(randomAlphaOfLength(5))), equalTo(false));
+    }
+
+    public void testXContentSerializationWithRollover() throws IOException {
+        Settings settings = null;
+        CompressedXContent mappings = null;
+        Map<String, AliasMetadata> aliases = null;
+        ComposableIndexTemplate.DataStreamTemplate dataStreamTemplate = randomDataStreamTemplate();
+        if (randomBoolean()) {
+            settings = randomSettings();
+        }
+        if (randomBoolean()) {
+            mappings = randomMappings(dataStreamTemplate);
+        }
+        if (randomBoolean()) {
+            aliases = randomAliases();
+        }
+        DataStreamLifecycle lifecycle = randomLifecycle();
+        Template template = new Template(settings, mappings, aliases, lifecycle);
+        ComposableIndexTemplate.builder()
+            .indexPatterns(List.of(randomAlphaOfLength(4)))
+            .template(template)
+            .componentTemplates(List.of())
+            .priority(randomNonNegativeLong())
+            .version(randomNonNegativeLong())
+            .dataStreamTemplate(dataStreamTemplate)
+            .build();
+
+        try (XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent())) {
+            builder.humanReadable(true);
+            RolloverConfiguration rolloverConfiguration = RolloverConfigurationTests.randomRolloverConditions();
+            template.toXContent(builder, ToXContent.EMPTY_PARAMS, rolloverConfiguration);
+            String serialized = Strings.toString(builder);
+            assertThat(serialized, containsString("rollover"));
+            for (String label : rolloverConfiguration.resolveRolloverConditions(lifecycle.getEffectiveDataRetention())
+                .getConditions()
+                .keySet()) {
+                assertThat(serialized, containsString(label));
+            }
+        }
+    }
+
+    public void testBuilderRoundtrip() {
+        ComposableIndexTemplate template = randomInstance();
+        assertEquals(template, template.toBuilder().build());
+    }
+}

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamTemplateTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamTemplateTests.java
@@ -33,7 +33,15 @@ public class DataStreamTemplateTests extends AbstractXContentSerializingTestCase
 
     @Override
     protected DataStreamTemplate mutateInstance(DataStreamTemplate instance) {
-        return null;// TODO implement https://github.com/elastic/elasticsearch/issues/25929
+        var hidden = instance.isHidden();
+        var allowCustomRouting = instance.isAllowCustomRouting();
+        var failureStore = instance.hasFailureStore();
+        switch (randomIntBetween(0, 2)) {
+            case 0 -> hidden = hidden == false;
+            case 1 -> allowCustomRouting = allowCustomRouting == false;
+            default -> failureStore = failureStore == false;
+        }
+        return new DataStreamTemplate(hidden, allowCustomRouting, failureStore);
     }
 
     public static DataStreamTemplate randomInstance() {

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamTemplateTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamTemplateTests.java
@@ -18,7 +18,7 @@ public class DataStreamTemplateTests extends AbstractXContentSerializingTestCase
 
     @Override
     protected DataStreamTemplate doParseInstance(XContentParser parser) throws IOException {
-        return DataStreamTemplate.PARSER.parse(parser, null);
+        return DataStreamTemplate.INTERNAL_PARSER.parse(parser, null);
     }
 
     @Override
@@ -47,5 +47,4 @@ public class DataStreamTemplateTests extends AbstractXContentSerializingTestCase
     public static DataStreamTemplate randomInstance() {
         return new ComposableIndexTemplate.DataStreamTemplate(randomBoolean(), randomBoolean(), randomBoolean());
     }
-
 }


### PR DESCRIPTION
In https://github.com/elastic/elasticsearch/issues/103365 the test fails because the node being upgraded crashed. The cause of the crash is a side effect of change in the feature flag state. 

The following scenario describes better the bug:

- Node is on version `8.12.0-SNAPSHOT`
- Node persists in the cluster state a composable index template of a data stream which has the following metadata:
```
{
  ...,
  "failure_store": false
}
```
The failure store flag is present because the failure store feature flag is enabled and even if there is no use of the field because the field is not optional.
- Node upgrades to `8.13.0`, feature flag is disabled.
- When retrieving the cluster state the node crashes because it cannot parse the template anymore.

Proposed solution:
For the lifetime of the feature flag we create two parsers:
- The internal parser which can handle the `failure_store` even when the feature flag is disabled.
- The user input parser which throws an error when it encounters the `failure_store` without the feature flag enabled.

The goal of this is to properly inform the user for an "unknown" field but not crash a node if someone enables the feature flag and the disables it.

Fixes: https://github.com/elastic/elasticsearch/issues/103365