### PR TITLE
[8.11] Exists query also works with only doc_values (#103647)

### DIFF
--- a/docs/reference/query-dsl/exists-query.asciidoc
+++ b/docs/reference/query-dsl/exists-query.asciidoc
@@ -9,7 +9,7 @@ Returns documents that contain an indexed value for a field.
 An indexed value may not exist for a document's field due to a variety of reasons:
 
 * The field in the source JSON is `null` or `[]`
-* The field has `"index" : false` set in the mapping
+* The field has `"index" : false` and `"doc_values" : false` set in the mapping
 * The length of the field value exceeded an `ignore_above` setting in the mapping
 * The field value was malformed and `ignore_malformed` was defined in the mapping
 


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Exists query also works with only doc_values (#103647)