### PR TITLE
[+DOC][ILM] age calculation resets post rollover

### DIFF
--- a/docs/reference/ilm/ilm-index-lifecycle.asciidoc
+++ b/docs/reference/ilm/ilm-index-lifecycle.asciidoc
@@ -33,7 +33,7 @@ update.
 [[ilm-phase-transitions]]
 === Phase transitions
 
-{ilm-init} moves indices through the lifecycle according to their `age` (time since rollover fallback index creation).
+{ilm-init} moves indices through the lifecycle according to their `age` (time since rollover, falling back to index creation if it has not yet rolled over).
 To control the timing of these transitions, you set a _minimum age_ `min_age` for each phase. For an index to
 move to the next phase, all actions in the current phase must be complete and the index must be
 older than the minimum age of the next phase. Configured minimum ages must increase between

--- a/docs/reference/ilm/ilm-index-lifecycle.asciidoc
+++ b/docs/reference/ilm/ilm-index-lifecycle.asciidoc
@@ -33,8 +33,8 @@ update.
 [[ilm-phase-transitions]]
 === Phase transitions
 
-{ilm-init} moves indices through the lifecycle according to their age.
-To control the timing of these transitions, you set a _minimum age_ for each phase. For an index to
+{ilm-init} moves indices through the lifecycle according to their `age` (time since rollover fallback index creation).
+To control the timing of these transitions, you set a _minimum age_ `min_age` for each phase. For an index to
 move to the next phase, all actions in the current phase must be complete and the index must be
 older than the minimum age of the next phase. Configured minimum ages must increase between
 subsequent phases, for example, a "warm" phase with a minimum age of 10 days can only be followed by


### PR DESCRIPTION
👋 howdy, team! 

I have the internal belief/understanding that [ILM Explain](https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-explain-lifecycle.html)'s `age` calculates based off rollover time fall back index creation time (or ILM creation time override settings). However, I'm not able to find that currently in existing docs, so adding it to [ILM > Phase Transitions](https://www.elastic.co/guide/en/elasticsearch/reference/8.11/ilm-index-lifecycle.html#ilm-phase-transitions). (Also adding column name references for doc searchability.)

TIA!

## Background

This surfaced from:

> ([doc](https://www.elastic.co/guide/en/elasticsearch/reference/current/getting-started-index-lifecycle-management.html#ilm-gs-check-progress)) The `age` of the indexed used to transition to the next phase (in this case it is the same with the age of the index).

Uh... I'm not actually(/currently) finding an official Elastic doc confirming `age` works off index creation time override to rollover time, but I know that's correspondingly true from the blog I wrote that LeeH had signed-off

> ([blog](https://www.elastic.co/blog/troubleshooting-elasticsearch-ilm-common-issues-and-fixes)) **Common issue 3: min_age calculation clarification**
> When working with customers, I have seen confusion about how `min_age` works. The min_age [must increase](https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-index-lifecycle.html#ilm-phase-transitions) between subsequent phases. If rollover is used, min_age is calculated off the rollover date. This is because rollover generates a new index and the new index’s creation date is used in the calculation. Otherwise, min_age is calculated off the original index’s creation date.

We're working to tighten-ship on docs+api for users to self-service understanding

> (internal) The `age` of an index is calculated based on:
> - The `index_creation_date_millis` of the index IF it did not go through `hot.rollover`
> - The rollover time of the index (TODO: `time_since_index_rollover`) IF it went through `hot.rollover` (noting rollover resets `age`)
> - Index ILM Setting overrides `index.lifecycle.origination_date` or `index.lifecycle.parse_origination_date` (related [blog](https://www.elastic.co/blog/control-ilm-phase-transition-timings-using-origination-date))


---

Related: https://github.com/elastic/elasticsearch/issues/103660, https://github.com/elastic/elasticsearch/issues/103659