### PR TITLE
ESQL: Improve local folding of aggregates

### DIFF
--- a/docs/changelog/103670.yaml
+++ b/docs/changelog/103670.yaml
@@ -1,0 +1,5 @@
+pr: 103670
+summary: "ESQL: Improve local folding of aggregates"
+area: ES|QL
+type: bug
+issues: []

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizer.java
@@ -7,15 +7,24 @@
 
 package org.elasticsearch.xpack.esql.optimizer;
 
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BlockUtils;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.Count;
 import org.elasticsearch.xpack.esql.expression.function.scalar.nulls.Coalesce;
+import org.elasticsearch.xpack.esql.optimizer.LogicalPlanOptimizer.PropagateEmptyRelation;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.TopN;
+import org.elasticsearch.xpack.esql.planner.AbstractPhysicalOperationProviders;
+import org.elasticsearch.xpack.esql.planner.PlannerUtils;
 import org.elasticsearch.xpack.esql.stats.SearchStats;
 import org.elasticsearch.xpack.ql.expression.Alias;
+import org.elasticsearch.xpack.ql.expression.Attribute;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.FieldAttribute;
 import org.elasticsearch.xpack.ql.expression.Literal;
 import org.elasticsearch.xpack.ql.expression.NamedExpression;
+import org.elasticsearch.xpack.ql.expression.function.aggregate.AggregateFunction;
 import org.elasticsearch.xpack.ql.optimizer.OptimizerRules;
 import org.elasticsearch.xpack.ql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.ql.plan.logical.EsRelation;
@@ -25,10 +34,15 @@ import org.elasticsearch.xpack.ql.plan.logical.OrderBy;
 import org.elasticsearch.xpack.ql.plan.logical.Project;
 import org.elasticsearch.xpack.ql.rule.ParameterizedRule;
 import org.elasticsearch.xpack.ql.rule.ParameterizedRuleExecutor;
+import org.elasticsearch.xpack.ql.type.DataType;
+import org.elasticsearch.xpack.ql.type.DataTypes;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import static java.util.Arrays.asList;
+import static org.elasticsearch.xpack.esql.optimizer.LogicalPlanOptimizer.cleanup;
+import static org.elasticsearch.xpack.esql.optimizer.LogicalPlanOptimizer.operators;
 import static org.elasticsearch.xpack.ql.optimizer.OptimizerRules.TransformDirection.UP;
 
 public class LocalLogicalPlanOptimizer extends ParameterizedRuleExecutor<LogicalPlan, LocalLogicalOptimizerContext> {
@@ -50,8 +64,21 @@ public class LocalLogicalPlanOptimizer extends ParameterizedRuleExecutor<Logical
         var rules = new ArrayList<Batch<LogicalPlan>>();
         rules.add(local);
         // TODO: if the local rules haven't touched the tree, the rest of the rules can be skipped
-        rules.addAll(LogicalPlanOptimizer.rules());
+        rules.addAll(asList(operators(), cleanup()));
+        replaceRules(rules);
         return rules;
+    }
+
+    private List<Batch<LogicalPlan>> replaceRules(List<Batch<LogicalPlan>> listOfRules) {
+        for (Batch<LogicalPlan> batch : listOfRules) {
+            var rules = batch.rules();
+            for (int i = 0; i < rules.length; i++) {
+                if (rules[i] instanceof PropagateEmptyRelation) {
+                    rules[i] = new LocalPropagateEmptyRelation();
+                }
+            }
+        }
+        return listOfRules;
     }
 
     public LogicalPlan localOptimize(LogicalPlan plan) {
@@ -129,6 +156,37 @@ public class LocalLogicalPlanOptimizer extends ParameterizedRuleExecutor<Logical
         @Override
         protected boolean skipExpression(Expression e) {
             return e instanceof Coalesce;
+        }
+    }
+
+    /**
+     * Local aggregation can only produce intermediate state that get wired into the global agg.
+     */
+    private static class LocalPropagateEmptyRelation extends PropagateEmptyRelation {
+
+        /**
+         * Local variant of the aggregation that returns the intermediate value.
+         */
+        @Override
+        protected void aggOutput(NamedExpression agg, AggregateFunction aggFunc, BlockFactory blockFactory, List<Block> blocks) {
+            List<Attribute> output = AbstractPhysicalOperationProviders.intermediateAttributes(List.of(agg), List.of());
+            for (Attribute o : output) {
+                DataType dataType = o.dataType();
+                // look for count(literal) with literal != null
+                var wrapper = BlockUtils.wrapperFor(blockFactory, PlannerUtils.toElementType(dataType), 1);
+                // seen output
+                if (dataType == DataTypes.BOOLEAN) {
+                    wrapper.accept(true);
+                } else {
+                    if (aggFunc instanceof Count count && (count.foldable() == false || count.fold() != null)) {
+                        wrapper.accept(0L);
+                    } else {
+                        // otherwise just put null
+                        wrapper.accept(null);
+                    }
+                }
+                blocks.add(wrapper.builder().build());
+            }
         }
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.optimizer;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BlockUtils;
 import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.evaluator.predicate.operator.comparison.Equals;
@@ -24,7 +25,6 @@ import org.elasticsearch.xpack.esql.plan.logical.TopN;
 import org.elasticsearch.xpack.esql.plan.logical.local.EsqlProject;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelation;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalSupplier;
-import org.elasticsearch.xpack.esql.planner.AbstractPhysicalOperationProviders;
 import org.elasticsearch.xpack.esql.planner.PlannerUtils;
 import org.elasticsearch.xpack.esql.type.EsqlDataTypes;
 import org.elasticsearch.xpack.ql.expression.Alias;
@@ -62,7 +62,6 @@ import org.elasticsearch.xpack.ql.rule.ParameterizedRule;
 import org.elasticsearch.xpack.ql.rule.ParameterizedRuleExecutor;
 import org.elasticsearch.xpack.ql.rule.Rule;
 import org.elasticsearch.xpack.ql.tree.Source;
-import org.elasticsearch.xpack.ql.type.DataType;
 import org.elasticsearch.xpack.ql.type.DataTypes;
 import org.elasticsearch.xpack.ql.util.CollectionUtils;
 import org.elasticsearch.xpack.ql.util.Holder;
@@ -100,17 +99,8 @@ public class LogicalPlanOptimizer extends ParameterizedRuleExecutor<LogicalPlan,
         return rules();
     }
 
-    protected static List<Batch<LogicalPlan>> rules() {
-        var substitutions = new Batch<>(
-            "Substitutions",
-            Limiter.ONCE,
-            new SubstituteSurrogates(),
-            new ReplaceRegexMatch(),
-            new ReplaceAliasingEvalWithProject()
-            // new NormalizeAggregate(), - waits on https://github.com/elastic/elasticsearch/issues/100634
-        );
-
-        var operators = new Batch<>(
+    protected static Batch<LogicalPlan> operators() {
+        return new Batch<>(
             "Operator Optimization",
             new CombineProjections(),
             new CombineEvals(),
@@ -145,19 +135,33 @@ public class LogicalPlanOptimizer extends ParameterizedRuleExecutor<LogicalPlan,
             new PruneOrderByBeforeStats(),
             new PruneRedundantSortClauses()
         );
+    }
 
-        var skip = new Batch<>("Skip Compute", new SkipQueryOnLimitZero());
-        var cleanup = new Batch<>(
+    protected static Batch<LogicalPlan> cleanup() {
+        return new Batch<>(
             "Clean Up",
             new ReplaceDuplicateAggWithEval(),
             // pushing down limits again, because ReplaceDuplicateAggWithEval could create new Project nodes that can still be optimized
             new PushDownAndCombineLimits(),
             new ReplaceLimitAndSortAsTopN()
         );
+    }
+
+    protected static List<Batch<LogicalPlan>> rules() {
+        var substitutions = new Batch<>(
+            "Substitutions",
+            Limiter.ONCE,
+            new SubstituteSurrogates(),
+            new ReplaceRegexMatch(),
+            new ReplaceAliasingEvalWithProject()
+            // new NormalizeAggregate(), - waits on https://github.com/elastic/elasticsearch/issues/100634
+        );
+
+        var skip = new Batch<>("Skip Compute", new SkipQueryOnLimitZero());
         var defaultTopN = new Batch<>("Add default TopN", new AddDefaultTopN());
         var label = new Batch<>("Set as Optimized", Limiter.ONCE, new SetAsOptimized());
 
-        return asList(substitutions, operators, skip, cleanup, defaultTopN, label);
+        return asList(substitutions, operators(), skip, cleanup(), defaultTopN, label);
     }
 
     // TODO: currently this rule only works for aggregate functions (AVG)
@@ -632,6 +636,7 @@ public class LogicalPlanOptimizer extends ParameterizedRuleExecutor<LogicalPlan,
         }
     }
 
+    @SuppressWarnings("removal")
     static class PropagateEmptyRelation extends OptimizerRules.OptimizerRule<UnaryPlan> {
 
         @Override
@@ -649,32 +654,14 @@ public class LogicalPlanOptimizer extends ParameterizedRuleExecutor<LogicalPlan,
             return p;
         }
 
-        private static List<Block> aggsFromEmpty(List<? extends NamedExpression> aggs) {
-            // TODO: Should we introduce skip operator that just never queries the source
+        private List<Block> aggsFromEmpty(List<? extends NamedExpression> aggs) {
             List<Block> blocks = new ArrayList<>();
+            var blockFactory = PlannerUtils.NON_BREAKING_BLOCK_FACTORY;
             int i = 0;
             for (var agg : aggs) {
                 // there needs to be an alias
                 if (agg instanceof Alias a && a.child() instanceof AggregateFunction aggFunc) {
-                    List<Attribute> output = AbstractPhysicalOperationProviders.intermediateAttributes(List.of(agg), List.of());
-                    for (Attribute o : output) {
-                        DataType dataType = o.dataType();
-                        // fill the boolean block later in LocalExecutionPlanner
-                        if (dataType != DataTypes.BOOLEAN) {
-                            // look for count(literal) with literal != null
-                            var wrapper = BlockUtils.wrapperFor(
-                                PlannerUtils.NON_BREAKING_BLOCK_FACTORY,
-                                PlannerUtils.toElementType(dataType),
-                                1
-                            );
-                            if (aggFunc instanceof Count count && (count.foldable() == false || count.fold() != null)) {
-                                wrapper.accept(0L);
-                            } else {
-                                wrapper.accept(null);
-                            }
-                            blocks.add(wrapper.builder().build());
-                        }
-                    }
+                    aggOutput(agg, aggFunc, blockFactory, blocks);
                 } else {
                     throw new EsqlIllegalArgumentException("Did not expect a non-aliased aggregation {}", agg);
                 }
@@ -682,6 +669,16 @@ public class LogicalPlanOptimizer extends ParameterizedRuleExecutor<LogicalPlan,
             return blocks;
         }
 
+        /**
+         * The folded aggregation output - this variant is for the coordinator/final.
+         */
+        protected void aggOutput(NamedExpression agg, AggregateFunction aggFunc, BlockFactory blockFactory, List<Block> blocks) {
+            // look for count(literal) with literal != null
+            Object value = aggFunc instanceof Count count && (count.foldable() == false || count.fold() != null) ? 0L : null;
+            var wrapper = BlockUtils.wrapperFor(blockFactory, PlannerUtils.toElementType(aggFunc.dataType()), 1);
+            wrapper.accept(value);
+            blocks.add(wrapper.builder().build());
+        }
     }
 
     private static LogicalPlan skipPlan(UnaryPlan plan) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -56,7 +56,6 @@ import org.elasticsearch.xpack.esql.enrich.EnrichLookupOperator;
 import org.elasticsearch.xpack.esql.enrich.EnrichLookupService;
 import org.elasticsearch.xpack.esql.evaluator.EvalMapper;
 import org.elasticsearch.xpack.esql.evaluator.command.GrokEvaluatorExtracter;
-import org.elasticsearch.xpack.esql.plan.logical.local.LocalSupplier;
 import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
 import org.elasticsearch.xpack.esql.plan.physical.DissectExec;
 import org.elasticsearch.xpack.esql.plan.physical.EnrichExec;
@@ -88,7 +87,6 @@ import org.elasticsearch.xpack.ql.expression.Literal;
 import org.elasticsearch.xpack.ql.expression.NameId;
 import org.elasticsearch.xpack.ql.expression.NamedExpression;
 import org.elasticsearch.xpack.ql.expression.Order;
-import org.elasticsearch.xpack.ql.type.DataTypes;
 import org.elasticsearch.xpack.ql.util.Holder;
 
 import java.util.ArrayList;
@@ -323,29 +321,6 @@ public class LocalExecutionPlanner {
     private PhysicalOperation planExchangeSink(ExchangeSinkExec exchangeSink, LocalExecutionPlannerContext context) {
         Objects.requireNonNull(exchangeSinkHandler, "ExchangeSinkHandler wasn't provided");
         var child = exchangeSink.child();
-        // see https://github.com/elastic/elasticsearch/issues/100807 - handle case where the plan has been fully minimized
-        // to a local relation and the aggregate intermediate data erased. For this scenario, match the output the exchange output
-        // with that of the local relation
-
-        if (child instanceof LocalSourceExec localExec) {
-            var output = exchangeSink.output();
-            var localOutput = localExec.output();
-            if (output.equals(localOutput) == false) {
-                // the outputs are going to be similar except for the bool "seen" flags which are added in below
-                List<Block> blocks = new ArrayList<>(asList(localExec.supplier().get()));
-                if (blocks.size() > 0) {
-                    for (int i = 0, s = output.size(); i < s; i++) {
-                        var out = output.get(i);
-                        if (out.dataType() == DataTypes.BOOLEAN) {
-                            blocks.add(i, PlannerUtils.NON_BREAKING_BLOCK_FACTORY.newConstantBooleanBlockWith(true, 1));
-                        }
-                    }
-                }
-                var newSupplier = LocalSupplier.of(blocks.toArray(Block[]::new));
-
-                child = new LocalSourceExec(localExec.source(), output, newSupplier);
-            }
-        }
 
         PhysicalOperation source = plan(child, context);
 

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/rule/RuleExecutor.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/rule/RuleExecutor.java
@@ -67,6 +67,10 @@ public abstract class RuleExecutor<TreeType extends Node<TreeType>> {
         public String name() {
             return name;
         }
+
+        public Rule<?, TreeType>[] rules() {
+            return rules;
+        }
     }
 
     private Iterable<Batch<TreeType>> batches = null;


### PR DESCRIPTION
Introduce a local rule for folding aggregates to take into account the
 aggregate intermediate state as oppose to that on the coordinator.