### PR TITLE
Revert "[Transform] Use deduced mappings for determining proper fields' format even if `deduce_mappings==false`"

### DIFF
--- a/docs/changelog/103135.yaml
+++ b/docs/changelog/103135.yaml
@@ -1,6 +1,0 @@
-pr: 103135
-summary: Use deduced mappings for determining proper fields' format even if `deduce_mappings==false`
-area: Transform
-type: bug
-issues:
- - 103115

--- a/docs/changelog/103677.yaml
+++ b/docs/changelog/103677.yaml
@@ -1,0 +1,6 @@
+pr: 103677
+summary: "Revert \"[Transform] Use deduced mappings for determining proper fields'\
+  \ format even if `deduce_mappings==false`\""
+area: Transform
+type: bug
+issues: []

--- a/docs/changelog/103677.yaml
+++ b/docs/changelog/103677.yaml
@@ -1,6 +1,0 @@
-pr: 103677
-summary: "Revert \"[Transform] Use deduced mappings for determining proper fields'\
-  \ format even if `deduce_mappings==false`\""
-area: Transform
-type: bug
-issues: []

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/transform/preview_transforms.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/transform/preview_transforms.yml
@@ -240,21 +240,6 @@ setup:
               "deduce_mappings": false
             }
           }
-  - match: { preview.0.airline: foo }
-  - match: { preview.0.by-hour: "2017-02-18T00:00:00.000Z" }
-  - match: { preview.0.avg_response: 1.0 }
-  - match: { preview.0.time.max: "2017-02-18T00:30:00.000Z" }
-  - match: { preview.0.time.min: "2017-02-18T00:00:00.000Z" }
-  - match: { preview.1.airline: bar }
-  - match: { preview.1.by-hour: "2017-02-18T01:00:00.000Z" }
-  - match: { preview.1.avg_response: 42.0 }
-  - match: { preview.1.time.max: "2017-02-18T01:00:00.000Z" }
-  - match: { preview.1.time.min: "2017-02-18T01:00:00.000Z" }
-  - match: { preview.2.airline: foo }
-  - match: { preview.2.by-hour: "2017-02-18T01:00:00.000Z" }
-  - match: { preview.2.avg_response: 42.0 }
-  - match: { preview.2.time.max: "2017-02-18T01:01:00.000Z" }
-  - match: { preview.2.time.min: "2017-02-18T01:01:00.000Z" }
   - match: { generated_dest_index.mappings.properties: {} }
 
 ---

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformDestIndexIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformDestIndexIT.java
@@ -174,7 +174,7 @@ public class TransformDestIndexIT extends TransformRestTestCase {
                     }
                   }
                 }""", destIndex);
-            Request createIndexTemplateRequest = new Request("PUT", "_template/test_dest_index_mappings_template");
+            Request createIndexTemplateRequest = new Request("PUT", "_template/test_dest_index_no_deduce_template");
             createIndexTemplateRequest.setJsonEntity(destIndexTemplate);
             createIndexTemplateRequest.setOptions(expectWarnings(RestPutIndexTemplateAction.DEPRECATION_WARNING));
             Map<String, Object> createIndexTemplateResponse = entityAsMap(client().performRequest(createIndexTemplateRequest));
@@ -253,9 +253,6 @@ public class TransformDestIndexIT extends TransformRestTestCase {
                 )
             )
         );
-        Map<String, Object> searchResult = getAsMap(destIndex + "/_search?q=reviewer:user_0");
-        String timestamp = (String) ((List<?>) XContentMapValues.extractValue("hits.hits._source.timestamp", searchResult)).get(0);
-        assertThat(timestamp, is(equalTo("2017-01-10T10:10:10.000Z")));
     }
 
     private static void assertAliases(String index, String... aliases) throws IOException {

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformPivotRestIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformPivotRestIT.java
@@ -1383,11 +1383,8 @@ public class TransformPivotRestIT extends TransformRestTestCase {
                     }
                   }
                 }
-              },
-              "settings": {
-                "deduce_mappings": %s
               }
-            }""", REVIEWS_INDEX_NAME, offset, randomBoolean());
+            }""", REVIEWS_INDEX_NAME, offset);
         createPreviewRequest.setJsonEntity(config);
 
         Map<String, Object> previewTransformResponse = entityAsMap(client().performRequest(createPreviewRequest));

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransformUpdater.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransformUpdater.java
@@ -299,7 +299,7 @@ public class TransformUpdater {
         TransformAuditor auditor,
         IndexNameExpressionResolver indexNameExpressionResolver,
         TransformConfig config,
-        Map<String, String> destIndexMappings,
+        Map<String, String> mappings,
         SeqNoPrimaryTermAndIndex seqNoPrimaryTermAndIndex,
         ClusterState clusterState,
         Settings destIndexSettings,
@@ -355,7 +355,7 @@ public class TransformUpdater {
                 clusterState,
                 config,
                 destIndexSettings,
-                destIndexMappings,
+                mappings,
                 createDestinationListener
             );
         } else {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPreviewTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPreviewTransformAction.java
@@ -47,7 +47,6 @@ import org.elasticsearch.xpack.core.transform.action.PreviewTransformAction;
 import org.elasticsearch.xpack.core.transform.action.PreviewTransformAction.Request;
 import org.elasticsearch.xpack.core.transform.action.PreviewTransformAction.Response;
 import org.elasticsearch.xpack.core.transform.transforms.DestAlias;
-import org.elasticsearch.xpack.core.transform.transforms.SettingsConfig;
 import org.elasticsearch.xpack.core.transform.transforms.SourceConfig;
 import org.elasticsearch.xpack.core.transform.transforms.SyncConfig;
 import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
@@ -66,7 +65,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static java.util.Collections.emptyMap;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.xpack.core.transform.action.PreviewTransformAction.DUMMY_DEST_INDEX_FOR_PREVIEW;
 import static org.elasticsearch.xpack.transform.utils.SecondaryAuthorizationUtils.getSecurityHeadersPreferringSecondary;
@@ -155,7 +153,6 @@ public class TransportPreviewTransformAction extends HandledTransportAction<Requ
                 config.getDestination().getIndex(),
                 config.getDestination().getAliases(),
                 config.getSyncConfig(),
-                config.getSettings(),
                 listener
             ),
             listener::onFailure
@@ -211,7 +208,6 @@ public class TransportPreviewTransformAction extends HandledTransportAction<Requ
         String dest,
         List<DestAlias> aliases,
         SyncConfig syncConfig,
-        SettingsConfig settingsConfig,
         ActionListener<Response> listener
     ) {
         Client parentTaskClient = new ParentTaskAssigningClient(client, parentTaskId);
@@ -289,17 +285,12 @@ public class TransportPreviewTransformAction extends HandledTransportAction<Requ
         }, listener::onFailure);
 
         ActionListener<Map<String, String>> deduceMappingsListener = ActionListener.wrap(deducedMappings -> {
-            if (Boolean.FALSE.equals(settingsConfig.getDeduceMappings())) {
-                mappings.set(emptyMap());
-            } else {
-                mappings.set(deducedMappings);
-            }
+            mappings.set(deducedMappings);
             function.preview(
                 parentTaskClient,
                 timeout,
                 filteredHeaders,
                 source,
-                // Use deduced mappings for generating preview even if "settings.deduce_mappings" is set to false
                 deducedMappings,
                 NUMBER_OF_PREVIEW_BUCKETS,
                 previewListener

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPutTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPutTransformAction.java
@@ -109,7 +109,7 @@ public class TransportPutTransformAction extends AcknowledgedTransportMasterNode
 
         // <3> Create the transform
         ActionListener<ValidateTransformAction.Response> validateTransformListener = ActionListener.wrap(
-            unusedValidationResponse -> putTransform(request, listener),
+            validationResponse -> putTransform(request, listener),
             listener::onFailure
         );
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/TransformIndex.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/TransformIndex.java
@@ -40,7 +40,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toMap;
@@ -139,7 +138,7 @@ public final class TransformIndex {
         if (dest.length == 0) {
             TransformDestIndexSettings generatedDestIndexSettings = createTransformDestIndexSettings(
                 destIndexSettings,
-                Boolean.FALSE.equals(config.getSettings().getDeduceMappings()) ? emptyMap() : destIndexMappings,
+                destIndexMappings,
                 config.getId(),
                 Clock.systemUTC()
             );

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexer.java
@@ -288,13 +288,13 @@ class ClientTransformIndexer extends TransformIndexer {
         SchemaUtil.getDestinationFieldMappings(client, getConfig().getDestination().getIndex(), fieldMappingsListener);
     }
 
-    void validate(ActionListener<ValidateTransformAction.Response> listener) {
+    void validate(ActionListener<Void> listener) {
         ClientHelper.executeAsyncWithOrigin(
             client,
             ClientHelper.TRANSFORM_ORIGIN,
             ValidateTransformAction.INSTANCE,
             new ValidateTransformAction.Request(transformConfig, false, AcknowledgedRequest.DEFAULT_ACK_TIMEOUT),
-            listener
+            ActionListener.wrap(response -> listener.onResponse(null), listener::onFailure)
         );
     }
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/Pivot.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/Pivot.java
@@ -43,6 +43,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import static java.util.Collections.emptyMap;
 import static java.util.stream.Collectors.toList;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 
@@ -92,6 +93,10 @@ public class Pivot extends AbstractCompositeAggFunction {
         SourceConfig sourceConfig,
         final ActionListener<Map<String, String>> listener
     ) {
+        if (Boolean.FALSE.equals(settings.getDeduceMappings())) {
+            listener.onResponse(emptyMap());
+            return;
+        }
         SchemaUtil.deduceMappings(
             client,
             headers,

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerStateTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerStateTests.java
@@ -35,7 +35,6 @@ import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.indexing.IndexerState;
 import org.elasticsearch.xpack.core.indexing.IterationResult;
-import org.elasticsearch.xpack.core.transform.action.ValidateTransformAction;
 import org.elasticsearch.xpack.core.transform.transforms.SettingsConfig;
 import org.elasticsearch.xpack.core.transform.transforms.TimeSyncConfig;
 import org.elasticsearch.xpack.core.transform.transforms.TransformCheckpoint;
@@ -249,7 +248,7 @@ public class TransformIndexerStateTests extends ESTestCase {
         }
 
         @Override
-        void validate(ActionListener<ValidateTransformAction.Response> listener) {
+        void validate(ActionListener<Void> listener) {
             listener.onResponse(null);
         }
     }
@@ -336,7 +335,7 @@ public class TransformIndexerStateTests extends ESTestCase {
         }
 
         @Override
-        void validate(ActionListener<ValidateTransformAction.Response> listener) {
+        void validate(ActionListener<Void> listener) {
             listener.onResponse(null);
         }
 

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerTests.java
@@ -34,7 +34,6 @@ import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.indexing.IndexerState;
 import org.elasticsearch.xpack.core.indexing.IterationResult;
-import org.elasticsearch.xpack.core.transform.action.ValidateTransformAction;
 import org.elasticsearch.xpack.core.transform.transforms.TimeRetentionPolicyConfigTests;
 import org.elasticsearch.xpack.core.transform.transforms.TimeSyncConfig;
 import org.elasticsearch.xpack.core.transform.transforms.TransformCheckpoint;
@@ -269,7 +268,7 @@ public class TransformIndexerTests extends ESTestCase {
         }
 
         @Override
-        void validate(ActionListener<ValidateTransformAction.Response> listener) {
+        void validate(ActionListener<Void> listener) {
             listener.onResponse(null);
         }
     }


### PR DESCRIPTION
Reverts elastic/elasticsearch#103135

The revert is needed because of unintended side-effect of the original change. The side-effect (bug) is that in the case of chained transforms (i.e.: where the destination index of the first transform is the source index of the second transform) the mapping deduction often fails for the second transform.
This causes an issue for Observability SLO transforms.