### PR TITLE
Reenable some ESQL yaml tests

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/100_bug_fix.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/100_bug_fix.yml
@@ -1,10 +1,8 @@
 ---
 "Coalesce and to_ip functions":
   - skip:
-      version: all
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/102871"
-      # version: " - 8.11.99"
-      # reason: "fixes in 8.12 or later"
+      version: " - 8.11.99"
+      reason: "fixes in 8.12 or later"
       features: warnings
   - do:
       bulk:
@@ -129,10 +127,10 @@
 
 
 ---
-"null MappedFieldType on single value detection (https://github.com/elastic/elasticsearch/issues/103141)":
+"null MappedFieldType on single value detection #103141":
   - skip:
-      version: all
-      reason: "AwaitsFix fix https://github.com/elastic/elasticsearch/issues/103561"
+      version: " - 8.12.99"
+      reason: "fixes in 8.13 or later"
   - do:
       indices.create:
         index: npe_single_value_1


### PR DESCRIPTION
One test has already been fixed, while another is failing on the serverless due to its name containing too many slashes.

Closes #103561