### PR TITLE
[stack monitoring] elasticsearch mappings updates

### DIFF
--- a/x-pack/plugin/core/template-resources/src/main/resources/monitoring-es-mb.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/monitoring-es-mb.json
@@ -8,6 +8,21 @@
         "@timestamp": {
           "type": "date"
         },
+        "cluster_settings": {
+          "properties": {
+            "cluster": {
+              "properties": {
+                "metadata": {
+                  "properties": {
+                    "display_name": {
+                      "type": "keyword"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "elasticsearch": {
           "properties": {
             "cluster": {
@@ -1469,9 +1484,6 @@
                 },
                 "hidden": {
                   "type": "boolean"
-                },
-                "created": {
-                  "type": "long"
                 },
                 "name": {
                   "ignore_above": 1024,

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java
@@ -77,7 +77,7 @@ public class MonitoringTemplateRegistry extends IndexTemplateRegistry {
      * writes monitoring data in ECS format as of 8.0. These templates define the ECS schema as well as alias fields for the old monitoring
      * mappings that point to the corresponding ECS fields.
      */
-    public static final int STACK_MONITORING_REGISTRY_VERSION = 8_00_00_99 + 12;
+    public static final int STACK_MONITORING_REGISTRY_VERSION = 8_00_00_99 + 13;
     private static final String STACK_MONITORING_REGISTRY_VERSION_VARIABLE = "xpack.stack.monitoring.template.release.version";
     private static final String STACK_TEMPLATE_VERSION = "8";
     private static final String STACK_TEMPLATE_VERSION_VARIABLE = "xpack.stack.monitoring.template.version";


### PR DESCRIPTION
### Summary
Part of https://github.com/elastic/kibana/issues/172558

- add `cluster_settings.cluster.metadata.display_name` mapping
- remove `elasticsearch.index.created` mapping

### Testing
- set a cluster display_name
```
PUT /_cluster/settings
{
  "persistent": {
    "cluster.metadata.display_name": "custom cluster name"
  }
}
```
- ingest elasticsearch data with metricbeat
- verify field is correctly ingested and mapped in `cluster_stats` dataset