### PR TITLE
List hidden shard stores by default

### DIFF
--- a/docs/changelog/103710.yaml
+++ b/docs/changelog/103710.yaml
@@ -1,0 +1,5 @@
+pr: 103710
+summary: List hidden shard stores by default
+area: Store
+type: enhancement
+issues: []

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoreRequestIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoreRequestIT.java
@@ -108,8 +108,13 @@ public class IndicesShardStoreRequestIT extends ESIntegTestCase {
         String index1 = "test1";
         String index2 = "test2";
         internalCluster().ensureAtLeastNumDataNodes(2);
-        assertAcked(prepareCreate(index1).setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, "2")));
-        assertAcked(prepareCreate(index2).setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, "2")));
+        for (final var index : List.of(index1, index2)) {
+            final var settings = Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 2);
+            if (randomBoolean()) {
+                settings.put(IndexMetadata.SETTING_INDEX_HIDDEN, randomBoolean());
+            }
+            assertAcked(prepareCreate(index).setSettings(settings));
+        }
         indexRandomData(index1);
         indexRandomData(index2);
         ensureGreen();

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoresRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoresRequest.java
@@ -32,7 +32,7 @@ public class IndicesShardStoresRequest extends MasterNodeReadRequest<IndicesShar
     static final int DEFAULT_MAX_CONCURRENT_SHARD_REQUESTS = 100;
 
     private String[] indices = Strings.EMPTY_ARRAY;
-    private IndicesOptions indicesOptions = IndicesOptions.strictExpand();
+    private IndicesOptions indicesOptions = IndicesOptions.strictExpandHidden();
     private EnumSet<ClusterHealthStatus> statuses = EnumSet.of(ClusterHealthStatus.YELLOW, ClusterHealthStatus.RED);
     private int maxConcurrentShardRequests = DEFAULT_MAX_CONCURRENT_SHARD_REQUESTS;
 


### PR DESCRIPTION
The shards stores API is for troubleshooting, but today it excludes
hidden indices by default. This just makes the troubleshooting more
difficult, so with this commit we change the default behaviour to
include hidden indices.