### PR TITLE
Remove unnecessary `actionGet(timeout)` overloads

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterHealthIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterHealthIT.java
@@ -46,8 +46,8 @@ public class ClusterHealthIT extends ESIntegTestCase {
                 .prepareHealth()
                 .setLocal(true)
                 .setWaitForEvents(Priority.LANGUID)
-                .setTimeout("30s")
-                .get("10s");
+                .setTimeout(TimeValue.timeValueSeconds(30))
+                .get(TimeValue.timeValueSeconds(10));
             logger.info("--> got cluster health on [{}]", node);
             assertFalse("timed out on " + node, health.isTimedOut());
             assertThat("health status on " + node, health.getStatus(), equalTo(ClusterHealthStatus.GREEN));

--- a/server/src/internalClusterTest/java/org/elasticsearch/discovery/ClusterDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/discovery/ClusterDisruptionIT.java
@@ -109,7 +109,7 @@ public class ClusterDisruptionIT extends AbstractDisruptionTestCase {
     public void testAckedIndexing() throws Exception {
 
         final int seconds = (TEST_NIGHTLY && rarely()) == false ? 1 : 5;
-        final String timeout = seconds + "s";
+        final TimeValue timeout = TimeValue.timeValueSeconds(seconds);
 
         final List<String> nodes = startCluster(rarely() ? 5 : 3);
 

--- a/server/src/main/java/org/elasticsearch/action/ActionFuture.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionFuture.java
@@ -32,22 +32,6 @@ public interface ActionFuture<T> extends Future<T> {
      * an {@link IllegalStateException} instead. Also catches
      * {@link java.util.concurrent.ExecutionException} and throws the actual cause instead.
      */
-    T actionGet(String timeout);
-
-    /**
-     * Similar to {@link #get(long, java.util.concurrent.TimeUnit)}, just catching the {@link InterruptedException} and throwing
-     * an {@link IllegalStateException} instead. Also catches
-     * {@link java.util.concurrent.ExecutionException} and throws the actual cause instead.
-     *
-     * @param timeoutMillis Timeout in millis
-     */
-    T actionGet(long timeoutMillis);
-
-    /**
-     * Similar to {@link #get(long, java.util.concurrent.TimeUnit)}, just catching the {@link InterruptedException} and throwing
-     * an {@link IllegalStateException} instead. Also catches
-     * {@link java.util.concurrent.ExecutionException} and throws the actual cause instead.
-     */
     T actionGet(long timeout, TimeUnit unit);
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/ActionRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionRequestBuilder.java
@@ -48,13 +48,6 @@ public abstract class ActionRequestBuilder<Request extends ActionRequest, Respon
         return execute().actionGet(timeout);
     }
 
-    /**
-     * Short version of execute().actionGet().
-     */
-    public Response get(String timeout) {
-        return execute().actionGet(timeout);
-    }
-
     public void execute(ActionListener<Response> listener) {
         client.execute(action, request, listener);
     }

--- a/server/src/main/java/org/elasticsearch/action/support/PlainActionFuture.java
+++ b/server/src/main/java/org/elasticsearch/action/support/PlainActionFuture.java
@@ -195,16 +195,6 @@ public class PlainActionFuture<T> implements ActionFuture<T>, ActionListener<T> 
     }
 
     @Override
-    public T actionGet(String timeout) {
-        return actionGet(TimeValue.parseTimeValue(timeout, null, getClass().getSimpleName() + ".actionGet.timeout"));
-    }
-
-    @Override
-    public T actionGet(long timeoutMillis) {
-        return actionGet(timeoutMillis, TimeUnit.MILLISECONDS);
-    }
-
-    @Override
     public T actionGet(TimeValue timeout) {
         return actionGet(timeout.millis(), TimeUnit.MILLISECONDS);
     }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/shards/TransportIndicesShardStoresActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/shards/TransportIndicesShardStoresActionTests.java
@@ -67,9 +67,8 @@ public class TransportIndicesShardStoresActionTests extends ESTestCase {
                     request,
                     future
                 );
-                assertTrue(future.isDone());
 
-                final var response = future.actionGet(0L);
+                final var response = future.result();
                 assertThat(response.getFailures(), empty());
                 assertThat(response.getStoreStatuses(), anEmptyMap());
                 assertThat(shardsWithFailures, empty());
@@ -132,8 +131,7 @@ public class TransportIndicesShardStoresActionTests extends ESTestCase {
                 listExpected = false;
                 assertFalse(future.isDone());
                 deterministicTaskQueue.runAllTasks();
-                assertTrue(future.isDone());
-                expectThrows(TaskCancelledException.class, () -> future.actionGet(0L));
+                expectThrows(TaskCancelledException.class, future::result);
             }
         });
     }
@@ -153,9 +151,8 @@ public class TransportIndicesShardStoresActionTests extends ESTestCase {
                 assertFalse(future.isDone());
                 failOneRequest = true;
                 deterministicTaskQueue.runAllTasks();
-                assertTrue(future.isDone());
                 assertFalse(failOneRequest);
-                assertEquals("simulated", expectThrows(ElasticsearchException.class, () -> future.actionGet(0L)).getMessage());
+                assertEquals("simulated", expectThrows(ElasticsearchException.class, future::result).getMessage());
             }
         });
     }

--- a/server/src/test/java/org/elasticsearch/action/support/PlainActionFutureTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/PlainActionFutureTests.java
@@ -34,13 +34,11 @@ public class PlainActionFutureTests extends ESTestCase {
 
         // test all possible methods that can be interrupted
         final Runnable runnable = () -> {
-            final int method = randomIntBetween(0, 4);
+            final int method = randomIntBetween(0, 2);
             switch (method) {
                 case 0 -> future.actionGet();
-                case 1 -> future.actionGet("30s");
-                case 2 -> future.actionGet(30000);
-                case 3 -> future.actionGet(TimeValue.timeValueSeconds(30));
-                case 4 -> future.actionGet(30, TimeUnit.SECONDS);
+                case 1 -> future.actionGet(TimeValue.timeValueSeconds(30));
+                case 2 -> future.actionGet(30, TimeUnit.SECONDS);
                 default -> throw new AssertionError(method);
             }
         };

--- a/server/src/test/java/org/elasticsearch/action/support/replication/BroadcastReplicationTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/replication/BroadcastReplicationTests.java
@@ -305,7 +305,7 @@ public class BroadcastReplicationTests extends ESTestCase {
     ) {
         PlainActionFuture<BaseBroadcastResponse> response = new PlainActionFuture<>();
         ActionTestUtils.execute(broadcastAction, null, request, response);
-        return response.actionGet("5s");
+        return response.actionGet(5, TimeUnit.SECONDS);
     }
 
     private void assertBroadcastResponse(int total, int successful, int failed, BaseBroadcastResponse response, Class<?> exceptionClass) {

--- a/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/DownsampleClusterDisruptionIT.java
+++ b/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/DownsampleClusterDisruptionIT.java
@@ -429,7 +429,7 @@ public class DownsampleClusterDisruptionIT extends ESIntegTestCase {
         assertAcked(
             internalCluster().client()
                 .execute(DownsampleAction.INSTANCE, new DownsampleAction.Request(sourceIndex, downsampleIndex, TIMEOUT, config))
-                .actionGet(TIMEOUT.millis())
+                .actionGet(TIMEOUT)
         );
     }
 

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ExplainDataFrameAnalyticsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ExplainDataFrameAnalyticsIT.java
@@ -32,6 +32,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.contains;
@@ -214,7 +215,7 @@ public class ExplainDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsInteg
             // The main purpose of this test is that actionGet() here will throw an exception
             // if any of the simultaneous calls returns an error due to interaction between
             // the many estimation processes that get run
-            ExplainDataFrameAnalyticsAction.Response current = future.actionGet(10000);
+            ExplainDataFrameAnalyticsAction.Response current = future.actionGet(10000, TimeUnit.MILLISECONDS);
             if (previous != null) {
                 // A secondary check the test can perform is that the multiple invocations
                 // return the same result (but it was failures due to unwanted interactions


### PR DESCRIPTION
These are not that useful in practice, let's use the `TimeValue` or
`TimeUnit` ones everywhere instead.