### PR TITLE
Avoid stacked timeout in testSimultaneousExplainSameConfig

### DIFF
--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ExplainDataFrameAnalyticsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ExplainDataFrameAnalyticsIT.java
@@ -7,11 +7,12 @@
 package org.elasticsearch.xpack.ml.integration;
 
 import org.elasticsearch.ResourceNotFoundException;
-import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.support.RefCountingListener;
+import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -27,11 +28,11 @@ import org.elasticsearch.xpack.core.ml.dataframe.explain.FieldSelection;
 import org.elasticsearch.xpack.core.ml.utils.QueryProvider;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.contains;
@@ -203,26 +204,26 @@ public class ExplainDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsInteg
             )
             .buildForExplain();
 
-        List<ActionFuture<ExplainDataFrameAnalyticsAction.Response>> futures = new ArrayList<>();
-
-        for (int i = 0; i < simultaneousInvocationCount; ++i) {
-            futures.add(client().execute(ExplainDataFrameAnalyticsAction.INSTANCE, new ExplainDataFrameAnalyticsAction.Request(config)));
-        }
-
-        ExplainDataFrameAnalyticsAction.Response previous = null;
-        for (ActionFuture<ExplainDataFrameAnalyticsAction.Response> future : futures) {
-            // The main purpose of this test is that actionGet() here will throw an exception
-            // if any of the simultaneous calls returns an error due to interaction between
-            // the many estimation processes that get run
-            ExplainDataFrameAnalyticsAction.Response current = future.actionGet(10000);
-            if (previous != null) {
-                // A secondary check the test can perform is that the multiple invocations
-                // return the same result (but it was failures due to unwanted interactions
-                // that caused this test to be written)
-                assertEquals(previous, current);
+        safeAwait(SubscribableListener.<Void>newForked(testListener -> {
+            try (var listeners = new RefCountingListener(testListener)) {
+                final var firstResponseRef = new AtomicReference<ExplainDataFrameAnalyticsAction.Response>();
+                for (int i = 0; i < simultaneousInvocationCount; ++i) {
+                    client().execute(
+                        ExplainDataFrameAnalyticsAction.INSTANCE,
+                        new ExplainDataFrameAnalyticsAction.Request(config),
+                        // The main purpose of this test is that the action will complete its listener exceptionally if any of the
+                        // simultaneous calls returns an error due to interaction between the many estimation processes that get run.
+                        listeners.acquire(response -> {
+                            // A secondary check the test can perform is that the multiple invocations return the same result
+                            // (but it was failures due to unwanted interactions that caused this test to be written)
+                            assertNotNull(response);
+                            firstResponseRef.compareAndSet(null, response);
+                            assertEquals(firstResponseRef.get(), response);
+                        })
+                    );
+                }
             }
-            previous = current;
-        }
+        }));
     }
 
     public void testRuntimeFields() {


### PR DESCRIPTION
This test waits for the results of 10 futures, each with a 10s timeout,
so it can in theory take up to 100s and still pass. This commit runs the
timeouts in parallel instead.