### PR TITLE
ESQL: Track the rest of DocVector

### DIFF
--- a/docs/changelog/103727.yaml
+++ b/docs/changelog/103727.yaml
@@ -1,0 +1,5 @@
+pr: 103727
+summary: "ESQL: Track the rest of `DocVector`"
+area: ES|QL
+type: enhancement
+issues: []

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocBlock.java
@@ -86,9 +86,21 @@ public class DocBlock extends AbstractVectorBlock implements Block {
         private final IntVector.Builder docs;
 
         private Builder(BlockFactory blockFactory, int estimatedSize) {
-            shards = blockFactory.newIntVectorBuilder(estimatedSize);
-            segments = blockFactory.newIntVectorBuilder(estimatedSize);
-            docs = blockFactory.newIntVectorBuilder(estimatedSize);
+            IntVector.Builder shards = null;
+            IntVector.Builder segments = null;
+            IntVector.Builder docs = null;
+            try {
+                shards = blockFactory.newIntVectorBuilder(estimatedSize);
+                segments = blockFactory.newIntVectorBuilder(estimatedSize);
+                docs = blockFactory.newIntVectorBuilder(estimatedSize);
+            } finally {
+                if (docs == null) {
+                    Releasables.closeExpectNoException(shards, segments, docs);
+                }
+            }
+            this.shards = shards;
+            this.segments = segments;
+            this.docs = docs;
         }
 
         public Builder appendShard(int shard) {
@@ -151,7 +163,21 @@ public class DocBlock extends AbstractVectorBlock implements Block {
         @Override
         public DocBlock build() {
             // Pass null for singleSegmentNonDecreasing so we calculate it when we first need it.
-            return new DocVector(shards.build(), segments.build(), docs.build(), null).asBlock();
+            IntVector shards = null;
+            IntVector segments = null;
+            IntVector docs = null;
+            DocVector result = null;
+            try {
+                shards = this.shards.build();
+                segments = this.segments.build();
+                docs = this.docs.build();
+                result = new DocVector(shards, segments, docs, null);
+                return result.asBlock();
+            } finally {
+                if (result == null) {
+                    Releasables.closeExpectNoException(shards, segments, docs);
+                }
+            }
         }
 
         @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocBlock.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.compute.data;
 
-import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Releasables;
 
@@ -17,8 +16,6 @@ import java.io.IOException;
  * Wrapper around {@link DocVector} to make a valid {@link Block}.
  */
 public class DocBlock extends AbstractVectorBlock implements Block {
-
-    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(DocBlock.class);
 
     private final DocVector vector;
 
@@ -67,7 +64,7 @@ public class DocBlock extends AbstractVectorBlock implements Block {
 
     @Override
     public long ramBytesUsed() {
-        return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(vector);
+        return vector.ramBytesUsed();
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocVector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocVector.java
@@ -47,7 +47,7 @@ public final class DocVector extends AbstractVector implements Vector {
     private int[] shardSegmentDocMapBackwards;
 
     public DocVector(IntVector shards, IntVector segments, IntVector docs, Boolean singleSegmentNonDecreasing) {
-        super(shards.getPositionCount(), null);
+        super(shards.getPositionCount(), shards.blockFactory());
         this.shards = shards;
         this.segments = segments;
         this.docs = docs;
@@ -62,6 +62,7 @@ public final class DocVector extends AbstractVector implements Vector {
                 "invalid position count [" + shards.getPositionCount() + " != " + docs.getPositionCount() + "]"
             );
         }
+        blockFactory().adjustBreaker(BASE_RAM_BYTES_USED, true);
     }
 
     public IntVector shards() {
@@ -127,43 +128,57 @@ public final class DocVector extends AbstractVector implements Vector {
             return;
         }
 
-        int[] forwards = shardSegmentDocMapForwards = new int[shards.getPositionCount()];
-        for (int p = 0; p < forwards.length; p++) {
-            forwards[p] = p;
-        }
-        new IntroSorter() {
-            int pivot;
-
-            @Override
-            protected void setPivot(int i) {
-                pivot = forwards[i];
+        boolean success = false;
+        long estimatedSize = sizeOfSegmentDocMap();
+        blockFactory().adjustBreaker(estimatedSize, true);
+        try {
+            int[] forwards = shardSegmentDocMapForwards = new int[shards.getPositionCount()];
+            for (int p = 0; p < forwards.length; p++) {
+                forwards[p] = p;
             }
+            new IntroSorter() {
+                int pivot;
 
-            @Override
-            protected int comparePivot(int j) {
-                int cmp = Integer.compare(shards.getInt(pivot), shards.getInt(forwards[j]));
-                if (cmp != 0) {
-                    return cmp;
+                @Override
+                protected void setPivot(int i) {
+                    pivot = forwards[i];
                 }
-                cmp = Integer.compare(segments.getInt(pivot), segments.getInt(forwards[j]));
-                if (cmp != 0) {
-                    return cmp;
+
+                @Override
+                protected int comparePivot(int j) {
+                    int cmp = Integer.compare(shards.getInt(pivot), shards.getInt(forwards[j]));
+                    if (cmp != 0) {
+                        return cmp;
+                    }
+                    cmp = Integer.compare(segments.getInt(pivot), segments.getInt(forwards[j]));
+                    if (cmp != 0) {
+                        return cmp;
+                    }
+                    return Integer.compare(docs.getInt(pivot), docs.getInt(forwards[j]));
                 }
-                return Integer.compare(docs.getInt(pivot), docs.getInt(forwards[j]));
-            }
 
-            @Override
-            protected void swap(int i, int j) {
-                int tmp = forwards[i];
-                forwards[i] = forwards[j];
-                forwards[j] = tmp;
-            }
-        }.sort(0, forwards.length);
+                @Override
+                protected void swap(int i, int j) {
+                    int tmp = forwards[i];
+                    forwards[i] = forwards[j];
+                    forwards[j] = tmp;
+                }
+            }.sort(0, forwards.length);
 
-        int[] backwards = shardSegmentDocMapBackwards = new int[forwards.length];
-        for (int p = 0; p < forwards.length; p++) {
-            backwards[forwards[p]] = p;
+            int[] backwards = shardSegmentDocMapBackwards = new int[forwards.length];
+            for (int p = 0; p < forwards.length; p++) {
+                backwards[forwards[p]] = p;
+            }
+            success = true;
+        } finally {
+            if (success == false) {
+                blockFactory().adjustBreaker(-estimatedSize, true);
+            }
         }
+    }
+
+    private long sizeOfSegmentDocMap() {
+        return 2 * (((long) RamUsageEstimator.NUM_BYTES_ARRAY_HEADER) + ((long) Integer.BYTES) * shards.getPositionCount());
     }
 
     @Override
@@ -243,6 +258,14 @@ public final class DocVector extends AbstractVector implements Vector {
 
     @Override
     public void closeInternal() {
-        Releasables.closeExpectNoException(shards.asBlock(), segments.asBlock(), docs.asBlock()); // Ugh! we always close blocks
+        Releasables.closeExpectNoException(
+            () -> blockFactory().adjustBreaker(
+                -BASE_RAM_BYTES_USED - (shardSegmentDocMapForwards == null ? 0 : sizeOfSegmentDocMap()),
+                true
+            ),
+            shards,
+            segments,
+            docs
+        );
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/DocVectorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/DocVectorTests.java
@@ -62,6 +62,34 @@ public class DocVectorTests extends ComputeTestCase {
         docs.close();
     }
 
+    private static int MAX_BUILD_BREAKS_LIMIT = 1391;
+
+    public void testBuildBreaks() {
+        testBuildBreaks(ByteSizeValue.ofBytes(between(0, MAX_BUILD_BREAKS_LIMIT)));
+    }
+
+    public void testBuildBreaksMax() {
+        testBuildBreaks(ByteSizeValue.ofBytes(MAX_BUILD_BREAKS_LIMIT));
+    }
+
+    private void testBuildBreaks(ByteSizeValue limit) {
+        int size = 100;
+        BlockFactory blockFactory = blockFactory(limit);
+        Exception e = expectThrows(CircuitBreakingException.class, () -> {
+            try (DocBlock.Builder builder = DocBlock.newBlockBuilder(blockFactory, size)) {
+                for (int r = 0; r < size; r++) {
+                    builder.appendShard(3 - size % 4);
+                    builder.appendSegment(size % 10);
+                    builder.appendDoc(size);
+                }
+                builder.build().close();
+            }
+        });
+        assertThat(e.getMessage(), equalTo("over test limit"));
+        logger.info("break position", e);
+        assertThat(blockFactory.breaker().getUsed(), equalTo(0L));
+    }
+
     public void testShardSegmentDocMap() {
         assertShardSegmentDocMap(
             new int[][] {
@@ -138,6 +166,35 @@ public class DocVectorTests extends ComputeTestCase {
                 }
 
                 assertThat(result, equalTo(data));
+            }
+        }
+        assertThat(blockFactory.breaker().getUsed(), equalTo(0L));
+    }
+
+    // TODO these are really difficult to maintain. can we figure these out of the fly?
+    private static final int MAX_SHARD_SEGMENT_DOC_MAP_BREAKS = 2220;
+
+    public void testShardSegmentDocMapBreaks() {
+        testShardSegmentDocMapBreaks(ByteSizeValue.ofBytes(between(MAX_BUILD_BREAKS_LIMIT + 1, MAX_SHARD_SEGMENT_DOC_MAP_BREAKS)));
+    }
+
+    public void testShardSegmentDocMapBreaksMax() {
+        testShardSegmentDocMapBreaks(ByteSizeValue.ofBytes(MAX_SHARD_SEGMENT_DOC_MAP_BREAKS));
+    }
+
+    private void testShardSegmentDocMapBreaks(ByteSizeValue limit) {
+        int size = 100;
+        BlockFactory blockFactory = blockFactory(limit);
+        try (DocBlock.Builder builder = DocBlock.newBlockBuilder(blockFactory, size)) {
+            for (int r = 0; r < size; r++) {
+                builder.appendShard(3 - size % 4);
+                builder.appendSegment(size % 10);
+                builder.appendDoc(size);
+            }
+            try (DocBlock docBlock = builder.build()) {
+                Exception e = expectThrows(CircuitBreakingException.class, docBlock.asVector()::shardSegmentDocMapForwards);
+                assertThat(e.getMessage(), equalTo("over test limit"));
+                logger.info("broke at", e);
             }
         }
         assertThat(blockFactory.breaker().getUsed(), equalTo(0L));

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/DocVectorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/DocVectorTests.java
@@ -108,7 +108,7 @@ public class DocVectorTests extends ComputeTestCase {
     }
 
     private void assertShardSegmentDocMap(int[][] data, int[][] expected) {
-        BlockFactory blockFactory = BlockFactoryTests.blockFactory(ByteSizeValue.ofGb(1));
+        BlockFactory blockFactory = blockFactory();
         try (DocBlock.Builder builder = DocBlock.newBlockBuilder(blockFactory, data.length)) {
             for (int r = 0; r < data.length; r++) {
                 builder.appendShard(data[r][0]);
@@ -116,7 +116,9 @@ public class DocVectorTests extends ComputeTestCase {
                 builder.appendDoc(data[r][2]);
             }
             try (DocVector docVector = builder.build().asVector()) {
+                assertThat(blockFactory.breaker().getUsed(), equalTo(docVector.ramBytesUsed()));
                 int[] forwards = docVector.shardSegmentDocMapForwards();
+                assertThat(blockFactory.breaker().getUsed(), equalTo(docVector.ramBytesUsed()));
 
                 int[][] result = new int[docVector.getPositionCount()][];
                 for (int p = 0; p < result.length; p++) {
@@ -195,7 +197,7 @@ public class DocVectorTests extends ComputeTestCase {
     }
 
     public void testFilterBreaks() {
-        BlockFactory factory = blockFactory(ByteSizeValue.ofBytes(between(160, 280)));
+        BlockFactory factory = blockFactory(ByteSizeValue.ofBytes(between(250, 370)));
         try (
             DocVector docs = new DocVector(
                 factory.newConstantIntVector(0, 10),

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/LuceneSourceOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/LuceneSourceOperatorTests.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.compute.lucene;
 
+import com.carrotsearch.randomizedtesting.annotations.Repeat;
+
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexableField;
@@ -59,6 +61,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@Repeat(iterations = 100)
 public class LuceneSourceOperatorTests extends AnyOperatorTestCase {
     private static final MappedFieldType S_FIELD = new NumberFieldMapper.NumberFieldType("s", NumberFieldMapper.NumberType.LONG);
     private Directory directory = newDirectory();

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/LuceneSourceOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/LuceneSourceOperatorTests.java
@@ -7,8 +7,6 @@
 
 package org.elasticsearch.compute.lucene;
 
-import com.carrotsearch.randomizedtesting.annotations.Repeat;
-
 import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexableField;
@@ -61,7 +59,6 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@Repeat(iterations = 100)
 public class LuceneSourceOperatorTests extends AnyOperatorTestCase {
     private static final MappedFieldType S_FIELD = new NumberFieldMapper.NumberFieldType("s", NumberFieldMapper.NumberType.LONG);
     private Directory directory = newDirectory();


### PR DESCRIPTION
This modifies the code the loads doc ids to enable tracking its "sorting" array. These arrays are used by the doc values loader implementation when we load from doc ids that aren't in sorted order - mostly because there's a `top_n` before the load.
