### PR TITLE
Pass global factory in async operator tests

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockFactory.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockFactory.java
@@ -41,7 +41,10 @@ public class BlockFactory {
         this(breaker, bigArrays, maxPrimitiveArraySize, null);
     }
 
-    public BlockFactory(CircuitBreaker breaker, BigArrays bigArrays, ByteSizeValue maxPrimitiveArraySize, BlockFactory parent) {
+    protected BlockFactory(CircuitBreaker breaker, BigArrays bigArrays, ByteSizeValue maxPrimitiveArraySize, BlockFactory parent) {
+        assert breaker instanceof LocalCircuitBreaker == false
+            || (parent != null && ((LocalCircuitBreaker) breaker).parentBreaker() == parent.breaker)
+            : "use local breaker without parent block factory";
         this.breaker = breaker;
         this.bigArrays = bigArrays;
         this.parent = parent;

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockFactoryTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockFactoryTests.java
@@ -650,12 +650,7 @@ public class BlockFactoryTests extends ESTestCase {
     public void testOwningFactoryOfVectorBlock() {
         BlockFactory parentFactory = blockFactory(ByteSizeValue.ofBytes(between(1024, 4096)));
         LocalCircuitBreaker localBreaker = new LocalCircuitBreaker(parentFactory.breaker(), between(0, 1024), between(0, 1024));
-        BlockFactory localFactory = new BlockFactory(
-            localBreaker,
-            bigArrays,
-            BlockFactory.DEFAULT_MAX_BLOCK_PRIMITIVE_ARRAY_SIZE,
-            parentFactory
-        );
+        BlockFactory localFactory = parentFactory.newChildFactory(localBreaker);
         int numValues = between(2, 10);
         try (var builder = localFactory.newIntVectorBuilder(numValues)) {
             for (int i = 0; i < numValues; i++) {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/MockBlockFactory.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/MockBlockFactory.java
@@ -73,7 +73,7 @@ public class MockBlockFactory extends BlockFactory {
         this(breaker, bigArrays, maxPrimitiveArraySize, null);
     }
 
-    public MockBlockFactory(CircuitBreaker breaker, BigArrays bigArrays, ByteSizeValue maxPrimitiveArraySize, BlockFactory parent) {
+    private MockBlockFactory(CircuitBreaker breaker, BigArrays bigArrays, ByteSizeValue maxPrimitiveArraySize, BlockFactory parent) {
         super(breaker, bigArrays, maxPrimitiveArraySize, parent);
     }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/AsyncOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/AsyncOperatorTests.java
@@ -76,7 +76,7 @@ public class AsyncOperatorTests extends ESTestCase {
         final DriverContext driverContext;
         if (randomBoolean()) {
             localBreaker = new LocalCircuitBreaker(globalBlockFactory.breaker(), between(0, 1024), between(0, 4096));
-            BlockFactory localFactory = new BlockFactory(localBreaker, globalBlockFactory.bigArrays());
+            BlockFactory localFactory = globalBlockFactory.newChildFactory(localBreaker);
             driverContext = new DriverContext(globalBlockFactory.bigArrays(), localFactory);
         } else {
             driverContext = new DriverContext(globalBlockFactory.bigArrays(), globalBlockFactory);
@@ -213,7 +213,7 @@ public class AsyncOperatorTests extends ESTestCase {
         final DriverContext driverContext;
         if (randomBoolean()) {
             localBreaker = new LocalCircuitBreaker(globalBlockFactory.breaker(), between(0, 1024), between(0, 4096));
-            BlockFactory localFactory = new BlockFactory(localBreaker, globalBlockFactory.bigArrays());
+            BlockFactory localFactory = globalBlockFactory.newChildFactory(localBreaker);
             driverContext = new DriverContext(globalBlockFactory.bigArrays(), localFactory);
         } else {
             driverContext = new DriverContext(globalBlockFactory.bigArrays(), globalBlockFactory);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlPlugin.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlPlugin.java
@@ -94,7 +94,7 @@ public class EsqlPlugin extends Plugin implements ActionPlugin {
             BlockFactory.DEFAULT_MAX_BLOCK_PRIMITIVE_ARRAY_SIZE
         );
         BigArrays bigArrays = services.indicesService().getBigArrays().withCircuitBreaking();
-        BlockFactory blockFactory = new BlockFactory(circuitBreaker, bigArrays, maxPrimitiveArrayBlockSize, null);
+        BlockFactory blockFactory = new BlockFactory(circuitBreaker, bigArrays, maxPrimitiveArrayBlockSize);
         return List.of(
             new PlanExecutor(
                 new IndexResolver(


### PR DESCRIPTION
When creating a block factory with a local breaker, it's important to pass the parent block factory. Otherwise, we won't return the memory to the global breaker after the local breaker is closed.

Closes #103553
Closes #103719