### PR TITLE
When summing cartesian centroids, use floats to reduce differences to test code

### DIFF
--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/CartesianShapeCentroidAggregatorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/CartesianShapeCentroidAggregatorTests.java
@@ -162,8 +162,9 @@ public class CartesianShapeCentroidAggregatorTests extends AggregatorTestCase {
                 w.addDocument(document);
                 if (targetShapeType.compareTo(calculator.getDimensionalShapeType()) == 0) {
                     double weight = calculator.sumWeight();
-                    compensatedSumLat.add(weight * calculator.getY());
-                    compensatedSumLon.add(weight * calculator.getX());
+                    // compute the centroid of centroids in float space
+                    compensatedSumLat.add(weight * (float) calculator.getY());
+                    compensatedSumLon.add(weight * (float) calculator.getX());
                     compensatedSumWeight.add(weight);
                 }
             }

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/CartesianShapeCentroidAggregatorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/CartesianShapeCentroidAggregatorTests.java
@@ -39,6 +39,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 
+import static java.lang.Math.signum;
 import static org.hamcrest.Matchers.equalTo;
 
 public class CartesianShapeCentroidAggregatorTests extends AggregatorTestCase {
@@ -154,6 +155,8 @@ public class CartesianShapeCentroidAggregatorTests extends AggregatorTestCase {
             CompensatedSum compensatedSumLon = new CompensatedSum(0, 0);
             CompensatedSum compensatedSumLat = new CompensatedSum(0, 0);
             CompensatedSum compensatedSumWeight = new CompensatedSum(0, 0);
+            TestExpected xExpected = new TestExpected();
+            TestExpected yExpected = new TestExpected();
             for (Geometry geometry : geometries) {
                 Document document = new Document();
                 CentroidCalculator calculator = new CentroidCalculator();
@@ -165,19 +168,17 @@ public class CartesianShapeCentroidAggregatorTests extends AggregatorTestCase {
                     compensatedSumLat.add(weight * calculator.getY());
                     compensatedSumLon.add(weight * calculator.getX());
                     compensatedSumWeight.add(weight);
+                    xExpected.setValue(compensatedSumLon.value() / compensatedSumWeight.value());
+                    yExpected.setValue(compensatedSumLat.value() / compensatedSumWeight.value());
                 }
             }
             // force using a single aggregator to compute the centroid
             w.forceMerge(1);
-            CartesianPoint expectedCentroid = new CartesianPoint(
-                compensatedSumLon.value() / compensatedSumWeight.value(),
-                compensatedSumLat.value() / compensatedSumWeight.value()
-            );
-            assertCentroid(w, expectedCentroid);
+            assertCentroid(w, xExpected, yExpected);
         }
     }
 
-    private void assertCentroid(RandomIndexWriter w, CartesianPoint expectedCentroid) throws IOException {
+    private void assertCentroid(RandomIndexWriter w, TestExpected xExpected, TestExpected yExpected) throws IOException {
         MappedFieldType fieldType = new ShapeFieldMapper.ShapeFieldType(
             "field",
             true,
@@ -193,20 +194,33 @@ public class CartesianShapeCentroidAggregatorTests extends AggregatorTestCase {
             assertEquals("my_agg", result.getName());
             SpatialPoint centroid = result.centroid();
             assertNotNull(centroid);
-            assertCentroid("x-value", result.count(), centroid.getX(), expectedCentroid.getX());
-            assertCentroid("y-value", result.count(), centroid.getY(), expectedCentroid.getY());
+            assertCentroid("x-value", centroid.getX(), xExpected);
+            assertCentroid("y-value", centroid.getY(), yExpected);
             assertTrue(AggregationInspectionHelper.hasValue(result));
         }
     }
 
-    private void assertCentroid(String name, long count, double value, double expected) {
-        assertEquals("Centroid over " + count + " had incorrect " + name, expected, value, tolerance(expected, count));
+    private void assertCentroid(String name, double value, TestExpected expected) {
+        assertEquals("Centroid over " + expected.count + " had incorrect " + name, expected.value, value, expected.tolerance());
     }
 
-    private double tolerance(double expected, long count) {
-        double tolerance = Math.abs(expected / 1e5);
-        // Very large numbers have more floating point error, also increasing with count
-        return tolerance > 1e25 ? tolerance * count : tolerance;
+    private static class TestExpected {
+        private double value;
+        private double previous;
+        private int count;
+
+        private void setValue(double value) {
+            this.previous = this.value;
+            this.value = value;
+            this.count++;
+        }
+
+        private double tolerance() {
+            // When last numbers change sign, they usually end up as much smaller numbers (but retain high errors)
+            double tolerance = signum(value) != signum(previous) ? Math.abs(value / 1e3) : Math.abs(value / 1e5);
+            // Very large numbers have more floating point error, also increasing with count
+            return tolerance > 1e25 ? tolerance * count : tolerance;
+        }
     }
 
     @Override


### PR DESCRIPTION
In this case we noticed very rare failures, usually less than 1/10000 test runs failed, but in the two cases we detected, the failure occurred when the last geometry caused the centroid summation to switch signs, which also lead to much smaller numbers (changing sign means the last value must be a very large value opposite of the previous sum). These small numbers could not reliably be used for relative error calculation because the error is based on the complete history, not the final value.

Fixes #103714
