### PR TITLE
Time sorting field, null default value (-9223372036854775808), format…

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/SearchSortValuesAndFormats.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchSortValuesAndFormats.java
@@ -31,6 +31,8 @@ public class SearchSortValuesAndFormats implements Writeable {
             Object sortValue = rawSortValues[i];
             if (sortValue instanceof BytesRef) {
                 this.formattedSortValues[i] = sortValueFormats[i].format((BytesRef) sortValue);
+            } else if (sortValueFormats[i] instanceof DocValueFormat.DateTime) {
+                this.formattedSortValues[i] = sortValueFormats[i].formatSortValue(sortValue);
             } else if (sortValue instanceof Long) {
                 this.formattedSortValues[i] = sortValueFormats[i].format((long) sortValue);
             } else if (sortValue instanceof Double) {


### PR DESCRIPTION
When a time type field is used as a sorting field, null will give a default value of -9223372036854775808 (Long.MIN_VALUE). Some time formats cannot be formatted, such as "epoch_millis".