### PR TITLE
search sort value format

### DIFF
--- a/docs/changelog/103611.yaml
+++ b/docs/changelog/103611.yaml
@@ -1,6 +1,6 @@
-pr: 103732
+pr: 103611
 summary: Fix NPE on missing event queries
 area: EQL
 type: bug
 issues:
- - 103608
+  - 103608

--- a/docs/changelog/103611.yaml
+++ b/docs/changelog/103611.yaml
@@ -1,4 +1,4 @@
-pr: 103611
+pr: 103732
 summary: Fix NPE on missing event queries
 area: EQL
 type: bug

--- a/docs/changelog/103711.yaml
+++ b/docs/changelog/103711.yaml
@@ -1,4 +1,4 @@
-pr: 103601
+pr: 103711
 summary: Time sorting field format
 area: Search
 type: bug

--- a/docs/changelog/103711.yaml
+++ b/docs/changelog/103711.yaml
@@ -1,0 +1,6 @@
+pr: 103601
+summary: Time sorting field format
+area: Search
+type: bug
+issues:
+  - 103489

--- a/docs/changelog/103733.yaml
+++ b/docs/changelog/103733.yaml
@@ -1,4 +1,4 @@
-pr: 103711
+pr: 103733
 summary: Time sorting field format
 area: Search
 type: bug

--- a/server/src/main/java/org/elasticsearch/search/SearchSortValuesAndFormats.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchSortValuesAndFormats.java
@@ -31,6 +31,8 @@ public class SearchSortValuesAndFormats implements Writeable {
             Object sortValue = rawSortValues[i];
             if (sortValue instanceof BytesRef) {
                 this.formattedSortValues[i] = sortValueFormats[i].format((BytesRef) sortValue);
+            } else if (sortValueFormats[i] instanceof DocValueFormat.DateTime) {
+                this.formattedSortValues[i] = sortValueFormats[i].formatSortValue(sortValue);
             } else if (sortValue instanceof Long) {
                 this.formattedSortValues[i] = sortValueFormats[i].format((long) sortValue);
             } else if (sortValue instanceof Double) {

--- a/server/src/test/java/org/elasticsearch/search/SearchSortValuesAndFormatsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchSortValuesAndFormatsTests.java
@@ -12,6 +12,8 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.time.DateFormatter;
+import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.junit.Before;
 
@@ -75,6 +77,20 @@ public class SearchSortValuesAndFormatsTests extends AbstractWireSerializingTest
         for (int i = 0; i < size; i++) {
             values[i] = randomSortValue();
             sortValueFormats[i] = DocValueFormat.RAW;
+        }
+        return new SearchSortValuesAndFormats(values, sortValueFormats);
+    }
+    public static SearchSortValuesAndFormats LongMaxMinValue() {
+        Object[] values = new Object[2];
+        DocValueFormat.DateTime formatter = new DocValueFormat.DateTime(
+            DateFormatter.forPattern("epoch_millis"),
+            randomZone(),
+            DateFieldMapper.Resolution.MILLISECONDS
+        );
+        DocValueFormat[] sortValueFormats = new DocValueFormat[2];
+        for (int i = 0; i < 2; i++) {
+            values[i] = Long.MAX_VALUE;
+            sortValueFormats[i] = formatter;
         }
         return new SearchSortValuesAndFormats(values, sortValueFormats);
     }


### PR DESCRIPTION
When a time type field is used as a sorting field, null will give a default value of -9223372036854775808 (Long.MIN_VALUE). Some time formats cannot be formatted, such as "epoch_millis".