### PR TITLE
Release resources acquired in `prepareRequest`

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
+++ b/server/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
@@ -14,6 +14,7 @@ import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.core.CheckedConsumer;
+import org.elasticsearch.core.RefCounted;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.core.Tuple;
@@ -157,6 +158,11 @@ public abstract class BaseRestHandler implements RestHandler {
      */
     @FunctionalInterface
     protected interface RestChannelConsumer extends CheckedConsumer<RestChannel, Exception>, Releasable {
+        /**
+         * Called just after the execution has started (or failed, if the request was invalid), but typically well before the execution has
+         * completed. This callback should be used to release (refs to) resources that were acquired when constructing this consumer, for
+         * instance by calling {@link RefCounted#decRef()} on any newly-created transport requests with nontrivial lifecycles.
+         */
         @Override
         default void close() {}
     }

--- a/server/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
+++ b/server/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
@@ -14,6 +14,7 @@ import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.core.CheckedConsumer;
+import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.plugins.ActionPlugin;
@@ -77,30 +78,33 @@ public abstract class BaseRestHandler implements RestHandler {
     @Override
     public final void handleRequest(RestRequest request, RestChannel channel, NodeClient client) throws Exception {
         // prepare the request for execution; has the side effect of touching the request parameters
-        final RestChannelConsumer action = prepareRequest(request, client);
+        try (var action = prepareRequest(request, client)) {
 
-        // validate unconsumed params, but we must exclude params used to format the response
-        // use a sorted set so the unconsumed parameters appear in a reliable sorted order
-        final SortedSet<String> unconsumedParams = request.unconsumedParams()
-            .stream()
-            .filter(p -> responseParams(request.getRestApiVersion()).contains(p) == false)
-            .collect(Collectors.toCollection(TreeSet::new));
+            // validate unconsumed params, but we must exclude params used to format the response
+            // use a sorted set so the unconsumed parameters appear in a reliable sorted order
+            final SortedSet<String> unconsumedParams = request.unconsumedParams()
+                .stream()
+                .filter(p -> responseParams(request.getRestApiVersion()).contains(p) == false)
+                .collect(Collectors.toCollection(TreeSet::new));
 
-        // validate the non-response params
-        if (unconsumedParams.isEmpty() == false) {
-            final Set<String> candidateParams = new HashSet<>();
-            candidateParams.addAll(request.consumedParams());
-            candidateParams.addAll(responseParams(request.getRestApiVersion()));
-            throw new IllegalArgumentException(unrecognized(request, unconsumedParams, candidateParams, "parameter"));
+            // validate the non-response params
+            if (unconsumedParams.isEmpty() == false) {
+                final Set<String> candidateParams = new HashSet<>();
+                candidateParams.addAll(request.consumedParams());
+                candidateParams.addAll(responseParams(request.getRestApiVersion()));
+                throw new IllegalArgumentException(unrecognized(request, unconsumedParams, candidateParams, "parameter"));
+            }
+
+            if (request.hasContent() && request.isContentConsumed() == false) {
+                throw new IllegalArgumentException(
+                    "request [" + request.method() + " " + request.path() + "] does not support having a body"
+                );
+            }
+
+            usageCount.increment();
+            // execute the action
+            action.accept(channel);
         }
-
-        if (request.hasContent() && request.isContentConsumed() == false) {
-            throw new IllegalArgumentException("request [" + request.method() + " " + request.path() + "] does not support having a body");
-        }
-
-        usageCount.increment();
-        // execute the action
-        action.accept(channel);
     }
 
     protected static String unrecognized(
@@ -149,11 +153,13 @@ public abstract class BaseRestHandler implements RestHandler {
     }
 
     /**
-     * REST requests are handled by preparing a channel consumer that represents the execution of
-     * the request against a channel.
+     * REST requests are handled by preparing a channel consumer that represents the execution of the request against a channel.
      */
     @FunctionalInterface
-    protected interface RestChannelConsumer extends CheckedConsumer<RestChannel, Exception> {}
+    protected interface RestChannelConsumer extends CheckedConsumer<RestChannel, Exception>, Releasable {
+        @Override
+        default void close() {}
+    }
 
     /**
      * Prepare the request for execution. Implementations should consume all request params before


### PR DESCRIPTION
Some `BaseRestHandler#prepareRequest` implementations may construct a
request with nontrivial lifecycle (e.g. containing a `SecureString`),
but there's no hook to clean up on an exception: the handler only
continues with execution if the REST request was valid. This commit adds
a `Releasable` superinterface to `RestChannelConsumer` whose `close()`
method is invoked whether the action executes or not.