### PR TITLE
Pass global factory in async operator tests (#103728)

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockFactory.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockFactory.java
@@ -40,6 +40,9 @@ public class BlockFactory {
     }
 
     protected BlockFactory(CircuitBreaker breaker, BigArrays bigArrays, BlockFactory parent) {
+        assert breaker instanceof LocalCircuitBreaker == false
+            || (parent != null && ((LocalCircuitBreaker) breaker).parentBreaker() == parent.breaker)
+            : "use local breaker without parent block factory";
         this.breaker = breaker;
         this.bigArrays = bigArrays;
         this.parent = parent;

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockFactoryTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockFactoryTests.java
@@ -651,7 +651,7 @@ public class BlockFactoryTests extends ESTestCase {
     public void testOwningFactoryOfVectorBlock() {
         BlockFactory parentFactory = blockFactory(ByteSizeValue.ofBytes(between(1024, 4096)));
         LocalCircuitBreaker localBreaker = new LocalCircuitBreaker(parentFactory.breaker(), between(0, 1024), between(0, 1024));
-        BlockFactory localFactory = new BlockFactory(localBreaker, bigArrays, parentFactory);
+        BlockFactory localFactory = parentFactory.newChildFactory(localBreaker);
         int numValues = between(2, 10);
         try (var builder = localFactory.newIntVectorBuilder(numValues)) {
             for (int i = 0; i < numValues; i++) {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/MockBlockFactory.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/MockBlockFactory.java
@@ -66,7 +66,7 @@ public class MockBlockFactory extends BlockFactory {
         this(breaker, bigArrays, null);
     }
 
-    protected MockBlockFactory(CircuitBreaker breaker, BigArrays bigArrays, BlockFactory parent) {
+    private MockBlockFactory(CircuitBreaker breaker, BigArrays bigArrays, BlockFactory parent) {
         super(breaker, bigArrays, parent);
     }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/AsyncOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/AsyncOperatorTests.java
@@ -76,7 +76,7 @@ public class AsyncOperatorTests extends ESTestCase {
         final DriverContext driverContext;
         if (randomBoolean()) {
             localBreaker = new LocalCircuitBreaker(globalBlockFactory.breaker(), between(0, 1024), between(0, 4096));
-            BlockFactory localFactory = new BlockFactory(localBreaker, globalBlockFactory.bigArrays());
+            BlockFactory localFactory = globalBlockFactory.newChildFactory(localBreaker);
             driverContext = new DriverContext(globalBlockFactory.bigArrays(), localFactory);
         } else {
             driverContext = new DriverContext(globalBlockFactory.bigArrays(), globalBlockFactory);
@@ -213,7 +213,7 @@ public class AsyncOperatorTests extends ESTestCase {
         final DriverContext driverContext;
         if (randomBoolean()) {
             localBreaker = new LocalCircuitBreaker(globalBlockFactory.breaker(), between(0, 1024), between(0, 4096));
-            BlockFactory localFactory = new BlockFactory(localBreaker, globalBlockFactory.bigArrays());
+            BlockFactory localFactory = globalBlockFactory.newChildFactory(localBreaker);
             driverContext = new DriverContext(globalBlockFactory.bigArrays(), localFactory);
         } else {
             driverContext = new DriverContext(globalBlockFactory.bigArrays(), globalBlockFactory);


### PR DESCRIPTION
When creating a block factory with a local breaker, it's important to pass the parent block factory. Otherwise, we won't return the memory to the global breaker after the local breaker is closed.

Closes #103553
Closes #103719
