### PR TITLE
fix search sort value format"epoch_millis"exception

### DIFF
--- a/docs/changelog/103745.yaml
+++ b/docs/changelog/103745.yaml
@@ -1,0 +1,6 @@
+pr: 103745
+summary: Fix search sort value format
+area: Search
+type: bug
+issues:
+  - 103489

--- a/server/src/main/java/org/elasticsearch/search/SearchSortValuesAndFormats.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchSortValuesAndFormats.java
@@ -31,6 +31,8 @@ public class SearchSortValuesAndFormats implements Writeable {
             Object sortValue = rawSortValues[i];
             if (sortValue instanceof BytesRef) {
                 this.formattedSortValues[i] = sortValueFormats[i].format((BytesRef) sortValue);
+            } else if (sortValueFormats[i] instanceof DocValueFormat.DateTime) {
+                this.formattedSortValues[i] = sortValueFormats[i].formatSortValue(sortValue);
             } else if (sortValue instanceof Long) {
                 this.formattedSortValues[i] = sortValueFormats[i].format((long) sortValue);
             } else if (sortValue instanceof Double) {

--- a/server/src/test/java/org/elasticsearch/search/SearchSortValuesAndFormatsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchSortValuesAndFormatsTests.java
@@ -12,9 +12,12 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.time.DateFormatter;
+import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.junit.Before;
 
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -76,6 +79,17 @@ public class SearchSortValuesAndFormatsTests extends AbstractWireSerializingTest
             values[i] = randomSortValue();
             sortValueFormats[i] = DocValueFormat.RAW;
         }
+        return new SearchSortValuesAndFormats(values, sortValueFormats);
+    }
+    public static SearchSortValuesAndFormats sortValueMAxMinInstance() {
+        DocValueFormat.DateTime format = new DocValueFormat.DateTime(
+            DateFormatter.forPattern("epoch_millis"),
+            ZoneOffset.UTC,
+            DateFieldMapper.Resolution.MILLISECONDS
+        );
+        Object[] values = {Long.MAX_VALUE,Long.MIN_VALUE};
+        DocValueFormat[] sortValueFormats = {format};
+        SearchSortValuesAndFormats searchSortValuesAndFormats = new SearchSortValuesAndFormats(values, sortValueFormats);
         return new SearchSortValuesAndFormats(values, sortValueFormats);
     }
 }


### PR DESCRIPTION
When a time type field is used as a sorting field, null will give a default value of -9223372036854775808 (Long.MIN_VALUE). Some time formats cannot be formatted, such as "epoch_millis".
- [x] https://github.com/elastic/elasticsearch/issues/103489