### PR TITLE
Bubble up some IOExceptions in ES|QL compute engine

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/AggregatorBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/AggregatorBenchmark.java
@@ -48,6 +48,7 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.LongStream;
@@ -104,7 +105,7 @@ public class AggregatorBenchmark {
                     }
                 }
             }
-        } catch (NoSuchFieldException e) {
+        } catch (NoSuchFieldException | IOException e) {
             throw new AssertionError();
         }
     }
@@ -564,11 +565,11 @@ public class AggregatorBenchmark {
 
     @Benchmark
     @OperationsPerInvocation(OP_COUNT * BLOCK_LENGTH)
-    public void run() {
+    public void run() throws IOException {
         run(grouping, op, blockType, OP_COUNT);
     }
 
-    private static void run(String grouping, String op, String blockType, int opCount) {
+    private static void run(String grouping, String op, String blockType, int opCount) throws IOException {
         String dataType = switch (blockType) {
             case VECTOR_LONGS, HALF_NULL_LONGS -> LONGS;
             case VECTOR_DOUBLES, HALF_NULL_DOUBLES -> DOUBLES;

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/EvalBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/EvalBenchmark.java
@@ -46,6 +46,7 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 
+import java.io.IOException;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Map;
@@ -77,7 +78,7 @@ public class EvalBenchmark {
             for (String operation : EvalBenchmark.class.getField("operation").getAnnotationsByType(Param.class)[0].value()) {
                 run(operation);
             }
-        } catch (NoSuchFieldException e) {
+        } catch (NoSuchFieldException | IOException e) {
             throw new AssertionError();
         }
     }
@@ -256,11 +257,11 @@ public class EvalBenchmark {
 
     @Benchmark
     @OperationsPerInvocation(1024 * BLOCK_LENGTH)
-    public void run() {
+    public void run() throws IOException {
         run(operation);
     }
 
-    private static void run(String operation) {
+    private static void run(String operation) throws IOException {
         try (Operator operator = operator(operation)) {
             Page page = page(operation);
             Page output = null;

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/TopNBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/TopNBenchmark.java
@@ -38,6 +38,7 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -74,7 +75,7 @@ public class TopNBenchmark {
                     run(data, Integer.parseInt(topCount));
                 }
             }
-        } catch (NoSuchFieldException e) {
+        } catch (NoSuchFieldException | IOException e) {
             throw new AssertionError();
         }
     }
@@ -182,11 +183,11 @@ public class TopNBenchmark {
 
     @Benchmark
     @OperationsPerInvocation(1024 * BLOCK_LENGTH)
-    public void run() {
+    public void run() throws IOException {
         run(data, topCount);
     }
 
-    private static void run(String data, int topCount) {
+    private static void run(String data, int topCount) throws IOException {
         try (Operator operator = operator(data, topCount)) {
             Page page = page(data);
             for (int i = 0; i < 1024; i++) {

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/ValuesSourceReaderBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/ValuesSourceReaderBenchmark.java
@@ -246,7 +246,7 @@ public class ValuesSourceReaderBenchmark {
 
     @Benchmark
     @OperationsPerInvocation(INDEX_SIZE)
-    public void benchmark() {
+    public void benchmark() throws IOException {
         ValuesSourceReaderOperator op = new ValuesSourceReaderOperator(
             blockFactory,
             fields(name),

--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/AggregatorImplementer.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/AggregatorImplementer.java
@@ -18,6 +18,7 @@ import com.squareup.javapoet.TypeSpec;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
@@ -395,6 +396,7 @@ public class AggregatorImplementer {
     private MethodSpec addIntermediateInput() {
         MethodSpec.Builder builder = MethodSpec.methodBuilder("addIntermediateInput");
         builder.addAnnotation(Override.class).addModifiers(Modifier.PUBLIC).addParameter(PAGE, "page");
+        builder.addException(IOException.class);
         builder.addStatement("assert channels.size() == intermediateBlockCount()");
         builder.addStatement("assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size()");
         for (int i = 0; i < intermediateState.size(); i++) {
@@ -471,6 +473,7 @@ public class AggregatorImplementer {
             .addParameter(BLOCK_ARRAY, "blocks")
             .addParameter(TypeName.INT, "offset")
             .addParameter(DRIVER_CONTEXT, "driverContext");
+        builder.addException(IOException.class);
         builder.addStatement("state.toIntermediate(blocks, offset, driverContext)");
         return builder.build();
     }

--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/GroupingAggregatorImplementer.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/GroupingAggregatorImplementer.java
@@ -18,6 +18,7 @@ import com.squareup.javapoet.TypeSpec;
 import org.elasticsearch.compute.ann.Aggregator;
 import org.elasticsearch.compute.ann.IntermediateState;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
@@ -401,6 +402,7 @@ public class GroupingAggregatorImplementer {
         builder.addParameter(TypeName.INT, "positionOffset");
         builder.addParameter(INT_VECTOR, "groups");
         builder.addParameter(PAGE, "page");
+        builder.addException(IOException.class);
 
         builder.addStatement("state.enableGroupIdTracking(new $T.Empty())", SEEN_GROUP_IDS);
         builder.addStatement("assert channels.size() == intermediateBlockCount()");
@@ -497,6 +499,7 @@ public class GroupingAggregatorImplementer {
             .addParameter(BLOCK_ARRAY, "blocks")
             .addParameter(TypeName.INT, "offset")
             .addParameter(INT_VECTOR, "selected");
+        builder.addException(IOException.class);
         builder.addStatement("state.toIntermediate(blocks, offset, selected, driverContext)");
         return builder.build();
     }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBooleanAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBooleanAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -83,7 +84,7 @@ public final class CountDistinctBooleanAggregatorFunction implements AggregatorF
   }
 
   @Override
-  public void addIntermediateInput(Page page) {
+  public void addIntermediateInput(Page page) throws IOException {
     assert channels.size() == intermediateBlockCount();
     assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
     Block fbitUncast = page.getBlock(channels.get(0));
@@ -102,7 +103,8 @@ public final class CountDistinctBooleanAggregatorFunction implements AggregatorF
   }
 
   @Override
-  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) throws
+      IOException {
     state.toIntermediate(blocks, offset, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBooleanGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBooleanGroupingAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -150,7 +151,8 @@ public final class CountDistinctBooleanGroupingAggregatorFunction implements Gro
   }
 
   @Override
-  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) throws
+      IOException {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
     assert channels.size() == intermediateBlockCount();
     BooleanVector fbit = page.<BooleanBlock>getBlock(channels.get(0)).asVector();
@@ -173,7 +175,8 @@ public final class CountDistinctBooleanGroupingAggregatorFunction implements Gro
   }
 
   @Override
-  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) {
+  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) throws
+      IOException {
     state.toIntermediate(blocks, offset, selected, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBytesRefAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBytesRefAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -92,7 +93,7 @@ public final class CountDistinctBytesRefAggregatorFunction implements Aggregator
   }
 
   @Override
-  public void addIntermediateInput(Page page) {
+  public void addIntermediateInput(Page page) throws IOException {
     assert channels.size() == intermediateBlockCount();
     assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
     Block hllUncast = page.getBlock(channels.get(0));
@@ -106,7 +107,8 @@ public final class CountDistinctBytesRefAggregatorFunction implements Aggregator
   }
 
   @Override
-  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) throws
+      IOException {
     state.toIntermediate(blocks, offset, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBytesRefGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBytesRefGroupingAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -157,7 +158,8 @@ public final class CountDistinctBytesRefGroupingAggregatorFunction implements Gr
   }
 
   @Override
-  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) throws
+      IOException {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
     assert channels.size() == intermediateBlockCount();
     BytesRefVector hll = page.<BytesRefBlock>getBlock(channels.get(0)).asVector();
@@ -179,7 +181,8 @@ public final class CountDistinctBytesRefGroupingAggregatorFunction implements Gr
   }
 
   @Override
-  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) {
+  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) throws
+      IOException {
     state.toIntermediate(blocks, offset, selected, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctDoubleAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctDoubleAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -92,7 +93,7 @@ public final class CountDistinctDoubleAggregatorFunction implements AggregatorFu
   }
 
   @Override
-  public void addIntermediateInput(Page page) {
+  public void addIntermediateInput(Page page) throws IOException {
     assert channels.size() == intermediateBlockCount();
     assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
     Block hllUncast = page.getBlock(channels.get(0));
@@ -106,7 +107,8 @@ public final class CountDistinctDoubleAggregatorFunction implements AggregatorFu
   }
 
   @Override
-  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) throws
+      IOException {
     state.toIntermediate(blocks, offset, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctDoubleGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctDoubleGroupingAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -155,7 +156,8 @@ public final class CountDistinctDoubleGroupingAggregatorFunction implements Grou
   }
 
   @Override
-  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) throws
+      IOException {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
     assert channels.size() == intermediateBlockCount();
     BytesRefVector hll = page.<BytesRefBlock>getBlock(channels.get(0)).asVector();
@@ -177,7 +179,8 @@ public final class CountDistinctDoubleGroupingAggregatorFunction implements Grou
   }
 
   @Override
-  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) {
+  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) throws
+      IOException {
     state.toIntermediate(blocks, offset, selected, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctIntAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -92,7 +93,7 @@ public final class CountDistinctIntAggregatorFunction implements AggregatorFunct
   }
 
   @Override
-  public void addIntermediateInput(Page page) {
+  public void addIntermediateInput(Page page) throws IOException {
     assert channels.size() == intermediateBlockCount();
     assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
     Block hllUncast = page.getBlock(channels.get(0));
@@ -106,7 +107,8 @@ public final class CountDistinctIntAggregatorFunction implements AggregatorFunct
   }
 
   @Override
-  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) throws
+      IOException {
     state.toIntermediate(blocks, offset, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctIntGroupingAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -153,7 +154,8 @@ public final class CountDistinctIntGroupingAggregatorFunction implements Groupin
   }
 
   @Override
-  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) throws
+      IOException {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
     assert channels.size() == intermediateBlockCount();
     BytesRefVector hll = page.<BytesRefBlock>getBlock(channels.get(0)).asVector();
@@ -175,7 +177,8 @@ public final class CountDistinctIntGroupingAggregatorFunction implements Groupin
   }
 
   @Override
-  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) {
+  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) throws
+      IOException {
     state.toIntermediate(blocks, offset, selected, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctLongAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctLongAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -92,7 +93,7 @@ public final class CountDistinctLongAggregatorFunction implements AggregatorFunc
   }
 
   @Override
-  public void addIntermediateInput(Page page) {
+  public void addIntermediateInput(Page page) throws IOException {
     assert channels.size() == intermediateBlockCount();
     assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
     Block hllUncast = page.getBlock(channels.get(0));
@@ -106,7 +107,8 @@ public final class CountDistinctLongAggregatorFunction implements AggregatorFunc
   }
 
   @Override
-  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) throws
+      IOException {
     state.toIntermediate(blocks, offset, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctLongGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctLongGroupingAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -155,7 +156,8 @@ public final class CountDistinctLongGroupingAggregatorFunction implements Groupi
   }
 
   @Override
-  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) throws
+      IOException {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
     assert channels.size() == intermediateBlockCount();
     BytesRefVector hll = page.<BytesRefBlock>getBlock(channels.get(0)).asVector();
@@ -177,7 +179,8 @@ public final class CountDistinctLongGroupingAggregatorFunction implements Groupi
   }
 
   @Override
-  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) {
+  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) throws
+      IOException {
     state.toIntermediate(blocks, offset, selected, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxDoubleAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxDoubleAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -87,7 +88,7 @@ public final class MaxDoubleAggregatorFunction implements AggregatorFunction {
   }
 
   @Override
-  public void addIntermediateInput(Page page) {
+  public void addIntermediateInput(Page page) throws IOException {
     assert channels.size() == intermediateBlockCount();
     assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
     Block maxUncast = page.getBlock(channels.get(0));
@@ -109,7 +110,8 @@ public final class MaxDoubleAggregatorFunction implements AggregatorFunction {
   }
 
   @Override
-  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) throws
+      IOException {
     state.toIntermediate(blocks, offset, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxDoubleGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxDoubleGroupingAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -147,7 +148,8 @@ public final class MaxDoubleGroupingAggregatorFunction implements GroupingAggreg
   }
 
   @Override
-  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) throws
+      IOException {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
     assert channels.size() == intermediateBlockCount();
     DoubleVector max = page.<DoubleBlock>getBlock(channels.get(0)).asVector();
@@ -174,7 +176,8 @@ public final class MaxDoubleGroupingAggregatorFunction implements GroupingAggreg
   }
 
   @Override
-  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) {
+  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) throws
+      IOException {
     state.toIntermediate(blocks, offset, selected, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxIntAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -87,7 +88,7 @@ public final class MaxIntAggregatorFunction implements AggregatorFunction {
   }
 
   @Override
-  public void addIntermediateInput(Page page) {
+  public void addIntermediateInput(Page page) throws IOException {
     assert channels.size() == intermediateBlockCount();
     assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
     Block maxUncast = page.getBlock(channels.get(0));
@@ -109,7 +110,8 @@ public final class MaxIntAggregatorFunction implements AggregatorFunction {
   }
 
   @Override
-  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) throws
+      IOException {
     state.toIntermediate(blocks, offset, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxIntGroupingAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -145,7 +146,8 @@ public final class MaxIntGroupingAggregatorFunction implements GroupingAggregato
   }
 
   @Override
-  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) throws
+      IOException {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
     assert channels.size() == intermediateBlockCount();
     IntVector max = page.<IntBlock>getBlock(channels.get(0)).asVector();
@@ -172,7 +174,8 @@ public final class MaxIntGroupingAggregatorFunction implements GroupingAggregato
   }
 
   @Override
-  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) {
+  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) throws
+      IOException {
     state.toIntermediate(blocks, offset, selected, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxLongAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxLongAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -87,7 +88,7 @@ public final class MaxLongAggregatorFunction implements AggregatorFunction {
   }
 
   @Override
-  public void addIntermediateInput(Page page) {
+  public void addIntermediateInput(Page page) throws IOException {
     assert channels.size() == intermediateBlockCount();
     assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
     Block maxUncast = page.getBlock(channels.get(0));
@@ -109,7 +110,8 @@ public final class MaxLongAggregatorFunction implements AggregatorFunction {
   }
 
   @Override
-  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) throws
+      IOException {
     state.toIntermediate(blocks, offset, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxLongGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxLongGroupingAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -147,7 +148,8 @@ public final class MaxLongGroupingAggregatorFunction implements GroupingAggregat
   }
 
   @Override
-  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) throws
+      IOException {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
     assert channels.size() == intermediateBlockCount();
     LongVector max = page.<LongBlock>getBlock(channels.get(0)).asVector();
@@ -174,7 +176,8 @@ public final class MaxLongGroupingAggregatorFunction implements GroupingAggregat
   }
 
   @Override
-  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) {
+  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) throws
+      IOException {
     state.toIntermediate(blocks, offset, selected, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -85,7 +86,7 @@ public final class MedianAbsoluteDeviationDoubleAggregatorFunction implements Ag
   }
 
   @Override
-  public void addIntermediateInput(Page page) {
+  public void addIntermediateInput(Page page) throws IOException {
     assert channels.size() == intermediateBlockCount();
     assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
     Block quartUncast = page.getBlock(channels.get(0));
@@ -99,7 +100,8 @@ public final class MedianAbsoluteDeviationDoubleAggregatorFunction implements Ag
   }
 
   @Override
-  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) throws
+      IOException {
     state.toIntermediate(blocks, offset, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleGroupingAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -151,7 +152,8 @@ public final class MedianAbsoluteDeviationDoubleGroupingAggregatorFunction imple
   }
 
   @Override
-  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) throws
+      IOException {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
     assert channels.size() == intermediateBlockCount();
     BytesRefVector quart = page.<BytesRefBlock>getBlock(channels.get(0)).asVector();
@@ -173,7 +175,8 @@ public final class MedianAbsoluteDeviationDoubleGroupingAggregatorFunction imple
   }
 
   @Override
-  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) {
+  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) throws
+      IOException {
     state.toIntermediate(blocks, offset, selected, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationIntAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -85,7 +86,7 @@ public final class MedianAbsoluteDeviationIntAggregatorFunction implements Aggre
   }
 
   @Override
-  public void addIntermediateInput(Page page) {
+  public void addIntermediateInput(Page page) throws IOException {
     assert channels.size() == intermediateBlockCount();
     assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
     Block quartUncast = page.getBlock(channels.get(0));
@@ -99,7 +100,8 @@ public final class MedianAbsoluteDeviationIntAggregatorFunction implements Aggre
   }
 
   @Override
-  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) throws
+      IOException {
     state.toIntermediate(blocks, offset, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationIntGroupingAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -149,7 +150,8 @@ public final class MedianAbsoluteDeviationIntGroupingAggregatorFunction implemen
   }
 
   @Override
-  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) throws
+      IOException {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
     assert channels.size() == intermediateBlockCount();
     BytesRefVector quart = page.<BytesRefBlock>getBlock(channels.get(0)).asVector();
@@ -171,7 +173,8 @@ public final class MedianAbsoluteDeviationIntGroupingAggregatorFunction implemen
   }
 
   @Override
-  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) {
+  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) throws
+      IOException {
     state.toIntermediate(blocks, offset, selected, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationLongAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationLongAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -85,7 +86,7 @@ public final class MedianAbsoluteDeviationLongAggregatorFunction implements Aggr
   }
 
   @Override
-  public void addIntermediateInput(Page page) {
+  public void addIntermediateInput(Page page) throws IOException {
     assert channels.size() == intermediateBlockCount();
     assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
     Block quartUncast = page.getBlock(channels.get(0));
@@ -99,7 +100,8 @@ public final class MedianAbsoluteDeviationLongAggregatorFunction implements Aggr
   }
 
   @Override
-  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) throws
+      IOException {
     state.toIntermediate(blocks, offset, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationLongGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationLongGroupingAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -151,7 +152,8 @@ public final class MedianAbsoluteDeviationLongGroupingAggregatorFunction impleme
   }
 
   @Override
-  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) throws
+      IOException {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
     assert channels.size() == intermediateBlockCount();
     BytesRefVector quart = page.<BytesRefBlock>getBlock(channels.get(0)).asVector();
@@ -173,7 +175,8 @@ public final class MedianAbsoluteDeviationLongGroupingAggregatorFunction impleme
   }
 
   @Override
-  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) {
+  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) throws
+      IOException {
     state.toIntermediate(blocks, offset, selected, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinDoubleAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinDoubleAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -87,7 +88,7 @@ public final class MinDoubleAggregatorFunction implements AggregatorFunction {
   }
 
   @Override
-  public void addIntermediateInput(Page page) {
+  public void addIntermediateInput(Page page) throws IOException {
     assert channels.size() == intermediateBlockCount();
     assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
     Block minUncast = page.getBlock(channels.get(0));
@@ -109,7 +110,8 @@ public final class MinDoubleAggregatorFunction implements AggregatorFunction {
   }
 
   @Override
-  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) throws
+      IOException {
     state.toIntermediate(blocks, offset, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinDoubleGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinDoubleGroupingAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -147,7 +148,8 @@ public final class MinDoubleGroupingAggregatorFunction implements GroupingAggreg
   }
 
   @Override
-  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) throws
+      IOException {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
     assert channels.size() == intermediateBlockCount();
     DoubleVector min = page.<DoubleBlock>getBlock(channels.get(0)).asVector();
@@ -174,7 +176,8 @@ public final class MinDoubleGroupingAggregatorFunction implements GroupingAggreg
   }
 
   @Override
-  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) {
+  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) throws
+      IOException {
     state.toIntermediate(blocks, offset, selected, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinIntAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -87,7 +88,7 @@ public final class MinIntAggregatorFunction implements AggregatorFunction {
   }
 
   @Override
-  public void addIntermediateInput(Page page) {
+  public void addIntermediateInput(Page page) throws IOException {
     assert channels.size() == intermediateBlockCount();
     assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
     Block minUncast = page.getBlock(channels.get(0));
@@ -109,7 +110,8 @@ public final class MinIntAggregatorFunction implements AggregatorFunction {
   }
 
   @Override
-  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) throws
+      IOException {
     state.toIntermediate(blocks, offset, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinIntGroupingAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -145,7 +146,8 @@ public final class MinIntGroupingAggregatorFunction implements GroupingAggregato
   }
 
   @Override
-  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) throws
+      IOException {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
     assert channels.size() == intermediateBlockCount();
     IntVector min = page.<IntBlock>getBlock(channels.get(0)).asVector();
@@ -172,7 +174,8 @@ public final class MinIntGroupingAggregatorFunction implements GroupingAggregato
   }
 
   @Override
-  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) {
+  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) throws
+      IOException {
     state.toIntermediate(blocks, offset, selected, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinLongAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinLongAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -87,7 +88,7 @@ public final class MinLongAggregatorFunction implements AggregatorFunction {
   }
 
   @Override
-  public void addIntermediateInput(Page page) {
+  public void addIntermediateInput(Page page) throws IOException {
     assert channels.size() == intermediateBlockCount();
     assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
     Block minUncast = page.getBlock(channels.get(0));
@@ -109,7 +110,8 @@ public final class MinLongAggregatorFunction implements AggregatorFunction {
   }
 
   @Override
-  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) throws
+      IOException {
     state.toIntermediate(blocks, offset, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinLongGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinLongGroupingAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -147,7 +148,8 @@ public final class MinLongGroupingAggregatorFunction implements GroupingAggregat
   }
 
   @Override
-  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) throws
+      IOException {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
     assert channels.size() == intermediateBlockCount();
     LongVector min = page.<LongBlock>getBlock(channels.get(0)).asVector();
@@ -174,7 +176,8 @@ public final class MinLongGroupingAggregatorFunction implements GroupingAggregat
   }
 
   @Override
-  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) {
+  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) throws
+      IOException {
     state.toIntermediate(blocks, offset, selected, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileDoubleAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileDoubleAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -88,7 +89,7 @@ public final class PercentileDoubleAggregatorFunction implements AggregatorFunct
   }
 
   @Override
-  public void addIntermediateInput(Page page) {
+  public void addIntermediateInput(Page page) throws IOException {
     assert channels.size() == intermediateBlockCount();
     assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
     Block quartUncast = page.getBlock(channels.get(0));
@@ -102,7 +103,8 @@ public final class PercentileDoubleAggregatorFunction implements AggregatorFunct
   }
 
   @Override
-  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) throws
+      IOException {
     state.toIntermediate(blocks, offset, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileDoubleGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileDoubleGroupingAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -155,7 +156,8 @@ public final class PercentileDoubleGroupingAggregatorFunction implements Groupin
   }
 
   @Override
-  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) throws
+      IOException {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
     assert channels.size() == intermediateBlockCount();
     BytesRefVector quart = page.<BytesRefBlock>getBlock(channels.get(0)).asVector();
@@ -177,7 +179,8 @@ public final class PercentileDoubleGroupingAggregatorFunction implements Groupin
   }
 
   @Override
-  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) {
+  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) throws
+      IOException {
     state.toIntermediate(blocks, offset, selected, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileIntAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -88,7 +89,7 @@ public final class PercentileIntAggregatorFunction implements AggregatorFunction
   }
 
   @Override
-  public void addIntermediateInput(Page page) {
+  public void addIntermediateInput(Page page) throws IOException {
     assert channels.size() == intermediateBlockCount();
     assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
     Block quartUncast = page.getBlock(channels.get(0));
@@ -102,7 +103,8 @@ public final class PercentileIntAggregatorFunction implements AggregatorFunction
   }
 
   @Override
-  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) throws
+      IOException {
     state.toIntermediate(blocks, offset, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileIntGroupingAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -153,7 +154,8 @@ public final class PercentileIntGroupingAggregatorFunction implements GroupingAg
   }
 
   @Override
-  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) throws
+      IOException {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
     assert channels.size() == intermediateBlockCount();
     BytesRefVector quart = page.<BytesRefBlock>getBlock(channels.get(0)).asVector();
@@ -175,7 +177,8 @@ public final class PercentileIntGroupingAggregatorFunction implements GroupingAg
   }
 
   @Override
-  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) {
+  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) throws
+      IOException {
     state.toIntermediate(blocks, offset, selected, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileLongAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileLongAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -88,7 +89,7 @@ public final class PercentileLongAggregatorFunction implements AggregatorFunctio
   }
 
   @Override
-  public void addIntermediateInput(Page page) {
+  public void addIntermediateInput(Page page) throws IOException {
     assert channels.size() == intermediateBlockCount();
     assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
     Block quartUncast = page.getBlock(channels.get(0));
@@ -102,7 +103,8 @@ public final class PercentileLongAggregatorFunction implements AggregatorFunctio
   }
 
   @Override
-  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) throws
+      IOException {
     state.toIntermediate(blocks, offset, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileLongGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileLongGroupingAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -155,7 +156,8 @@ public final class PercentileLongGroupingAggregatorFunction implements GroupingA
   }
 
   @Override
-  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) throws
+      IOException {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
     assert channels.size() == intermediateBlockCount();
     BytesRefVector quart = page.<BytesRefBlock>getBlock(channels.get(0)).asVector();
@@ -177,7 +179,8 @@ public final class PercentileLongGroupingAggregatorFunction implements GroupingA
   }
 
   @Override
-  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) {
+  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) throws
+      IOException {
     state.toIntermediate(blocks, offset, selected, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumDoubleAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumDoubleAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -88,7 +89,7 @@ public final class SumDoubleAggregatorFunction implements AggregatorFunction {
   }
 
   @Override
-  public void addIntermediateInput(Page page) {
+  public void addIntermediateInput(Page page) throws IOException {
     assert channels.size() == intermediateBlockCount();
     assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
     Block valueUncast = page.getBlock(channels.get(0));
@@ -113,7 +114,8 @@ public final class SumDoubleAggregatorFunction implements AggregatorFunction {
   }
 
   @Override
-  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) throws
+      IOException {
     state.toIntermediate(blocks, offset, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumDoubleGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumDoubleGroupingAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -153,7 +154,8 @@ public final class SumDoubleGroupingAggregatorFunction implements GroupingAggreg
   }
 
   @Override
-  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) throws
+      IOException {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
     assert channels.size() == intermediateBlockCount();
     DoubleVector value = page.<DoubleBlock>getBlock(channels.get(0)).asVector();
@@ -177,7 +179,8 @@ public final class SumDoubleGroupingAggregatorFunction implements GroupingAggreg
   }
 
   @Override
-  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) {
+  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) throws
+      IOException {
     state.toIntermediate(blocks, offset, selected, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumIntAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -89,7 +90,7 @@ public final class SumIntAggregatorFunction implements AggregatorFunction {
   }
 
   @Override
-  public void addIntermediateInput(Page page) {
+  public void addIntermediateInput(Page page) throws IOException {
     assert channels.size() == intermediateBlockCount();
     assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
     Block sumUncast = page.getBlock(channels.get(0));
@@ -111,7 +112,8 @@ public final class SumIntAggregatorFunction implements AggregatorFunction {
   }
 
   @Override
-  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) throws
+      IOException {
     state.toIntermediate(blocks, offset, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumIntGroupingAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -147,7 +148,8 @@ public final class SumIntGroupingAggregatorFunction implements GroupingAggregato
   }
 
   @Override
-  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) throws
+      IOException {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
     assert channels.size() == intermediateBlockCount();
     LongVector sum = page.<LongBlock>getBlock(channels.get(0)).asVector();
@@ -174,7 +176,8 @@ public final class SumIntGroupingAggregatorFunction implements GroupingAggregato
   }
 
   @Override
-  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) {
+  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) throws
+      IOException {
     state.toIntermediate(blocks, offset, selected, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumLongAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumLongAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -87,7 +88,7 @@ public final class SumLongAggregatorFunction implements AggregatorFunction {
   }
 
   @Override
-  public void addIntermediateInput(Page page) {
+  public void addIntermediateInput(Page page) throws IOException {
     assert channels.size() == intermediateBlockCount();
     assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
     Block sumUncast = page.getBlock(channels.get(0));
@@ -109,7 +110,8 @@ public final class SumLongAggregatorFunction implements AggregatorFunction {
   }
 
   @Override
-  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+  public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) throws
+      IOException {
     state.toIntermediate(blocks, offset, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumLongGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumLongGroupingAggregatorFunction.java
@@ -4,6 +4,7 @@
 // 2.0.
 package org.elasticsearch.compute.aggregation;
 
+import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
@@ -147,7 +148,8 @@ public final class SumLongGroupingAggregatorFunction implements GroupingAggregat
   }
 
   @Override
-  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
+  public void addIntermediateInput(int positionOffset, IntVector groups, Page page) throws
+      IOException {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
     assert channels.size() == intermediateBlockCount();
     LongVector sum = page.<LongBlock>getBlock(channels.get(0)).asVector();
@@ -174,7 +176,8 @@ public final class SumLongGroupingAggregatorFunction implements GroupingAggregat
   }
 
   @Override
-  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) {
+  public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) throws
+      IOException {
     state.toIntermediate(blocks, offset, selected, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/Aggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/Aggregator.java
@@ -13,6 +13,7 @@ import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.core.Releasable;
 
+import java.io.IOException;
 import java.util.function.Function;
 
 public class Aggregator implements Releasable {
@@ -35,7 +36,7 @@ public class Aggregator implements Releasable {
         return mode.isOutputPartial() ? aggregatorFunction.intermediateBlockCount() : 1;
     }
 
-    public void processPage(Page page) {
+    public void processPage(Page page) throws IOException {
         if (mode.isInputPartial()) {
             aggregatorFunction.addIntermediateInput(page);
         } else {
@@ -43,7 +44,7 @@ public class Aggregator implements Releasable {
         }
     }
 
-    public void evaluate(Block[] blocks, int offset, DriverContext driverContext) {
+    public void evaluate(Block[] blocks, int offset, DriverContext driverContext) throws IOException {
         if (mode.isOutputPartial()) {
             aggregatorFunction.evaluateIntermediate(blocks, offset, driverContext);
         } else {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/AggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/AggregatorFunction.java
@@ -12,13 +12,15 @@ import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.core.Releasable;
 
+import java.io.IOException;
+
 public interface AggregatorFunction extends Releasable {
 
     void addRawInput(Page page);
 
-    void addIntermediateInput(Page page);
+    void addIntermediateInput(Page page) throws IOException;
 
-    void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext);
+    void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) throws IOException;
 
     void evaluateFinal(Block[] blocks, int offset, DriverContext driverContext);
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/AggregatorState.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/AggregatorState.java
@@ -11,8 +11,10 @@ import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.core.Releasable;
 
+import java.io.IOException;
+
 public interface AggregatorState extends Releasable {
 
     /** Extracts an intermediate view of the contents of this state.  */
-    void toIntermediate(Block[] blocks, int offset, DriverContext driverContext);
+    void toIntermediate(Block[] blocks, int offset, DriverContext driverContext) throws IOException;
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountDistinctBytesRefAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountDistinctBytesRefAggregator.java
@@ -17,6 +17,8 @@ import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.operator.DriverContext;
 
+import java.io.IOException;
+
 @Aggregator({ @IntermediateState(name = "hll", type = "BYTES_REF") })
 @GroupingAggregator
 public class CountDistinctBytesRefAggregator {
@@ -29,7 +31,7 @@ public class CountDistinctBytesRefAggregator {
         current.collect(v);
     }
 
-    public static void combineIntermediate(HllStates.SingleState current, BytesRef inValue) {
+    public static void combineIntermediate(HllStates.SingleState current, BytesRef inValue) throws IOException {
         current.merge(0, inValue, 0);
     }
 
@@ -46,7 +48,7 @@ public class CountDistinctBytesRefAggregator {
         current.collect(groupId, v);
     }
 
-    public static void combineIntermediate(HllStates.GroupingState current, int groupId, BytesRef inValue) {
+    public static void combineIntermediate(HllStates.GroupingState current, int groupId, BytesRef inValue) throws IOException {
         current.merge(groupId, inValue, 0);
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountDistinctDoubleAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountDistinctDoubleAggregator.java
@@ -17,6 +17,8 @@ import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.operator.DriverContext;
 
+import java.io.IOException;
+
 @Aggregator({ @IntermediateState(name = "hll", type = "BYTES_REF") })
 @GroupingAggregator
 public class CountDistinctDoubleAggregator {
@@ -29,7 +31,7 @@ public class CountDistinctDoubleAggregator {
         current.collect(v);
     }
 
-    public static void combineIntermediate(HllStates.SingleState current, BytesRef inValue) {
+    public static void combineIntermediate(HllStates.SingleState current, BytesRef inValue) throws IOException {
         current.merge(0, inValue, 0);
     }
 
@@ -46,7 +48,7 @@ public class CountDistinctDoubleAggregator {
         current.collect(groupId, v);
     }
 
-    public static void combineIntermediate(HllStates.GroupingState current, int groupId, BytesRef inValue) {
+    public static void combineIntermediate(HllStates.GroupingState current, int groupId, BytesRef inValue) throws IOException {
         current.merge(groupId, inValue, 0);
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountDistinctIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountDistinctIntAggregator.java
@@ -17,6 +17,8 @@ import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.operator.DriverContext;
 
+import java.io.IOException;
+
 @Aggregator({ @IntermediateState(name = "hll", type = "BYTES_REF") })
 @GroupingAggregator
 public class CountDistinctIntAggregator {
@@ -29,7 +31,7 @@ public class CountDistinctIntAggregator {
         current.collect(v);
     }
 
-    public static void combineIntermediate(HllStates.SingleState current, BytesRef inValue) {
+    public static void combineIntermediate(HllStates.SingleState current, BytesRef inValue) throws IOException {
         current.merge(0, inValue, 0);
     }
 
@@ -46,7 +48,7 @@ public class CountDistinctIntAggregator {
         current.collect(groupId, v);
     }
 
-    public static void combineIntermediate(HllStates.GroupingState current, int groupId, BytesRef inValue) {
+    public static void combineIntermediate(HllStates.GroupingState current, int groupId, BytesRef inValue) throws IOException {
         current.merge(groupId, inValue, 0);
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountDistinctLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/CountDistinctLongAggregator.java
@@ -17,6 +17,8 @@ import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.operator.DriverContext;
 
+import java.io.IOException;
+
 @Aggregator({ @IntermediateState(name = "hll", type = "BYTES_REF") })
 @GroupingAggregator
 public class CountDistinctLongAggregator {
@@ -29,7 +31,7 @@ public class CountDistinctLongAggregator {
         current.collect(v);
     }
 
-    public static void combineIntermediate(HllStates.SingleState current, BytesRef inValue) {
+    public static void combineIntermediate(HllStates.SingleState current, BytesRef inValue) throws IOException {
         current.merge(0, inValue, 0);
     }
 
@@ -46,7 +48,7 @@ public class CountDistinctLongAggregator {
         current.collect(groupId, v);
     }
 
-    public static void combineIntermediate(HllStates.GroupingState current, int groupId, BytesRef inValue) {
+    public static void combineIntermediate(HllStates.GroupingState current, int groupId, BytesRef inValue) throws IOException {
         current.merge(groupId, inValue, 0);
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/GroupingAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/GroupingAggregator.java
@@ -15,6 +15,7 @@ import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.core.Releasable;
 
+import java.io.IOException;
 import java.util.function.Function;
 
 public class GroupingAggregator implements Releasable {
@@ -46,7 +47,7 @@ public class GroupingAggregator implements Releasable {
                 }
 
                 @Override
-                public void add(int positionOffset, IntVector groupIds) {
+                public void add(int positionOffset, IntVector groupIds) throws IOException {
                     aggregatorFunction.addIntermediateInput(positionOffset, groupIds, page);
                 }
             };
@@ -67,7 +68,7 @@ public class GroupingAggregator implements Releasable {
      * @param selected the groupIds that have been selected to be included in
      *                 the results. Always ascending.
      */
-    public void evaluate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
+    public void evaluate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) throws IOException {
         if (mode.isOutputPartial()) {
             aggregatorFunction.evaluateIntermediate(blocks, offset, selected);
         } else {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/GroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/GroupingAggregatorFunction.java
@@ -15,6 +15,8 @@ import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.core.Releasable;
 
+import java.io.IOException;
+
 /**
  * Applies some grouping function like {@code min} or {@code avg} to many values,
  * grouped into buckets.
@@ -48,7 +50,7 @@ public interface GroupingAggregatorFunction extends Releasable {
          * @param groupIds {@link Block} of group id, some of which may be null
          *                 or multivalued
          */
-        void add(int positionOffset, IntBlock groupIds);
+        void add(int positionOffset, IntBlock groupIds) throws IOException;
 
         /**
          * Send a batch of group ids to the aggregator. The {@code groupIds}
@@ -64,7 +66,7 @@ public interface GroupingAggregatorFunction extends Releasable {
          * @param groupIds {@link Vector} of group id, some of which may be null
          *                 or multivalued
          */
-        void add(int positionOffset, IntVector groupIds);
+        void add(int positionOffset, IntVector groupIds) throws IOException;
     }
 
     /**
@@ -79,7 +81,7 @@ public interface GroupingAggregatorFunction extends Releasable {
     /**
      * Add data produced by {@link #evaluateIntermediate}.
      */
-    void addIntermediateInput(int positionOffset, IntVector groupIdVector, Page page);
+    void addIntermediateInput(int positionOffset, IntVector groupIdVector, Page page) throws IOException;
 
     /**
      * Add the position-th row from the intermediate output of the given aggregator function to the groupId
@@ -91,7 +93,7 @@ public interface GroupingAggregatorFunction extends Releasable {
      * @param selected the groupIds that have been selected to be included in
      *                 the results. Always ascending.
      */
-    void evaluateIntermediate(Block[] blocks, int offset, IntVector selected);
+    void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) throws IOException;
 
     /**
      * Build the final results for this aggregation.

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/GroupingAggregatorState.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/GroupingAggregatorState.java
@@ -12,9 +12,11 @@ import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.core.Releasable;
 
+import java.io.IOException;
+
 public interface GroupingAggregatorState extends Releasable {
 
     /** Extracts an intermediate view of the contents of this state.  */
-    void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext);
+    void toIntermediate(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) throws IOException;
 
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleAggregator.java
@@ -16,6 +16,8 @@ import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.operator.DriverContext;
 
+import java.io.IOException;
+
 @Aggregator({ @IntermediateState(name = "quart", type = "BYTES_REF") })
 @GroupingAggregator
 class MedianAbsoluteDeviationDoubleAggregator {
@@ -28,7 +30,7 @@ class MedianAbsoluteDeviationDoubleAggregator {
         current.add(v);
     }
 
-    public static void combineIntermediate(QuantileStates.SingleState state, BytesRef inValue) {
+    public static void combineIntermediate(QuantileStates.SingleState state, BytesRef inValue) throws IOException {
         state.add(inValue);
     }
 
@@ -44,7 +46,7 @@ class MedianAbsoluteDeviationDoubleAggregator {
         state.add(groupId, v);
     }
 
-    public static void combineIntermediate(QuantileStates.GroupingState state, int groupId, BytesRef inValue) {
+    public static void combineIntermediate(QuantileStates.GroupingState state, int groupId, BytesRef inValue) throws IOException {
         state.add(groupId, inValue);
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationIntAggregator.java
@@ -16,6 +16,8 @@ import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.operator.DriverContext;
 
+import java.io.IOException;
+
 @Aggregator({ @IntermediateState(name = "quart", type = "BYTES_REF") })
 @GroupingAggregator
 class MedianAbsoluteDeviationIntAggregator {
@@ -28,7 +30,7 @@ class MedianAbsoluteDeviationIntAggregator {
         current.add(v);
     }
 
-    public static void combineIntermediate(QuantileStates.SingleState state, BytesRef inValue) {
+    public static void combineIntermediate(QuantileStates.SingleState state, BytesRef inValue) throws IOException {
         state.add(inValue);
     }
 
@@ -44,7 +46,7 @@ class MedianAbsoluteDeviationIntAggregator {
         state.add(groupId, v);
     }
 
-    public static void combineIntermediate(QuantileStates.GroupingState state, int groupId, BytesRef inValue) {
+    public static void combineIntermediate(QuantileStates.GroupingState state, int groupId, BytesRef inValue) throws IOException {
         state.add(groupId, inValue);
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationLongAggregator.java
@@ -16,6 +16,8 @@ import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.operator.DriverContext;
 
+import java.io.IOException;
+
 @Aggregator({ @IntermediateState(name = "quart", type = "BYTES_REF") })
 @GroupingAggregator
 class MedianAbsoluteDeviationLongAggregator {
@@ -28,7 +30,7 @@ class MedianAbsoluteDeviationLongAggregator {
         current.add(v);
     }
 
-    public static void combineIntermediate(QuantileStates.SingleState state, BytesRef inValue) {
+    public static void combineIntermediate(QuantileStates.SingleState state, BytesRef inValue) throws IOException {
         state.add(inValue);
     }
 
@@ -44,7 +46,7 @@ class MedianAbsoluteDeviationLongAggregator {
         state.add(groupId, v);
     }
 
-    public static void combineIntermediate(QuantileStates.GroupingState state, int groupId, BytesRef inValue) {
+    public static void combineIntermediate(QuantileStates.GroupingState state, int groupId, BytesRef inValue) throws IOException {
         state.add(groupId, inValue);
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/PercentileDoubleAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/PercentileDoubleAggregator.java
@@ -16,6 +16,8 @@ import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.operator.DriverContext;
 
+import java.io.IOException;
+
 @Aggregator({ @IntermediateState(name = "quart", type = "BYTES_REF") })
 @GroupingAggregator
 class PercentileDoubleAggregator {
@@ -28,7 +30,7 @@ class PercentileDoubleAggregator {
         current.add(v);
     }
 
-    public static void combineIntermediate(QuantileStates.SingleState state, BytesRef inValue) {
+    public static void combineIntermediate(QuantileStates.SingleState state, BytesRef inValue) throws IOException {
         state.add(inValue);
     }
 
@@ -44,7 +46,7 @@ class PercentileDoubleAggregator {
         state.add(groupId, v);
     }
 
-    public static void combineIntermediate(QuantileStates.GroupingState state, int groupId, BytesRef inValue) {
+    public static void combineIntermediate(QuantileStates.GroupingState state, int groupId, BytesRef inValue) throws IOException {
         state.add(groupId, inValue);
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/PercentileIntAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/PercentileIntAggregator.java
@@ -16,6 +16,8 @@ import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.operator.DriverContext;
 
+import java.io.IOException;
+
 @Aggregator({ @IntermediateState(name = "quart", type = "BYTES_REF") })
 @GroupingAggregator
 class PercentileIntAggregator {
@@ -28,7 +30,7 @@ class PercentileIntAggregator {
         current.add(v);
     }
 
-    public static void combineIntermediate(QuantileStates.SingleState state, BytesRef inValue) {
+    public static void combineIntermediate(QuantileStates.SingleState state, BytesRef inValue) throws IOException {
         state.add(inValue);
     }
 
@@ -44,7 +46,7 @@ class PercentileIntAggregator {
         state.add(groupId, v);
     }
 
-    public static void combineIntermediate(QuantileStates.GroupingState state, int groupId, BytesRef inValue) {
+    public static void combineIntermediate(QuantileStates.GroupingState state, int groupId, BytesRef inValue) throws IOException {
         state.add(groupId, inValue);
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/PercentileLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/PercentileLongAggregator.java
@@ -16,6 +16,8 @@ import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.operator.DriverContext;
 
+import java.io.IOException;
+
 @Aggregator({ @IntermediateState(name = "quart", type = "BYTES_REF") })
 @GroupingAggregator
 class PercentileLongAggregator {
@@ -28,7 +30,7 @@ class PercentileLongAggregator {
         current.add(v);
     }
 
-    public static void combineIntermediate(QuantileStates.SingleState state, BytesRef inValue) {
+    public static void combineIntermediate(QuantileStates.SingleState state, BytesRef inValue) throws IOException {
         state.add(inValue);
     }
 
@@ -44,7 +46,7 @@ class PercentileLongAggregator {
         state.add(groupId, v);
     }
 
-    public static void combineIntermediate(QuantileStates.GroupingState state, int groupId, BytesRef inValue) {
+    public static void combineIntermediate(QuantileStates.GroupingState state, int groupId, BytesRef inValue) throws IOException {
         state.add(groupId, inValue);
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BlockHash.java
@@ -23,6 +23,7 @@ import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.HashAggregationOperator;
 import org.elasticsearch.core.Releasable;
 
+import java.io.IOException;
 import java.util.List;
 
 /**
@@ -48,7 +49,7 @@ public abstract sealed class BlockHash implements Releasable, SeenGroupIds //
      * Add all values for the "group by" columns in the page to the hash and
      * pass the ordinals to the provided {@link GroupingAggregatorFunction.AddInput}.
      */
-    public abstract void add(Page page, GroupingAggregatorFunction.AddInput addInput);
+    public abstract void add(Page page, GroupingAggregatorFunction.AddInput addInput) throws IOException;
 
     /**
      * Returns a {@link Block} that contains all the keys that are inserted by {@link #add}.

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BooleanBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BooleanBlockHash.java
@@ -18,6 +18,8 @@ import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.MultivalueDedupeBoolean;
 
+import java.io.IOException;
+
 import static org.elasticsearch.compute.operator.MultivalueDedupeBoolean.FALSE_ORD;
 import static org.elasticsearch.compute.operator.MultivalueDedupeBoolean.NULL_ORD;
 import static org.elasticsearch.compute.operator.MultivalueDedupeBoolean.TRUE_ORD;
@@ -36,7 +38,7 @@ final class BooleanBlockHash extends BlockHash {
     }
 
     @Override
-    public void add(Page page, GroupingAggregatorFunction.AddInput addInput) {
+    public void add(Page page, GroupingAggregatorFunction.AddInput addInput) throws IOException {
         var block = page.getBlock(channel);
         if (block.areAllValuesNull()) {
             everSeen[NULL_ORD] = true;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BytesRefBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BytesRefBlockHash.java
@@ -53,7 +53,7 @@ final class BytesRefBlockHash extends BlockHash {
     }
 
     @Override
-    public void add(Page page, GroupingAggregatorFunction.AddInput addInput) {
+    public void add(Page page, GroupingAggregatorFunction.AddInput addInput) throws IOException {
         Block block = page.getBlock(channel);
         if (block.areAllValuesNull()) {
             seenNull = true;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BytesRefLongBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BytesRefLongBlockHash.java
@@ -25,6 +25,8 @@ import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.core.Releasables;
 
+import java.io.IOException;
+
 /**
  * Maps a {@link LongBlock} column paired with a {@link BytesRefBlock} column to group ids.
  */
@@ -65,7 +67,7 @@ final class BytesRefLongBlockHash extends BlockHash {
     }
 
     @Override
-    public void add(Page page, GroupingAggregatorFunction.AddInput addInput) {
+    public void add(Page page, GroupingAggregatorFunction.AddInput addInput) throws IOException {
         BytesRefBlock block1 = page.getBlock(channel1);
         LongBlock block2 = page.getBlock(channel2);
         BytesRefVector vector1 = block1.asVector();
@@ -104,7 +106,7 @@ final class BytesRefLongBlockHash extends BlockHash {
             this.block2 = block2;
         }
 
-        void add() {
+        void add() throws IOException {
             BytesRef scratch = new BytesRef();
             int positions = block1.getPositionCount();
             long[] seen1 = EMPTY;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/DoubleBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/DoubleBlockHash.java
@@ -22,6 +22,7 @@ import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.MultivalueDedupe;
 import org.elasticsearch.compute.operator.MultivalueDedupeDouble;
 
+import java.io.IOException;
 import java.util.BitSet;
 
 /**
@@ -47,7 +48,7 @@ final class DoubleBlockHash extends BlockHash {
     }
 
     @Override
-    public void add(Page page, GroupingAggregatorFunction.AddInput addInput) {
+    public void add(Page page, GroupingAggregatorFunction.AddInput addInput) throws IOException {
         var block = page.getBlock(channel);
         if (block.areAllValuesNull()) {
             seenNull = true;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/IntBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/IntBlockHash.java
@@ -20,6 +20,7 @@ import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.MultivalueDedupe;
 import org.elasticsearch.compute.operator.MultivalueDedupeInt;
 
+import java.io.IOException;
 import java.util.BitSet;
 
 /**
@@ -44,7 +45,7 @@ final class IntBlockHash extends BlockHash {
     }
 
     @Override
-    public void add(Page page, GroupingAggregatorFunction.AddInput addInput) {
+    public void add(Page page, GroupingAggregatorFunction.AddInput addInput) throws IOException {
         var block = page.getBlock(channel);
         if (block.areAllValuesNull()) {
             seenNull = true;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/LongBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/LongBlockHash.java
@@ -22,6 +22,7 @@ import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.MultivalueDedupe;
 import org.elasticsearch.compute.operator.MultivalueDedupeLong;
 
+import java.io.IOException;
 import java.util.BitSet;
 
 /**
@@ -47,7 +48,7 @@ final class LongBlockHash extends BlockHash {
     }
 
     @Override
-    public void add(Page page, GroupingAggregatorFunction.AddInput addInput) {
+    public void add(Page page, GroupingAggregatorFunction.AddInput addInput) throws IOException {
         var block = page.getBlock(channel);
         if (block.areAllValuesNull()) {
             seenNull = true;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneOperator.java
@@ -77,7 +77,7 @@ public abstract class LuceneOperator extends SourceOperator {
     @Override
     public void close() {}
 
-    LuceneScorer getCurrentOrLoadNextScorer() {
+    LuceneScorer getCurrentOrLoadNextScorer() throws IOException {
         while (currentScorer == null || currentScorer.isDone()) {
             if (currentSlice == null || sliceIndex >= currentSlice.numLeaves()) {
                 sliceIndex = 0;
@@ -128,7 +128,7 @@ public abstract class LuceneOperator extends SourceOperator {
         private int maxPosition;
         private Thread executingThread;
 
-        LuceneScorer(int shardIndex, SearchContext searchContext, Weight weight, LeafReaderContext leafReaderContext) {
+        LuceneScorer(int shardIndex, SearchContext searchContext, Weight weight, LeafReaderContext leafReaderContext) throws IOException {
             this.shardIndex = shardIndex;
             this.searchContext = searchContext;
             this.weight = weight;
@@ -136,13 +136,9 @@ public abstract class LuceneOperator extends SourceOperator {
             reinitialize();
         }
 
-        private void reinitialize() {
+        private void reinitialize() throws IOException {
             this.executingThread = Thread.currentThread();
-            try {
-                this.bulkScorer = weight.bulkScorer(leafReaderContext);
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
-            }
+            this.bulkScorer = weight.bulkScorer(leafReaderContext);
         }
 
         void scoreNextRange(LeafCollector collector, Bits acceptDocs, int numDocs) throws IOException {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneTopNSourceOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneTopNSourceOperator.java
@@ -29,7 +29,6 @@ import org.elasticsearch.search.sort.SortAndFormats;
 import org.elasticsearch.search.sort.SortBuilder;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -137,7 +136,7 @@ public final class LuceneTopNSourceOperator extends LuceneOperator {
     }
 
     @Override
-    public Page getOutput() {
+    public Page getOutput() throws IOException {
         if (isFinished()) {
             return null;
         }
@@ -148,7 +147,7 @@ public final class LuceneTopNSourceOperator extends LuceneOperator {
         }
     }
 
-    private Page collect() {
+    private Page collect() throws IOException {
         assert doneCollecting == false;
         var scorer = getCurrentOrLoadNextScorer();
         if (scorer == null) {
@@ -165,8 +164,6 @@ public final class LuceneTopNSourceOperator extends LuceneOperator {
         } catch (CollectionTerminatedException cte) {
             // Lucene terminated early the collection (doing topN for an index that's sorted and the topN uses the same sorting)
             scorer.markAsDone();
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
         }
         if (scorer.isDone()) {
             var nextScorer = getCurrentOrLoadNextScorer();

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/ValuesSourceReaderOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/ValuesSourceReaderOperator.java
@@ -37,7 +37,6 @@ import org.elasticsearch.search.fetch.StoredFieldsSpec;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -125,7 +124,7 @@ public class ValuesSourceReaderOperator extends AbstractPageMappingOperator {
     }
 
     @Override
-    protected Page process(Page page) {
+    protected Page process(Page page) throws IOException {
         DocVector docVector = page.<DocBlock>getBlock(docChannel).asVector();
 
         Block[] blocks = new Block[fields.size()];
@@ -137,8 +136,6 @@ public class ValuesSourceReaderOperator extends AbstractPageMappingOperator {
                 loadFromManyLeaves(blocks, docVector);
             }
             success = true;
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
         } finally {
             if (success == false) {
                 Releasables.closeExpectNoException(blocks);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/AbstractPageMappingOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/AbstractPageMappingOperator.java
@@ -30,7 +30,7 @@ public abstract class AbstractPageMappingOperator implements Operator {
      */
     private int pagesProcessed;
 
-    protected abstract Page process(Page page);
+    protected abstract Page process(Page page) throws IOException;
 
     @Override
     public abstract String toString();
@@ -57,7 +57,7 @@ public abstract class AbstractPageMappingOperator implements Operator {
     }
 
     @Override
-    public final Page getOutput() {
+    public final Page getOutput() throws IOException {
         if (prev == null) {
             return null;
         }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/AggregationOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/AggregationOperator.java
@@ -14,6 +14,7 @@ import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.core.Releasables;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -71,7 +72,7 @@ public class AggregationOperator implements Operator {
     }
 
     @Override
-    public void addInput(Page page) {
+    public void addInput(Page page) throws IOException {
         checkState(needsInput(), "Operator is already finishing");
         requireNonNull(page, "page is null");
         try {
@@ -91,7 +92,7 @@ public class AggregationOperator implements Operator {
     }
 
     @Override
-    public void finish() {
+    public void finish() throws IOException {
         if (finished) {
             return;
         }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/Driver.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/Driver.java
@@ -20,6 +20,7 @@ import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.tasks.TaskCancelledException;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -130,7 +131,7 @@ public class Driver implements Releasable, Describable {
      * Returns a blocked future when the chain of operators is blocked, allowing the caller
      * thread to do other work instead of blocking or busy-spinning on the blocked operator.
      */
-    private SubscribableListener<Void> run(TimeValue maxTime, int maxIterations) {
+    private SubscribableListener<Void> run(TimeValue maxTime, int maxIterations) throws IOException {
         long maxTimeNanos = maxTime.nanos();
         long startTime = System.nanoTime();
         long nextStatus = startTime + statusNanos;
@@ -189,7 +190,7 @@ public class Driver implements Releasable, Describable {
         }
     }
 
-    private SubscribableListener<Void> runSingleLoopIteration() {
+    private SubscribableListener<Void> runSingleLoopIteration() throws IOException {
         ensureNotCancelled();
         boolean movedPage = false;
 
@@ -319,7 +320,7 @@ public class Driver implements Releasable, Describable {
         executor.execute(new AbstractRunnable() {
 
             @Override
-            protected void doRun() {
+            protected void doRun() throws IOException {
                 if (driver.isFinished()) {
                     onComplete(listener);
                     return;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/HashAggregationOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/HashAggregationOperator.java
@@ -19,6 +19,7 @@ import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.core.Releasables;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -93,7 +94,7 @@ public class HashAggregationOperator implements Operator {
     }
 
     @Override
-    public void addInput(Page page) {
+    public void addInput(Page page) throws IOException {
         try {
             checkState(needsInput(), "Operator is already finishing");
             requireNonNull(page, "page is null");
@@ -105,7 +106,7 @@ public class HashAggregationOperator implements Operator {
 
             blockHash.add(wrapPage(page), new GroupingAggregatorFunction.AddInput() {
                 @Override
-                public void add(int positionOffset, IntBlock groupIds) {
+                public void add(int positionOffset, IntBlock groupIds) throws IOException {
                     IntVector groupIdsVector = groupIds.asVector();
                     if (groupIdsVector != null) {
                         add(positionOffset, groupIdsVector);
@@ -117,7 +118,7 @@ public class HashAggregationOperator implements Operator {
                 }
 
                 @Override
-                public void add(int positionOffset, IntVector groupIds) {
+                public void add(int positionOffset, IntVector groupIds) throws IOException {
                     for (GroupingAggregatorFunction.AddInput p : prepared) {
                         p.add(positionOffset, groupIds);
                     }
@@ -136,7 +137,7 @@ public class HashAggregationOperator implements Operator {
     }
 
     @Override
-    public void finish() {
+    public void finish() throws IOException {
         if (finished) {
             return;
         }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/Operator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/Operator.java
@@ -16,6 +16,8 @@ import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.xcontent.ToXContentObject;
 
+import java.io.IOException;
+
 /**
  * Operator is low-level building block that consumes, transforms and produces data.
  * An operator can have state, and assumes single-threaded access.
@@ -50,12 +52,12 @@ public interface Operator extends Releasable {
      * adds an input page to the operator. only called when needsInput() == true and isFinished() == false
      * @throws UnsupportedOperationException  if the operator is a {@link SourceOperator}
      */
-    void addInput(Page page);
+    void addInput(Page page) throws IOException;
 
     /**
      * notifies the operator that it won't receive any more input pages
      */
-    void finish();
+    void finish() throws IOException;
 
     /**
      * whether the operator has finished processing all input pages and made the corresponding output pages available
@@ -66,7 +68,7 @@ public interface Operator extends Releasable {
      * returns non-null if output page available. Only called when isFinished() == false
      * @throws UnsupportedOperationException  if the operator is a {@link SinkOperator}
      */
-    Page getOutput();
+    Page getOutput() throws IOException;
 
     /**
      * notifies the operator that it won't be used anymore (i.e. none of the other methods called),

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/OrdinalsGroupingOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/OrdinalsGroupingOperator.java
@@ -131,7 +131,7 @@ public class OrdinalsGroupingOperator implements Operator {
     }
 
     @Override
-    public void addInput(Page page) {
+    public void addInput(Page page) throws IOException {
         checkState(needsInput(), "Operator is already finishing");
         requireNonNull(page, "page is null");
         DocVector docVector = page.<DocBlock>getBlock(docChannel).asVector();
@@ -201,7 +201,7 @@ public class OrdinalsGroupingOperator implements Operator {
     }
 
     @Override
-    public Page getOutput() {
+    public Page getOutput() throws IOException {
         if (finished == false) {
             return null;
         }
@@ -217,8 +217,6 @@ public class OrdinalsGroupingOperator implements Operator {
         if (ordinalAggregators.isEmpty() == false) {
             try {
                 return mergeOrdinalsSegmentResults();
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
             } finally {
                 Releasables.close(() -> Releasables.close(ordinalAggregators.values()), ordinalAggregators::clear);
             }
@@ -227,7 +225,7 @@ public class OrdinalsGroupingOperator implements Operator {
     }
 
     @Override
-    public void finish() {
+    public void finish() throws IOException {
         finished = true;
         if (valuesAggregator != null) {
             valuesAggregator.finish();
@@ -368,7 +366,7 @@ public class OrdinalsGroupingOperator implements Operator {
             }
         }
 
-        void addInput(IntVector docs, Page page) {
+        void addInput(IntVector docs, Page page) throws IOException {
             try {
                 GroupingAggregatorFunction.AddInput[] prepared = new GroupingAggregatorFunction.AddInput[aggregators.size()];
                 for (int i = 0; i < prepared.length; i++) {
@@ -391,8 +389,6 @@ public class OrdinalsGroupingOperator implements Operator {
                         addInput.add(0, ordinals);
                     }
                 }
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
             } finally {
                 page.releaseBlocks();
             }
@@ -487,7 +483,7 @@ public class OrdinalsGroupingOperator implements Operator {
             );
         }
 
-        void addInput(Page page) {
+        void addInput(Page page) throws IOException {
             extractor.addInput(page);
             Page out = extractor.getOutput();
             if (out != null) {
@@ -495,7 +491,7 @@ public class OrdinalsGroupingOperator implements Operator {
             }
         }
 
-        void finish() {
+        void finish() throws IOException {
             aggregator.finish();
         }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AggregatorFunctionTestCase.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AggregatorFunctionTestCase.java
@@ -32,6 +32,7 @@ import org.elasticsearch.compute.operator.Operator;
 import org.elasticsearch.compute.operator.PositionMergingSourceOperator;
 import org.elasticsearch.compute.operator.TestResultPageSinkOperator;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.DoubleStream;
@@ -92,7 +93,7 @@ public abstract class AggregatorFunctionTestCase extends ForkingOperatorTestCase
         return ByteSizeValue.ofBytes(20);
     }
 
-    public final void testIgnoresNulls() {
+    public final void testIgnoresNulls() throws IOException {
         int end = between(1_000, 100_000);
         List<Page> results = new ArrayList<>();
         DriverContext driverContext = driverContext();
@@ -114,7 +115,7 @@ public abstract class AggregatorFunctionTestCase extends ForkingOperatorTestCase
         assertSimpleOutput(origInput, results);
     }
 
-    public final void testMultivalued() {
+    public final void testMultivalued() throws IOException {
         int end = between(1_000, 100_000);
         DriverContext driverContext = driverContext();
         BlockFactory blockFactory = driverContext.blockFactory();
@@ -125,7 +126,7 @@ public abstract class AggregatorFunctionTestCase extends ForkingOperatorTestCase
         assertSimpleOutput(origInput, drive(simple(BigArrays.NON_RECYCLING_INSTANCE).get(driverContext), input.iterator(), driverContext));
     }
 
-    public final void testMultivaluedWithNulls() {
+    public final void testMultivaluedWithNulls() throws IOException {
         int end = between(1_000, 100_000);
         DriverContext driverContext = driverContext();
         BlockFactory blockFactory = driverContext.blockFactory();

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/GroupingAggregatorFunctionTestCase.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/GroupingAggregatorFunctionTestCase.java
@@ -34,6 +34,7 @@ import org.elasticsearch.compute.operator.PositionMergingSourceOperator;
 import org.elasticsearch.compute.operator.SourceOperator;
 import org.elasticsearch.core.Releasables;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.SortedSet;
@@ -151,7 +152,7 @@ public abstract class GroupingAggregatorFunctionTestCase extends ForkingOperator
         return ByteSizeValue.ofBytes(100);
     }
 
-    public final void testNullGroupsAndValues() {
+    public final void testNullGroupsAndValues() throws IOException {
         DriverContext driverContext = driverContext();
         BlockFactory blockFactory = driverContext.blockFactory();
         int end = between(50, 60);
@@ -167,7 +168,7 @@ public abstract class GroupingAggregatorFunctionTestCase extends ForkingOperator
         assertSimpleOutput(origInput, results);
     }
 
-    public final void testNullGroups() {
+    public final void testNullGroups() throws IOException {
         DriverContext driverContext = driverContext();
         BlockFactory blockFactory = driverContext.blockFactory();
         int end = between(50, 60);
@@ -181,7 +182,7 @@ public abstract class GroupingAggregatorFunctionTestCase extends ForkingOperator
         assertSimpleOutput(origInput, results);
     }
 
-    public void testAllKeyNulls() {
+    public void testAllKeyNulls() throws IOException {
         DriverContext driverContext = driverContext();
         BlockFactory blockFactory = driverContext.blockFactory();
         List<Page> input = new ArrayList<>();
@@ -228,7 +229,7 @@ public abstract class GroupingAggregatorFunctionTestCase extends ForkingOperator
         };
     }
 
-    public final void testNullValues() {
+    public final void testNullValues() throws IOException {
         DriverContext driverContext = driverContext();
         BlockFactory blockFactory = driverContext.blockFactory();
         int end = between(50, 60);
@@ -242,7 +243,7 @@ public abstract class GroupingAggregatorFunctionTestCase extends ForkingOperator
         assertSimpleOutput(origInput, results);
     }
 
-    public final void testNullValuesInitialIntermediateFinal() {
+    public final void testNullValuesInitialIntermediateFinal() throws IOException {
         DriverContext driverContext = driverContext();
         BlockFactory blockFactory = driverContext.blockFactory();
         int end = between(50, 60);
@@ -273,7 +274,7 @@ public abstract class GroupingAggregatorFunctionTestCase extends ForkingOperator
         };
     }
 
-    public final void testMultivalued() {
+    public final void testMultivalued() throws IOException {
         DriverContext driverContext = driverContext();
         int end = between(1_000, 100_000);
         List<Page> input = CannedSourceOperator.collectPages(
@@ -288,7 +289,7 @@ public abstract class GroupingAggregatorFunctionTestCase extends ForkingOperator
         assertSimpleOutput(origInput, results);
     }
 
-    public final void testMulitvaluedNullGroupsAndValues() {
+    public final void testMulitvaluedNullGroupsAndValues() throws IOException {
         DriverContext driverContext = driverContext();
         BlockFactory blockFactory = driverContext.blockFactory();
         int end = between(50, 60);
@@ -304,7 +305,7 @@ public abstract class GroupingAggregatorFunctionTestCase extends ForkingOperator
         assertSimpleOutput(origInput, results);
     }
 
-    public void testMulitvaluedNullGroup() {
+    public void testMulitvaluedNullGroup() throws IOException {
         DriverContext driverContext = driverContext();
         BlockFactory blockFactory = driverContext.blockFactory();
         int end = between(1, 2);  // TODO revert
@@ -319,7 +320,7 @@ public abstract class GroupingAggregatorFunctionTestCase extends ForkingOperator
         assertSimpleOutput(origInput, results);
     }
 
-    public final void testMulitvaluedNullValues() {
+    public final void testMulitvaluedNullValues() throws IOException {
         DriverContext driverContext = driverContext();
         BlockFactory blockFactory = driverContext.blockFactory();
         int end = between(50, 60);
@@ -383,12 +384,12 @@ public abstract class GroupingAggregatorFunctionTestCase extends ForkingOperator
         }
     }
 
-    public final void testNullSome() {
+    public final void testNullSome() throws IOException {
         DriverContext driverContext = driverContext();
         assertNullSome(driverContext, List.of(simple(nonBreakingBigArrays().withCircuitBreaking()).get(driverContext)));
     }
 
-    public final void testNullSomeInitialFinal() {
+    public final void testNullSomeInitialFinal() throws IOException {
         DriverContext driverContext = driverContext();
         assertNullSome(
             driverContext,
@@ -399,7 +400,7 @@ public abstract class GroupingAggregatorFunctionTestCase extends ForkingOperator
         );
     }
 
-    public final void testNullSomeInitialIntermediateFinal() {
+    public final void testNullSomeInitialIntermediateFinal() throws IOException {
         DriverContext driverContext = driverContext();
         assertNullSome(
             driverContext,
@@ -414,7 +415,7 @@ public abstract class GroupingAggregatorFunctionTestCase extends ForkingOperator
     /**
      * Run the agg on some data where one group is always null.
      */
-    private void assertNullSome(DriverContext driverContext, List<Operator> operators) {
+    private void assertNullSome(DriverContext driverContext, List<Operator> operators) throws IOException {
         List<Page> inputData = CannedSourceOperator.collectPages(simpleInput(driverContext.blockFactory(), 1000));
         SeenGroups seenGroups = seenGroups(inputData);
 
@@ -566,7 +567,7 @@ public abstract class GroupingAggregatorFunctionTestCase extends ForkingOperator
                             }, page);
 
                             @Override
-                            public void add(int positionOffset, IntBlock groupIds) {
+                            public void add(int positionOffset, IntBlock groupIds) throws IOException {
                                 for (int offset = 0; offset < groupIds.getPositionCount(); offset += emitChunkSize) {
                                     IntBlock.Builder builder = blockFactory().newIntBlockBuilder(emitChunkSize);
                                     int endP = Math.min(groupIds.getPositionCount(), offset + emitChunkSize);
@@ -597,7 +598,7 @@ public abstract class GroupingAggregatorFunctionTestCase extends ForkingOperator
                             }
 
                             @Override
-                            public void add(int positionOffset, IntVector groupIds) {
+                            public void add(int positionOffset, IntVector groupIds) throws IOException {
                                 int[] chunk = new int[emitChunkSize];
                                 for (int offset = 0; offset < groupIds.getPositionCount(); offset += emitChunkSize) {
                                     int count = 0;
@@ -614,7 +615,7 @@ public abstract class GroupingAggregatorFunctionTestCase extends ForkingOperator
                     }
 
                     @Override
-                    public void addIntermediateInput(int positionOffset, IntVector groupIds, Page page) {
+                    public void addIntermediateInput(int positionOffset, IntVector groupIds, Page page) throws IOException {
                         int[] chunk = new int[emitChunkSize];
                         for (int offset = 0; offset < groupIds.getPositionCount(); offset += emitChunkSize) {
                             int count = 0;
@@ -632,7 +633,7 @@ public abstract class GroupingAggregatorFunctionTestCase extends ForkingOperator
                     }
 
                     @Override
-                    public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) {
+                    public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) throws IOException {
                         delegate.evaluateIntermediate(blocks, offset, selected);
                     }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashRandomizedTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashRandomizedTests.java
@@ -30,6 +30,7 @@ import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.ListMatcher;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -98,13 +99,13 @@ public class BlockHashRandomizedTests extends ESTestCase {
         this.allowedTypes = allowedTypes;
     }
 
-    public void test() {
+    public void test() throws IOException {
         CircuitBreaker breaker = new MockBigArrays.LimitedBreaker("esql-test-breaker", ByteSizeValue.ofGb(1));
         BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, mockBreakerService(breaker));
         test(new MockBlockFactory(breaker, bigArrays));
     }
 
-    public void testWithCranky() {
+    public void testWithCranky() throws IOException {
         CircuitBreakerService service = new CrankyCircuitBreakerService();
         CircuitBreaker breaker = service.getBreaker(CircuitBreaker.REQUEST);
         BigArrays bigArrays = new MockBigArrays(PageCacheRecycler.NON_RECYCLING_INSTANCE, service);
@@ -117,7 +118,7 @@ public class BlockHashRandomizedTests extends ESTestCase {
         }
     }
 
-    private void test(MockBlockFactory blockFactory) {
+    private void test(MockBlockFactory blockFactory) throws IOException {
         List<ElementType> types = randomList(groups, groups, () -> randomFrom(allowedTypes));
         BasicBlockTests.RandomBlock[] randomBlocks = new BasicBlockTests.RandomBlock[types.size()];
         Block[] blocks = new Block[types.size()];

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashTests.java
@@ -34,6 +34,7 @@ import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.After;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -78,7 +79,7 @@ public class BlockHashTests extends ESTestCase {
         this.forcePackedHash = forcePackedHash;
     }
 
-    public void testIntHash() {
+    public void testIntHash() throws IOException {
         int[] values = new int[] { 1, 2, 3, 1, 2, 3, 1, 2, 3 };
         hash(ordsAndKeys -> {
             if (forcePackedHash) {
@@ -94,7 +95,7 @@ public class BlockHashTests extends ESTestCase {
         }, blockFactory.newIntArrayVector(values, values.length).asBlock());
     }
 
-    public void testIntHashWithNulls() {
+    public void testIntHashWithNulls() throws IOException {
         try (IntBlock.Builder builder = blockFactory.newIntBlockBuilder(4)) {
             builder.appendInt(0);
             builder.appendNull();
@@ -116,7 +117,7 @@ public class BlockHashTests extends ESTestCase {
         }
     }
 
-    public void testIntHashWithMultiValuedFields() {
+    public void testIntHashWithMultiValuedFields() throws IOException {
         try (IntBlock.Builder builder = blockFactory.newIntBlockBuilder(8)) {
             builder.appendInt(1);
             builder.beginPositionEntry();
@@ -169,7 +170,7 @@ public class BlockHashTests extends ESTestCase {
         }
     }
 
-    public void testLongHash() {
+    public void testLongHash() throws IOException {
         long[] values = new long[] { 2, 1, 4, 2, 4, 1, 3, 4 };
 
         hash(ordsAndKeys -> {
@@ -186,7 +187,7 @@ public class BlockHashTests extends ESTestCase {
         }, blockFactory.newLongArrayVector(values, values.length).asBlock());
     }
 
-    public void testLongHashWithNulls() {
+    public void testLongHashWithNulls() throws IOException {
         try (LongBlock.Builder builder = blockFactory.newLongBlockBuilder(4)) {
             builder.appendLong(0);
             builder.appendNull();
@@ -208,7 +209,7 @@ public class BlockHashTests extends ESTestCase {
         }
     }
 
-    public void testLongHashWithMultiValuedFields() {
+    public void testLongHashWithMultiValuedFields() throws IOException {
         try (LongBlock.Builder builder = blockFactory.newLongBlockBuilder(8)) {
             builder.appendLong(1);
             builder.beginPositionEntry();
@@ -261,7 +262,7 @@ public class BlockHashTests extends ESTestCase {
         }
     }
 
-    public void testDoubleHash() {
+    public void testDoubleHash() throws IOException {
         double[] values = new double[] { 2.0, 1.0, 4.0, 2.0, 4.0, 1.0, 3.0, 4.0 };
         hash(ordsAndKeys -> {
             if (forcePackedHash) {
@@ -277,7 +278,7 @@ public class BlockHashTests extends ESTestCase {
         }, blockFactory.newDoubleArrayVector(values, values.length).asBlock());
     }
 
-    public void testDoubleHashWithNulls() {
+    public void testDoubleHashWithNulls() throws IOException {
         try (DoubleBlock.Builder builder = blockFactory.newDoubleBlockBuilder(4)) {
             builder.appendDouble(0);
             builder.appendNull();
@@ -299,7 +300,7 @@ public class BlockHashTests extends ESTestCase {
         }
     }
 
-    public void testDoubleHashWithMultiValuedFields() {
+    public void testDoubleHashWithMultiValuedFields() throws IOException {
         try (DoubleBlock.Builder builder = blockFactory.newDoubleBlockBuilder(8)) {
             builder.appendDouble(1);
             builder.beginPositionEntry();
@@ -351,7 +352,7 @@ public class BlockHashTests extends ESTestCase {
         }
     }
 
-    public void testBasicBytesRefHash() {
+    public void testBasicBytesRefHash() throws IOException {
         try (BytesRefBlock.Builder builder = blockFactory.newBytesRefBlockBuilder(8)) {
             builder.appendBytesRef(new BytesRef("item-2"));
             builder.appendBytesRef(new BytesRef("item-1"));
@@ -379,7 +380,7 @@ public class BlockHashTests extends ESTestCase {
         }
     }
 
-    public void testBytesRefHashWithNulls() {
+    public void testBytesRefHashWithNulls() throws IOException {
         try (BytesRefBlock.Builder builder = blockFactory.newBytesRefBlockBuilder(4)) {
             builder.appendBytesRef(new BytesRef("cat"));
             builder.appendNull();
@@ -403,7 +404,7 @@ public class BlockHashTests extends ESTestCase {
         }
     }
 
-    public void testBytesRefHashWithMultiValuedFields() {
+    public void testBytesRefHashWithMultiValuedFields() throws IOException {
         try (BytesRefBlock.Builder builder = blockFactory.newBytesRefBlockBuilder(8)) {
             builder.appendBytesRef(new BytesRef("foo"));
             builder.beginPositionEntry();
@@ -458,7 +459,7 @@ public class BlockHashTests extends ESTestCase {
         }
     }
 
-    public void testBooleanHashFalseFirst() {
+    public void testBooleanHashFalseFirst() throws IOException {
         boolean[] values = new boolean[] { false, true, true, true, true };
         hash(ordsAndKeys -> {
             if (forcePackedHash) {
@@ -474,7 +475,7 @@ public class BlockHashTests extends ESTestCase {
         }, blockFactory.newBooleanArrayVector(values, values.length).asBlock());
     }
 
-    public void testBooleanHashTrueFirst() {
+    public void testBooleanHashTrueFirst() throws IOException {
         boolean[] values = new boolean[] { true, false, false, true, true };
         hash(ordsAndKeys -> {
             if (forcePackedHash) {
@@ -491,7 +492,7 @@ public class BlockHashTests extends ESTestCase {
         }, blockFactory.newBooleanArrayVector(values, values.length).asBlock());
     }
 
-    public void testBooleanHashTrueOnly() {
+    public void testBooleanHashTrueOnly() throws IOException {
         boolean[] values = new boolean[] { true, true, true, true };
         hash(ordsAndKeys -> {
             if (forcePackedHash) {
@@ -508,7 +509,7 @@ public class BlockHashTests extends ESTestCase {
         }, blockFactory.newBooleanArrayVector(values, values.length).asBlock());
     }
 
-    public void testBooleanHashFalseOnly() {
+    public void testBooleanHashFalseOnly() throws IOException {
         boolean[] values = new boolean[] { false, false, false, false };
         hash(ordsAndKeys -> {
             if (forcePackedHash) {
@@ -524,7 +525,7 @@ public class BlockHashTests extends ESTestCase {
         }, blockFactory.newBooleanArrayVector(values, values.length).asBlock());
     }
 
-    public void testBooleanHashWithNulls() {
+    public void testBooleanHashWithNulls() throws IOException {
         try (BooleanBlock.Builder builder = blockFactory.newBooleanBlockBuilder(4)) {
             builder.appendBoolean(false);
             builder.appendNull();
@@ -549,7 +550,7 @@ public class BlockHashTests extends ESTestCase {
         }
     }
 
-    public void testBooleanHashWithMultiValuedFields() {
+    public void testBooleanHashWithMultiValuedFields() throws IOException {
         try (BooleanBlock.Builder builder = blockFactory.newBooleanBlockBuilder(8)) {
             builder.appendBoolean(false);
             builder.beginPositionEntry();
@@ -604,7 +605,7 @@ public class BlockHashTests extends ESTestCase {
         }
     }
 
-    public void testLongLongHash() {
+    public void testLongLongHash() throws IOException {
         long[] values1 = new long[] { 0, 1, 0, 1, 0, 1 };
         long[] values2 = new long[] { 0, 0, 0, 1, 1, 1 };
         hash(ordsAndKeys -> {
@@ -654,7 +655,7 @@ public class BlockHashTests extends ESTestCase {
         }
     }
 
-    public void testLongLongHashWithMultiValuedFields() {
+    public void testLongLongHashWithMultiValuedFields() throws IOException {
         try (LongBlock.Builder b1 = blockFactory.newLongBlockBuilder(8); LongBlock.Builder b2 = blockFactory.newLongBlockBuilder(8)) {
             append(b1, b2, new long[] { 1, 2 }, new long[] { 10, 20 });
             append(b1, b2, new long[] { 1, 2 }, new long[] { 10 });
@@ -728,7 +729,7 @@ public class BlockHashTests extends ESTestCase {
         }
     }
 
-    public void testLongLongHashHugeCombinatorialExplosion() {
+    public void testLongLongHashHugeCombinatorialExplosion() throws IOException {
         long[] v1 = LongStream.range(0, 5000).toArray();
         long[] v2 = LongStream.range(100, 200).toArray();
 
@@ -762,7 +763,7 @@ public class BlockHashTests extends ESTestCase {
         }
     }
 
-    public void testIntLongHash() {
+    public void testIntLongHash() throws IOException {
         int[] values1 = new int[] { 0, 1, 0, 1, 0, 1 };
         long[] values2 = new long[] { 0, 0, 0, 1, 1, 1 };
         Object[][] expectedKeys = { new Object[] { 0, 0L }, new Object[] { 1, 0L }, new Object[] { 1, 1L }, new Object[] { 0, 1L } };
@@ -777,7 +778,7 @@ public class BlockHashTests extends ESTestCase {
         );
     }
 
-    public void testLongDoubleHash() {
+    public void testLongDoubleHash() throws IOException {
         long[] values1 = new long[] { 0, 1, 0, 1, 0, 1 };
         double[] values2 = new double[] { 0, 0, 0, 1, 1, 1 };
         Object[][] expectedKeys = { new Object[] { 0L, 0d }, new Object[] { 1L, 0d }, new Object[] { 1L, 1d }, new Object[] { 0L, 1d } };
@@ -792,7 +793,7 @@ public class BlockHashTests extends ESTestCase {
         );
     }
 
-    public void testIntBooleanHash() {
+    public void testIntBooleanHash() throws IOException {
         int[] values1 = new int[] { 0, 1, 0, 1, 0, 1 };
         boolean[] values2 = new boolean[] { false, false, false, true, true, true };
         Object[][] expectedKeys = {
@@ -811,7 +812,7 @@ public class BlockHashTests extends ESTestCase {
         );
     }
 
-    public void testLongLongHashWithNull() {
+    public void testLongLongHashWithNull() throws IOException {
         try (LongBlock.Builder b1 = blockFactory.newLongBlockBuilder(2); LongBlock.Builder b2 = blockFactory.newLongBlockBuilder(2)) {
             b1.appendLong(1);
             b2.appendLong(0);
@@ -848,7 +849,7 @@ public class BlockHashTests extends ESTestCase {
         }
     }
 
-    public void testLongBytesRefHash() {
+    public void testLongBytesRefHash() throws IOException {
         try (
             LongBlock.Builder b1 = blockFactory.newLongBlockBuilder(8);
             BytesRefBlock.Builder b2 = blockFactory.newBytesRefBlockBuilder(8)
@@ -888,7 +889,7 @@ public class BlockHashTests extends ESTestCase {
         }
     }
 
-    public void testLongBytesRefHashWithNull() {
+    public void testLongBytesRefHashWithNull() throws IOException {
         try (
             LongBlock.Builder b1 = blockFactory.newLongBlockBuilder(2);
             BytesRefBlock.Builder b2 = blockFactory.newBytesRefBlockBuilder(2)
@@ -958,7 +959,7 @@ public class BlockHashTests extends ESTestCase {
         }
     }
 
-    public void testLongBytesRefHashWithMultiValuedFields() {
+    public void testLongBytesRefHashWithMultiValuedFields() throws IOException {
         try (
             LongBlock.Builder b1 = blockFactory.newLongBlockBuilder(8);
             BytesRefBlock.Builder b2 = blockFactory.newBytesRefBlockBuilder(8)
@@ -1041,7 +1042,7 @@ public class BlockHashTests extends ESTestCase {
         }
     }
 
-    public void testBytesRefLongHashHugeCombinatorialExplosion() {
+    public void testBytesRefLongHashHugeCombinatorialExplosion() throws IOException {
         long[] v1 = LongStream.range(0, 3000).toArray();
         String[] v2 = LongStream.range(100, 200).mapToObj(l -> "a" + l).toArray(String[]::new);
 
@@ -1089,7 +1090,7 @@ public class BlockHashTests extends ESTestCase {
      * Hash some values into a single block of group ids. If the hash produces
      * more than one block of group ids this will fail.
      */
-    private void hash(Consumer<OrdsAndKeys> callback, Block.Builder... values) {
+    private void hash(Consumer<OrdsAndKeys> callback, Block.Builder... values) throws IOException {
         Block[] blocks = new Block[values.length];
         for (int i = 0; i < blocks.length; i++) {
             blocks[i] = values[i].build();
@@ -1101,7 +1102,7 @@ public class BlockHashTests extends ESTestCase {
      * Hash some values into a single block of group ids. If the hash produces
      * more than one block of group ids this will fail.
      */
-    private void hash(Consumer<OrdsAndKeys> callback, Block... values) {
+    private void hash(Consumer<OrdsAndKeys> callback, Block... values) throws IOException {
         boolean[] called = new boolean[] { false };
         hash(ordsAndKeys -> {
             if (called[0]) {
@@ -1112,7 +1113,7 @@ public class BlockHashTests extends ESTestCase {
         }, 16 * 1024, values);
     }
 
-    private void hash(Consumer<OrdsAndKeys> callback, int emitBatchSize, Block.Builder... values) {
+    private void hash(Consumer<OrdsAndKeys> callback, int emitBatchSize, Block.Builder... values) throws IOException {
         Block[] blocks = new Block[values.length];
         for (int i = 0; i < blocks.length; i++) {
             blocks[i] = values[i].build();
@@ -1120,7 +1121,7 @@ public class BlockHashTests extends ESTestCase {
         hash(callback, emitBatchSize, blocks);
     }
 
-    private void hash(Consumer<OrdsAndKeys> callback, int emitBatchSize, Block... values) {
+    private void hash(Consumer<OrdsAndKeys> callback, int emitBatchSize, Block... values) throws IOException {
         try {
             List<HashAggregationOperator.GroupSpec> specs = new ArrayList<>(values.length);
             for (int c = 0; c < values.length; c++) {
@@ -1139,7 +1140,7 @@ public class BlockHashTests extends ESTestCase {
         }
     }
 
-    static void hash(boolean collectKeys, BlockHash blockHash, Consumer<OrdsAndKeys> callback, Block... values) {
+    static void hash(boolean collectKeys, BlockHash blockHash, Consumer<OrdsAndKeys> callback, Block... values) throws IOException {
         blockHash.add(new Page(values), new GroupingAggregatorFunction.AddInput() {
             @Override
             public void add(int positionOffset, IntBlock groupIds) {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockSerializationTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockSerializationTests.java
@@ -200,7 +200,7 @@ public class BlockSerializationTests extends SerializationTestCase {
     }
 
     // TODO: more types, grouping, etc...
-    public void testSimulateAggs() {
+    public void testSimulateAggs() throws IOException {
         DriverContext driverCtx = driverContext();
         Page page = new Page(blockFactory.newLongArrayVector(new long[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }, 10).asBlock());
         var bigArrays = BigArrays.NON_RECYCLING_INSTANCE;

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/ValuesSourceReaderOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/ValuesSourceReaderOperatorTests.java
@@ -277,7 +277,7 @@ public class ValuesSourceReaderOperatorTests extends OperatorTestCase {
         return ByteSizeValue.ofKb(1);
     }
 
-    public void testLoadAll() {
+    public void testLoadAll() throws IOException {
         DriverContext driverContext = driverContext();
         loadSimpleAndAssert(
             driverContext,
@@ -286,7 +286,7 @@ public class ValuesSourceReaderOperatorTests extends OperatorTestCase {
         );
     }
 
-    public void testLoadAllInOnePage() {
+    public void testLoadAllInOnePage() throws IOException {
         DriverContext driverContext = driverContext();
         loadSimpleAndAssert(
             driverContext,
@@ -299,7 +299,7 @@ public class ValuesSourceReaderOperatorTests extends OperatorTestCase {
         );
     }
 
-    public void testManySingleDocPages() {
+    public void testManySingleDocPages() throws IOException {
         DriverContext driverContext = driverContext();
         int numDocs = between(10, 100);
         List<Page> input = CannedSourceOperator.collectPages(simpleInput(driverContext, numDocs, between(1, numDocs), 1));
@@ -330,7 +330,7 @@ public class ValuesSourceReaderOperatorTests extends OperatorTestCase {
         }
     }
 
-    public void testEmpty() {
+    public void testEmpty() throws IOException {
         DriverContext driverContext = driverContext();
         loadSimpleAndAssert(
             driverContext,
@@ -339,7 +339,7 @@ public class ValuesSourceReaderOperatorTests extends OperatorTestCase {
         );
     }
 
-    public void testLoadAllInOnePageShuffled() {
+    public void testLoadAllInOnePageShuffled() throws IOException {
         DriverContext driverContext = driverContext();
         Page source = CannedSourceOperator.mergePages(
             CannedSourceOperator.collectPages(simpleInput(driverContext.blockFactory(), between(100, 5000)))
@@ -461,7 +461,7 @@ public class ValuesSourceReaderOperatorTests extends OperatorTestCase {
      * Asserts that {@link ValuesSourceReaderOperator#status} claims that only
      * the expected readers are built after loading singleton pages.
      */
-    public void testLoadAllStatus() {
+    public void testLoadAllStatus() throws IOException {
         testLoadAllStatus(false);
     }
 
@@ -469,11 +469,11 @@ public class ValuesSourceReaderOperatorTests extends OperatorTestCase {
      * Asserts that {@link ValuesSourceReaderOperator#status} claims that only
      * the expected readers are built after loading non-singleton pages.
      */
-    public void testLoadAllStatusAllInOnePage() {
+    public void testLoadAllStatusAllInOnePage() throws IOException {
         testLoadAllStatus(true);
     }
 
-    private void testLoadAllStatus(boolean allInOnePage) {
+    private void testLoadAllStatus(boolean allInOnePage) throws IOException {
         DriverContext driverContext = driverContext();
         int numDocs = between(100, 5000);
         List<Page> input = CannedSourceOperator.collectPages(simpleInput(driverContext, numDocs, commitEvery(numDocs), numDocs));
@@ -1313,18 +1313,18 @@ public class ValuesSourceReaderOperatorTests extends OperatorTestCase {
         assertDriverContext(driverContext);
     }
 
-    public void testSequentialStoredFieldsTooSmall() {
+    public void testSequentialStoredFieldsTooSmall() throws IOException {
         testSequentialStoredFields(false, between(1, ValuesSourceReaderOperator.SEQUENTIAL_BOUNDARY - 1));
     }
 
-    public void testSequentialStoredFieldsBigEnough() {
+    public void testSequentialStoredFieldsBigEnough() throws IOException {
         testSequentialStoredFields(
             true,
             between(ValuesSourceReaderOperator.SEQUENTIAL_BOUNDARY, ValuesSourceReaderOperator.SEQUENTIAL_BOUNDARY * 2)
         );
     }
 
-    private void testSequentialStoredFields(boolean sequential, int docCount) {
+    private void testSequentialStoredFields(boolean sequential, int docCount) throws IOException {
         DriverContext driverContext = driverContext();
         List<Page> source = CannedSourceOperator.collectPages(simpleInput(driverContext, docCount, docCount, docCount));
         assertThat(source, hasSize(1)); // We want one page for simpler assertions, and we want them all in one segment

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/CannedSourceOperator.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/CannedSourceOperator.java
@@ -15,6 +15,7 @@ import org.elasticsearch.compute.data.TestBlockFactory;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -23,7 +24,7 @@ import java.util.List;
  * {@link SourceOperator} that returns a sequence of pre-built {@link Page}s.
  */
 public class CannedSourceOperator extends SourceOperator {
-    public static List<Page> collectPages(SourceOperator source) {
+    public static List<Page> collectPages(SourceOperator source) throws IOException {
         try {
             List<Page> pages = new ArrayList<>();
             while (source.isFinished() == false) {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/EvalOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/EvalOperatorTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.EvalOperator.EvalOperatorFactory;
 import org.elasticsearch.core.Tuple;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
@@ -102,7 +103,7 @@ public class EvalOperatorTests extends OperatorTestCase {
         }
     }
 
-    public void testReadFromBlock() {
+    public void testReadFromBlock() throws IOException {
         DriverContext context = driverContext();
         List<Page> input = CannedSourceOperator.collectPages(simpleInput(context.blockFactory(), 10));
         List<Page> results = drive(new EvalOperatorFactory(dvrCtx -> new LoadFromPage(0)).get(context), input.iterator(), context);

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/FilterOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/FilterOperatorTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.core.Tuple;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -91,11 +92,11 @@ public class FilterOperatorTests extends OperatorTestCase {
         assertThat(actualCount, equalTo(expectedCount));
     }
 
-    public void testNoResults() {
+    public void testNoResults() throws IOException {
         assertSimple(driverContext(), 3);
     }
 
-    public void testReadFromBlock() {
+    public void testReadFromBlock() throws IOException {
         DriverContext context = driverContext();
         List<Page> input = CannedSourceOperator.collectPages(
             new SequenceBooleanBlockSourceOperator(context.blockFactory(), List.of(true, false, true, false))

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/ForkingOperatorTestCase.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/ForkingOperatorTestCase.java
@@ -28,6 +28,7 @@ import org.elasticsearch.threadpool.TestThreadPool;
 import org.junit.After;
 import org.junit.Before;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -57,7 +58,7 @@ public abstract class ForkingOperatorTestCase extends OperatorTestCase {
         return simpleWithMode(bigArrays, AggregatorMode.SINGLE);
     }
 
-    public final void testInitialFinal() {
+    public final void testInitialFinal() throws IOException {
         BigArrays bigArrays = nonBreakingBigArrays();
         DriverContext driverContext = driverContext();
         List<Page> input = CannedSourceOperator.collectPages(simpleInput(driverContext.blockFactory(), between(1_000, 100_000)));
@@ -81,7 +82,7 @@ public abstract class ForkingOperatorTestCase extends OperatorTestCase {
         assertDriverContext(driverContext);
     }
 
-    public final void testManyInitialFinal() {
+    public final void testManyInitialFinal() throws IOException {
         BigArrays bigArrays = nonBreakingBigArrays();
         DriverContext driverContext = driverContext();
         List<Page> input = CannedSourceOperator.collectPages(simpleInput(driverContext.blockFactory(), between(1_000, 100_000)));
@@ -103,7 +104,7 @@ public abstract class ForkingOperatorTestCase extends OperatorTestCase {
         assertDriverContext(driverContext);
     }
 
-    public final void testInitialIntermediateFinal() {
+    public final void testInitialIntermediateFinal() throws IOException {
         BigArrays bigArrays = nonBreakingBigArrays();
         DriverContext driverContext = driverContext();
         List<Page> input = CannedSourceOperator.collectPages(simpleInput(driverContext.blockFactory(), between(1_000, 100_000)));
@@ -129,7 +130,7 @@ public abstract class ForkingOperatorTestCase extends OperatorTestCase {
         assertDriverContext(driverContext);
     }
 
-    public final void testManyInitialManyPartialFinal() {
+    public final void testManyInitialManyPartialFinal() throws IOException {
         BigArrays bigArrays = nonBreakingBigArrays();
         DriverContext driverContext = driverContext();
         List<Page> input = CannedSourceOperator.collectPages(simpleInput(driverContext.blockFactory(), between(1_000, 100_000)));
@@ -160,7 +161,7 @@ public abstract class ForkingOperatorTestCase extends OperatorTestCase {
 
     // Similar to testManyInitialManyPartialFinal, but uses with the DriverRunner infrastructure
     // to move the data through the pipeline.
-    public final void testManyInitialManyPartialFinalRunner() {
+    public final void testManyInitialManyPartialFinalRunner() throws IOException {
         BigArrays bigArrays = nonBreakingBigArrays();
         List<Page> input = CannedSourceOperator.collectPages(simpleInput(driverContext().blockFactory(), between(1_000, 100_000)));
         List<Page> origInput = BlockTestUtils.deepCopyOf(input, TestBlockFactory.getNonBreakingInstance());

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/MappingSourceOperator.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/MappingSourceOperator.java
@@ -9,6 +9,8 @@ package org.elasticsearch.compute.operator;
 
 import org.elasticsearch.compute.data.Page;
 
+import java.io.IOException;
+
 public abstract class MappingSourceOperator extends SourceOperator {
     private final SourceOperator delegate;
 
@@ -19,7 +21,7 @@ public abstract class MappingSourceOperator extends SourceOperator {
     protected abstract Page map(Page page);
 
     @Override
-    public void finish() {
+    public void finish() throws IOException {
         delegate.finish();
     }
 
@@ -29,7 +31,7 @@ public abstract class MappingSourceOperator extends SourceOperator {
     }
 
     @Override
-    public Page getOutput() {
+    public Page getOutput() throws IOException {
         Page p = delegate.getOutput();
         if (p == null) {
             return p;

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/MvExpandOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/MvExpandOperatorTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.data.TestBlockFactory;
 
+import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 
@@ -236,7 +237,7 @@ public class MvExpandOperatorTests extends OperatorTestCase {
         result.forEach(Page::releaseBlocks);
     }
 
-    public void testExpandWithBytesRefs() {
+    public void testExpandWithBytesRefs() throws IOException {
         DriverContext context = driverContext();
         List<Page> input = CannedSourceOperator.collectPages(new AbstractBlockSourceOperator(context.blockFactory(), 8 * 1024) {
             private int idx;

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/ProjectOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/ProjectOperatorTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.core.Tuple;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -25,14 +26,14 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 public class ProjectOperatorTests extends OperatorTestCase {
-    public void testProjectionOnEmptyPage() {
+    public void testProjectionOnEmptyPage() throws IOException {
         var page = new Page(0);
         var projection = new ProjectOperator(randomProjection(10));
         projection.addInput(page);
         assertEquals(page, projection.getOutput());
     }
 
-    public void testProjection() {
+    public void testProjection() throws IOException {
         DriverContext context = driverContext();
         var size = randomIntBetween(2, 5);
         var blocks = new Block[size];

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/RowOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/RowOperatorTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.compute.data.TestBlockFactory;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.test.ESTestCase;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
@@ -31,7 +32,7 @@ public class RowOperatorTests extends ESTestCase {
         TestBlockFactory.getNonBreakingInstance()
     );
 
-    public void testBoolean() {
+    public void testBoolean() throws IOException {
         RowOperator.RowOperatorFactory factory = new RowOperator.RowOperatorFactory(List.of(false));
         assertThat(factory.describe(), equalTo("RowOperator[objects = false]"));
         assertThat(factory.get(driverContext).toString(), equalTo("RowOperator[objects=[false]]"));
@@ -39,7 +40,7 @@ public class RowOperatorTests extends ESTestCase {
         assertThat(block.getBoolean(0), equalTo(false));
     }
 
-    public void testInt() {
+    public void testInt() throws IOException {
         RowOperator.RowOperatorFactory factory = new RowOperator.RowOperatorFactory(List.of(213));
         assertThat(factory.describe(), equalTo("RowOperator[objects = 213]"));
         assertThat(factory.get(driverContext).toString(), equalTo("RowOperator[objects=[213]]"));
@@ -47,7 +48,7 @@ public class RowOperatorTests extends ESTestCase {
         assertThat(block.getInt(0), equalTo(213));
     }
 
-    public void testLong() {
+    public void testLong() throws IOException {
         RowOperator.RowOperatorFactory factory = new RowOperator.RowOperatorFactory(List.of(21321343214L));
         assertThat(factory.describe(), equalTo("RowOperator[objects = 21321343214]"));
         assertThat(factory.get(driverContext).toString(), equalTo("RowOperator[objects=[21321343214]]"));
@@ -55,7 +56,7 @@ public class RowOperatorTests extends ESTestCase {
         assertThat(block.getLong(0), equalTo(21321343214L));
     }
 
-    public void testDouble() {
+    public void testDouble() throws IOException {
         RowOperator.RowOperatorFactory factory = new RowOperator.RowOperatorFactory(List.of(2.0));
         assertThat(factory.describe(), equalTo("RowOperator[objects = 2.0]"));
         assertThat(factory.get(driverContext).toString(), equalTo("RowOperator[objects=[2.0]]"));
@@ -63,7 +64,7 @@ public class RowOperatorTests extends ESTestCase {
         assertThat(block.getDouble(0), equalTo(2.0));
     }
 
-    public void testString() {
+    public void testString() throws IOException {
         RowOperator.RowOperatorFactory factory = new RowOperator.RowOperatorFactory(List.of(new BytesRef("cat")));
         assertThat(factory.describe(), equalTo("RowOperator[objects = [63 61 74]]"));
         assertThat(factory.get(driverContext).toString(), equalTo("RowOperator[objects=[[63 61 74]]]"));
@@ -71,7 +72,7 @@ public class RowOperatorTests extends ESTestCase {
         assertThat(block.getBytesRef(0, new BytesRef()), equalTo(new BytesRef("cat")));
     }
 
-    public void testNull() {
+    public void testNull() throws IOException {
         RowOperator.RowOperatorFactory factory = new RowOperator.RowOperatorFactory(Arrays.asList(new Object[] { null }));
         assertThat(factory.describe(), equalTo("RowOperator[objects = null]"));
         assertThat(factory.get(driverContext).toString(), equalTo("RowOperator[objects=[null]]"));

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/TopNOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/TopNOperatorTests.java
@@ -39,6 +39,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.ListMatcher;
 import org.elasticsearch.xpack.versionfield.Version;
 
+import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -186,7 +187,7 @@ public class TopNOperatorTests extends OperatorTestCase {
         return ByteSizeValue.ofBytes(775);
     }
 
-    public void testRamBytesUsed() {
+    public void testRamBytesUsed() throws IOException {
         RamUsageTester.Accumulator acc = new RamUsageTester.Accumulator() {
             @Override
             public long accumulateObject(Object o, long shallowSize, Map<Field, Object> fieldValues, Collection<Object> queue) {


### PR DESCRIPTION
The ES|QL compute engine is currently making all IOexceptions unchecked which might hide real issues that needs to bubble up. This PR mainly adds IOException to LuceneOperator interface that helps removing many of the wrapped IOExceptions,