### PR TITLE
Fix test logic for immediate results in EsqlAsyncActionIT

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlAsyncActionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlAsyncActionIT.java
@@ -23,18 +23,16 @@ import org.elasticsearch.xpack.core.async.DeleteAsyncResultAction;
 import org.elasticsearch.xpack.core.async.DeleteAsyncResultRequest;
 import org.elasticsearch.xpack.core.async.GetAsyncResultRequest;
 import org.elasticsearch.xpack.esql.TestBlockFactory;
-import org.elasticsearch.xpack.esql.analysis.VerificationException;
-import org.elasticsearch.xpack.esql.parser.ParsingException;
 import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.core.TimeValue.timeValueSeconds;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsEqual.equalTo;

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlAsyncActionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlAsyncActionIT.java
@@ -7,11 +7,14 @@
 
 package org.elasticsearch.xpack.esql.action;
 
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BlockUtils;
+import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.plugins.Plugin;
@@ -19,6 +22,9 @@ import org.elasticsearch.xpack.core.LocalStateCompositeXPackPlugin;
 import org.elasticsearch.xpack.core.async.DeleteAsyncResultAction;
 import org.elasticsearch.xpack.core.async.DeleteAsyncResultRequest;
 import org.elasticsearch.xpack.core.async.GetAsyncResultRequest;
+import org.elasticsearch.xpack.esql.TestBlockFactory;
+import org.elasticsearch.xpack.esql.analysis.VerificationException;
+import org.elasticsearch.xpack.esql.parser.ParsingException;
 import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 import java.nio.file.Path;
@@ -28,15 +34,16 @@ import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.core.TimeValue.timeValueSeconds;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.IsNot.not;
 
 /**
  * Runs test scenarios from EsqlActionIT, with an extra level of indirection
  * through the async query and async get APIs.
  */
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/103748")
 public class EsqlAsyncActionIT extends EsqlActionIT {
 
     @Override
@@ -61,12 +68,28 @@ public class EsqlAsyncActionIT extends EsqlActionIT {
 
         var response = run(request);
         if (response.asyncExecutionId().isPresent()) {
+            List<ColumnInfo> initialColumns = null;
+            List<Page> initialPages = null;
             String id = response.asyncExecutionId().get();
-            assertThat(response.isRunning(), is(true));
-            assertThat(response.columns(), is(empty())); // no partial results
-            assertThat(response.pages(), is(empty()));
+            if (response.isRunning() == false) {
+                assertThat(request.keepOnCompletion(), is(true));
+                assertThat(response.columns(), is(not(empty())));
+                assertThat(response.pages(), is(not(empty())));
+                initialColumns = List.copyOf(response.columns());
+                initialPages = deepCopyOf(response.pages(), TestBlockFactory.getNonBreakingInstance());
+            } else {
+                assertThat(response.columns(), is(empty())); // no partial results
+                assertThat(response.pages(), is(empty()));
+            }
             response.close();
             var getResponse = getAsyncResponse(id);
+
+            // assert initial contents, if any, are the same as async get contents
+            if (initialColumns != null) {
+                assertEquals(initialColumns, getResponse.columns());
+                assertEquals(initialPages, getResponse.pages());
+            }
+
             assertDeletable(id);
             return getResponse;
         } else {
@@ -118,5 +141,19 @@ public class EsqlAsyncActionIT extends EsqlActionIT {
         public LocalStateEsqlAsync(final Settings settings, final Path configPath) {
             super(settings, configPath);
         }
+    }
+
+    // -- TODO: eventually remove and use common compute test infra
+
+    public static List<Page> deepCopyOf(List<Page> pages, BlockFactory blockFactory) {
+        return pages.stream().map(page -> deepCopyOf(page, blockFactory)).toList();
+    }
+
+    public static Page deepCopyOf(Page page, BlockFactory blockFactory) {
+        Block[] blockCopies = new Block[page.getBlockCount()];
+        for (int i = 0; i < blockCopies.length; i++) {
+            blockCopies[i] = BlockUtils.deepCopyOf(page.getBlock(i), blockFactory);
+        }
+        return new Page(blockCopies);
     }
 }


### PR DESCRIPTION
There is a race in the test logic. The request can return results immediately and also an async execution id if _keepOnCompletion_ is true. The test should be updated to reflect this.

closes #103748