### PR TITLE
[8.12] Fix the transport version of PlanStreamOutput (#103758)

### DIFF
--- a/docs/changelog/103758.yaml
+++ b/docs/changelog/103758.yaml
@@ -1,0 +1,5 @@
+pr: 103758
+summary: Fix the transport version of `PlanStreamOutput`
+area: ES|QL
+type: bug
+issues: []

--- a/x-pack/plugin/esql/qa/server/mixed-cluster/build.gradle
+++ b/x-pack/plugin/esql/qa/server/mixed-cluster/build.gradle
@@ -26,18 +26,23 @@ restResources {
 BuildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
 
   if (bwcVersion != VersionProperties.getElasticsearchVersion() && bwcVersion.onOrAfter(Version.fromString("8.11.0"))) {
-    /* This project runs the ESQL spec tests against a 4 node cluster where two of the nodes has a different minor.  */
     def baseCluster = testClusters.register(baseName) {
-      versions = [bwcVersion.toString(), bwcVersion.toString(), project.version, project.version]
+      versions = [bwcVersion.toString(), project.version]
       numberOfNodes = 4
       testDistribution = 'DEFAULT'
       setting 'xpack.license.self_generated.type', 'trial'
       setting 'xpack.security.enabled', 'false'
+      // disable relocation until we have retry in ESQL
+      setting 'cluster.routing.rebalance.enable', 'none'
     }
 
     tasks.register("${baseName}#mixedClusterTest", StandaloneRestIntegTestTask) {
       useCluster baseCluster
       mustRunAfter("precommit")
+      doFirst {
+        baseCluster.get().nextNodeToNextVersion()
+        baseCluster.get().nextNodeToNextVersion()
+      }
       nonInputProperties.systemProperty('tests.rest.cluster', baseCluster.map(c -> c.allHttpSocketURI.join(",")))
       nonInputProperties.systemProperty('tests.clustername', baseName)
       systemProperty 'tests.bwc_nodes_version', bwcVersion.toString().replace('-SNAPSHOT', '')

--- a/x-pack/plugin/esql/qa/server/mixed-cluster/src/test/java/org/elasticsearch/xpack/esql/qa/mixed/MixedClusterEsqlSpecIT.java
+++ b/x-pack/plugin/esql/qa/server/mixed-cluster/src/test/java/org/elasticsearch/xpack/esql/qa/mixed/MixedClusterEsqlSpecIT.java
@@ -7,12 +7,14 @@
 
 package org.elasticsearch.xpack.esql.qa.mixed;
 
+import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.Version;
 import org.elasticsearch.xpack.esql.qa.rest.EsqlSpecTestCase;
 import org.elasticsearch.xpack.ql.CsvSpecReader.CsvTestCase;
 
 import static org.elasticsearch.xpack.esql.CsvTestUtils.isEnabled;
 
+@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/103765")
 public class MixedClusterEsqlSpecIT extends EsqlSpecTestCase {
 
     static final Version bwcVersion = Version.fromString(System.getProperty("tests.bwc_nodes_version"));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/io/stream/PlanStreamOutputTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/io/stream/PlanStreamOutputTests.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.io.stream;
+
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.TransportVersionUtils;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class PlanStreamOutputTests extends ESTestCase {
+
+    public void testTransportVersion() {
+        BytesStreamOutput out = new BytesStreamOutput();
+        TransportVersion v1 = TransportVersionUtils.randomCompatibleVersion(random());
+        out.setTransportVersion(v1);
+        PlanStreamOutput planOut = new PlanStreamOutput(out, PlanNameRegistry.INSTANCE);
+        assertThat(planOut.getTransportVersion(), equalTo(v1));
+        TransportVersion v2 = TransportVersionUtils.randomCompatibleVersion(random());
+        planOut.setTransportVersion(v2);
+        assertThat(planOut.getTransportVersion(), equalTo(v2));
+        assertThat(out.getTransportVersion(), equalTo(v2));
+    }
+}

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/40_unsupported_types.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/40_unsupported_types.yml
@@ -394,7 +394,7 @@ unsupported with sort:
 ---
 spatial types unsupported in 8.11:
   - skip:
-      version: " - 8.10.99, 8.12.0 - "
+      version: " - "
       reason: "Elasticsearch 8.11 did not support any spatial types"
 
   - do:


### PR DESCRIPTION
Backports the following commits to 8.12:
 - Fix the transport version of PlanStreamOutput (#103758)