### PR TITLE
docs: fix numbering in restore-snapshot.asciidoc

### DIFF
--- a/docs/reference/snapshot-restore/restore-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/restore-snapshot.asciidoc
@@ -359,12 +359,7 @@ POST _watcher/_start
 ----
 // TEST[continued]
 ////
---
 
-
-. {blank}
-+
---
 * Universal Profiling
 +
 Check if Universal Profiling index template management is enabled:
@@ -386,8 +381,7 @@ PUT _cluster/settings
 }
 ----
 
-[[restore-create-file-realm-user]]
-If you use {es} security features, log in to a node host, navigate to the {es}
+. If you use {es} security features, log in to a node host, navigate to the {es}
 installation directory, and add a user with the `superuser` role to the file
 realm using the <<users-command,`elasticsearch-users`>> tool.
 

--- a/docs/reference/snapshot-restore/restore-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/restore-snapshot.asciidoc
@@ -380,21 +380,25 @@ PUT _cluster/settings
   }
 }
 ----
+--
 
-. If you use {es} security features, log in to a node host, navigate to the {es}
-installation directory, and add a user with the `superuser` role to the file
-realm using the <<users-command,`elasticsearch-users`>> tool.
+. [[restore-create-file-realm-user]]If you use {es} security features, log in to
+a node host, navigate to the {es} installation directory, and add a user with
+the `superuser` role to the file realm using the
+<<users-command,`elasticsearch-users`>> tool.
++
 
 For example, the following command creates a user named `restore_user`.
++
 
 [source,sh]
 ----
 ./bin/elasticsearch-users useradd restore_user -p my_password -r superuser
 ----
++
 
 Use this file realm user to authenticate requests until the restore operation is
 complete.
---
 
 . Use the <<cluster-update-settings,cluster update settings API>> to set
 <<action-destructive-requires-name,`action.destructive_requires_name`>> to


### PR DESCRIPTION
Fix numbering in "Restore an entire cluster" section. 
Remove "3." for "Universal Profiling" and add "3." just before "If you use Elasticsearch security features"
