### PR TITLE
Use correct and efficient XContent type recognition in XContentHelper.convertToJson

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
@@ -323,7 +323,7 @@ public class XContentHelper {
 
     @Deprecated
     public static String convertToJson(BytesReference bytes, boolean reformatJson, boolean prettyPrint) throws IOException {
-        return convertToJson(bytes, reformatJson, prettyPrint, XContentFactory.xContentType(bytes.toBytesRef().bytes));
+        return convertToJson(bytes, reformatJson, prettyPrint, xContentType(bytes));
     }
 
     public static String convertToJson(BytesReference bytes, boolean reformatJson, XContentType xContentType) throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/mapper/SourceFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/SourceFieldMapperTests.java
@@ -73,7 +73,7 @@ public class SourceFieldMapperTests extends MetadataMapperTestCase {
             )
         );
 
-        assertThat(XContentFactory.xContentType(doc.source().toBytesRef().bytes), equalTo(XContentType.JSON));
+        assertThat(XContentHelper.xContentType(doc.source()), equalTo(XContentType.JSON));
 
         doc = documentMapper.parse(
             new SourceToParse(


### PR DESCRIPTION
Use the more efficient utility that does not require copying/allocating bytes. Also, this logic could become buggy if we make use of non-zero offset-, array- based bytes references in the future.
