### PR TITLE
[Profiling] Mark all templates as managed

### DIFF
--- a/docs/changelog/103783.yaml
+++ b/docs/changelog/103783.yaml
@@ -1,0 +1,5 @@
+pr: 103783
+summary: "[Profiling] Mark all templates as managed"
+area: Application
+type: enhancement
+issues: []

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/component-template/profiling-events.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/component-template/profiling-events.json
@@ -26,7 +26,8 @@
       },
       "_meta": {
         "index-template-version": ${xpack.profiling.template.version},
-        "index-version": ${xpack.profiling.index.events.version}
+        "index-version": ${xpack.profiling.index.events.version},
+        "managed": true
       },
       "dynamic": false,
       "properties": {

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/component-template/profiling-executables.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/component-template/profiling-executables.json
@@ -15,7 +15,8 @@
       },
       "_meta": {
         "index-template-version": ${xpack.profiling.template.version},
-        "index-version": ${xpack.profiling.index.executables.version}
+        "index-version": ${xpack.profiling.index.executables.version},
+        "managed": true
       },
       "dynamic": false,
       "properties": {

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/component-template/profiling-hosts.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/component-template/profiling-hosts.json
@@ -21,7 +21,8 @@
       },
       "_meta": {
         "index-template-version": ${xpack.profiling.template.version},
-        "index-version": ${xpack.profiling.index.hosts.version}
+        "index-version": ${xpack.profiling.index.hosts.version},
+        "managed": true
       },
       "dynamic": false,
       "properties": {

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/component-template/profiling-hot-tier.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/component-template/profiling-hot-tier.json
@@ -6,5 +6,9 @@
       }
     }
   },
+  "_meta": {
+    "index-template-version": ${xpack.profiling.template.version},
+    "managed": true
+  },
   "version": ${xpack.profiling.template.version}
 }

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/component-template/profiling-ilm.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/component-template/profiling-ilm.json
@@ -8,5 +8,9 @@
       }
     }
   },
+  "_meta": {
+    "index-template-version": ${xpack.profiling.template.version},
+    "managed": true
+  },
   "version": ${xpack.profiling.template.version}
 }

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/component-template/profiling-metrics.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/component-template/profiling-metrics.json
@@ -21,7 +21,8 @@
       },
       "_meta": {
         "index-template-version": ${xpack.profiling.template.version},
-        "index-version": ${xpack.profiling.index.metrics.version}
+        "index-version": ${xpack.profiling.index.metrics.version},
+        "managed": true
       },
       /*
        We intentionally allow dynamic mappings for metrics. Which metrics are added is guarded by

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/component-template/profiling-stackframes.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/component-template/profiling-stackframes.json
@@ -23,7 +23,8 @@
       },
       "_meta": {
         "index-template-version": ${xpack.profiling.template.version},
-        "index-version": ${xpack.profiling.index.stackframes.version}
+        "index-version": ${xpack.profiling.index.stackframes.version},
+        "managed": true
       },
       "dynamic": false,
       "properties": {

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/component-template/profiling-stacktraces.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/component-template/profiling-stacktraces.json
@@ -21,7 +21,8 @@
       },
       "_meta": {
         "index-template-version": ${xpack.profiling.template.version},
-        "index-version": ${xpack.profiling.index.stacktraces.version}
+        "index-version": ${xpack.profiling.index.stacktraces.version},
+        "managed": true
       },
       "dynamic": false,
       "properties": {

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/component-template/profiling-symbols.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/component-template/profiling-symbols.json
@@ -19,7 +19,8 @@
       },
       "_meta": {
         "index-template-version": ${xpack.profiling.template.version},
-        "index-version": ${xpack.profiling.index.symbols.version}
+        "index-version": ${xpack.profiling.index.symbols.version},
+        "managed": true
       },
       "dynamic": false,
       "properties": {

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-events.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-events.json
@@ -13,7 +13,8 @@
   "ignore_missing_component_templates": ["profiling-ilm@custom"],
   "priority": 100,
   "_meta": {
-    "description": "Index template for profiling-events"
+    "description": "Index template for profiling-events",
+    "managed": true
   },
   "version": ${xpack.profiling.template.version}
 }

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-executables.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-executables.json
@@ -11,7 +11,8 @@
   "ignore_missing_component_templates": ["profiling-ilm@custom"],
   "priority": 100,
   "_meta": {
-    "description": "Index template for .profiling-executables"
+    "description": "Index template for .profiling-executables",
+    "managed": true
   },
   "version": ${xpack.profiling.template.version}
 }

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-hosts.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-hosts.json
@@ -11,7 +11,8 @@
   "ignore_missing_component_templates": ["profiling-ilm@custom"],
   "priority": 100,
   "_meta": {
-    "description": "Template for profiling-hosts"
+    "description": "Index template for profiling-hosts",
+    "managed": true
   },
   "version": ${xpack.profiling.template.version}
 }

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-metrics.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-metrics.json
@@ -11,7 +11,8 @@
   "ignore_missing_component_templates": ["profiling-ilm@custom"],
   "priority": 100,
   "_meta": {
-    "description": "Template for profiling-metrics"
+    "description": "Index template for profiling-metrics",
+    "managed": true
   },
   "version": ${xpack.profiling.template.version}
 }

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-returnpads-private.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-returnpads-private.json
@@ -21,7 +21,9 @@
       },
       "_meta": {
         "index-template-version": ${xpack.profiling.template.version},
-        "index-version": ${xpack.profiling.index.returnpads.private.version}
+        "index-version": ${xpack.profiling.index.returnpads.private.version},
+        "description": "Index template for .profiling-returnpads-private",
+        "managed": true
       },
       "dynamic": false,
       "properties": {

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-sq-executables.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-sq-executables.json
@@ -17,7 +17,9 @@
       },
       "_meta": {
         "index-template-version": ${xpack.profiling.template.version},
-        "index-version": ${xpack.profiling.index.sq.executables.version}
+        "index-version": ${xpack.profiling.index.sq.executables.version},
+        "description": "Index template for .profiling-sq-executables",
+        "managed": true
       },
       "dynamic": false,
       "properties": {

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-sq-leafframes.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-sq-leafframes.json
@@ -17,7 +17,9 @@
       },
       "_meta": {
         "index-template-version": ${xpack.profiling.template.version},
-        "index-version": ${xpack.profiling.index.sq.leafframes.version}
+        "index-version": ${xpack.profiling.index.sq.leafframes.version},
+        "description": "Index template for .profiling-sq-leafframes",
+        "managed": true
       },
       "dynamic": false,
       "properties": {

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-stackframes.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-stackframes.json
@@ -11,7 +11,8 @@
   "ignore_missing_component_templates": ["profiling-ilm@custom"],
   "priority": 100,
   "_meta": {
-    "description": "Index template for .profiling-stackframes"
+    "description": "Index template for .profiling-stackframes",
+    "managed": true
   },
   "version": ${xpack.profiling.template.version}
 }

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-stacktraces.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-stacktraces.json
@@ -11,7 +11,8 @@
   "ignore_missing_component_templates": ["profiling-ilm@custom"],
   "priority": 100,
   "_meta": {
-    "description": "Index template for .profiling-stacktraces"
+    "description": "Index template for .profiling-stacktraces",
+    "managed": true
   },
   "version": ${xpack.profiling.template.version}
 }

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-symbols-global.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-symbols-global.json
@@ -18,7 +18,8 @@
   },
   "priority": 100,
   "_meta": {
-    "description": "Index template for .profiling-symbols-global"
+    "description": "Index template for .profiling-symbols-global",
+    "managed": true
   },
   "version": ${xpack.profiling.template.version}
 }

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-symbols-private.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-symbols-private.json
@@ -7,7 +7,8 @@
   ],
   "priority": 100,
   "_meta": {
-    "description": "Index template for .profiling-symbols-private"
+    "description": "Index template for .profiling-symbols-private",
+    "managed": true
   },
   "version": ${xpack.profiling.template.version}
 }


### PR DESCRIPTION
With this commit we mark all component and index templates for Universal Profiling as managed. This allows Kibana to highlight this accordingly in the index management UI.