### PR TITLE
[8.12][Fleet] added `download_rate` mapping to `.fleet-agents` index (#103566)

### DIFF
--- a/x-pack/plugin/core/template-resources/src/main/resources/fleet-agents.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/fleet-agents.json
@@ -270,6 +270,9 @@
                 "download_percent": {
                   "type": "double"
                 },
+                "download_rate": {
+                  "type": "double"
+                },
                 "failed_state": {
                   "type": "keyword"
                 },
@@ -281,6 +284,18 @@
                       "ignore_above": 1024
                     }
                   }
+                },
+                "retry_error_msg": {
+                  "type": "text",
+                  "fields": {
+                    "keyword": {
+                      "type": "keyword",
+                      "ignore_above": 1024
+                    }
+                  }
+                },
+                "retry_until": {
+                  "type": "date"
                 }
               }
             }


### PR DESCRIPTION
Backport https://github.com/elastic/elasticsearch/pull/103566 to 8.12