### PR TITLE
[8.12] Handle timeout on standalone rewrite calls (#103546)

### DIFF
--- a/docs/changelog/103546.yaml
+++ b/docs/changelog/103546.yaml
@@ -1,0 +1,5 @@
+pr: 103546
+summary: Handle timeout on standalone rewrite calls
+area: Search
+type: bug
+issues: []


### PR DESCRIPTION
Backports the following commits to 8.12:
 - Handle timeout on standalone rewrite calls (#103546)