### PR TITLE
[8.12] Restore inter-segment search concurrency with synthetic source is enabled (#103690)

### DIFF
--- a/docs/changelog/103690.yaml
+++ b/docs/changelog/103690.yaml
@@ -1,0 +1,5 @@
+pr: 103690
+summary: Restore inter-segment search concurrency with synthetic source is enabled
+area: Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceLoader.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -79,12 +80,15 @@ public interface SourceLoader {
      * Load {@code _source} from doc values.
      */
     class Synthetic implements SourceLoader {
-        private final SyntheticFieldLoader loader;
-        private final Map<String, SyntheticFieldLoader.StoredFieldLoader> storedFieldLoaders;
+        private final Supplier<SyntheticFieldLoader> syntheticFieldLoaderLeafSupplier;
+        private final Set<String> requiredStoredFields;
 
         public Synthetic(Mapping mapping) {
-            loader = mapping.syntheticFieldLoader();
-            storedFieldLoaders = Map.copyOf(loader.storedFieldLoaders().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+            this.syntheticFieldLoaderLeafSupplier = mapping::syntheticFieldLoader;
+            this.requiredStoredFields = syntheticFieldLoaderLeafSupplier.get()
+                .storedFieldLoaders()
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toSet());
         }
 
         @Override
@@ -94,19 +98,26 @@ public interface SourceLoader {
 
         @Override
         public Set<String> requiredStoredFields() {
-            return storedFieldLoaders.keySet();
+            return requiredStoredFields;
         }
 
         @Override
         public Leaf leaf(LeafReader reader, int[] docIdsInLeaf) throws IOException {
-            return new SyntheticLeaf(loader.docValuesLoader(reader, docIdsInLeaf));
+            SyntheticFieldLoader loader = syntheticFieldLoaderLeafSupplier.get();
+            return new SyntheticLeaf(loader, loader.docValuesLoader(reader, docIdsInLeaf));
         }
 
-        private class SyntheticLeaf implements Leaf {
+        private static class SyntheticLeaf implements Leaf {
+            private final SyntheticFieldLoader loader;
             private final SyntheticFieldLoader.DocValuesLoader docValuesLoader;
+            private final Map<String, SyntheticFieldLoader.StoredFieldLoader> storedFieldLoaders;
 
-            private SyntheticLeaf(SyntheticFieldLoader.DocValuesLoader docValuesLoader) {
+            private SyntheticLeaf(SyntheticFieldLoader loader, SyntheticFieldLoader.DocValuesLoader docValuesLoader) {
+                this.loader = loader;
                 this.docValuesLoader = docValuesLoader;
+                this.storedFieldLoaders = Map.copyOf(
+                    loader.storedFieldLoaders().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))
+                );
             }
 
             @Override

--- a/server/src/test/java/org/elasticsearch/search/DefaultSearchContextTests.java
+++ b/server/src/test/java/org/elasticsearch/search/DefaultSearchContextTests.java
@@ -395,8 +395,6 @@ public class DefaultSearchContextTests extends ESTestCase {
         when(indexShard.getThreadPool()).thenReturn(threadPool);
 
         IndexService indexService = mock(IndexService.class);
-        MapperService mapperService = mock(MapperService.class);
-        when(indexService.mapperService()).thenReturn(mapperService);
 
         try (Directory dir = newDirectory(); RandomIndexWriter w = new RandomIndexWriter(random(), dir)) {
 


### PR DESCRIPTION
Backports the following commits to 8.12:
 - Restore inter-segment search concurrency with synthetic source is enabled (#103690)