### PR TITLE
[ML] Fix step change test

### DIFF
--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/changepoint/ChangePointAggregatorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/changepoint/ChangePointAggregatorTests.java
@@ -333,7 +333,6 @@ public class ChangePointAggregatorTests extends AggregatorTestCase {
         });
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/103790")
     public void testStepChange() throws IOException {
         NormalDistribution normal = new NormalDistribution(RandomGeneratorFactory.createRandomGenerator(Randomness.get()), 0, 1);
         double[] bucketValues = DoubleStream.concat(
@@ -341,7 +340,15 @@ public class ChangePointAggregatorTests extends AggregatorTestCase {
             DoubleStream.generate(() -> 30 + normal.sample()).limit(20)
         ).toArray();
         testChangeType(bucketValues, changeType -> {
-            assertThat(Arrays.toString(bucketValues), changeType, instanceOf(ChangeType.StepChange.class));
+            assertThat(
+                Arrays.toString(bucketValues),
+                changeType,
+                anyOf(
+                    // Due to the random nature of the values generated, either of these could be detected
+                    instanceOf(ChangeType.StepChange.class),
+                    instanceOf(ChangeType.TrendChange.class)
+                )
+            );
             assertThat(changeType.changePoint(), equalTo(20));
         });
     }


### PR DESCRIPTION
We can get "unlucky" in this test and produce data which is more consistent with a trend before or after the change point. We are also now more sensitive to better data fit for complex hypotheses.

As long as we get the change at the correct point and either a step or trend change that's all we really care about; I've updated the test accordingly.

Fixes #103790.