### PR TITLE
[8.12] Migrate ESQL mixed cluster to new test framework (#103771)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/RestrictedBuildApiService.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/RestrictedBuildApiService.java
@@ -166,7 +166,6 @@ public abstract class RestrictedBuildApiService implements BuildService<Restrict
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:vector-tile:qa:multi-cluster");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:watcher:qa:rest");
         map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:watcher:qa:with-security");
-        map.put(LegacyRestTestBasePlugin.class, ":x-pack:plugin:esql:qa:server:mixed-cluster");
         return map;
     }
 

--- a/x-pack/plugin/esql/qa/server/mixed-cluster/build.gradle
+++ b/x-pack/plugin/esql/qa/server/mixed-cluster/build.gradle
@@ -4,15 +4,8 @@ import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
-apply plugin: 'elasticsearch.internal-testclusters'
-apply plugin: 'elasticsearch.standalone-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.bwc-test'
-apply plugin: 'elasticsearch.rest-resources'
-
-dependencies {
-  testImplementation project(xpackModule('esql:qa:testFixtures'))
-  testImplementation project(xpackModule('esql:qa:server'))
-}
 
 restResources {
   restApi {
@@ -23,36 +16,20 @@ restResources {
   }
 }
 
-BuildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
-
-  if (bwcVersion != VersionProperties.getElasticsearchVersion() && bwcVersion.onOrAfter(Version.fromString("8.11.0"))) {
-    def baseCluster = testClusters.register(baseName) {
-      versions = [bwcVersion.toString(), project.version]
-      numberOfNodes = 4
-      testDistribution = 'DEFAULT'
-      setting 'xpack.license.self_generated.type', 'trial'
-      setting 'xpack.security.enabled', 'false'
-      // disable relocation until we have retry in ESQL
-      setting 'cluster.routing.rebalance.enable', 'none'
-    }
-
-    tasks.register("${baseName}#mixedClusterTest", StandaloneRestIntegTestTask) {
-      useCluster baseCluster
-      mustRunAfter("precommit")
-      doFirst {
-        baseCluster.get().nextNodeToNextVersion()
-        baseCluster.get().nextNodeToNextVersion()
-      }
-      nonInputProperties.systemProperty('tests.rest.cluster', baseCluster.map(c -> c.allHttpSocketURI.join(",")))
-      nonInputProperties.systemProperty('tests.clustername', baseName)
-      systemProperty 'tests.bwc_nodes_version', bwcVersion.toString().replace('-SNAPSHOT', '')
-      systemProperty 'tests.new_nodes_version', project.version.toString().replace('-SNAPSHOT', '')
-      onlyIf("BWC tests disabled") { project.bwc_tests_enabled }
-    }
-
-    tasks.register(bwcTaskName(bwcVersion)) {
-      dependsOn "${baseName}#mixedClusterTest"
-    }
-  }
+dependencies {
+  javaRestTestImplementation project(xpackModule('esql:qa:testFixtures'))
+  javaRestTestImplementation project(xpackModule('esql:qa:server'))
 }
 
+def supportedVersion = bwcVersion -> {
+  // ESQL is available in 8.11 or later
+  return bwcVersion.onOrAfter(Version.fromString("8.11.0"));
+}
+
+BuildParams.bwcVersions.withWireCompatible(supportedVersion) { bwcVersion, baseName ->
+  tasks.register(bwcTaskName(bwcVersion), StandaloneRestIntegTestTask) {
+    usesBwcDistribution(bwcVersion)
+    systemProperty("tests.old_cluster_version", bwcVersion)
+    maxParallelForks = 1
+  }
+}

--- a/x-pack/plugin/esql/qa/server/mixed-cluster/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/mixed/Clusters.java
+++ b/x-pack/plugin/esql/qa/server/mixed-cluster/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/mixed/Clusters.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.qa.mixed;
+
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.local.distribution.DistributionType;
+import org.elasticsearch.test.cluster.util.Version;
+
+public class Clusters {
+    public static ElasticsearchCluster mixedVersionCluster() {
+        Version oldVersion = Version.fromString(System.getProperty("tests.old_cluster_version"));
+        return ElasticsearchCluster.local()
+            .distribution(DistributionType.DEFAULT)
+            .withNode(node -> node.version(oldVersion))
+            .withNode(node -> node.version(Version.CURRENT))
+            .withNode(node -> node.version(oldVersion))
+            .withNode(node -> node.version(Version.CURRENT))
+            .setting("xpack.security.enabled", "false")
+            .setting("xpack.license.self_generated.type", "trial")
+            .setting("cluster.routing.rebalance.enable", "none") // disable relocation until we have retry in ESQL
+            .shared(true)
+            .build();
+    }
+}

--- a/x-pack/plugin/esql/qa/server/mixed-cluster/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/mixed/EsqlClientYamlIT.java
+++ b/x-pack/plugin/esql/qa/server/mixed-cluster/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/mixed/EsqlClientYamlIT.java
@@ -8,14 +8,26 @@
 package org.elasticsearch.xpack.esql.qa.mixed;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
 
+import org.elasticsearch.test.TestClustersThreadFilter;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
 import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
 import org.elasticsearch.xpack.esql.qa.rest.EsqlSpecTestCase;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
 
+@ThreadLeakFilters(filters = TestClustersThreadFilter.class)
 public class EsqlClientYamlIT extends ESClientYamlSuiteTestCase {
+    @ClassRule
+    public static ElasticsearchCluster cluster = Clusters.mixedVersionCluster();
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
+    }
 
     public EsqlClientYamlIT(final ClientYamlTestCandidate testCandidate) {
         super(testCandidate);

--- a/x-pack/plugin/esql/qa/server/mixed-cluster/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/mixed/MixedClusterEsqlSpecIT.java
+++ b/x-pack/plugin/esql/qa/server/mixed-cluster/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/mixed/MixedClusterEsqlSpecIT.java
@@ -7,18 +7,30 @@
 
 package org.elasticsearch.xpack.esql.qa.mixed;
 
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
+
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.Version;
+import org.elasticsearch.test.TestClustersThreadFilter;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.xpack.esql.qa.rest.EsqlSpecTestCase;
 import org.elasticsearch.xpack.ql.CsvSpecReader.CsvTestCase;
+import org.junit.ClassRule;
 
 import static org.elasticsearch.xpack.esql.CsvTestUtils.isEnabled;
 
+@ThreadLeakFilters(filters = TestClustersThreadFilter.class)
 @LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/103765")
 public class MixedClusterEsqlSpecIT extends EsqlSpecTestCase {
+    @ClassRule
+    public static ElasticsearchCluster cluster = Clusters.mixedVersionCluster();
 
-    static final Version bwcVersion = Version.fromString(System.getProperty("tests.bwc_nodes_version"));
-    static final Version newVersion = Version.fromString(System.getProperty("tests.new_nodes_version"));
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
+    }
+
+    static final Version bwcVersion = Version.fromString(System.getProperty("tests.old_cluster_version"));
 
     public MixedClusterEsqlSpecIT(String fileName, String groupName, String testName, Integer lineNumber, CsvTestCase testCase) {
         super(fileName, groupName, testName, lineNumber, testCase);
@@ -26,7 +38,7 @@ public class MixedClusterEsqlSpecIT extends EsqlSpecTestCase {
 
     @Override
     protected void shouldSkipTest(String testName) {
+        super.shouldSkipTest(testName);
         assumeTrue("Test " + testName + " is skipped on " + bwcVersion, isEnabled(testName, bwcVersion));
-        assumeTrue("Test " + testName + " is skipped on " + newVersion, isEnabled(testName, newVersion));
     }
 }


### PR DESCRIPTION
Backports the following commits to 8.12:
 - Migrate ESQL mixed cluster to new test framework (#103771)