### PR TITLE
[8.11] [DOCS] Warn against using ES|QL on production environments (#103797)

### DIFF
--- a/docs/reference/esql/esql-get-started.asciidoc
+++ b/docs/reference/esql/esql-get-started.asciidoc
@@ -5,6 +5,8 @@
 <titleabbrev>Getting started</titleabbrev>
 ++++
 
+preview::["Do not use {esql} on production environments. This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features."]
+
 This guide shows how you can use {esql} to query and aggregate your data.
 
 [discrete]

--- a/docs/reference/esql/index.asciidoc
+++ b/docs/reference/esql/index.asciidoc
@@ -6,7 +6,7 @@
 
 [partintro]
 
-preview::[]
+preview::["Do not use {esql} on production environments. This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features."]
 
 The {es} Query Language ({esql}) provides a powerful way to filter, transform,
 and analyze data stored in {es}, and in the future in other runtimes. It is


### PR DESCRIPTION
Backports the following commits to 8.11:
 - [DOCS] Warn against using ES|QL on production environments (#103797)