### PR TITLE
ESQL: Add single value checks on LIKE/RLIKE pushdown

### DIFF
--- a/docs/changelog/103807.yaml
+++ b/docs/changelog/103807.yaml
@@ -1,0 +1,6 @@
+pr: 103807
+summary: "ESQL: Add single value checks on LIKE/RLIKE pushdown"
+area: ES|QL
+type: bug
+issues:
+ - 103806

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/where-like.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/where-like.csv-spec
@@ -298,3 +298,24 @@ FROM sample_data
 
 @timestamp:date | client_ip:ip | event_duration:long | message:keyword
 ;
+
+multiValueLike
+from employees | where job_positions like "Account*" | keep emp_no, job_positions;
+
+warning:Line 1:24: evaluation of [job_positions like \"Account*\"] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 1:24: java.lang.IllegalArgumentException: single-value function encountered multi-value
+
+emp_no:integer | job_positions:keyword 
+10025          | Accountant 
+;
+
+
+multiValueRLike
+from employees | where job_positions rlike "Account.*" | keep emp_no, job_positions;
+
+warning:Line 1:24: evaluation of [job_positions rlike \"Account.*\"] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 1:24: java.lang.IllegalArgumentException: single-value function encountered multi-value
+
+emp_no:integer | job_positions:keyword 
+10025          | Accountant 
+;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
@@ -1388,8 +1388,9 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
 
         QueryBuilder query = source.query();
         assertNotNull(query);
-        assertEquals(WildcardQueryBuilder.class, query.getClass());
-        WildcardQueryBuilder wildcard = ((WildcardQueryBuilder) query);
+        assertEquals(SingleValueQuery.Builder.class, query.getClass());
+        assertThat(((SingleValueQuery.Builder) query).next(), instanceOf(WildcardQueryBuilder.class));
+        WildcardQueryBuilder wildcard = ((WildcardQueryBuilder) ((SingleValueQuery.Builder) query).next());
         assertEquals("first_name", wildcard.fieldName());
         assertEquals("*foo*", wildcard.value());
     }
@@ -1453,8 +1454,9 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
 
         QueryBuilder query = source.query();
         assertNotNull(query);
-        assertEquals(RegexpQueryBuilder.class, query.getClass());
-        RegexpQueryBuilder wildcard = ((RegexpQueryBuilder) query);
+        assertEquals(SingleValueQuery.Builder.class, query.getClass());
+        assertThat(((SingleValueQuery.Builder) query).next(), instanceOf(RegexpQueryBuilder.class));
+        RegexpQueryBuilder wildcard = ((RegexpQueryBuilder) ((SingleValueQuery.Builder) query).next());
         assertEquals("first_name", wildcard.fieldName());
         assertEquals(".*foo.*", wildcard.value());
     }
@@ -1475,8 +1477,9 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
 
         QueryBuilder query = source.query();
         assertNotNull(query);
-        assertThat(query, instanceOf(BoolQueryBuilder.class));
-        var boolQuery = (BoolQueryBuilder) query;
+        assertThat(query, instanceOf(SingleValueQuery.Builder.class));
+        assertThat(((SingleValueQuery.Builder) query).next(), instanceOf(BoolQueryBuilder.class));
+        var boolQuery = (BoolQueryBuilder) ((SingleValueQuery.Builder) query).next();
         List<QueryBuilder> mustNot = boolQuery.mustNot();
         assertThat(mustNot.size(), is(1));
         assertThat(mustNot.get(0), instanceOf(RegexpQueryBuilder.class));

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/planner/ExpressionTranslators.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/planner/ExpressionTranslators.java
@@ -133,7 +133,7 @@ public final class ExpressionTranslators {
             Expression field = e.field();
 
             if (field instanceof FieldAttribute fa) {
-                q = translateField(e, handler.nameOf(fa.exactAttribute()));
+                return handler.wrapFunctionQuery(e, fa, () -> translateField(e, handler.nameOf(fa.exactAttribute())));
             } else if (field instanceof MetadataAttribute ma) {
                 q = translateField(e, handler.nameOf(ma));
             } else {


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/103806

Using `SingleValueQuery` also when pushing down LIKE/RLIKE filters, so that the MV semantics are preserved also in this case (ie. that `multi_value LIKE "something*"` always returns false, same as it does for all the other binary operators, and as it does in case of no push-down)