### PR TITLE
[7.17] Support different snyk organisations (#97808)

### DIFF
--- a/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/snyk/SnykDependencyMonitoringGradlePluginFuncTest.groovy
+++ b/build-tools-internal/src/integTest/groovy/org/elasticsearch/gradle/internal/snyk/SnykDependencyMonitoringGradlePluginFuncTest.groovy
@@ -34,18 +34,22 @@ class SnykDependencyMonitoringGradlePluginFuncTest extends AbstractGradleInterna
             version = "$version"
 
             repositories {
-                mavenCentral() 
+                mavenCentral()
             }
-            
+
             dependencies {
                 implementation 'org.apache.lucene:lucene-monitor:9.2.0'
+            }
+
+            tasks.named('generateSnykDependencyGraph').configure {
+                remoteUrl = "http://acme.org"
             }
         """
         when:
         def build = gradleRunner("generateSnykDependencyGraph").build()
         then:
         build.task(":generateSnykDependencyGraph").outcome == TaskOutcome.SUCCESS
-        JSONAssert.assertEquals(file("build/snyk/dependencies.json").text, """{
+        JSONAssert.assertEquals("""{
             "meta": {
                 "method": "custom gradle",
                 "id": "gradle",
@@ -100,7 +104,7 @@ class SnykDependencyMonitoringGradlePluginFuncTest extends AbstractGradleInterna
                         {
                             "nodeId": "org.apache.lucene:lucene-core@9.2.0",
                             "deps": [
-                                
+
                             ],
                             "pkgId": "org.apache.lucene:lucene-core@9.2.0"
                         },
@@ -154,7 +158,7 @@ class SnykDependencyMonitoringGradlePluginFuncTest extends AbstractGradleInterna
                 ]
             },
             "target": {
-                "remoteUrl": "http://github.com/elastic/elasticsearch.git",
+                "remoteUrl": "http://acme.org",
                 "branch": "unknown"
             },
             "targetReference": "$version",
@@ -163,7 +167,7 @@ class SnykDependencyMonitoringGradlePluginFuncTest extends AbstractGradleInterna
                   "$expectedLifecycle"
                 ]
             }
-        }""", true)
+        }""", file("build/snyk/dependencies.json").text, true)
 
         where:
         version        | expectedLifecycle

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/snyk/GenerateSnykDependencyGraph.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/snyk/GenerateSnykDependencyGraph.java
@@ -57,6 +57,7 @@ public class GenerateSnykDependencyGraph extends DefaultTask {
     private final Property<String> projectPath;
     private final Property<String> targetReference;
     private final Property<String> version;
+    private final Property<String> remoteUrl;
 
     @Inject
     public GenerateSnykDependencyGraph(ObjectFactory objectFactory) {
@@ -66,6 +67,7 @@ public class GenerateSnykDependencyGraph extends DefaultTask {
         projectName = objectFactory.property(String.class);
         projectPath = objectFactory.property(String.class);
         version = objectFactory.property(String.class);
+        remoteUrl = objectFactory.property(String.class);
         targetReference = objectFactory.property(String.class);
     }
 
@@ -115,7 +117,7 @@ public class GenerateSnykDependencyGraph extends DefaultTask {
     }
 
     private Object buildTargetData() {
-        return Map.of("remoteUrl", "http://github.com/elastic/elasticsearch.git", "branch", BuildParams.getGitRevision());
+        return Map.of("remoteUrl", remoteUrl.get(), "branch", BuildParams.getGitRevision());
     }
 
     @InputFiles
@@ -146,6 +148,11 @@ public class GenerateSnykDependencyGraph extends DefaultTask {
     @Input
     public Property<String> getGradleVersion() {
         return gradleVersion;
+    }
+
+    @Input
+    public Property<String> getRemoteUrl() {
+        return remoteUrl;
     }
 
     @Input

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/snyk/UploadSnykDependenciesGraph.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/snyk/UploadSnykDependenciesGraph.java
@@ -42,12 +42,12 @@ public class UploadSnykDependenciesGraph extends DefaultTask {
     private final RegularFileProperty inputFile;
     private final Property<String> token;
     private final Property<String> url;
-    private final Property<String> projectId;
+    private final Property<String> snykOrganisation;
 
     @Inject
     public UploadSnykDependenciesGraph(ObjectFactory objectFactory) {
         url = objectFactory.property(String.class).convention(DEFAULT_SERVER + GRADLE_GRAPH_ENDPOINT);
-        projectId = objectFactory.property(String.class);
+        snykOrganisation = objectFactory.property(String.class);
         token = objectFactory.property(String.class);
         inputFile = objectFactory.fileProperty();
     }
@@ -76,7 +76,7 @@ public class UploadSnykDependenciesGraph extends DefaultTask {
 
     private String calculateEffectiveEndpoint() {
         String url = this.url.get();
-        return url.endsWith(GRADLE_GRAPH_ENDPOINT) ? url : projectId.map(id -> url + "?org=" + id).getOrElse(url);
+        return snykOrganisation.map(id -> url + "?org=" + id).getOrElse(url);
     }
 
     @Input
@@ -91,8 +91,8 @@ public class UploadSnykDependenciesGraph extends DefaultTask {
 
     @Input
     @Optional
-    public Property<String> getProjectId() {
-        return projectId;
+    public Property<String> getSnykOrganisation() {
+        return snykOrganisation;
     }
 
     @InputFile


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Support different snyk organisations (#97808)](https://github.com/elastic/elasticsearch/pull/97808)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)