### PR TITLE
Minor doc fixes for PKI realm

### DIFF
--- a/docs/reference/security/authentication/configuring-pki-realm.asciidoc
+++ b/docs/reference/security/authentication/configuring-pki-realm.asciidoc
@@ -6,11 +6,6 @@ the desired network layers (transport or http), and map the Distinguished Names
 (DNs) from the Subject field in the user certificates to roles. You create the
 mappings in a role mapping file or use the role mappings API.
 
-TIP: You can use a combination of PKI and username/password authentication. For
-example, you can enable SSL/TLS on the transport layer and define a PKI realm to
-require transport clients to authenticate with X.509 certificates, while still
-authenticating HTTP traffic using username and password credentials.
-
 . Add a realm configuration for a `pki` realm to `elasticsearch.yml` under the
 `xpack.security.authc.realms.pki` namespace. You must explicitly set the `order`
 attribute. See <<ref-pki-settings>> for all of the options you can set for a
@@ -42,7 +37,8 @@ realms you specify are used for authentication. If you also want to use the
 
 --
 
-. Optional: If you want to use something other than the CN of the Subject DN as
+. Optional: The username (as defined by the username_pattern) is used for auditing and logging.
+If you want to use something other than the CN of the Subject DN as
 the username, you can specify a regex to extract the desired username. The regex
 is applied on the Subject DN.
 +

--- a/docs/reference/security/authentication/configuring-pki-realm.asciidoc
+++ b/docs/reference/security/authentication/configuring-pki-realm.asciidoc
@@ -37,7 +37,7 @@ realms you specify are used for authentication. If you also want to use the
 
 --
 
-. Optional: The username (as defined by the username_pattern) is used for auditing and logging.
+. Optional: The username is defined by the <<ref-pki-settings, username_pattern>>.
 If you want to use something other than the CN of the Subject DN as
 the username, you can specify a regex to extract the desired username. The regex
 is applied on the Subject DN.

--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -1015,7 +1015,8 @@ the following settings:
 `username_pattern`::
 (<<static-cluster-setting,Static>>)
 The regular expression pattern used to extract the username from the
-certificate DN. The username is used for auditing and logging (not role mapping).
+certificate DN. The username is used for auditing and logging. The username can also be used
+with the <<role-mapping-resources, role mapping API>> and <<configuring-authorization-delegation, authorization delegation>>.
 The first match group is the used as the username.
 Defaults to `CN=(.*?)(?:,|$)`.
 

--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -1015,8 +1015,9 @@ the following settings:
 `username_pattern`::
 (<<static-cluster-setting,Static>>)
 The regular expression pattern used to extract the username from the
-certificate DN. The first match group is the used as the username.
-Defaults to `CN=(.*?)(?:,\|$)`.
+certificate DN. The username is used for auditing and logging (not role mapping).
+The first match group is the used as the username.
+Defaults to `CN=(.*?)(?:,|$)`.
 
 `certificate_authorities`::
 (<<static-cluster-setting,Static>>)


### PR DESCRIPTION
Remove the reference to the transport client and clarify the usage of `username_pattern`
