### PR TITLE
Re-enable spec tests in mixed cluster (#103832)

### DIFF
--- a/x-pack/plugin/esql/qa/server/mixed-cluster/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/mixed/MixedClusterEsqlSpecIT.java
+++ b/x-pack/plugin/esql/qa/server/mixed-cluster/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/mixed/MixedClusterEsqlSpecIT.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.esql.qa.mixed;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
 
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.Version;
 import org.elasticsearch.test.TestClustersThreadFilter;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
@@ -20,7 +19,6 @@ import org.junit.ClassRule;
 import static org.elasticsearch.xpack.esql.CsvTestUtils.isEnabled;
 
 @ThreadLeakFilters(filters = TestClustersThreadFilter.class)
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/103765")
 public class MixedClusterEsqlSpecIT extends EsqlSpecTestCase {
     @ClassRule
     public static ElasticsearchCluster cluster = Clusters.mixedVersionCluster();

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -435,7 +435,7 @@ g:keyword  | l:integer
  null      | 5
 ;
 
-repetitiveAggregation
+repetitiveAggregation#[skip:-8.11.99,reason:ReplaceDuplicateAggWithEval breaks bwc]
 from employees | stats m1 = max(salary), m2 = min(salary), m3 = min(salary), m4 = max(salary);
 
 m1:i | m2:i | m3:i | m4:i

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats_percentile.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats_percentile.csv-spec
@@ -70,14 +70,14 @@ NULL
 ;
 
 
-medianOfLong
+medianOfLong#[skip:-8.11.99,reason:ReplaceDuplicateAggWithEval breaks bwc gh-103765]
 from employees | stats m = median(salary_change.long), p50 = percentile(salary_change.long, 50);
 
 m:double   | p50:double
 0          | 0 
 ;
 
-medianOfInteger
+medianOfInteger#[skip:-8.11.99,reason:ReplaceDuplicateAggWithEval breaks bwc gh-103765]
 // tag::median[]
 FROM employees
 | STATS MEDIAN(salary), PERCENTILE(salary, 50)
@@ -90,7 +90,7 @@ MEDIAN(salary):double | PERCENTILE(salary,50):double
 // end::median-result[]
 ;
 
-medianOfDouble
+medianOfDouble#[skip:-8.11.99,reason:ReplaceDuplicateAggWithEval breaks bwc gh-103765]
 from employees | stats m = median(salary_change), p50 = percentile(salary_change, 50);
 
 m:double   | p50:double
@@ -98,7 +98,7 @@ m:double   | p50:double
 ;
 
 
-medianOfLongByKeyword
+medianOfLongByKeyword#[skip:-8.11.99,reason:ReplaceDuplicateAggWithEval breaks bwc gh-103765]
 from employees | stats m = median(salary_change.long), p50 = percentile(salary_change.long, 50) by job_positions | sort m desc | limit 4;
 
 m:double   | p50:double        | job_positions:keyword
@@ -109,7 +109,7 @@ m:double   | p50:double        | job_positions:keyword
 ;
 
 
-medianOfIntegerByKeyword
+medianOfIntegerByKeyword#[skip:-8.11.99,reason:ReplaceDuplicateAggWithEval breaks bwc gh-103765]
 from employees | stats m = median(salary), p50 = percentile(salary, 50) by job_positions | sort m | limit 4;
 
 m:double   | p50:double      | job_positions:keyword
@@ -120,7 +120,7 @@ m:double   | p50:double      | job_positions:keyword
 ;
 
 
-medianOfDoubleByKeyword
+medianOfDoubleByKeyword#[skip:-8.11.99,reason:ReplaceDuplicateAggWithEval breaks bwc gh-103765]
 from employees | stats m = median(salary_change), p50 = percentile(salary_change, 50)by job_positions | sort m desc | limit 4;
 
 m:double           | p50:double           | job_positions:keyword


### PR DESCRIPTION
This pull request re-enables ESQL spec tests in a mixed cluster by implementing these changes:

1. Skipping spec tests with repeated aggregations in a mixed cluster between versions 8.11 and 8.12+ due to the impact of the ReplaceDuplicateAggWithEval rule.

2. Avoiding access to the block factory in the InMapper constructor to prevent AssertionError when the driver context is ThrowingContextDriver.

Closes #103765
