### PR TITLE
ESQL: Skip bwc tests for LIKE/RLIKE on MV before v 8.13

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/where-like.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/where-like.csv-spec
@@ -299,7 +299,7 @@ FROM sample_data
 @timestamp:date | client_ip:ip | event_duration:long | message:keyword
 ;
 
-multiValueLike
+multiValueLike#[skip:-8.12.99]
 from employees | where job_positions like "Account*" | keep emp_no, job_positions;
 
 warning:Line 1:24: evaluation of [job_positions like \"Account*\"] failed, treating result as null. Only first 20 failures recorded.
@@ -310,7 +310,7 @@ emp_no:integer | job_positions:keyword
 ;
 
 
-multiValueRLike
+multiValueRLike#[skip:-8.12.99]
 from employees | where job_positions rlike "Account.*" | keep emp_no, job_positions;
 
 warning:Line 1:24: evaluation of [job_positions rlike \"Account.*\"] failed, treating result as null. Only first 20 failures recorded.


### PR DESCRIPTION
Disabling bwc tests for LIKE/RLIKE pushdown before v 8.13 (where the fix was intruduced, see https://github.com/elastic/elasticsearch/pull/103807)