### PR TITLE
[7.17] Only run snyk for 7.17 and main branch (#103820)

### DIFF
--- a/.buildkite/pipelines/periodic.yml
+++ b/.buildkite/pipelines/periodic.yml
@@ -1370,7 +1370,7 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: n2-standard-8
       buildDirectory: /dev/shm/bk
-    if: build.branch == "main" || build.branch =~ /^[0-9]+\.[0-9]+\$/
+    if: build.branch == "main" || build.branch == "7.17"
   - label: Check branch consistency
     command: .ci/scripts/run-gradle.sh branchConsistency
     timeout_in_minutes: 15


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Only run snyk for 7.17 and main branch (#103820)