### PR TITLE
Mute DownsampleActionIT.testDownsampleTwiceSameInterval

### DIFF
--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/DownsampleActionIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/DownsampleActionIT.java
@@ -494,6 +494,7 @@ public class DownsampleActionIT extends ESRestTestCase {
         }
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/101428")
     public void testDownsampleTwiceSameInterval() throws Exception {
         // Create the ILM policy
         Request request = new Request("PUT", "_ilm/policy/" + policy);


### PR DESCRIPTION
Muting DownsampleActionIT.testDownsampleTwiceSameInterval, see https://github.com/elastic/elasticsearch/issues/101428