### PR TITLE
Cache ObjectMappers to prevent continual recursion during dynamic mapper building

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/index/mapper/DynamicMapperBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/index/mapper/DynamicMapperBenchmark.java
@@ -108,7 +108,8 @@ public class DynamicMapperBenchmark {
             if (random.nextBoolean()) {
                 continue;
             }
-            String objFieldPrefix = Stream.generate(() -> "obj_field_" + idx).limit(objFieldDepth).collect(Collectors.joining("."));
+            int objFieldDepthActual = random.nextInt(1, objFieldDepth);
+            String objFieldPrefix = Stream.generate(() -> "obj_field_" + idx).limit(objFieldDepthActual).collect(Collectors.joining("."));
             for (int j = 0; j < textFields; j++) {
                 if (random.nextBoolean()) {
                     StringBuilder fieldValueBuilder = generateTextField(fieldValueCountMax);

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/index/mapper/MapperServiceFactory.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/index/mapper/MapperServiceFactory.java
@@ -45,7 +45,7 @@ public class MapperServiceFactory {
             .put("index.number_of_replicas", 0)
             .put("index.number_of_shards", 1)
             .put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current())
-            .put("index.mapping.total_fields.limit", 10000)
+            .put("index.mapping.total_fields.limit", 100000)
             .build();
         IndexMetadata meta = IndexMetadata.builder("index").settings(settings).build();
         IndexSettings indexSettings = new IndexSettings(meta, settings);

--- a/docs/changelog/103858.yaml
+++ b/docs/changelog/103858.yaml
@@ -1,0 +1,6 @@
+pr: 103858
+summary: Cache `ObjectMappers` to prevent continual recursion during dynamic mapper
+  building
+area: Mapping
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentMapper.java
@@ -27,9 +27,10 @@ public class DocumentMapper {
      * @return the newly created document mapper
      */
     public static DocumentMapper createEmpty(MapperService mapperService) {
-        RootObjectMapper root = new RootObjectMapper.Builder(MapperService.SINGLE_MAPPING_NAME, ObjectMapper.Defaults.SUBOBJECTS).build(
-            MapperBuilderContext.root(false, false)
-        );
+        RootObjectMapper root = (RootObjectMapper) new RootObjectMapper.Builder(
+            MapperService.SINGLE_MAPPING_NAME,
+            ObjectMapper.Defaults.SUBOBJECTS
+        ).build(MapperBuilderContext.root(false, false));
         MetadataFieldMapper[] metadata = mapperService.getMetadataMappers().values().toArray(new MetadataFieldMapper[0]);
         Mapping mapping = new Mapping(root, metadata, null);
         return new DocumentMapper(mapperService.documentParser(), mapping, mapping.toCompressedXContent(), IndexVersion.current());

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -256,7 +256,9 @@ public final class DocumentParser {
         for (RuntimeField runtimeField : context.getDynamicRuntimeFields()) {
             rootBuilder.addRuntimeField(runtimeField);
         }
-        RootObjectMapper root = rootBuilder.build(MapperBuilderContext.root(context.mappingLookup().isSourceSynthetic(), false));
+        RootObjectMapper root = (RootObjectMapper) rootBuilder.build(
+            MapperBuilderContext.root(context.mappingLookup().isSourceSynthetic(), false)
+        );
         return context.mappingLookup().getMapping().mappingUpdate(root);
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/Mapping.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Mapping.java
@@ -29,7 +29,7 @@ import java.util.Map;
 public final class Mapping implements ToXContentFragment {
 
     public static final Mapping EMPTY = new Mapping(
-        new RootObjectMapper.Builder(MapperService.SINGLE_MAPPING_NAME, ObjectMapper.Defaults.SUBOBJECTS).build(
+        (RootObjectMapper) new RootObjectMapper.Builder(MapperService.SINGLE_MAPPING_NAME, ObjectMapper.Defaults.SUBOBJECTS).build(
             MapperBuilderContext.root(false, false)
         ),
         new MetadataFieldMapper[0],

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappingParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappingParser.java
@@ -178,7 +178,7 @@ public final class MappingParser {
         }
 
         return new Mapping(
-            rootObjectMapper.build(MapperBuilderContext.root(isSourceSynthetic, isDataStream)),
+            (RootObjectMapper) rootObjectMapper.build(MapperBuilderContext.root(isSourceSynthetic, isDataStream)),
             metadataMappers.values().toArray(new MetadataFieldMapper[0]),
             meta
         );

--- a/server/src/main/java/org/elasticsearch/index/mapper/NestedObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NestedObjectMapper.java
@@ -38,17 +38,19 @@ public class NestedObjectMapper extends ObjectMapper {
         }
 
         Builder includeInRoot(boolean includeInRoot) {
+            clearObjectMapperCache();
             this.includeInRoot = Explicit.explicitBoolean(includeInRoot);
             return this;
         }
 
         Builder includeInParent(boolean includeInParent) {
+            clearObjectMapperCache();
             this.includeInParent = Explicit.explicitBoolean(includeInParent);
             return this;
         }
 
         @Override
-        public NestedObjectMapper build(MapperBuilderContext context) {
+        protected NestedObjectMapper doBuild(MapperBuilderContext context) {
             boolean parentIncludedInRoot = this.includeInRoot.value();
             if (context instanceof NestedMapperBuilderContext nc) {
                 // we're already inside a nested mapper, so adjust our includes

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -90,13 +90,13 @@ public class ObjectMapper extends Mapper {
             this.subobjects = subobjects;
         }
 
-        public Builder enabled(boolean enabled) {
+        public final Builder enabled(boolean enabled) {
             this.enabled = Explicit.explicitBoolean(enabled);
             clearObjectMapperCache();
             return this;
         }
 
-        public Builder dynamic(Dynamic dynamic) {
+        public final Builder dynamic(Dynamic dynamic) {
             this.dynamic = dynamic;
             clearObjectMapperCache();
             return this;
@@ -180,12 +180,8 @@ public class ObjectMapper extends Mapper {
             return mappers;
         }
 
-        @Override
-        public ObjectMapper build(MapperBuilderContext context) {
-            if (objectMapperCache != null) {
-                return objectMapperCache;
-            }
-            objectMapperCache = new ObjectMapper(
+        protected ObjectMapper doBuild(MapperBuilderContext context) {
+            return new ObjectMapper(
                 name,
                 context.buildFullName(name),
                 enabled,
@@ -193,10 +189,18 @@ public class ObjectMapper extends Mapper {
                 dynamic,
                 buildMappers(context.createChildContext(name))
             );
+        }
+
+        @Override
+        public final ObjectMapper build(MapperBuilderContext context) {
+            if (objectMapperCache != null) {
+                return objectMapperCache;
+            }
+            objectMapperCache = doBuild(context);
             return objectMapperCache;
         }
 
-        private void clearObjectMapperCache() {
+        protected void clearObjectMapperCache() {
             objectMapperCache = null;
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
@@ -79,22 +79,26 @@ public class RootObjectMapper extends ObjectMapper {
         }
 
         public Builder dynamicDateTimeFormatter(Collection<DateFormatter> dateTimeFormatters) {
+            clearObjectMapperCache();
             this.dynamicDateTimeFormatters = new Explicit<>(dateTimeFormatters.toArray(new DateFormatter[0]), true);
             return this;
         }
 
         public Builder dynamicTemplates(Collection<DynamicTemplate> templates) {
+            clearObjectMapperCache();
             this.dynamicTemplates = new Explicit<>(templates.toArray(new DynamicTemplate[0]), true);
             return this;
         }
 
         @Override
         public RootObjectMapper.Builder add(Mapper.Builder builder) {
+            clearObjectMapperCache();
             super.add(builder);
             return this;
         }
 
         public RootObjectMapper.Builder addRuntimeField(RuntimeField runtimeField) {
+            clearObjectMapperCache();
             this.runtimeFields.put(runtimeField.name(), runtimeField);
             return this;
         }
@@ -105,7 +109,7 @@ public class RootObjectMapper extends ObjectMapper {
         }
 
         @Override
-        public RootObjectMapper build(MapperBuilderContext context) {
+        protected RootObjectMapper doBuild(MapperBuilderContext context) {
             return new RootObjectMapper(
                 name,
                 enabled,


### PR DESCRIPTION
When building dynamic mappers, it is possible to recurse down the ObjectMapper tree more than once. If the ObjectMapper.Builder keeps rebuilding the objects every time, even if there is no change, the runtime increases significantly.

This commit addresses this by caching the ObjectMapper that is built by the Builder. Invalidating the cache when something is changed.

closes: https://github.com/elastic/elasticsearch/issues/103011