### PR TITLE
[DOCS] Use shortened URL to link to ES|QL demo env

### DIFF
--- a/docs/reference/tab-widgets/esql/esql-getting-started-enrich-policy.asciidoc
+++ b/docs/reference/tab-widgets/esql/esql-getting-started-enrich-policy.asciidoc
@@ -58,9 +58,9 @@ DELETE /_enrich/policy/clientip_policy
 
 // tag::demo-env[]
 
-On the demo environment at https://esql.demo.elastic.co/[esql.demo.elastic.co],
+On the demo environment at https://ela.st/ql/[ela.st/ql],
 an enrich policy called `clientip_policy` has already been created an executed.
 The policy links an IP address to an environment ("Development", "QA", or
-"Production")
+"Production").
 
 // end::demo-env[]

--- a/docs/reference/tab-widgets/esql/esql-getting-started-sample-data.asciidoc
+++ b/docs/reference/tab-widgets/esql/esql-getting-started-sample-data.asciidoc
@@ -43,6 +43,6 @@ PUT sample_data/_bulk
 
 The data set used in this guide has been preloaded into the Elastic {esql}
 public demo environment. Visit
-https://esql.demo.elastic.co/[esql.demo.elastic.co] to start using it.
+https://ela.st/ql[ela.st/ql] to start using it.
 
 // end::demo-env[]


### PR DESCRIPTION
At the request of the PMM team (@radoondas ), use the shortened URL [ela.st/ql](https://ela.st/ql) to link to the ES|QL demo environment.