### PR TITLE
[8.12] [DOCS] Stop recommending dot_product over cosine similarity (#103856)

### DIFF
--- a/docs/reference/how-to/knn-search.asciidoc
+++ b/docs/reference/how-to/knn-search.asciidoc
@@ -11,21 +11,6 @@ the indexing algorithm runs searches under the hood to create the vector index
 structures. So these same recommendations also help with indexing speed.
 
 [discrete]
-=== Prefer `dot_product` over `cosine`
-
-When indexing vectors for approximate kNN search, you need to specify the
-<<dense-vector-similarity, `similarity` function>> for comparing the vectors.
-If you'd like to compare vectors through cosine similarity, there are two
-options.
-
-The `cosine` option accepts any float vector and computes the cosine
-similarity. While this is convenient for testing, it's not the most efficient
-approach. Instead, we recommend using the `dot_product` option to compute the
-similarity. To use `dot_product`, all vectors need to be normalized in advance
-to have length 1. The `dot_product` option is significantly faster, since it
-avoids performing extra vector length computations during the search.
-
-[discrete]
 === Ensure data nodes have enough memory
 
 {es} uses the https://arxiv.org/abs/1603.09320[HNSW] algorithm for approximate
@@ -52,12 +37,10 @@ of datasets and configurations that we use for our nightly benchmarks.
 include::search-speed.asciidoc[tag=warm-fs-cache]
 
 The following file extensions are used for the approximate kNN search:
-+
---
+
 * `vec` and `veq` for vector values
 * `vex` for HNSW graph
 * `vem`, `vemf`, and `vemq` for metadata
---
 
 [discrete]
 === Reduce vector dimensionality


### PR DESCRIPTION
Backports the following commits to 8.12:
 - [DOCS] Stop recommending dot_product over cosine similarity (#103856)