### PR TITLE
[ES|QL] Add function - improve test coverge (#102830)

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractFunctionTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractFunctionTestCase.java
@@ -235,7 +235,8 @@ public abstract class AbstractFunctionTestCase extends ESTestCase {
         assertFalse("expected resolved", expression.typeResolved().unresolved());
         expression = new FoldNull().rule(expression);
         assertThat(expression.dataType(), equalTo(testCase.expectedType));
-        // TODO should we convert unsigned_long into BigDecimal so it's easier to assert?
+        logger.info("Result type: " + expression.dataType());
+
         Object result;
         try (ExpressionEvaluator evaluator = evaluator(expression).get(driverContext())) {
             try (Block block = evaluator.eval(row(testCase.getDataValues()))) {
@@ -722,6 +723,10 @@ public abstract class AbstractFunctionTestCase extends ESTestCase {
         return suppliers;
     }
 
+    /**
+     * Validate that we know the types for all the test cases already created
+     * @param suppliers - list of suppliers before adding in the illegal type combinations
+     */
     private static void typesRequired(List<TestCaseSupplier> suppliers) {
         String bad = suppliers.stream().filter(s -> s.types() == null).map(s -> s.name()).collect(Collectors.joining("\n"));
         if (bad.equals("") == false) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/TestCaseSupplier.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/TestCaseSupplier.java
@@ -23,10 +23,13 @@ import org.elasticsearch.xpack.versionfield.Version;
 import org.hamcrest.Matcher;
 
 import java.math.BigInteger;
+import java.time.Duration;
 import java.time.Instant;
+import java.time.Period;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.BiFunction;
 import java.util.function.BinaryOperator;
 import java.util.function.DoubleFunction;
 import java.util.function.Function;
@@ -165,12 +168,42 @@ public record TestCaseSupplier(String name, List<DataType> types, Supplier<TestC
         List<String> warnings
     ) {
         List<TestCaseSupplier> suppliers = new ArrayList<>();
+        casesCrossProduct(
+            (l, r) -> expected.apply(((Number) l).doubleValue(), ((Number) r).doubleValue()),
+            lhsSuppliers,
+            rhsSuppliers,
+            (lhsType, rhsType) -> name
+                + "["
+                + lhsName
+                + "="
+                + castToDoubleEvaluator("Attribute[channel=0]", lhsType)
+                + ", "
+                + rhsName
+                + "="
+                + castToDoubleEvaluator("Attribute[channel=1]", rhsType)
+                + "]",
+            warnings,
+            suppliers,
+            DataTypes.DOUBLE
+        );
+        return suppliers;
+    }
+
+    private static void casesCrossProduct(
+        BinaryOperator<Object> expected,
+        List<TypedDataSupplier> lhsSuppliers,
+        List<TypedDataSupplier> rhsSuppliers,
+        BiFunction<DataType, DataType, String> evaluatorToString,
+        List<String> warnings,
+        List<TestCaseSupplier> suppliers,
+        DataType expectedType
+    ) {
         for (TypedDataSupplier lhsSupplier : lhsSuppliers) {
             for (TypedDataSupplier rhsSupplier : rhsSuppliers) {
                 String caseName = lhsSupplier.name() + ", " + rhsSupplier.name();
                 suppliers.add(new TestCaseSupplier(caseName, List.of(lhsSupplier.type(), rhsSupplier.type()), () -> {
-                    Number lhs = (Number) lhsSupplier.supplier().get();
-                    Number rhs = (Number) rhsSupplier.supplier().get();
+                    Object lhs = lhsSupplier.supplier().get();
+                    Object rhs = rhsSupplier.supplier().get();
                     TypedData lhsTyped = new TypedData(
                         // TODO there has to be a better way to handle unsigned long
                         lhs instanceof BigInteger b ? NumericUtils.asLongUnsigned(b) : lhs,
@@ -182,13 +215,11 @@ public record TestCaseSupplier(String name, List<DataType> types, Supplier<TestC
                         rhsSupplier.type(),
                         "rhs"
                     );
-                    String lhsEvalName = castToDoubleEvaluator("Attribute[channel=0]", lhsSupplier.type());
-                    String rhsEvalName = castToDoubleEvaluator("Attribute[channel=1]", rhsSupplier.type());
                     TestCase testCase = new TestCase(
                         List.of(lhsTyped, rhsTyped),
-                        name + "[" + lhsName + "=" + lhsEvalName + ", " + rhsName + "=" + rhsEvalName + "]",
-                        DataTypes.DOUBLE,
-                        equalTo(expected.apply(lhs.doubleValue(), rhs.doubleValue()))
+                        evaluatorToString.apply(lhsSupplier.type(), rhsSupplier.type()),
+                        expectedType,
+                        equalTo(expected.apply(lhs, rhs))
                     );
                     for (String warning : warnings) {
                         testCase = testCase.withWarning(warning);
@@ -197,8 +228,6 @@ public record TestCaseSupplier(String name, List<DataType> types, Supplier<TestC
                 }));
             }
         }
-
-        return suppliers;
     }
 
     public static List<TypedDataSupplier> castToDoubleSuppliersFromRange(Double Min, Double Max) {
@@ -207,6 +236,146 @@ public record TestCaseSupplier(String name, List<DataType> types, Supplier<TestC
         suppliers.addAll(longCases(Min.longValue(), Max.longValue()));
         suppliers.addAll(ulongCases(BigInteger.valueOf((long) Math.ceil(Min)), BigInteger.valueOf((long) Math.floor(Max))));
         suppliers.addAll(doubleCases(Min, Max));
+        return suppliers;
+    }
+
+    public static List<TestCaseSupplier> forBinaryNumericNotCasting(
+        String name,
+        String lhsName,
+        String rhsName,
+        BinaryOperator<Number> expected,
+        DataType expectedType,
+        List<TypedDataSupplier> lhsSuppliers,
+        List<TypedDataSupplier> rhsSuppliers,
+        List<String> warnings,
+        boolean symetric
+    ) {
+        return forBinaryNotCasting(
+            name,
+            lhsName,
+            rhsName,
+            (lhs, rhs) -> expected.apply((Number) lhs, (Number) rhs),
+            expectedType,
+            lhsSuppliers,
+            rhsSuppliers,
+            warnings,
+            symetric
+        );
+    }
+
+    public record NumericTypeTestConfig(Number min, Number max, BinaryOperator<Number> expected, String evaluatorName) {}
+
+    public record NumericTypeTestConfigs(
+        NumericTypeTestConfig intStuff,
+        NumericTypeTestConfig longStuff,
+        NumericTypeTestConfig doubleStuff
+    ) {
+        public NumericTypeTestConfig get(DataType type) {
+            if (type == DataTypes.INTEGER) {
+                return intStuff;
+            }
+            if (type == DataTypes.LONG) {
+                return longStuff;
+            }
+            if (type == DataTypes.DOUBLE) {
+                return doubleStuff;
+            }
+            throw new IllegalArgumentException("bogus numeric type [" + type + "]");
+        }
+    }
+
+    private static DataType widen(DataType lhs, DataType rhs) {
+        if (lhs == rhs) {
+            return lhs;
+        }
+        if (lhs == DataTypes.DOUBLE || rhs == DataTypes.DOUBLE) {
+            return DataTypes.DOUBLE;
+        }
+        if (lhs == DataTypes.LONG || rhs == DataTypes.LONG) {
+            return DataTypes.LONG;
+        }
+        throw new IllegalArgumentException("Invalid numeric widening lhs: [" + lhs + "] rhs: [" + rhs + "]");
+    }
+
+    private static List<TypedDataSupplier> getSuppliersForNumericType(DataType type, Number min, Number max) {
+        if (type == DataTypes.INTEGER) {
+            return intCases(NumericUtils.saturatingIntValue(min), NumericUtils.saturatingIntValue(max));
+        }
+        if (type == DataTypes.LONG) {
+            return longCases(min.longValue(), max.longValue());
+        }
+        if (type == DataTypes.UNSIGNED_LONG) {
+            return ulongCases(
+                min instanceof BigInteger ? (BigInteger) min : BigInteger.valueOf(Math.max(min.longValue(), 0L)),
+                max instanceof BigInteger ? (BigInteger) max : BigInteger.valueOf(Math.max(max.longValue(), 0L))
+            );
+        }
+        if (type == DataTypes.DOUBLE) {
+            return doubleCases(min.doubleValue(), max.doubleValue());
+        }
+        throw new IllegalArgumentException("bogus numeric type [" + type + "]");
+    }
+
+    public static List<TestCaseSupplier> forBinaryWithWidening(
+        NumericTypeTestConfigs typeStuff,
+        String lhsName,
+        String rhsName,
+        List<String> warnings
+    ) {
+        List<TestCaseSupplier> suppliers = new ArrayList<>();
+        List<DataType> numericTypes = List.of(DataTypes.INTEGER, DataTypes.LONG, DataTypes.DOUBLE);
+
+        for (DataType lhsType : numericTypes) {
+            for (DataType rhsType : numericTypes) {
+                DataType expected = widen(lhsType, rhsType);
+                NumericTypeTestConfig expectedTypeStuff = typeStuff.get(expected);
+                String evaluator = expectedTypeStuff.evaluatorName()
+                    + "["
+                    + lhsName
+                    + "="
+                    + getCastEvaluator("Attribute[channel=0]", lhsType, expected)
+                    + ", "
+                    + rhsName
+                    + "="
+                    + getCastEvaluator("Attribute[channel=1]", rhsType, expected)
+                    + "]";
+                casesCrossProduct(
+                    (l, r) -> expectedTypeStuff.expected().apply((Number) l, (Number) r),
+                    getSuppliersForNumericType(lhsType, expectedTypeStuff.min(), expectedTypeStuff.max()),
+                    getSuppliersForNumericType(rhsType, expectedTypeStuff.min(), expectedTypeStuff.max()),
+                    // TODO: This doesn't really need to be a function
+                    (lt, rt) -> evaluator,
+                    warnings,
+                    suppliers,
+                    expected
+                );
+            }
+        }
+
+        return suppliers;
+    }
+
+    public static List<TestCaseSupplier> forBinaryNotCasting(
+        String name,
+        String lhsName,
+        String rhsName,
+        BinaryOperator<Object> expected,
+        DataType expectedType,
+        List<TypedDataSupplier> lhsSuppliers,
+        List<TypedDataSupplier> rhsSuppliers,
+        List<String> warnings,
+        boolean symetric
+    ) {
+        List<TestCaseSupplier> suppliers = new ArrayList<>();
+        casesCrossProduct(
+            expected,
+            lhsSuppliers,
+            rhsSuppliers,
+            (lhsType, rhsType) -> name + "[" + lhsName + "=Attribute[channel=0], " + rhsName + "=Attribute[channel=1]]",
+            warnings,
+            suppliers,
+            expectedType
+        );
         return suppliers;
     }
 
@@ -716,7 +885,7 @@ public record TestCaseSupplier(String name, List<DataType> types, Supplier<TestC
         );
     }
 
-    private static List<TypedDataSupplier> dateCases() {
+    public static List<TypedDataSupplier> dateCases() {
         return List.of(
             new TypedDataSupplier("<1970-01-01T00:00:00Z>", () -> 0L, DataTypes.DATETIME),
             new TypedDataSupplier(
@@ -733,6 +902,32 @@ public record TestCaseSupplier(String name, List<DataType> types, Supplier<TestC
         );
     }
 
+    public static List<TypedDataSupplier> datePeriodCases() {
+        return List.of(
+            new TypedDataSupplier("<zero date period>", () -> Period.ZERO, EsqlDataTypes.DATE_PERIOD),
+            new TypedDataSupplier(
+                "<random date period>",
+                () -> Period.of(
+                    ESTestCase.randomIntBetween(-1000, 1000),
+                    ESTestCase.randomIntBetween(-13, 13),
+                    ESTestCase.randomIntBetween(-32, 32)
+                ),
+                EsqlDataTypes.DATE_PERIOD
+            )
+        );
+    }
+
+    public static List<TypedDataSupplier> timeDurationCases() {
+        return List.of(
+            new TypedDataSupplier("<zero time duration>", () -> Duration.ZERO, EsqlDataTypes.TIME_DURATION),
+            new TypedDataSupplier(
+                "<up to 7 days duration>",
+                () -> Duration.ofMillis(ESTestCase.randomLongBetween(-604800000L, 604800000L)), // plus/minus 7 days
+                EsqlDataTypes.TIME_DURATION
+            )
+        );
+    }
+
     private static List<TypedDataSupplier> geoPointCases() {
         return List.of(new TypedDataSupplier("<geo_point>", () -> GEO.pointAsLong(randomGeoPoint()), EsqlDataTypes.GEO_POINT));
     }
@@ -743,7 +938,7 @@ public record TestCaseSupplier(String name, List<DataType> types, Supplier<TestC
         );
     }
 
-    private static List<TypedDataSupplier> ipCases() {
+    public static List<TypedDataSupplier> ipCases() {
         return List.of(
             new TypedDataSupplier(
                 "<127.0.0.1 ip>",
@@ -803,6 +998,54 @@ public record TestCaseSupplier(String name, List<DataType> types, Supplier<TestC
                 DataTypes.VERSION
             )
         );
+    }
+
+    private static String getCastEvaluator(String original, DataType current, DataType target) {
+        if (current == target) {
+            return original;
+        }
+        if (target == DataTypes.LONG) {
+            return castToLongEvaluator(original, current);
+        }
+        if (target == DataTypes.UNSIGNED_LONG) {
+            return castToUnsignedLongEvaluator(original, current);
+        }
+        if (target == DataTypes.DOUBLE) {
+            return castToDoubleEvaluator(original, current);
+        }
+        throw new IllegalArgumentException("Invalid numeric cast to [" + target + "]");
+    }
+
+    private static String castToLongEvaluator(String original, DataType current) {
+        if (current == DataTypes.LONG) {
+            return original;
+        }
+        if (current == DataTypes.INTEGER) {
+            return "CastIntToLongEvaluator[v=" + original + "]";
+        }
+        if (current == DataTypes.DOUBLE) {
+            return "CastDoubleToLongEvaluator[v=" + original + "]";
+        }
+        if (current == DataTypes.UNSIGNED_LONG) {
+            return "CastUnsignedLongToLong[v=" + original + "]";
+        }
+        throw new UnsupportedOperationException();
+    }
+
+    private static String castToUnsignedLongEvaluator(String original, DataType current) {
+        if (current == DataTypes.UNSIGNED_LONG) {
+            return original;
+        }
+        if (current == DataTypes.INTEGER) {
+            return "CastIntToUnsignedLongEvaluator[v=" + original + "]";
+        }
+        if (current == DataTypes.LONG) {
+            return "CastLongToUnsignedLongEvaluator[v=" + original + "]";
+        }
+        if (current == DataTypes.DOUBLE) {
+            return "CastDoubleToUnsignedLongEvaluator[v=" + original + "]";
+        }
+        throw new UnsupportedOperationException();
     }
 
     private static String castToDoubleEvaluator(String original, DataType current) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/AddTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/arithmetic/AddTests.java
@@ -21,6 +21,7 @@ import java.math.BigInteger;
 import java.time.Duration;
 import java.time.Period;
 import java.time.temporal.TemporalAmount;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
 
@@ -31,7 +32,6 @@ import static org.elasticsearch.xpack.ql.type.DateUtils.asDateTime;
 import static org.elasticsearch.xpack.ql.type.DateUtils.asMillis;
 import static org.elasticsearch.xpack.ql.util.NumericUtils.asLongUnsigned;
 import static org.elasticsearch.xpack.ql.util.NumericUtils.unsignedLongAsBigInteger;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -42,131 +42,138 @@ public class AddTests extends AbstractDateTimeArithmeticTestCase {
 
     @ParametersFactory
     public static Iterable<Object[]> parameters() {
-        return parameterSuppliersFromTypedData(List.of(new TestCaseSupplier("Int + Int", () -> {
-            // Ensure we don't have an overflow
-            int rhs = randomIntBetween((Integer.MIN_VALUE >> 1) - 1, (Integer.MAX_VALUE >> 1) - 1);
-            int lhs = randomIntBetween((Integer.MIN_VALUE >> 1) - 1, (Integer.MAX_VALUE >> 1) - 1);
-            return new TestCaseSupplier.TestCase(
-                List.of(
-                    new TestCaseSupplier.TypedData(lhs, DataTypes.INTEGER, "lhs"),
-                    new TestCaseSupplier.TypedData(rhs, DataTypes.INTEGER, "rhs")
+        List<TestCaseSupplier> suppliers = new ArrayList<>();
+        suppliers.addAll(
+            TestCaseSupplier.forBinaryWithWidening(
+                new TestCaseSupplier.NumericTypeTestConfigs(
+                    new TestCaseSupplier.NumericTypeTestConfig(
+                        (Integer.MIN_VALUE >> 1) - 1,
+                        (Integer.MAX_VALUE >> 1) - 1,
+                        (l, r) -> l.intValue() + r.intValue(),
+                        "AddIntsEvaluator"
+                    ),
+                    new TestCaseSupplier.NumericTypeTestConfig(
+                        (Long.MIN_VALUE >> 1) - 1,
+                        (Long.MAX_VALUE >> 1) - 1,
+                        (l, r) -> l.longValue() + r.longValue(),
+                        "AddLongsEvaluator"
+                    ),
+                    new TestCaseSupplier.NumericTypeTestConfig(
+                        Double.NEGATIVE_INFINITY,
+                        Double.POSITIVE_INFINITY,
+                        (l, r) -> l.doubleValue() + r.doubleValue(),
+                        "AddDoublesEvaluator"
+                    )
                 ),
-                "AddIntsEvaluator[lhs=Attribute[channel=0], rhs=Attribute[channel=1]]",
-                DataTypes.INTEGER,
-                equalTo(lhs + rhs)
-            );
-        }), new TestCaseSupplier("Long + Long", () -> {
-            // Ensure we don't have an overflow
-            long rhs = randomLongBetween((Long.MIN_VALUE >> 1) - 1, (Long.MAX_VALUE >> 1) - 1);
-            long lhs = randomLongBetween((Long.MIN_VALUE >> 1) - 1, (Long.MAX_VALUE >> 1) - 1);
-            return new TestCaseSupplier.TestCase(
-                List.of(
-                    new TestCaseSupplier.TypedData(lhs, DataTypes.LONG, "lhs"),
-                    new TestCaseSupplier.TypedData(rhs, DataTypes.LONG, "rhs")
-                ),
-                "AddLongsEvaluator[lhs=Attribute[channel=0], rhs=Attribute[channel=1]]",
-                DataTypes.LONG,
-                equalTo(lhs + rhs)
-            );
-        }), new TestCaseSupplier("Double + Double", () -> {
-            double rhs = randomDouble();
-            double lhs = randomDouble();
-            return new TestCaseSupplier.TestCase(
-                List.of(
-                    new TestCaseSupplier.TypedData(lhs, DataTypes.DOUBLE, "lhs"),
-                    new TestCaseSupplier.TypedData(rhs, DataTypes.DOUBLE, "rhs")
-                ),
-                "AddDoublesEvaluator[lhs=Attribute[channel=0], rhs=Attribute[channel=1]]",
-                DataTypes.DOUBLE,
-                equalTo(lhs + rhs)
-            );
-        })/*, new TestCaseSupplier("ULong + ULong", () -> {
-            // Ensure we don't have an overflow
-            // TODO: we should be able to test values over Long.MAX_VALUE too...
-            long rhs = randomLongBetween(0, (Long.MAX_VALUE >> 1) - 1);
-            long lhs = randomLongBetween(0, (Long.MAX_VALUE >> 1) - 1);
-            BigInteger lhsBI = unsignedLongAsBigInteger(lhs);
-            BigInteger rhsBI = unsignedLongAsBigInteger(rhs);
-            return new TestCase(
-                Source.EMPTY,
-                List.of(new TypedData(lhs, DataTypes.UNSIGNED_LONG, "lhs"), new TypedData(rhs, DataTypes.UNSIGNED_LONG, "rhs")),
-                "AddUnsignedLongsEvaluator[lhs=Attribute[channel=0], rhs=Attribute[channel=1]]",
-                equalTo(asLongUnsigned(lhsBI.add(rhsBI).longValue()))
-            );
-          }) */, new TestCaseSupplier("Datetime + Period", () -> {
-            long lhs = (Long) randomLiteral(DataTypes.DATETIME).value();
-            Period rhs = (Period) randomLiteral(EsqlDataTypes.DATE_PERIOD).value();
-            return new TestCaseSupplier.TestCase(
-                List.of(
-                    new TestCaseSupplier.TypedData(lhs, DataTypes.DATETIME, "lhs"),
-                    new TestCaseSupplier.TypedData(rhs, EsqlDataTypes.DATE_PERIOD, "rhs")
-                ),
+                "lhs",
+                "rhs",
+                List.of()
+            )
+        );
+
+        // Unsigned Long cases
+        // TODO: These should be integrated into the type cross product above, but are currently broken
+        // see https://github.com/elastic/elasticsearch/issues/102935
+        suppliers.addAll(
+            TestCaseSupplier.forBinaryNotCasting(
+                "AddUnsignedLongsEvaluator",
+                "lhs",
+                "rhs",
+                (l, r) -> (((BigInteger) l).add((BigInteger) r)),
+                DataTypes.UNSIGNED_LONG,
+                TestCaseSupplier.ulongCases(BigInteger.ZERO, BigInteger.valueOf(Long.MAX_VALUE)),
+                TestCaseSupplier.ulongCases(BigInteger.ZERO, BigInteger.valueOf(Long.MAX_VALUE)),
+                List.of(),
+                false
+            )
+        );
+
+        // AwaitsFix https://github.com/elastic/elasticsearch/issues/103085
+        // After fixing that issue, please move this line to below where the date cases are generated
+        suppliers = anyNullIsNull(true, suppliers);
+
+        // Datetime Cases
+        suppliers.addAll(
+            TestCaseSupplier.forBinaryNotCasting(
                 // TODO: There is an evaluator for Datetime + Period, so it should be tested. Similarly below.
                 "No evaluator, the tests only trigger the folding code since Period is not representable",
+                "lhs",
+                "rhs",
+                (lhs, rhs) -> {
+                    // this weird casting dance makes the expected value lambda symmetric
+                    Long date;
+                    Period period;
+                    if (lhs instanceof Long) {
+                        date = (Long) lhs;
+                        period = (Period) rhs;
+                    } else {
+                        date = (Long) rhs;
+                        period = (Period) lhs;
+                    }
+                    return asMillis(asDateTime(date).plus(period));
+                },
                 DataTypes.DATETIME,
-                equalTo(asMillis(asDateTime(lhs).plus(rhs)))
-            );
-        }), new TestCaseSupplier("Period + Datetime", () -> {
-            Period lhs = (Period) randomLiteral(EsqlDataTypes.DATE_PERIOD).value();
-            long rhs = (Long) randomLiteral(DataTypes.DATETIME).value();
-            return new TestCaseSupplier.TestCase(
-                List.of(
-                    new TestCaseSupplier.TypedData(lhs, EsqlDataTypes.DATE_PERIOD, "lhs"),
-                    new TestCaseSupplier.TypedData(rhs, DataTypes.DATETIME, "rhs")
-                ),
+                TestCaseSupplier.dateCases(),
+                TestCaseSupplier.datePeriodCases(),
+                List.of(),
+                true
+            )
+        );
+        suppliers.addAll(
+            TestCaseSupplier.forBinaryNotCasting(
                 "No evaluator, the tests only trigger the folding code since Period is not representable",
-                DataTypes.DATETIME,
-                equalTo(asMillis(asDateTime(rhs).plus(lhs)))
-            );
-        }), new TestCaseSupplier("Period + Period", () -> {
-            Period lhs = (Period) randomLiteral(EsqlDataTypes.DATE_PERIOD).value();
-            Period rhs = (Period) randomLiteral(EsqlDataTypes.DATE_PERIOD).value();
-            return new TestCaseSupplier.TestCase(
-                List.of(
-                    new TestCaseSupplier.TypedData(lhs, EsqlDataTypes.DATE_PERIOD, "lhs"),
-                    new TestCaseSupplier.TypedData(rhs, EsqlDataTypes.DATE_PERIOD, "rhs")
-                ),
-                "Only folding possible, so there's no evaluator",
+                "lhs",
+                "rhs",
+                (lhs, rhs) -> ((Period) lhs).plus((Period) rhs),
                 EsqlDataTypes.DATE_PERIOD,
-                equalTo(lhs.plus(rhs))
-            );
-        }), new TestCaseSupplier("Datetime + Duration", () -> {
-            long lhs = (Long) randomLiteral(DataTypes.DATETIME).value();
-            Duration rhs = (Duration) randomLiteral(EsqlDataTypes.TIME_DURATION).value();
-            return new TestCaseSupplier.TestCase(
-                List.of(
-                    new TestCaseSupplier.TypedData(lhs, DataTypes.DATETIME, "lhs"),
-                    new TestCaseSupplier.TypedData(rhs, EsqlDataTypes.TIME_DURATION, "rhs")
-                ),
+                TestCaseSupplier.datePeriodCases(),
+                TestCaseSupplier.datePeriodCases(),
+                List.of(),
+                false
+            )
+        );
+        suppliers.addAll(
+            TestCaseSupplier.forBinaryNotCasting(
+                // TODO: There is an evaluator for Datetime + Duration, so it should be tested. Similarly below.
                 "No evaluator, the tests only trigger the folding code since Duration is not representable",
+                "lhs",
+                "rhs",
+                (lhs, rhs) -> {
+                    // this weird casting dance makes the expected value lambda symmetric
+                    Long date;
+                    Duration duration;
+                    if (lhs instanceof Long) {
+                        date = (Long) lhs;
+                        duration = (Duration) rhs;
+                    } else {
+                        date = (Long) rhs;
+                        duration = (Duration) lhs;
+                    }
+                    return asMillis(asDateTime(date).plus(duration));
+                },
                 DataTypes.DATETIME,
-                equalTo(asMillis(asDateTime(lhs).plus(rhs)))
-            );
-        }), new TestCaseSupplier("Duration + Datetime", () -> {
-            long lhs = (Long) randomLiteral(DataTypes.DATETIME).value();
-            Duration rhs = (Duration) randomLiteral(EsqlDataTypes.TIME_DURATION).value();
-            return new TestCaseSupplier.TestCase(
-                List.of(
-                    new TestCaseSupplier.TypedData(lhs, DataTypes.DATETIME, "lhs"),
-                    new TestCaseSupplier.TypedData(rhs, EsqlDataTypes.TIME_DURATION, "rhs")
-                ),
+                TestCaseSupplier.dateCases(),
+                TestCaseSupplier.timeDurationCases(),
+                List.of(),
+                true
+            )
+        );
+        suppliers.addAll(
+            TestCaseSupplier.forBinaryNotCasting(
                 "No evaluator, the tests only trigger the folding code since Duration is not representable",
-                DataTypes.DATETIME,
-                equalTo(asMillis(asDateTime(lhs).plus(rhs)))
-            );
-        }), new TestCaseSupplier("Duration + Duration", () -> {
-            Duration lhs = (Duration) randomLiteral(EsqlDataTypes.TIME_DURATION).value();
-            Duration rhs = (Duration) randomLiteral(EsqlDataTypes.TIME_DURATION).value();
-            return new TestCaseSupplier.TestCase(
-                List.of(
-                    new TestCaseSupplier.TypedData(lhs, EsqlDataTypes.TIME_DURATION, "lhs"),
-                    new TestCaseSupplier.TypedData(rhs, EsqlDataTypes.TIME_DURATION, "rhs")
-                ),
-                "Only folding possible, so there's no evaluator",
+                "lhs",
+                "rhs",
+                (lhs, rhs) -> ((Duration) lhs).plus((Duration) rhs),
                 EsqlDataTypes.TIME_DURATION,
-                equalTo(lhs.plus(rhs))
-            );
-        }), new TestCaseSupplier("MV", () -> {
+                TestCaseSupplier.timeDurationCases(),
+                TestCaseSupplier.timeDurationCases(),
+                List.of(),
+                false
+            )
+        );
+
+        // Cases that should generate warnings
+        suppliers.addAll(List.of(new TestCaseSupplier("MV", () -> {
             // Ensure we don't have an overflow
             int rhs = randomIntBetween((Integer.MIN_VALUE >> 1) - 1, (Integer.MAX_VALUE >> 1) - 1);
             int lhs = randomIntBetween((Integer.MIN_VALUE >> 1) - 1, (Integer.MAX_VALUE >> 1) - 1);
@@ -182,6 +189,8 @@ public class AddTests extends AbstractDateTimeArithmeticTestCase {
             ).withWarning("Line -1:-1: evaluation of [] failed, treating result as null. Only first 20 failures recorded.")
                 .withWarning("Line -1:-1: java.lang.IllegalArgumentException: single-value function encountered multi-value");
         })));
+
+        return parameterSuppliersFromTypedData(suppliers);
     }
 
     @Override

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/util/NumericUtils.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/util/NumericUtils.java
@@ -145,4 +145,25 @@ public abstract class NumericUtils {
         }
         return dbl;
     }
+
+    /**
+     * Converts a number to an integer, saturating that integer if the number doesn't fit naturally.  That is to say, values
+     * greater than Integer.MAX_VALUE yield Integer.MAX_VALUE and values less than Integer.MIN_VALUE yield Integer.MIN_VALUE
+     *
+     * This function exists because Long::intValue() yields -1 and 0 for Long.MAX_VALUE and Long.MIN_VALUE, respectively.
+     *
+     * @param n the nubmer to convert
+     * @return a valid integer
+     */
+    public static int saturatingIntValue(Number n) {
+        if (n instanceof Long ln) {
+            if (ln > Integer.MAX_VALUE) {
+                return Integer.MAX_VALUE;
+            }
+            if (ln < Integer.MIN_VALUE) {
+                return Integer.MIN_VALUE;
+            }
+        }
+        return n.intValue();
+    }
 }


### PR DESCRIPTION
Relates to #100558

Adds testing, docs, etc for the Addition operator. Importantly, this PR pulls addition into the test framework type checking and null validation logic, which is not currently being applied.

This PR also includes some new test infrastructure for binary numeric functions which do not cast their arguments to doubles, an area the test framework currently doesn't cover very well.

I encountered a couple of issues while writing this. One of them is tracked in #103085, around null handling in date math. There's also a problem with how we're doing type checking for mixed type functions, which I haven't opened an issue for yet. That said, I'd rather merge this as partial work now, since it adds functionality we can reuse elsewhere and improves the test coverage for Add. We'll just need more work before we can check it off the list.

(cherry picked from commit 50e59ca20e78bfb77db94700936290d24d633552)
