### PR TITLE
Fail operations without blocking on engine close

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/gateway/ReplicaShardAllocatorSyncIdIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/gateway/ReplicaShardAllocatorSyncIdIT.java
@@ -14,7 +14,6 @@ import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.concurrent.ReleasableLock;
 import org.elasticsearch.core.UpdateForV9;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexService;
@@ -97,7 +96,7 @@ public class ReplicaShardAllocatorSyncIdIT extends ESIntegTestCase {
             // make sure that background merges won't happen; otherwise, IndexWriter#hasUncommittedChanges can become true again
             forceMerge(false, 1, false, UUIDs.randomBase64UUID());
             assertNotNull(indexWriter);
-            try (ReleasableLock ignored = readLock.acquire()) {
+            try (var ignored = acquireEnsureOpenRef()) {
                 assertThat(getTranslogStats().getUncommittedOperations(), equalTo(0));
                 Map<String, String> userData = new HashMap<>(getLastCommittedSegmentInfos().userData);
                 SequenceNumbers.CommitInfo commitInfo = SequenceNumbers.loadSeqNoInfoFromLuceneCommit(userData.entrySet());

--- a/server/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -33,6 +33,8 @@ import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.action.support.SubscribableListener;
+import org.elasticsearch.cluster.service.ClusterApplierService;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.lucene.Lucene;
@@ -43,8 +45,10 @@ import org.elasticsearch.common.lucene.uid.VersionsAndSeqNoResolver.DocIdAndVers
 import org.elasticsearch.common.metrics.CounterMetric;
 import org.elasticsearch.common.util.concurrent.ReleasableLock;
 import org.elasticsearch.common.util.concurrent.UncategorizedExecutionException;
+import org.elasticsearch.core.AbstractRefCounted;
 import org.elasticsearch.core.CheckedRunnable;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.RefCounted;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.TimeValue;
@@ -91,7 +95,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -123,10 +126,13 @@ public abstract class Engine implements Closeable {
     private final CountDownLatch closedLatch = new CountDownLatch(1);
     protected final EventListener eventListener;
     protected final ReentrantLock failEngineLock = new ReentrantLock();
-    protected final ReentrantReadWriteLock rwl = new ReentrantReadWriteLock();
-    protected final ReleasableLock readLock = new ReleasableLock(rwl.readLock());
-    protected final ReleasableLock writeLock = new ReleasableLock(rwl.writeLock());
     protected final SetOnce<Exception> failedEngine = new SetOnce<>();
+
+    private final AtomicBoolean isClosing = new AtomicBoolean();
+    private final SubscribableListener<Void> drainOnCloseListener = new SubscribableListener<>();
+    private final RefCounted ensureOpenRefs = AbstractRefCounted.of(() -> drainOnCloseListener.onResponse(null));
+    private final Releasable releaseEnsureOpenRef = ensureOpenRefs::decRef; // reuse this to avoid allocation for each op
+
     /*
      * on {@code lastWriteNanos} we use System.nanoTime() to initialize this since:
      *  - we use the value for figuring out if the shard / engine is active so if we startup and no write has happened yet we still
@@ -1161,15 +1167,15 @@ public abstract class Engine implements Closeable {
      *                      indicating no flush and unknown generation.
      */
     public final void flush(boolean force, boolean waitIfOngoing, ActionListener<FlushResult> listener) throws EngineException {
-        try (var ignored = readLock.acquire()) {
-            ensureOpen();
+        try (var ignored = acquireEnsureOpenRef()) {
             flushHoldingLock(force, waitIfOngoing, listener);
         }
     }
 
     /**
-     * The actual implementation of {@link #flush(boolean, boolean, ActionListener)}, which should only be called when holding either {@link
-     * #readLock} (the normal case) or {@link #writeLock} (if this flush is happening because the shard is closing gracefully)
+     * The actual implementation of {@link #flush(boolean, boolean, ActionListener)}, to be called either when holding a ref that ensures
+     * the engine remains open, or holding {@code IndexShard#engineMutex} while closing the engine.
+     *
      */
     protected abstract void flushHoldingLock(boolean force, boolean waitIfOngoing, ActionListener<FlushResult> listener)
         throws EngineException;
@@ -1871,26 +1877,67 @@ public abstract class Engine implements Closeable {
      */
     protected abstract void closeNoLock(String reason, CountDownLatch closedLatch);
 
+    protected final boolean isDrainedForClose() {
+        return ensureOpenRefs.hasReferences() == false;
+    }
+
+    protected final boolean isClosing() {
+        return isClosing.get();
+    }
+
+    protected final Releasable acquireEnsureOpenRef() {
+        if (isClosing() || ensureOpenRefs.tryIncRef() == false) {
+            ensureOpen(); // throws "engine is closed" exception if we're actually closed, otherwise ...
+            throw new AlreadyClosedException(shardId + " engine is closing", failedEngine.get());
+        }
+        return Releasables.assertOnce(releaseEnsureOpenRef);
+    }
+
+    protected final void drainForClose() {
+        if (isClosing.compareAndSet(false, true)) {
+            releaseEnsureOpenRef.close();
+        }
+        final var future = new PlainActionFuture<Void>() {
+            @Override
+            protected boolean blockingAllowed() {
+                // TODO remove this blocking, or at least do it elsewhere, see https://github.com/elastic/elasticsearch/issues/89821
+                return Thread.currentThread().getName().contains(ClusterApplierService.CLUSTER_UPDATE_THREAD_NAME)
+                    || super.blockingAllowed();
+            }
+        };
+        drainOnCloseListener.addListener(future);
+        try {
+            future.get();
+        } catch (ExecutionException e) {
+            logger.error("failure while draining operations on close", e);
+            assert false : e;
+            throw new IllegalStateException(e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            logger.error("interrupted while draining operations on close");
+            throw new IllegalStateException(e);
+        }
+    }
+
     /**
      * Flush the engine (committing segments to disk and truncating the
      * translog) and close it.
      */
     public void flushAndClose() throws IOException {
         if (isClosed.get() == false) {
-            logger.trace("flushAndClose now acquire writeLock");
-            try (ReleasableLock lock = writeLock.acquire()) {
-                logger.trace("flushAndClose now acquired writeLock");
+            logger.trace("flushAndClose now draining ops");
+            drainForClose();
+            logger.trace("flushAndClose drained ops");
+            try {
+                logger.debug("flushing shard on close - this might take some time to sync files to disk");
                 try {
-                    logger.debug("flushing shard on close - this might take some time to sync files to disk");
-                    try {
-                        // TODO: We are not waiting for full durability here atm because we are on the cluster state update thread
-                        flushHoldingLock(false, false, ActionListener.noop());
-                    } catch (AlreadyClosedException ex) {
-                        logger.debug("engine already closed - skipping flushAndClose");
-                    }
-                } finally {
-                    close(); // double close is not a problem
+                    // TODO: We are not waiting for full durability here atm because we are on the cluster state update thread
+                    flushHoldingLock(false, false, ActionListener.noop());
+                } catch (AlreadyClosedException ex) {
+                    logger.debug("engine already closed - skipping flushAndClose");
                 }
+            } finally {
+                close(); // double close is not a problem
             }
         }
         awaitPendingClose();
@@ -1899,11 +1946,10 @@ public abstract class Engine implements Closeable {
     @Override
     public void close() throws IOException {
         if (isClosed.get() == false) { // don't acquire the write lock if we are already closed
-            logger.debug("close now acquiring writeLock");
-            try (ReleasableLock lock = writeLock.acquire()) {
-                logger.debug("close acquired writeLock");
-                closeNoLock("api", closedLatch);
-            }
+            logger.debug("close now draining ops");
+            drainForClose();
+            logger.debug("close drained ops");
+            closeNoLock("api", closedLatch);
         }
         awaitPendingClose();
     }

--- a/server/src/main/java/org/elasticsearch/index/engine/NoOpEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/NoOpEngine.java
@@ -16,7 +16,6 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SegmentReader;
 import org.apache.lucene.store.Directory;
 import org.elasticsearch.common.lucene.Lucene;
-import org.elasticsearch.common.util.concurrent.ReleasableLock;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.seqno.SeqNoStats;
 import org.elasticsearch.index.seqno.SequenceNumbers;
@@ -147,8 +146,7 @@ public final class NoOpEngine extends ReadOnlyEngine {
     public void trimUnreferencedTranslogFiles() {
         final Store store = this.engineConfig.getStore();
         store.incRef();
-        try (ReleasableLock lock = readLock.acquire()) {
-            ensureOpen();
+        try (var ignored = acquireEnsureOpenRef()) {
             final List<IndexCommit> commits = DirectoryReader.listCommits(store.directory());
             if (commits.size() == 1 && translogStats.getTranslogSizeInBytes() > translogStats.getUncommittedSizeInBytes()) {
                 final Map<String, String> commitUserData = getLastCommittedSegmentInfos().getUserData();

--- a/server/src/main/java/org/elasticsearch/index/engine/ReadOnlyEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/ReadOnlyEngine.java
@@ -23,7 +23,6 @@ import org.elasticsearch.action.admin.indices.forcemerge.ForceMergeRequest;
 import org.elasticsearch.common.hash.MessageDigests;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.index.ElasticsearchDirectoryReader;
-import org.elasticsearch.common.util.concurrent.ReleasableLock;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.IndexVersion;
@@ -527,8 +526,7 @@ public class ReadOnlyEngine extends Engine {
         ActionListener<Void> listener
     ) {
         ActionListener.run(listener, l -> {
-            try (ReleasableLock lock = readLock.acquire()) {
-                ensureOpen();
+            try (var ignored = acquireEnsureOpenRef()) {
                 try {
                     translogRecoveryRunner.run(this, Translog.Snapshot.EMPTY);
                 } catch (final Exception e) {

--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -91,7 +91,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
-import org.elasticsearch.common.util.concurrent.ReleasableLock;
 import org.elasticsearch.core.CheckedRunnable;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.TimeValue;
@@ -1347,7 +1346,7 @@ public class InternalEngineTests extends EngineTestCase {
     }
 
     void syncFlush(IndexWriter writer, InternalEngine engine, String syncId) throws IOException {
-        try (ReleasableLock ignored = engine.readLock.acquire()) {
+        try (var ignored = engine.acquireEnsureOpenRef()) {
             Map<String, String> userData = new HashMap<>();
             writer.getLiveCommitData().forEach(e -> userData.put(e.getKey(), e.getValue()));
             userData.put(Engine.SYNC_COMMIT_ID, syncId);


### PR DESCRIPTION
Today we prevent an engine from processing operations after close using
a read/write lock pair, which means that operations received during
closing will block until the write lock is released after closing (which
potentially includes a flush). These operations are going to see a
closed engine and fail anyway so we may as well not wait.

Also the read/write lock pair is not a fair one so theoretically it's
possible that a continuous stream of operations could starve the closing
thread forever (but in practice there's a heuristic anti-starvation
mechanism which seems to work).

With this commit we move to a refcount-based approach so that we can
reject operations against a closing engine immediately. We also reject
attempts to acquire a reference as soon as the closing process has
started to ensure that the closing thread takes precedence.

Relates #102445
Relates #103123