### PR TITLE
Minor array block cleanup

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayBlock.java
@@ -50,6 +50,23 @@ final class BooleanArrayBlock extends AbstractArrayBlock implements BooleanBlock
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
+        checkInvariants();
+    }
+
+    private void checkInvariants() {
+        if (firstValueIndexes != null) {
+            assert firstValueIndexes.length == getPositionCount() + 1;
+            assert firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
+            for (int i = 0; i < getPositionCount(); i++) {
+                assert (firstValueIndexes[i + 1] - firstValueIndexes[i]) >= 0;
+            }
+        }
+        if (firstValueIndexes != null && nullsMask != null) {
+            for (int i = 0; i < getPositionCount(); i++) {
+                // Either we have multi-values or a null but never both.
+                assert ((nullsMask.get(i) == false) || (firstValueIndexes[i + 1] - firstValueIndexes[i]) == 1);
+            }
+        }
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayBlock.java
@@ -50,24 +50,7 @@ final class BooleanArrayBlock extends AbstractArrayBlock implements BooleanBlock
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
-        assert assertInvariants();
-    }
-
-    private boolean assertInvariants() {
-        if (firstValueIndexes != null) {
-            assert firstValueIndexes.length == getPositionCount() + 1;
-            assert firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
-            for (int i = 0; i < getPositionCount(); i++) {
-                assert (firstValueIndexes[i + 1] - firstValueIndexes[i]) >= 0;
-            }
-        }
-        if (firstValueIndexes != null && nullsMask != null) {
-            for (int i = 0; i < getPositionCount(); i++) {
-                // Either we have multi-values or a null but never both.
-                assert ((nullsMask.get(i) == false) || (firstValueIndexes[i + 1] - firstValueIndexes[i]) == 1);
-            }
-        }
-        return true;
+        assert firstValueIndexes == null ? true : firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayBlock.java
@@ -50,7 +50,8 @@ final class BooleanArrayBlock extends AbstractArrayBlock implements BooleanBlock
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
-        assert firstValueIndexes == null ? true : firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
+        assert firstValueIndexes == null ? vector.getPositionCount() == getPositionCount()
+            : firstValueIndexes[getPositionCount()] == vector.getPositionCount();
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayBlock.java
@@ -107,7 +107,7 @@ final class BooleanArrayBlock extends AbstractArrayBlock implements BooleanBlock
 
         // The following line is correct because positions with multi-values are never null.
         int expandedPositionCount = vector.getPositionCount();
-        long bitSetRamUsedEstimate = BlockRamUsageEstimator.sizeOfBitSet(expandedPositionCount);
+        long bitSetRamUsedEstimate = Math.max(nullsMask.size(), BlockRamUsageEstimator.sizeOfBitSet(expandedPositionCount));
         blockFactory().adjustBreaker(bitSetRamUsedEstimate, false);
 
         BooleanArrayBlock expanded = new BooleanArrayBlock(

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayBlock.java
@@ -50,10 +50,10 @@ final class BooleanArrayBlock extends AbstractArrayBlock implements BooleanBlock
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
-        checkInvariants();
+        assert assertInvariants();
     }
 
-    private void checkInvariants() {
+    private boolean assertInvariants() {
         if (firstValueIndexes != null) {
             assert firstValueIndexes.length == getPositionCount() + 1;
             assert firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
@@ -67,6 +67,7 @@ final class BooleanArrayBlock extends AbstractArrayBlock implements BooleanBlock
                 assert ((nullsMask.get(i) == false) || (firstValueIndexes[i + 1] - firstValueIndexes[i]) == 1);
             }
         }
+        return true;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayBlock.java
@@ -50,7 +50,8 @@ final class BooleanArrayBlock extends AbstractArrayBlock implements BooleanBlock
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
-        assert firstValueIndexes == null ? vector.getPositionCount() == getPositionCount()
+        assert firstValueIndexes == null
+            ? vector.getPositionCount() == getPositionCount()
             : firstValueIndexes[getPositionCount()] == vector.getPositionCount();
     }
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBigArrayBlock.java
@@ -51,10 +51,10 @@ public final class BooleanBigArrayBlock extends AbstractArrayBlock implements Bo
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
-        checkInvariants();
+        assert assertInvariants();
     }
 
-    private void checkInvariants() {
+    private boolean assertInvariants() {
         if (firstValueIndexes != null) {
             assert firstValueIndexes.length == getPositionCount() + 1;
             assert firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
@@ -68,6 +68,7 @@ public final class BooleanBigArrayBlock extends AbstractArrayBlock implements Bo
                 assert ((nullsMask.get(i) == false) || (firstValueIndexes[i + 1] - firstValueIndexes[i]) == 1);
             }
         }
+        return true;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBigArrayBlock.java
@@ -51,7 +51,8 @@ public final class BooleanBigArrayBlock extends AbstractArrayBlock implements Bo
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
-        assert firstValueIndexes == null ? vector.getPositionCount() == getPositionCount()
+        assert firstValueIndexes == null
+            ? vector.getPositionCount() == getPositionCount()
             : firstValueIndexes[getPositionCount()] == vector.getPositionCount();
     }
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBigArrayBlock.java
@@ -51,7 +51,8 @@ public final class BooleanBigArrayBlock extends AbstractArrayBlock implements Bo
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
-        assert firstValueIndexes == null ? true : firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
+        assert firstValueIndexes == null ? vector.getPositionCount() == getPositionCount()
+            : firstValueIndexes[getPositionCount()] == vector.getPositionCount();
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBigArrayBlock.java
@@ -108,7 +108,7 @@ public final class BooleanBigArrayBlock extends AbstractArrayBlock implements Bo
 
         // The following line is correct because positions with multi-values are never null.
         int expandedPositionCount = vector.getPositionCount();
-        long bitSetRamUsedEstimate = BlockRamUsageEstimator.sizeOfBitSet(expandedPositionCount);
+        long bitSetRamUsedEstimate = Math.max(nullsMask.size(), BlockRamUsageEstimator.sizeOfBitSet(expandedPositionCount));
         blockFactory().adjustBreaker(bitSetRamUsedEstimate, false);
 
         BooleanBigArrayBlock expanded = new BooleanBigArrayBlock(

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBigArrayBlock.java
@@ -51,6 +51,23 @@ public final class BooleanBigArrayBlock extends AbstractArrayBlock implements Bo
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
+        checkInvariants();
+    }
+
+    private void checkInvariants() {
+        if (firstValueIndexes != null) {
+            assert firstValueIndexes.length == getPositionCount() + 1;
+            assert firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
+            for (int i = 0; i < getPositionCount(); i++) {
+                assert (firstValueIndexes[i + 1] - firstValueIndexes[i]) >= 0;
+            }
+        }
+        if (firstValueIndexes != null && nullsMask != null) {
+            for (int i = 0; i < getPositionCount(); i++) {
+                // Either we have multi-values or a null but never both.
+                assert ((nullsMask.get(i) == false) || (firstValueIndexes[i + 1] - firstValueIndexes[i]) == 1);
+            }
+        }
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBigArrayBlock.java
@@ -51,24 +51,7 @@ public final class BooleanBigArrayBlock extends AbstractArrayBlock implements Bo
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
-        assert assertInvariants();
-    }
-
-    private boolean assertInvariants() {
-        if (firstValueIndexes != null) {
-            assert firstValueIndexes.length == getPositionCount() + 1;
-            assert firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
-            for (int i = 0; i < getPositionCount(); i++) {
-                assert (firstValueIndexes[i + 1] - firstValueIndexes[i]) >= 0;
-            }
-        }
-        if (firstValueIndexes != null && nullsMask != null) {
-            for (int i = 0; i < getPositionCount(); i++) {
-                // Either we have multi-values or a null but never both.
-                assert ((nullsMask.get(i) == false) || (firstValueIndexes[i + 1] - firstValueIndexes[i]) == 1);
-            }
-        }
-        return true;
+        assert firstValueIndexes == null ? true : firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayBlock.java
@@ -111,7 +111,7 @@ final class BytesRefArrayBlock extends AbstractArrayBlock implements BytesRefBlo
 
         // The following line is correct because positions with multi-values are never null.
         int expandedPositionCount = vector.getPositionCount();
-        long bitSetRamUsedEstimate = BlockRamUsageEstimator.sizeOfBitSet(expandedPositionCount);
+        long bitSetRamUsedEstimate = Math.max(nullsMask.size(), BlockRamUsageEstimator.sizeOfBitSet(expandedPositionCount));
         blockFactory().adjustBreaker(bitSetRamUsedEstimate, false);
 
         BytesRefArrayBlock expanded = new BytesRefArrayBlock(

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayBlock.java
@@ -53,7 +53,8 @@ final class BytesRefArrayBlock extends AbstractArrayBlock implements BytesRefBlo
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
-        assert firstValueIndexes == null ? true : firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
+        assert firstValueIndexes == null ? vector.getPositionCount() == getPositionCount()
+            : firstValueIndexes[getPositionCount()] == vector.getPositionCount();
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayBlock.java
@@ -53,6 +53,23 @@ final class BytesRefArrayBlock extends AbstractArrayBlock implements BytesRefBlo
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
+        checkInvariants();
+    }
+
+    private void checkInvariants() {
+        if (firstValueIndexes != null) {
+            assert firstValueIndexes.length == getPositionCount() + 1;
+            assert firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
+            for (int i = 0; i < getPositionCount(); i++) {
+                assert (firstValueIndexes[i + 1] - firstValueIndexes[i]) >= 0;
+            }
+        }
+        if (firstValueIndexes != null && nullsMask != null) {
+            for (int i = 0; i < getPositionCount(); i++) {
+                // Either we have multi-values or a null but never both.
+                assert ((nullsMask.get(i) == false) || (firstValueIndexes[i + 1] - firstValueIndexes[i]) == 1);
+            }
+        }
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayBlock.java
@@ -53,7 +53,8 @@ final class BytesRefArrayBlock extends AbstractArrayBlock implements BytesRefBlo
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
-        assert firstValueIndexes == null ? vector.getPositionCount() == getPositionCount()
+        assert firstValueIndexes == null
+            ? vector.getPositionCount() == getPositionCount()
             : firstValueIndexes[getPositionCount()] == vector.getPositionCount();
     }
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayBlock.java
@@ -53,10 +53,10 @@ final class BytesRefArrayBlock extends AbstractArrayBlock implements BytesRefBlo
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
-        checkInvariants();
+        assert assertInvariants();
     }
 
-    private void checkInvariants() {
+    private boolean assertInvariants() {
         if (firstValueIndexes != null) {
             assert firstValueIndexes.length == getPositionCount() + 1;
             assert firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
@@ -70,6 +70,7 @@ final class BytesRefArrayBlock extends AbstractArrayBlock implements BytesRefBlo
                 assert ((nullsMask.get(i) == false) || (firstValueIndexes[i + 1] - firstValueIndexes[i]) == 1);
             }
         }
+        return true;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayBlock.java
@@ -53,24 +53,7 @@ final class BytesRefArrayBlock extends AbstractArrayBlock implements BytesRefBlo
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
-        assert assertInvariants();
-    }
-
-    private boolean assertInvariants() {
-        if (firstValueIndexes != null) {
-            assert firstValueIndexes.length == getPositionCount() + 1;
-            assert firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
-            for (int i = 0; i < getPositionCount(); i++) {
-                assert (firstValueIndexes[i + 1] - firstValueIndexes[i]) >= 0;
-            }
-        }
-        if (firstValueIndexes != null && nullsMask != null) {
-            for (int i = 0; i < getPositionCount(); i++) {
-                // Either we have multi-values or a null but never both.
-                assert ((nullsMask.get(i) == false) || (firstValueIndexes[i + 1] - firstValueIndexes[i]) == 1);
-            }
-        }
-        return true;
+        assert firstValueIndexes == null ? true : firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayBlock.java
@@ -50,7 +50,8 @@ final class DoubleArrayBlock extends AbstractArrayBlock implements DoubleBlock {
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
-        assert firstValueIndexes == null ? vector.getPositionCount() == getPositionCount()
+        assert firstValueIndexes == null
+            ? vector.getPositionCount() == getPositionCount()
             : firstValueIndexes[getPositionCount()] == vector.getPositionCount();
     }
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayBlock.java
@@ -50,6 +50,23 @@ final class DoubleArrayBlock extends AbstractArrayBlock implements DoubleBlock {
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
+        checkInvariants();
+    }
+
+    private void checkInvariants() {
+        if (firstValueIndexes != null) {
+            assert firstValueIndexes.length == getPositionCount() + 1;
+            assert firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
+            for (int i = 0; i < getPositionCount(); i++) {
+                assert (firstValueIndexes[i + 1] - firstValueIndexes[i]) >= 0;
+            }
+        }
+        if (firstValueIndexes != null && nullsMask != null) {
+            for (int i = 0; i < getPositionCount(); i++) {
+                // Either we have multi-values or a null but never both.
+                assert ((nullsMask.get(i) == false) || (firstValueIndexes[i + 1] - firstValueIndexes[i]) == 1);
+            }
+        }
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayBlock.java
@@ -50,10 +50,10 @@ final class DoubleArrayBlock extends AbstractArrayBlock implements DoubleBlock {
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
-        checkInvariants();
+        assert assertInvariants();
     }
 
-    private void checkInvariants() {
+    private boolean assertInvariants() {
         if (firstValueIndexes != null) {
             assert firstValueIndexes.length == getPositionCount() + 1;
             assert firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
@@ -67,6 +67,7 @@ final class DoubleArrayBlock extends AbstractArrayBlock implements DoubleBlock {
                 assert ((nullsMask.get(i) == false) || (firstValueIndexes[i + 1] - firstValueIndexes[i]) == 1);
             }
         }
+        return true;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayBlock.java
@@ -50,7 +50,8 @@ final class DoubleArrayBlock extends AbstractArrayBlock implements DoubleBlock {
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
-        assert firstValueIndexes == null ? true : firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
+        assert firstValueIndexes == null ? vector.getPositionCount() == getPositionCount()
+            : firstValueIndexes[getPositionCount()] == vector.getPositionCount();
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayBlock.java
@@ -107,7 +107,7 @@ final class DoubleArrayBlock extends AbstractArrayBlock implements DoubleBlock {
 
         // The following line is correct because positions with multi-values are never null.
         int expandedPositionCount = vector.getPositionCount();
-        long bitSetRamUsedEstimate = BlockRamUsageEstimator.sizeOfBitSet(expandedPositionCount);
+        long bitSetRamUsedEstimate = Math.max(nullsMask.size(), BlockRamUsageEstimator.sizeOfBitSet(expandedPositionCount));
         blockFactory().adjustBreaker(bitSetRamUsedEstimate, false);
 
         DoubleArrayBlock expanded = new DoubleArrayBlock(

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayBlock.java
@@ -50,24 +50,7 @@ final class DoubleArrayBlock extends AbstractArrayBlock implements DoubleBlock {
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
-        assert assertInvariants();
-    }
-
-    private boolean assertInvariants() {
-        if (firstValueIndexes != null) {
-            assert firstValueIndexes.length == getPositionCount() + 1;
-            assert firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
-            for (int i = 0; i < getPositionCount(); i++) {
-                assert (firstValueIndexes[i + 1] - firstValueIndexes[i]) >= 0;
-            }
-        }
-        if (firstValueIndexes != null && nullsMask != null) {
-            for (int i = 0; i < getPositionCount(); i++) {
-                // Either we have multi-values or a null but never both.
-                assert ((nullsMask.get(i) == false) || (firstValueIndexes[i + 1] - firstValueIndexes[i]) == 1);
-            }
-        }
-        return true;
+        assert firstValueIndexes == null ? true : firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBigArrayBlock.java
@@ -51,7 +51,8 @@ public final class DoubleBigArrayBlock extends AbstractArrayBlock implements Dou
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
-        assert firstValueIndexes == null ? true : firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
+        assert firstValueIndexes == null ? vector.getPositionCount() == getPositionCount()
+            : firstValueIndexes[getPositionCount()] == vector.getPositionCount();
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBigArrayBlock.java
@@ -51,6 +51,23 @@ public final class DoubleBigArrayBlock extends AbstractArrayBlock implements Dou
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
+        checkInvariants();
+    }
+
+    private void checkInvariants() {
+        if (firstValueIndexes != null) {
+            assert firstValueIndexes.length == getPositionCount() + 1;
+            assert firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
+            for (int i = 0; i < getPositionCount(); i++) {
+                assert (firstValueIndexes[i + 1] - firstValueIndexes[i]) >= 0;
+            }
+        }
+        if (firstValueIndexes != null && nullsMask != null) {
+            for (int i = 0; i < getPositionCount(); i++) {
+                // Either we have multi-values or a null but never both.
+                assert ((nullsMask.get(i) == false) || (firstValueIndexes[i + 1] - firstValueIndexes[i]) == 1);
+            }
+        }
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBigArrayBlock.java
@@ -51,24 +51,7 @@ public final class DoubleBigArrayBlock extends AbstractArrayBlock implements Dou
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
-        assert assertInvariants();
-    }
-
-    private boolean assertInvariants() {
-        if (firstValueIndexes != null) {
-            assert firstValueIndexes.length == getPositionCount() + 1;
-            assert firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
-            for (int i = 0; i < getPositionCount(); i++) {
-                assert (firstValueIndexes[i + 1] - firstValueIndexes[i]) >= 0;
-            }
-        }
-        if (firstValueIndexes != null && nullsMask != null) {
-            for (int i = 0; i < getPositionCount(); i++) {
-                // Either we have multi-values or a null but never both.
-                assert ((nullsMask.get(i) == false) || (firstValueIndexes[i + 1] - firstValueIndexes[i]) == 1);
-            }
-        }
-        return true;
+        assert firstValueIndexes == null ? true : firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBigArrayBlock.java
@@ -51,7 +51,8 @@ public final class DoubleBigArrayBlock extends AbstractArrayBlock implements Dou
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
-        assert firstValueIndexes == null ? vector.getPositionCount() == getPositionCount()
+        assert firstValueIndexes == null
+            ? vector.getPositionCount() == getPositionCount()
             : firstValueIndexes[getPositionCount()] == vector.getPositionCount();
     }
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBigArrayBlock.java
@@ -108,7 +108,7 @@ public final class DoubleBigArrayBlock extends AbstractArrayBlock implements Dou
 
         // The following line is correct because positions with multi-values are never null.
         int expandedPositionCount = vector.getPositionCount();
-        long bitSetRamUsedEstimate = BlockRamUsageEstimator.sizeOfBitSet(expandedPositionCount);
+        long bitSetRamUsedEstimate = Math.max(nullsMask.size(), BlockRamUsageEstimator.sizeOfBitSet(expandedPositionCount));
         blockFactory().adjustBreaker(bitSetRamUsedEstimate, false);
 
         DoubleBigArrayBlock expanded = new DoubleBigArrayBlock(

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBigArrayBlock.java
@@ -51,10 +51,10 @@ public final class DoubleBigArrayBlock extends AbstractArrayBlock implements Dou
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
-        checkInvariants();
+        assert assertInvariants();
     }
 
-    private void checkInvariants() {
+    private boolean assertInvariants() {
         if (firstValueIndexes != null) {
             assert firstValueIndexes.length == getPositionCount() + 1;
             assert firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
@@ -68,6 +68,7 @@ public final class DoubleBigArrayBlock extends AbstractArrayBlock implements Dou
                 assert ((nullsMask.get(i) == false) || (firstValueIndexes[i + 1] - firstValueIndexes[i]) == 1);
             }
         }
+        return true;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayBlock.java
@@ -107,7 +107,7 @@ final class IntArrayBlock extends AbstractArrayBlock implements IntBlock {
 
         // The following line is correct because positions with multi-values are never null.
         int expandedPositionCount = vector.getPositionCount();
-        long bitSetRamUsedEstimate = BlockRamUsageEstimator.sizeOfBitSet(expandedPositionCount);
+        long bitSetRamUsedEstimate = Math.max(nullsMask.size(), BlockRamUsageEstimator.sizeOfBitSet(expandedPositionCount));
         blockFactory().adjustBreaker(bitSetRamUsedEstimate, false);
 
         IntArrayBlock expanded = new IntArrayBlock(

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayBlock.java
@@ -50,6 +50,23 @@ final class IntArrayBlock extends AbstractArrayBlock implements IntBlock {
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
+        checkInvariants();
+    }
+
+    private void checkInvariants() {
+        if (firstValueIndexes != null) {
+            assert firstValueIndexes.length == getPositionCount() + 1;
+            assert firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
+            for (int i = 0; i < getPositionCount(); i++) {
+                assert (firstValueIndexes[i + 1] - firstValueIndexes[i]) >= 0;
+            }
+        }
+        if (firstValueIndexes != null && nullsMask != null) {
+            for (int i = 0; i < getPositionCount(); i++) {
+                // Either we have multi-values or a null but never both.
+                assert ((nullsMask.get(i) == false) || (firstValueIndexes[i + 1] - firstValueIndexes[i]) == 1);
+            }
+        }
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayBlock.java
@@ -50,7 +50,8 @@ final class IntArrayBlock extends AbstractArrayBlock implements IntBlock {
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
-        assert firstValueIndexes == null ? vector.getPositionCount() == getPositionCount()
+        assert firstValueIndexes == null
+            ? vector.getPositionCount() == getPositionCount()
             : firstValueIndexes[getPositionCount()] == vector.getPositionCount();
     }
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayBlock.java
@@ -50,10 +50,10 @@ final class IntArrayBlock extends AbstractArrayBlock implements IntBlock {
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
-        checkInvariants();
+        assert assertInvariants();
     }
 
-    private void checkInvariants() {
+    private boolean assertInvariants() {
         if (firstValueIndexes != null) {
             assert firstValueIndexes.length == getPositionCount() + 1;
             assert firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
@@ -67,6 +67,7 @@ final class IntArrayBlock extends AbstractArrayBlock implements IntBlock {
                 assert ((nullsMask.get(i) == false) || (firstValueIndexes[i + 1] - firstValueIndexes[i]) == 1);
             }
         }
+        return true;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayBlock.java
@@ -50,24 +50,7 @@ final class IntArrayBlock extends AbstractArrayBlock implements IntBlock {
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
-        assert assertInvariants();
-    }
-
-    private boolean assertInvariants() {
-        if (firstValueIndexes != null) {
-            assert firstValueIndexes.length == getPositionCount() + 1;
-            assert firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
-            for (int i = 0; i < getPositionCount(); i++) {
-                assert (firstValueIndexes[i + 1] - firstValueIndexes[i]) >= 0;
-            }
-        }
-        if (firstValueIndexes != null && nullsMask != null) {
-            for (int i = 0; i < getPositionCount(); i++) {
-                // Either we have multi-values or a null but never both.
-                assert ((nullsMask.get(i) == false) || (firstValueIndexes[i + 1] - firstValueIndexes[i]) == 1);
-            }
-        }
-        return true;
+        assert firstValueIndexes == null ? true : firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayBlock.java
@@ -50,7 +50,8 @@ final class IntArrayBlock extends AbstractArrayBlock implements IntBlock {
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
-        assert firstValueIndexes == null ? true : firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
+        assert firstValueIndexes == null ? vector.getPositionCount() == getPositionCount()
+            : firstValueIndexes[getPositionCount()] == vector.getPositionCount();
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBigArrayBlock.java
@@ -51,7 +51,8 @@ public final class IntBigArrayBlock extends AbstractArrayBlock implements IntBlo
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
-        assert firstValueIndexes == null ? vector.getPositionCount() == getPositionCount()
+        assert firstValueIndexes == null
+            ? vector.getPositionCount() == getPositionCount()
             : firstValueIndexes[getPositionCount()] == vector.getPositionCount();
     }
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBigArrayBlock.java
@@ -51,24 +51,7 @@ public final class IntBigArrayBlock extends AbstractArrayBlock implements IntBlo
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
-        assert assertInvariants();
-    }
-
-    private boolean assertInvariants() {
-        if (firstValueIndexes != null) {
-            assert firstValueIndexes.length == getPositionCount() + 1;
-            assert firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
-            for (int i = 0; i < getPositionCount(); i++) {
-                assert (firstValueIndexes[i + 1] - firstValueIndexes[i]) >= 0;
-            }
-        }
-        if (firstValueIndexes != null && nullsMask != null) {
-            for (int i = 0; i < getPositionCount(); i++) {
-                // Either we have multi-values or a null but never both.
-                assert ((nullsMask.get(i) == false) || (firstValueIndexes[i + 1] - firstValueIndexes[i]) == 1);
-            }
-        }
-        return true;
+        assert firstValueIndexes == null ? true : firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBigArrayBlock.java
@@ -51,7 +51,8 @@ public final class IntBigArrayBlock extends AbstractArrayBlock implements IntBlo
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
-        assert firstValueIndexes == null ? true : firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
+        assert firstValueIndexes == null ? vector.getPositionCount() == getPositionCount()
+            : firstValueIndexes[getPositionCount()] == vector.getPositionCount();
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBigArrayBlock.java
@@ -51,10 +51,10 @@ public final class IntBigArrayBlock extends AbstractArrayBlock implements IntBlo
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
-        checkInvariants();
+        assert assertInvariants();
     }
 
-    private void checkInvariants() {
+    private boolean assertInvariants() {
         if (firstValueIndexes != null) {
             assert firstValueIndexes.length == getPositionCount() + 1;
             assert firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
@@ -68,6 +68,7 @@ public final class IntBigArrayBlock extends AbstractArrayBlock implements IntBlo
                 assert ((nullsMask.get(i) == false) || (firstValueIndexes[i + 1] - firstValueIndexes[i]) == 1);
             }
         }
+        return true;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBigArrayBlock.java
@@ -51,6 +51,23 @@ public final class IntBigArrayBlock extends AbstractArrayBlock implements IntBlo
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
+        checkInvariants();
+    }
+
+    private void checkInvariants() {
+        if (firstValueIndexes != null) {
+            assert firstValueIndexes.length == getPositionCount() + 1;
+            assert firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
+            for (int i = 0; i < getPositionCount(); i++) {
+                assert (firstValueIndexes[i + 1] - firstValueIndexes[i]) >= 0;
+            }
+        }
+        if (firstValueIndexes != null && nullsMask != null) {
+            for (int i = 0; i < getPositionCount(); i++) {
+                // Either we have multi-values or a null but never both.
+                assert ((nullsMask.get(i) == false) || (firstValueIndexes[i + 1] - firstValueIndexes[i]) == 1);
+            }
+        }
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBigArrayBlock.java
@@ -108,7 +108,7 @@ public final class IntBigArrayBlock extends AbstractArrayBlock implements IntBlo
 
         // The following line is correct because positions with multi-values are never null.
         int expandedPositionCount = vector.getPositionCount();
-        long bitSetRamUsedEstimate = BlockRamUsageEstimator.sizeOfBitSet(expandedPositionCount);
+        long bitSetRamUsedEstimate = Math.max(nullsMask.size(), BlockRamUsageEstimator.sizeOfBitSet(expandedPositionCount));
         blockFactory().adjustBreaker(bitSetRamUsedEstimate, false);
 
         IntBigArrayBlock expanded = new IntBigArrayBlock(

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayBlock.java
@@ -107,7 +107,7 @@ final class LongArrayBlock extends AbstractArrayBlock implements LongBlock {
 
         // The following line is correct because positions with multi-values are never null.
         int expandedPositionCount = vector.getPositionCount();
-        long bitSetRamUsedEstimate = BlockRamUsageEstimator.sizeOfBitSet(expandedPositionCount);
+        long bitSetRamUsedEstimate = Math.max(nullsMask.size(), BlockRamUsageEstimator.sizeOfBitSet(expandedPositionCount));
         blockFactory().adjustBreaker(bitSetRamUsedEstimate, false);
 
         LongArrayBlock expanded = new LongArrayBlock(

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayBlock.java
@@ -50,6 +50,23 @@ final class LongArrayBlock extends AbstractArrayBlock implements LongBlock {
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
+        checkInvariants();
+    }
+
+    private void checkInvariants() {
+        if (firstValueIndexes != null) {
+            assert firstValueIndexes.length == getPositionCount() + 1;
+            assert firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
+            for (int i = 0; i < getPositionCount(); i++) {
+                assert (firstValueIndexes[i + 1] - firstValueIndexes[i]) >= 0;
+            }
+        }
+        if (firstValueIndexes != null && nullsMask != null) {
+            for (int i = 0; i < getPositionCount(); i++) {
+                // Either we have multi-values or a null but never both.
+                assert ((nullsMask.get(i) == false) || (firstValueIndexes[i + 1] - firstValueIndexes[i]) == 1);
+            }
+        }
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayBlock.java
@@ -50,7 +50,8 @@ final class LongArrayBlock extends AbstractArrayBlock implements LongBlock {
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
-        assert firstValueIndexes == null ? vector.getPositionCount() == getPositionCount()
+        assert firstValueIndexes == null
+            ? vector.getPositionCount() == getPositionCount()
             : firstValueIndexes[getPositionCount()] == vector.getPositionCount();
     }
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayBlock.java
@@ -50,10 +50,10 @@ final class LongArrayBlock extends AbstractArrayBlock implements LongBlock {
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
-        checkInvariants();
+        assert assertInvariants();
     }
 
-    private void checkInvariants() {
+    private boolean assertInvariants() {
         if (firstValueIndexes != null) {
             assert firstValueIndexes.length == getPositionCount() + 1;
             assert firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
@@ -67,6 +67,7 @@ final class LongArrayBlock extends AbstractArrayBlock implements LongBlock {
                 assert ((nullsMask.get(i) == false) || (firstValueIndexes[i + 1] - firstValueIndexes[i]) == 1);
             }
         }
+        return true;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayBlock.java
@@ -50,24 +50,7 @@ final class LongArrayBlock extends AbstractArrayBlock implements LongBlock {
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
-        assert assertInvariants();
-    }
-
-    private boolean assertInvariants() {
-        if (firstValueIndexes != null) {
-            assert firstValueIndexes.length == getPositionCount() + 1;
-            assert firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
-            for (int i = 0; i < getPositionCount(); i++) {
-                assert (firstValueIndexes[i + 1] - firstValueIndexes[i]) >= 0;
-            }
-        }
-        if (firstValueIndexes != null && nullsMask != null) {
-            for (int i = 0; i < getPositionCount(); i++) {
-                // Either we have multi-values or a null but never both.
-                assert ((nullsMask.get(i) == false) || (firstValueIndexes[i + 1] - firstValueIndexes[i]) == 1);
-            }
-        }
-        return true;
+        assert firstValueIndexes == null ? true : firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayBlock.java
@@ -50,7 +50,8 @@ final class LongArrayBlock extends AbstractArrayBlock implements LongBlock {
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
-        assert firstValueIndexes == null ? true : firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
+        assert firstValueIndexes == null ? vector.getPositionCount() == getPositionCount()
+            : firstValueIndexes[getPositionCount()] == vector.getPositionCount();
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBigArrayBlock.java
@@ -51,7 +51,8 @@ public final class LongBigArrayBlock extends AbstractArrayBlock implements LongB
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
-        assert firstValueIndexes == null ? vector.getPositionCount() == getPositionCount()
+        assert firstValueIndexes == null
+            ? vector.getPositionCount() == getPositionCount()
             : firstValueIndexes[getPositionCount()] == vector.getPositionCount();
     }
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBigArrayBlock.java
@@ -51,24 +51,7 @@ public final class LongBigArrayBlock extends AbstractArrayBlock implements LongB
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
-        assert assertInvariants();
-    }
-
-    private boolean assertInvariants() {
-        if (firstValueIndexes != null) {
-            assert firstValueIndexes.length == getPositionCount() + 1;
-            assert firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
-            for (int i = 0; i < getPositionCount(); i++) {
-                assert (firstValueIndexes[i + 1] - firstValueIndexes[i]) >= 0;
-            }
-        }
-        if (firstValueIndexes != null && nullsMask != null) {
-            for (int i = 0; i < getPositionCount(); i++) {
-                // Either we have multi-values or a null but never both.
-                assert ((nullsMask.get(i) == false) || (firstValueIndexes[i + 1] - firstValueIndexes[i]) == 1);
-            }
-        }
-        return true;
+        assert firstValueIndexes == null ? true : firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBigArrayBlock.java
@@ -51,10 +51,10 @@ public final class LongBigArrayBlock extends AbstractArrayBlock implements LongB
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
-        checkInvariants();
+        assert assertInvariants();
     }
 
-    private void checkInvariants() {
+    private boolean assertInvariants() {
         if (firstValueIndexes != null) {
             assert firstValueIndexes.length == getPositionCount() + 1;
             assert firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
@@ -68,6 +68,7 @@ public final class LongBigArrayBlock extends AbstractArrayBlock implements LongB
                 assert ((nullsMask.get(i) == false) || (firstValueIndexes[i + 1] - firstValueIndexes[i]) == 1);
             }
         }
+        return true;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBigArrayBlock.java
@@ -51,6 +51,23 @@ public final class LongBigArrayBlock extends AbstractArrayBlock implements LongB
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
+        checkInvariants();
+    }
+
+    private void checkInvariants() {
+        if (firstValueIndexes != null) {
+            assert firstValueIndexes.length == getPositionCount() + 1;
+            assert firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
+            for (int i = 0; i < getPositionCount(); i++) {
+                assert (firstValueIndexes[i + 1] - firstValueIndexes[i]) >= 0;
+            }
+        }
+        if (firstValueIndexes != null && nullsMask != null) {
+            for (int i = 0; i < getPositionCount(); i++) {
+                // Either we have multi-values or a null but never both.
+                assert ((nullsMask.get(i) == false) || (firstValueIndexes[i + 1] - firstValueIndexes[i]) == 1);
+            }
+        }
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBigArrayBlock.java
@@ -108,7 +108,7 @@ public final class LongBigArrayBlock extends AbstractArrayBlock implements LongB
 
         // The following line is correct because positions with multi-values are never null.
         int expandedPositionCount = vector.getPositionCount();
-        long bitSetRamUsedEstimate = BlockRamUsageEstimator.sizeOfBitSet(expandedPositionCount);
+        long bitSetRamUsedEstimate = Math.max(nullsMask.size(), BlockRamUsageEstimator.sizeOfBitSet(expandedPositionCount));
         blockFactory().adjustBreaker(bitSetRamUsedEstimate, false);
 
         LongBigArrayBlock expanded = new LongBigArrayBlock(

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBigArrayBlock.java
@@ -51,7 +51,8 @@ public final class LongBigArrayBlock extends AbstractArrayBlock implements LongB
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
-        assert firstValueIndexes == null ? true : firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
+        assert firstValueIndexes == null ? vector.getPositionCount() == getPositionCount()
+            : firstValueIndexes[getPositionCount()] == vector.getPositionCount();
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AbstractArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AbstractArrayBlock.java
@@ -52,7 +52,7 @@ abstract class AbstractArrayBlock extends AbstractBlock {
     }
 
     protected BitSet shiftNullsToExpandedPositions() {
-        BitSet expanded = new BitSet(getTotalValueCount());
+        BitSet expanded = new BitSet(nullsMask.size());
         int next = -1;
         while ((next = nullsMask.nextSetBit(next + 1)) != -1) {
             expanded.set(getFirstValueIndex(next));

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AbstractBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AbstractBlock.java
@@ -54,6 +54,9 @@ abstract class AbstractBlock extends AbstractNonThreadSafeRefCounted implements 
                 assert (firstValueIndexes[i + 1] - firstValueIndexes[i]) >= 0;
             }
         }
+        if (nullsMask != null) {
+            assert nullsMask.nextSetBit(getPositionCount() + 1) == -1;
+        }
         if (firstValueIndexes != null && nullsMask != null) {
             for (int i = 0; i < getPositionCount(); i++) {
                 // Either we have multi-values or a null but never both.

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AbstractBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AbstractBlock.java
@@ -31,6 +31,7 @@ abstract class AbstractBlock extends AbstractNonThreadSafeRefCounted implements 
         this.blockFactory = blockFactory;
         this.firstValueIndexes = null;
         this.nullsMask = null;
+        assert assertInvariants();
     }
 
     /**
@@ -43,6 +44,23 @@ abstract class AbstractBlock extends AbstractNonThreadSafeRefCounted implements 
         this.firstValueIndexes = firstValueIndexes;
         this.nullsMask = nullsMask == null || nullsMask.isEmpty() ? null : nullsMask;
         assert nullsMask != null || firstValueIndexes != null : "Create VectorBlock instead";
+        assert assertInvariants();
+    }
+
+    private boolean assertInvariants() {
+        if (firstValueIndexes != null) {
+            assert firstValueIndexes.length == getPositionCount() + 1;
+            for (int i = 0; i < getPositionCount(); i++) {
+                assert (firstValueIndexes[i + 1] - firstValueIndexes[i]) >= 0;
+            }
+        }
+        if (firstValueIndexes != null && nullsMask != null) {
+            for (int i = 0; i < getPositionCount(); i++) {
+                // Either we have multi-values or a null but never both.
+                assert ((nullsMask.get(i) == false) || (firstValueIndexes[i + 1] - firstValueIndexes[i]) == 1);
+            }
+        }
+        return true;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockRamUsageEstimator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/BlockRamUsageEstimator.java
@@ -27,6 +27,8 @@ public final class BlockRamUsageEstimator {
     }
 
     public static long sizeOfBitSet(long size) {
-        return BITSET_BASE_RAM_USAGE + (size / Byte.SIZE);
+        // BitSet is normally made up of words, represented by longs. So we need to divide and round up.
+        long wordCount = (size + Long.SIZE - 1) / Long.SIZE;
+        return BITSET_BASE_RAM_USAGE + wordCount * Long.BYTES;
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
@@ -61,6 +61,23 @@ final class $Type$ArrayBlock extends AbstractArrayBlock implements $Type$Block {
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
+        checkInvariants();
+    }
+
+    private void checkInvariants() {
+        if (firstValueIndexes != null) {
+            assert firstValueIndexes.length == getPositionCount() + 1;
+            assert firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
+            for (int i = 0; i < getPositionCount(); i++) {
+                assert (firstValueIndexes[i + 1] - firstValueIndexes[i]) >= 0;
+            }
+        }
+        if (firstValueIndexes != null && nullsMask != null) {
+            for (int i = 0; i < getPositionCount(); i++) {
+                // Either we have multi-values or a null but never both.
+                assert ((nullsMask.get(i) == false) || (firstValueIndexes[i + 1] - firstValueIndexes[i]) == 1);
+            }
+        }
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
@@ -61,7 +61,8 @@ final class $Type$ArrayBlock extends AbstractArrayBlock implements $Type$Block {
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
-        assert firstValueIndexes == null ? vector.getPositionCount() == getPositionCount()
+        assert firstValueIndexes == null
+            ? vector.getPositionCount() == getPositionCount()
             : firstValueIndexes[getPositionCount()] == vector.getPositionCount();
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
@@ -126,7 +126,7 @@ $endif$
 
         // The following line is correct because positions with multi-values are never null.
         int expandedPositionCount = vector.getPositionCount();
-        long bitSetRamUsedEstimate = BlockRamUsageEstimator.sizeOfBitSet(expandedPositionCount);
+        long bitSetRamUsedEstimate = Math.max(nullsMask.size(), BlockRamUsageEstimator.sizeOfBitSet(expandedPositionCount));
         blockFactory().adjustBreaker(bitSetRamUsedEstimate, false);
 
         $Type$ArrayBlock expanded = new $Type$ArrayBlock(

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
@@ -61,7 +61,8 @@ final class $Type$ArrayBlock extends AbstractArrayBlock implements $Type$Block {
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
-        assert firstValueIndexes == null ? true : firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
+        assert firstValueIndexes == null ? vector.getPositionCount() == getPositionCount()
+            : firstValueIndexes[getPositionCount()] == vector.getPositionCount();
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
@@ -61,10 +61,10 @@ final class $Type$ArrayBlock extends AbstractArrayBlock implements $Type$Block {
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
-        checkInvariants();
+        assert assertInvariants();
     }
 
-    private void checkInvariants() {
+    private boolean assertInvariants() {
         if (firstValueIndexes != null) {
             assert firstValueIndexes.length == getPositionCount() + 1;
             assert firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
@@ -78,6 +78,7 @@ final class $Type$ArrayBlock extends AbstractArrayBlock implements $Type$Block {
                 assert ((nullsMask.get(i) == false) || (firstValueIndexes[i + 1] - firstValueIndexes[i]) == 1);
             }
         }
+        return true;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
@@ -61,24 +61,7 @@ final class $Type$ArrayBlock extends AbstractArrayBlock implements $Type$Block {
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
-        assert assertInvariants();
-    }
-
-    private boolean assertInvariants() {
-        if (firstValueIndexes != null) {
-            assert firstValueIndexes.length == getPositionCount() + 1;
-            assert firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
-            for (int i = 0; i < getPositionCount(); i++) {
-                assert (firstValueIndexes[i + 1] - firstValueIndexes[i]) >= 0;
-            }
-        }
-        if (firstValueIndexes != null && nullsMask != null) {
-            for (int i = 0; i < getPositionCount(); i++) {
-                // Either we have multi-values or a null but never both.
-                assert ((nullsMask.get(i) == false) || (firstValueIndexes[i + 1] - firstValueIndexes[i]) == 1);
-            }
-        }
-        return true;
+        assert firstValueIndexes == null ? true : firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BigArrayBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BigArrayBlock.java.st
@@ -51,7 +51,8 @@ public final class $Type$BigArrayBlock extends AbstractArrayBlock implements $Ty
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
-        assert firstValueIndexes == null ? vector.getPositionCount() == getPositionCount()
+        assert firstValueIndexes == null
+            ? vector.getPositionCount() == getPositionCount()
             : firstValueIndexes[getPositionCount()] == vector.getPositionCount();
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BigArrayBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BigArrayBlock.java.st
@@ -51,24 +51,7 @@ public final class $Type$BigArrayBlock extends AbstractArrayBlock implements $Ty
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
-        assert assertInvariants();
-    }
-
-    private boolean assertInvariants() {
-        if (firstValueIndexes != null) {
-            assert firstValueIndexes.length == getPositionCount() + 1;
-            assert firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
-            for (int i = 0; i < getPositionCount(); i++) {
-                assert (firstValueIndexes[i + 1] - firstValueIndexes[i]) >= 0;
-            }
-        }
-        if (firstValueIndexes != null && nullsMask != null) {
-            for (int i = 0; i < getPositionCount(); i++) {
-                // Either we have multi-values or a null but never both.
-                assert ((nullsMask.get(i) == false) || (firstValueIndexes[i + 1] - firstValueIndexes[i]) == 1);
-            }
-        }
-        return true;
+        assert firstValueIndexes == null ? true : firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BigArrayBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BigArrayBlock.java.st
@@ -51,10 +51,10 @@ public final class $Type$BigArrayBlock extends AbstractArrayBlock implements $Ty
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
-        checkInvariants();
+        assert assertInvariants();
     }
 
-    private void checkInvariants() {
+    private boolean assertInvariants() {
         if (firstValueIndexes != null) {
             assert firstValueIndexes.length == getPositionCount() + 1;
             assert firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
@@ -68,6 +68,7 @@ public final class $Type$BigArrayBlock extends AbstractArrayBlock implements $Ty
                 assert ((nullsMask.get(i) == false) || (firstValueIndexes[i + 1] - firstValueIndexes[i]) == 1);
             }
         }
+        return true;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BigArrayBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BigArrayBlock.java.st
@@ -51,6 +51,23 @@ public final class $Type$BigArrayBlock extends AbstractArrayBlock implements $Ty
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
+        checkInvariants();
+    }
+
+    private void checkInvariants() {
+        if (firstValueIndexes != null) {
+            assert firstValueIndexes.length == getPositionCount() + 1;
+            assert firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
+            for (int i = 0; i < getPositionCount(); i++) {
+                assert (firstValueIndexes[i + 1] - firstValueIndexes[i]) >= 0;
+            }
+        }
+        if (firstValueIndexes != null && nullsMask != null) {
+            for (int i = 0; i < getPositionCount(); i++) {
+                // Either we have multi-values or a null but never both.
+                assert ((nullsMask.get(i) == false) || (firstValueIndexes[i + 1] - firstValueIndexes[i]) == 1);
+            }
+        }
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BigArrayBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BigArrayBlock.java.st
@@ -108,7 +108,7 @@ public final class $Type$BigArrayBlock extends AbstractArrayBlock implements $Ty
 
         // The following line is correct because positions with multi-values are never null.
         int expandedPositionCount = vector.getPositionCount();
-        long bitSetRamUsedEstimate = BlockRamUsageEstimator.sizeOfBitSet(expandedPositionCount);
+        long bitSetRamUsedEstimate = Math.max(nullsMask.size(), BlockRamUsageEstimator.sizeOfBitSet(expandedPositionCount));
         blockFactory().adjustBreaker(bitSetRamUsedEstimate, false);
 
         $Type$BigArrayBlock expanded = new $Type$BigArrayBlock(

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BigArrayBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BigArrayBlock.java.st
@@ -51,7 +51,8 @@ public final class $Type$BigArrayBlock extends AbstractArrayBlock implements $Ty
     ) {
         super(positionCount, firstValueIndexes, nulls, mvOrdering, blockFactory);
         this.vector = vector;
-        assert firstValueIndexes == null ? true : firstValueIndexes[getPositionCount()] <= vector.getPositionCount();
+        assert firstValueIndexes == null ? vector.getPositionCount() == getPositionCount()
+            : firstValueIndexes[getPositionCount()] == vector.getPositionCount();
     }
 
     @Override


### PR DESCRIPTION
While working on `mv_expand`, I came upon a couple minor things that I think are worth cleaning up:
- During tests, ensure that an `X-ArrayBlock`'s (and `X-BigArrayBlock`'s) invariants are actually valid; these invariants are currently only implicit and not documented.
- Simplify the initial allocation of the shifted `nullsMask` when expanding; currently we compute the number of non-null values, which does not indicate how big the shifted nulls mask should be - just use the current nulls mask as lower bound instead, avoiding unnecessary computations.
- Estimate the size of a BitSet more precisely to avoid (minor) underestimations, esp. when expanding.