### PR TITLE
Avoid `VND_*` content types

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -2376,7 +2376,7 @@ public abstract class ESRestTestCase extends ESTestCase {
     }
 
     public static void addXContentBody(Request request, ToXContent body) throws IOException {
-        final var xContentType = randomFrom(XContentType.values());
+        final var xContentType = randomFrom(XContentType.JSON, XContentType.CBOR, XContentType.YAML, XContentType.SMILE);
         final var bodyBytes = XContentHelper.toXContent(body, xContentType, EMPTY_PARAMS, randomBoolean());
         request.setEntity(
             new InputStreamEntity(


### PR DESCRIPTION
We have some tests that go all the way back to 7.0 which do not
understand the newer `VND_*` content types. This commit restricts the
Java REST tests to use only content types that all tests support.

Closes #103860