### PR TITLE
Test block loading with non-synthetic _source

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
@@ -1240,24 +1240,30 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
     }
 
     public final void testBlockLoaderFromColumnReader() throws IOException {
-        testBlockLoader(true);
+        testBlockLoader(false, true);
     }
 
     public final void testBlockLoaderFromRowStrideReader() throws IOException {
-        testBlockLoader(false);
+        testBlockLoader(false, false);
+    }
+
+    public final void testBlockLoaderFromColumnReaderWithSyntheticSource() throws IOException {
+        testBlockLoader(true, true);
+    }
+
+    public final void testBlockLoaderFromRowStrideReaderWithSyntheticSource() throws IOException {
+        testBlockLoader(true, false);
     }
 
     protected boolean supportsColumnAtATimeReader(MapperService mapper, MappedFieldType ft) {
         return ft.hasDocValues();
     }
 
-    private void testBlockLoader(boolean columnReader) throws IOException {
+    private void testBlockLoader(boolean syntheticSource, boolean columnReader) throws IOException {
         SyntheticSourceExample example = syntheticSourceSupport(false).example(5);
-        MapperService mapper = createMapperService(syntheticSourceMapping(b -> { // TODO randomly use syntheticSourceMapping or normal
-            b.startObject("field");
-            example.mapping().accept(b);
-            b.endObject();
-        }));
+        // TODO when synthetic _source is disabled disable doc values.
+        XContentBuilder mapping = syntheticSource ? syntheticSourceFieldMapping(example.mapping) : fieldMapping(example.mapping);
+        MapperService mapper = createMapperService(mapping);
         testBlockLoader(columnReader, example, mapper, "field");
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
@@ -1260,8 +1260,8 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
     }
 
     private void testBlockLoader(boolean syntheticSource, boolean columnReader) throws IOException {
+        // TODO if we're not using synthetic source use a different sort of example. Or something.
         SyntheticSourceExample example = syntheticSourceSupport(false).example(5);
-        // TODO when synthetic _source is disabled disable doc values.
         XContentBuilder mapping = syntheticSource ? syntheticSourceFieldMapping(example.mapping) : fieldMapping(example.mapping);
         MapperService mapper = createMapperService(mapping);
         testBlockLoader(columnReader, example, mapper, "field");


### PR DESCRIPTION
This adds tests for `Block` loading with non-synthetic _source. We had this as a TODO and not doing it was confusing us. Non-synthetic _source is much more common than synthetic _source too!
