### PR TITLE
Avoid throw AssertionError in ThrowingDriverContext

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/ThrowingDriverContext.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/ThrowingDriverContext.java
@@ -17,24 +17,37 @@ import org.elasticsearch.common.util.LongArray;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.core.Releasable;
 
-public class ThrowingDriverContext extends DriverContext {
-    public ThrowingDriverContext() {
+/**
+ * A driver context that doesn't support any interaction. Consider it as a place holder where we need a dummy driver context.
+ */
+final class ThrowingDriverContext extends DriverContext {
+    ThrowingDriverContext() {
         super(new ThrowingBigArrays(), BlockFactory.getInstance(new NoopCircuitBreaker("throwing-context"), new ThrowingBigArrays()));
     }
 
     @Override
     public BigArrays bigArrays() {
-        throw new AssertionError("should not reach here");
+        throw unsupported();
     }
 
     @Override
     public BlockFactory blockFactory() {
-        throw new AssertionError("should not reach here");
+        throw unsupported();
     }
 
     @Override
     public boolean addReleasable(Releasable releasable) {
-        throw new AssertionError("should not reach here");
+        throw unsupported();
+    }
+
+    @Override
+    public void addAsyncAction() {
+        throw unsupported();
+    }
+
+    static UnsupportedOperationException unsupported() {
+        assert false : "ThrowingDriverContext doesn't support any interaction";
+        throw new UnsupportedOperationException("ThrowingDriverContext doesn't support any interaction");
     }
 
     static class ThrowingBigArrays extends BigArrays {
@@ -45,27 +58,27 @@ public class ThrowingDriverContext extends DriverContext {
 
         @Override
         public ByteArray newByteArray(long size, boolean clearOnResize) {
-            throw new AssertionError("should not reach here");
+            throw unsupported();
         }
 
         @Override
         public IntArray newIntArray(long size, boolean clearOnResize) {
-            throw new AssertionError("should not reach here");
+            throw unsupported();
         }
 
         @Override
         public LongArray newLongArray(long size, boolean clearOnResize) {
-            throw new AssertionError("should not reach here");
+            throw unsupported();
         }
 
         @Override
         public FloatArray newFloatArray(long size, boolean clearOnResize) {
-            throw new AssertionError("should not reach here");
+            throw unsupported();
         }
 
         @Override
         public DoubleArray newDoubleArray(long size, boolean clearOnResize) {
-            throw new AssertionError("should not reach here");
+            throw unsupported();
         }
     }
 }


### PR DESCRIPTION
ThrowingDriverContext can bring down Elasticsearch instances as it throws AssertionError. An unreleased bug caused this class to throw AssertionError. This change replaces AssertionError with an assertion and an unsupported exception. I attempted to remove this class, but it requires additional effort to make ExpressionEvaluator.Factory Describable.