### PR TITLE
Use only JSON in REST tests

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -2376,7 +2376,7 @@ public abstract class ESRestTestCase extends ESTestCase {
     }
 
     public static void addXContentBody(Request request, ToXContent body) throws IOException {
-        final var xContentType = randomFrom(XContentType.JSON, XContentType.CBOR, XContentType.YAML, XContentType.SMILE);
+        final var xContentType = XContentType.JSON;
         final var bodyBytes = XContentHelper.toXContent(body, xContentType, EMPTY_PARAMS, randomBoolean());
         request.setEntity(
             new InputStreamEntity(


### PR DESCRIPTION
A temporary fix for the broken tests while we iterate on something more
comprehensive in #103880.

Closes #103884