### PR TITLE
Change index.look_ahead_time setting's default value from 2 hours to 30 minutes.

### DIFF
--- a/docs/changelog/103898.yaml
+++ b/docs/changelog/103898.yaml
@@ -1,15 +1,15 @@
 pr: 103898
-summary: Change `index.look_ahead_time` index setting's default value from 2 hours to 30 minutes.
+summary: Change `index.look_ahead_time` index setting's default value from 2 hours
+  to 30 minutes.
 area: TSDB
-type: bug
+type: "breaking, bug"
 issues: []
 breaking:
-  title: Change `index.look_ahead_time` index setting's default value from 2 hours to 30 minutes.
+  title: Change `index.look_ahead_time` index setting's default value from 2 hours
+    to 30 minutes.
   area: Index setting
-  details: "Lower the `index.look_ahead_time` index setting's max value from 2 hours to 30 minutes."
-  impact: >
-    Documents with @timestamp of 30 minutes or more in the future will be rejected.
-    Before documents with @timestamp of 2 hours or more in the future were rejected.
-    If the previous behaviour should be kept, then update the `index.look_ahead_time`
-    setting to two hours before performing the upgrade.
+  details: Lower the `index.look_ahead_time` index setting's max value from 2 hours
+    to 30 minutes.
+  impact: |
+    Documents with @timestamp of 30 minutes or more in the future will be rejected. Before documents with @timestamp of 2 hours or more in the future were rejected. If the previous behaviour should be kept, then update the `index.look_ahead_time` setting to two hours before performing the upgrade.
   notable: false

--- a/docs/changelog/103898.yaml
+++ b/docs/changelog/103898.yaml
@@ -1,0 +1,5 @@
+pr: 103898
+summary: Change `index.look_ahead_time` index setting's default value
+area: TSDB
+type: bug
+issues: []

--- a/docs/changelog/103898.yaml
+++ b/docs/changelog/103898.yaml
@@ -1,6 +1,5 @@
 pr: 103898
-summary: Change `index.look_ahead_time` index setting's default value from 2 hours
-  to 30 minutes.
+summary: Change `index.look_ahead_time` index setting's default value from 2 hours to 30 minutes.
 area: TSDB
 type: breaking
 issues: []

--- a/docs/changelog/103898.yaml
+++ b/docs/changelog/103898.yaml
@@ -1,5 +1,15 @@
 pr: 103898
-summary: Change `index.look_ahead_time` index setting's default value
+summary: Change `index.look_ahead_time` index setting's default value from 2 hours to 30 minutes.
 area: TSDB
 type: bug
 issues: []
+breaking:
+  title: Change `index.look_ahead_time` index setting's default value from 2 hours to 30 minutes.
+  area: Index setting
+  details: "Lower the `index.look_ahead_time` index setting's max value from 2 hours to 30 minutes."
+  impact: >
+    Document with @timestamp of 30 minutes or more in the future will be rejected.
+    Before documents with @timestamp of 2 hours or more in the future were rejected.
+    If the previous behaviour should be kept, then update the `index.look_ahead_time`
+    setting to two hours before performing the upgrade.
+  notable: false

--- a/docs/changelog/103898.yaml
+++ b/docs/changelog/103898.yaml
@@ -8,7 +8,7 @@ breaking:
   area: Index setting
   details: "Lower the `index.look_ahead_time` index setting's max value from 2 hours to 30 minutes."
   impact: >
-    Document with @timestamp of 30 minutes or more in the future will be rejected.
+    Documents with @timestamp of 30 minutes or more in the future will be rejected.
     Before documents with @timestamp of 2 hours or more in the future were rejected.
     If the previous behaviour should be kept, then update the `index.look_ahead_time`
     setting to two hours before performing the upgrade.

--- a/docs/changelog/103898.yaml
+++ b/docs/changelog/103898.yaml
@@ -2,14 +2,14 @@ pr: 103898
 summary: Change `index.look_ahead_time` index setting's default value from 2 hours
   to 30 minutes.
 area: TSDB
-type: "breaking, bug"
+type: breaking
 issues: []
 breaking:
-  title: Change `index.look_ahead_time` index setting's default value from 2 hours
-    to 30 minutes.
+  title: Change `index.look_ahead_time` index setting's default value from 2 hours to 30 minutes.
   area: Index setting
-  details: Lower the `index.look_ahead_time` index setting's max value from 2 hours
-    to 30 minutes.
-  impact: |
-    Documents with @timestamp of 30 minutes or more in the future will be rejected. Before documents with @timestamp of 2 hours or more in the future were rejected. If the previous behaviour should be kept, then update the `index.look_ahead_time` setting to two hours before performing the upgrade.
+  details: Lower the `index.look_ahead_time` index setting's max value from 2 hours to 30 minutes.
+  impact: >
+    Documents with @timestamp of 30 minutes or more in the future will be rejected.
+    Before documents with @timestamp of 2 hours or more in the future were rejected.
+    If the previous behaviour should be kept, then update the `index.look_ahead_time` setting to two hours before performing the upgrade.
   notable: false

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/DataStreamsPlugin.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/DataStreamsPlugin.java
@@ -93,7 +93,7 @@ public class DataStreamsPlugin extends Plugin implements ActionPlugin, HealthPlu
     private static final TimeValue MAX_LOOK_AHEAD_TIME = TimeValue.timeValueHours(2);
     public static final Setting<TimeValue> LOOK_AHEAD_TIME = Setting.timeSetting(
         "index.look_ahead_time",
-        TimeValue.timeValueHours(2),
+        TimeValue.timeValueMinutes(30),
         TimeValue.timeValueMinutes(1),
         TimeValue.timeValueDays(7), // is effectively 2h now.
         Setting.Property.IndexScope,

--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/DataStreamGetWriteIndexTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/DataStreamGetWriteIndexTests.java
@@ -87,24 +87,24 @@ public class DataStreamGetWriteIndexTests extends ESTestCase {
         assertThat(backingIndex, notNullValue());
         // Ensure truncate to seconds:
         assertThat(backingIndex.getSettings().get("index.time_series.start_time"), equalTo("2022-03-15T06:29:36.000Z"));
-        assertThat(backingIndex.getSettings().get("index.time_series.end_time"), equalTo("2022-03-15T10:29:36.000Z"));
+        assertThat(backingIndex.getSettings().get("index.time_series.end_time"), equalTo("2022-03-15T08:59:36.000Z"));
 
         // advance time and rollover:
-        time = time.plusSeconds(80 * 60);
+        time = time.plusSeconds(20 * 60);
         var result = rolloverOver(state, "logs-myapp", time);
         state = result.clusterState();
 
         DataStream dataStream = state.getMetadata().dataStreams().get("logs-myapp");
         backingIndex = state.getMetadata().index(dataStream.getIndices().get(1));
         assertThat(backingIndex, notNullValue());
-        assertThat(backingIndex.getSettings().get("index.time_series.start_time"), equalTo("2022-03-15T10:29:36.000Z"));
-        assertThat(backingIndex.getSettings().get("index.time_series.end_time"), equalTo("2022-03-15T12:29:36.000Z"));
+        assertThat(backingIndex.getSettings().get("index.time_series.start_time"), equalTo("2022-03-15T08:59:36.000Z"));
+        assertThat(backingIndex.getSettings().get("index.time_series.end_time"), equalTo("2022-03-15T09:29:36.000Z"));
         String secondBackingIndex = backingIndex.getIndex().getName();
 
         // first backing index:
         {
             long start = MILLIS_FORMATTER.parseMillis("2022-03-15T06:29:36.000Z");
-            long end = MILLIS_FORMATTER.parseMillis("2022-03-15T10:29:36.000Z") - 1;
+            long end = MILLIS_FORMATTER.parseMillis("2022-03-15T08:59:36.000Z") - 1;
             for (int i = 0; i < 256; i++) {
                 String timestamp = MILLIS_FORMATTER.formatMillis(randomLongBetween(start, end));
                 var writeIndex = getWriteIndex(state, "logs-myapp", timestamp);
@@ -114,14 +114,14 @@ public class DataStreamGetWriteIndexTests extends ESTestCase {
 
         // Borderline:
         {
-            var writeIndex = getWriteIndex(state, "logs-myapp", "2022-03-15T10:29:35.999Z");
+            var writeIndex = getWriteIndex(state, "logs-myapp", "2022-03-15T08:59:35.999Z");
             assertThat(writeIndex.getName(), equalTo(".ds-logs-myapp-2022.03.15-000001"));
         }
 
         // Second backing index:
         {
-            long start = MILLIS_FORMATTER.parseMillis("2022-03-15T10:29:36.000Z");
-            long end = MILLIS_FORMATTER.parseMillis("2022-03-15T12:29:36.000Z") - 1;
+            long start = MILLIS_FORMATTER.parseMillis("2022-03-15T08:59:36.000Z");
+            long end = MILLIS_FORMATTER.parseMillis("2022-03-15T09:29:36.000Z") - 1;
             for (int i = 0; i < 256; i++) {
                 String timestamp = MILLIS_FORMATTER.formatMillis(randomLongBetween(start, end));
                 var writeIndex = getWriteIndex(state, "logs-myapp", timestamp);
@@ -131,19 +131,19 @@ public class DataStreamGetWriteIndexTests extends ESTestCase {
 
         // Borderline (again):
         {
-            var writeIndex = getWriteIndex(state, "logs-myapp", "2022-03-15T12:29:35.999Z");
+            var writeIndex = getWriteIndex(state, "logs-myapp", "2022-03-15T09:29:35.999Z");
             assertThat(writeIndex.getName(), equalTo(secondBackingIndex));
         }
 
         // Outside the valid temporal ranges:
         {
             var finalState = state;
-            var e = expectThrows(IllegalArgumentException.class, () -> getWriteIndex(finalState, "logs-myapp", "2022-03-15T12:29:36.000Z"));
+            var e = expectThrows(IllegalArgumentException.class, () -> getWriteIndex(finalState, "logs-myapp", "2022-03-15T09:29:36.000Z"));
             assertThat(
                 e.getMessage(),
                 equalTo(
-                    "the document timestamp [2022-03-15T12:29:36.000Z] is outside of ranges of currently writable indices ["
-                        + "[2022-03-15T06:29:36.000Z,2022-03-15T10:29:36.000Z][2022-03-15T10:29:36.000Z,2022-03-15T12:29:36.000Z]]"
+                    "the document timestamp [2022-03-15T09:29:36.000Z] is outside of ranges of currently writable indices ["
+                        + "[2022-03-15T06:29:36.000Z,2022-03-15T08:59:36.000Z][2022-03-15T08:59:36.000Z,2022-03-15T09:29:36.000Z]]"
                 )
             );
         }
@@ -158,24 +158,24 @@ public class DataStreamGetWriteIndexTests extends ESTestCase {
         assertThat(backingIndex, notNullValue());
         // Ensure truncate to seconds and millis format:
         assertThat(backingIndex.getSettings().get("index.time_series.start_time"), equalTo("2022-03-15T06:29:36.000Z"));
-        assertThat(backingIndex.getSettings().get("index.time_series.end_time"), equalTo("2022-03-15T10:29:36.000Z"));
+        assertThat(backingIndex.getSettings().get("index.time_series.end_time"), equalTo("2022-03-15T08:59:36.000Z"));
 
         // advance time and rollover:
-        time = time.plusSeconds(80 * 60);
+        time = time.plusSeconds(20 * 60);
         var result = rolloverOver(state, "logs-myapp", time);
         state = result.clusterState();
 
         DataStream dataStream = state.getMetadata().dataStreams().get("logs-myapp");
         backingIndex = state.getMetadata().index(dataStream.getIndices().get(1));
         assertThat(backingIndex, notNullValue());
-        assertThat(backingIndex.getSettings().get("index.time_series.start_time"), equalTo("2022-03-15T10:29:36.000Z"));
-        assertThat(backingIndex.getSettings().get("index.time_series.end_time"), equalTo("2022-03-15T12:29:36.000Z"));
+        assertThat(backingIndex.getSettings().get("index.time_series.start_time"), equalTo("2022-03-15T08:59:36.000Z"));
+        assertThat(backingIndex.getSettings().get("index.time_series.end_time"), equalTo("2022-03-15T09:29:36.000Z"));
         String secondBackingIndex = backingIndex.getIndex().getName();
 
         // first backing index:
         {
             long start = NANOS_FORMATTER.parseMillis("2022-03-15T06:29:36.000000000Z");
-            long end = NANOS_FORMATTER.parseMillis("2022-03-15T10:29:36.000000000Z") - 1;
+            long end = NANOS_FORMATTER.parseMillis("2022-03-15T08:59:36.000000000Z") - 1;
             for (int i = 0; i < 256; i++) {
                 String timestamp = NANOS_FORMATTER.formatMillis(randomLongBetween(start, end));
                 var writeIndex = getWriteIndex(state, "logs-myapp", timestamp);
@@ -185,14 +185,14 @@ public class DataStreamGetWriteIndexTests extends ESTestCase {
 
         // Borderline:
         {
-            var writeIndex = getWriteIndex(state, "logs-myapp", "2022-03-15T10:29:35.999999999Z");
+            var writeIndex = getWriteIndex(state, "logs-myapp", "2022-03-15T08:59:35.999999999Z");
             assertThat(writeIndex.getName(), equalTo(".ds-logs-myapp-2022.03.15-000001"));
         }
 
         // Second backing index:
         {
-            long start = NANOS_FORMATTER.parseMillis("2022-03-15T10:29:36.000000000Z");
-            long end = NANOS_FORMATTER.parseMillis("2022-03-15T12:29:36.000000000Z") - 1;
+            long start = NANOS_FORMATTER.parseMillis("2022-03-15T08:59:36.000000000Z");
+            long end = NANOS_FORMATTER.parseMillis("2022-03-15T09:29:36.000000000Z") - 1;
             for (int i = 0; i < 256; i++) {
                 String timestamp = NANOS_FORMATTER.formatMillis(randomLongBetween(start, end));
                 var writeIndex = getWriteIndex(state, "logs-myapp", timestamp);
@@ -202,7 +202,7 @@ public class DataStreamGetWriteIndexTests extends ESTestCase {
 
         // Borderline (again):
         {
-            var writeIndex = getWriteIndex(state, "logs-myapp", "2022-03-15T12:29:35.999999999Z");
+            var writeIndex = getWriteIndex(state, "logs-myapp", "2022-03-15T09:29:35.999999999Z");
             assertThat(writeIndex.getName(), equalTo(secondBackingIndex));
         }
     }

--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/DataStreamIndexSettingsProviderTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/DataStreamIndexSettingsProviderTests.java
@@ -39,7 +39,7 @@ import static org.hamcrest.Matchers.equalTo;
 public class DataStreamIndexSettingsProviderTests extends ESTestCase {
 
     private static final TimeValue DEFAULT_LOOK_BACK_TIME = TimeValue.timeValueHours(2); // default
-    private static final TimeValue DEFAULT_LOOK_AHEAD_TIME = TimeValue.timeValueHours(2); // default
+    private static final TimeValue DEFAULT_LOOK_AHEAD_TIME = TimeValue.timeValueMinutes(30); // default
 
     DataStreamIndexSettingsProvider provider;
 
@@ -94,7 +94,6 @@ public class DataStreamIndexSettingsProviderTests extends ESTestCase {
         String dataStreamName = "logs-app1";
 
         Instant now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-        TimeValue lookAheadTime = TimeValue.timeValueHours(2); // default
         Settings settings = builder().putList(IndexMetadata.INDEX_ROUTING_PATH.getKey(), "field2").build();
         String mapping = """
             {
@@ -126,8 +125,8 @@ public class DataStreamIndexSettingsProviderTests extends ESTestCase {
             List.of(new CompressedXContent(mapping))
         );
         assertThat(result.size(), equalTo(2));
-        assertThat(IndexSettings.TIME_SERIES_START_TIME.get(result), equalTo(now.minusMillis(lookAheadTime.getMillis())));
-        assertThat(IndexSettings.TIME_SERIES_END_TIME.get(result), equalTo(now.plusMillis(lookAheadTime.getMillis())));
+        assertThat(IndexSettings.TIME_SERIES_START_TIME.get(result), equalTo(now.minusMillis(DEFAULT_LOOK_BACK_TIME.getMillis())));
+        assertThat(IndexSettings.TIME_SERIES_END_TIME.get(result), equalTo(now.plusMillis(DEFAULT_LOOK_AHEAD_TIME.getMillis())));
     }
 
     public void testGetAdditionalIndexSettingsMappingsMerging() throws Exception {
@@ -135,7 +134,6 @@ public class DataStreamIndexSettingsProviderTests extends ESTestCase {
         String dataStreamName = "logs-app1";
 
         Instant now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-        TimeValue lookAheadTime = TimeValue.timeValueHours(2); // default
         Settings settings = Settings.EMPTY;
         String mapping1 = """
             {
@@ -193,8 +191,8 @@ public class DataStreamIndexSettingsProviderTests extends ESTestCase {
             List.of(new CompressedXContent(mapping1), new CompressedXContent(mapping2), new CompressedXContent(mapping3))
         );
         assertThat(result.size(), equalTo(3));
-        assertThat(IndexSettings.TIME_SERIES_START_TIME.get(result), equalTo(now.minusMillis(lookAheadTime.getMillis())));
-        assertThat(IndexSettings.TIME_SERIES_END_TIME.get(result), equalTo(now.plusMillis(lookAheadTime.getMillis())));
+        assertThat(IndexSettings.TIME_SERIES_START_TIME.get(result), equalTo(now.minusMillis(DEFAULT_LOOK_BACK_TIME.getMillis())));
+        assertThat(IndexSettings.TIME_SERIES_END_TIME.get(result), equalTo(now.plusMillis(DEFAULT_LOOK_AHEAD_TIME.getMillis())));
         assertThat(IndexMetadata.INDEX_ROUTING_PATH.get(result), containsInAnyOrder("field1", "field3"));
     }
 
@@ -203,7 +201,6 @@ public class DataStreamIndexSettingsProviderTests extends ESTestCase {
         String dataStreamName = "logs-app1";
 
         Instant now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-        TimeValue lookAheadTime = TimeValue.timeValueHours(2); // default
         Settings settings = Settings.EMPTY;
         Settings result = provider.getAdditionalIndexSettings(
             DataStream.getDefaultBackingIndexName(dataStreamName, 1),
@@ -215,8 +212,8 @@ public class DataStreamIndexSettingsProviderTests extends ESTestCase {
             List.of()
         );
         assertThat(result.size(), equalTo(2));
-        assertThat(IndexSettings.TIME_SERIES_START_TIME.get(result), equalTo(now.minusMillis(lookAheadTime.getMillis())));
-        assertThat(IndexSettings.TIME_SERIES_END_TIME.get(result), equalTo(now.plusMillis(lookAheadTime.getMillis())));
+        assertThat(IndexSettings.TIME_SERIES_START_TIME.get(result), equalTo(now.minusMillis(DEFAULT_LOOK_BACK_TIME.getMillis())));
+        assertThat(IndexSettings.TIME_SERIES_END_TIME.get(result), equalTo(now.plusMillis(DEFAULT_LOOK_AHEAD_TIME.getMillis())));
     }
 
     public void testGetAdditionalIndexSettingsLookAheadTime() throws Exception {
@@ -263,7 +260,7 @@ public class DataStreamIndexSettingsProviderTests extends ESTestCase {
 
     public void testGetAdditionalIndexSettingsDataStreamAlreadyCreated() throws Exception {
         String dataStreamName = "logs-app1";
-        TimeValue lookAheadTime = TimeValue.timeValueHours(2);
+        TimeValue lookAheadTime = TimeValue.timeValueMinutes(30);
 
         Instant sixHoursAgo = Instant.now().minus(6, ChronoUnit.HOURS).truncatedTo(ChronoUnit.SECONDS);
         Instant currentEnd = sixHoursAgo.plusMillis(lookAheadTime.getMillis());
@@ -415,7 +412,6 @@ public class DataStreamIndexSettingsProviderTests extends ESTestCase {
 
     public void testGenerateRoutingPathFromDynamicTemplate() throws Exception {
         Instant now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-        TimeValue lookAheadTime = TimeValue.timeValueHours(2); // default
         String mapping = """
             {
                 "_doc": {
@@ -448,14 +444,13 @@ public class DataStreamIndexSettingsProviderTests extends ESTestCase {
             """;
         Settings result = generateTsdbSettings(mapping, now);
         assertThat(result.size(), equalTo(3));
-        assertThat(IndexSettings.TIME_SERIES_START_TIME.get(result), equalTo(now.minusMillis(lookAheadTime.getMillis())));
-        assertThat(IndexSettings.TIME_SERIES_END_TIME.get(result), equalTo(now.plusMillis(lookAheadTime.getMillis())));
+        assertThat(IndexSettings.TIME_SERIES_START_TIME.get(result), equalTo(now.minusMillis(DEFAULT_LOOK_BACK_TIME.getMillis())));
+        assertThat(IndexSettings.TIME_SERIES_END_TIME.get(result), equalTo(now.plusMillis(DEFAULT_LOOK_AHEAD_TIME.getMillis())));
         assertThat(IndexMetadata.INDEX_ROUTING_PATH.get(result), containsInAnyOrder("host.id", "prometheus.labels.*"));
     }
 
     public void testGenerateRoutingPathFromDynamicTemplateWithMultiplePathMatchEntries() throws Exception {
         Instant now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-        TimeValue lookAheadTime = TimeValue.timeValueHours(2); // default
         String mapping = """
             {
                 "_doc": {
@@ -488,8 +483,8 @@ public class DataStreamIndexSettingsProviderTests extends ESTestCase {
             """;
         Settings result = generateTsdbSettings(mapping, now);
         assertThat(result.size(), equalTo(3));
-        assertThat(IndexSettings.TIME_SERIES_START_TIME.get(result), equalTo(now.minusMillis(lookAheadTime.getMillis())));
-        assertThat(IndexSettings.TIME_SERIES_END_TIME.get(result), equalTo(now.plusMillis(lookAheadTime.getMillis())));
+        assertThat(IndexSettings.TIME_SERIES_START_TIME.get(result), equalTo(now.minusMillis(DEFAULT_LOOK_BACK_TIME.getMillis())));
+        assertThat(IndexSettings.TIME_SERIES_END_TIME.get(result), equalTo(now.plusMillis(DEFAULT_LOOK_AHEAD_TIME.getMillis())));
         assertThat(
             IndexMetadata.INDEX_ROUTING_PATH.get(result),
             containsInAnyOrder("host.id", "xprometheus.labels.*", "yprometheus.labels.*")
@@ -500,7 +495,6 @@ public class DataStreamIndexSettingsProviderTests extends ESTestCase {
 
     public void testGenerateRoutingPathFromDynamicTemplate_templateWithNoPathMatch() throws Exception {
         Instant now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-        TimeValue lookAheadTime = TimeValue.timeValueHours(2); // default
         String mapping = """
             {
                 "_doc": {
@@ -542,14 +536,13 @@ public class DataStreamIndexSettingsProviderTests extends ESTestCase {
             """;
         Settings result = generateTsdbSettings(mapping, now);
         assertThat(result.size(), equalTo(3));
-        assertThat(IndexSettings.TIME_SERIES_START_TIME.get(result), equalTo(now.minusMillis(lookAheadTime.getMillis())));
-        assertThat(IndexSettings.TIME_SERIES_END_TIME.get(result), equalTo(now.plusMillis(lookAheadTime.getMillis())));
+        assertThat(IndexSettings.TIME_SERIES_START_TIME.get(result), equalTo(now.minusMillis(DEFAULT_LOOK_BACK_TIME.getMillis())));
+        assertThat(IndexSettings.TIME_SERIES_END_TIME.get(result), equalTo(now.plusMillis(DEFAULT_LOOK_AHEAD_TIME.getMillis())));
         assertThat(IndexMetadata.INDEX_ROUTING_PATH.get(result), containsInAnyOrder("host.id", "prometheus.labels.*"));
     }
 
     public void testGenerateRoutingPathFromDynamicTemplate_nonKeywordTemplate() throws Exception {
         Instant now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-        TimeValue lookAheadTime = TimeValue.timeValueHours(2); // default
         String mapping = """
             {
                 "_doc": {
@@ -590,8 +583,8 @@ public class DataStreamIndexSettingsProviderTests extends ESTestCase {
             }
             """;
         Settings result = generateTsdbSettings(mapping, now);
-        assertThat(IndexSettings.TIME_SERIES_START_TIME.get(result), equalTo(now.minusMillis(lookAheadTime.getMillis())));
-        assertThat(IndexSettings.TIME_SERIES_END_TIME.get(result), equalTo(now.plusMillis(lookAheadTime.getMillis())));
+        assertThat(IndexSettings.TIME_SERIES_START_TIME.get(result), equalTo(now.minusMillis(DEFAULT_LOOK_BACK_TIME.getMillis())));
+        assertThat(IndexSettings.TIME_SERIES_END_TIME.get(result), equalTo(now.plusMillis(DEFAULT_LOOK_AHEAD_TIME.getMillis())));
         assertThat(IndexMetadata.INDEX_ROUTING_PATH.get(result), containsInAnyOrder("host.id", "prometheus.labels.*"));
         assertEquals(2, IndexMetadata.INDEX_ROUTING_PATH.get(result).size());
     }

--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/MetadataDataStreamRolloverServiceTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/MetadataDataStreamRolloverServiceTests.java
@@ -244,7 +244,7 @@ public class MetadataDataStreamRolloverServiceTests extends ESTestCase {
             Instant endTime = IndexSettings.TIME_SERIES_END_TIME.get(im.getSettings());
             assertThat(startTime.isBefore(endTime), is(true));
             assertThat(startTime, equalTo(now.minus(2, ChronoUnit.HOURS)));
-            assertThat(endTime, equalTo(now.plus(2, ChronoUnit.HOURS)));
+            assertThat(endTime, equalTo(now.plus(30, ChronoUnit.MINUTES)));
         } finally {
             testThreadPool.shutdown();
         }
@@ -339,7 +339,7 @@ public class MetadataDataStreamRolloverServiceTests extends ESTestCase {
             endTime = IndexSettings.TIME_SERIES_END_TIME.get(im.getSettings());
             assertThat(startTime.isBefore(endTime), is(true));
             assertThat(startTime, equalTo(now.minus(2, ChronoUnit.HOURS)));
-            assertThat(endTime, equalTo(now.plus(2, ChronoUnit.HOURS)));
+            assertThat(endTime, equalTo(now.plus(30, ChronoUnit.MINUTES)));
         } finally {
             testThreadPool.shutdown();
         }
@@ -416,7 +416,7 @@ public class MetadataDataStreamRolloverServiceTests extends ESTestCase {
                 var lastStartTime = IndexSettings.TIME_SERIES_START_TIME.get(im.getSettings());
                 var kastEndTime = IndexSettings.TIME_SERIES_END_TIME.get(im.getSettings());
                 assertThat(lastStartTime, equalTo(now.minus(2, ChronoUnit.HOURS).truncatedTo(ChronoUnit.SECONDS)));
-                assertThat(kastEndTime, equalTo(now.plus(2, ChronoUnit.HOURS).truncatedTo(ChronoUnit.SECONDS)));
+                assertThat(kastEndTime, equalTo(now.plus(30, ChronoUnit.MINUTES).truncatedTo(ChronoUnit.SECONDS)));
                 assertThat(im.getIndexMode(), equalTo(IndexMode.TIME_SERIES));
             }
         } finally {

--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/UpdateTimeSeriesRangeServiceTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/UpdateTimeSeriesRangeServiceTests.java
@@ -62,7 +62,7 @@ public class UpdateTimeSeriesRangeServiceTests extends ESTestCase {
         String dataStreamName = "logs-app1";
         Instant now = Instant.now().truncatedTo(ChronoUnit.MILLIS);
         Instant start = now.minus(2, ChronoUnit.HOURS);
-        Instant end = now.plus(3, ChronoUnit.HOURS);
+        Instant end = now.plus(40, ChronoUnit.MINUTES);
         Metadata metadata = DataStreamTestHelper.getClusterStateWithDataStream(
             dataStreamName,
             List.of(new Tuple<>(start.minus(4, ChronoUnit.HOURS), start), new Tuple<>(start, end))
@@ -89,7 +89,7 @@ public class UpdateTimeSeriesRangeServiceTests extends ESTestCase {
         assertThat(getEndTime(result, dataStreamName, 1), not(equalTo(previousEndTime2)));
         assertThat(
             getEndTime(result, dataStreamName, 1),
-            equalTo(now.plus(2, ChronoUnit.HOURS).plus(5, ChronoUnit.MINUTES).truncatedTo(ChronoUnit.SECONDS))
+            equalTo(now.plus(30, ChronoUnit.MINUTES).plus(5, ChronoUnit.MINUTES).truncatedTo(ChronoUnit.SECONDS))
         );
     }
 
@@ -133,7 +133,7 @@ public class UpdateTimeSeriesRangeServiceTests extends ESTestCase {
         String dataStreamName = "logs-app1";
         Instant now = Instant.now().truncatedTo(ChronoUnit.MILLIS);
         Instant start = now.minus(2, ChronoUnit.HOURS);
-        Instant end = now.plus(3, ChronoUnit.HOURS);
+        Instant end = now.plus(31, ChronoUnit.MINUTES);
         Metadata metadata = DataStreamTestHelper.getClusterStateWithDataStream(
             dataStreamName,
             List.of(new Tuple<>(start.minus(4, ChronoUnit.HOURS), start), new Tuple<>(start, end))
@@ -182,25 +182,25 @@ public class UpdateTimeSeriesRangeServiceTests extends ESTestCase {
         String dataStreamName3 = "logs-app3";
         Instant now = Instant.now().truncatedTo(ChronoUnit.MILLIS);
 
-        Instant start = now.minus(6, ChronoUnit.HOURS);
+        Instant start = now.minus(90, ChronoUnit.MINUTES);
         Metadata.Builder mbBuilder = new Metadata.Builder();
         for (String dataStreamName : List.of(dataStreamName1, dataStreamName2, dataStreamName3)) {
-            Instant end = start.plus(2, ChronoUnit.HOURS);
+            Instant end = start.plus(30, ChronoUnit.MINUTES);
             DataStreamTestHelper.getClusterStateWithDataStream(mbBuilder, dataStreamName, List.of(new Tuple<>(start, end)));
             start = end;
         }
 
-        now = now.minus(3, ChronoUnit.HOURS);
+        now = now.minus(45, ChronoUnit.MINUTES);
         ClusterState before = ClusterState.builder(ClusterState.EMPTY_STATE).metadata(mbBuilder).build();
         ClusterState result = instance.updateTimeSeriesTemporalRange(before, now);
         assertThat(result, not(sameInstance(before)));
         assertThat(
             getEndTime(result, dataStreamName1, 0),
-            equalTo(now.plus(2, ChronoUnit.HOURS).plus(5, ChronoUnit.MINUTES).truncatedTo(ChronoUnit.SECONDS))
+            equalTo(now.plus(30, ChronoUnit.MINUTES).plus(5, ChronoUnit.MINUTES).truncatedTo(ChronoUnit.SECONDS))
         );
         assertThat(
             getEndTime(result, dataStreamName2, 0),
-            equalTo(now.plus(2, ChronoUnit.HOURS).plus(5, ChronoUnit.MINUTES).truncatedTo(ChronoUnit.SECONDS))
+            equalTo(now.plus(30, ChronoUnit.MINUTES).plus(5, ChronoUnit.MINUTES).truncatedTo(ChronoUnit.SECONDS))
         );
         assertThat(getEndTime(result, dataStreamName3, 0), equalTo(start));
     }

--- a/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/DownsampleActionSingleNodeTests.java
+++ b/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/DownsampleActionSingleNodeTests.java
@@ -558,7 +558,7 @@ public class DownsampleActionSingleNodeTests extends ESSingleNodeTestCase {
 
         final Instant now = Instant.now();
         SourceSupplier sourceSupplier = () -> {
-            String ts = randomDateForRange(now.minusSeconds(60 * 60).toEpochMilli(), now.plusSeconds(60 * 60).toEpochMilli());
+            String ts = randomDateForRange(now.minusSeconds(60 * 60).toEpochMilli(), now.plusSeconds(60 * 29).toEpochMilli());
             return XContentFactory.jsonBuilder()
                 .startObject()
                 .field(FIELD_TIMESTAMP, ts)


### PR DESCRIPTION
A followup from #103434

The impact of this change is that by default  documents with `@timestamp` of 30 minutes or more in the future will be rejected. Prior to this change by default documents with `@timestamp` of 2 hours or more in the future were rejected.
If the previous behaviour should be kept, then update the `index.look_ahead_time` setting to two hours before performing the upgrade.

By reducing the default look ahead time, new metrics will sooner be indexed into the new backing index. With the current default it takes up to 2 hours before writes get indexed into the new backing index. This is after rollover has occurred. This delayed effect can result in previous backing index growing well beyond the rollover conditions. This change should reduce this effect.