### PR TITLE
Filter without deep copy

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/BlockBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/BlockBenchmark.java
@@ -74,6 +74,7 @@ public class BlockBenchmark {
      */
     // We could also consider DocBlocks/DocVectors but they do not implement any of the typed block interfaces like IntBlock etc.
     public static final String[] RELEVANT_TYPE_BLOCK_COMBINATIONS = {
+        // TODO: add filtered blocks
         "boolean/array",
         "boolean/array-multivalue-null",
         "boolean/big-array",

--- a/x-pack/plugin/esql/compute/build.gradle
+++ b/x-pack/plugin/esql/compute/build.gradle
@@ -283,6 +283,27 @@ tasks.named('stringTemplates').configure {
     it.inputFile =  filterVectorBlockInputFile
     it.outputFile = "org/elasticsearch/compute/data/FilterBooleanVectorBlock.java"
   }
+  File filterBigArrayBlockInputFile = new File("${projectDir}/src/main/java/org/elasticsearch/compute/data/X-FilterBigArrayBlock.java.st")
+  template {
+    it.properties = intProperties
+    it.inputFile =  filterBigArrayBlockInputFile
+    it.outputFile = "org/elasticsearch/compute/data/FilterIntBigArrayBlock.java"
+  }
+  template {
+    it.properties = longProperties
+    it.inputFile =  filterBigArrayBlockInputFile
+    it.outputFile = "org/elasticsearch/compute/data/FilterLongBigArrayBlock.java"
+  }
+  template {
+    it.properties = doubleProperties
+    it.inputFile =  filterBigArrayBlockInputFile
+    it.outputFile = "org/elasticsearch/compute/data/FilterDoubleBigArrayBlock.java"
+  }
+  template {
+    it.properties = booleanProperties
+    it.inputFile =  filterBigArrayBlockInputFile
+    it.outputFile = "org/elasticsearch/compute/data/FilterBooleanBigArrayBlock.java"
+  }
   // vector blocks
   File vectorBlockInputFile = new File("${projectDir}/src/main/java/org/elasticsearch/compute/data/X-VectorBlock.java.st")
   template {

--- a/x-pack/plugin/esql/compute/build.gradle
+++ b/x-pack/plugin/esql/compute/build.gradle
@@ -257,6 +257,32 @@ tasks.named('stringTemplates').configure {
     it.inputFile =  filterBlockInputFile
     it.outputFile = "org/elasticsearch/compute/data/FilterBooleanBlock.java"
   }
+  File filterVectorBlockInputFile = new File("${projectDir}/src/main/java/org/elasticsearch/compute/data/X-FilterVectorBlock.java.st")
+  template {
+    it.properties = intProperties
+    it.inputFile =  filterVectorBlockInputFile
+    it.outputFile = "org/elasticsearch/compute/data/FilterIntVectorBlock.java"
+  }
+  template {
+    it.properties = longProperties
+    it.inputFile =  filterVectorBlockInputFile
+    it.outputFile = "org/elasticsearch/compute/data/FilterLongVectorBlock.java"
+  }
+  template {
+    it.properties = doubleProperties
+    it.inputFile =  filterVectorBlockInputFile
+    it.outputFile = "org/elasticsearch/compute/data/FilterDoubleVectorBlock.java"
+  }
+  template {
+    it.properties = bytesRefProperties
+    it.inputFile =  filterVectorBlockInputFile
+    it.outputFile = "org/elasticsearch/compute/data/FilterBytesRefVectorBlock.java"
+  }
+  template {
+    it.properties = booleanProperties
+    it.inputFile =  filterVectorBlockInputFile
+    it.outputFile = "org/elasticsearch/compute/data/FilterBooleanVectorBlock.java"
+  }
   // vector blocks
   File vectorBlockInputFile = new File("${projectDir}/src/main/java/org/elasticsearch/compute/data/X-VectorBlock.java.st")
   template {

--- a/x-pack/plugin/esql/compute/build.gradle
+++ b/x-pack/plugin/esql/compute/build.gradle
@@ -230,6 +230,33 @@ tasks.named('stringTemplates').configure {
     it.inputFile =  bigArrayBlockInputFile
     it.outputFile = "org/elasticsearch/compute/data/BooleanBigArrayBlock.java"
   }
+  // filter blocks
+  File filterBlockInputFile = new File("${projectDir}/src/main/java/org/elasticsearch/compute/data/X-FilterBlock.java.st")
+  template {
+    it.properties = intProperties
+    it.inputFile =  filterBlockInputFile
+    it.outputFile = "org/elasticsearch/compute/data/FilterIntBlock.java"
+  }
+  template {
+    it.properties = longProperties
+    it.inputFile =  filterBlockInputFile
+    it.outputFile = "org/elasticsearch/compute/data/FilterLongBlock.java"
+  }
+  template {
+    it.properties = doubleProperties
+    it.inputFile =  filterBlockInputFile
+    it.outputFile = "org/elasticsearch/compute/data/FilterDoubleBlock.java"
+  }
+  template {
+    it.properties = bytesRefProperties
+    it.inputFile =  filterBlockInputFile
+    it.outputFile = "org/elasticsearch/compute/data/FilterBytesRefBlock.java"
+  }
+  template {
+    it.properties = booleanProperties
+    it.inputFile =  filterBlockInputFile
+    it.outputFile = "org/elasticsearch/compute/data/FilterBooleanBlock.java"
+  }
   // vector blocks
   File vectorBlockInputFile = new File("${projectDir}/src/main/java/org/elasticsearch/compute/data/X-VectorBlock.java.st")
   template {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayBlock.java
@@ -67,27 +67,9 @@ final class BooleanArrayBlock extends AbstractArrayBlock implements BooleanBlock
 
     @Override
     public BooleanBlock filter(int... positions) {
-        // TODO use reference counting to share the vector
-        try (var builder = blockFactory().newBooleanBlockBuilder(positions.length)) {
-            for (int pos : positions) {
-                if (isNull(pos)) {
-                    builder.appendNull();
-                    continue;
-                }
-                int valueCount = getValueCount(pos);
-                int first = getFirstValueIndex(pos);
-                if (valueCount == 1) {
-                    builder.appendBoolean(getBoolean(getFirstValueIndex(pos)));
-                } else {
-                    builder.beginPositionEntry();
-                    for (int c = 0; c < valueCount; c++) {
-                        builder.appendBoolean(getBoolean(first + c));
-                    }
-                    builder.endPositionEntry();
-                }
-            }
-            return builder.mvOrdering(mvOrdering()).build();
-        }
+        BooleanBlock filtered = new FilterBooleanBlock(this, positions);
+        this.incRef();
+        return filtered;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBigArrayBlock.java
@@ -68,27 +68,9 @@ public final class BooleanBigArrayBlock extends AbstractArrayBlock implements Bo
 
     @Override
     public BooleanBlock filter(int... positions) {
-        // TODO use reference counting to share the vector
-        try (var builder = blockFactory().newBooleanBlockBuilder(positions.length)) {
-            for (int pos : positions) {
-                if (isNull(pos)) {
-                    builder.appendNull();
-                    continue;
-                }
-                int valueCount = getValueCount(pos);
-                int first = getFirstValueIndex(pos);
-                if (valueCount == 1) {
-                    builder.appendBoolean(getBoolean(getFirstValueIndex(pos)));
-                } else {
-                    builder.beginPositionEntry();
-                    for (int c = 0; c < valueCount; c++) {
-                        builder.appendBoolean(getBoolean(first + c));
-                    }
-                    builder.endPositionEntry();
-                }
-            }
-            return builder.mvOrdering(mvOrdering()).build();
-        }
+        BooleanBlock filtered = new FilterBooleanBigArrayBlock(this, positions);
+        this.incRef();
+        return filtered;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBigArrayBlock.java
@@ -68,27 +68,9 @@ public final class BooleanBigArrayBlock extends AbstractArrayBlock implements Bo
 
     @Override
     public BooleanBlock filter(int... positions) {
-        // TODO use reference counting to share the vector
-        try (var builder = blockFactory().newBooleanBlockBuilder(positions.length)) {
-            for (int pos : positions) {
-                if (isNull(pos)) {
-                    builder.appendNull();
-                    continue;
-                }
-                int valueCount = getValueCount(pos);
-                int first = getFirstValueIndex(pos);
-                if (valueCount == 1) {
-                    builder.appendBoolean(getBoolean(getFirstValueIndex(pos)));
-                } else {
-                    builder.beginPositionEntry();
-                    for (int c = 0; c < valueCount; c++) {
-                        builder.appendBoolean(getBoolean(first + c));
-                    }
-                    builder.endPositionEntry();
-                }
-            }
-            return builder.mvOrdering(mvOrdering()).build();
-        }
+        BooleanBlock filtered = new FilterBooleanBlock(this, positions);
+        this.incRef();
+        return filtered;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBlock.java
@@ -18,7 +18,7 @@ import java.io.IOException;
  * Block that stores boolean values.
  * This class is generated. Do not edit it.
  */
-public sealed interface BooleanBlock extends Block permits BooleanArrayBlock, BooleanVectorBlock, ConstantNullBlock, BooleanBigArrayBlock {
+public sealed interface BooleanBlock extends Block permits BooleanArrayBlock, BooleanVectorBlock, ConstantNullBlock, BooleanBigArrayBlock, FilterBooleanBlock {
 
     /**
      * Retrieves the boolean value stored at the given value index.

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBlock.java
@@ -19,7 +19,7 @@ import java.io.IOException;
  * This class is generated. Do not edit it.
  */
 public sealed interface BooleanBlock extends Block permits BooleanArrayBlock, BooleanVectorBlock, ConstantNullBlock, BooleanBigArrayBlock,
-    FilterBooleanBlock {
+    FilterBooleanBlock, FilterBooleanVectorBlock {
 
     /**
      * Retrieves the boolean value stored at the given value index.

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBlock.java
@@ -19,7 +19,7 @@ import java.io.IOException;
  * This class is generated. Do not edit it.
  */
 public sealed interface BooleanBlock extends Block permits BooleanArrayBlock, BooleanVectorBlock, ConstantNullBlock, BooleanBigArrayBlock,
-    FilterBooleanBlock, FilterBooleanVectorBlock {
+    FilterBooleanBlock, FilterBooleanVectorBlock, FilterBooleanBigArrayBlock {
 
     /**
      * Retrieves the boolean value stored at the given value index.

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBlock.java
@@ -18,7 +18,8 @@ import java.io.IOException;
  * Block that stores boolean values.
  * This class is generated. Do not edit it.
  */
-public sealed interface BooleanBlock extends Block permits BooleanArrayBlock, BooleanVectorBlock, ConstantNullBlock, BooleanBigArrayBlock, FilterBooleanBlock {
+public sealed interface BooleanBlock extends Block permits BooleanArrayBlock, BooleanVectorBlock, ConstantNullBlock, BooleanBigArrayBlock,
+    FilterBooleanBlock {
 
     /**
      * Retrieves the boolean value stored at the given value index.

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVector.java
@@ -23,6 +23,9 @@ public sealed interface BooleanVector extends Vector permits ConstantBooleanVect
     @Override
     BooleanBlock asBlock();
 
+    /**
+     * Creates a new vector containing only the values at the given positions.
+     */
     @Override
     BooleanVector filter(int... positions);
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVectorBlock.java
@@ -47,9 +47,7 @@ public final class BooleanVectorBlock extends AbstractVectorBlock implements Boo
 
     @Override
     public BooleanBlock filter(int... positions) {
-        BooleanBlock filtered = new FilterBooleanBlock(this, positions);
-        this.incRef();
-        return filtered;
+        return vector.filter(positions).asBlock();
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVectorBlock.java
@@ -47,7 +47,9 @@ public final class BooleanVectorBlock extends AbstractVectorBlock implements Boo
 
     @Override
     public BooleanBlock filter(int... positions) {
-        return vector.filter(positions).asBlock();
+        BooleanBlock filtered = new FilterBooleanVectorBlock(this, positions);
+        this.incRef();
+        return filtered;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVectorBlock.java
@@ -47,7 +47,9 @@ public final class BooleanVectorBlock extends AbstractVectorBlock implements Boo
 
     @Override
     public BooleanBlock filter(int... positions) {
-        return vector.filter(positions).asBlock();
+        BooleanBlock filtered = new FilterBooleanBlock(this, positions);
+        this.incRef();
+        return filtered;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefBlock.java
@@ -19,7 +19,8 @@ import java.io.IOException;
  * Block that stores BytesRef values.
  * This class is generated. Do not edit it.
  */
-public sealed interface BytesRefBlock extends Block permits BytesRefArrayBlock, BytesRefVectorBlock, ConstantNullBlock, FilterBytesRefBlock {
+public sealed interface BytesRefBlock extends Block permits BytesRefArrayBlock, BytesRefVectorBlock, ConstantNullBlock,
+    FilterBytesRefBlock {
 
     BytesRef NULL_VALUE = new BytesRef();
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefBlock.java
@@ -21,7 +21,6 @@ import java.io.IOException;
  */
 public sealed interface BytesRefBlock extends Block permits BytesRefArrayBlock, BytesRefVectorBlock, ConstantNullBlock,
     FilterBytesRefBlock, FilterBytesRefVectorBlock {
-
     BytesRef NULL_VALUE = new BytesRef();
 
     /**

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefBlock.java
@@ -20,7 +20,7 @@ import java.io.IOException;
  * This class is generated. Do not edit it.
  */
 public sealed interface BytesRefBlock extends Block permits BytesRefArrayBlock, BytesRefVectorBlock, ConstantNullBlock,
-    FilterBytesRefBlock {
+    FilterBytesRefBlock, FilterBytesRefVectorBlock {
 
     BytesRef NULL_VALUE = new BytesRef();
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefBlock.java
@@ -19,7 +19,7 @@ import java.io.IOException;
  * Block that stores BytesRef values.
  * This class is generated. Do not edit it.
  */
-public sealed interface BytesRefBlock extends Block permits BytesRefArrayBlock, BytesRefVectorBlock, ConstantNullBlock {
+public sealed interface BytesRefBlock extends Block permits BytesRefArrayBlock, BytesRefVectorBlock, ConstantNullBlock, FilterBytesRefBlock {
 
     BytesRef NULL_VALUE = new BytesRef();
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVector.java
@@ -23,6 +23,9 @@ public sealed interface BytesRefVector extends Vector permits ConstantBytesRefVe
     @Override
     BytesRefBlock asBlock();
 
+    /**
+     * Creates a new vector containing only the values at the given positions.
+     */
     @Override
     BytesRefVector filter(int... positions);
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVectorBlock.java
@@ -48,7 +48,9 @@ public final class BytesRefVectorBlock extends AbstractVectorBlock implements By
 
     @Override
     public BytesRefBlock filter(int... positions) {
-        return vector.filter(positions).asBlock();
+        BytesRefBlock filtered = new FilterBytesRefBlock(this, positions);
+        this.incRef();
+        return filtered;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVectorBlock.java
@@ -48,7 +48,9 @@ public final class BytesRefVectorBlock extends AbstractVectorBlock implements By
 
     @Override
     public BytesRefBlock filter(int... positions) {
-        return vector.filter(positions).asBlock();
+        BytesRefBlock filtered = new FilterBytesRefVectorBlock(this, positions);
+        this.incRef();
+        return filtered;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVectorBlock.java
@@ -48,9 +48,7 @@ public final class BytesRefVectorBlock extends AbstractVectorBlock implements By
 
     @Override
     public BytesRefBlock filter(int... positions) {
-        BytesRefBlock filtered = new FilterBytesRefBlock(this, positions);
-        this.incRef();
-        return filtered;
+        return vector.filter(positions).asBlock();
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayBlock.java
@@ -67,27 +67,9 @@ final class DoubleArrayBlock extends AbstractArrayBlock implements DoubleBlock {
 
     @Override
     public DoubleBlock filter(int... positions) {
-        // TODO use reference counting to share the vector
-        try (var builder = blockFactory().newDoubleBlockBuilder(positions.length)) {
-            for (int pos : positions) {
-                if (isNull(pos)) {
-                    builder.appendNull();
-                    continue;
-                }
-                int valueCount = getValueCount(pos);
-                int first = getFirstValueIndex(pos);
-                if (valueCount == 1) {
-                    builder.appendDouble(getDouble(getFirstValueIndex(pos)));
-                } else {
-                    builder.beginPositionEntry();
-                    for (int c = 0; c < valueCount; c++) {
-                        builder.appendDouble(getDouble(first + c));
-                    }
-                    builder.endPositionEntry();
-                }
-            }
-            return builder.mvOrdering(mvOrdering()).build();
-        }
+        DoubleBlock filtered = new FilterDoubleBlock(this, positions);
+        this.incRef();
+        return filtered;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBigArrayBlock.java
@@ -68,27 +68,9 @@ public final class DoubleBigArrayBlock extends AbstractArrayBlock implements Dou
 
     @Override
     public DoubleBlock filter(int... positions) {
-        // TODO use reference counting to share the vector
-        try (var builder = blockFactory().newDoubleBlockBuilder(positions.length)) {
-            for (int pos : positions) {
-                if (isNull(pos)) {
-                    builder.appendNull();
-                    continue;
-                }
-                int valueCount = getValueCount(pos);
-                int first = getFirstValueIndex(pos);
-                if (valueCount == 1) {
-                    builder.appendDouble(getDouble(getFirstValueIndex(pos)));
-                } else {
-                    builder.beginPositionEntry();
-                    for (int c = 0; c < valueCount; c++) {
-                        builder.appendDouble(getDouble(first + c));
-                    }
-                    builder.endPositionEntry();
-                }
-            }
-            return builder.mvOrdering(mvOrdering()).build();
-        }
+        DoubleBlock filtered = new FilterDoubleBlock(this, positions);
+        this.incRef();
+        return filtered;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBigArrayBlock.java
@@ -68,27 +68,9 @@ public final class DoubleBigArrayBlock extends AbstractArrayBlock implements Dou
 
     @Override
     public DoubleBlock filter(int... positions) {
-        // TODO use reference counting to share the vector
-        try (var builder = blockFactory().newDoubleBlockBuilder(positions.length)) {
-            for (int pos : positions) {
-                if (isNull(pos)) {
-                    builder.appendNull();
-                    continue;
-                }
-                int valueCount = getValueCount(pos);
-                int first = getFirstValueIndex(pos);
-                if (valueCount == 1) {
-                    builder.appendDouble(getDouble(getFirstValueIndex(pos)));
-                } else {
-                    builder.beginPositionEntry();
-                    for (int c = 0; c < valueCount; c++) {
-                        builder.appendDouble(getDouble(first + c));
-                    }
-                    builder.endPositionEntry();
-                }
-            }
-            return builder.mvOrdering(mvOrdering()).build();
-        }
+        DoubleBlock filtered = new FilterDoubleBigArrayBlock(this, positions);
+        this.incRef();
+        return filtered;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBlock.java
@@ -19,7 +19,7 @@ import java.io.IOException;
  * This class is generated. Do not edit it.
  */
 public sealed interface DoubleBlock extends Block permits DoubleArrayBlock, DoubleVectorBlock, ConstantNullBlock, DoubleBigArrayBlock,
-    FilterDoubleBlock, FilterDoubleVectorBlock {
+    FilterDoubleBlock, FilterDoubleVectorBlock, FilterDoubleBigArrayBlock {
 
     /**
      * Retrieves the double value stored at the given value index.

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBlock.java
@@ -18,7 +18,8 @@ import java.io.IOException;
  * Block that stores double values.
  * This class is generated. Do not edit it.
  */
-public sealed interface DoubleBlock extends Block permits DoubleArrayBlock, DoubleVectorBlock, ConstantNullBlock, DoubleBigArrayBlock, FilterDoubleBlock {
+public sealed interface DoubleBlock extends Block permits DoubleArrayBlock, DoubleVectorBlock, ConstantNullBlock, DoubleBigArrayBlock,
+    FilterDoubleBlock {
 
     /**
      * Retrieves the double value stored at the given value index.

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBlock.java
@@ -18,7 +18,7 @@ import java.io.IOException;
  * Block that stores double values.
  * This class is generated. Do not edit it.
  */
-public sealed interface DoubleBlock extends Block permits DoubleArrayBlock, DoubleVectorBlock, ConstantNullBlock, DoubleBigArrayBlock {
+public sealed interface DoubleBlock extends Block permits DoubleArrayBlock, DoubleVectorBlock, ConstantNullBlock, DoubleBigArrayBlock, FilterDoubleBlock {
 
     /**
      * Retrieves the double value stored at the given value index.

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBlock.java
@@ -19,7 +19,7 @@ import java.io.IOException;
  * This class is generated. Do not edit it.
  */
 public sealed interface DoubleBlock extends Block permits DoubleArrayBlock, DoubleVectorBlock, ConstantNullBlock, DoubleBigArrayBlock,
-    FilterDoubleBlock {
+    FilterDoubleBlock, FilterDoubleVectorBlock {
 
     /**
      * Retrieves the double value stored at the given value index.

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleVector.java
@@ -23,6 +23,9 @@ public sealed interface DoubleVector extends Vector permits ConstantDoubleVector
     @Override
     DoubleBlock asBlock();
 
+    /**
+     * Creates a new vector containing only the values at the given positions.
+     */
     @Override
     DoubleVector filter(int... positions);
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleVectorBlock.java
@@ -47,7 +47,9 @@ public final class DoubleVectorBlock extends AbstractVectorBlock implements Doub
 
     @Override
     public DoubleBlock filter(int... positions) {
-        return vector.filter(positions).asBlock();
+        DoubleBlock filtered = new FilterDoubleVectorBlock(this, positions);
+        this.incRef();
+        return filtered;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleVectorBlock.java
@@ -47,7 +47,9 @@ public final class DoubleVectorBlock extends AbstractVectorBlock implements Doub
 
     @Override
     public DoubleBlock filter(int... positions) {
-        return vector.filter(positions).asBlock();
+        DoubleBlock filtered = new FilterDoubleBlock(this, positions);
+        this.incRef();
+        return filtered;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleVectorBlock.java
@@ -47,9 +47,7 @@ public final class DoubleVectorBlock extends AbstractVectorBlock implements Doub
 
     @Override
     public DoubleBlock filter(int... positions) {
-        DoubleBlock filtered = new FilterDoubleBlock(this, positions);
-        this.incRef();
-        return filtered;
+        return vector.filter(positions).asBlock();
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterBooleanBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterBooleanBigArrayBlock.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data;
+
+import org.apache.lucene.util.RamUsageEstimator;
+
+import java.util.Arrays;
+
+/**
+ * Filter block for BooleanBlocks.
+ * This class is generated. Do not edit it.
+ */
+// TODO: check if javadoc needs updating, both here, in the interfaces and in the abstract filter block
+final class FilterBooleanBigArrayBlock extends AbstractFilterBlock implements BooleanBlock {
+
+    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(FilterBooleanBlock.class);
+    private final BooleanBigArrayBlock block;
+
+    FilterBooleanBigArrayBlock(BooleanBigArrayBlock block, int... positions) {
+        super(positions, block.blockFactory());
+        this.block = block;
+    }
+
+    @Override
+    public BooleanVector asVector() {
+        return null;
+    }
+
+    @Override
+    public boolean getBoolean(int valueIndex) {
+        return block.getBoolean(valueIndex);
+    }
+
+    @Override
+    public ElementType elementType() {
+        return ElementType.BOOLEAN;
+    }
+
+    @Override
+    public boolean isNull(int position) {
+        return block.isNull(mapPosition(position));
+    }
+
+    @Override
+    public boolean mayHaveNulls() {
+        return block.mayHaveNulls();
+    }
+
+    @Override
+    public boolean areAllValuesNull() {
+        return block.areAllValuesNull();
+    }
+
+    @Override
+    public boolean mayHaveMultivaluedFields() {
+        /*
+         * This could return a false positive. The block may have multivalued
+         * fields, but we're not pointing to any of them. That's acceptable.
+         */
+        return block.mayHaveMultivaluedFields();
+    }
+
+    @Override
+    public final int getTotalValueCount() {
+        // TODO this is expensive. maybe cache or something.
+        int total = 0;
+        for (int p = 0; p < positions.length; p++) {
+            total += getValueCount(p);
+        }
+        return total;
+    }
+
+    @Override
+    public final int getValueCount(int position) {
+        return block.getValueCount(mapPosition(position));
+    }
+
+    @Override
+    public final int getPositionCount() {
+        return positions.length;
+    }
+
+    @Override
+    public final int getFirstValueIndex(int position) {
+        return block.getFirstValueIndex(mapPosition(position));
+    }
+
+    @Override
+    public MvOrdering mvOrdering() {
+        return block.mvOrdering();
+    }
+
+    @Override
+    public BooleanBlock filter(int... positions) {
+        int[] mappedPositions = Arrays.stream(positions).map(this::mapPosition).toArray();
+        BooleanBlock filtered = new FilterBooleanBigArrayBlock(block, mappedPositions);
+        block.incRef();
+        return filtered;
+    }
+
+    @Override
+    public BooleanBlock expand() {
+        if (false == block.mayHaveMultivaluedFields()) {
+            return this;
+        }
+        // TODO: use the underlying block's expand
+        /*
+         * Build a copy of the target block, selecting only the positions
+         * we've been assigned and expanding all multivalued fields
+         * into single valued fields.
+         */
+        try (BooleanBlock.Builder builder = new BooleanBlockBuilder(positions.length * Integer.BYTES, blockFactory())) {
+            for (int p : positions) {
+                if (block.isNull(p)) {
+                    builder.appendNull();
+                    continue;
+                }
+                int start = block.getFirstValueIndex(p);
+                int end = start + block.getValueCount(p);
+                for (int i = start; i < end; i++) {
+                    builder.appendBoolean(block.getBoolean(i));
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        // TODO: check this
+        // from a usage and resource point of view filter blocks encapsulate
+        // their inner block, rather than listing it as a child resource
+        return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(block) + RamUsageEstimator.sizeOf(positions);
+    }
+
+    @Override
+    public void allowPassingToDifferentDriver() {
+        super.allowPassingToDifferentDriver();
+        block.allowPassingToDifferentDriver();
+    }
+
+    @Override
+    protected void closeInternal() {
+        block.close();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof BooleanBlock that) {
+            return BooleanBlock.equals(this, that);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return BooleanBlock.hash(this);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(this.getClass().getSimpleName());
+        sb.append("[positions=" + getPositionCount());
+        if (isReleased() == false) {
+            sb.append(", values=[");
+            appendValues(sb);
+            sb.append("]");
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+    private void appendValues(StringBuilder sb) {
+        final int positions = getPositionCount();
+        for (int p = 0; p < positions; p++) {
+            if (p > 0) {
+                sb.append(", ");
+            }
+            int start = getFirstValueIndex(p);
+            int count = getValueCount(p);
+            if (count == 1) {
+                sb.append(getBoolean(start));
+                continue;
+            }
+            sb.append('[');
+            int end = start + count;
+            for (int i = start; i < end; i++) {
+                if (i > start) {
+                    sb.append(", ");
+                }
+                sb.append(getBoolean(i));
+            }
+            sb.append(']');
+        }
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterBooleanBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterBooleanBlock.java
@@ -13,15 +13,12 @@ import org.apache.lucene.util.RamUsageEstimator;
  * Filter block for BooleanBlocks.
  * This class is generated. Do not edit it.
  */
-final class FilterBooleanBlock extends AbstractFilterBlock implements BooleanBlock {
+final class FilterBooleanBlock extends AbstractFilterBlock<BooleanBlock> implements BooleanBlock {
 
     private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(FilterBooleanBlock.class);
 
-    private final BooleanBlock block;
-
     FilterBooleanBlock(BooleanBlock block, int... positions) {
         super(block, positions);
-        this.block = block;
     }
 
     @Override
@@ -130,10 +127,5 @@ final class FilterBooleanBlock extends AbstractFilterBlock implements BooleanBlo
             }
             sb.append(']');
         }
-    }
-
-    @Override
-    protected void closeInternal() {
-        block.close();
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterBooleanBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterBooleanBlock.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data;
+
+import org.apache.lucene.util.RamUsageEstimator;
+
+/**
+ * Filter block for BooleanBlocks.
+ * This class is generated. Do not edit it.
+ */
+final class FilterBooleanBlock extends AbstractFilterBlock implements BooleanBlock {
+
+    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(FilterBooleanBlock.class);
+
+    private final BooleanBlock block;
+
+    FilterBooleanBlock(BooleanBlock block, int... positions) {
+        super(block, positions);
+        this.block = block;
+    }
+
+    @Override
+    public BooleanVector asVector() {
+        return null;
+    }
+
+    @Override
+    public boolean getBoolean(int valueIndex) {
+        return block.getBoolean(valueIndex);
+    }
+
+    @Override
+    public ElementType elementType() {
+        return ElementType.BOOLEAN;
+    }
+
+    @Override
+    public BooleanBlock filter(int... positions) {
+        // TODO: avoid multi-layered FilterBooleanBlocks; compute subset of filter instead.
+        return new FilterBooleanBlock(this, positions);
+    }
+
+    @Override
+    public BooleanBlock expand() {
+        if (false == block.mayHaveMultivaluedFields()) {
+            return this;
+        }
+        // TODO: use the underlying block's expand
+        /*
+         * Build a copy of the target block, selecting only the positions
+         * we've been assigned and expanding all multivalued fields
+         * into single valued fields.
+         */
+        try (BooleanBlock.Builder builder = new BooleanBlockBuilder(positions.length * Integer.BYTES, blockFactory())) {
+            for (int p : positions) {
+                if (block.isNull(p)) {
+                    builder.appendNull();
+                    continue;
+                }
+                int start = block.getFirstValueIndex(p);
+                int end = start + block.getValueCount(p);
+                for (int i = start; i < end; i++) {
+                    builder.appendBoolean(block.getBoolean(i));
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        // TODO: check this
+        // from a usage and resource point of view filter blocks encapsulate
+        // their inner block, rather than listing it as a child resource
+        return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(block) + RamUsageEstimator.sizeOf(positions);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof BooleanBlock that) {
+            return BooleanBlock.equals(this, that);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return BooleanBlock.hash(this);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(this.getClass().getSimpleName());
+        sb.append("[positions=" + getPositionCount());
+        sb.append(", released=" + isReleased());
+        if (isReleased() == false) {
+            sb.append(", values=[");
+            appendValues(sb);
+            sb.append("]");
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+    private void appendValues(StringBuilder sb) {
+        final int positions = getPositionCount();
+        for (int p = 0; p < positions; p++) {
+            if (p > 0) {
+                sb.append(", ");
+            }
+            int start = getFirstValueIndex(p);
+            int count = getValueCount(p);
+            if (count == 1) {
+                sb.append(getBoolean(start));
+                continue;
+            }
+            sb.append('[');
+            int end = start + count;
+            for (int i = start; i < end; i++) {
+                if (i > start) {
+                    sb.append(", ");
+                }
+                sb.append(getBoolean(i));
+            }
+            sb.append(']');
+        }
+    }
+
+    @Override
+    protected void closeInternal() {
+        block.close();
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterBooleanBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterBooleanBlock.java
@@ -13,6 +13,7 @@ import org.apache.lucene.util.RamUsageEstimator;
  * Filter block for BooleanBlocks.
  * This class is generated. Do not edit it.
  */
+// TODO: check if javadoc needs updating, both here, in the interfaces and in the abstract filter block
 final class FilterBooleanBlock extends AbstractFilterBlock<BooleanBlock> implements BooleanBlock {
 
     private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(FilterBooleanBlock.class);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterBooleanBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterBooleanBlock.java
@@ -39,7 +39,9 @@ final class FilterBooleanBlock extends AbstractFilterBlock<BooleanBlock> impleme
     @Override
     public BooleanBlock filter(int... positions) {
         // TODO: avoid multi-layered FilterBooleanBlocks; compute subset of filter instead.
-        return new FilterBooleanBlock(this, positions);
+        BooleanBlock filtered = new FilterBooleanBlock(this, positions);
+        this.incRef();
+        return filtered;
     }
 
     @Override
@@ -95,7 +97,6 @@ final class FilterBooleanBlock extends AbstractFilterBlock<BooleanBlock> impleme
         StringBuilder sb = new StringBuilder();
         sb.append(this.getClass().getSimpleName());
         sb.append("[positions=" + getPositionCount());
-        sb.append(", released=" + isReleased());
         if (isReleased() == false) {
             sb.append(", values=[");
             appendValues(sb);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterBooleanVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterBooleanVectorBlock.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data;
+
+import org.apache.lucene.util.RamUsageEstimator;
+
+import java.util.Arrays;
+
+/**
+ * Filter block for BooleanBlocks.
+ * This class is generated. Do not edit it.
+ */
+// TODO: check if javadoc needs updating, both here, in the interfaces and in the abstract filter block
+final class FilterBooleanVectorBlock extends AbstractFilterBlock implements BooleanBlock {
+
+    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(FilterBooleanBlock.class);
+    private final BooleanVectorBlock block;
+
+    FilterBooleanVectorBlock(BooleanVectorBlock block, int... positions) {
+        super(positions, block.blockFactory());
+        this.block = block;
+    }
+
+    @Override
+    public BooleanVector asVector() {
+        return null;
+    }
+
+    @Override
+    public boolean getBoolean(int valueIndex) {
+        return block.getBoolean(valueIndex);
+    }
+
+    @Override
+    public ElementType elementType() {
+        return ElementType.BOOLEAN;
+    }
+
+    @Override
+    public boolean isNull(int position) {
+        return false;
+    }
+
+    @Override
+    public boolean mayHaveNulls() {
+        return false;
+    }
+
+    @Override
+    public boolean areAllValuesNull() {
+        return false;
+    }
+
+    @Override
+    public boolean mayHaveMultivaluedFields() {
+        return false;
+    }
+
+    @Override
+    public final int getTotalValueCount() {
+        return positions.length;
+    }
+
+    @Override
+    public final int getValueCount(int position) {
+        return 1;
+    }
+
+    @Override
+    public final int getPositionCount() {
+        return positions.length;
+    }
+
+    @Override
+    public final int getFirstValueIndex(int position) {
+        return mapPosition(position);
+    }
+
+    @Override
+    public MvOrdering mvOrdering() {
+        return MvOrdering.DEDUPLICATED_AND_SORTED_ASCENDING;
+    }
+
+    @Override
+    public BooleanBlock filter(int... positions) {
+        int[] mappedPositions = Arrays.stream(positions).map(this::mapPosition).toArray();
+        BooleanBlock filtered = new FilterBooleanVectorBlock(block, mappedPositions);
+        block.incRef();
+        return filtered;
+    }
+
+    @Override
+    public BooleanBlock expand() {
+        if (false == block.mayHaveMultivaluedFields()) {
+            return this;
+        }
+        // TODO: use the underlying block's expand
+        /*
+         * Build a copy of the target block, selecting only the positions
+         * we've been assigned and expanding all multivalued fields
+         * into single valued fields.
+         */
+        try (BooleanBlock.Builder builder = new BooleanBlockBuilder(positions.length * Integer.BYTES, blockFactory())) {
+            for (int p : positions) {
+                if (block.isNull(p)) {
+                    builder.appendNull();
+                    continue;
+                }
+                int start = block.getFirstValueIndex(p);
+                int end = start + block.getValueCount(p);
+                for (int i = start; i < end; i++) {
+                    builder.appendBoolean(block.getBoolean(i));
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        // TODO: check this
+        // from a usage and resource point of view filter blocks encapsulate
+        // their inner block, rather than listing it as a child resource
+        return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(block) + RamUsageEstimator.sizeOf(positions);
+    }
+
+    @Override
+    public void allowPassingToDifferentDriver() {
+        super.allowPassingToDifferentDriver();
+        block.allowPassingToDifferentDriver();
+    }
+
+    @Override
+    protected void closeInternal() {
+        block.close();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof BooleanBlock that) {
+            return BooleanBlock.equals(this, that);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return BooleanBlock.hash(this);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(this.getClass().getSimpleName());
+        sb.append("[positions=" + getPositionCount());
+        if (isReleased() == false) {
+            sb.append(", values=[");
+            appendValues(sb);
+            sb.append("]");
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+    private void appendValues(StringBuilder sb) {
+        final int positions = getPositionCount();
+        for (int p = 0; p < positions; p++) {
+            if (p > 0) {
+                sb.append(", ");
+            }
+            int start = getFirstValueIndex(p);
+            int count = getValueCount(p);
+            if (count == 1) {
+                sb.append(getBoolean(start));
+                continue;
+            }
+            sb.append('[');
+            int end = start + count;
+            for (int i = start; i < end; i++) {
+                if (i > start) {
+                    sb.append(", ");
+                }
+                sb.append(getBoolean(i));
+            }
+            sb.append(']');
+        }
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterBytesRefBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterBytesRefBlock.java
@@ -10,17 +10,21 @@ package org.elasticsearch.compute.data;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.RamUsageEstimator;
 
+import java.util.Arrays;
+
 /**
  * Filter block for BytesRefBlocks.
  * This class is generated. Do not edit it.
  */
 // TODO: check if javadoc needs updating, both here, in the interfaces and in the abstract filter block
-final class FilterBytesRefBlock extends AbstractFilterBlock<BytesRefBlock> implements BytesRefBlock {
+final class FilterBytesRefBlock extends AbstractFilterBlock implements BytesRefBlock {
 
     private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(FilterBytesRefBlock.class);
+    private final BytesRefArrayBlock block;
 
-    FilterBytesRefBlock(BytesRefBlock block, int... positions) {
-        super(block, positions);
+    FilterBytesRefBlock(BytesRefArrayBlock block, int... positions) {
+        super(positions, block.blockFactory());
+        this.block = block;
     }
 
     @Override
@@ -39,10 +43,64 @@ final class FilterBytesRefBlock extends AbstractFilterBlock<BytesRefBlock> imple
     }
 
     @Override
+    public boolean isNull(int position) {
+        return block.isNull(mapPosition(position));
+    }
+
+    @Override
+    public boolean mayHaveNulls() {
+        return block.mayHaveNulls();
+    }
+
+    @Override
+    public boolean areAllValuesNull() {
+        return block.areAllValuesNull();
+    }
+
+    @Override
+    public boolean mayHaveMultivaluedFields() {
+        /*
+         * This could return a false positive. The block may have multivalued
+         * fields, but we're not pointing to any of them. That's acceptable.
+         */
+        return block.mayHaveMultivaluedFields();
+    }
+
+    @Override
+    public final int getTotalValueCount() {
+        // TODO this is expensive. maybe cache or something.
+        int total = 0;
+        for (int p = 0; p < positions.length; p++) {
+            total += getValueCount(p);
+        }
+        return total;
+    }
+
+    @Override
+    public final int getValueCount(int position) {
+        return block.getValueCount(mapPosition(position));
+    }
+
+    @Override
+    public final int getPositionCount() {
+        return positions.length;
+    }
+
+    @Override
+    public final int getFirstValueIndex(int position) {
+        return block.getFirstValueIndex(mapPosition(position));
+    }
+
+    @Override
+    public MvOrdering mvOrdering() {
+        return block.mvOrdering();
+    }
+
+    @Override
     public BytesRefBlock filter(int... positions) {
-        // TODO: avoid multi-layered FilterBytesRefBlocks; compute subset of filter instead.
-        BytesRefBlock filtered = new FilterBytesRefBlock(this, positions);
-        this.incRef();
+        int[] mappedPositions = Arrays.stream(positions).map(this::mapPosition).toArray();
+        BytesRefBlock filtered = new FilterBytesRefBlock(block, mappedPositions);
+        block.incRef();
         return filtered;
     }
 
@@ -81,6 +139,17 @@ final class FilterBytesRefBlock extends AbstractFilterBlock<BytesRefBlock> imple
         // from a usage and resource point of view filter blocks encapsulate
         // their inner block, rather than listing it as a child resource
         return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(block) + RamUsageEstimator.sizeOf(positions);
+    }
+
+    @Override
+    public void allowPassingToDifferentDriver() {
+        super.allowPassingToDifferentDriver();
+        block.allowPassingToDifferentDriver();
+    }
+
+    @Override
+    protected void closeInternal() {
+        block.close();
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterBytesRefBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterBytesRefBlock.java
@@ -40,7 +40,9 @@ final class FilterBytesRefBlock extends AbstractFilterBlock<BytesRefBlock> imple
     @Override
     public BytesRefBlock filter(int... positions) {
         // TODO: avoid multi-layered FilterBytesRefBlocks; compute subset of filter instead.
-        return new FilterBytesRefBlock(this, positions);
+        BytesRefBlock filtered = new FilterBytesRefBlock(this, positions);
+        this.incRef();
+        return filtered;
     }
 
     @Override
@@ -98,7 +100,6 @@ final class FilterBytesRefBlock extends AbstractFilterBlock<BytesRefBlock> imple
         StringBuilder sb = new StringBuilder();
         sb.append(this.getClass().getSimpleName());
         sb.append("[positions=" + getPositionCount());
-        sb.append(", released=" + isReleased());
         if (isReleased() == false) {
             sb.append(", values=[");
             appendValues(sb);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterBytesRefBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterBytesRefBlock.java
@@ -14,15 +14,12 @@ import org.apache.lucene.util.RamUsageEstimator;
  * Filter block for BytesRefBlocks.
  * This class is generated. Do not edit it.
  */
-final class FilterBytesRefBlock extends AbstractFilterBlock implements BytesRefBlock {
+final class FilterBytesRefBlock extends AbstractFilterBlock<BytesRefBlock> implements BytesRefBlock {
 
     private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(FilterBytesRefBlock.class);
 
-    private final BytesRefBlock block;
-
     FilterBytesRefBlock(BytesRefBlock block, int... positions) {
         super(block, positions);
-        this.block = block;
     }
 
     @Override
@@ -133,10 +130,5 @@ final class FilterBytesRefBlock extends AbstractFilterBlock implements BytesRefB
             }
             sb.append(']');
         }
-    }
-
-    @Override
-    protected void closeInternal() {
-        block.close();
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterBytesRefBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterBytesRefBlock.java
@@ -14,6 +14,7 @@ import org.apache.lucene.util.RamUsageEstimator;
  * Filter block for BytesRefBlocks.
  * This class is generated. Do not edit it.
  */
+// TODO: check if javadoc needs updating, both here, in the interfaces and in the abstract filter block
 final class FilterBytesRefBlock extends AbstractFilterBlock<BytesRefBlock> implements BytesRefBlock {
 
     private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(FilterBytesRefBlock.class);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterBytesRefBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterBytesRefBlock.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.RamUsageEstimator;
+
+/**
+ * Filter block for BytesRefBlocks.
+ * This class is generated. Do not edit it.
+ */
+final class FilterBytesRefBlock extends AbstractFilterBlock implements BytesRefBlock {
+
+    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(FilterBytesRefBlock.class);
+
+    private final BytesRefBlock block;
+
+    FilterBytesRefBlock(BytesRefBlock block, int... positions) {
+        super(block, positions);
+        this.block = block;
+    }
+
+    @Override
+    public BytesRefVector asVector() {
+        return null;
+    }
+
+    @Override
+    public BytesRef getBytesRef(int valueIndex, BytesRef dest) {
+        return block.getBytesRef(valueIndex, dest);
+    }
+
+    @Override
+    public ElementType elementType() {
+        return ElementType.BYTES_REF;
+    }
+
+    @Override
+    public BytesRefBlock filter(int... positions) {
+        // TODO: avoid multi-layered FilterBytesRefBlocks; compute subset of filter instead.
+        return new FilterBytesRefBlock(this, positions);
+    }
+
+    @Override
+    public BytesRefBlock expand() {
+        if (false == block.mayHaveMultivaluedFields()) {
+            return this;
+        }
+        // TODO: use the underlying block's expand
+        /*
+         * Build a copy of the target block, selecting only the positions
+         * we've been assigned and expanding all multivalued fields
+         * into single valued fields.
+         */
+        try (BytesRefBlock.Builder builder = new BytesRefBlockBuilder(positions.length * Integer.BYTES, blockFactory())) {
+            BytesRef scratch = new BytesRef();
+            for (int p : positions) {
+                if (block.isNull(p)) {
+                    builder.appendNull();
+                    continue;
+                }
+                int start = block.getFirstValueIndex(p);
+                int end = start + block.getValueCount(p);
+                for (int i = start; i < end; i++) {
+                    BytesRef v = block.getBytesRef(i, scratch);
+                    builder.appendBytesRef(v);
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        // TODO: check this
+        // from a usage and resource point of view filter blocks encapsulate
+        // their inner block, rather than listing it as a child resource
+        return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(block) + RamUsageEstimator.sizeOf(positions);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof BytesRefBlock that) {
+            return BytesRefBlock.equals(this, that);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return BytesRefBlock.hash(this);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(this.getClass().getSimpleName());
+        sb.append("[positions=" + getPositionCount());
+        sb.append(", released=" + isReleased());
+        if (isReleased() == false) {
+            sb.append(", values=[");
+            appendValues(sb);
+            sb.append("]");
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+    private void appendValues(StringBuilder sb) {
+        final int positions = getPositionCount();
+        for (int p = 0; p < positions; p++) {
+            if (p > 0) {
+                sb.append(", ");
+            }
+            int start = getFirstValueIndex(p);
+            int count = getValueCount(p);
+            if (count == 1) {
+                sb.append(getBytesRef(start, new BytesRef()));
+                continue;
+            }
+            sb.append('[');
+            int end = start + count;
+            for (int i = start; i < end; i++) {
+                if (i > start) {
+                    sb.append(", ");
+                }
+                sb.append(getBytesRef(i, new BytesRef()));
+            }
+            sb.append(']');
+        }
+    }
+
+    @Override
+    protected void closeInternal() {
+        block.close();
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterBytesRefVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterBytesRefVectorBlock.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.RamUsageEstimator;
+
+import java.util.Arrays;
+
+/**
+ * Filter block for BytesRefBlocks.
+ * This class is generated. Do not edit it.
+ */
+// TODO: check if javadoc needs updating, both here, in the interfaces and in the abstract filter block
+final class FilterBytesRefVectorBlock extends AbstractFilterBlock implements BytesRefBlock {
+
+    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(FilterBytesRefBlock.class);
+    private final BytesRefVectorBlock block;
+
+    FilterBytesRefVectorBlock(BytesRefVectorBlock block, int... positions) {
+        super(positions, block.blockFactory());
+        this.block = block;
+    }
+
+    @Override
+    public BytesRefVector asVector() {
+        return null;
+    }
+
+    @Override
+    public BytesRef getBytesRef(int valueIndex, BytesRef dest) {
+        return block.getBytesRef(valueIndex, dest);
+    }
+
+    @Override
+    public ElementType elementType() {
+        return ElementType.BYTES_REF;
+    }
+
+    @Override
+    public boolean isNull(int position) {
+        return false;
+    }
+
+    @Override
+    public boolean mayHaveNulls() {
+        return false;
+    }
+
+    @Override
+    public boolean areAllValuesNull() {
+        return false;
+    }
+
+    @Override
+    public boolean mayHaveMultivaluedFields() {
+        return false;
+    }
+
+    @Override
+    public final int getTotalValueCount() {
+        return positions.length;
+    }
+
+    @Override
+    public final int getValueCount(int position) {
+        return 1;
+    }
+
+    @Override
+    public final int getPositionCount() {
+        return positions.length;
+    }
+
+    @Override
+    public final int getFirstValueIndex(int position) {
+        return mapPosition(position);
+    }
+
+    @Override
+    public MvOrdering mvOrdering() {
+        return MvOrdering.DEDUPLICATED_AND_SORTED_ASCENDING;
+    }
+
+    @Override
+    public BytesRefBlock filter(int... positions) {
+        int[] mappedPositions = Arrays.stream(positions).map(this::mapPosition).toArray();
+        BytesRefBlock filtered = new FilterBytesRefVectorBlock(block, mappedPositions);
+        block.incRef();
+        return filtered;
+    }
+
+    @Override
+    public BytesRefBlock expand() {
+        if (false == block.mayHaveMultivaluedFields()) {
+            return this;
+        }
+        // TODO: use the underlying block's expand
+        /*
+         * Build a copy of the target block, selecting only the positions
+         * we've been assigned and expanding all multivalued fields
+         * into single valued fields.
+         */
+        try (BytesRefBlock.Builder builder = new BytesRefBlockBuilder(positions.length * Integer.BYTES, blockFactory())) {
+            BytesRef scratch = new BytesRef();
+            for (int p : positions) {
+                if (block.isNull(p)) {
+                    builder.appendNull();
+                    continue;
+                }
+                int start = block.getFirstValueIndex(p);
+                int end = start + block.getValueCount(p);
+                for (int i = start; i < end; i++) {
+                    BytesRef v = block.getBytesRef(i, scratch);
+                    builder.appendBytesRef(v);
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        // TODO: check this
+        // from a usage and resource point of view filter blocks encapsulate
+        // their inner block, rather than listing it as a child resource
+        return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(block) + RamUsageEstimator.sizeOf(positions);
+    }
+
+    @Override
+    public void allowPassingToDifferentDriver() {
+        super.allowPassingToDifferentDriver();
+        block.allowPassingToDifferentDriver();
+    }
+
+    @Override
+    protected void closeInternal() {
+        block.close();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof BytesRefBlock that) {
+            return BytesRefBlock.equals(this, that);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return BytesRefBlock.hash(this);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(this.getClass().getSimpleName());
+        sb.append("[positions=" + getPositionCount());
+        if (isReleased() == false) {
+            sb.append(", values=[");
+            appendValues(sb);
+            sb.append("]");
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+    private void appendValues(StringBuilder sb) {
+        final int positions = getPositionCount();
+        for (int p = 0; p < positions; p++) {
+            if (p > 0) {
+                sb.append(", ");
+            }
+            int start = getFirstValueIndex(p);
+            int count = getValueCount(p);
+            if (count == 1) {
+                sb.append(getBytesRef(start, new BytesRef()));
+                continue;
+            }
+            sb.append('[');
+            int end = start + count;
+            for (int i = start; i < end; i++) {
+                if (i > start) {
+                    sb.append(", ");
+                }
+                sb.append(getBytesRef(i, new BytesRef()));
+            }
+            sb.append(']');
+        }
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterDoubleBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterDoubleBigArrayBlock.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data;
+
+import org.apache.lucene.util.RamUsageEstimator;
+
+import java.util.Arrays;
+
+/**
+ * Filter block for DoubleBlocks.
+ * This class is generated. Do not edit it.
+ */
+// TODO: check if javadoc needs updating, both here, in the interfaces and in the abstract filter block
+final class FilterDoubleBigArrayBlock extends AbstractFilterBlock implements DoubleBlock {
+
+    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(FilterDoubleBlock.class);
+    private final DoubleBigArrayBlock block;
+
+    FilterDoubleBigArrayBlock(DoubleBigArrayBlock block, int... positions) {
+        super(positions, block.blockFactory());
+        this.block = block;
+    }
+
+    @Override
+    public DoubleVector asVector() {
+        return null;
+    }
+
+    @Override
+    public double getDouble(int valueIndex) {
+        return block.getDouble(valueIndex);
+    }
+
+    @Override
+    public ElementType elementType() {
+        return ElementType.DOUBLE;
+    }
+
+    @Override
+    public boolean isNull(int position) {
+        return block.isNull(mapPosition(position));
+    }
+
+    @Override
+    public boolean mayHaveNulls() {
+        return block.mayHaveNulls();
+    }
+
+    @Override
+    public boolean areAllValuesNull() {
+        return block.areAllValuesNull();
+    }
+
+    @Override
+    public boolean mayHaveMultivaluedFields() {
+        /*
+         * This could return a false positive. The block may have multivalued
+         * fields, but we're not pointing to any of them. That's acceptable.
+         */
+        return block.mayHaveMultivaluedFields();
+    }
+
+    @Override
+    public final int getTotalValueCount() {
+        // TODO this is expensive. maybe cache or something.
+        int total = 0;
+        for (int p = 0; p < positions.length; p++) {
+            total += getValueCount(p);
+        }
+        return total;
+    }
+
+    @Override
+    public final int getValueCount(int position) {
+        return block.getValueCount(mapPosition(position));
+    }
+
+    @Override
+    public final int getPositionCount() {
+        return positions.length;
+    }
+
+    @Override
+    public final int getFirstValueIndex(int position) {
+        return block.getFirstValueIndex(mapPosition(position));
+    }
+
+    @Override
+    public MvOrdering mvOrdering() {
+        return block.mvOrdering();
+    }
+
+    @Override
+    public DoubleBlock filter(int... positions) {
+        int[] mappedPositions = Arrays.stream(positions).map(this::mapPosition).toArray();
+        DoubleBlock filtered = new FilterDoubleBigArrayBlock(block, mappedPositions);
+        block.incRef();
+        return filtered;
+    }
+
+    @Override
+    public DoubleBlock expand() {
+        if (false == block.mayHaveMultivaluedFields()) {
+            return this;
+        }
+        // TODO: use the underlying block's expand
+        /*
+         * Build a copy of the target block, selecting only the positions
+         * we've been assigned and expanding all multivalued fields
+         * into single valued fields.
+         */
+        try (DoubleBlock.Builder builder = new DoubleBlockBuilder(positions.length * Integer.BYTES, blockFactory())) {
+            for (int p : positions) {
+                if (block.isNull(p)) {
+                    builder.appendNull();
+                    continue;
+                }
+                int start = block.getFirstValueIndex(p);
+                int end = start + block.getValueCount(p);
+                for (int i = start; i < end; i++) {
+                    builder.appendDouble(block.getDouble(i));
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        // TODO: check this
+        // from a usage and resource point of view filter blocks encapsulate
+        // their inner block, rather than listing it as a child resource
+        return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(block) + RamUsageEstimator.sizeOf(positions);
+    }
+
+    @Override
+    public void allowPassingToDifferentDriver() {
+        super.allowPassingToDifferentDriver();
+        block.allowPassingToDifferentDriver();
+    }
+
+    @Override
+    protected void closeInternal() {
+        block.close();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof DoubleBlock that) {
+            return DoubleBlock.equals(this, that);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return DoubleBlock.hash(this);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(this.getClass().getSimpleName());
+        sb.append("[positions=" + getPositionCount());
+        if (isReleased() == false) {
+            sb.append(", values=[");
+            appendValues(sb);
+            sb.append("]");
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+    private void appendValues(StringBuilder sb) {
+        final int positions = getPositionCount();
+        for (int p = 0; p < positions; p++) {
+            if (p > 0) {
+                sb.append(", ");
+            }
+            int start = getFirstValueIndex(p);
+            int count = getValueCount(p);
+            if (count == 1) {
+                sb.append(getDouble(start));
+                continue;
+            }
+            sb.append('[');
+            int end = start + count;
+            for (int i = start; i < end; i++) {
+                if (i > start) {
+                    sb.append(", ");
+                }
+                sb.append(getDouble(i));
+            }
+            sb.append(']');
+        }
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterDoubleBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterDoubleBlock.java
@@ -13,15 +13,12 @@ import org.apache.lucene.util.RamUsageEstimator;
  * Filter block for DoubleBlocks.
  * This class is generated. Do not edit it.
  */
-final class FilterDoubleBlock extends AbstractFilterBlock implements DoubleBlock {
+final class FilterDoubleBlock extends AbstractFilterBlock<DoubleBlock> implements DoubleBlock {
 
     private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(FilterDoubleBlock.class);
 
-    private final DoubleBlock block;
-
     FilterDoubleBlock(DoubleBlock block, int... positions) {
         super(block, positions);
-        this.block = block;
     }
 
     @Override
@@ -130,10 +127,5 @@ final class FilterDoubleBlock extends AbstractFilterBlock implements DoubleBlock
             }
             sb.append(']');
         }
-    }
-
-    @Override
-    protected void closeInternal() {
-        block.close();
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterDoubleBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterDoubleBlock.java
@@ -9,17 +9,21 @@ package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.RamUsageEstimator;
 
+import java.util.Arrays;
+
 /**
  * Filter block for DoubleBlocks.
  * This class is generated. Do not edit it.
  */
 // TODO: check if javadoc needs updating, both here, in the interfaces and in the abstract filter block
-final class FilterDoubleBlock extends AbstractFilterBlock<DoubleBlock> implements DoubleBlock {
+final class FilterDoubleBlock extends AbstractFilterBlock implements DoubleBlock {
 
     private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(FilterDoubleBlock.class);
+    private final DoubleArrayBlock block;
 
-    FilterDoubleBlock(DoubleBlock block, int... positions) {
-        super(block, positions);
+    FilterDoubleBlock(DoubleArrayBlock block, int... positions) {
+        super(positions, block.blockFactory());
+        this.block = block;
     }
 
     @Override
@@ -38,10 +42,64 @@ final class FilterDoubleBlock extends AbstractFilterBlock<DoubleBlock> implement
     }
 
     @Override
+    public boolean isNull(int position) {
+        return block.isNull(mapPosition(position));
+    }
+
+    @Override
+    public boolean mayHaveNulls() {
+        return block.mayHaveNulls();
+    }
+
+    @Override
+    public boolean areAllValuesNull() {
+        return block.areAllValuesNull();
+    }
+
+    @Override
+    public boolean mayHaveMultivaluedFields() {
+        /*
+         * This could return a false positive. The block may have multivalued
+         * fields, but we're not pointing to any of them. That's acceptable.
+         */
+        return block.mayHaveMultivaluedFields();
+    }
+
+    @Override
+    public final int getTotalValueCount() {
+        // TODO this is expensive. maybe cache or something.
+        int total = 0;
+        for (int p = 0; p < positions.length; p++) {
+            total += getValueCount(p);
+        }
+        return total;
+    }
+
+    @Override
+    public final int getValueCount(int position) {
+        return block.getValueCount(mapPosition(position));
+    }
+
+    @Override
+    public final int getPositionCount() {
+        return positions.length;
+    }
+
+    @Override
+    public final int getFirstValueIndex(int position) {
+        return block.getFirstValueIndex(mapPosition(position));
+    }
+
+    @Override
+    public MvOrdering mvOrdering() {
+        return block.mvOrdering();
+    }
+
+    @Override
     public DoubleBlock filter(int... positions) {
-        // TODO: avoid multi-layered FilterDoubleBlocks; compute subset of filter instead.
-        DoubleBlock filtered = new FilterDoubleBlock(this, positions);
-        this.incRef();
+        int[] mappedPositions = Arrays.stream(positions).map(this::mapPosition).toArray();
+        DoubleBlock filtered = new FilterDoubleBlock(block, mappedPositions);
+        block.incRef();
         return filtered;
     }
 
@@ -78,6 +136,17 @@ final class FilterDoubleBlock extends AbstractFilterBlock<DoubleBlock> implement
         // from a usage and resource point of view filter blocks encapsulate
         // their inner block, rather than listing it as a child resource
         return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(block) + RamUsageEstimator.sizeOf(positions);
+    }
+
+    @Override
+    public void allowPassingToDifferentDriver() {
+        super.allowPassingToDifferentDriver();
+        block.allowPassingToDifferentDriver();
+    }
+
+    @Override
+    protected void closeInternal() {
+        block.close();
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterDoubleBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterDoubleBlock.java
@@ -13,6 +13,7 @@ import org.apache.lucene.util.RamUsageEstimator;
  * Filter block for DoubleBlocks.
  * This class is generated. Do not edit it.
  */
+// TODO: check if javadoc needs updating, both here, in the interfaces and in the abstract filter block
 final class FilterDoubleBlock extends AbstractFilterBlock<DoubleBlock> implements DoubleBlock {
 
     private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(FilterDoubleBlock.class);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterDoubleBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterDoubleBlock.java
@@ -39,7 +39,9 @@ final class FilterDoubleBlock extends AbstractFilterBlock<DoubleBlock> implement
     @Override
     public DoubleBlock filter(int... positions) {
         // TODO: avoid multi-layered FilterDoubleBlocks; compute subset of filter instead.
-        return new FilterDoubleBlock(this, positions);
+        DoubleBlock filtered = new FilterDoubleBlock(this, positions);
+        this.incRef();
+        return filtered;
     }
 
     @Override
@@ -95,7 +97,6 @@ final class FilterDoubleBlock extends AbstractFilterBlock<DoubleBlock> implement
         StringBuilder sb = new StringBuilder();
         sb.append(this.getClass().getSimpleName());
         sb.append("[positions=" + getPositionCount());
-        sb.append(", released=" + isReleased());
         if (isReleased() == false) {
             sb.append(", values=[");
             appendValues(sb);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterDoubleBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterDoubleBlock.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data;
+
+import org.apache.lucene.util.RamUsageEstimator;
+
+/**
+ * Filter block for DoubleBlocks.
+ * This class is generated. Do not edit it.
+ */
+final class FilterDoubleBlock extends AbstractFilterBlock implements DoubleBlock {
+
+    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(FilterDoubleBlock.class);
+
+    private final DoubleBlock block;
+
+    FilterDoubleBlock(DoubleBlock block, int... positions) {
+        super(block, positions);
+        this.block = block;
+    }
+
+    @Override
+    public DoubleVector asVector() {
+        return null;
+    }
+
+    @Override
+    public double getDouble(int valueIndex) {
+        return block.getDouble(valueIndex);
+    }
+
+    @Override
+    public ElementType elementType() {
+        return ElementType.DOUBLE;
+    }
+
+    @Override
+    public DoubleBlock filter(int... positions) {
+        // TODO: avoid multi-layered FilterDoubleBlocks; compute subset of filter instead.
+        return new FilterDoubleBlock(this, positions);
+    }
+
+    @Override
+    public DoubleBlock expand() {
+        if (false == block.mayHaveMultivaluedFields()) {
+            return this;
+        }
+        // TODO: use the underlying block's expand
+        /*
+         * Build a copy of the target block, selecting only the positions
+         * we've been assigned and expanding all multivalued fields
+         * into single valued fields.
+         */
+        try (DoubleBlock.Builder builder = new DoubleBlockBuilder(positions.length * Integer.BYTES, blockFactory())) {
+            for (int p : positions) {
+                if (block.isNull(p)) {
+                    builder.appendNull();
+                    continue;
+                }
+                int start = block.getFirstValueIndex(p);
+                int end = start + block.getValueCount(p);
+                for (int i = start; i < end; i++) {
+                    builder.appendDouble(block.getDouble(i));
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        // TODO: check this
+        // from a usage and resource point of view filter blocks encapsulate
+        // their inner block, rather than listing it as a child resource
+        return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(block) + RamUsageEstimator.sizeOf(positions);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof DoubleBlock that) {
+            return DoubleBlock.equals(this, that);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return DoubleBlock.hash(this);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(this.getClass().getSimpleName());
+        sb.append("[positions=" + getPositionCount());
+        sb.append(", released=" + isReleased());
+        if (isReleased() == false) {
+            sb.append(", values=[");
+            appendValues(sb);
+            sb.append("]");
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+    private void appendValues(StringBuilder sb) {
+        final int positions = getPositionCount();
+        for (int p = 0; p < positions; p++) {
+            if (p > 0) {
+                sb.append(", ");
+            }
+            int start = getFirstValueIndex(p);
+            int count = getValueCount(p);
+            if (count == 1) {
+                sb.append(getDouble(start));
+                continue;
+            }
+            sb.append('[');
+            int end = start + count;
+            for (int i = start; i < end; i++) {
+                if (i > start) {
+                    sb.append(", ");
+                }
+                sb.append(getDouble(i));
+            }
+            sb.append(']');
+        }
+    }
+
+    @Override
+    protected void closeInternal() {
+        block.close();
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterDoubleVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterDoubleVectorBlock.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data;
+
+import org.apache.lucene.util.RamUsageEstimator;
+
+import java.util.Arrays;
+
+/**
+ * Filter block for DoubleBlocks.
+ * This class is generated. Do not edit it.
+ */
+// TODO: check if javadoc needs updating, both here, in the interfaces and in the abstract filter block
+final class FilterDoubleVectorBlock extends AbstractFilterBlock implements DoubleBlock {
+
+    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(FilterDoubleBlock.class);
+    private final DoubleVectorBlock block;
+
+    FilterDoubleVectorBlock(DoubleVectorBlock block, int... positions) {
+        super(positions, block.blockFactory());
+        this.block = block;
+    }
+
+    @Override
+    public DoubleVector asVector() {
+        return null;
+    }
+
+    @Override
+    public double getDouble(int valueIndex) {
+        return block.getDouble(valueIndex);
+    }
+
+    @Override
+    public ElementType elementType() {
+        return ElementType.DOUBLE;
+    }
+
+    @Override
+    public boolean isNull(int position) {
+        return false;
+    }
+
+    @Override
+    public boolean mayHaveNulls() {
+        return false;
+    }
+
+    @Override
+    public boolean areAllValuesNull() {
+        return false;
+    }
+
+    @Override
+    public boolean mayHaveMultivaluedFields() {
+        return false;
+    }
+
+    @Override
+    public final int getTotalValueCount() {
+        return positions.length;
+    }
+
+    @Override
+    public final int getValueCount(int position) {
+        return 1;
+    }
+
+    @Override
+    public final int getPositionCount() {
+        return positions.length;
+    }
+
+    @Override
+    public final int getFirstValueIndex(int position) {
+        return mapPosition(position);
+    }
+
+    @Override
+    public MvOrdering mvOrdering() {
+        return MvOrdering.DEDUPLICATED_AND_SORTED_ASCENDING;
+    }
+
+    @Override
+    public DoubleBlock filter(int... positions) {
+        int[] mappedPositions = Arrays.stream(positions).map(this::mapPosition).toArray();
+        DoubleBlock filtered = new FilterDoubleVectorBlock(block, mappedPositions);
+        block.incRef();
+        return filtered;
+    }
+
+    @Override
+    public DoubleBlock expand() {
+        if (false == block.mayHaveMultivaluedFields()) {
+            return this;
+        }
+        // TODO: use the underlying block's expand
+        /*
+         * Build a copy of the target block, selecting only the positions
+         * we've been assigned and expanding all multivalued fields
+         * into single valued fields.
+         */
+        try (DoubleBlock.Builder builder = new DoubleBlockBuilder(positions.length * Integer.BYTES, blockFactory())) {
+            for (int p : positions) {
+                if (block.isNull(p)) {
+                    builder.appendNull();
+                    continue;
+                }
+                int start = block.getFirstValueIndex(p);
+                int end = start + block.getValueCount(p);
+                for (int i = start; i < end; i++) {
+                    builder.appendDouble(block.getDouble(i));
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        // TODO: check this
+        // from a usage and resource point of view filter blocks encapsulate
+        // their inner block, rather than listing it as a child resource
+        return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(block) + RamUsageEstimator.sizeOf(positions);
+    }
+
+    @Override
+    public void allowPassingToDifferentDriver() {
+        super.allowPassingToDifferentDriver();
+        block.allowPassingToDifferentDriver();
+    }
+
+    @Override
+    protected void closeInternal() {
+        block.close();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof DoubleBlock that) {
+            return DoubleBlock.equals(this, that);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return DoubleBlock.hash(this);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(this.getClass().getSimpleName());
+        sb.append("[positions=" + getPositionCount());
+        if (isReleased() == false) {
+            sb.append(", values=[");
+            appendValues(sb);
+            sb.append("]");
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+    private void appendValues(StringBuilder sb) {
+        final int positions = getPositionCount();
+        for (int p = 0; p < positions; p++) {
+            if (p > 0) {
+                sb.append(", ");
+            }
+            int start = getFirstValueIndex(p);
+            int count = getValueCount(p);
+            if (count == 1) {
+                sb.append(getDouble(start));
+                continue;
+            }
+            sb.append('[');
+            int end = start + count;
+            for (int i = start; i < end; i++) {
+                if (i > start) {
+                    sb.append(", ");
+                }
+                sb.append(getDouble(i));
+            }
+            sb.append(']');
+        }
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterIntBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterIntBigArrayBlock.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data;
+
+import org.apache.lucene.util.RamUsageEstimator;
+
+import java.util.Arrays;
+
+/**
+ * Filter block for IntBlocks.
+ * This class is generated. Do not edit it.
+ */
+// TODO: check if javadoc needs updating, both here, in the interfaces and in the abstract filter block
+final class FilterIntBigArrayBlock extends AbstractFilterBlock implements IntBlock {
+
+    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(FilterIntBlock.class);
+    private final IntBigArrayBlock block;
+
+    FilterIntBigArrayBlock(IntBigArrayBlock block, int... positions) {
+        super(positions, block.blockFactory());
+        this.block = block;
+    }
+
+    @Override
+    public IntVector asVector() {
+        return null;
+    }
+
+    @Override
+    public int getInt(int valueIndex) {
+        return block.getInt(valueIndex);
+    }
+
+    @Override
+    public ElementType elementType() {
+        return ElementType.INT;
+    }
+
+    @Override
+    public boolean isNull(int position) {
+        return block.isNull(mapPosition(position));
+    }
+
+    @Override
+    public boolean mayHaveNulls() {
+        return block.mayHaveNulls();
+    }
+
+    @Override
+    public boolean areAllValuesNull() {
+        return block.areAllValuesNull();
+    }
+
+    @Override
+    public boolean mayHaveMultivaluedFields() {
+        /*
+         * This could return a false positive. The block may have multivalued
+         * fields, but we're not pointing to any of them. That's acceptable.
+         */
+        return block.mayHaveMultivaluedFields();
+    }
+
+    @Override
+    public final int getTotalValueCount() {
+        // TODO this is expensive. maybe cache or something.
+        int total = 0;
+        for (int p = 0; p < positions.length; p++) {
+            total += getValueCount(p);
+        }
+        return total;
+    }
+
+    @Override
+    public final int getValueCount(int position) {
+        return block.getValueCount(mapPosition(position));
+    }
+
+    @Override
+    public final int getPositionCount() {
+        return positions.length;
+    }
+
+    @Override
+    public final int getFirstValueIndex(int position) {
+        return block.getFirstValueIndex(mapPosition(position));
+    }
+
+    @Override
+    public MvOrdering mvOrdering() {
+        return block.mvOrdering();
+    }
+
+    @Override
+    public IntBlock filter(int... positions) {
+        int[] mappedPositions = Arrays.stream(positions).map(this::mapPosition).toArray();
+        IntBlock filtered = new FilterIntBigArrayBlock(block, mappedPositions);
+        block.incRef();
+        return filtered;
+    }
+
+    @Override
+    public IntBlock expand() {
+        if (false == block.mayHaveMultivaluedFields()) {
+            return this;
+        }
+        // TODO: use the underlying block's expand
+        /*
+         * Build a copy of the target block, selecting only the positions
+         * we've been assigned and expanding all multivalued fields
+         * into single valued fields.
+         */
+        try (IntBlock.Builder builder = new IntBlockBuilder(positions.length * Integer.BYTES, blockFactory())) {
+            for (int p : positions) {
+                if (block.isNull(p)) {
+                    builder.appendNull();
+                    continue;
+                }
+                int start = block.getFirstValueIndex(p);
+                int end = start + block.getValueCount(p);
+                for (int i = start; i < end; i++) {
+                    builder.appendInt(block.getInt(i));
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        // TODO: check this
+        // from a usage and resource point of view filter blocks encapsulate
+        // their inner block, rather than listing it as a child resource
+        return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(block) + RamUsageEstimator.sizeOf(positions);
+    }
+
+    @Override
+    public void allowPassingToDifferentDriver() {
+        super.allowPassingToDifferentDriver();
+        block.allowPassingToDifferentDriver();
+    }
+
+    @Override
+    protected void closeInternal() {
+        block.close();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof IntBlock that) {
+            return IntBlock.equals(this, that);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return IntBlock.hash(this);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(this.getClass().getSimpleName());
+        sb.append("[positions=" + getPositionCount());
+        if (isReleased() == false) {
+            sb.append(", values=[");
+            appendValues(sb);
+            sb.append("]");
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+    private void appendValues(StringBuilder sb) {
+        final int positions = getPositionCount();
+        for (int p = 0; p < positions; p++) {
+            if (p > 0) {
+                sb.append(", ");
+            }
+            int start = getFirstValueIndex(p);
+            int count = getValueCount(p);
+            if (count == 1) {
+                sb.append(getInt(start));
+                continue;
+            }
+            sb.append('[');
+            int end = start + count;
+            for (int i = start; i < end; i++) {
+                if (i > start) {
+                    sb.append(", ");
+                }
+                sb.append(getInt(i));
+            }
+            sb.append(']');
+        }
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterIntBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterIntBlock.java
@@ -13,15 +13,12 @@ import org.apache.lucene.util.RamUsageEstimator;
  * Filter block for IntBlocks.
  * This class is generated. Do not edit it.
  */
-final class FilterIntBlock extends AbstractFilterBlock implements IntBlock {
+final class FilterIntBlock extends AbstractFilterBlock<IntBlock> implements IntBlock {
 
     private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(FilterIntBlock.class);
 
-    private final IntBlock block;
-
     FilterIntBlock(IntBlock block, int... positions) {
         super(block, positions);
-        this.block = block;
     }
 
     @Override
@@ -130,10 +127,5 @@ final class FilterIntBlock extends AbstractFilterBlock implements IntBlock {
             }
             sb.append(']');
         }
-    }
-
-    @Override
-    protected void closeInternal() {
-        block.close();
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterIntBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterIntBlock.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data;
+
+import org.apache.lucene.util.RamUsageEstimator;
+
+/**
+ * Filter block for IntBlocks.
+ * This class is generated. Do not edit it.
+ */
+final class FilterIntBlock extends AbstractFilterBlock implements IntBlock {
+
+    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(FilterIntBlock.class);
+
+    private final IntBlock block;
+
+    FilterIntBlock(IntBlock block, int... positions) {
+        super(block, positions);
+        this.block = block;
+    }
+
+    @Override
+    public IntVector asVector() {
+        return null;
+    }
+
+    @Override
+    public int getInt(int valueIndex) {
+        return block.getInt(valueIndex);
+    }
+
+    @Override
+    public ElementType elementType() {
+        return ElementType.INT;
+    }
+
+    @Override
+    public IntBlock filter(int... positions) {
+        // TODO: avoid multi-layered FilterIntBlocks; compute subset of filter instead.
+        return new FilterIntBlock(this, positions);
+    }
+
+    @Override
+    public IntBlock expand() {
+        if (false == block.mayHaveMultivaluedFields()) {
+            return this;
+        }
+        // TODO: use the underlying block's expand
+        /*
+         * Build a copy of the target block, selecting only the positions
+         * we've been assigned and expanding all multivalued fields
+         * into single valued fields.
+         */
+        try (IntBlock.Builder builder = new IntBlockBuilder(positions.length * Integer.BYTES, blockFactory())) {
+            for (int p : positions) {
+                if (block.isNull(p)) {
+                    builder.appendNull();
+                    continue;
+                }
+                int start = block.getFirstValueIndex(p);
+                int end = start + block.getValueCount(p);
+                for (int i = start; i < end; i++) {
+                    builder.appendInt(block.getInt(i));
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        // TODO: check this
+        // from a usage and resource point of view filter blocks encapsulate
+        // their inner block, rather than listing it as a child resource
+        return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(block) + RamUsageEstimator.sizeOf(positions);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof IntBlock that) {
+            return IntBlock.equals(this, that);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return IntBlock.hash(this);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(this.getClass().getSimpleName());
+        sb.append("[positions=" + getPositionCount());
+        sb.append(", released=" + isReleased());
+        if (isReleased() == false) {
+            sb.append(", values=[");
+            appendValues(sb);
+            sb.append("]");
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+    private void appendValues(StringBuilder sb) {
+        final int positions = getPositionCount();
+        for (int p = 0; p < positions; p++) {
+            if (p > 0) {
+                sb.append(", ");
+            }
+            int start = getFirstValueIndex(p);
+            int count = getValueCount(p);
+            if (count == 1) {
+                sb.append(getInt(start));
+                continue;
+            }
+            sb.append('[');
+            int end = start + count;
+            for (int i = start; i < end; i++) {
+                if (i > start) {
+                    sb.append(", ");
+                }
+                sb.append(getInt(i));
+            }
+            sb.append(']');
+        }
+    }
+
+    @Override
+    protected void closeInternal() {
+        block.close();
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterIntBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterIntBlock.java
@@ -13,6 +13,7 @@ import org.apache.lucene.util.RamUsageEstimator;
  * Filter block for IntBlocks.
  * This class is generated. Do not edit it.
  */
+// TODO: check if javadoc needs updating, both here, in the interfaces and in the abstract filter block
 final class FilterIntBlock extends AbstractFilterBlock<IntBlock> implements IntBlock {
 
     private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(FilterIntBlock.class);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterIntBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterIntBlock.java
@@ -9,17 +9,21 @@ package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.RamUsageEstimator;
 
+import java.util.Arrays;
+
 /**
  * Filter block for IntBlocks.
  * This class is generated. Do not edit it.
  */
 // TODO: check if javadoc needs updating, both here, in the interfaces and in the abstract filter block
-final class FilterIntBlock extends AbstractFilterBlock<IntBlock> implements IntBlock {
+final class FilterIntBlock extends AbstractFilterBlock implements IntBlock {
 
     private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(FilterIntBlock.class);
+    private final IntArrayBlock block;
 
-    FilterIntBlock(IntBlock block, int... positions) {
-        super(block, positions);
+    FilterIntBlock(IntArrayBlock block, int... positions) {
+        super(positions, block.blockFactory());
+        this.block = block;
     }
 
     @Override
@@ -38,10 +42,64 @@ final class FilterIntBlock extends AbstractFilterBlock<IntBlock> implements IntB
     }
 
     @Override
+    public boolean isNull(int position) {
+        return block.isNull(mapPosition(position));
+    }
+
+    @Override
+    public boolean mayHaveNulls() {
+        return block.mayHaveNulls();
+    }
+
+    @Override
+    public boolean areAllValuesNull() {
+        return block.areAllValuesNull();
+    }
+
+    @Override
+    public boolean mayHaveMultivaluedFields() {
+        /*
+         * This could return a false positive. The block may have multivalued
+         * fields, but we're not pointing to any of them. That's acceptable.
+         */
+        return block.mayHaveMultivaluedFields();
+    }
+
+    @Override
+    public final int getTotalValueCount() {
+        // TODO this is expensive. maybe cache or something.
+        int total = 0;
+        for (int p = 0; p < positions.length; p++) {
+            total += getValueCount(p);
+        }
+        return total;
+    }
+
+    @Override
+    public final int getValueCount(int position) {
+        return block.getValueCount(mapPosition(position));
+    }
+
+    @Override
+    public final int getPositionCount() {
+        return positions.length;
+    }
+
+    @Override
+    public final int getFirstValueIndex(int position) {
+        return block.getFirstValueIndex(mapPosition(position));
+    }
+
+    @Override
+    public MvOrdering mvOrdering() {
+        return block.mvOrdering();
+    }
+
+    @Override
     public IntBlock filter(int... positions) {
-        // TODO: avoid multi-layered FilterIntBlocks; compute subset of filter instead.
-        IntBlock filtered = new FilterIntBlock(this, positions);
-        this.incRef();
+        int[] mappedPositions = Arrays.stream(positions).map(this::mapPosition).toArray();
+        IntBlock filtered = new FilterIntBlock(block, mappedPositions);
+        block.incRef();
         return filtered;
     }
 
@@ -78,6 +136,17 @@ final class FilterIntBlock extends AbstractFilterBlock<IntBlock> implements IntB
         // from a usage and resource point of view filter blocks encapsulate
         // their inner block, rather than listing it as a child resource
         return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(block) + RamUsageEstimator.sizeOf(positions);
+    }
+
+    @Override
+    public void allowPassingToDifferentDriver() {
+        super.allowPassingToDifferentDriver();
+        block.allowPassingToDifferentDriver();
+    }
+
+    @Override
+    protected void closeInternal() {
+        block.close();
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterIntBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterIntBlock.java
@@ -39,7 +39,9 @@ final class FilterIntBlock extends AbstractFilterBlock<IntBlock> implements IntB
     @Override
     public IntBlock filter(int... positions) {
         // TODO: avoid multi-layered FilterIntBlocks; compute subset of filter instead.
-        return new FilterIntBlock(this, positions);
+        IntBlock filtered = new FilterIntBlock(this, positions);
+        this.incRef();
+        return filtered;
     }
 
     @Override
@@ -95,7 +97,6 @@ final class FilterIntBlock extends AbstractFilterBlock<IntBlock> implements IntB
         StringBuilder sb = new StringBuilder();
         sb.append(this.getClass().getSimpleName());
         sb.append("[positions=" + getPositionCount());
-        sb.append(", released=" + isReleased());
         if (isReleased() == false) {
             sb.append(", values=[");
             appendValues(sb);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterIntVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterIntVectorBlock.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data;
+
+import org.apache.lucene.util.RamUsageEstimator;
+
+import java.util.Arrays;
+
+/**
+ * Filter block for IntBlocks.
+ * This class is generated. Do not edit it.
+ */
+// TODO: check if javadoc needs updating, both here, in the interfaces and in the abstract filter block
+final class FilterIntVectorBlock extends AbstractFilterBlock implements IntBlock {
+
+    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(FilterIntBlock.class);
+    private final IntVectorBlock block;
+
+    FilterIntVectorBlock(IntVectorBlock block, int... positions) {
+        super(positions, block.blockFactory());
+        this.block = block;
+    }
+
+    @Override
+    public IntVector asVector() {
+        return null;
+    }
+
+    @Override
+    public int getInt(int valueIndex) {
+        return block.getInt(valueIndex);
+    }
+
+    @Override
+    public ElementType elementType() {
+        return ElementType.INT;
+    }
+
+    @Override
+    public boolean isNull(int position) {
+        return false;
+    }
+
+    @Override
+    public boolean mayHaveNulls() {
+        return false;
+    }
+
+    @Override
+    public boolean areAllValuesNull() {
+        return false;
+    }
+
+    @Override
+    public boolean mayHaveMultivaluedFields() {
+        return false;
+    }
+
+    @Override
+    public final int getTotalValueCount() {
+        return positions.length;
+    }
+
+    @Override
+    public final int getValueCount(int position) {
+        return 1;
+    }
+
+    @Override
+    public final int getPositionCount() {
+        return positions.length;
+    }
+
+    @Override
+    public final int getFirstValueIndex(int position) {
+        return mapPosition(position);
+    }
+
+    @Override
+    public MvOrdering mvOrdering() {
+        return MvOrdering.DEDUPLICATED_AND_SORTED_ASCENDING;
+    }
+
+    @Override
+    public IntBlock filter(int... positions) {
+        int[] mappedPositions = Arrays.stream(positions).map(this::mapPosition).toArray();
+        IntBlock filtered = new FilterIntVectorBlock(block, mappedPositions);
+        block.incRef();
+        return filtered;
+    }
+
+    @Override
+    public IntBlock expand() {
+        if (false == block.mayHaveMultivaluedFields()) {
+            return this;
+        }
+        // TODO: use the underlying block's expand
+        /*
+         * Build a copy of the target block, selecting only the positions
+         * we've been assigned and expanding all multivalued fields
+         * into single valued fields.
+         */
+        try (IntBlock.Builder builder = new IntBlockBuilder(positions.length * Integer.BYTES, blockFactory())) {
+            for (int p : positions) {
+                if (block.isNull(p)) {
+                    builder.appendNull();
+                    continue;
+                }
+                int start = block.getFirstValueIndex(p);
+                int end = start + block.getValueCount(p);
+                for (int i = start; i < end; i++) {
+                    builder.appendInt(block.getInt(i));
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        // TODO: check this
+        // from a usage and resource point of view filter blocks encapsulate
+        // their inner block, rather than listing it as a child resource
+        return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(block) + RamUsageEstimator.sizeOf(positions);
+    }
+
+    @Override
+    public void allowPassingToDifferentDriver() {
+        super.allowPassingToDifferentDriver();
+        block.allowPassingToDifferentDriver();
+    }
+
+    @Override
+    protected void closeInternal() {
+        block.close();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof IntBlock that) {
+            return IntBlock.equals(this, that);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return IntBlock.hash(this);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(this.getClass().getSimpleName());
+        sb.append("[positions=" + getPositionCount());
+        if (isReleased() == false) {
+            sb.append(", values=[");
+            appendValues(sb);
+            sb.append("]");
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+    private void appendValues(StringBuilder sb) {
+        final int positions = getPositionCount();
+        for (int p = 0; p < positions; p++) {
+            if (p > 0) {
+                sb.append(", ");
+            }
+            int start = getFirstValueIndex(p);
+            int count = getValueCount(p);
+            if (count == 1) {
+                sb.append(getInt(start));
+                continue;
+            }
+            sb.append('[');
+            int end = start + count;
+            for (int i = start; i < end; i++) {
+                if (i > start) {
+                    sb.append(", ");
+                }
+                sb.append(getInt(i));
+            }
+            sb.append(']');
+        }
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterLongBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterLongBigArrayBlock.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data;
+
+import org.apache.lucene.util.RamUsageEstimator;
+
+import java.util.Arrays;
+
+/**
+ * Filter block for LongBlocks.
+ * This class is generated. Do not edit it.
+ */
+// TODO: check if javadoc needs updating, both here, in the interfaces and in the abstract filter block
+final class FilterLongBigArrayBlock extends AbstractFilterBlock implements LongBlock {
+
+    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(FilterLongBlock.class);
+    private final LongBigArrayBlock block;
+
+    FilterLongBigArrayBlock(LongBigArrayBlock block, int... positions) {
+        super(positions, block.blockFactory());
+        this.block = block;
+    }
+
+    @Override
+    public LongVector asVector() {
+        return null;
+    }
+
+    @Override
+    public long getLong(int valueIndex) {
+        return block.getLong(valueIndex);
+    }
+
+    @Override
+    public ElementType elementType() {
+        return ElementType.LONG;
+    }
+
+    @Override
+    public boolean isNull(int position) {
+        return block.isNull(mapPosition(position));
+    }
+
+    @Override
+    public boolean mayHaveNulls() {
+        return block.mayHaveNulls();
+    }
+
+    @Override
+    public boolean areAllValuesNull() {
+        return block.areAllValuesNull();
+    }
+
+    @Override
+    public boolean mayHaveMultivaluedFields() {
+        /*
+         * This could return a false positive. The block may have multivalued
+         * fields, but we're not pointing to any of them. That's acceptable.
+         */
+        return block.mayHaveMultivaluedFields();
+    }
+
+    @Override
+    public final int getTotalValueCount() {
+        // TODO this is expensive. maybe cache or something.
+        int total = 0;
+        for (int p = 0; p < positions.length; p++) {
+            total += getValueCount(p);
+        }
+        return total;
+    }
+
+    @Override
+    public final int getValueCount(int position) {
+        return block.getValueCount(mapPosition(position));
+    }
+
+    @Override
+    public final int getPositionCount() {
+        return positions.length;
+    }
+
+    @Override
+    public final int getFirstValueIndex(int position) {
+        return block.getFirstValueIndex(mapPosition(position));
+    }
+
+    @Override
+    public MvOrdering mvOrdering() {
+        return block.mvOrdering();
+    }
+
+    @Override
+    public LongBlock filter(int... positions) {
+        int[] mappedPositions = Arrays.stream(positions).map(this::mapPosition).toArray();
+        LongBlock filtered = new FilterLongBigArrayBlock(block, mappedPositions);
+        block.incRef();
+        return filtered;
+    }
+
+    @Override
+    public LongBlock expand() {
+        if (false == block.mayHaveMultivaluedFields()) {
+            return this;
+        }
+        // TODO: use the underlying block's expand
+        /*
+         * Build a copy of the target block, selecting only the positions
+         * we've been assigned and expanding all multivalued fields
+         * into single valued fields.
+         */
+        try (LongBlock.Builder builder = new LongBlockBuilder(positions.length * Integer.BYTES, blockFactory())) {
+            for (int p : positions) {
+                if (block.isNull(p)) {
+                    builder.appendNull();
+                    continue;
+                }
+                int start = block.getFirstValueIndex(p);
+                int end = start + block.getValueCount(p);
+                for (int i = start; i < end; i++) {
+                    builder.appendLong(block.getLong(i));
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        // TODO: check this
+        // from a usage and resource point of view filter blocks encapsulate
+        // their inner block, rather than listing it as a child resource
+        return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(block) + RamUsageEstimator.sizeOf(positions);
+    }
+
+    @Override
+    public void allowPassingToDifferentDriver() {
+        super.allowPassingToDifferentDriver();
+        block.allowPassingToDifferentDriver();
+    }
+
+    @Override
+    protected void closeInternal() {
+        block.close();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof LongBlock that) {
+            return LongBlock.equals(this, that);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return LongBlock.hash(this);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(this.getClass().getSimpleName());
+        sb.append("[positions=" + getPositionCount());
+        if (isReleased() == false) {
+            sb.append(", values=[");
+            appendValues(sb);
+            sb.append("]");
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+    private void appendValues(StringBuilder sb) {
+        final int positions = getPositionCount();
+        for (int p = 0; p < positions; p++) {
+            if (p > 0) {
+                sb.append(", ");
+            }
+            int start = getFirstValueIndex(p);
+            int count = getValueCount(p);
+            if (count == 1) {
+                sb.append(getLong(start));
+                continue;
+            }
+            sb.append('[');
+            int end = start + count;
+            for (int i = start; i < end; i++) {
+                if (i > start) {
+                    sb.append(", ");
+                }
+                sb.append(getLong(i));
+            }
+            sb.append(']');
+        }
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterLongBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterLongBlock.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data;
+
+import org.apache.lucene.util.RamUsageEstimator;
+
+/**
+ * Filter block for LongBlocks.
+ * This class is generated. Do not edit it.
+ */
+final class FilterLongBlock extends AbstractFilterBlock implements LongBlock {
+
+    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(FilterLongBlock.class);
+
+    private final LongBlock block;
+
+    FilterLongBlock(LongBlock block, int... positions) {
+        super(block, positions);
+        this.block = block;
+    }
+
+    @Override
+    public LongVector asVector() {
+        return null;
+    }
+
+    @Override
+    public long getLong(int valueIndex) {
+        return block.getLong(valueIndex);
+    }
+
+    @Override
+    public ElementType elementType() {
+        return ElementType.LONG;
+    }
+
+    @Override
+    public LongBlock filter(int... positions) {
+        // TODO: avoid multi-layered FilterLongBlocks; compute subset of filter instead.
+        return new FilterLongBlock(this, positions);
+    }
+
+    @Override
+    public LongBlock expand() {
+        if (false == block.mayHaveMultivaluedFields()) {
+            return this;
+        }
+        // TODO: use the underlying block's expand
+        /*
+         * Build a copy of the target block, selecting only the positions
+         * we've been assigned and expanding all multivalued fields
+         * into single valued fields.
+         */
+        try (LongBlock.Builder builder = new LongBlockBuilder(positions.length * Integer.BYTES, blockFactory())) {
+            for (int p : positions) {
+                if (block.isNull(p)) {
+                    builder.appendNull();
+                    continue;
+                }
+                int start = block.getFirstValueIndex(p);
+                int end = start + block.getValueCount(p);
+                for (int i = start; i < end; i++) {
+                    builder.appendLong(block.getLong(i));
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        // TODO: check this
+        // from a usage and resource point of view filter blocks encapsulate
+        // their inner block, rather than listing it as a child resource
+        return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(block) + RamUsageEstimator.sizeOf(positions);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof LongBlock that) {
+            return LongBlock.equals(this, that);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return LongBlock.hash(this);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(this.getClass().getSimpleName());
+        sb.append("[positions=" + getPositionCount());
+        sb.append(", released=" + isReleased());
+        if (isReleased() == false) {
+            sb.append(", values=[");
+            appendValues(sb);
+            sb.append("]");
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+    private void appendValues(StringBuilder sb) {
+        final int positions = getPositionCount();
+        for (int p = 0; p < positions; p++) {
+            if (p > 0) {
+                sb.append(", ");
+            }
+            int start = getFirstValueIndex(p);
+            int count = getValueCount(p);
+            if (count == 1) {
+                sb.append(getLong(start));
+                continue;
+            }
+            sb.append('[');
+            int end = start + count;
+            for (int i = start; i < end; i++) {
+                if (i > start) {
+                    sb.append(", ");
+                }
+                sb.append(getLong(i));
+            }
+            sb.append(']');
+        }
+    }
+
+    @Override
+    protected void closeInternal() {
+        block.close();
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterLongBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterLongBlock.java
@@ -9,17 +9,21 @@ package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.RamUsageEstimator;
 
+import java.util.Arrays;
+
 /**
  * Filter block for LongBlocks.
  * This class is generated. Do not edit it.
  */
 // TODO: check if javadoc needs updating, both here, in the interfaces and in the abstract filter block
-final class FilterLongBlock extends AbstractFilterBlock<LongBlock> implements LongBlock {
+final class FilterLongBlock extends AbstractFilterBlock implements LongBlock {
 
     private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(FilterLongBlock.class);
+    private final LongArrayBlock block;
 
-    FilterLongBlock(LongBlock block, int... positions) {
-        super(block, positions);
+    FilterLongBlock(LongArrayBlock block, int... positions) {
+        super(positions, block.blockFactory());
+        this.block = block;
     }
 
     @Override
@@ -38,10 +42,64 @@ final class FilterLongBlock extends AbstractFilterBlock<LongBlock> implements Lo
     }
 
     @Override
+    public boolean isNull(int position) {
+        return block.isNull(mapPosition(position));
+    }
+
+    @Override
+    public boolean mayHaveNulls() {
+        return block.mayHaveNulls();
+    }
+
+    @Override
+    public boolean areAllValuesNull() {
+        return block.areAllValuesNull();
+    }
+
+    @Override
+    public boolean mayHaveMultivaluedFields() {
+        /*
+         * This could return a false positive. The block may have multivalued
+         * fields, but we're not pointing to any of them. That's acceptable.
+         */
+        return block.mayHaveMultivaluedFields();
+    }
+
+    @Override
+    public final int getTotalValueCount() {
+        // TODO this is expensive. maybe cache or something.
+        int total = 0;
+        for (int p = 0; p < positions.length; p++) {
+            total += getValueCount(p);
+        }
+        return total;
+    }
+
+    @Override
+    public final int getValueCount(int position) {
+        return block.getValueCount(mapPosition(position));
+    }
+
+    @Override
+    public final int getPositionCount() {
+        return positions.length;
+    }
+
+    @Override
+    public final int getFirstValueIndex(int position) {
+        return block.getFirstValueIndex(mapPosition(position));
+    }
+
+    @Override
+    public MvOrdering mvOrdering() {
+        return block.mvOrdering();
+    }
+
+    @Override
     public LongBlock filter(int... positions) {
-        // TODO: avoid multi-layered FilterLongBlocks; compute subset of filter instead.
-        LongBlock filtered = new FilterLongBlock(this, positions);
-        this.incRef();
+        int[] mappedPositions = Arrays.stream(positions).map(this::mapPosition).toArray();
+        LongBlock filtered = new FilterLongBlock(block, mappedPositions);
+        block.incRef();
         return filtered;
     }
 
@@ -78,6 +136,17 @@ final class FilterLongBlock extends AbstractFilterBlock<LongBlock> implements Lo
         // from a usage and resource point of view filter blocks encapsulate
         // their inner block, rather than listing it as a child resource
         return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(block) + RamUsageEstimator.sizeOf(positions);
+    }
+
+    @Override
+    public void allowPassingToDifferentDriver() {
+        super.allowPassingToDifferentDriver();
+        block.allowPassingToDifferentDriver();
+    }
+
+    @Override
+    protected void closeInternal() {
+        block.close();
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterLongBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterLongBlock.java
@@ -13,6 +13,7 @@ import org.apache.lucene.util.RamUsageEstimator;
  * Filter block for LongBlocks.
  * This class is generated. Do not edit it.
  */
+// TODO: check if javadoc needs updating, both here, in the interfaces and in the abstract filter block
 final class FilterLongBlock extends AbstractFilterBlock<LongBlock> implements LongBlock {
 
     private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(FilterLongBlock.class);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterLongBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterLongBlock.java
@@ -39,7 +39,9 @@ final class FilterLongBlock extends AbstractFilterBlock<LongBlock> implements Lo
     @Override
     public LongBlock filter(int... positions) {
         // TODO: avoid multi-layered FilterLongBlocks; compute subset of filter instead.
-        return new FilterLongBlock(this, positions);
+        LongBlock filtered = new FilterLongBlock(this, positions);
+        this.incRef();
+        return filtered;
     }
 
     @Override
@@ -95,7 +97,6 @@ final class FilterLongBlock extends AbstractFilterBlock<LongBlock> implements Lo
         StringBuilder sb = new StringBuilder();
         sb.append(this.getClass().getSimpleName());
         sb.append("[positions=" + getPositionCount());
-        sb.append(", released=" + isReleased());
         if (isReleased() == false) {
             sb.append(", values=[");
             appendValues(sb);

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterLongBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterLongBlock.java
@@ -13,15 +13,12 @@ import org.apache.lucene.util.RamUsageEstimator;
  * Filter block for LongBlocks.
  * This class is generated. Do not edit it.
  */
-final class FilterLongBlock extends AbstractFilterBlock implements LongBlock {
+final class FilterLongBlock extends AbstractFilterBlock<LongBlock> implements LongBlock {
 
     private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(FilterLongBlock.class);
 
-    private final LongBlock block;
-
     FilterLongBlock(LongBlock block, int... positions) {
         super(block, positions);
-        this.block = block;
     }
 
     @Override
@@ -130,10 +127,5 @@ final class FilterLongBlock extends AbstractFilterBlock implements LongBlock {
             }
             sb.append(']');
         }
-    }
-
-    @Override
-    protected void closeInternal() {
-        block.close();
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterLongVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/FilterLongVectorBlock.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data;
+
+import org.apache.lucene.util.RamUsageEstimator;
+
+import java.util.Arrays;
+
+/**
+ * Filter block for LongBlocks.
+ * This class is generated. Do not edit it.
+ */
+// TODO: check if javadoc needs updating, both here, in the interfaces and in the abstract filter block
+final class FilterLongVectorBlock extends AbstractFilterBlock implements LongBlock {
+
+    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(FilterLongBlock.class);
+    private final LongVectorBlock block;
+
+    FilterLongVectorBlock(LongVectorBlock block, int... positions) {
+        super(positions, block.blockFactory());
+        this.block = block;
+    }
+
+    @Override
+    public LongVector asVector() {
+        return null;
+    }
+
+    @Override
+    public long getLong(int valueIndex) {
+        return block.getLong(valueIndex);
+    }
+
+    @Override
+    public ElementType elementType() {
+        return ElementType.LONG;
+    }
+
+    @Override
+    public boolean isNull(int position) {
+        return false;
+    }
+
+    @Override
+    public boolean mayHaveNulls() {
+        return false;
+    }
+
+    @Override
+    public boolean areAllValuesNull() {
+        return false;
+    }
+
+    @Override
+    public boolean mayHaveMultivaluedFields() {
+        return false;
+    }
+
+    @Override
+    public final int getTotalValueCount() {
+        return positions.length;
+    }
+
+    @Override
+    public final int getValueCount(int position) {
+        return 1;
+    }
+
+    @Override
+    public final int getPositionCount() {
+        return positions.length;
+    }
+
+    @Override
+    public final int getFirstValueIndex(int position) {
+        return mapPosition(position);
+    }
+
+    @Override
+    public MvOrdering mvOrdering() {
+        return MvOrdering.DEDUPLICATED_AND_SORTED_ASCENDING;
+    }
+
+    @Override
+    public LongBlock filter(int... positions) {
+        int[] mappedPositions = Arrays.stream(positions).map(this::mapPosition).toArray();
+        LongBlock filtered = new FilterLongVectorBlock(block, mappedPositions);
+        block.incRef();
+        return filtered;
+    }
+
+    @Override
+    public LongBlock expand() {
+        if (false == block.mayHaveMultivaluedFields()) {
+            return this;
+        }
+        // TODO: use the underlying block's expand
+        /*
+         * Build a copy of the target block, selecting only the positions
+         * we've been assigned and expanding all multivalued fields
+         * into single valued fields.
+         */
+        try (LongBlock.Builder builder = new LongBlockBuilder(positions.length * Integer.BYTES, blockFactory())) {
+            for (int p : positions) {
+                if (block.isNull(p)) {
+                    builder.appendNull();
+                    continue;
+                }
+                int start = block.getFirstValueIndex(p);
+                int end = start + block.getValueCount(p);
+                for (int i = start; i < end; i++) {
+                    builder.appendLong(block.getLong(i));
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        // TODO: check this
+        // from a usage and resource point of view filter blocks encapsulate
+        // their inner block, rather than listing it as a child resource
+        return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(block) + RamUsageEstimator.sizeOf(positions);
+    }
+
+    @Override
+    public void allowPassingToDifferentDriver() {
+        super.allowPassingToDifferentDriver();
+        block.allowPassingToDifferentDriver();
+    }
+
+    @Override
+    protected void closeInternal() {
+        block.close();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof LongBlock that) {
+            return LongBlock.equals(this, that);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return LongBlock.hash(this);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(this.getClass().getSimpleName());
+        sb.append("[positions=" + getPositionCount());
+        if (isReleased() == false) {
+            sb.append(", values=[");
+            appendValues(sb);
+            sb.append("]");
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+    private void appendValues(StringBuilder sb) {
+        final int positions = getPositionCount();
+        for (int p = 0; p < positions; p++) {
+            if (p > 0) {
+                sb.append(", ");
+            }
+            int start = getFirstValueIndex(p);
+            int count = getValueCount(p);
+            if (count == 1) {
+                sb.append(getLong(start));
+                continue;
+            }
+            sb.append('[');
+            int end = start + count;
+            for (int i = start; i < end; i++) {
+                if (i > start) {
+                    sb.append(", ");
+                }
+                sb.append(getLong(i));
+            }
+            sb.append(']');
+        }
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayBlock.java
@@ -67,27 +67,9 @@ final class IntArrayBlock extends AbstractArrayBlock implements IntBlock {
 
     @Override
     public IntBlock filter(int... positions) {
-        // TODO use reference counting to share the vector
-        try (var builder = blockFactory().newIntBlockBuilder(positions.length)) {
-            for (int pos : positions) {
-                if (isNull(pos)) {
-                    builder.appendNull();
-                    continue;
-                }
-                int valueCount = getValueCount(pos);
-                int first = getFirstValueIndex(pos);
-                if (valueCount == 1) {
-                    builder.appendInt(getInt(getFirstValueIndex(pos)));
-                } else {
-                    builder.beginPositionEntry();
-                    for (int c = 0; c < valueCount; c++) {
-                        builder.appendInt(getInt(first + c));
-                    }
-                    builder.endPositionEntry();
-                }
-            }
-            return builder.mvOrdering(mvOrdering()).build();
-        }
+        IntBlock filtered = new FilterIntBlock(this, positions);
+        this.incRef();
+        return filtered;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBigArrayBlock.java
@@ -68,9 +68,27 @@ public final class IntBigArrayBlock extends AbstractArrayBlock implements IntBlo
 
     @Override
     public IntBlock filter(int... positions) {
-        IntBlock filtered = new FilterIntBlock(this, positions);
-        this.incRef();
-        return filtered;
+        // TODO use reference counting to share the vector
+        try (var builder = blockFactory().newIntBlockBuilder(positions.length)) {
+            for (int pos : positions) {
+                if (isNull(pos)) {
+                    builder.appendNull();
+                    continue;
+                }
+                int valueCount = getValueCount(pos);
+                int first = getFirstValueIndex(pos);
+                if (valueCount == 1) {
+                    builder.appendInt(getInt(getFirstValueIndex(pos)));
+                } else {
+                    builder.beginPositionEntry();
+                    for (int c = 0; c < valueCount; c++) {
+                        builder.appendInt(getInt(first + c));
+                    }
+                    builder.endPositionEntry();
+                }
+            }
+            return builder.mvOrdering(mvOrdering()).build();
+        }
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBigArrayBlock.java
@@ -68,27 +68,9 @@ public final class IntBigArrayBlock extends AbstractArrayBlock implements IntBlo
 
     @Override
     public IntBlock filter(int... positions) {
-        // TODO use reference counting to share the vector
-        try (var builder = blockFactory().newIntBlockBuilder(positions.length)) {
-            for (int pos : positions) {
-                if (isNull(pos)) {
-                    builder.appendNull();
-                    continue;
-                }
-                int valueCount = getValueCount(pos);
-                int first = getFirstValueIndex(pos);
-                if (valueCount == 1) {
-                    builder.appendInt(getInt(getFirstValueIndex(pos)));
-                } else {
-                    builder.beginPositionEntry();
-                    for (int c = 0; c < valueCount; c++) {
-                        builder.appendInt(getInt(first + c));
-                    }
-                    builder.endPositionEntry();
-                }
-            }
-            return builder.mvOrdering(mvOrdering()).build();
-        }
+        IntBlock filtered = new FilterIntBigArrayBlock(this, positions);
+        this.incRef();
+        return filtered;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBigArrayBlock.java
@@ -68,27 +68,9 @@ public final class IntBigArrayBlock extends AbstractArrayBlock implements IntBlo
 
     @Override
     public IntBlock filter(int... positions) {
-        // TODO use reference counting to share the vector
-        try (var builder = blockFactory().newIntBlockBuilder(positions.length)) {
-            for (int pos : positions) {
-                if (isNull(pos)) {
-                    builder.appendNull();
-                    continue;
-                }
-                int valueCount = getValueCount(pos);
-                int first = getFirstValueIndex(pos);
-                if (valueCount == 1) {
-                    builder.appendInt(getInt(getFirstValueIndex(pos)));
-                } else {
-                    builder.beginPositionEntry();
-                    for (int c = 0; c < valueCount; c++) {
-                        builder.appendInt(getInt(first + c));
-                    }
-                    builder.endPositionEntry();
-                }
-            }
-            return builder.mvOrdering(mvOrdering()).build();
-        }
+        IntBlock filtered = new FilterIntBlock(this, positions);
+        this.incRef();
+        return filtered;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBlock.java
@@ -19,7 +19,7 @@ import java.io.IOException;
  * This class is generated. Do not edit it.
  */
 public sealed interface IntBlock extends Block permits IntArrayBlock, IntVectorBlock, ConstantNullBlock, IntBigArrayBlock,
-    FilterIntBlock, FilterIntVectorBlock {
+    FilterIntBlock, FilterIntVectorBlock, FilterIntBigArrayBlock {
 
     /**
      * Retrieves the int value stored at the given value index.

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBlock.java
@@ -19,7 +19,6 @@ import java.io.IOException;
  * This class is generated. Do not edit it.
  */
 public sealed interface IntBlock extends Block permits IntArrayBlock, IntVectorBlock, ConstantNullBlock, IntBigArrayBlock, FilterIntBlock {
-
     /**
      * Retrieves the int value stored at the given value index.
      *

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBlock.java
@@ -18,7 +18,9 @@ import java.io.IOException;
  * Block that stores int values.
  * This class is generated. Do not edit it.
  */
-public sealed interface IntBlock extends Block permits IntArrayBlock, IntVectorBlock, ConstantNullBlock, IntBigArrayBlock, FilterIntBlock {
+public sealed interface IntBlock extends Block permits IntArrayBlock, IntVectorBlock, ConstantNullBlock, IntBigArrayBlock,
+    FilterIntBlock, FilterIntVectorBlock {
+
     /**
      * Retrieves the int value stored at the given value index.
      *

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBlock.java
@@ -18,7 +18,7 @@ import java.io.IOException;
  * Block that stores int values.
  * This class is generated. Do not edit it.
  */
-public sealed interface IntBlock extends Block permits IntArrayBlock, IntVectorBlock, ConstantNullBlock, IntBigArrayBlock {
+public sealed interface IntBlock extends Block permits IntArrayBlock, IntVectorBlock, ConstantNullBlock, IntBigArrayBlock, FilterIntBlock {
 
     /**
      * Retrieves the int value stored at the given value index.

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVector.java
@@ -23,6 +23,9 @@ public sealed interface IntVector extends Vector permits ConstantIntVector, IntA
     @Override
     IntBlock asBlock();
 
+    /**
+     * Creates a new vector containing only the values at the given positions.
+     */
     @Override
     IntVector filter(int... positions);
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVectorBlock.java
@@ -47,7 +47,9 @@ public final class IntVectorBlock extends AbstractVectorBlock implements IntBloc
 
     @Override
     public IntBlock filter(int... positions) {
-        return vector.filter(positions).asBlock();
+        IntBlock filtered = new FilterIntVectorBlock(this, positions);
+        this.incRef();
+        return filtered;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVectorBlock.java
@@ -47,7 +47,9 @@ public final class IntVectorBlock extends AbstractVectorBlock implements IntBloc
 
     @Override
     public IntBlock filter(int... positions) {
-        return vector.filter(positions).asBlock();
+        IntBlock filtered = new FilterIntBlock(this, positions);
+        this.incRef();
+        return filtered;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVectorBlock.java
@@ -47,9 +47,7 @@ public final class IntVectorBlock extends AbstractVectorBlock implements IntBloc
 
     @Override
     public IntBlock filter(int... positions) {
-        IntBlock filtered = new FilterIntBlock(this, positions);
-        this.incRef();
-        return filtered;
+        return vector.filter(positions).asBlock();
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayBlock.java
@@ -67,27 +67,9 @@ final class LongArrayBlock extends AbstractArrayBlock implements LongBlock {
 
     @Override
     public LongBlock filter(int... positions) {
-        // TODO use reference counting to share the vector
-        try (var builder = blockFactory().newLongBlockBuilder(positions.length)) {
-            for (int pos : positions) {
-                if (isNull(pos)) {
-                    builder.appendNull();
-                    continue;
-                }
-                int valueCount = getValueCount(pos);
-                int first = getFirstValueIndex(pos);
-                if (valueCount == 1) {
-                    builder.appendLong(getLong(getFirstValueIndex(pos)));
-                } else {
-                    builder.beginPositionEntry();
-                    for (int c = 0; c < valueCount; c++) {
-                        builder.appendLong(getLong(first + c));
-                    }
-                    builder.endPositionEntry();
-                }
-            }
-            return builder.mvOrdering(mvOrdering()).build();
-        }
+        LongBlock filtered = new FilterLongBlock(this, positions);
+        this.incRef();
+        return filtered;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBigArrayBlock.java
@@ -68,9 +68,27 @@ public final class LongBigArrayBlock extends AbstractArrayBlock implements LongB
 
     @Override
     public LongBlock filter(int... positions) {
-        LongBlock filtered = new FilterLongBlock(this, positions);
-        this.incRef();
-        return filtered;
+        // TODO use reference counting to share the vector
+        try (var builder = blockFactory().newLongBlockBuilder(positions.length)) {
+            for (int pos : positions) {
+                if (isNull(pos)) {
+                    builder.appendNull();
+                    continue;
+                }
+                int valueCount = getValueCount(pos);
+                int first = getFirstValueIndex(pos);
+                if (valueCount == 1) {
+                    builder.appendLong(getLong(getFirstValueIndex(pos)));
+                } else {
+                    builder.beginPositionEntry();
+                    for (int c = 0; c < valueCount; c++) {
+                        builder.appendLong(getLong(first + c));
+                    }
+                    builder.endPositionEntry();
+                }
+            }
+            return builder.mvOrdering(mvOrdering()).build();
+        }
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBigArrayBlock.java
@@ -68,27 +68,9 @@ public final class LongBigArrayBlock extends AbstractArrayBlock implements LongB
 
     @Override
     public LongBlock filter(int... positions) {
-        // TODO use reference counting to share the vector
-        try (var builder = blockFactory().newLongBlockBuilder(positions.length)) {
-            for (int pos : positions) {
-                if (isNull(pos)) {
-                    builder.appendNull();
-                    continue;
-                }
-                int valueCount = getValueCount(pos);
-                int first = getFirstValueIndex(pos);
-                if (valueCount == 1) {
-                    builder.appendLong(getLong(getFirstValueIndex(pos)));
-                } else {
-                    builder.beginPositionEntry();
-                    for (int c = 0; c < valueCount; c++) {
-                        builder.appendLong(getLong(first + c));
-                    }
-                    builder.endPositionEntry();
-                }
-            }
-            return builder.mvOrdering(mvOrdering()).build();
-        }
+        LongBlock filtered = new FilterLongBigArrayBlock(this, positions);
+        this.incRef();
+        return filtered;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBigArrayBlock.java
@@ -68,27 +68,9 @@ public final class LongBigArrayBlock extends AbstractArrayBlock implements LongB
 
     @Override
     public LongBlock filter(int... positions) {
-        // TODO use reference counting to share the vector
-        try (var builder = blockFactory().newLongBlockBuilder(positions.length)) {
-            for (int pos : positions) {
-                if (isNull(pos)) {
-                    builder.appendNull();
-                    continue;
-                }
-                int valueCount = getValueCount(pos);
-                int first = getFirstValueIndex(pos);
-                if (valueCount == 1) {
-                    builder.appendLong(getLong(getFirstValueIndex(pos)));
-                } else {
-                    builder.beginPositionEntry();
-                    for (int c = 0; c < valueCount; c++) {
-                        builder.appendLong(getLong(first + c));
-                    }
-                    builder.endPositionEntry();
-                }
-            }
-            return builder.mvOrdering(mvOrdering()).build();
-        }
+        LongBlock filtered = new FilterLongBlock(this, positions);
+        this.incRef();
+        return filtered;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBlock.java
@@ -19,7 +19,7 @@ import java.io.IOException;
  * This class is generated. Do not edit it.
  */
 public sealed interface LongBlock extends Block permits LongArrayBlock, LongVectorBlock, ConstantNullBlock, LongBigArrayBlock,
-    FilterLongBlock {
+    FilterLongBlock, FilterLongVectorBlock {
 
     /**
      * Retrieves the long value stored at the given value index.

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBlock.java
@@ -19,7 +19,7 @@ import java.io.IOException;
  * This class is generated. Do not edit it.
  */
 public sealed interface LongBlock extends Block permits LongArrayBlock, LongVectorBlock, ConstantNullBlock, LongBigArrayBlock,
-    FilterLongBlock, FilterLongVectorBlock {
+    FilterLongBlock, FilterLongVectorBlock, FilterLongBigArrayBlock {
 
     /**
      * Retrieves the long value stored at the given value index.

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBlock.java
@@ -18,7 +18,7 @@ import java.io.IOException;
  * Block that stores long values.
  * This class is generated. Do not edit it.
  */
-public sealed interface LongBlock extends Block permits LongArrayBlock, LongVectorBlock, ConstantNullBlock, LongBigArrayBlock {
+public sealed interface LongBlock extends Block permits LongArrayBlock, LongVectorBlock, ConstantNullBlock, LongBigArrayBlock, FilterLongBlock {
 
     /**
      * Retrieves the long value stored at the given value index.

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBlock.java
@@ -18,7 +18,8 @@ import java.io.IOException;
  * Block that stores long values.
  * This class is generated. Do not edit it.
  */
-public sealed interface LongBlock extends Block permits LongArrayBlock, LongVectorBlock, ConstantNullBlock, LongBigArrayBlock, FilterLongBlock {
+public sealed interface LongBlock extends Block permits LongArrayBlock, LongVectorBlock, ConstantNullBlock, LongBigArrayBlock,
+    FilterLongBlock {
 
     /**
      * Retrieves the long value stored at the given value index.

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVector.java
@@ -23,6 +23,9 @@ public sealed interface LongVector extends Vector permits ConstantLongVector, Lo
     @Override
     LongBlock asBlock();
 
+    /**
+     * Creates a new vector containing only the values at the given positions.
+     */
     @Override
     LongVector filter(int... positions);
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVectorBlock.java
@@ -47,9 +47,7 @@ public final class LongVectorBlock extends AbstractVectorBlock implements LongBl
 
     @Override
     public LongBlock filter(int... positions) {
-        LongBlock filtered = new FilterLongBlock(this, positions);
-        this.incRef();
-        return filtered;
+        return vector.filter(positions).asBlock();
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVectorBlock.java
@@ -47,7 +47,9 @@ public final class LongVectorBlock extends AbstractVectorBlock implements LongBl
 
     @Override
     public LongBlock filter(int... positions) {
-        return vector.filter(positions).asBlock();
+        LongBlock filtered = new FilterLongVectorBlock(this, positions);
+        this.incRef();
+        return filtered;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVectorBlock.java
@@ -47,7 +47,9 @@ public final class LongVectorBlock extends AbstractVectorBlock implements LongBl
 
     @Override
     public LongBlock filter(int... positions) {
-        return vector.filter(positions).asBlock();
+        LongBlock filtered = new FilterLongBlock(this, positions);
+        this.incRef();
+        return filtered;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AbstractBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AbstractBlock.java
@@ -75,7 +75,7 @@ abstract class AbstractBlock extends AbstractNonThreadSafeRefCounted implements 
     }
 
     @Override
-    public final int getPositionCount() {
+    public int getPositionCount() {
         return positionCount;
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AbstractFilterBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AbstractFilterBlock.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data;
+
+
+import java.util.Arrays;
+
+abstract class AbstractFilterBlock extends AbstractBlock implements Block {
+
+    // TODO: positions need to be tracked
+    protected final int[] positions;
+
+    // TODO: needs to be incRef'd/decRef'd correctly
+    private final Block block;
+
+    AbstractFilterBlock(Block block, int[] positions) {
+        // TODO: assert positions here, also check that we map to valid positions
+        super(positions.length, block.blockFactory());
+        this.positions = positions;
+        this.block = block;
+    }
+
+    @Override
+    public ElementType elementType() {
+        return block.elementType();
+    }
+
+    @Override
+    public boolean isNull(int position) {
+        return block.isNull(mapPosition(position));
+    }
+
+    @Override
+    public boolean mayHaveNulls() {
+        return block.mayHaveNulls();
+    }
+
+    @Override
+    public boolean areAllValuesNull() {
+        return block.areAllValuesNull();
+    }
+
+    @Override
+    public boolean mayHaveMultivaluedFields() {
+        /*
+         * This could return a false positive. The block may have multivalued
+         * fields, but we're not pointing to any of them. That's acceptable.
+         */
+        return block.mayHaveMultivaluedFields();
+    }
+
+    @Override
+    public final int nullValuesCount() {
+        if (mayHaveNulls() == false) {
+            return 0;
+        } else if (areAllValuesNull()) {
+            return getPositionCount();
+        } else {
+            int nulls = 0;
+            for (int i = 0; i < getPositionCount(); i++) {
+                if (isNull(i)) {
+                    nulls++;
+                }
+            }
+            return nulls;
+        }
+    }
+
+    @Override
+    public final int getTotalValueCount() {
+        if (positions.length == block.getPositionCount()) {
+            // All the positions are still in the block, just jumbled.
+            return block.getTotalValueCount();
+        }
+        // TODO this is expensive. maybe cache or something.
+        int total = 0;
+        for (int p = 0; p < positions.length; p++) {
+            total += getValueCount(p);
+        }
+        return total;
+    }
+
+    @Override
+    public final int getValueCount(int position) {
+        return block.getValueCount(mapPosition(position));
+    }
+
+    @Override
+    public final int getPositionCount() {
+        return positions.length;
+    }
+
+    @Override
+    public final int getFirstValueIndex(int position) {
+        return block.getFirstValueIndex(mapPosition(position));
+    }
+
+    @Override
+    public MvOrdering mvOrdering() {
+        return block.mvOrdering();
+    }
+
+    @Override
+    public BlockFactory blockFactory() {
+        return block.blockFactory();
+    }
+
+    private int mapPosition(int position) {
+        assert assertPosition(position);
+        return positions[position];
+    }
+
+    @Override
+    public String toString() {
+        return "FilteredBlock{" + "positions=" + Arrays.toString(positions) + ", block=" + block + '}';
+    }
+
+    protected final boolean assertPosition(int position) {
+        assert (position >= 0 || position < getPositionCount())
+            : "illegal position, " + position + ", position count:" + getPositionCount();
+        return true;
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AbstractFilterBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AbstractFilterBlock.java
@@ -125,6 +125,12 @@ abstract class AbstractFilterBlock<B extends Block> extends AbstractBlock implem
     }
 
     @Override
+    public void allowPassingToDifferentDriver() {
+        super.allowPassingToDifferentDriver();
+        block.allowPassingToDifferentDriver();
+    }
+
+    @Override
     protected void closeInternal() {
         block.close();
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocBlock.java
@@ -44,6 +44,7 @@ public class DocBlock extends AbstractVectorBlock implements Block {
         return ElementType.DOC;
     }
 
+    // TODO: use refCounting to avoid deep copies
     @Override
     public Block filter(int... positions) {
         return new DocBlock(asVector().filter(positions));

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
@@ -83,30 +83,9 @@ $endif$
 
     @Override
     public $Type$Block filter(int... positions) {
-        // TODO use reference counting to share the vector
-$if(BytesRef)$
-        final BytesRef scratch = new BytesRef();
-$endif$
-        try (var builder = blockFactory().new$Type$BlockBuilder(positions.length)) {
-            for (int pos : positions) {
-                if (isNull(pos)) {
-                    builder.appendNull();
-                    continue;
-                }
-                int valueCount = getValueCount(pos);
-                int first = getFirstValueIndex(pos);
-                if (valueCount == 1) {
-                    builder.append$Type$(get$Type$(getFirstValueIndex(pos)$if(BytesRef)$, scratch$endif$));
-                } else {
-                    builder.beginPositionEntry();
-                    for (int c = 0; c < valueCount; c++) {
-                        builder.append$Type$(get$Type$(first + c$if(BytesRef)$, scratch$endif$));
-                    }
-                    builder.endPositionEntry();
-                }
-            }
-            return builder.mvOrdering(mvOrdering()).build();
-        }
+        $Type$Block filtered = new Filter$Type$Block(this, positions);
+        this.incRef();
+        return filtered;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BigArrayBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BigArrayBlock.java.st
@@ -68,9 +68,27 @@ public final class $Type$BigArrayBlock extends AbstractArrayBlock implements $Ty
 
     @Override
     public $Type$Block filter(int... positions) {
-        $Type$Block filtered = new Filter$Type$Block(this, positions);
-        this.incRef();
-        return filtered;
+        // TODO use reference counting to share the vector
+        try (var builder = blockFactory().new$Type$BlockBuilder(positions.length)) {
+            for (int pos : positions) {
+                if (isNull(pos)) {
+                    builder.appendNull();
+                    continue;
+                }
+                int valueCount = getValueCount(pos);
+                int first = getFirstValueIndex(pos);
+                if (valueCount == 1) {
+                    builder.append$Type$(get$Type$(getFirstValueIndex(pos)$if(BytesRef)$, scratch$endif$));
+                } else {
+                    builder.beginPositionEntry();
+                    for (int c = 0; c < valueCount; c++) {
+                        builder.append$Type$(get$Type$(first + c$if(BytesRef)$, scratch$endif$));
+                    }
+                    builder.endPositionEntry();
+                }
+            }
+            return builder.mvOrdering(mvOrdering()).build();
+        }
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BigArrayBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BigArrayBlock.java.st
@@ -68,27 +68,9 @@ public final class $Type$BigArrayBlock extends AbstractArrayBlock implements $Ty
 
     @Override
     public $Type$Block filter(int... positions) {
-        // TODO use reference counting to share the vector
-        try (var builder = blockFactory().new$Type$BlockBuilder(positions.length)) {
-            for (int pos : positions) {
-                if (isNull(pos)) {
-                    builder.appendNull();
-                    continue;
-                }
-                int valueCount = getValueCount(pos);
-                int first = getFirstValueIndex(pos);
-                if (valueCount == 1) {
-                    builder.append$Type$(get$Type$(getFirstValueIndex(pos)$if(BytesRef)$, scratch$endif$));
-                } else {
-                    builder.beginPositionEntry();
-                    for (int c = 0; c < valueCount; c++) {
-                        builder.append$Type$(get$Type$(first + c$if(BytesRef)$, scratch$endif$));
-                    }
-                    builder.endPositionEntry();
-                }
-            }
-            return builder.mvOrdering(mvOrdering()).build();
-        }
+        $Type$Block filtered = new Filter$Type$BigArrayBlock(this, positions);
+        this.incRef();
+        return filtered;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BigArrayBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BigArrayBlock.java.st
@@ -68,27 +68,9 @@ public final class $Type$BigArrayBlock extends AbstractArrayBlock implements $Ty
 
     @Override
     public $Type$Block filter(int... positions) {
-        // TODO use reference counting to share the vector
-        try (var builder = blockFactory().new$Type$BlockBuilder(positions.length)) {
-            for (int pos : positions) {
-                if (isNull(pos)) {
-                    builder.appendNull();
-                    continue;
-                }
-                int valueCount = getValueCount(pos);
-                int first = getFirstValueIndex(pos);
-                if (valueCount == 1) {
-                    builder.append$Type$(get$Type$(getFirstValueIndex(pos)$if(BytesRef)$, scratch$endif$));
-                } else {
-                    builder.beginPositionEntry();
-                    for (int c = 0; c < valueCount; c++) {
-                        builder.append$Type$(get$Type$(first + c$if(BytesRef)$, scratch$endif$));
-                    }
-                    builder.endPositionEntry();
-                }
-            }
-            return builder.mvOrdering(mvOrdering()).build();
-        }
+        $Type$Block filtered = new Filter$Type$Block(this, positions);
+        this.incRef();
+        return filtered;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Block.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Block.java.st
@@ -22,8 +22,13 @@ import java.io.IOException;
  * Block that stores $type$ values.
  * This class is generated. Do not edit it.
  */
+$if(BytesRef)$
 public sealed interface $Type$Block extends Block permits $Type$ArrayBlock, $Type$VectorBlock, ConstantNullBlock$if(BytesRef)$$else$, $Type$BigArrayBlock$endif$,
     Filter$Type$Block, Filter$Type$VectorBlock {
+$else$
+public sealed interface $Type$Block extends Block permits $Type$ArrayBlock, $Type$VectorBlock, ConstantNullBlock$if(BytesRef)$$else$, $Type$BigArrayBlock$endif$,
+    Filter$Type$Block, Filter$Type$VectorBlock, Filter$Type$BigArrayBlock {
+$endif$
 
 $if(BytesRef)$
     BytesRef NULL_VALUE = new BytesRef();

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Block.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Block.java.st
@@ -22,12 +22,8 @@ import java.io.IOException;
  * Block that stores $type$ values.
  * This class is generated. Do not edit it.
  */
-$if(int)$
-public sealed interface $Type$Block extends Block permits $Type$ArrayBlock, $Type$VectorBlock, ConstantNullBlock$if(BytesRef)$$else$, $Type$BigArrayBlock$endif$, Filter$Type$Block {
-$else$
 public sealed interface $Type$Block extends Block permits $Type$ArrayBlock, $Type$VectorBlock, ConstantNullBlock$if(BytesRef)$$else$, $Type$BigArrayBlock$endif$,
-    Filter$Type$Block {
-$endif$
+    Filter$Type$Block, Filter$Type$VectorBlock {
 
 $if(BytesRef)$
     BytesRef NULL_VALUE = new BytesRef();

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Block.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Block.java.st
@@ -22,7 +22,7 @@ import java.io.IOException;
  * Block that stores $type$ values.
  * This class is generated. Do not edit it.
  */
-public sealed interface $Type$Block extends Block permits $Type$ArrayBlock, $Type$VectorBlock, ConstantNullBlock$if(BytesRef)$$else$, $Type$BigArrayBlock$endif$ {
+public sealed interface $Type$Block extends Block permits $Type$ArrayBlock, $Type$VectorBlock, ConstantNullBlock$if(BytesRef)$$else$, $Type$BigArrayBlock$endif$, Filter$Type$Block {
 
 $if(BytesRef)$
     BytesRef NULL_VALUE = new BytesRef();

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Block.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Block.java.st
@@ -22,7 +22,12 @@ import java.io.IOException;
  * Block that stores $type$ values.
  * This class is generated. Do not edit it.
  */
+$if(int)$
 public sealed interface $Type$Block extends Block permits $Type$ArrayBlock, $Type$VectorBlock, ConstantNullBlock$if(BytesRef)$$else$, $Type$BigArrayBlock$endif$, Filter$Type$Block {
+$else$
+public sealed interface $Type$Block extends Block permits $Type$ArrayBlock, $Type$VectorBlock, ConstantNullBlock$if(BytesRef)$$else$, $Type$BigArrayBlock$endif$,
+    Filter$Type$Block {
+$endif$
 
 $if(BytesRef)$
     BytesRef NULL_VALUE = new BytesRef();

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-FilterBigArrayBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-FilterBigArrayBlock.java.st
@@ -1,0 +1,202 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data;
+
+import org.apache.lucene.util.RamUsageEstimator;
+
+import java.util.Arrays;
+
+/**
+ * Filter block for $Type$Blocks.
+ * This class is generated. Do not edit it.
+ */
+// TODO: check if javadoc needs updating, both here, in the interfaces and in the abstract filter block
+final class Filter$Type$BigArrayBlock extends AbstractFilterBlock implements $Type$Block {
+
+    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(Filter$Type$Block.class);
+    private final $Type$BigArrayBlock block;
+
+    Filter$Type$BigArrayBlock($Type$BigArrayBlock block, int... positions) {
+        super(positions, block.blockFactory());
+        this.block = block;
+    }
+
+    @Override
+    public $Type$Vector asVector() {
+        return null;
+    }
+
+    @Override
+    public $type$ get$Type$(int valueIndex) {
+        return block.get$Type$(valueIndex);
+    }
+
+    @Override
+    public ElementType elementType() {
+        return ElementType.$TYPE$;
+    }
+
+    @Override
+    public boolean isNull(int position) {
+        return block.isNull(mapPosition(position));
+    }
+
+    @Override
+    public boolean mayHaveNulls() {
+        return block.mayHaveNulls();
+    }
+
+    @Override
+    public boolean areAllValuesNull() {
+        return block.areAllValuesNull();
+    }
+
+    @Override
+    public boolean mayHaveMultivaluedFields() {
+        /*
+         * This could return a false positive. The block may have multivalued
+         * fields, but we're not pointing to any of them. That's acceptable.
+         */
+        return block.mayHaveMultivaluedFields();
+    }
+
+    @Override
+    public final int getTotalValueCount() {
+        // TODO this is expensive. maybe cache or something.
+        int total = 0;
+        for (int p = 0; p < positions.length; p++) {
+            total += getValueCount(p);
+        }
+        return total;
+    }
+
+    @Override
+    public final int getValueCount(int position) {
+        return block.getValueCount(mapPosition(position));
+    }
+
+    @Override
+    public final int getPositionCount() {
+        return positions.length;
+    }
+
+    @Override
+    public final int getFirstValueIndex(int position) {
+        return block.getFirstValueIndex(mapPosition(position));
+    }
+
+    @Override
+    public MvOrdering mvOrdering() {
+        return block.mvOrdering();
+    }
+
+    @Override
+    public $Type$Block filter(int... positions) {
+        int[] mappedPositions = Arrays.stream(positions).map(this::mapPosition).toArray();
+        $Type$Block filtered = new Filter$Type$BigArrayBlock(block, mappedPositions);
+        block.incRef();
+        return filtered;
+    }
+
+    @Override
+    public $Type$Block expand() {
+        if (false == block.mayHaveMultivaluedFields()) {
+            return this;
+        }
+        // TODO: use the underlying block's expand
+        /*
+         * Build a copy of the target block, selecting only the positions
+         * we've been assigned and expanding all multivalued fields
+         * into single valued fields.
+         */
+        try ($Type$Block.Builder builder = new $Type$BlockBuilder(positions.length * Integer.BYTES, blockFactory())) {
+            for (int p : positions) {
+                if (block.isNull(p)) {
+                    builder.appendNull();
+                    continue;
+                }
+                int start = block.getFirstValueIndex(p);
+                int end = start + block.getValueCount(p);
+                for (int i = start; i < end; i++) {
+                    builder.append$Type$(block.get$Type$(i));
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        // TODO: check this
+        // from a usage and resource point of view filter blocks encapsulate
+        // their inner block, rather than listing it as a child resource
+        return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(block) + RamUsageEstimator.sizeOf(positions);
+    }
+
+    @Override
+    public void allowPassingToDifferentDriver() {
+        super.allowPassingToDifferentDriver();
+        block.allowPassingToDifferentDriver();
+    }
+
+    @Override
+    protected void closeInternal() {
+        block.close();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof $Type$Block that) {
+            return $Type$Block.equals(this, that);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return $Type$Block.hash(this);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(this.getClass().getSimpleName());
+        sb.append("[positions=" + getPositionCount());
+        if (isReleased() == false) {
+            sb.append(", values=[");
+            appendValues(sb);
+            sb.append("]");
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+    private void appendValues(StringBuilder sb) {
+        final int positions = getPositionCount();
+        for (int p = 0; p < positions; p++) {
+            if (p > 0) {
+                sb.append(", ");
+            }
+            int start = getFirstValueIndex(p);
+            int count = getValueCount(p);
+            if (count == 1) {
+                sb.append(get$Type$(start));
+                continue;
+            }
+            sb.append('[');
+            int end = start + count;
+            for (int i = start; i < end; i++) {
+                if (i > start) {
+                    sb.append(", ");
+                }
+                sb.append(get$Type$(i));
+            }
+            sb.append(']');
+        }
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-FilterBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-FilterBlock.java.st
@@ -12,17 +12,21 @@ import org.apache.lucene.util.BytesRef;
 $endif$
 import org.apache.lucene.util.RamUsageEstimator;
 
+import java.util.Arrays;
+
 /**
  * Filter block for $Type$Blocks.
  * This class is generated. Do not edit it.
  */
 // TODO: check if javadoc needs updating, both here, in the interfaces and in the abstract filter block
-final class Filter$Type$Block extends AbstractFilterBlock<$Type$Block> implements $Type$Block {
+final class Filter$Type$Block extends AbstractFilterBlock implements $Type$Block {
 
     private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(Filter$Type$Block.class);
+    private final $Type$ArrayBlock block;
 
-    Filter$Type$Block($Type$Block block, int... positions) {
-        super(block, positions);
+    Filter$Type$Block($Type$ArrayBlock block, int... positions) {
+        super(positions, block.blockFactory());
+        this.block = block;
     }
 
     @Override
@@ -46,10 +50,64 @@ $endif$
     }
 
     @Override
+    public boolean isNull(int position) {
+        return block.isNull(mapPosition(position));
+    }
+
+    @Override
+    public boolean mayHaveNulls() {
+        return block.mayHaveNulls();
+    }
+
+    @Override
+    public boolean areAllValuesNull() {
+        return block.areAllValuesNull();
+    }
+
+    @Override
+    public boolean mayHaveMultivaluedFields() {
+        /*
+         * This could return a false positive. The block may have multivalued
+         * fields, but we're not pointing to any of them. That's acceptable.
+         */
+        return block.mayHaveMultivaluedFields();
+    }
+
+    @Override
+    public final int getTotalValueCount() {
+        // TODO this is expensive. maybe cache or something.
+        int total = 0;
+        for (int p = 0; p < positions.length; p++) {
+            total += getValueCount(p);
+        }
+        return total;
+    }
+
+    @Override
+    public final int getValueCount(int position) {
+        return block.getValueCount(mapPosition(position));
+    }
+
+    @Override
+    public final int getPositionCount() {
+        return positions.length;
+    }
+
+    @Override
+    public final int getFirstValueIndex(int position) {
+        return block.getFirstValueIndex(mapPosition(position));
+    }
+
+    @Override
+    public MvOrdering mvOrdering() {
+        return block.mvOrdering();
+    }
+
+    @Override
     public $Type$Block filter(int... positions) {
-        // TODO: avoid multi-layered Filter$Type$Blocks; compute subset of filter instead.
-        $Type$Block filtered = new Filter$Type$Block(this, positions);
-        this.incRef();
+        int[] mappedPositions = Arrays.stream(positions).map(this::mapPosition).toArray();
+        $Type$Block filtered = new Filter$Type$Block(block, mappedPositions);
+        block.incRef();
         return filtered;
     }
 
@@ -94,6 +152,17 @@ $endif$
         // from a usage and resource point of view filter blocks encapsulate
         // their inner block, rather than listing it as a child resource
         return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(block) + RamUsageEstimator.sizeOf(positions);
+    }
+
+    @Override
+    public void allowPassingToDifferentDriver() {
+        super.allowPassingToDifferentDriver();
+        block.allowPassingToDifferentDriver();
+    }
+
+    @Override
+    protected void closeInternal() {
+        block.close();
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-FilterBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-FilterBlock.java.st
@@ -16,15 +16,12 @@ import org.apache.lucene.util.RamUsageEstimator;
  * Filter block for $Type$Blocks.
  * This class is generated. Do not edit it.
  */
-final class Filter$Type$Block extends AbstractFilterBlock implements $Type$Block {
+final class Filter$Type$Block extends AbstractFilterBlock<$Type$Block> implements $Type$Block {
 
     private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(Filter$Type$Block.class);
 
-    private final $Type$Block block;
-
     Filter$Type$Block($Type$Block block, int... positions) {
         super(block, positions);
-        this.block = block;
     }
 
     @Override
@@ -154,10 +151,5 @@ $endif$
             }
             sb.append(']');
         }
-    }
-
-    @Override
-    protected void closeInternal() {
-        block.close();
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-FilterBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-FilterBlock.java.st
@@ -1,0 +1,163 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data;
+
+$if(BytesRef)$
+import org.apache.lucene.util.BytesRef;
+$endif$
+import org.apache.lucene.util.RamUsageEstimator;
+
+/**
+ * Filter block for $Type$Blocks.
+ * This class is generated. Do not edit it.
+ */
+final class Filter$Type$Block extends AbstractFilterBlock implements $Type$Block {
+
+    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(Filter$Type$Block.class);
+
+    private final $Type$Block block;
+
+    Filter$Type$Block($Type$Block block, int... positions) {
+        super(block, positions);
+        this.block = block;
+    }
+
+    @Override
+    public $Type$Vector asVector() {
+        return null;
+    }
+
+    @Override
+$if(BytesRef)$
+    public BytesRef getBytesRef(int valueIndex, BytesRef dest) {
+        return block.getBytesRef(valueIndex, dest);
+$else$
+    public $type$ get$Type$(int valueIndex) {
+        return block.get$Type$(valueIndex);
+$endif$
+    }
+
+    @Override
+    public ElementType elementType() {
+        return ElementType.$TYPE$;
+    }
+
+    @Override
+    public $Type$Block filter(int... positions) {
+        // TODO: avoid multi-layered Filter$Type$Blocks; compute subset of filter instead.
+        return new Filter$Type$Block(this, positions);
+    }
+
+    @Override
+    public $Type$Block expand() {
+        if (false == block.mayHaveMultivaluedFields()) {
+            return this;
+        }
+        // TODO: use the underlying block's expand
+        /*
+         * Build a copy of the target block, selecting only the positions
+         * we've been assigned and expanding all multivalued fields
+         * into single valued fields.
+         */
+        try ($Type$Block.Builder builder = new $Type$BlockBuilder(positions.length * Integer.BYTES, blockFactory())) {
+$if(BytesRef)$
+            BytesRef scratch = new BytesRef();
+$endif$
+            for (int p : positions) {
+                if (block.isNull(p)) {
+                    builder.appendNull();
+                    continue;
+                }
+                int start = block.getFirstValueIndex(p);
+                int end = start + block.getValueCount(p);
+                for (int i = start; i < end; i++) {
+$if(BytesRef)$
+                    BytesRef v = block.getBytesRef(i, scratch);
+                    builder.appendBytesRef(v);
+$else$
+                    builder.append$Type$(block.get$Type$(i));
+$endif$
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        // TODO: check this
+        // from a usage and resource point of view filter blocks encapsulate
+        // their inner block, rather than listing it as a child resource
+        return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(block) + RamUsageEstimator.sizeOf(positions);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof $Type$Block that) {
+            return $Type$Block.equals(this, that);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return $Type$Block.hash(this);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(this.getClass().getSimpleName());
+        sb.append("[positions=" + getPositionCount());
+        sb.append(", released=" + isReleased());
+        if (isReleased() == false) {
+            sb.append(", values=[");
+            appendValues(sb);
+            sb.append("]");
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+    private void appendValues(StringBuilder sb) {
+        final int positions = getPositionCount();
+        for (int p = 0; p < positions; p++) {
+            if (p > 0) {
+                sb.append(", ");
+            }
+            int start = getFirstValueIndex(p);
+            int count = getValueCount(p);
+            if (count == 1) {
+$if(BytesRef)$
+                sb.append(get$Type$(start, new BytesRef()));
+$else$
+                sb.append(get$Type$(start));
+$endif$
+                continue;
+            }
+            sb.append('[');
+            int end = start + count;
+            for (int i = start; i < end; i++) {
+                if (i > start) {
+                    sb.append(", ");
+                }
+$if(BytesRef)$
+                sb.append(get$Type$(i, new BytesRef()));
+$else$
+                sb.append(get$Type$(i));
+$endif$
+            }
+            sb.append(']');
+        }
+    }
+
+    @Override
+    protected void closeInternal() {
+        block.close();
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-FilterBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-FilterBlock.java.st
@@ -16,6 +16,7 @@ import org.apache.lucene.util.RamUsageEstimator;
  * Filter block for $Type$Blocks.
  * This class is generated. Do not edit it.
  */
+// TODO: check if javadoc needs updating, both here, in the interfaces and in the abstract filter block
 final class Filter$Type$Block extends AbstractFilterBlock<$Type$Block> implements $Type$Block {
 
     private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(Filter$Type$Block.class);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-FilterBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-FilterBlock.java.st
@@ -47,7 +47,9 @@ $endif$
     @Override
     public $Type$Block filter(int... positions) {
         // TODO: avoid multi-layered Filter$Type$Blocks; compute subset of filter instead.
-        return new Filter$Type$Block(this, positions);
+        $Type$Block filtered = new Filter$Type$Block(this, positions);
+        this.incRef();
+        return filtered;
     }
 
     @Override
@@ -111,7 +113,6 @@ $endif$
         StringBuilder sb = new StringBuilder();
         sb.append(this.getClass().getSimpleName());
         sb.append("[positions=" + getPositionCount());
-        sb.append(", released=" + isReleased());
         if (isReleased() == false) {
             sb.append(", values=[");
             appendValues(sb);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-FilterVectorBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-FilterVectorBlock.java.st
@@ -1,0 +1,217 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data;
+
+$if(BytesRef)$
+import org.apache.lucene.util.BytesRef;
+$endif$
+import org.apache.lucene.util.RamUsageEstimator;
+
+import java.util.Arrays;
+
+/**
+ * Filter block for $Type$Blocks.
+ * This class is generated. Do not edit it.
+ */
+// TODO: check if javadoc needs updating, both here, in the interfaces and in the abstract filter block
+final class Filter$Type$VectorBlock extends AbstractFilterBlock implements $Type$Block {
+
+    private static final long BASE_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(Filter$Type$Block.class);
+    private final $Type$VectorBlock block;
+
+    Filter$Type$VectorBlock($Type$VectorBlock block, int... positions) {
+        super(positions, block.blockFactory());
+        this.block = block;
+    }
+
+    @Override
+    public $Type$Vector asVector() {
+        return null;
+    }
+
+    @Override
+$if(BytesRef)$
+    public BytesRef getBytesRef(int valueIndex, BytesRef dest) {
+        return block.getBytesRef(valueIndex, dest);
+$else$
+    public $type$ get$Type$(int valueIndex) {
+        return block.get$Type$(valueIndex);
+$endif$
+    }
+
+    @Override
+    public ElementType elementType() {
+        return ElementType.$TYPE$;
+    }
+
+    @Override
+    public boolean isNull(int position) {
+        return false;
+    }
+
+    @Override
+    public boolean mayHaveNulls() {
+        return false;
+    }
+
+    @Override
+    public boolean areAllValuesNull() {
+        return false;
+    }
+
+    @Override
+    public boolean mayHaveMultivaluedFields() {
+        return false;
+    }
+
+    @Override
+    public final int getTotalValueCount() {
+        return positions.length;
+    }
+
+    @Override
+    public final int getValueCount(int position) {
+        return 1;
+    }
+
+    @Override
+    public final int getPositionCount() {
+        return positions.length;
+    }
+
+    @Override
+    public final int getFirstValueIndex(int position) {
+        return mapPosition(position);
+    }
+
+    @Override
+    public MvOrdering mvOrdering() {
+        return MvOrdering.DEDUPLICATED_AND_SORTED_ASCENDING;
+    }
+
+    @Override
+    public $Type$Block filter(int... positions) {
+        int[] mappedPositions = Arrays.stream(positions).map(this::mapPosition).toArray();
+        $Type$Block filtered = new Filter$Type$VectorBlock(block, mappedPositions);
+        block.incRef();
+        return filtered;
+    }
+
+    @Override
+    public $Type$Block expand() {
+        if (false == block.mayHaveMultivaluedFields()) {
+            return this;
+        }
+        // TODO: use the underlying block's expand
+        /*
+         * Build a copy of the target block, selecting only the positions
+         * we've been assigned and expanding all multivalued fields
+         * into single valued fields.
+         */
+        try ($Type$Block.Builder builder = new $Type$BlockBuilder(positions.length * Integer.BYTES, blockFactory())) {
+$if(BytesRef)$
+            BytesRef scratch = new BytesRef();
+$endif$
+            for (int p : positions) {
+                if (block.isNull(p)) {
+                    builder.appendNull();
+                    continue;
+                }
+                int start = block.getFirstValueIndex(p);
+                int end = start + block.getValueCount(p);
+                for (int i = start; i < end; i++) {
+$if(BytesRef)$
+                    BytesRef v = block.getBytesRef(i, scratch);
+                    builder.appendBytesRef(v);
+$else$
+                    builder.append$Type$(block.get$Type$(i));
+$endif$
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        // TODO: check this
+        // from a usage and resource point of view filter blocks encapsulate
+        // their inner block, rather than listing it as a child resource
+        return BASE_RAM_BYTES_USED + RamUsageEstimator.sizeOf(block) + RamUsageEstimator.sizeOf(positions);
+    }
+
+    @Override
+    public void allowPassingToDifferentDriver() {
+        super.allowPassingToDifferentDriver();
+        block.allowPassingToDifferentDriver();
+    }
+
+    @Override
+    protected void closeInternal() {
+        block.close();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof $Type$Block that) {
+            return $Type$Block.equals(this, that);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return $Type$Block.hash(this);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(this.getClass().getSimpleName());
+        sb.append("[positions=" + getPositionCount());
+        if (isReleased() == false) {
+            sb.append(", values=[");
+            appendValues(sb);
+            sb.append("]");
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+    private void appendValues(StringBuilder sb) {
+        final int positions = getPositionCount();
+        for (int p = 0; p < positions; p++) {
+            if (p > 0) {
+                sb.append(", ");
+            }
+            int start = getFirstValueIndex(p);
+            int count = getValueCount(p);
+            if (count == 1) {
+$if(BytesRef)$
+                sb.append(get$Type$(start, new BytesRef()));
+$else$
+                sb.append(get$Type$(start));
+$endif$
+                continue;
+            }
+            sb.append('[');
+            int end = start + count;
+            for (int i = start; i < end; i++) {
+                if (i > start) {
+                    sb.append(", ");
+                }
+$if(BytesRef)$
+                sb.append(get$Type$(i, new BytesRef()));
+$else$
+                sb.append(get$Type$(i));
+$endif$
+            }
+            sb.append(']');
+        }
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Vector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Vector.java.st
@@ -41,6 +41,9 @@ $endif$
     @Override
     $Type$Block asBlock();
 
+    /**
+     * Creates a new vector containing only the values at the given positions.
+     */
     @Override
     $Type$Vector filter(int... positions);
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorBlock.java.st
@@ -55,7 +55,9 @@ $endif$
 
     @Override
     public $Type$Block filter(int... positions) {
-        return vector.filter(positions).asBlock();
+        $Type$Block filtered = new Filter$Type$Block(this, positions);
+        this.incRef();
+        return filtered;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorBlock.java.st
@@ -55,7 +55,9 @@ $endif$
 
     @Override
     public $Type$Block filter(int... positions) {
-        return vector.filter(positions).asBlock();
+        $Type$Block filtered = new Filter$Type$VectorBlock(this, positions);
+        this.incRef();
+        return filtered;
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorBlock.java.st
@@ -55,9 +55,7 @@ $endif$
 
     @Override
     public $Type$Block filter(int... positions) {
-        $Type$Block filtered = new Filter$Type$Block(this, positions);
-        this.incRef();
-        return filtered;
+        return vector.filter(positions).asBlock();
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicBlockTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicBlockTests.java
@@ -748,16 +748,16 @@ public class BasicBlockTests extends ESTestCase {
             }
             for (IntBlock block : List.of(intBlock, intVector.asBlock())) {
                 try (var filter = block.filter(0)) {
-                    assertThat(filter.toString(), containsString("IntVectorBlock[vector=ConstantIntVector[positions=1, value=1]]"));
+                    assertThat(filter.toString(), containsString("FilterIntBlock[positions=1, values=[1]]"));
                 }
                 try (var filter = block.filter(1)) {
-                    assertThat(filter.toString(), containsString("IntVectorBlock[vector=ConstantIntVector[positions=1, value=2]]"));
+                    assertThat(filter.toString(), containsString("FilterIntBlock[positions=1, values=[2]]"));
                 }
                 try (var filter = block.filter(0, 1)) {
-                    assertThat(filter.toString(), containsString("IntVectorBlock[vector=IntArrayVector[positions=2, values=[1, 2]]]"));
+                    assertThat(filter.toString(), containsString("FilterIntBlock[positions=2, values=[1, 2]]"));
                 }
                 try (var filter = block.filter()) {
-                    assertThat(filter.toString(), containsString("IntVectorBlock[vector=IntArrayVector[positions=0, values=[]]]"));
+                    assertThat(filter.toString(), containsString("FilterIntBlock[positions=0, values=[]]"));
                 }
             }
             for (IntVector vector : List.of(intVector, intBlock.asVector())) {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BigArrayVectorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BigArrayVectorTests.java
@@ -49,7 +49,7 @@ public class BigArrayVectorTests extends SerializationTestCase {
                 assertThat(block.getValueCount(i), is(1));
                 assertThat(block.getFirstValueIndex(i), is(i));
                 try (BooleanBlock filter = block.filter(i)) {
-                    assertThat(filter.getBoolean(0), is(values[i]));
+                    assertThat(filter.getBoolean(filter.getFirstValueIndex(0)), is(values[i]));
                 }
             });
             BasicBlockTests.assertSingleValueDenseBlock(vector.asBlock());
@@ -80,7 +80,7 @@ public class BigArrayVectorTests extends SerializationTestCase {
                 assertThat(block.getValueCount(i), is(1));
                 assertThat(block.getFirstValueIndex(i), is(i));
                 try (IntBlock filter = block.filter(i)) {
-                    assertThat(filter.getInt(0), is(values[i]));
+                    assertThat(filter.getInt(filter.getFirstValueIndex(0)), is(values[i]));
                 }
             });
             BasicBlockTests.assertSingleValueDenseBlock(vector.asBlock());
@@ -111,7 +111,7 @@ public class BigArrayVectorTests extends SerializationTestCase {
                 assertThat(block.getValueCount(i), is(1));
                 assertThat(block.getFirstValueIndex(i), is(i));
                 try (LongBlock filter = block.filter(i)) {
-                    assertThat(filter.getLong(0), is(values[i]));
+                    assertThat(filter.getLong(filter.getFirstValueIndex(0)), is(values[i]));
                 }
             });
             BasicBlockTests.assertSingleValueDenseBlock(vector.asBlock());
@@ -142,7 +142,7 @@ public class BigArrayVectorTests extends SerializationTestCase {
                 assertThat(block.getValueCount(i), is(1));
                 assertThat(block.getFirstValueIndex(i), is(i));
                 try (DoubleBlock filter = block.filter(i)) {
-                    assertThat(filter.getDouble(0), is(values[i]));
+                    assertThat(filter.getDouble(filter.getFirstValueIndex(0)), is(values[i]));
                 }
             });
             BasicBlockTests.assertSingleValueDenseBlock(vector.asBlock());

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockAccountingTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockAccountingTests.java
@@ -25,7 +25,6 @@ import java.util.stream.IntStream;
 
 import static org.apache.lucene.util.RamUsageEstimator.alignObjectSize;
 import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockAccountingTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockAccountingTests.java
@@ -318,6 +318,7 @@ public class BlockAccountingTests extends ComputeTestCase {
         assertThat(emptyPlusSome.ramBytesUsed(), is(expected));
 
         Block filterBlock = emptyPlusSome.filter(1);
+        // TODO: UPPER_BOUND is too small, ends up being smaller than emptyPlusSome's size.
         assertThat(filterBlock.ramBytesUsed(), between(emptyPlusSome.ramBytesUsed(), UPPER_BOUND));
         Releasables.close(filterBlock);
     }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockAccountingTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockAccountingTests.java
@@ -25,6 +25,7 @@ import java.util.stream.IntStream;
 
 import static org.apache.lucene.util.RamUsageEstimator.alignObjectSize;
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
@@ -168,7 +169,7 @@ public class BlockAccountingTests extends ComputeTestCase {
         assertThat(emptyPlusSome.ramBytesUsed(), is(expected));
 
         Block filterBlock = emptyPlusSome.filter(1);
-        assertThat(filterBlock.ramBytesUsed(), lessThan(emptyPlusOne.ramBytesUsed()));
+        assertThat(filterBlock.ramBytesUsed(), greaterThan(emptyPlusSome.ramBytesUsed()));
         Releasables.close(filterBlock);
     }
 
@@ -218,7 +219,7 @@ public class BlockAccountingTests extends ComputeTestCase {
         assertThat(emptyPlusSome.ramBytesUsed(), is(expected));
 
         Block filterBlock = emptyPlusSome.filter(1);
-        assertThat(filterBlock.ramBytesUsed(), lessThan(emptyPlusOne.ramBytesUsed()));
+        assertThat(filterBlock.ramBytesUsed(), greaterThan(emptyPlusSome.ramBytesUsed()));
         Releasables.close(filterBlock);
     }
 
@@ -265,7 +266,7 @@ public class BlockAccountingTests extends ComputeTestCase {
         assertThat(emptyPlusSome.ramBytesUsed(), is(expected));
 
         Block filterBlock = emptyPlusSome.filter(1);
-        assertThat(filterBlock.ramBytesUsed(), lessThan(emptyPlusOne.ramBytesUsed()));
+        assertThat(filterBlock.ramBytesUsed(), greaterThan(emptyPlusSome.ramBytesUsed()));
         Releasables.close(filterBlock);
     }
 
@@ -318,7 +319,7 @@ public class BlockAccountingTests extends ComputeTestCase {
         assertThat(emptyPlusSome.ramBytesUsed(), is(expected));
 
         Block filterBlock = emptyPlusSome.filter(1);
-        assertThat(filterBlock.ramBytesUsed(), lessThan(emptyPlusOne.ramBytesUsed()));
+        assertThat(filterBlock.ramBytesUsed(), greaterThan(emptyPlusSome.ramBytesUsed()));
         Releasables.close(filterBlock);
     }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockAccountingTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockAccountingTests.java
@@ -169,7 +169,7 @@ public class BlockAccountingTests extends ComputeTestCase {
         assertThat(emptyPlusSome.ramBytesUsed(), is(expected));
 
         Block filterBlock = emptyPlusSome.filter(1);
-        assertThat(filterBlock.ramBytesUsed(), greaterThan(emptyPlusSome.ramBytesUsed()));
+        assertThat(filterBlock.ramBytesUsed(), between(emptyPlusSome.ramBytesUsed(), UPPER_BOUND));
         Releasables.close(filterBlock);
     }
 
@@ -219,7 +219,7 @@ public class BlockAccountingTests extends ComputeTestCase {
         assertThat(emptyPlusSome.ramBytesUsed(), is(expected));
 
         Block filterBlock = emptyPlusSome.filter(1);
-        assertThat(filterBlock.ramBytesUsed(), greaterThan(emptyPlusSome.ramBytesUsed()));
+        assertThat(filterBlock.ramBytesUsed(), between(emptyPlusSome.ramBytesUsed(), UPPER_BOUND));
         Releasables.close(filterBlock);
     }
 
@@ -266,7 +266,7 @@ public class BlockAccountingTests extends ComputeTestCase {
         assertThat(emptyPlusSome.ramBytesUsed(), is(expected));
 
         Block filterBlock = emptyPlusSome.filter(1);
-        assertThat(filterBlock.ramBytesUsed(), greaterThan(emptyPlusSome.ramBytesUsed()));
+        assertThat(filterBlock.ramBytesUsed(), between(emptyPlusSome.ramBytesUsed(), UPPER_BOUND));
         Releasables.close(filterBlock);
     }
 
@@ -319,7 +319,7 @@ public class BlockAccountingTests extends ComputeTestCase {
         assertThat(emptyPlusSome.ramBytesUsed(), is(expected));
 
         Block filterBlock = emptyPlusSome.filter(1);
-        assertThat(filterBlock.ramBytesUsed(), greaterThan(emptyPlusSome.ramBytesUsed()));
+        assertThat(filterBlock.ramBytesUsed(), between(emptyPlusSome.ramBytesUsed(), UPPER_BOUND));
         Releasables.close(filterBlock);
     }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BooleanBlockEqualityTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BooleanBlockEqualityTests.java
@@ -22,7 +22,6 @@ public class BooleanBlockEqualityTests extends ESTestCase {
             blockFactory.newBooleanArrayVector(new boolean[] {}, 0),
             blockFactory.newBooleanArrayVector(new boolean[] { randomBoolean() }, 0),
             blockFactory.newConstantBooleanBlockWith(randomBoolean(), 0).asVector(),
-            blockFactory.newConstantBooleanBlockWith(randomBoolean(), 0).filter().asVector(),
             blockFactory.newBooleanBlockBuilder(0).build().asVector(),
             blockFactory.newBooleanBlockBuilder(0).appendBoolean(randomBoolean()).build().asVector().filter()
         );
@@ -74,14 +73,6 @@ public class BooleanBlockEqualityTests extends ESTestCase {
                 .appendBoolean(false)
                 .appendBoolean(true)
                 .build()
-                .filter(0, 2, 3)
-                .asVector(),
-            blockFactory.newBooleanBlockBuilder(3)
-                .appendBoolean(true)
-                .appendBoolean(true)
-                .appendBoolean(false)
-                .appendBoolean(true)
-                .build()
                 .asVector()
                 .filter(0, 2, 3)
         );
@@ -105,14 +96,6 @@ public class BooleanBlockEqualityTests extends ESTestCase {
                 .build()
                 .asVector()
                 .filter(0, 1, 2),
-            blockFactory.newBooleanBlockBuilder(3)
-                .appendBoolean(true)
-                .appendBoolean(false)
-                .appendBoolean(true)
-                .appendBoolean(true)
-                .build()
-                .filter(0, 2, 3)
-                .asVector(),
             blockFactory.newBooleanBlockBuilder(3)
                 .appendBoolean(true)
                 .appendBoolean(false)

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BytesRefBlockEqualityTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BytesRefBlockEqualityTests.java
@@ -31,7 +31,6 @@ public class BytesRefBlockEqualityTests extends ComputeTestCase {
                 new BytesRefArrayVector(bytesRefArray1, 0, blockFactory),
                 new BytesRefArrayVector(bytesRefArray2, 0, blockFactory),
                 blockFactory.newConstantBytesRefBlockWith(new BytesRef(), 0).asVector(),
-                blockFactory.newConstantBytesRefBlockWith(new BytesRef(), 0).filter().asVector(),
                 blockFactory.newBytesRefBlockBuilder(0).build().asVector(),
                 blockFactory.newBytesRefBlockBuilder(0).appendBytesRef(new BytesRef()).build().asVector().filter()
             );
@@ -96,14 +95,6 @@ public class BytesRefBlockEqualityTests extends ComputeTestCase {
                     .appendBytesRef(new BytesRef("2"))
                     .appendBytesRef(new BytesRef("3"))
                     .build()
-                    .filter(0, 2, 3)
-                    .asVector(),
-                blockFactory.newBytesRefBlockBuilder(3)
-                    .appendBytesRef(new BytesRef("1"))
-                    .appendBytesRef(new BytesRef("4"))
-                    .appendBytesRef(new BytesRef("2"))
-                    .appendBytesRef(new BytesRef("3"))
-                    .build()
                     .asVector()
                     .filter(0, 2, 3)
             );
@@ -132,14 +123,6 @@ public class BytesRefBlockEqualityTests extends ComputeTestCase {
                     .build()
                     .asVector()
                     .filter(0, 1, 2),
-                blockFactory.newBytesRefBlockBuilder(3)
-                    .appendBytesRef(new BytesRef("1"))
-                    .appendBytesRef(new BytesRef("4"))
-                    .appendBytesRef(new BytesRef("1"))
-                    .appendBytesRef(new BytesRef("1"))
-                    .build()
-                    .filter(0, 2, 3)
-                    .asVector(),
                 blockFactory.newBytesRefBlockBuilder(3)
                     .appendBytesRef(new BytesRef("1"))
                     .appendBytesRef(new BytesRef("4"))

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/DoubleBlockEqualityTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/DoubleBlockEqualityTests.java
@@ -23,7 +23,6 @@ public class DoubleBlockEqualityTests extends ComputeTestCase {
             blockFactory.newDoubleArrayVector(new double[] {}, 0),
             blockFactory.newDoubleArrayVector(new double[] { 0 }, 0),
             blockFactory.newConstantDoubleVector(0, 0),
-            blockFactory.newConstantDoubleBlockWith(0, 0).filter().asVector(),
             blockFactory.newDoubleBlockBuilder(0).build().asVector(),
             blockFactory.newDoubleBlockBuilder(0).appendDouble(1).build().asVector().filter()
         );
@@ -74,14 +73,6 @@ public class DoubleBlockEqualityTests extends ComputeTestCase {
                 .appendDouble(2)
                 .appendDouble(3)
                 .build()
-                .filter(0, 2, 3)
-                .asVector(),
-            blockFactory.newDoubleBlockBuilder(3)
-                .appendDouble(1)
-                .appendDouble(4)
-                .appendDouble(2)
-                .appendDouble(3)
-                .build()
                 .asVector()
                 .filter(0, 2, 3)
         );
@@ -99,14 +90,6 @@ public class DoubleBlockEqualityTests extends ComputeTestCase {
             blockFactory.newConstantDoubleBlockWith(1, 3).asVector(),
             blockFactory.newDoubleBlockBuilder(3).appendDouble(1).appendDouble(1).appendDouble(1).build().asVector(),
             blockFactory.newDoubleBlockBuilder(3).appendDouble(1).appendDouble(1).appendDouble(1).build().asVector().filter(0, 1, 2),
-            blockFactory.newDoubleBlockBuilder(3)
-                .appendDouble(1)
-                .appendDouble(4)
-                .appendDouble(1)
-                .appendDouble(1)
-                .build()
-                .filter(0, 2, 3)
-                .asVector(),
             blockFactory.newDoubleBlockBuilder(3)
                 .appendDouble(1)
                 .appendDouble(4)

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/FilteredBlockTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/FilteredBlockTests.java
@@ -55,10 +55,11 @@ public class FilteredBlockTests extends ESTestCase {
         expectThrows(ArrayIndexOutOfBoundsException.class, () -> filteredVector.getInt(0));
         filteredVector.close();
 
-        var filteredBlock = vector.asBlock().filter();
+        var block = vector.asBlock();
+
+        var filteredBlock = block.filter();
         assertEquals(0, filteredBlock.getPositionCount());
-        expectThrows(ArrayIndexOutOfBoundsException.class, () -> filteredBlock.getInt(0));
-        vector.close();
+        block.close();
         releaseAndAssertBreaker(filteredBlock);
     }
 
@@ -92,10 +93,11 @@ public class FilteredBlockTests extends ESTestCase {
         assertEquals(anyPosition * 2, filteredVector.asBlock().getInt(anyPosition));
         filteredVector.close();
 
-        var filteredBlock = vector.asBlock().filter(positions);
+        var block = vector.asBlock();
+        var filteredBlock = block.filter(positions);
         assertEquals(positionCount / 2, filteredBlock.getPositionCount());
-        assertEquals(anyPosition * 2, filteredBlock.getInt(anyPosition));
-        vector.close();
+        assertEquals(anyPosition * 2, filteredBlock.getInt(filteredBlock.getFirstValueIndex(anyPosition)));
+        block.close();
         releaseAndAssertBreaker(filteredBlock);
     }
 
@@ -187,9 +189,9 @@ public class FilteredBlockTests extends ESTestCase {
         assertEquals(0, filtered.nullValuesCount());
         assertEquals(3, filtered.getTotalValueCount());
 
-        assertEquals(20, filtered.asVector().getInt(0));
-        assertEquals(30, filtered.asVector().getInt(1));
-        assertEquals(40, filtered.asVector().getInt(2));
+        assertEquals(20, filtered.getInt(filtered.getFirstValueIndex(0)));
+        assertEquals(30, filtered.getInt(filtered.getFirstValueIndex(1)));
+        assertEquals(40, filtered.getInt(filtered.getFirstValueIndex(2)));
         block.close();
         releaseAndAssertBreaker(filtered);
     }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/FilteredBlockTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/FilteredBlockTests.java
@@ -271,7 +271,7 @@ public class FilteredBlockTests extends ESTestCase {
                 obj.toString(),
                 either(equalTo("BytesRefArrayVector[positions=2]")).or(
                     equalTo("BytesRefVectorBlock[vector=BytesRefArrayVector[positions=2]]")
-                )
+                ).or(equalTo("FilterBytesRefBlock[positions=2, values=[[31 61], [33 63]]]"))
             );
             Releasables.close(obj);
         }
@@ -286,13 +286,7 @@ public class FilteredBlockTests extends ESTestCase {
             builder.beginPositionEntry().appendBoolean(false).appendBoolean(false).endPositionEntry();
             BooleanBlock block = builder.build();
             var filter = block.filter(0, 1);
-            assertThat(
-                filter.toString(),
-                containsString(
-                    "BooleanArrayBlock[positions=2, mvOrdering=UNORDERED, "
-                        + "vector=BooleanArrayVector[positions=4, values=[true, true, false, false]]]"
-                )
-            );
+            assertThat(filter.toString(), containsString("FilterBooleanBlock[positions=2, values=[[true, true], [false, false]]]"));
             Releasables.close(builder, block);
             releaseAndAssertBreaker(filter);
         }
@@ -303,12 +297,7 @@ public class FilteredBlockTests extends ESTestCase {
             builder.beginPositionEntry().appendInt(90).appendInt(1000).endPositionEntry();
             var block = builder.build();
             var filter = block.filter(0, 1);
-            assertThat(
-                filter.toString(),
-                containsString(
-                    "IntArrayBlock[positions=2, mvOrdering=UNORDERED, vector=IntArrayVector[positions=4, values=[0, 10, 20, 50]]]"
-                )
-            );
+            assertThat(filter.toString(), containsString("FilterIntBlock[positions=2, values=[[0, 10], [20, 50]]]"));
             Releasables.close(builder, block);
             releaseAndAssertBreaker(filter);
         }
@@ -319,12 +308,7 @@ public class FilteredBlockTests extends ESTestCase {
             builder.beginPositionEntry().appendLong(90).appendLong(1000).endPositionEntry();
             var block = builder.build();
             var filter = block.filter(0, 1);
-            assertThat(
-                filter.toString(),
-                containsString(
-                    "LongArrayBlock[positions=2, mvOrdering=UNORDERED, vector=LongArrayVector[positions=4, values=[0, 10, 20, 50]]]"
-                )
-            );
+            assertThat(filter.toString(), containsString("FilterLongBlock[positions=2, values=[[0, 10], [20, 50]]]"));
             Releasables.close(builder, block);
             releaseAndAssertBreaker(filter);
         }
@@ -335,13 +319,7 @@ public class FilteredBlockTests extends ESTestCase {
             builder.beginPositionEntry().appendDouble(90).appendDouble(1000).endPositionEntry();
             var block = builder.build();
             var filter = block.filter(0, 1);
-            assertThat(
-                filter.toString(),
-                containsString(
-                    "DoubleArrayBlock[positions=2, mvOrdering=UNORDERED, "
-                        + "vector=DoubleArrayVector[positions=4, values=[0.0, 10.0, 0.002, 1.0E9]]]"
-                )
-            );
+            assertThat(filter.toString(), containsString("FilterDoubleBlock[positions=2, values=[[0.0, 10.0], [0.002, 1.0E9]]]"));
             Releasables.close(builder, block);
             releaseAndAssertBreaker(filter);
         }
@@ -356,7 +334,7 @@ public class FilteredBlockTests extends ESTestCase {
             var filter = block.filter(0, 1);
             assertThat(
                 filter.toString(),
-                containsString("BytesRefArrayBlock[positions=2, mvOrdering=UNORDERED, vector=BytesRefArrayVector[positions=4]]")
+                containsString("FilterBytesRefBlock[positions=2, values=[[[31 61], [33 63]], [[63 61 74], [64 6f 67]]]]")
             );
             assertThat(filter.getPositionCount(), equalTo(2));
             Releasables.close(builder, block);

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/IntBlockEqualityTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/IntBlockEqualityTests.java
@@ -66,7 +66,6 @@ public class IntBlockEqualityTests extends ComputeTestCase {
             blockFactory.newIntArrayVector(new int[] { 1, 4, 2, 3 }, 4).filter(0, 2, 3),
             blockFactory.newIntBlockBuilder(3).appendInt(1).appendInt(2).appendInt(3).build().asVector(),
             blockFactory.newIntBlockBuilder(3).appendInt(1).appendInt(2).appendInt(3).build().asVector().filter(0, 1, 2),
-            blockFactory.newIntBlockBuilder(3).appendInt(1).appendInt(4).appendInt(2).appendInt(3).build().filter(0, 2, 3).asVector(),
             blockFactory.newIntBlockBuilder(3).appendInt(1).appendInt(4).appendInt(2).appendInt(3).build().asVector().filter(0, 2, 3)
         );
         assertAllEquals(vectors);
@@ -83,7 +82,6 @@ public class IntBlockEqualityTests extends ComputeTestCase {
             blockFactory.newConstantIntBlockWith(1, 3).asVector(),
             blockFactory.newIntBlockBuilder(3).appendInt(1).appendInt(1).appendInt(1).build().asVector(),
             blockFactory.newIntBlockBuilder(3).appendInt(1).appendInt(1).appendInt(1).build().asVector().filter(0, 1, 2),
-            blockFactory.newIntBlockBuilder(3).appendInt(1).appendInt(4).appendInt(1).appendInt(1).build().filter(0, 2, 3).asVector(),
             blockFactory.newIntBlockBuilder(3).appendInt(1).appendInt(4).appendInt(1).appendInt(1).build().asVector().filter(0, 2, 3)
         );
         assertAllEquals(moreVectors);

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/LongBlockEqualityTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/LongBlockEqualityTests.java
@@ -22,7 +22,6 @@ public class LongBlockEqualityTests extends ComputeTestCase {
             blockFactory.newLongArrayVector(new long[] {}, 0),
             blockFactory.newLongArrayVector(new long[] { 0 }, 0),
             blockFactory.newConstantLongBlockWith(0, 0).asVector(),
-            blockFactory.newConstantLongBlockWith(0, 0).filter().asVector(),
             blockFactory.newLongBlockBuilder(0).build().asVector(),
             blockFactory.newLongBlockBuilder(0).appendLong(1).build().asVector().filter()
         );
@@ -66,7 +65,6 @@ public class LongBlockEqualityTests extends ComputeTestCase {
             blockFactory.newLongArrayVector(new long[] { 1, 4, 2, 3 }, 4).filter(0, 2, 3),
             blockFactory.newLongBlockBuilder(3).appendLong(1).appendLong(2).appendLong(3).build().asVector(),
             blockFactory.newLongBlockBuilder(3).appendLong(1).appendLong(2).appendLong(3).build().asVector().filter(0, 1, 2),
-            blockFactory.newLongBlockBuilder(3).appendLong(1).appendLong(4).appendLong(2).appendLong(3).build().filter(0, 2, 3).asVector(),
             blockFactory.newLongBlockBuilder(3).appendLong(1).appendLong(4).appendLong(2).appendLong(3).build().asVector().filter(0, 2, 3)
         );
         assertAllEquals(vectors);
@@ -83,7 +81,6 @@ public class LongBlockEqualityTests extends ComputeTestCase {
             blockFactory.newConstantLongBlockWith(1, 3).asVector(),
             blockFactory.newLongBlockBuilder(3).appendLong(1).appendLong(1).appendLong(1).build().asVector(),
             blockFactory.newLongBlockBuilder(3).appendLong(1).appendLong(1).appendLong(1).build().asVector().filter(0, 1, 2),
-            blockFactory.newLongBlockBuilder(3).appendLong(1).appendLong(4).appendLong(1).appendLong(1).build().filter(0, 2, 3).asVector(),
             blockFactory.newLongBlockBuilder(3).appendLong(1).appendLong(4).appendLong(1).appendLong(1).build().asVector().filter(0, 2, 3)
         );
         assertAllEquals(moreVectors);


### PR DESCRIPTION
This brings back filtering with shallow copies but this time with correct memory accounting.

Based on reference counting of blocks and the filtered blocks that were removed in https://github.com/elastic/elasticsearch/pull/100465.