### PR TITLE
Remove bogus assertion in InternalEngine#flushHoldingLock

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -2177,8 +2177,7 @@ public class InternalEngine extends Engine {
 
     @Override
     protected void flushHoldingLock(boolean force, boolean waitIfOngoing, ActionListener<FlushResult> listener) throws EngineException {
-        assert isClosed.get() == false; // might be closing, but not closed yet
-        ensureOpen();
+        ensureOpen(); // best-effort, a concurrent failEngine() can still happen but that's ok
         if (force && waitIfOngoing == false) {
             assert false : "wait_if_ongoing must be true for a force flush: force=" + force + " wait_if_ongoing=" + waitIfOngoing;
             throw new IllegalArgumentException(

--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -3675,7 +3675,6 @@ public class InternalEngineTests extends EngineTestCase {
     /**
      * Tests that when the close method returns the engine is actually guaranteed to have cleaned up and that resources are closed
      */
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/103861")
     public void testConcurrentEngineClosed() throws BrokenBarrierException, InterruptedException {
         Thread[] closingThreads = new Thread[3];
         CyclicBarrier barrier = new CyclicBarrier(1 + closingThreads.length + 1);


### PR DESCRIPTION
This assertion was introduced in #103871 but in fact it does not hold.
This is not a new thing, it would have failed before #103871 too:

```diff
diff --git a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
index ca9ed06d4d2..ff305291fce 100644
--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -2181,6 +2181,15 @@ public class InternalEngine extends Engine {
     @Override
     protected void flushHoldingLock(boolean force, boolean waitIfOngoing, ActionListener<FlushResult> listener) throws EngineException {
         ensureOpen();
+
+        try {
+            Thread.sleep(100);
+        } catch (Exception e) {
+            throw new AssertionError(e);
+        }
+
+        assert isClosed.get() == false;
+
         if (force && waitIfOngoing == false) {
             assert false : "wait_if_ongoing must be true for a force flush: force=" + force + " wait_if_ongoing=" + waitIfOngoing;
             throw new IllegalArgumentException(
diff --git a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
index cbb713f01ec..3d3a478ecc0 100644
--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -3688,6 +3688,7 @@ public class InternalEngineTests extends EngineTestCase {
             @Override
             protected void doRun() throws Exception {
                 barrier.await();
+                Thread.sleep(50);
                 engine.failEngine("test", new RuntimeException("test"));
             }
         });
```

Closes #103861