### PR TITLE
Install the slm/ilm history templates only when all cluster upgraded

### DIFF
--- a/x-pack/plugin/ilm/src/main/java/module-info.java
+++ b/x-pack/plugin/ilm/src/main/java/module-info.java
@@ -18,4 +18,6 @@ module org.elasticsearch.ilm {
     provides org.elasticsearch.reservedstate.ReservedClusterStateHandlerProvider
         with
             org.elasticsearch.xpack.ilm.ReservedLifecycleStateHandlerProvider;
+
+    provides org.elasticsearch.features.FeatureSpecification with org.elasticsearch.xpack.ilm.IndexLifecycleFeatures;
 }

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycle.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycle.java
@@ -147,6 +147,7 @@ public class IndexLifecycle extends Plugin implements ActionPlugin, HealthPlugin
         ILMHistoryTemplateRegistry ilmTemplateRegistry = new ILMHistoryTemplateRegistry(
             settings,
             services.clusterService(),
+            services.featureService(),
             services.threadPool(),
             services.client(),
             services.xContentRegistry()

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleFeatures.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleFeatures.java
@@ -17,9 +17,6 @@ import java.util.Map;
 public class IndexLifecycleFeatures implements FeatureSpecification {
     @Override
     public Map<NodeFeature, Version> getHistoricalFeatures() {
-        return Map.of(
-            ILMHistoryTemplateRegistry.MANAGED_BY_DATA_STREAM_LIFECYCLE,
-            Version.V_8_12_0
-        );
+        return Map.of(ILMHistoryTemplateRegistry.MANAGED_BY_DATA_STREAM_LIFECYCLE, Version.V_8_12_0);
     }
 }

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleFeatures.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleFeatures.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ilm;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.features.FeatureSpecification;
+import org.elasticsearch.features.NodeFeature;
+import org.elasticsearch.xpack.ilm.history.ILMHistoryTemplateRegistry;
+
+import java.util.Map;
+
+public class IndexLifecycleFeatures implements FeatureSpecification {
+    @Override
+    public Map<NodeFeature, Version> getHistoricalFeatures() {
+        return Map.of(
+            ILMHistoryTemplateRegistry.MANAGED_BY_DATA_STREAM_LIFECYCLE,
+            Version.V_8_12_0
+        );
+    }
+}

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/history/ILMHistoryTemplateRegistry.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/history/ILMHistoryTemplateRegistry.java
@@ -8,9 +8,12 @@
 package org.elasticsearch.xpack.ilm.history;
 
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.features.FeatureService;
+import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.core.ClientHelper;
@@ -37,11 +40,13 @@ public class ILMHistoryTemplateRegistry extends IndexTemplateRegistry {
     // version 6: manage by data stream lifecycle
     // version 7: version the index template name so we can upgrade existing deployments
     public static final int INDEX_TEMPLATE_VERSION = 7;
+    public static final NodeFeature MANAGED_BY_DATA_STREAM_LIFECYCLE = new NodeFeature("ilm-history-managed-by-dsl");
 
     public static final String ILM_TEMPLATE_VERSION_VARIABLE = "xpack.ilm_history.template.version";
     public static final String ILM_TEMPLATE_NAME = "ilm-history-" + INDEX_TEMPLATE_VERSION;
 
     public static final String ILM_POLICY_NAME = "ilm-history-ilm-policy";
+    private final FeatureService featureService;
 
     @Override
     protected boolean requiresMasterNode() {
@@ -53,11 +58,13 @@ public class ILMHistoryTemplateRegistry extends IndexTemplateRegistry {
     public ILMHistoryTemplateRegistry(
         Settings nodeSettings,
         ClusterService clusterService,
+        FeatureService featureService,
         ThreadPool threadPool,
         Client client,
         NamedXContentRegistry xContentRegistry
     ) {
         super(nodeSettings, clusterService, threadPool, client, xContentRegistry);
+        this.featureService = featureService;
         this.ilmHistoryEnabled = LifecycleSettings.LIFECYCLE_HISTORY_INDEX_ENABLED_SETTING.get(nodeSettings);
     }
 
@@ -96,5 +103,10 @@ public class ILMHistoryTemplateRegistry extends IndexTemplateRegistry {
     @Override
     protected String getOrigin() {
         return ClientHelper.INDEX_LIFECYCLE_ORIGIN;
+    }
+
+    @Override
+    protected boolean isClusterReady(ClusterChangedEvent event) {
+        return featureService.clusterHasFeature(event.state(), MANAGED_BY_DATA_STREAM_LIFECYCLE);
     }
 }

--- a/x-pack/plugin/ilm/src/main/resources/META-INF/services/org.elasticsearch.features.FeatureSpecification
+++ b/x-pack/plugin/ilm/src/main/resources/META-INF/services/org.elasticsearch.features.FeatureSpecification
@@ -1,0 +1,8 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+#
+
+org.elasticsearch.xpack.ilm.IndexLifecycleFeatures

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/history/ILMHistoryStoreTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/history/ILMHistoryStoreTests.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ClusterServiceUtils;
@@ -39,6 +40,7 @@ import org.elasticsearch.test.client.NoOpClient;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
+import org.elasticsearch.xpack.ilm.IndexLifecycleFeatures;
 import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
@@ -78,6 +80,7 @@ public class ILMHistoryStoreTests extends ESTestCase {
         ILMHistoryTemplateRegistry registry = new ILMHistoryTemplateRegistry(
             clusterService.getSettings(),
             clusterService,
+            new FeatureService(List.of(new IndexLifecycleFeatures())),
             threadPool,
             client,
             NamedXContentRegistry.EMPTY

--- a/x-pack/plugin/slm/src/main/java/module-info.java
+++ b/x-pack/plugin/slm/src/main/java/module-info.java
@@ -18,4 +18,6 @@ module org.elasticsearch.slm {
     provides org.elasticsearch.reservedstate.ReservedClusterStateHandlerProvider
         with
             org.elasticsearch.xpack.slm.ReservedLifecycleStateHandlerProvider;
+
+    provides org.elasticsearch.features.FeatureSpecification with org.elasticsearch.xpack.slm.SnapshotLifecycleFeatures;
 }

--- a/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycle.java
+++ b/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycle.java
@@ -124,6 +124,7 @@ public class SnapshotLifecycle extends Plugin implements ActionPlugin, HealthPlu
         SnapshotLifecycleTemplateRegistry templateRegistry = new SnapshotLifecycleTemplateRegistry(
             settings,
             clusterService,
+            services.featureService(),
             threadPool,
             client,
             services.xContentRegistry()

--- a/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycleFeatures.java
+++ b/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycleFeatures.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.slm;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.features.FeatureSpecification;
+import org.elasticsearch.features.NodeFeature;
+import org.elasticsearch.xpack.slm.history.SnapshotLifecycleTemplateRegistry;
+
+import java.util.Map;
+
+public class SnapshotLifecycleFeatures implements FeatureSpecification {
+    @Override
+    public Map<NodeFeature, Version> getHistoricalFeatures() {
+        return Map.of(
+            SnapshotLifecycleTemplateRegistry.MANAGED_BY_DATA_STREAM_LIFECYCLE,
+            Version.V_8_12_0
+        );
+    }
+}

--- a/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycleFeatures.java
+++ b/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/SnapshotLifecycleFeatures.java
@@ -17,9 +17,6 @@ import java.util.Map;
 public class SnapshotLifecycleFeatures implements FeatureSpecification {
     @Override
     public Map<NodeFeature, Version> getHistoricalFeatures() {
-        return Map.of(
-            SnapshotLifecycleTemplateRegistry.MANAGED_BY_DATA_STREAM_LIFECYCLE,
-            Version.V_8_12_0
-        );
+        return Map.of(SnapshotLifecycleTemplateRegistry.MANAGED_BY_DATA_STREAM_LIFECYCLE, Version.V_8_12_0);
     }
 }

--- a/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/history/SnapshotLifecycleTemplateRegistry.java
+++ b/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/history/SnapshotLifecycleTemplateRegistry.java
@@ -8,10 +8,13 @@
 package org.elasticsearch.xpack.slm.history;
 
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.features.FeatureService;
+import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.core.ilm.IndexLifecycleMetadata;
@@ -44,11 +47,13 @@ public class SnapshotLifecycleTemplateRegistry extends IndexTemplateRegistry {
     // version 6: manage by data stream lifecycle
     // version 7: version the index template name so we can upgrade existing deployments
     public static final int INDEX_TEMPLATE_VERSION = 7;
+    public static final NodeFeature MANAGED_BY_DATA_STREAM_LIFECYCLE = new NodeFeature("slm-history-managed-by-dsl");
 
     public static final String SLM_TEMPLATE_VERSION_VARIABLE = "xpack.slm.template.version";
     public static final String SLM_TEMPLATE_NAME = ".slm-history-" + INDEX_TEMPLATE_VERSION;
 
     public static final String SLM_POLICY_NAME = "slm-history-ilm-policy";
+    private final FeatureService featureService;
 
     @Override
     protected boolean requiresMasterNode() {
@@ -60,11 +65,13 @@ public class SnapshotLifecycleTemplateRegistry extends IndexTemplateRegistry {
     public SnapshotLifecycleTemplateRegistry(
         Settings nodeSettings,
         ClusterService clusterService,
+        FeatureService featureService,
         ThreadPool threadPool,
         Client client,
         NamedXContentRegistry xContentRegistry
     ) {
         super(nodeSettings, clusterService, threadPool, client, xContentRegistry);
+        this.featureService = featureService;
         slmHistoryEnabled = SLM_HISTORY_INDEX_ENABLED_SETTING.get(nodeSettings);
     }
 
@@ -114,5 +121,10 @@ public class SnapshotLifecycleTemplateRegistry extends IndexTemplateRegistry {
 
         boolean allPoliciesPresent = maybePolicies.map(policies -> policies.keySet().containsAll(policyNames)).orElse(false);
         return allTemplatesPresent && allPoliciesPresent;
+    }
+
+    @Override
+    protected boolean isClusterReady(ClusterChangedEvent event) {
+        return featureService.clusterHasFeature(event.state(), MANAGED_BY_DATA_STREAM_LIFECYCLE);
     }
 }

--- a/x-pack/plugin/slm/src/main/resources/META-INF/services/org.elasticsearch.features.FeatureSpecification
+++ b/x-pack/plugin/slm/src/main/resources/META-INF/services/org.elasticsearch.features.FeatureSpecification
@@ -1,0 +1,8 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+#
+
+org.elasticsearch.xpack.slm.SnapshotLifecycleFeatures

--- a/x-pack/plugin/slm/src/test/java/org/elasticsearch/xpack/slm/history/SnapshotLifecycleTemplateRegistryTests.java
+++ b/x-pack/plugin/slm/src/test/java/org/elasticsearch/xpack/slm/history/SnapshotLifecycleTemplateRegistryTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.TriFunction;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.test.ClusterServiceUtils;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.client.NoOpClient;
@@ -46,6 +47,7 @@ import org.elasticsearch.xpack.core.ilm.OperationMode;
 import org.elasticsearch.xpack.core.ilm.RolloverAction;
 import org.elasticsearch.xpack.core.ilm.TimeseriesLifecycleType;
 import org.elasticsearch.xpack.core.ilm.action.PutLifecycleAction;
+import org.elasticsearch.xpack.slm.SnapshotLifecycleFeatures;
 import org.junit.After;
 import org.junit.Before;
 
@@ -98,7 +100,14 @@ public class SnapshotLifecycleTemplateRegistryTests extends ESTestCase {
             )
         );
         xContentRegistry = new NamedXContentRegistry(entries);
-        registry = new SnapshotLifecycleTemplateRegistry(Settings.EMPTY, clusterService, threadPool, client, xContentRegistry);
+        registry = new SnapshotLifecycleTemplateRegistry(
+            Settings.EMPTY,
+            clusterService,
+            new FeatureService(List.of(new SnapshotLifecycleFeatures())),
+            threadPool,
+            client,
+            xContentRegistry
+        );
     }
 
     @After
@@ -113,6 +122,7 @@ public class SnapshotLifecycleTemplateRegistryTests extends ESTestCase {
         SnapshotLifecycleTemplateRegistry disabledRegistry = new SnapshotLifecycleTemplateRegistry(
             settings,
             clusterService,
+            new FeatureService(List.of(new SnapshotLifecycleFeatures())),
             threadPool,
             client,
             xContentRegistry


### PR DESCRIPTION
The ilm and slm history index templates were updated so that the data streams in new deployments are managed by data stream lifecycle. The data stream lifecycle functionality is not available prior to 8.11 so a jump from 8.10 to 8.12 (the version where we upgraded the index templates) would potentially break the rolling upgrade.

This changes the index template registry infrastructure for these templates to wait until all nodes in the cluster are on at least 8.12 before attempting to install the index templates.

Relates to https://github.com/elastic/elasticsearch/pull/103906

Fixes #103899