### PR TITLE
[8.12] [Test] Use larger client ports range for tests running on Windows (#103894)

### DIFF
--- a/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/transport/netty4/Netty4TransportMultiPortIntegrationIT.java
+++ b/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/transport/netty4/Netty4TransportMultiPortIntegrationIT.java
@@ -7,6 +7,7 @@
  */
 package org.elasticsearch.transport.netty4;
 
+import org.apache.lucene.util.Constants;
 import org.elasticsearch.ESNetty4IntegTestCase;
 import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoResponse;
@@ -31,14 +32,16 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 @ClusterScope(scope = Scope.SUITE, supportsDedicatedMasters = false, numDataNodes = 1, numClientNodes = 0)
 public class Netty4TransportMultiPortIntegrationIT extends ESNetty4IntegTestCase {
 
+    private static final int NUMBER_OF_CLIENT_PORTS = Constants.WINDOWS ? 300 : 10;
+
     private static int randomPort = -1;
     private static String randomPortRange;
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
         if (randomPort == -1) {
-            randomPort = randomIntBetween(49152, 65525);
-            randomPortRange = Strings.format("%s-%s", randomPort, randomPort + 10);
+            randomPort = randomIntBetween(49152, 65535 - NUMBER_OF_CLIENT_PORTS);
+            randomPortRange = Strings.format("%s-%s", randomPort, randomPort + NUMBER_OF_CLIENT_PORTS);
         }
         Settings.Builder builder = Settings.builder()
             .put(super.nodeSettings(nodeOrdinal, otherSettings))

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/pki/PkiOptionalClientAuthTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/pki/PkiOptionalClientAuthTests.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.security.authc.pki;
 
 import org.apache.http.nio.conn.ssl.SSLIOSessionStrategy;
+import org.apache.lucene.util.Constants;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
@@ -34,11 +35,13 @@ import static org.hamcrest.Matchers.is;
 
 public class PkiOptionalClientAuthTests extends SecuritySingleNodeTestCase {
 
+    private static final int NUMBER_OF_CLIENT_PORTS = Constants.WINDOWS ? 300 : 100;
+
     private static int randomClientPort;
 
     @BeforeClass
     public static void initPort() {
-        randomClientPort = randomIntBetween(49000, 65500);
+        randomClientPort = randomIntBetween(49152, 65535 - NUMBER_OF_CLIENT_PORTS);
     }
 
     @Override
@@ -47,7 +50,7 @@ public class PkiOptionalClientAuthTests extends SecuritySingleNodeTestCase {
     }
 
     protected Settings nodeSettings() {
-        String randomClientPortRange = randomClientPort + "-" + (randomClientPort + 100);
+        String randomClientPortRange = randomClientPort + "-" + (randomClientPort + NUMBER_OF_CLIENT_PORTS);
 
         Settings.Builder builder = Settings.builder()
             .put(super.nodeSettings())

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/transport/filter/IpFilteringIntegrationTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/transport/filter/IpFilteringIntegrationTests.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.security.transport.filter;
 
+import org.apache.lucene.util.Constants;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.core.SuppressForbidden;
@@ -28,11 +29,14 @@ import static org.hamcrest.Matchers.is;
 // no client nodes as they all get rejected on network connections
 @ClusterScope(scope = Scope.SUITE, numDataNodes = 0, numClientNodes = 0)
 public class IpFilteringIntegrationTests extends SecurityIntegTestCase {
+
+    private static final int NUMBER_OF_CLIENT_PORTS = Constants.WINDOWS ? 300 : 100;
+
     private static int randomClientPort;
 
     @BeforeClass
     public static void getRandomPort() {
-        randomClientPort = randomIntBetween(49000, 65500); // ephemeral port
+        randomClientPort = randomIntBetween(49152, 65535 - NUMBER_OF_CLIENT_PORTS); // ephemeral port
     }
 
     @Override
@@ -42,7 +46,7 @@ public class IpFilteringIntegrationTests extends SecurityIntegTestCase {
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
-        String randomClientPortRange = randomClientPort + "-" + (randomClientPort + 100);
+        String randomClientPortRange = randomClientPort + "-" + (randomClientPort + NUMBER_OF_CLIENT_PORTS);
         return Settings.builder()
             .put(super.nodeSettings(nodeOrdinal, otherSettings))
             .put("transport.profiles.client.port", randomClientPortRange)

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/transport/filter/IpFilteringUpdateTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/transport/filter/IpFilteringUpdateTests.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.security.transport.filter;
 
+import org.apache.lucene.util.Constants;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Strings;
@@ -26,13 +27,15 @@ import static org.hamcrest.Matchers.is;
 @ClusterScope(scope = TEST, supportsDedicatedMasters = false, numDataNodes = 1)
 public class IpFilteringUpdateTests extends SecurityIntegTestCase {
 
+    private static final int NUMBER_OF_CLIENT_PORTS = Constants.WINDOWS ? 300 : 100;
+
     private static int randomClientPort;
 
     private final boolean httpEnabled = randomBoolean();
 
     @BeforeClass
     public static void getRandomPort() {
-        randomClientPort = randomIntBetween(49000, 65500);
+        randomClientPort = randomIntBetween(49152, 65535 - NUMBER_OF_CLIENT_PORTS);
     }
 
     @Override
@@ -42,7 +45,7 @@ public class IpFilteringUpdateTests extends SecurityIntegTestCase {
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
-        String randomClientPortRange = randomClientPort + "-" + (randomClientPort + 100);
+        String randomClientPortRange = randomClientPort + "-" + (randomClientPort + NUMBER_OF_CLIENT_PORTS);
         return Settings.builder()
             .put(super.nodeSettings(nodeOrdinal, otherSettings))
             .put("xpack.security.transport.filter.deny", "127.0.0.200")


### PR DESCRIPTION
Backports the following commits to 8.12:
 - [Test] Use larger client ports range for tests running on Windows (#103894)