### PR TITLE
Update jmh benchmark for dynamic mappers

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/index/mapper/DynamicMapperBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/index/mapper/DynamicMapperBenchmark.java
@@ -108,7 +108,8 @@ public class DynamicMapperBenchmark {
             if (random.nextBoolean()) {
                 continue;
             }
-            String objFieldPrefix = Stream.generate(() -> "obj_field_" + idx).limit(objFieldDepth).collect(Collectors.joining("."));
+            int objFieldDepthActual = random.nextInt(1, objFieldDepth);
+            String objFieldPrefix = Stream.generate(() -> "obj_field_" + idx).limit(objFieldDepthActual).collect(Collectors.joining("."));
             for (int j = 0; j < textFields; j++) {
                 if (random.nextBoolean()) {
                     StringBuilder fieldValueBuilder = generateTextField(fieldValueCountMax);

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/index/mapper/MapperServiceFactory.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/index/mapper/MapperServiceFactory.java
@@ -45,7 +45,7 @@ public class MapperServiceFactory {
             .put("index.number_of_replicas", 0)
             .put("index.number_of_shards", 1)
             .put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current())
-            .put("index.mapping.total_fields.limit", 10000)
+            .put("index.mapping.total_fields.limit", 100000)
             .build();
         IndexMetadata meta = IndexMetadata.builder("index").settings(settings).build();
         IndexSettings indexSettings = new IndexSettings(meta, settings);


### PR DESCRIPTION
This updates the jmh benchmark for dynamic mappers. Specifically, it adds variable depth to the dynamic objects that need parsed.

This change helped show that: https://github.com/elastic/elasticsearch/issues/103011 was still not addressed after merging: https://github.com/elastic/elasticsearch/pull/103047