### PR TITLE
[Test] Fix - mutateInstance in BulkUpdateApiKeyRequestSerializationTests not unique

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/apikey/BulkUpdateApiKeyRequestSerializationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/apikey/BulkUpdateApiKeyRequestSerializationTests.java
@@ -67,7 +67,7 @@ public class BulkUpdateApiKeyRequestSerializationTests extends AbstractWireSeria
             instance.getIds(),
             instance.getRoleDescriptors(),
             metadata,
-            TimeValue.parseTimeValue((days + 1) + "d", null, "expiration")
+            TimeValue.parseTimeValue(days + "d", null, "expiration")
         );
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/apikey/BulkUpdateApiKeyRequestSerializationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/apikey/BulkUpdateApiKeyRequestSerializationTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.core.security.action.apikey;
 
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.TimeValue;
@@ -21,7 +20,6 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.nullValue;
 
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/103913")
 public class BulkUpdateApiKeyRequestSerializationTests extends AbstractWireSerializingTestCase<BulkUpdateApiKeyRequest> {
     public void testSerializationBackwardsCompatibility() throws IOException {
         BulkUpdateApiKeyRequest testInstance = createTestInstance();


### PR DESCRIPTION
Leftover `+ 1` from previous testing strategy that should have been removed. 

Relates: https://github.com/elastic/elasticsearch/issues/103913