### PR TITLE
Forbid exceptions from ClusterStateObserver listeners

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/ClusterStateObserver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterStateObserver.java
@@ -12,6 +12,7 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.cluster.service.ClusterApplierService;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
@@ -226,7 +227,11 @@ public class ClusterStateObserver {
                     clusterApplierService.removeTimeoutListener(this);
                     logger.trace("observer: accepting cluster state change ({})", state);
                     lastObservedVersion = state.version();
-                    context.listener.onNewClusterState(state);
+                    try {
+                        context.listener.onNewClusterState(state);
+                    } catch (Exception e) {
+                        logUnexpectedException(e, "cluster state version [%d]", state.version());
+                    }
                 } else {
                     logger.trace(
                         "observer: predicate approved change but observing context has changed "
@@ -253,7 +258,11 @@ public class ClusterStateObserver {
                     logger.trace("observer: post adding listener: accepting current cluster state ({})", newState);
                     clusterApplierService.removeTimeoutListener(this);
                     lastObservedVersion = newState.version();
-                    context.listener.onNewClusterState(newState);
+                    try {
+                        context.listener.onNewClusterState(newState);
+                    } catch (Exception e) {
+                        logUnexpectedException(e, "cluster state version [%d]", newState.version());
+                    }
                 } else {
                     logger.trace(
                         "observer: postAdded - predicate approved state but observing context has changed - ignoring ({})",
@@ -272,7 +281,11 @@ public class ClusterStateObserver {
             if (context != null) {
                 logger.trace("observer: cluster service closed. notifying listener.");
                 clusterApplierService.removeTimeoutListener(this);
-                context.listener.onClusterServiceClose();
+                try {
+                    context.listener.onClusterServiceClose();
+                } catch (Exception e) {
+                    logUnexpectedException(e, "cluster service close");
+                }
             }
         }
 
@@ -290,13 +303,30 @@ public class ClusterStateObserver {
                 // update to latest, in case people want to retry
                 lastObservedVersion = clusterApplierService.state().version();
                 timedOut = true;
-                context.listener.onTimeout(timeOutValue);
+                try {
+                    context.listener.onTimeout(timeOutValue);
+                } catch (Exception e) {
+                    logUnexpectedException(e, "timeout after [%s]", timeOutValue);
+                }
             }
         }
 
         @Override
         public String toString() {
             return "ClusterStateObserver[" + observingContext.get() + "]";
+        }
+
+        private void logUnexpectedException(Exception exception, String format, Object... args) {
+            final var illegalStateException = new IllegalStateException(
+                Strings.format(
+                    "unexpected exception processing %s in context [%s]",
+                    Strings.format(format, args),
+                    ObserverClusterStateListener.this
+                ),
+                exception
+            );
+            logger.error(illegalStateException.getMessage(), illegalStateException);
+            assert false : illegalStateException;
         }
     }
 


### PR DESCRIPTION
If a `ClusterStateObserver` listener throws an exception then today it
is not really handled properly. Exceptions from new cluster states
bubble up to the cluster applier where they are logged and suppressed,
but exceptions while adding a new listener and timing out a listener go
unhandled. This commit adds some production-time protection against
exceptions in these places, and asserts that they do not happen.