### PR TITLE
Fix incorrect assumptions about BytesReference in StateToProcessWriterHelper

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/StateToProcessWriterHelper.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/StateToProcessWriterHelper.java
@@ -6,8 +6,6 @@
  */
 package org.elasticsearch.xpack.ml.process;
 
-import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.BytesRefIterator;
 import org.elasticsearch.common.bytes.BytesReference;
 
 import java.io.IOException;
@@ -23,17 +21,12 @@ public final class StateToProcessWriterHelper {
     public static void writeStateToStream(BytesReference source, OutputStream stream) throws IOException {
         // The source bytes are already UTF-8. The C++ process wants UTF-8, so we
         // can avoid converting to a Java String only to convert back again.
-        BytesRefIterator iterator = source.iterator();
-        for (BytesRef ref = iterator.next(); ref != null; ref = iterator.next()) {
-            // There's a complication that the source can already have trailing 0 bytes
-            int length = ref.bytes.length;
-            while (length > 0 && ref.bytes[length - 1] == 0) {
-                --length;
-            }
-            if (length > 0) {
-                stream.write(ref.bytes, 0, length);
-            }
+        int length = source.length();
+        // There's a complication that the source can already have trailing 0 bytes
+        while (length > 0 && source.get(length - 1) == 0) {
+            --length;
         }
+        source.slice(0, length).writeTo(stream);
         // This is dictated by RapidJSON on the C++ side; it treats a '\0' as end-of-file
         // even when it's not really end-of-file, and this is what we need because we're
         // sending multiple JSON documents via the same named pipe.


### PR DESCRIPTION
The logic here only works accidentally if the `source` is backed by a single `byte[]` with offset `0`.
Fixed by using the `writeTo` API and just working on the bytes reference via its index handling to find the zero byte offset.

Non issue since this isn't causing trouble right now but broke when I tried using this with sliced buffers for #102030 