### PR TITLE
Introduce a noop, never-released ref counted constant

### DIFF
--- a/libs/core/src/main/java/org/elasticsearch/core/RefCounted.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/RefCounted.java
@@ -80,9 +80,7 @@ public interface RefCounted {
      */
     RefCounted ALWAYS_REFERENCED = new RefCounted() {
         @Override
-        public void incRef() {
-
-        }
+        public void incRef() {}
 
         @Override
         public boolean tryIncRef() {

--- a/libs/core/src/main/java/org/elasticsearch/core/RefCounted.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/RefCounted.java
@@ -74,4 +74,29 @@ public interface RefCounted {
         assert false : AbstractRefCounted.ALREADY_CLOSED_MESSAGE;
         incRef(); // throws an ISE
     }
+
+    /**
+     * A noop implementation that always behaves as if it is referenced and cannot be released.
+     */
+    RefCounted ALWAYS_REFERENCED = new RefCounted() {
+        @Override
+        public void incRef() {
+
+        }
+
+        @Override
+        public boolean tryIncRef() {
+            return true;
+        }
+
+        @Override
+        public boolean decRef() {
+            return false;
+        }
+
+        @Override
+        public boolean hasReferences() {
+            return true;
+        }
+    };
 }

--- a/server/src/main/java/org/elasticsearch/common/bytes/ReleasableBytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/ReleasableBytesReference.java
@@ -26,9 +26,7 @@ import java.io.OutputStream;
  */
 public final class ReleasableBytesReference implements RefCounted, Releasable, BytesReference {
 
-    public static final Releasable NO_OP = () -> {};
-
-    private static final ReleasableBytesReference EMPTY = new ReleasableBytesReference(BytesArray.EMPTY, NO_OP);
+    private static final ReleasableBytesReference EMPTY = new ReleasableBytesReference(BytesArray.EMPTY, RefCounted.ALWAYS_REFERENCED);
 
     private final BytesReference delegate;
     private final RefCounted refCounted;
@@ -50,7 +48,7 @@ public final class ReleasableBytesReference implements RefCounted, Releasable, B
 
     public static ReleasableBytesReference wrap(BytesReference reference) {
         assert reference instanceof ReleasableBytesReference == false : "use #retain() instead of #wrap() on a " + reference.getClass();
-        return reference.length() == 0 ? empty() : new ReleasableBytesReference(reference, NO_OP);
+        return reference.length() == 0 ? empty() : new ReleasableBytesReference(reference, ALWAYS_REFERENCED);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/common/bytes/ReleasableBytesReferenceStreamInputTests.java
+++ b/server/src/test/java/org/elasticsearch/common/bytes/ReleasableBytesReferenceStreamInputTests.java
@@ -71,7 +71,7 @@ public class ReleasableBytesReferenceStreamInputTests extends AbstractStreamTest
         BytesStreamOutput out = new BytesStreamOutput();
         testData.writeTo(out);
 
-        ReleasableBytesReference ref = ReleasableBytesReference.wrap(out.bytes());
+        ReleasableBytesReference ref = wrapAsReleasable(out.bytes());
 
         try (IntArray in = IntArray.readFrom(ref.streamInput())) {
             ref.decRef();
@@ -90,7 +90,7 @@ public class ReleasableBytesReferenceStreamInputTests extends AbstractStreamTest
         BytesStreamOutput out = new BytesStreamOutput();
         testData.writeTo(out);
 
-        ReleasableBytesReference ref = ReleasableBytesReference.wrap(out.bytes());
+        ReleasableBytesReference ref = wrapAsReleasable(out.bytes());
 
         try (DoubleArray in = DoubleArray.readFrom(ref.streamInput())) {
             ref.decRef();
@@ -109,7 +109,7 @@ public class ReleasableBytesReferenceStreamInputTests extends AbstractStreamTest
         BytesStreamOutput out = new BytesStreamOutput();
         testData.writeTo(out);
 
-        ReleasableBytesReference ref = ReleasableBytesReference.wrap(out.bytes());
+        ReleasableBytesReference ref = wrapAsReleasable(out.bytes());
 
         try (LongArray in = LongArray.readFrom(ref.streamInput())) {
             ref.decRef();
@@ -128,7 +128,7 @@ public class ReleasableBytesReferenceStreamInputTests extends AbstractStreamTest
         BytesStreamOutput out = new BytesStreamOutput();
         testData.writeTo(out);
 
-        ReleasableBytesReference ref = ReleasableBytesReference.wrap(out.bytes());
+        ReleasableBytesReference ref = wrapAsReleasable(out.bytes());
 
         try (ByteArray in = ByteArray.readFrom(ref.streamInput())) {
             ref.decRef();
@@ -140,4 +140,7 @@ public class ReleasableBytesReferenceStreamInputTests extends AbstractStreamTest
         assertThat(ref.hasReferences(), equalTo(false));
     }
 
+    public static ReleasableBytesReference wrapAsReleasable(BytesReference bytesReference) {
+        return new ReleasableBytesReference(bytesReference, () -> {});
+    }
 }

--- a/server/src/test/java/org/elasticsearch/transport/InboundAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/InboundAggregatorTests.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.function.Predicate;
 
+import static org.elasticsearch.common.bytes.ReleasableBytesReferenceStreamInputTests.wrapAsReleasable;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -63,20 +64,20 @@ public class InboundAggregatorTests extends ESTestCase {
         BytesArray bytes = new BytesArray(randomByteArrayOfLength(10));
         ArrayList<ReleasableBytesReference> references = new ArrayList<>();
         if (randomBoolean()) {
-            final ReleasableBytesReference content = ReleasableBytesReference.wrap(bytes);
+            final ReleasableBytesReference content = wrapAsReleasable(bytes);
             references.add(content);
             aggregator.aggregate(content);
             content.close();
         } else {
-            final ReleasableBytesReference content1 = ReleasableBytesReference.wrap(bytes.slice(0, 3));
+            final ReleasableBytesReference content1 = wrapAsReleasable(bytes.slice(0, 3));
             references.add(content1);
             aggregator.aggregate(content1);
             content1.close();
-            final ReleasableBytesReference content2 = ReleasableBytesReference.wrap(bytes.slice(3, 3));
+            final ReleasableBytesReference content2 = wrapAsReleasable(bytes.slice(3, 3));
             references.add(content2);
             aggregator.aggregate(content2);
             content2.close();
-            final ReleasableBytesReference content3 = ReleasableBytesReference.wrap(bytes.slice(6, 4));
+            final ReleasableBytesReference content3 = wrapAsReleasable(bytes.slice(6, 4));
             references.add(content3);
             aggregator.aggregate(content3);
             content3.close();
@@ -108,7 +109,7 @@ public class InboundAggregatorTests extends ESTestCase {
         aggregator.headerReceived(header);
 
         BytesArray bytes = new BytesArray(randomByteArrayOfLength(10));
-        final ReleasableBytesReference content = ReleasableBytesReference.wrap(bytes);
+        final ReleasableBytesReference content = wrapAsReleasable(bytes);
         aggregator.aggregate(content);
         content.close();
         assertFalse(content.hasReferences());
@@ -137,7 +138,7 @@ public class InboundAggregatorTests extends ESTestCase {
         aggregator.headerReceived(breakableHeader);
 
         BytesArray bytes = new BytesArray(randomByteArrayOfLength(10));
-        final ReleasableBytesReference content1 = ReleasableBytesReference.wrap(bytes);
+        final ReleasableBytesReference content1 = wrapAsReleasable(bytes);
         aggregator.aggregate(content1);
         content1.close();
 
@@ -161,7 +162,7 @@ public class InboundAggregatorTests extends ESTestCase {
         // Initiate Message
         aggregator.headerReceived(unbreakableHeader);
 
-        final ReleasableBytesReference content2 = ReleasableBytesReference.wrap(bytes);
+        final ReleasableBytesReference content2 = wrapAsReleasable(bytes);
         aggregator.aggregate(content2);
         content2.close();
 
@@ -180,7 +181,7 @@ public class InboundAggregatorTests extends ESTestCase {
         // Initiate Message
         aggregator.headerReceived(handshakeHeader);
 
-        final ReleasableBytesReference content3 = ReleasableBytesReference.wrap(bytes);
+        final ReleasableBytesReference content3 = wrapAsReleasable(bytes);
         aggregator.aggregate(content3);
         content3.close();
 
@@ -203,16 +204,16 @@ public class InboundAggregatorTests extends ESTestCase {
         BytesArray bytes = new BytesArray(randomByteArrayOfLength(10));
         ArrayList<ReleasableBytesReference> references = new ArrayList<>();
         if (randomBoolean()) {
-            final ReleasableBytesReference content = ReleasableBytesReference.wrap(bytes);
+            final ReleasableBytesReference content = wrapAsReleasable(bytes);
             references.add(content);
             aggregator.aggregate(content);
             content.close();
         } else {
-            final ReleasableBytesReference content1 = ReleasableBytesReference.wrap(bytes.slice(0, 5));
+            final ReleasableBytesReference content1 = wrapAsReleasable(bytes.slice(0, 5));
             references.add(content1);
             aggregator.aggregate(content1);
             content1.close();
-            final ReleasableBytesReference content2 = ReleasableBytesReference.wrap(bytes.slice(5, 5));
+            final ReleasableBytesReference content2 = wrapAsReleasable(bytes.slice(5, 5));
             references.add(content2);
             aggregator.aggregate(content2);
             content2.close();
@@ -243,7 +244,7 @@ public class InboundAggregatorTests extends ESTestCase {
             streamOutput.writeString(actionName);
             streamOutput.write(randomByteArrayOfLength(10));
 
-            final ReleasableBytesReference content = ReleasableBytesReference.wrap(streamOutput.bytes());
+            final ReleasableBytesReference content = wrapAsReleasable(streamOutput.bytes());
             aggregator.aggregate(content);
             content.close();
 

--- a/server/src/test/java/org/elasticsearch/transport/InboundDecoderTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/InboundDecoderTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.transport.InboundDecoder.ChannelType;
 import java.io.IOException;
 import java.util.ArrayList;
 
+import static org.elasticsearch.common.bytes.ReleasableBytesReferenceStreamInputTests.wrapAsReleasable;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.instanceOf;
@@ -82,7 +83,7 @@ public class InboundDecoderTests extends ESTestCase {
 
             InboundDecoder decoder = new InboundDecoder(recycler);
             final ArrayList<Object> fragments = new ArrayList<>();
-            final ReleasableBytesReference releasable1 = ReleasableBytesReference.wrap(totalBytes);
+            final ReleasableBytesReference releasable1 = wrapAsReleasable(totalBytes);
             int bytesConsumed = decoder.decode(releasable1, fragments::add);
             assertEquals(totalHeaderSize, bytesConsumed);
             assertTrue(releasable1.hasReferences());
@@ -104,7 +105,7 @@ public class InboundDecoderTests extends ESTestCase {
             fragments.clear();
 
             final BytesReference bytes2 = totalBytes.slice(bytesConsumed, totalBytes.length() - bytesConsumed);
-            final ReleasableBytesReference releasable2 = ReleasableBytesReference.wrap(bytes2);
+            final ReleasableBytesReference releasable2 = wrapAsReleasable(bytes2);
             int bytesConsumed2 = decoder.decode(releasable2, fragments::add);
             assertEquals(totalBytes.length() - totalHeaderSize, bytesConsumed2);
 
@@ -146,7 +147,7 @@ public class InboundDecoderTests extends ESTestCase {
 
             InboundDecoder decoder = new InboundDecoder(recycler);
             final ArrayList<Object> fragments = new ArrayList<>();
-            final ReleasableBytesReference releasable1 = ReleasableBytesReference.wrap(totalBytes);
+            final ReleasableBytesReference releasable1 = wrapAsReleasable(totalBytes);
             int bytesConsumed = decoder.decode(releasable1, fragments::add);
             assertEquals(partialHeaderSize, bytesConsumed);
             assertTrue(releasable1.hasReferences());
@@ -165,7 +166,7 @@ public class InboundDecoderTests extends ESTestCase {
             fragments.clear();
 
             final BytesReference bytes2 = totalBytes.slice(bytesConsumed, totalBytes.length() - bytesConsumed);
-            final ReleasableBytesReference releasable2 = ReleasableBytesReference.wrap(bytes2);
+            final ReleasableBytesReference releasable2 = wrapAsReleasable(bytes2);
             int bytesConsumed2 = decoder.decode(releasable2, fragments::add);
             if (compressionScheme == null) {
                 assertEquals(2, fragments.size());
@@ -203,7 +204,7 @@ public class InboundDecoderTests extends ESTestCase {
 
             InboundDecoder decoder = new InboundDecoder(recycler);
             final ArrayList<Object> fragments = new ArrayList<>();
-            final ReleasableBytesReference releasable1 = ReleasableBytesReference.wrap(bytes);
+            final ReleasableBytesReference releasable1 = wrapAsReleasable(bytes);
             int bytesConsumed = decoder.decode(releasable1, fragments::add);
             assertEquals(totalHeaderSize, bytesConsumed);
             assertTrue(releasable1.hasReferences());
@@ -249,14 +250,14 @@ public class InboundDecoderTests extends ESTestCase {
             try (InboundDecoder clientDecoder = new InboundDecoder(recycler, ChannelType.CLIENT)) {
                 IllegalArgumentException e = expectThrows(
                     IllegalArgumentException.class,
-                    () -> clientDecoder.decode(ReleasableBytesReference.wrap(bytes), ignored -> {})
+                    () -> clientDecoder.decode(wrapAsReleasable(bytes), ignored -> {})
                 );
                 assertThat(e.getMessage(), containsString("client channels do not accept inbound requests, only responses"));
             }
             // the same message will be decoded by a server or mixed decoder
             try (InboundDecoder decoder = new InboundDecoder(recycler, randomFrom(ChannelType.SERVER, ChannelType.MIX))) {
                 final ArrayList<Object> fragments = new ArrayList<>();
-                int bytesConsumed = decoder.decode(ReleasableBytesReference.wrap(bytes), fragments::add);
+                int bytesConsumed = decoder.decode(wrapAsReleasable(bytes), fragments::add);
                 int totalHeaderSize = TcpHeader.headerSize(TransportVersion.current()) + bytes.getInt(
                     TcpHeader.VARIABLE_HEADER_SIZE_POSITION
                 );
@@ -291,14 +292,14 @@ public class InboundDecoderTests extends ESTestCase {
         try (RecyclerBytesStreamOutput os = new RecyclerBytesStreamOutput(recycler)) {
             final BytesReference bytes = message.serialize(os);
             try (InboundDecoder decoder = new InboundDecoder(recycler, ChannelType.SERVER)) {
-                final ReleasableBytesReference releasable1 = ReleasableBytesReference.wrap(bytes);
+                final ReleasableBytesReference releasable1 = wrapAsReleasable(bytes);
                 IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> decoder.decode(releasable1, ignored -> {}));
                 assertThat(e.getMessage(), containsString("server channels do not accept inbound responses, only requests"));
             }
             // the same message will be decoded by a client or mixed decoder
             try (InboundDecoder decoder = new InboundDecoder(recycler, randomFrom(ChannelType.CLIENT, ChannelType.MIX))) {
                 final ArrayList<Object> fragments = new ArrayList<>();
-                int bytesConsumed = decoder.decode(ReleasableBytesReference.wrap(bytes), fragments::add);
+                int bytesConsumed = decoder.decode(wrapAsReleasable(bytes), fragments::add);
                 int totalHeaderSize = TcpHeader.headerSize(TransportVersion.current()) + bytes.getInt(
                     TcpHeader.VARIABLE_HEADER_SIZE_POSITION
                 );
@@ -350,7 +351,7 @@ public class InboundDecoderTests extends ESTestCase {
 
             InboundDecoder decoder = new InboundDecoder(recycler);
             final ArrayList<Object> fragments = new ArrayList<>();
-            final ReleasableBytesReference releasable1 = ReleasableBytesReference.wrap(totalBytes);
+            final ReleasableBytesReference releasable1 = wrapAsReleasable(totalBytes);
             int bytesConsumed = decoder.decode(releasable1, fragments::add);
             assertEquals(totalHeaderSize, bytesConsumed);
             assertTrue(releasable1.hasReferences());
@@ -372,7 +373,7 @@ public class InboundDecoderTests extends ESTestCase {
             fragments.clear();
 
             final BytesReference bytes2 = totalBytes.slice(bytesConsumed, totalBytes.length() - bytesConsumed);
-            final ReleasableBytesReference releasable2 = ReleasableBytesReference.wrap(bytes2);
+            final ReleasableBytesReference releasable2 = wrapAsReleasable(bytes2);
             int bytesConsumed2 = decoder.decode(releasable2, fragments::add);
             assertEquals(totalBytes.length() - totalHeaderSize, bytesConsumed2);
 
@@ -414,7 +415,7 @@ public class InboundDecoderTests extends ESTestCase {
 
             InboundDecoder decoder = new InboundDecoder(recycler);
             final ArrayList<Object> fragments = new ArrayList<>();
-            final ReleasableBytesReference releasable1 = ReleasableBytesReference.wrap(bytes);
+            final ReleasableBytesReference releasable1 = wrapAsReleasable(bytes);
             int bytesConsumed = decoder.decode(releasable1, fragments::add);
             assertEquals(totalHeaderSize, bytesConsumed);
             assertTrue(releasable1.hasReferences());
@@ -451,7 +452,7 @@ public class InboundDecoderTests extends ESTestCase {
 
             InboundDecoder decoder = new InboundDecoder(recycler);
             final ArrayList<Object> fragments = new ArrayList<>();
-            try (ReleasableBytesReference r = ReleasableBytesReference.wrap(bytes)) {
+            try (ReleasableBytesReference r = wrapAsReleasable(bytes)) {
                 releasable1 = r;
                 expectThrows(IllegalStateException.class, () -> decoder.decode(releasable1, fragments::add));
             }


### PR DESCRIPTION
This is needed for the search response pooling work. Also, the one usage in `ReleasableBytesReference` actually makes outright sense. We shouldn't be ref-counting on a global constant, that just needlessly introduces contention that isn't entirely obvious. This change required a couple tests to be adjusted where we were checking release mechanics on noop instances.
