### PR TITLE
[DOCS] ES|QL backtick changes in 8.13

### DIFF
--- a/docs/reference/esql/esql-syntax.asciidoc
+++ b/docs/reference/esql/esql-syntax.asciidoc
@@ -40,37 +40,28 @@ source-command | processing-command1 | processing-command2
 [[esql-identifiers]]
 ==== Identifiers
 
-The identifiers can be used as they are and don't require quoting, unless
-containing special characters, in which case they must be quoted with
-backticks (+{backtick}+). What "special characters" means is command dependent.
+Identifiers need to be quoted with backticks (+{backtick}+) if:
 
-For <<esql-from, FROM>>, <<esql-keep, KEEP>>, <<esql-drop, DROP>>,
-<<esql-rename, RENAME>>, <<esql-mv_expand, MV_EXPAND>> and
-<<esql-enrich, ENRICH>> these are: `=`, +{backtick}+, `,`, ` ` (space), `|` ,
-`[`, `]`, `\t` (TAB), `\r` (CR), `\n` (LF); one `/` is allowed unquoted, but
-a sequence of two or more require quoting.
+* they don't start with a letter, `_` or `@`
+* any of the other characters is not a letter, number, or `_`
 
-The rest of the commands - those allowing for identifiers be used in
-expressions - require quoting if the identifier contains characters other than
-letters, numbers and `_` and doesn't start with a letter, `_` or `@`.
-
-For instance:
+For example:
 
 [source,esql]
 ----
-// Retain just one field
 FROM index
-| KEEP 1.field
+| KEEP `1.field`
 ----
 
-is legal. However, if same field is to be used with an <<esql-eval, EVAL>>,
-it'd have to be quoted:
+When referencing a function alias that itself uses a quoted identifier, the
+backticks of the quoted identifier need to be escaped with another backtick. For
+example:
 
 [source,esql]
 ----
-// Copy one field
 FROM index
-| EVAL my_field = `1.field`
+| STATS COUNT(`1.field`)
+| EVAL my_count = `COUNT(``1.field``)`
 ----
 
 [discrete]


### PR DESCRIPTION
Updates the "Identifiers" section in the ES|QL syntax docs for the changes implemented by https://github.com/elastic/elasticsearch/pull/100740.