### PR TITLE
Add semantic_text feature flag for non-snapshot tests

### DIFF
--- a/x-pack/plugin/ml/build.gradle
+++ b/x-pack/plugin/ml/build.gradle
@@ -1,5 +1,6 @@
 import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.dra.DraResolvePlugin
+import org.elasticsearch.gradle.internal.info.BuildParams
 
 apply plugin: 'elasticsearch.internal-es-plugin'
 apply plugin: 'elasticsearch.internal-cluster-test'
@@ -111,6 +112,12 @@ dependencies {
 artifacts {
   // normal es plugins do not publish the jar but we need to since users need it for extensions
   archives tasks.named("jar")
+}
+
+if (BuildParams.isSnapshotBuild() == false) {
+  tasks.named("test").configure {
+    systemProperty 'es.semantic_text_feature_flag_enabled', 'true'
+  }
 }
 
 tasks.register("extractNativeLicenses", Copy) {


### PR DESCRIPTION
Closes https://github.com/elastic/elasticsearch/issues/103966 https://github.com/elastic/elasticsearch/issues/103925

Does what it says on the tin.