### PR TITLE
All acknowledgedResponse actions are local-only

### DIFF
--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/action/DeleteDataStreamLifecycleAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/action/DeleteDataStreamLifecycleAction.java
@@ -26,9 +26,7 @@ import java.util.Objects;
  */
 public class DeleteDataStreamLifecycleAction {
 
-    public static final ActionType<AcknowledgedResponse> INSTANCE = ActionType.acknowledgedResponse(
-        "indices:admin/data_stream/lifecycle/delete"
-    );
+    public static final ActionType<AcknowledgedResponse> INSTANCE = ActionType.localOnly("indices:admin/data_stream/lifecycle/delete");
 
     private DeleteDataStreamLifecycleAction() {/* no instances */}
 

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/action/PutDataStreamLifecycleAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/action/PutDataStreamLifecycleAction.java
@@ -40,9 +40,7 @@ import static org.elasticsearch.cluster.metadata.DataStreamLifecycle.ENABLED_FIE
  */
 public class PutDataStreamLifecycleAction {
 
-    public static final ActionType<AcknowledgedResponse> INSTANCE = ActionType.acknowledgedResponse(
-        "indices:admin/data_stream/lifecycle/put"
-    );
+    public static final ActionType<AcknowledgedResponse> INSTANCE = ActionType.localOnly("indices:admin/data_stream/lifecycle/put");
 
     private PutDataStreamLifecycleAction() {/* no instances */}
 

--- a/server/src/main/java/org/elasticsearch/action/ActionType.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionType.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.action;
 
-import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.io.stream.Writeable;
 
 /**
@@ -25,10 +24,6 @@ public class ActionType<Response extends ActionResponse> {
 
     public static ActionType<ActionResponse.Empty> emptyResponse(String name) {
         return new ActionType<>(name, in -> ActionResponse.Empty.INSTANCE);
-    }
-
-    public static ActionType<AcknowledgedResponse> acknowledgedResponse(String name) {
-        return new ActionType<>(name, AcknowledgedResponse::readFrom);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/delete/TransportDeleteRepositoryAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/delete/TransportDeleteRepositoryAction.java
@@ -34,7 +34,7 @@ import java.util.Set;
  */
 public class TransportDeleteRepositoryAction extends AcknowledgedTransportMasterNodeAction<DeleteRepositoryRequest> {
 
-    public static final ActionType<AcknowledgedResponse> TYPE = ActionType.acknowledgedResponse("cluster:admin/repository/delete");
+    public static final ActionType<AcknowledgedResponse> TYPE = ActionType.localOnly("cluster:admin/repository/delete");
     private final RepositoriesService repositoriesService;
 
     @Inject

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/put/TransportPutRepositoryAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/put/TransportPutRepositoryAction.java
@@ -34,7 +34,7 @@ import java.util.Set;
  */
 public class TransportPutRepositoryAction extends AcknowledgedTransportMasterNodeAction<PutRepositoryRequest> {
 
-    public static final ActionType<AcknowledgedResponse> TYPE = ActionType.acknowledgedResponse("cluster:admin/repository/put");
+    public static final ActionType<AcknowledgedResponse> TYPE = ActionType.localOnly("cluster:admin/repository/put");
     private final RepositoriesService repositoriesService;
 
     @Inject

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/clone/TransportCloneSnapshotAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/clone/TransportCloneSnapshotAction.java
@@ -30,7 +30,7 @@ import org.elasticsearch.transport.TransportService;
  */
 public final class TransportCloneSnapshotAction extends AcknowledgedTransportMasterNodeAction<CloneSnapshotRequest> {
 
-    public static final ActionType<AcknowledgedResponse> TYPE = ActionType.acknowledgedResponse("cluster:admin/snapshot/clone");
+    public static final ActionType<AcknowledgedResponse> TYPE = ActionType.localOnly("cluster:admin/snapshot/clone");
     private final SnapshotsService snapshotsService;
 
     @Inject

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/delete/TransportDeleteSnapshotAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/delete/TransportDeleteSnapshotAction.java
@@ -29,7 +29,7 @@ import org.elasticsearch.transport.TransportService;
  * Transport action for delete snapshot operation
  */
 public class TransportDeleteSnapshotAction extends AcknowledgedTransportMasterNodeAction<DeleteSnapshotRequest> {
-    public static final ActionType<AcknowledgedResponse> TYPE = ActionType.acknowledgedResponse("cluster:admin/snapshot/delete");
+    public static final ActionType<AcknowledgedResponse> TYPE = ActionType.localOnly("cluster:admin/snapshot/delete");
     private final SnapshotsService snapshotsService;
 
     @Inject

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/storedscripts/TransportDeleteStoredScriptAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/storedscripts/TransportDeleteStoredScriptAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.transport.TransportService;
 
 public class TransportDeleteStoredScriptAction extends AcknowledgedTransportMasterNodeAction<DeleteStoredScriptRequest> {
 
-    public static final ActionType<AcknowledgedResponse> TYPE = ActionType.acknowledgedResponse("cluster:admin/script/delete");
+    public static final ActionType<AcknowledgedResponse> TYPE = ActionType.localOnly("cluster:admin/script/delete");
 
     @Inject
     public TransportDeleteStoredScriptAction(

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/storedscripts/TransportPutStoredScriptAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/storedscripts/TransportPutStoredScriptAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.transport.TransportService;
 
 public class TransportPutStoredScriptAction extends AcknowledgedTransportMasterNodeAction<PutStoredScriptRequest> {
 
-    public static final ActionType<AcknowledgedResponse> TYPE = ActionType.acknowledgedResponse("cluster:admin/script/put");
+    public static final ActionType<AcknowledgedResponse> TYPE = ActionType.localOnly("cluster:admin/script/put");
     private final ScriptService scriptService;
 
     @Inject

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/TransportIndicesAliasesAction.java
@@ -59,7 +59,7 @@ import static java.util.Collections.unmodifiableList;
 public class TransportIndicesAliasesAction extends AcknowledgedTransportMasterNodeAction<IndicesAliasesRequest> {
 
     public static final String NAME = "indices:admin/aliases";
-    public static final ActionType<AcknowledgedResponse> TYPE = ActionType.acknowledgedResponse(NAME);
+    public static final ActionType<AcknowledgedResponse> TYPE = ActionType.localOnly(NAME);
     private static final Logger logger = LogManager.getLogger(TransportIndicesAliasesAction.class);
 
     private final MetadataIndexAliasesService indexAliasesService;

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/dangling/delete/TransportDeleteDanglingIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/dangling/delete/TransportDeleteDanglingIndexAction.java
@@ -49,7 +49,7 @@ import java.util.stream.Collectors;
  * to add the index to the index graveyard.
  */
 public class TransportDeleteDanglingIndexAction extends AcknowledgedTransportMasterNodeAction<DeleteDanglingIndexRequest> {
-    public static final ActionType<AcknowledgedResponse> TYPE = ActionType.acknowledgedResponse("cluster:admin/indices/dangling/delete");
+    public static final ActionType<AcknowledgedResponse> TYPE = ActionType.localOnly("cluster:admin/indices/dangling/delete");
     private static final Logger logger = LogManager.getLogger(TransportDeleteDanglingIndexAction.class);
 
     private final Settings settings;

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/dangling/import_index/TransportImportDanglingIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/dangling/import_index/TransportImportDanglingIndexAction.java
@@ -39,7 +39,7 @@ import java.util.stream.Collectors;
  * to perform the actual allocation.
  */
 public class TransportImportDanglingIndexAction extends HandledTransportAction<ImportDanglingIndexRequest, AcknowledgedResponse> {
-    public static final ActionType<AcknowledgedResponse> TYPE = ActionType.acknowledgedResponse("cluster:admin/indices/dangling/import");
+    public static final ActionType<AcknowledgedResponse> TYPE = ActionType.localOnly("cluster:admin/indices/dangling/import");
     private static final Logger logger = LogManager.getLogger(TransportImportDanglingIndexAction.class);
 
     private final LocalAllocateDangledIndices danglingIndexAllocator;

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/delete/TransportDeleteIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/delete/TransportDeleteIndexAction.java
@@ -37,7 +37,7 @@ import java.util.Set;
  */
 public class TransportDeleteIndexAction extends AcknowledgedTransportMasterNodeAction<DeleteIndexRequest> {
 
-    public static final ActionType<AcknowledgedResponse> TYPE = ActionType.acknowledgedResponse("indices:admin/delete");
+    public static final ActionType<AcknowledgedResponse> TYPE = ActionType.localOnly("indices:admin/delete");
     private static final Logger logger = LogManager.getLogger(TransportDeleteIndexAction.class);
 
     private final MetadataDeleteIndexService deleteIndexService;

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/TransportAutoPutMappingAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/TransportAutoPutMappingAction.java
@@ -32,7 +32,7 @@ import static org.elasticsearch.action.admin.indices.mapping.put.TransportPutMap
 
 public class TransportAutoPutMappingAction extends AcknowledgedTransportMasterNodeAction<PutMappingRequest> {
 
-    public static final ActionType<AcknowledgedResponse> TYPE = ActionType.acknowledgedResponse("indices:admin/mapping/auto_put");
+    public static final ActionType<AcknowledgedResponse> TYPE = ActionType.localOnly("indices:admin/mapping/auto_put");
     private static final Logger logger = LogManager.getLogger(TransportAutoPutMappingAction.class);
 
     private final MetadataMappingService metadataMappingService;

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/TransportPutMappingAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/put/TransportPutMappingAction.java
@@ -45,7 +45,7 @@ import java.util.Optional;
  */
 public class TransportPutMappingAction extends AcknowledgedTransportMasterNodeAction<PutMappingRequest> {
 
-    public static final ActionType<AcknowledgedResponse> TYPE = ActionType.acknowledgedResponse("indices:admin/mapping/put");
+    public static final ActionType<AcknowledgedResponse> TYPE = ActionType.localOnly("indices:admin/mapping/put");
     private static final Logger logger = LogManager.getLogger(TransportPutMappingAction.class);
 
     private final MetadataMappingService metadataMappingService;

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/settings/put/TransportUpdateSettingsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/settings/put/TransportUpdateSettingsAction.java
@@ -45,7 +45,7 @@ import static org.elasticsearch.indices.SystemIndexMappingUpdateService.MANAGED_
 
 public class TransportUpdateSettingsAction extends AcknowledgedTransportMasterNodeAction<UpdateSettingsRequest> {
 
-    public static final ActionType<AcknowledgedResponse> TYPE = ActionType.acknowledgedResponse("indices:admin/settings/update");
+    public static final ActionType<AcknowledgedResponse> TYPE = ActionType.localOnly("indices:admin/settings/update");
     private static final Logger logger = LogManager.getLogger(TransportUpdateSettingsAction.class);
 
     private final MetadataUpdateSettingsService updateSettingsService;

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/delete/TransportDeleteIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/delete/TransportDeleteIndexTemplateAction.java
@@ -31,7 +31,7 @@ import org.elasticsearch.transport.TransportService;
  */
 public class TransportDeleteIndexTemplateAction extends AcknowledgedTransportMasterNodeAction<DeleteIndexTemplateRequest> {
 
-    public static final ActionType<AcknowledgedResponse> TYPE = ActionType.acknowledgedResponse("indices:admin/template/delete");
+    public static final ActionType<AcknowledgedResponse> TYPE = ActionType.localOnly("indices:admin/template/delete");
     private static final Logger logger = LogManager.getLogger(TransportDeleteIndexTemplateAction.class);
 
     private final MetadataIndexTemplateService indexTemplateService;

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/TransportPutIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/put/TransportPutIndexTemplateAction.java
@@ -37,7 +37,7 @@ import java.io.IOException;
  */
 public class TransportPutIndexTemplateAction extends AcknowledgedTransportMasterNodeAction<PutIndexTemplateRequest> {
 
-    public static final ActionType<AcknowledgedResponse> TYPE = ActionType.acknowledgedResponse("indices:admin/template/put");
+    public static final ActionType<AcknowledgedResponse> TYPE = ActionType.localOnly("indices:admin/template/put");
     private static final Logger logger = LogManager.getLogger(TransportPutIndexTemplateAction.class);
 
     private final MetadataIndexTemplateService indexTemplateService;

--- a/server/src/main/java/org/elasticsearch/action/ingest/DeletePipelineTransportAction.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/DeletePipelineTransportAction.java
@@ -29,7 +29,7 @@ import java.util.Set;
 
 public class DeletePipelineTransportAction extends AcknowledgedTransportMasterNodeAction<DeletePipelineRequest> {
 
-    public static final ActionType<AcknowledgedResponse> TYPE = ActionType.acknowledgedResponse("cluster:admin/ingest/pipeline/delete");
+    public static final ActionType<AcknowledgedResponse> TYPE = ActionType.localOnly("cluster:admin/ingest/pipeline/delete");
     private final IngestService ingestService;
 
     @Inject

--- a/server/src/main/java/org/elasticsearch/action/ingest/PutPipelineTransportAction.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/PutPipelineTransportAction.java
@@ -34,7 +34,7 @@ import java.util.Set;
 import static org.elasticsearch.ingest.IngestService.INGEST_ORIGIN;
 
 public class PutPipelineTransportAction extends AcknowledgedTransportMasterNodeAction<PutPipelineRequest> {
-    public static final ActionType<AcknowledgedResponse> TYPE = ActionType.acknowledgedResponse("cluster:admin/ingest/pipeline/put");
+    public static final ActionType<AcknowledgedResponse> TYPE = ActionType.localOnly("cluster:admin/ingest/pipeline/put");
     private final IngestService ingestService;
     private final OriginSettingClient client;
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/TransportDeleteLicenseAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/TransportDeleteLicenseAction.java
@@ -26,7 +26,7 @@ import org.elasticsearch.transport.TransportService;
 
 public class TransportDeleteLicenseAction extends AcknowledgedTransportMasterNodeAction<DeleteLicenseRequest> {
 
-    public static final ActionType<AcknowledgedResponse> TYPE = ActionType.acknowledgedResponse("cluster:admin/xpack/license/delete");
+    public static final ActionType<AcknowledgedResponse> TYPE = ActionType.localOnly("cluster:admin/xpack/license/delete");
     private final MutableLicenseService licenseService;
 
     @Inject

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/TransportDeleteAsyncResultAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/TransportDeleteAsyncResultAction.java
@@ -27,7 +27,7 @@ import org.elasticsearch.xpack.core.XPackPlugin;
 import static org.elasticsearch.xpack.core.ClientHelper.ASYNC_SEARCH_ORIGIN;
 
 public class TransportDeleteAsyncResultAction extends HandledTransportAction<DeleteAsyncResultRequest, AcknowledgedResponse> {
-    public static final ActionType<AcknowledgedResponse> TYPE = ActionType.acknowledgedResponse("indices:data/read/async_search/delete");
+    public static final ActionType<AcknowledgedResponse> TYPE = ActionType.localOnly("indices:data/read/async_search/delete");
     private final DeleteAsyncResultsService deleteResultsService;
     private final ClusterService clusterService;
     private final TransportService transportService;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/action/ILMActions.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/action/ILMActions.java
@@ -11,9 +11,9 @@ import org.elasticsearch.action.support.master.AcknowledgedResponse;
 
 public enum ILMActions {
     ;
-    public static final ActionType<AcknowledgedResponse> START = ActionType.acknowledgedResponse("cluster:admin/ilm/start");
-    public static final ActionType<AcknowledgedResponse> STOP = ActionType.acknowledgedResponse("cluster:admin/ilm/stop");
-    public static final ActionType<AcknowledgedResponse> RETRY = ActionType.acknowledgedResponse("indices:admin/ilm/retry");
-    public static final ActionType<AcknowledgedResponse> MOVE_TO_STEP = ActionType.acknowledgedResponse("cluster:admin/ilm/_move/post");
-    public static final ActionType<AcknowledgedResponse> PUT = ActionType.acknowledgedResponse("cluster:admin/ilm/put");
+    public static final ActionType<AcknowledgedResponse> START = ActionType.localOnly("cluster:admin/ilm/start");
+    public static final ActionType<AcknowledgedResponse> STOP = ActionType.localOnly("cluster:admin/ilm/stop");
+    public static final ActionType<AcknowledgedResponse> RETRY = ActionType.localOnly("indices:admin/ilm/retry");
+    public static final ActionType<AcknowledgedResponse> MOVE_TO_STEP = ActionType.localOnly("cluster:admin/ilm/_move/post");
+    public static final ActionType<AcknowledgedResponse> PUT = ActionType.localOnly("cluster:admin/ilm/put");
 }


### PR DESCRIPTION
Actions returning `AcknowledgedResponse` are for cluster state updates
which we do not send to remote clusters, so we can mark all these
actions as `localOnly()`.

Relates #103242
Relates #103330