### PR TITLE
Allowing warnings caused by the presence of a global template in simulate ingest yaml rest tests

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/simulate.ingest/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/simulate.ingest/10_basic.yml
@@ -117,9 +117,7 @@ setup:
 "Test index templates with pipelines":
 
   - skip:
-      features: headers
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/102339"
+      features: [headers, allowed_warnings]
 
   - do:
       headers:
@@ -146,6 +144,8 @@ setup:
   - match: { acknowledged: true }
 
   - do:
+      allowed_warnings:
+        - "index template [my-template] has index patterns [index-*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-template] will take precedence during new index creation"
       indices.put_index_template:
         name: my-template
         body:
@@ -196,9 +196,7 @@ setup:
 "Test bad pipeline substitution":
 
   - skip:
-      features: headers
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/102339"
+      features: [headers, allowed_warnings]
 
   - do:
       headers:
@@ -213,6 +211,8 @@ setup:
   - match: { acknowledged: true }
 
   - do:
+      allowed_warnings:
+        - "index template [my-template] has index patterns [index-*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-template] will take precedence during new index creation"
       indices.put_index_template:
         name: my-template
         body:


### PR DESCRIPTION
We randomly rarely add a global index template in our yaml tests (https://github.com/elastic/elasticsearch/blob/main/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCase.java#L129). When this happens, we get the warning:
```
index template [my-template1] has index patterns [simple-data-stream1] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-template1] will take precedence during new index creation
```
The test still does what we want (use our template), but the existence of that warning kills the test. This PR makes it so that the warning is ignored.
Closes #102339