### PR TITLE
[7.17] bump junit version (#103941)

### DIFF
--- a/build-tools-internal/version.properties
+++ b/build-tools-internal/version.properties
@@ -28,7 +28,7 @@ commons_lang3                   = 3.9
 bouncycastle=1.64
 # test dependencies
 randomizedrunner  = 2.8.0
-junit             = 4.12
+junit             = 4.13.2
 junit5            = 5.7.1
 httpclient        = 4.5.10
 httpcore          = 4.4.12


### PR DESCRIPTION
Backports the following commits to 7.17:
 - bump junit version (#103941)