### PR TITLE
[8.11] Mute testContinuousEvents (#103986)

### DIFF
--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TransformContinuousIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TransformContinuousIT.java
@@ -136,6 +136,7 @@ public class TransformContinuousIT extends TransformRestTestCase {
         deletePipeline(ContinuousTestCase.INGEST_PIPELINE);
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/97263")
     public void testContinuousEvents() throws Exception {
         String sourceIndexName = ContinuousTestCase.CONTINUOUS_EVENTS_SOURCE_INDEX;
         DecimalFormat numberFormat = new DecimalFormat("000", new DecimalFormatSymbols(Locale.ROOT));


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Mute testContinuousEvents (#103986)