### PR TITLE
Disambiguate `@Inject` annotation in errors

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/inject/internal/Errors.java
+++ b/server/src/main/java/org/elasticsearch/common/inject/internal/Errors.java
@@ -19,6 +19,7 @@ package org.elasticsearch.common.inject.internal;
 import org.apache.lucene.util.CollectionUtil;
 import org.elasticsearch.common.inject.ConfigurationException;
 import org.elasticsearch.common.inject.CreationException;
+import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Key;
 import org.elasticsearch.common.inject.MembersInjector;
 import org.elasticsearch.common.inject.Provider;
@@ -251,8 +252,9 @@ public final class Errors {
         );
     }
 
-    private static final String CONSTRUCTOR_RULES = "Classes must have either one (and only one) constructor "
-        + "annotated with @Inject or a zero-argument constructor that is not private.";
+    private static final String CONSTRUCTOR_RULES = "Classes must have either one (and only one) constructor annotated with @"
+        + Inject.class.getCanonicalName()
+        + " or a zero-argument constructor that is not private.";
 
     public Errors missingConstructor(Class<?> implementation) {
         return addMessage("Could not find a suitable constructor in %s. " + CONSTRUCTOR_RULES, implementation);

--- a/server/src/main/java/org/elasticsearch/indices/analysis/wrappers/StableApiWrappers.java
+++ b/server/src/main/java/org/elasticsearch/indices/analysis/wrappers/StableApiWrappers.java
@@ -204,7 +204,9 @@ public class StableApiWrappers {
                     }
                     return (T) constructor.newInstance(parameters);
                 } else {
-                    throw new IllegalStateException("Missing @Inject annotation for constructor with settings.");
+                    throw new IllegalStateException(
+                        "Missing @" + Inject.class.getCanonicalName() + " annotation for constructor with settings."
+                    );
                 }
             }
 

--- a/server/src/test/java/org/elasticsearch/indices/analysis/IncorrectSetupStablePluginsTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/analysis/IncorrectSetupStablePluginsTests.java
@@ -94,7 +94,7 @@ public class IncorrectSetupStablePluginsTests extends ESTestCase {
                 Map.of("noInjectCharFilter", new PluginInfo("noInjectCharFilter", NoInjectCharFilter.class.getName(), classLoader))
             )
         );
-        assertThat(e.getMessage(), equalTo("Missing @Inject annotation for constructor with settings."));
+        assertThat(e.getMessage(), equalTo("Missing @org.elasticsearch.plugin.Inject annotation for constructor with settings."));
     }
 
     @NamedComponent("multipleConstructors")

--- a/server/src/test/java/org/elasticsearch/indices/analysis/wrappers/StableApiWrappersTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/analysis/wrappers/StableApiWrappersTests.java
@@ -75,7 +75,10 @@ public class StableApiWrappersTests extends ESTestCase {
             IllegalStateException.class,
             () -> oldTokenFilter.get(null, mock(Environment.class), null, null)
         );
-        assertThat(illegalStateException.getMessage(), equalTo("Missing @Inject annotation for constructor with settings."));
+        assertThat(
+            illegalStateException.getMessage(),
+            equalTo("Missing @org.elasticsearch.plugin.Inject annotation for constructor with settings.")
+        );
     }
 
     public void testAnalyzerFactoryDelegation() throws IOException {


### PR DESCRIPTION
There's two `@Inject` annotations, one for plugins and another for
transport actions. It's awfully confusing when you use the wrong one.
This commit properly qualifies the annotation name in the resulting
error message to help pin down what's going on.