### PR TITLE
Fix all "lambda can be folded" warnings in the codebase

### DIFF
--- a/build-tools/src/main/java/org/elasticsearch/gradle/util/GradleUtils.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/util/GradleUtils.java
@@ -48,7 +48,7 @@ public abstract class GradleUtils {
     }
 
     public static void maybeConfigure(TaskContainer tasks, String name, Action<? super Task> config) {
-        tasks.matching(t -> t.getName().equals(name)).configureEach(t -> config.execute(t));
+        tasks.matching(t -> t.getName().equals(name)).configureEach(config);
     }
 
     public static <T extends Task> void maybeConfigure(
@@ -57,7 +57,7 @@ public abstract class GradleUtils {
         Class<? extends T> type,
         Action<? super T> config
     ) {
-        tasks.withType(type).matching((Spec<T>) t -> t.getName().equals(name)).configureEach(task -> { config.execute(task); });
+        tasks.withType(type).matching((Spec<T>) t -> t.getName().equals(name)).configureEach(config);
     }
 
     public static TaskProvider<?> findByName(TaskContainer tasks, String name) {

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/SimilarityScriptTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/SimilarityScriptTests.java
@@ -54,7 +54,7 @@ public class SimilarityScriptTests extends ScriptTestCase {
             SimilarityScript.CONTEXT,
             Collections.emptyMap()
         );
-        ScriptedSimilarity sim = new ScriptedSimilarity("foobar", null, "foobaz", factory::newInstance, true);
+        ScriptedSimilarity sim = new ScriptedSimilarity("foobar", null, "foobaz", factory, true);
         try (Directory dir = new ByteBuffersDirectory()) {
             IndexWriter w = new IndexWriter(dir, newIndexWriterConfig().setSimilarity(sim));
 
@@ -103,7 +103,7 @@ public class SimilarityScriptTests extends ScriptTestCase {
             SimilarityScript.CONTEXT,
             Collections.emptyMap()
         );
-        ScriptedSimilarity sim = new ScriptedSimilarity("foobar", weightFactory::newInstance, "foobaz", factory::newInstance, true);
+        ScriptedSimilarity sim = new ScriptedSimilarity("foobar", weightFactory, "foobaz", factory, true);
         try (Directory dir = new ByteBuffersDirectory()) {
             IndexWriter w = new IndexWriter(dir, newIndexWriterConfig().setSimilarity(sim));
 

--- a/server/src/main/java/org/elasticsearch/index/similarity/ScriptedSimilarityProvider.java
+++ b/server/src/main/java/org/elasticsearch/index/similarity/ScriptedSimilarityProvider.java
@@ -35,9 +35,9 @@ final class ScriptedSimilarityProvider implements TriFunction<Settings, IndexVer
         }
         return new ScriptedSimilarity(
             weightScript == null ? null : weightScript.toString(),
-            weightScriptFactory == null ? null : weightScriptFactory::newInstance,
+            weightScriptFactory,
             script.toString(),
-            scriptFactory::newInstance,
+            scriptFactory,
             discountOverlaps
         );
     }

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexReaderWrapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexReaderWrapperTests.java
@@ -163,7 +163,7 @@ public class IndexReaderWrapperTests extends ESTestCase {
                     IndexSearcher.getDefaultSimilarity(),
                     IndexSearcher.getDefaultQueryCache(),
                     IndexSearcher.getDefaultQueryCachingPolicy(),
-                    open::close
+                    open
                 ),
                 mock(ShardFieldUsageTracker.FieldUsageStatsTrackingSession.class),
                 wrapper

--- a/server/src/test/java/org/elasticsearch/search/vectors/TestQueryVectorBuilderPlugin.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/TestQueryVectorBuilderPlugin.java
@@ -108,7 +108,7 @@ class TestQueryVectorBuilderPlugin implements SearchPlugin {
     @Override
     public List<QueryVectorBuilderSpec<?>> getQueryVectorBuilders() {
         return List.of(
-            new QueryVectorBuilderSpec<>(TestQueryVectorBuilder.NAME, TestQueryVectorBuilder::new, TestQueryVectorBuilder.PARSER::apply)
+            new QueryVectorBuilderSpec<>(TestQueryVectorBuilder.NAME, TestQueryVectorBuilder::new, TestQueryVectorBuilder.PARSER)
         );
     }
 }

--- a/test/external-modules/error-query/src/main/java/org/elasticsearch/test/errorquery/ErrorQueryBuilder.java
+++ b/test/external-modules/error-query/src/main/java/org/elasticsearch/test/errorquery/ErrorQueryBuilder.java
@@ -134,7 +134,7 @@ public class ErrorQueryBuilder extends AbstractQueryBuilder<ErrorQueryBuilder> {
     });
 
     static {
-        PARSER.declareObjectArray(constructorArg(), (p, c) -> IndexError.PARSER.parse(p, c), new ParseField("indices"));
+        PARSER.declareObjectArray(constructorArg(), IndexError.PARSER, new ParseField("indices"));
         PARSER.declareFloat(ConstructingObjectParser.optionalConstructorArg(), BOOST_FIELD);
         PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), NAME_FIELD);
     }

--- a/test/framework/src/main/java/org/elasticsearch/script/MockScriptEngine.java
+++ b/test/framework/src/main/java/org/elasticsearch/script/MockScriptEngine.java
@@ -397,7 +397,7 @@ public class MockScriptEngine implements ScriptEngine {
         }
         ContextCompiler compiler = contexts.get(context);
         if (compiler != null) {
-            return context.factoryClazz.cast(compiler.compile(script::apply, params));
+            return context.factoryClazz.cast(compiler.compile(script, params));
         }
         throw new IllegalArgumentException("mock script engine does not know how to handle context [" + context.name + "]");
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ConfigurableClusterPrivileges.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ConfigurableClusterPrivileges.java
@@ -166,7 +166,7 @@ public final class ConfigurableClusterPrivileges {
                 if (request instanceof final UpdateProfileDataRequest updateProfileRequest) {
                     assert null == updateProfileRequest.validate();
                     final Collection<String> requestApplicationNames = updateProfileRequest.getApplicationNames();
-                    return requestApplicationNames.stream().allMatch(application -> applicationPredicate.test(application));
+                    return requestApplicationNames.stream().allMatch(applicationPredicate);
                 }
                 return false;
             };
@@ -274,7 +274,7 @@ public final class ConfigurableClusterPrivileges {
                     final Collection<String> requestApplicationNames = privRequest.getApplicationNames();
                     return requestApplicationNames.isEmpty()
                         ? this.applicationNames.contains("*")
-                        : requestApplicationNames.stream().allMatch(application -> applicationPredicate.test(application));
+                        : requestApplicationNames.stream().allMatch(applicationPredicate);
                 }
                 return false;
             };

--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/Methods.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/Methods.java
@@ -83,7 +83,7 @@ public class Methods {
         if (method.getParameters().isEmpty()) {
             return new VariableElement[0];
         }
-        return method.getParameters().stream().filter(e -> filter.test(e)).toArray(VariableElement[]::new);
+        return method.getParameters().stream().filter(filter).toArray(VariableElement[]::new);
     }
 
     /**

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/GroupingAggregatorFunctionTestCase.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/GroupingAggregatorFunctionTestCase.java
@@ -608,7 +608,7 @@ public abstract class GroupingAggregatorFunctionTestCase extends ForkingOperator
 
                     @Override
                     public void close() {
-                        Releasables.close(delegate::close, seenGroupIds);
+                        Releasables.close(delegate, seenGroupIds);
                     }
 
                     @Override

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/session/RowView.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/session/RowView.java
@@ -29,7 +29,7 @@ public interface RowView extends Iterable<Object> {
 
     @Override
     default void forEach(Consumer<? super Object> action) {
-        forEachColumn(action::accept);
+        forEachColumn(action);
     }
 
     default void forEachColumn(Consumer<? super Object> action) {


### PR DESCRIPTION
Just some obvious cleanup.
