### PR TITLE
Simplify `TransportInstanceSingleOperationAction#ShardTransportHandler`

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/single/instance/TransportInstanceSingleOperationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/single/instance/TransportInstanceSingleOperationAction.java
@@ -11,8 +11,10 @@ package org.elasticsearch.action.support.single.instance;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionListenerResponseHandler;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.UnavailableShardsException;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.ChannelActionListener;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateObserver;
@@ -25,7 +27,6 @@ import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
@@ -37,7 +38,6 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.ConnectTransportException;
 import org.elasticsearch.transport.TransportChannel;
 import org.elasticsearch.transport.TransportException;
-import org.elasticsearch.transport.TransportRequestHandler;
 import org.elasticsearch.transport.TransportRequestOptions;
 import org.elasticsearch.transport.TransportResponseHandler;
 import org.elasticsearch.transport.TransportService;
@@ -72,7 +72,7 @@ public abstract class TransportInstanceSingleOperationAction<
         this.transportService = transportService;
         this.indexNameExpressionResolver = indexNameExpressionResolver;
         this.shardActionName = actionName + "[s]";
-        transportService.registerRequestHandler(shardActionName, EsExecutors.DIRECT_EXECUTOR_SERVICE, request, new ShardTransportHandler());
+        transportService.registerRequestHandler(shardActionName, EsExecutors.DIRECT_EXECUTOR_SERVICE, request, this::handleShardRequest);
     }
 
     @Override
@@ -257,26 +257,8 @@ public abstract class TransportInstanceSingleOperationAction<
         }
     }
 
-    private class ShardTransportHandler implements TransportRequestHandler<Request> {
-
-        @Override
-        public void messageReceived(final Request request, final TransportChannel channel, Task task) throws Exception {
-            threadPool.executor(executor(request.shardId)).execute(new AbstractRunnable() {
-                @Override
-                public void onFailure(Exception e) {
-                    try {
-                        channel.sendResponse(e);
-                    } catch (Exception inner) {
-                        inner.addSuppressed(e);
-                        logger.warn("failed to send response for " + shardActionName, inner);
-                    }
-                }
-
-                @Override
-                protected void doRun() {
-                    shardOperation(request, ActionListener.wrap(channel::sendResponse, this::onFailure));
-                }
-            });
-        }
+    private void handleShardRequest(Request request, TransportChannel channel, Task task) {
+        threadPool.executor(executor(request.shardId))
+            .execute(ActionRunnable.wrap(new ChannelActionListener<Response>(channel), l -> shardOperation(request, l)));
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/update/TransportUpdateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/update/TransportUpdateAction.java
@@ -221,7 +221,7 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
                             update.setGetResult(null);
                         }
                         update.setForcedRefresh(response.forcedRefresh());
-                        ActionListener.respondAndRelease(listener, update);
+                        listener.onResponse(update);
                     }, exception -> handleUpdateFailureWithRetry(listener, request, exception, retryCount)))
                 );
             }
@@ -254,7 +254,7 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
                             )
                         );
                         update.setForcedRefresh(response.forcedRefresh());
-                        ActionListener.respondAndRelease(listener, update);
+                        listener.onResponse(update);
                     }, exception -> handleUpdateFailureWithRetry(listener, request, exception, retryCount)))
                 );
             }
@@ -285,7 +285,7 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
                             )
                         );
                         update.setForcedRefresh(response.forcedRefresh());
-                        ActionListener.respondAndRelease(listener, update);
+                        listener.onResponse(update);
                     }, exception -> handleUpdateFailureWithRetry(listener, request, exception, retryCount)))
                 );
             }
@@ -298,7 +298,7 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
                         shard.noopUpdate();
                     }
                 }
-                ActionListener.respondAndRelease(listener, update);
+                listener.onResponse(update);
             }
             default -> throw new IllegalStateException("Illegal result " + result.getResponseResult());
         }

--- a/server/src/main/java/org/elasticsearch/action/update/TransportUpdateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/update/TransportUpdateAction.java
@@ -221,7 +221,7 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
                             update.setGetResult(null);
                         }
                         update.setForcedRefresh(response.forcedRefresh());
-                        listener.onResponse(update);
+                        ActionListener.respondAndRelease(listener, update);
                     }, exception -> handleUpdateFailureWithRetry(listener, request, exception, retryCount)))
                 );
             }
@@ -254,7 +254,7 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
                             )
                         );
                         update.setForcedRefresh(response.forcedRefresh());
-                        listener.onResponse(update);
+                        ActionListener.respondAndRelease(listener, update);
                     }, exception -> handleUpdateFailureWithRetry(listener, request, exception, retryCount)))
                 );
             }
@@ -285,7 +285,7 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
                             )
                         );
                         update.setForcedRefresh(response.forcedRefresh());
-                        listener.onResponse(update);
+                        ActionListener.respondAndRelease(listener, update);
                     }, exception -> handleUpdateFailureWithRetry(listener, request, exception, retryCount)))
                 );
             }
@@ -298,7 +298,7 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
                         shard.noopUpdate();
                     }
                 }
-                listener.onResponse(update);
+                ActionListener.respondAndRelease(listener, update);
             }
             default -> throw new IllegalStateException("Illegal result " + result.getResponseResult());
         }


### PR DESCRIPTION
No need for the `ActionListener#wrap` or the bespoke error handling,
this is just `ChannelActionListener` with extra steps.