### PR TITLE
Remove `TransportChannel#getChannelType`

### DIFF
--- a/server/src/main/java/org/elasticsearch/tasks/TaskManager.java
+++ b/server/src/main/java/org/elasticsearch/tasks/TaskManager.java
@@ -505,7 +505,7 @@ public class TaskManager implements ClusterStateApplier {
             if (channel instanceof TcpTransportChannel) {
                 startTrackingChannel(((TcpTransportChannel) channel).getChannel(), ban::registerChannel);
             } else {
-                assert channel.getChannelType().equals("direct") : "expect direct channel; got [" + channel + "]";
+                assert TransportService.isDirectResponseChannel(channel) : "expect direct channel; got [" + channel + "]";
                 ban.registerChannel(DIRECT_CHANNEL_TRACKER);
             }
         }

--- a/server/src/main/java/org/elasticsearch/transport/RequestHandlerRegistry.java
+++ b/server/src/main/java/org/elasticsearch/transport/RequestHandlerRegistry.java
@@ -63,7 +63,7 @@ public class RequestHandlerRegistry<Request extends TransportRequest> implements
     }
 
     public void processMessageReceived(Request request, TransportChannel channel) throws Exception {
-        final Task task = taskManager.register(channel.getChannelType(), action, request);
+        final Task task = taskManager.register("transport", action, request);
         Releasable unregisterTask = () -> taskManager.unregister(task);
         try {
             if (channel instanceof TcpTransportChannel tcpTransportChannel && task instanceof CancellableTask cancellableTask) {

--- a/server/src/main/java/org/elasticsearch/transport/TaskTransportChannel.java
+++ b/server/src/main/java/org/elasticsearch/transport/TaskTransportChannel.java
@@ -32,11 +32,6 @@ public class TaskTransportChannel implements TransportChannel {
     }
 
     @Override
-    public String getChannelType() {
-        return channel.getChannelType();
-    }
-
-    @Override
     public void sendResponse(TransportResponse response) throws IOException {
         try {
             channel.sendResponse(response);

--- a/server/src/main/java/org/elasticsearch/transport/TcpTransportChannel.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransportChannel.java
@@ -96,11 +96,6 @@ public final class TcpTransportChannel implements TransportChannel {
     }
 
     @Override
-    public String getChannelType() {
-        return "transport";
-    }
-
-    @Override
     public TransportVersion getVersion() {
         return version;
     }

--- a/server/src/main/java/org/elasticsearch/transport/TransportChannel.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportChannel.java
@@ -19,8 +19,6 @@ public interface TransportChannel {
 
     String getProfileName();
 
-    String getChannelType();
-
     void sendResponse(TransportResponse response) throws IOException;
 
     void sendResponse(Exception exception) throws IOException;

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -1456,6 +1456,10 @@ public class TransportService extends AbstractLifecycleComponent
         }
     }
 
+    public static boolean isDirectResponseChannel(TransportChannel transportChannel) {
+        return transportChannel instanceof DirectResponseChannel;
+    }
+
     static class DirectResponseChannel implements TransportChannel {
         final DiscoveryNode localNode;
         private final String action;
@@ -1572,11 +1576,6 @@ public class TransportService extends AbstractLifecycleComponent
             } catch (Exception e) {
                 logger.error(() -> format("failed to handle exception for action [%s], handler [%s]", action, handler), e);
             }
-        }
-
-        @Override
-        public String getChannelType() {
-            return "direct";
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/transport/InboundHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/InboundHandlerTests.java
@@ -198,7 +198,6 @@ public class InboundHandlerTests extends ESTestCase {
 
         TransportChannel transportChannel = channelCaptor.get();
         assertEquals(TransportVersion.current(), transportChannel.getVersion());
-        assertEquals("transport", transportChannel.getChannelType());
         assertEquals(requestValue, requestCaptor.get().value);
 
         String responseValue = randomAlphaOfLength(10);

--- a/server/src/test/java/org/elasticsearch/transport/TransportActionProxyTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportActionProxyTests.java
@@ -519,11 +519,6 @@ public class TransportActionProxyTests extends ESTestCase {
         }
 
         @Override
-        public String getChannelType() {
-            return in.getChannelType();
-        }
-
-        @Override
         public void sendResponse(TransportResponse response) throws IOException {
             onResponse.accept(response);
             in.sendResponse(response);

--- a/server/src/test/java/org/elasticsearch/transport/TransportServiceHandshakeTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportServiceHandshakeTests.java
@@ -439,11 +439,6 @@ public class TransportServiceHandshakeTests extends ESTestCase {
                     }
 
                     @Override
-                    public String getChannelType() {
-                        return channel.getChannelType();
-                    }
-
-                    @Override
                     public void sendResponse(TransportResponse response) throws IOException {
                         assertThat(response, instanceOf(TransportService.HandshakeResponse.class));
                         if (modifyBuildHash) {

--- a/test/framework/src/main/java/org/elasticsearch/transport/DisruptableMockTransport.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/DisruptableMockTransport.java
@@ -262,11 +262,6 @@ public abstract class DisruptableMockTransport extends MockTransport {
             }
 
             @Override
-            public String getChannelType() {
-                return "disruptable-mock-transport-channel";
-            }
-
-            @Override
             public void sendResponse(final TransportResponse response) {
                 execute(new RebootSensitiveRunnable() {
                     @Override

--- a/test/framework/src/main/java/org/elasticsearch/transport/TestTransportChannel.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/TestTransportChannel.java
@@ -32,9 +32,4 @@ public class TestTransportChannel implements TransportChannel {
     public void sendResponse(Exception exception) {
         listener.onFailure(exception);
     }
-
-    @Override
-    public String getChannelType() {
-        return "test";
-    }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/exchange/ExchangeServiceTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/exchange/ExchangeServiceTests.java
@@ -468,11 +468,6 @@ public class ExchangeServiceTests extends ESTestCase {
         }
 
         @Override
-        public String getChannelType() {
-            return in.getChannelType();
-        }
-
-        @Override
         public void sendResponse(TransportResponse response) throws IOException {
             in.sendResponse(response);
         }

--- a/x-pack/plugin/snapshot-based-recoveries/src/internalClusterTest/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/SnapshotBasedIndexRecoveryIT.java
+++ b/x-pack/plugin/snapshot-based-recoveries/src/internalClusterTest/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/SnapshotBasedIndexRecoveryIT.java
@@ -695,11 +695,6 @@ public class SnapshotBasedIndexRecoveryIT extends AbstractSnapshotIntegTestCase 
                             }
 
                             @Override
-                            public String getChannelType() {
-                                return channel.getChannelType();
-                            }
-
-                            @Override
                             public void sendResponse(TransportResponse response) {
                                 fail("recovery should not succeed");
                             }


### PR DESCRIPTION
This method is essentially unused. In production it only serves to
distinguish `direct` tasks spawned via transport requests on the local
node from `transport` tasks serving requests from other nodes, but in
practice this is not a useful distinction to make and may even cause
more confusion than it solves.