### PR TITLE
ESQL: Fix rounding error in BlockBenchmark

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/BlockBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/compute/operator/BlockBenchmark.java
@@ -720,7 +720,7 @@ public class BlockBenchmark {
     }
 
     private static long computeDoubleCheckSum(DoubleBlock block, int[] traversalOrder) {
-        double sum = 0;
+        long sum = 0;
 
         for (int position : traversalOrder) {
             if (block.isNull(position)) {
@@ -729,11 +729,12 @@ public class BlockBenchmark {
             int start = block.getFirstValueIndex(position);
             int end = start + block.getValueCount(position);
             for (int i = start; i < end; i++) {
-                sum += block.getDouble(i);
+                // Use an operation that is not affected by rounding errors. Otherwise, the result may depend on the traversalOrder.
+                sum += (long) block.getDouble(i);
             }
         }
 
-        return (long) sum;
+        return sum;
     }
 
     private static long computeIntCheckSum(IntBlock block, int[] traversalOrder) {


### PR DESCRIPTION
When benchmarking access to double blocks, summing the block's double values can depend on the traversal order due to rounding errors.

Round before summing instead to make this deterministic.

On my machine, this seems to add ~0.3ns to the double block benchmark runs (around 1 CPU cycle or so per value). This is not perfect but small enough and avoids running the benchmark for an hour or two and then realizing that the double benchmark run needs to be redone...

Quick, non-optimized run on my _noisy_ machine:
```
Benchmark           (accessType)            (dataTypeAndBlockKind)  Mode  Cnt  Score   Error  Units
BlockBenchmark.run    sequential                      double/array  avgt    4  1.663 ± 0.136  ns/op
BlockBenchmark.run    sequential      double/array-multivalue-null  avgt    4  1.042 ± 0.115  ns/op
BlockBenchmark.run    sequential                  double/big-array  avgt    4  3.197 ± 0.257  ns/op
BlockBenchmark.run    sequential  double/big-array-multivalue-null  avgt    4  1.723 ± 0.099  ns/op
BlockBenchmark.run    sequential                     double/vector  avgt    4  2.418 ± 0.045  ns/op
BlockBenchmark.run    sequential           double/vector-big-array  avgt    4  3.368 ± 0.566  ns/op
BlockBenchmark.run    sequential               double/vector-const  avgt    4  2.081 ± 0.073  ns/op
BlockBenchmark.run        random                      double/array  avgt    4  2.354 ± 0.476  ns/op
BlockBenchmark.run        random      double/array-multivalue-null  avgt    4  1.398 ± 0.222  ns/op
BlockBenchmark.run        random                  double/big-array  avgt    4  4.210 ± 0.996  ns/op
BlockBenchmark.run        random  double/big-array-multivalue-null  avgt    4  2.105 ± 0.361  ns/op
BlockBenchmark.run        random                     double/vector  avgt    4  3.374 ± 0.285  ns/op
BlockBenchmark.run        random           double/vector-big-array  avgt    4  4.376 ± 0.106  ns/op
BlockBenchmark.run        random               double/vector-const  avgt    4  2.215 ± 0.200  ns/op
```
Compare to previous [run here](https://github.com/elastic/elasticsearch/pull/102872#issuecomment-1864160686).