### PR TITLE
Rename `StreamInput#readGenericMap`

### DIFF
--- a/modules/aggregations/src/main/java/org/elasticsearch/aggregations/metric/ArrayValuesSourceAggregationBuilder.java
+++ b/modules/aggregations/src/main/java/org/elasticsearch/aggregations/metric/ArrayValuesSourceAggregationBuilder.java
@@ -110,7 +110,7 @@ public abstract class ArrayValuesSourceAggregationBuilder<AB extends ArrayValues
         fields = (ArrayList<String>) in.readGenericValue();
         userValueTypeHint = in.readOptionalWriteable(ValueType::readFromStream);
         format = in.readOptionalString();
-        missingMap = in.readMap();
+        missingMap = in.readGenericMap();
     }
 
     @Override

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/SearchTemplateRequest.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/SearchTemplateRequest.java
@@ -54,7 +54,7 @@ public class SearchTemplateRequest extends ActionRequest implements CompositeInd
         scriptType = ScriptType.readFrom(in);
         script = in.readOptionalString();
         if (in.readBoolean()) {
-            scriptParams = in.readMap();
+            scriptParams = in.readGenericMap();
         }
     }
 

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RatedRequest.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RatedRequest.java
@@ -179,7 +179,7 @@ public class RatedRequest implements Writeable, ToXContentObject {
         for (int i = 0; i < intentSize; i++) {
             ratedDocs.add(new RatedDocument(in));
         }
-        this.params = in.readMap();
+        this.params = in.readGenericMap();
         int summaryFieldsSize = in.readInt();
         summaryFields = new ArrayList<>(summaryFieldsSize);
         for (int i = 0; i < summaryFieldsSize; i++) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequest.java
@@ -104,7 +104,7 @@ public class CreateSnapshotRequest extends MasterNodeRequest<CreateSnapshotReque
         includeGlobalState = in.readBoolean();
         waitForCompletion = in.readBoolean();
         partial = in.readBoolean();
-        userMetadata = in.readMap();
+        userMetadata = in.readGenericMap();
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeAction.java
@@ -441,7 +441,7 @@ public class AnalyzeAction extends ActionType<AnalyzeAction.Response> {
                 positionLength = 1;
             }
             type = in.readOptionalString();
-            attributes = in.readMap();
+            attributes = in.readGenericMap();
         }
 
         public String getTerm() {

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesNodeRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesNodeRequest.java
@@ -54,7 +54,7 @@ class FieldCapabilitiesNodeRequest extends ActionRequest implements IndicesReque
         originalIndices = OriginalIndices.readOriginalIndices(in);
         indexFilter = in.readOptionalNamedWriteable(QueryBuilder.class);
         nowInMillis = in.readLong();
-        runtimeFields = in.readMap();
+        runtimeFields = in.readGenericMap();
     }
 
     FieldCapabilitiesNodeRequest(

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesRequest.java
@@ -57,7 +57,7 @@ public final class FieldCapabilitiesRequest extends ActionRequest implements Ind
         includeUnmapped = in.readBoolean();
         indexFilter = in.readOptionalNamedWriteable(QueryBuilder.class);
         nowInMillis = in.readOptionalLong();
-        runtimeFields = in.readMap();
+        runtimeFields = in.readGenericMap();
         if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_2_0)) {
             filters = in.readStringArray();
             types = in.readStringArray();

--- a/server/src/main/java/org/elasticsearch/action/ingest/WriteableIngestDocument.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/WriteableIngestDocument.java
@@ -103,7 +103,7 @@ final class WriteableIngestDocument implements Writeable, ToXContentFragment {
     }
 
     WriteableIngestDocument(StreamInput in) throws IOException {
-        this(in.readMap(), in.readMap());
+        this(in.readGenericMap(), in.readGenericMap());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/termvectors/TermVectorsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/termvectors/TermVectorsRequest.java
@@ -156,7 +156,7 @@ public final class TermVectorsRequest extends SingleShardRequest<TermVectorsRequ
             }
         }
         if (in.readBoolean()) {
-            perFieldAnalyzer = readPerFieldAnalyzer(in.readMap());
+            perFieldAnalyzer = readPerFieldAnalyzer(in.readGenericMap());
         }
         if (in.readBoolean()) {
             filterSettings = new FilterSettings();

--- a/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
+++ b/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
@@ -908,7 +908,7 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
             final Map<ShardId, ShardSnapshotStatus> shards = in.readImmutableMap(ShardId::new, ShardSnapshotStatus::readFrom);
             final long repositoryStateId = in.readLong();
             final String failure = in.readOptionalString();
-            final Map<String, Object> userMetadata = in.readMap();
+            final Map<String, Object> userMetadata = in.readGenericMap();
             final IndexVersion version = IndexVersion.readVersion(in);
             final List<String> dataStreams = in.readStringCollectionAsImmutableList();
             final SnapshotId source = in.readOptionalWriteable(SnapshotId::new);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ComponentTemplate.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ComponentTemplate.java
@@ -88,7 +88,7 @@ public class ComponentTemplate implements SimpleDiffable<ComponentTemplate>, ToX
         this.template = new Template(in);
         this.version = in.readOptionalVLong();
         if (in.readBoolean()) {
-            this.metadata = in.readMap();
+            this.metadata = in.readGenericMap();
         } else {
             this.metadata = null;
         }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplate.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplate.java
@@ -145,7 +145,7 @@ public class ComposableIndexTemplate implements SimpleDiffable<ComposableIndexTe
         this.componentTemplates = in.readOptionalStringCollectionAsList();
         this.priority = in.readOptionalVLong();
         this.version = in.readOptionalVLong();
-        this.metadata = in.readMap();
+        this.metadata = in.readGenericMap();
         this.dataStreamTemplate = in.readOptionalWriteable(DataStreamTemplate::new);
         this.allowAutoCreate = in.readOptionalBoolean();
         if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_7_0)) {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
@@ -859,7 +859,7 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
             readName(in),
             readIndices(in),
             in.readVLong(),
-            in.readMap(),
+            in.readGenericMap(),
             in.readBoolean(),
             in.readBoolean(),
             in.readBoolean(),

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DiffableStringMap.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DiffableStringMap.java
@@ -34,7 +34,7 @@ public class DiffableStringMap extends AbstractMap<String, String> implements Di
 
     @SuppressWarnings("unchecked")
     public static DiffableStringMap readFrom(StreamInput in) throws IOException {
-        final Map<String, String> map = (Map) in.readMap();
+        final Map<String, String> map = (Map) in.readGenericMap();
         return map.isEmpty() ? EMPTY : new DiffableStringMap(map);
     }
 

--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -694,7 +694,7 @@ public abstract class StreamInput extends InputStream {
      */
     @Nullable
     @SuppressWarnings("unchecked")
-    public Map<String, Object> readMap() throws IOException {
+    public Map<String, Object> readGenericMap() throws IOException {
         return (Map<String, Object>) readGenericValue();
     }
 

--- a/server/src/main/java/org/elasticsearch/script/Script.java
+++ b/server/src/main/java/org/elasticsearch/script/Script.java
@@ -556,9 +556,9 @@ public final class Script implements ToXContentObject, Writeable {
         this.lang = in.readOptionalString();
         this.idOrCode = in.readString();
         @SuppressWarnings("unchecked")
-        Map<String, String> options = (Map<String, String>) (Map) in.readMap();
+        Map<String, String> options = (Map<String, String>) (Map) in.readGenericMap();
         this.options = options;
-        this.params = in.readMap();
+        this.params = in.readGenericMap();
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/script/StoredScriptSource.java
+++ b/server/src/main/java/org/elasticsearch/script/StoredScriptSource.java
@@ -289,7 +289,7 @@ public class StoredScriptSource implements SimpleDiffable<StoredScriptSource>, W
         this.lang = in.readString();
         this.source = in.readString();
         @SuppressWarnings("unchecked")
-        Map<String, String> options = (Map<String, String>) (Map) in.readMap();
+        Map<String, String> options = (Map<String, String>) (Map) in.readGenericMap();
         this.options = options;
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AbstractAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AbstractAggregationBuilder.java
@@ -48,7 +48,7 @@ public abstract class AbstractAggregationBuilder<AB extends AbstractAggregationB
     protected AbstractAggregationBuilder(StreamInput in) throws IOException {
         super(in.readString());
         factoriesBuilder = new AggregatorFactories.Builder(in);
-        metadata = in.readMap();
+        metadata = in.readGenericMap();
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/InternalAggregation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/InternalAggregation.java
@@ -50,7 +50,7 @@ public abstract class InternalAggregation implements Aggregation, NamedWriteable
      */
     protected InternalAggregation(StreamInput in) throws IOException {
         name = in.readString();
-        metadata = in.readMap();
+        metadata = in.readGenericMap();
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregationBuilder.java
@@ -108,7 +108,7 @@ public class CompositeAggregationBuilder extends AbstractAggregationBuilder<Comp
         }
         this.size = in.readVInt();
         if (in.readBoolean()) {
-            this.after = in.readMap();
+            this.after = in.readGenericMap();
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricAggregationBuilder.java
@@ -94,7 +94,7 @@ public class ScriptedMetricAggregationBuilder extends AbstractAggregationBuilder
         combineScript = in.readOptionalWriteable(Script::new);
         reduceScript = in.readOptionalWriteable(Script::new);
         if (in.readBoolean()) {
-            params = in.readMap();
+            params = in.readGenericMap();
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/AbstractPipelineAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/AbstractPipelineAggregationBuilder.java
@@ -45,7 +45,7 @@ public abstract class AbstractPipelineAggregationBuilder<PAB extends AbstractPip
      */
     protected AbstractPipelineAggregationBuilder(StreamInput in, String type) throws IOException {
         this(in.readString(), type, in.readStringArray());
-        metadata = in.readMap();
+        metadata = in.readGenericMap();
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -260,7 +260,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
             fetchFields = in.readCollectionAsList(FieldAndFormat::new);
         }
         pointInTimeBuilder = in.readOptionalWriteable(PointInTimeBuilder::new);
-        runtimeMappings = in.readMap();
+        runtimeMappings = in.readGenericMap();
         if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_4_0)) {
             if (in.getTransportVersion().before(TransportVersions.V_8_7_0)) {
                 KnnSearchBuilder searchBuilder = in.readOptionalWriteable(KnnSearchBuilder::new);

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/AbstractHighlighterBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/AbstractHighlighterBuilder.java
@@ -158,7 +158,7 @@ public abstract class AbstractHighlighterBuilder<HB extends AbstractHighlighterB
         noMatchSize(in.readOptionalVInt());
         phraseLimit(in.readOptionalVInt());
         if (in.readBoolean()) {
-            options(in.readMap());
+            options(in.readGenericMap());
         }
         requireFieldMatch(in.readOptionalBoolean());
         maxAnalyzedOffset(in.readOptionalInt());

--- a/server/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilder.java
@@ -127,7 +127,7 @@ public class PhraseSuggestionBuilder extends SuggestionBuilder<PhraseSuggestionB
         if (in.readBoolean()) {
             collateQuery = new Script(in);
         }
-        collateParams = in.readMap();
+        collateParams = in.readGenericMap();
         collatePrune = in.readOptionalBoolean();
         int generatorsEntries = in.readVInt();
         for (int i = 0; i < generatorsEntries; i++) {

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
@@ -512,7 +512,7 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContentF
         final List<SnapshotShardFailure> shardFailures = in.readCollectionAsImmutableList(SnapshotShardFailure::new);
         final IndexVersion version = in.readBoolean() ? IndexVersion.readVersion(in) : null;
         final Boolean includeGlobalState = in.readOptionalBoolean();
-        final Map<String, Object> userMetadata = in.readMap();
+        final Map<String, Object> userMetadata = in.readGenericMap();
         final List<String> dataStreams = in.readStringCollectionAsImmutableList();
         final List<SnapshotFeatureInfo> featureStates = in.readCollectionAsImmutableList(SnapshotFeatureInfo::new);
         final Map<String, IndexSnapshotDetails> indexSnapshotDetails = in.readImmutableMap(IndexSnapshotDetails::new);

--- a/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrationTaskState.java
+++ b/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrationTaskState.java
@@ -62,7 +62,7 @@ public class SystemIndexMigrationTaskState implements PersistentTaskState {
     public SystemIndexMigrationTaskState(StreamInput in) throws IOException {
         this.currentIndex = in.readString();
         this.currentFeature = in.readString();
-        this.featureCallbackMetadata = in.readMap();
+        this.featureCallbackMetadata = in.readGenericMap();
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
@@ -692,7 +692,7 @@ public class BytesStreamsTests extends ESTestCase {
         try (TestStreamOutput streamOut = new TestStreamOutput()) {
             streamOut.writeMapWithConsistentOrder(streamOutMap);
             StreamInput in = StreamInput.wrap(BytesReference.toBytes(streamOut.bytes()));
-            Map<String, Object> streamInMap = in.readMap();
+            Map<String, Object> streamInMap = in.readGenericMap();
             assertEquals(streamOutMap, streamInMap);
         }
     }

--- a/server/src/test/java/org/elasticsearch/common/io/stream/RecyclerBytesStreamOutputTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/RecyclerBytesStreamOutputTests.java
@@ -788,7 +788,7 @@ public class RecyclerBytesStreamOutputTests extends ESTestCase {
         try (RecyclerBytesStreamOutput streamOut = new RecyclerBytesStreamOutput(recycler)) {
             streamOut.writeMapWithConsistentOrder(streamOutMap);
             StreamInput in = StreamInput.wrap(BytesReference.toBytes(streamOut.bytes()));
-            Map<String, Object> streamInMap = in.readMap();
+            Map<String, Object> streamInMap = in.readGenericMap();
             assertEquals(streamOutMap, streamInMap);
         }
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/XPackInfoResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/XPackInfoResponse.java
@@ -362,7 +362,7 @@ public class XPackInfoResponse extends ActionResponse implements ToXContentObjec
             public FeatureSet(StreamInput in) throws IOException {
                 this(in.readString(), readAvailable(in), in.readBoolean());
                 if (in.getTransportVersion().before(TransportVersions.V_8_0_0)) {
-                    in.readMap(); // backcompat reading native code info, but no longer used here
+                    in.readGenericMap(); // backcompat reading native code info, but no longer used here
                 }
             }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/HealthApiFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/HealthApiFeatureSetUsage.java
@@ -77,7 +77,7 @@ public class HealthApiFeatureSetUsage extends XPackFeatureSet.Usage {
 
     public HealthApiFeatureSetUsage(StreamInput in) throws IOException {
         super(in);
-        usageStats = in.readMap();
+        usageStats = in.readGenericMap();
     }
 
     public HealthApiFeatureSetUsage(boolean available, boolean enabled, @Nullable Counters stats) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/application/EnterpriseSearchFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/application/EnterpriseSearchFeatureSetUsage.java
@@ -54,14 +54,14 @@ public class EnterpriseSearchFeatureSetUsage extends XPackFeatureSet.Usage {
 
     public EnterpriseSearchFeatureSetUsage(StreamInput in) throws IOException {
         super(in);
-        this.searchApplicationsUsage = in.readMap();
+        this.searchApplicationsUsage = in.readGenericMap();
         Map<String, Object> analyticsCollectionsUsage = new HashMap<>();
         Map<String, Object> queryRulesUsage = new HashMap<>();
         if (in.getTransportVersion().onOrAfter(QUERY_RULES_TRANSPORT_VERSION)) {
-            analyticsCollectionsUsage = in.readMap();
-            queryRulesUsage = in.readMap();
+            analyticsCollectionsUsage = in.readGenericMap();
+            queryRulesUsage = in.readGenericMap();
         } else if (in.getTransportVersion().onOrAfter(BEHAVIORAL_ANALYTICS_TRANSPORT_VERSION)) {
-            analyticsCollectionsUsage = in.readMap();
+            analyticsCollectionsUsage = in.readGenericMap();
         }
         this.analyticsCollectionsUsage = analyticsCollectionsUsage;
         this.queryRulesUsage = queryRulesUsage;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/deprecation/DeprecationIssue.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/deprecation/DeprecationIssue.java
@@ -98,7 +98,7 @@ public class DeprecationIssue implements Writeable, ToXContentObject {
         url = in.readString();
         details = in.readOptionalString();
         resolveDuringRollingUpgrade = in.readBoolean();
-        meta = in.readMap();
+        meta = in.readGenericMap();
     }
 
     public Level getLevel() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/eql/EqlFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/eql/EqlFeatureSetUsage.java
@@ -24,7 +24,7 @@ public class EqlFeatureSetUsage extends XPackFeatureSet.Usage {
 
     public EqlFeatureSetUsage(StreamInput in) throws IOException {
         super(in);
-        stats = in.readMap();
+        stats = in.readGenericMap();
     }
 
     public EqlFeatureSetUsage(Map<String, Object> stats) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/esql/EsqlFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/esql/EsqlFeatureSetUsage.java
@@ -24,7 +24,7 @@ public class EsqlFeatureSetUsage extends XPackFeatureSet.Usage {
 
     public EsqlFeatureSetUsage(StreamInput in) throws IOException {
         super(in);
-        stats = in.readMap();
+        stats = in.readGenericMap();
     }
 
     public EsqlFeatureSetUsage(Map<String, Object> stats) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicy.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicy.java
@@ -109,7 +109,7 @@ public class LifecyclePolicy implements SimpleDiffable<LifecyclePolicy>, ToXCont
         type = in.readNamedWriteable(LifecycleType.class);
         name = in.readString();
         phases = in.readImmutableMap(Phase::new);
-        this.metadata = in.readMap();
+        this.metadata = in.readGenericMap();
         if (in.getTransportVersion().onOrAfter(TransportVersions.DEPRECATED_COMPONENT_TEMPLATES_ADDED)) {
             this.deprecated = in.readOptionalBoolean();
         } else {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/action/InferenceAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/action/InferenceAction.java
@@ -83,7 +83,7 @@ public class InferenceAction extends ActionType<InferenceAction.Response> {
             } else {
                 this.input = List.of(in.readString());
             }
-            this.taskSettings = in.readMap();
+            this.taskSettings = in.readGenericMap();
         }
 
         public TaskType getTaskType() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MachineLearningFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MachineLearningFeatureSetUsage.java
@@ -57,10 +57,10 @@ public class MachineLearningFeatureSetUsage extends XPackFeatureSet.Usage {
 
     public MachineLearningFeatureSetUsage(StreamInput in) throws IOException {
         super(in);
-        this.jobsUsage = in.readMap();
-        this.datafeedsUsage = in.readMap();
-        this.analyticsUsage = in.readMap();
-        this.inferenceUsage = in.readMap();
+        this.jobsUsage = in.readGenericMap();
+        this.datafeedsUsage = in.readGenericMap();
+        this.analyticsUsage = in.readGenericMap();
+        this.inferenceUsage = in.readGenericMap();
         this.nodeCount = in.readInt();
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/CoordinatedInferenceAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/CoordinatedInferenceAction.java
@@ -125,8 +125,8 @@ public class CoordinatedInferenceAction extends ActionType<InferModelAction.Resp
             this.modelId = in.readString();
             this.requestModelType = in.readEnum(RequestModelType.class);
             this.inputs = in.readOptionalStringCollectionAsList();
-            this.taskSettings = in.readMap();
-            this.objectsToInfer = in.readOptionalCollectionAsList(StreamInput::readMap);
+            this.taskSettings = in.readGenericMap();
+            this.objectsToInfer = in.readOptionalCollectionAsList(StreamInput::readGenericMap);
             this.inferenceConfigUpdate = in.readOptionalNamedWriteable(InferenceConfigUpdate.class);
             this.previouslyLicensed = in.readOptionalBoolean();
             this.inferenceTimeout = in.readOptionalTimeValue();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferModelAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferModelAction.java
@@ -176,7 +176,7 @@ public class InferModelAction extends ActionType<InferModelAction.Response> {
         public Request(StreamInput in) throws IOException {
             super(in);
             this.id = in.readString();
-            this.objectsToInfer = in.readCollectionAsImmutableList(StreamInput::readMap);
+            this.objectsToInfer = in.readCollectionAsImmutableList(StreamInput::readGenericMap);
             this.update = in.readNamedWriteable(InferenceConfigUpdate.class);
             this.previouslyLicensed = in.readBoolean();
             if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_3_0)) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferTrainedModelDeploymentAction.java
@@ -147,7 +147,7 @@ public class InferTrainedModelDeploymentAction extends ActionType<InferTrainedMo
         public Request(StreamInput in) throws IOException {
             super(in);
             id = in.readString();
-            docs = in.readCollectionAsImmutableList(StreamInput::readMap);
+            docs = in.readCollectionAsImmutableList(StreamInput::readGenericMap);
             update = in.readOptionalNamedWriteable(InferenceConfigUpdate.class);
             inferenceTimeout = in.readOptionalTimeValue();
             if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_3_0)) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/MlInfoAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/MlInfoAction.java
@@ -59,7 +59,7 @@ public class MlInfoAction extends ActionType<MlInfoAction.Response> {
 
         public Response(StreamInput in) throws IOException {
             super(in);
-            info = in.readMap();
+            info = in.readGenericMap();
         }
 
         public Map<String, Object> getInfo() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PreviewDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PreviewDataFrameAnalyticsAction.java
@@ -143,7 +143,7 @@ public class PreviewDataFrameAnalyticsAction extends ActionType<PreviewDataFrame
 
         public Response(StreamInput in) throws IOException {
             super(in);
-            this.featureValues = in.readCollectionAsList(StreamInput::readMap);
+            this.featureValues = in.readCollectionAsList(StreamInput::readGenericMap);
         }
 
         public List<Map<String, Object>> getFeatureValues() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/AggProvider.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/AggProvider.java
@@ -114,7 +114,7 @@ class AggProvider implements Writeable, ToXContentObject {
 
     static AggProvider fromStream(StreamInput in) throws IOException {
         return new AggProvider(
-            in.readMap(),
+            in.readGenericMap(),
             in.readOptionalWriteable(AggregatorFactories.Builder::new),
             in.readException(),
             in.getTransportVersion().onOrAfter(TransportVersions.V_8_0_0) ? in.readBoolean() : false

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
@@ -300,7 +300,7 @@ public class DatafeedConfig implements SimpleDiffable<DatafeedConfig>, ToXConten
         delayedDataCheckConfig = in.readOptionalWriteable(DelayedDataCheckConfig::new);
         maxEmptySearches = in.readOptionalVInt();
         indicesOptions = IndicesOptions.readIndicesOptions(in);
-        runtimeMappings = in.readMap();
+        runtimeMappings = in.readGenericMap();
     }
 
     /**
@@ -815,7 +815,7 @@ public class DatafeedConfig implements SimpleDiffable<DatafeedConfig>, ToXConten
             if (in.readBoolean()) {
                 indicesOptions = IndicesOptions.readIndicesOptions(in);
             }
-            runtimeMappings = in.readMap();
+            runtimeMappings = in.readGenericMap();
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedUpdate.java
@@ -166,7 +166,7 @@ public class DatafeedUpdate implements Writeable, ToXContentObject {
         delayedDataCheckConfig = in.readOptionalWriteable(DelayedDataCheckConfig::new);
         maxEmptySearches = in.readOptionalInt();
         indicesOptions = in.readBoolean() ? IndicesOptions.readIndicesOptions(in) : null;
-        this.runtimeMappings = in.readBoolean() ? in.readMap() : null;
+        this.runtimeMappings = in.readBoolean() ? in.readGenericMap() : null;
     }
 
     /**

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java
@@ -192,7 +192,7 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
         this.allowLazyStart = in.readBoolean();
         this.maxNumThreads = in.readVInt();
         if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_8_0)) {
-            Map<String, Object> readMeta = in.readMap();
+            Map<String, Object> readMeta = in.readGenericMap();
             this.meta = readMeta == null ? null : Collections.unmodifiableMap(readMeta);
         } else {
             this.meta = null;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfigUpdate.java
@@ -84,7 +84,7 @@ public class DataFrameAnalyticsConfigUpdate implements Writeable, ToXContentObje
         this.allowLazyStart = in.readOptionalBoolean();
         this.maxNumThreads = in.readOptionalVInt();
         if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_8_0)) {
-            Map<String, Object> readMeta = in.readMap();
+            Map<String, Object> readMeta = in.readGenericMap();
             this.meta = readMeta == null ? null : Collections.unmodifiableMap(readMeta);
         } else {
             this.meta = null;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsSource.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsSource.java
@@ -107,7 +107,7 @@ public class DataFrameAnalyticsSource implements Writeable, ToXContentObject {
         index = in.readStringArray();
         queryProvider = QueryProvider.fromStream(in);
         sourceFiltering = in.readOptionalWriteable(FetchSourceContext::readFrom);
-        runtimeMappings = in.readMap();
+        runtimeMappings = in.readGenericMap();
     }
 
     public DataFrameAnalyticsSource(DataFrameAnalyticsSource other) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfig.java
@@ -271,7 +271,7 @@ public class TrainedModelConfig implements ToXContentObject, Writeable {
         createTime = in.readInstant();
         definition = in.readOptionalWriteable(LazyModelDefinition::fromStreamInput);
         tags = in.readCollectionAsImmutableList(StreamInput::readString);
-        metadata = in.readMap();
+        metadata = in.readGenericMap();
         input = new TrainedModelInput(in);
         modelSize = in.readVLong();
         estimatedOperations = in.readVLong();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/LearningToRankConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/LearningToRankConfig.java
@@ -98,7 +98,7 @@ public class LearningToRankConfig extends RegressionConfig implements Rewriteabl
     public LearningToRankConfig(StreamInput in) throws IOException {
         super(in);
         this.featureExtractorBuilders = in.readNamedWriteableCollectionAsList(LearningToRankFeatureExtractorBuilder.class);
-        this.paramsDefaults = in.readMap();
+        this.paramsDefaults = in.readGenericMap();
     }
 
     public List<LearningToRankFeatureExtractorBuilder> getFeatureExtractorBuilders() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ModelPackageConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/ModelPackageConfig.java
@@ -173,8 +173,8 @@ public class ModelPackageConfig implements ToXContentObject, Writeable {
         this.createTime = in.readOptionalInstant();
         this.size = in.readVLong();
         this.sha256 = in.readOptionalString();
-        this.inferenceConfigSource = in.readMap();
-        this.metadata = in.readMap();
+        this.inferenceConfigSource = in.readGenericMap();
+        this.metadata = in.readGenericMap();
         this.modelType = in.readOptionalString();
         this.tags = in.readOptionalCollectionAsList(StreamInput::readString);
         this.vocabularyFile = in.readOptionalString();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Job.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/Job.java
@@ -291,7 +291,7 @@ public class Job implements SimpleDiffable<Job>, Writeable, ToXContentObject {
         modelSnapshotRetentionDays = in.readOptionalLong();
         dailyModelSnapshotRetentionAfterDays = in.readOptionalLong();
         resultsRetentionDays = in.readOptionalLong();
-        Map<String, Object> readCustomSettings = in.readMap();
+        Map<String, Object> readCustomSettings = in.readGenericMap();
         customSettings = readCustomSettings == null ? null : Collections.unmodifiableMap(readCustomSettings);
         modelSnapshotId = in.readOptionalString();
         if (in.readBoolean()) {
@@ -843,7 +843,7 @@ public class Job implements SimpleDiffable<Job>, Writeable, ToXContentObject {
             modelSnapshotRetentionDays = in.readOptionalLong();
             dailyModelSnapshotRetentionAfterDays = in.readOptionalLong();
             resultsRetentionDays = in.readOptionalLong();
-            customSettings = in.readMap();
+            customSettings = in.readGenericMap();
             modelSnapshotId = in.readOptionalString();
             if (in.readBoolean()) {
                 modelSnapshotMinVersion = MlConfigVersion.readVersion(in);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/JobUpdate.java
@@ -178,7 +178,7 @@ public class JobUpdate implements Writeable, ToXContentObject {
             categorizationFilters = null;
         }
         perPartitionCategorizationConfig = in.readOptionalWriteable(PerPartitionCategorizationConfig::new);
-        customSettings = in.readMap();
+        customSettings = in.readGenericMap();
         modelSnapshotId = in.readOptionalString();
         if (in.readBoolean()) {
             jobVersion = MlConfigVersion.readVersion(in);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/QueryProvider.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/QueryProvider.java
@@ -73,7 +73,7 @@ public class QueryProvider implements Writeable, ToXContentObject, Rewriteable<Q
     }
 
     public static QueryProvider fromStream(StreamInput in) throws IOException {
-        return new QueryProvider(in.readMap(), in.readOptionalNamedWriteable(QueryBuilder.class), in.readException());
+        return new QueryProvider(in.readGenericMap(), in.readOptionalNamedWriteable(QueryBuilder.class), in.readException());
     }
 
     QueryProvider(Map<String, Object> query, QueryBuilder parsedQuery, Exception parsingException) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/monitoring/MonitoringFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/monitoring/MonitoringFeatureSetUsage.java
@@ -28,7 +28,7 @@ public class MonitoringFeatureSetUsage extends XPackFeatureSet.Usage {
 
     public MonitoringFeatureSetUsage(StreamInput in) throws IOException {
         super(in);
-        exporters = in.readMap();
+        exporters = in.readGenericMap();
         collectionEnabled = in.readOptionalBoolean();
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/RollupJobCaps.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/RollupJobCaps.java
@@ -211,7 +211,7 @@ public class RollupJobCaps implements Writeable, ToXContentObject {
             int size = in.readInt();
             List<Map<String, Object>> inAggs = new ArrayList<>(size);
             for (int i = 0; i < size; i++) {
-                inAggs.add(in.readMap());
+                inAggs.add(in.readGenericMap());
             }
             this.aggs = Collections.unmodifiableList(inAggs);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/job/RollupJobStatus.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/job/RollupJobStatus.java
@@ -74,7 +74,7 @@ public class RollupJobStatus implements Task.Status, PersistentTaskState {
 
     public RollupJobStatus(StreamInput in) throws IOException {
         state = IndexerState.fromStream(in);
-        currentPosition = in.readBoolean() ? new TreeMap<>(in.readMap()) : null;
+        currentPosition = in.readBoolean() ? new TreeMap<>(in.readGenericMap()) : null;
         if (in.getTransportVersion().before(TransportVersions.V_8_0_0)) {
             // 7.x nodes serialize `upgradedDocumentID` flag. We don't need it anymore, but
             // we need to pull it off the stream

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/SecurityFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/SecurityFeatureSetUsage.java
@@ -52,31 +52,31 @@ public class SecurityFeatureSetUsage extends XPackFeatureSet.Usage {
 
     public SecurityFeatureSetUsage(StreamInput in) throws IOException {
         super(in);
-        realmsUsage = in.readMap();
-        rolesStoreUsage = in.readMap();
-        sslUsage = in.readMap();
+        realmsUsage = in.readGenericMap();
+        rolesStoreUsage = in.readGenericMap();
+        sslUsage = in.readGenericMap();
         if (in.getTransportVersion().onOrAfter(TransportVersions.V_7_2_0)) {
-            tokenServiceUsage = in.readMap();
-            apiKeyServiceUsage = in.readMap();
+            tokenServiceUsage = in.readGenericMap();
+            apiKeyServiceUsage = in.readGenericMap();
         }
-        auditUsage = in.readMap();
-        ipFilterUsage = in.readMap();
-        anonymousUsage = in.readMap();
-        roleMappingStoreUsage = in.readMap();
+        auditUsage = in.readGenericMap();
+        ipFilterUsage = in.readGenericMap();
+        anonymousUsage = in.readGenericMap();
+        roleMappingStoreUsage = in.readGenericMap();
         if (in.getTransportVersion().onOrAfter(TransportVersions.V_7_5_0)) {
-            fips140Usage = in.readMap();
+            fips140Usage = in.readGenericMap();
         }
         if (in.getTransportVersion().onOrAfter(TransportVersions.V_7_11_0)) {
-            operatorPrivilegesUsage = in.readMap();
+            operatorPrivilegesUsage = in.readGenericMap();
         }
         if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_2_0)) {
-            domainsUsage = in.readMap();
+            domainsUsage = in.readGenericMap();
         }
         if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_5_0)) {
-            userProfileUsage = in.readMap();
+            userProfileUsage = in.readGenericMap();
         }
         if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_8_0)) {
-            remoteClusterServerUsage = in.readMap();
+            remoteClusterServerUsage = in.readGenericMap();
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/ApiKey.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/ApiKey.java
@@ -191,7 +191,7 @@ public final class ApiKey implements ToXContentObject, Writeable {
         this.username = in.readString();
         this.realm = in.readString();
         if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_0_0)) {
-            this.metadata = in.readMap();
+            this.metadata = in.readGenericMap();
         } else {
             this.metadata = Map.of();
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/BaseUpdateApiKeyRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/BaseUpdateApiKeyRequest.java
@@ -46,7 +46,7 @@ public abstract class BaseUpdateApiKeyRequest extends ActionRequest {
     public BaseUpdateApiKeyRequest(StreamInput in) throws IOException {
         super(in);
         this.roleDescriptors = in.readOptionalCollectionAsList(RoleDescriptor::new);
-        this.metadata = in.readMap();
+        this.metadata = in.readGenericMap();
         if (in.getTransportVersion().onOrAfter(TransportVersions.UPDATE_API_KEY_EXPIRATION_TIME_ADDED)) {
             expiration = in.readOptionalTimeValue();
         } else {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/CreateApiKeyRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/CreateApiKeyRequest.java
@@ -66,7 +66,7 @@ public final class CreateApiKeyRequest extends AbstractCreateApiKeyRequest {
         this.roleDescriptors = in.readCollectionAsImmutableList(RoleDescriptor::new);
         this.refreshPolicy = WriteRequest.RefreshPolicy.readFrom(in);
         if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_0_0)) {
-            this.metadata = in.readMap();
+            this.metadata = in.readGenericMap();
         } else {
             this.metadata = null;
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/CreateCrossClusterApiKeyRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/CreateCrossClusterApiKeyRequest.java
@@ -43,7 +43,7 @@ public final class CreateCrossClusterApiKeyRequest extends AbstractCreateApiKeyR
         this.expiration = in.readOptionalTimeValue();
         this.roleDescriptors = in.readCollectionAsImmutableList(RoleDescriptor::new);
         this.refreshPolicy = WriteRequest.RefreshPolicy.readFrom(in);
-        this.metadata = in.readMap();
+        this.metadata = in.readGenericMap();
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/profile/Profile.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/profile/Profile.java
@@ -108,7 +108,15 @@ public record Profile(
     }
 
     public Profile(StreamInput in) throws IOException {
-        this(in.readString(), in.readBoolean(), in.readLong(), new ProfileUser(in), in.readMap(), in.readMap(), new VersionControl(in));
+        this(
+            in.readString(),
+            in.readBoolean(),
+            in.readLong(),
+            new ProfileUser(in),
+            in.readGenericMap(),
+            in.readGenericMap(),
+            new VersionControl(in)
+        );
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/profile/UpdateProfileDataRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/profile/UpdateProfileDataRequest.java
@@ -50,8 +50,8 @@ public class UpdateProfileDataRequest extends ActionRequest {
     public UpdateProfileDataRequest(StreamInput in) throws IOException {
         super(in);
         this.uid = in.readString();
-        this.labels = in.readMap();
-        this.data = in.readMap();
+        this.labels = in.readGenericMap();
+        this.data = in.readGenericMap();
         this.ifPrimaryTerm = in.readLong();
         this.ifSeqNo = in.readLong();
         this.refreshPolicy = RefreshPolicy.readFrom(in);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/PutRoleRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/PutRoleRequest.java
@@ -58,7 +58,7 @@ public class PutRoleRequest extends ActionRequest implements WriteRequest<PutRol
         configurableClusterPrivileges = ConfigurableClusterPrivileges.readArray(in);
         runAs = in.readStringArray();
         refreshPolicy = RefreshPolicy.readFrom(in);
-        metadata = in.readMap();
+        metadata = in.readGenericMap();
         if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_8_0)) {
             remoteIndicesPrivileges = in.readCollectionAsList(RoleDescriptor.RemoteIndicesPrivileges::new);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/rolemapping/PutRoleMappingRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/rolemapping/PutRoleMappingRequest.java
@@ -51,7 +51,7 @@ public class PutRoleMappingRequest extends ActionRequest implements WriteRequest
             this.roleTemplates = in.readCollectionAsList(TemplateRoleName::new);
         }
         this.rules = ExpressionParser.readExpression(in);
-        this.metadata = in.readMap();
+        this.metadata = in.readGenericMap();
         this.refreshPolicy = RefreshPolicy.readFrom(in);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/settings/UpdateSecuritySettingsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/settings/UpdateSecuritySettingsAction.java
@@ -78,9 +78,9 @@ public class UpdateSecuritySettingsAction extends ActionType<AcknowledgedRespons
         }
 
         public Request(StreamInput in) throws IOException {
-            this.mainIndexSettings = in.readMap();
-            this.tokensIndexSettings = in.readMap();
-            this.profilesIndexSettings = in.readMap();
+            this.mainIndexSettings = in.readGenericMap();
+            this.tokensIndexSettings = in.readGenericMap();
+            this.profilesIndexSettings = in.readGenericMap();
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/PutUserRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/PutUserRequest.java
@@ -44,7 +44,7 @@ public class PutUserRequest extends ActionRequest implements UserRequest, WriteR
         roles = in.readStringArray();
         fullName = in.readOptionalString();
         email = in.readOptionalString();
-        metadata = in.readBoolean() ? in.readMap() : null;
+        metadata = in.readBoolean() ? in.readGenericMap() : null;
         refreshPolicy = RefreshPolicy.readFrom(in);
         enabled = in.readBoolean();
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Authentication.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Authentication.java
@@ -757,7 +757,7 @@ public final class Authentication implements ToXContentObject {
             }
             return metadata;
         } else {
-            return in.readMap();
+            return in.readGenericMap();
         }
     }
 
@@ -1467,7 +1467,7 @@ public final class Authentication implements ToXContentObject {
                 return InternalUsers.getUser(username);
             }
             String[] roles = input.readStringArray();
-            Map<String, Object> metadata = input.readMap();
+            Map<String, Object> metadata = input.readGenericMap();
             String fullName = input.readOptionalString();
             String email = input.readOptionalString();
             boolean enabled = input.readBoolean();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/mapper/ExpressionRoleMapping.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/mapper/ExpressionRoleMapping.java
@@ -102,7 +102,7 @@ public class ExpressionRoleMapping implements ToXContentObject, Writeable {
             this.roleTemplates = Collections.emptyList();
         }
         this.expression = ExpressionParser.readExpression(in);
-        this.metadata = in.readMap();
+        this.metadata = in.readGenericMap();
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/RoleDescriptor.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/RoleDescriptor.java
@@ -188,8 +188,8 @@ public class RoleDescriptor implements ToXContentObject, Writeable {
             indicesPrivileges[i] = new IndicesPrivileges(in);
         }
         this.runAs = in.readStringArray();
-        this.metadata = in.readMap();
-        this.transientMetadata = in.readMap();
+        this.metadata = in.readGenericMap();
+        this.transientMetadata = in.readGenericMap();
 
         this.applicationPrivileges = in.readArray(ApplicationResourcePrivileges::new, ApplicationResourcePrivileges[]::new);
         this.configurableClusterPrivileges = ConfigurableClusterPrivileges.readArray(in);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ApplicationPrivilegeDescriptor.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ApplicationPrivilegeDescriptor.java
@@ -66,7 +66,7 @@ public class ApplicationPrivilegeDescriptor implements ToXContentObject, Writeab
         this.application = input.readString();
         this.name = input.readString();
         this.actions = input.readCollectionAsImmutableSet(StreamInput::readString);
-        this.metadata = Collections.unmodifiableMap(input.readMap());
+        this.metadata = Collections.unmodifiableMap(input.readGenericMap());
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecyclePolicy.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecyclePolicy.java
@@ -99,7 +99,7 @@ public class SnapshotLifecyclePolicy implements SimpleDiffable<SnapshotLifecycle
         this.name = in.readString();
         this.schedule = in.readString();
         this.repository = in.readString();
-        this.configuration = in.readMap();
+        this.configuration = in.readGenericMap();
         this.retentionPolicy = in.readOptionalWriteable(SnapshotRetentionConfiguration::new);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/sql/SqlFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/sql/SqlFeatureSetUsage.java
@@ -24,7 +24,7 @@ public class SqlFeatureSetUsage extends XPackFeatureSet.Usage {
 
     public SqlFeatureSetUsage(StreamInput in) throws IOException {
         super(in);
-        stats = in.readMap();
+        stats = in.readGenericMap();
     }
 
     public SqlFeatureSetUsage(Map<String, Object> stats) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/textstructure/structurefinder/FieldStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/textstructure/structurefinder/FieldStats.java
@@ -123,7 +123,7 @@ public class FieldStats implements ToXContentObject, Writeable {
         medianValue = in.readOptionalDouble();
         earliestTimestamp = in.readOptionalString();
         latestTimestamp = in.readOptionalString();
-        topHits = in.readCollectionAsList(StreamInput::readMap);
+        topHits = in.readCollectionAsList(StreamInput::readGenericMap);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/textstructure/structurefinder/TextStructure.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/textstructure/structurefinder/TextStructure.java
@@ -235,8 +235,8 @@ public class TextStructure implements ToXContentObject, Writeable {
         javaTimestampFormats = in.readBoolean() ? in.readCollectionAsImmutableList(StreamInput::readString) : null;
         timestampField = in.readOptionalString();
         needClientTimezone = in.readBoolean();
-        mappings = Collections.unmodifiableSortedMap(new TreeMap<>(in.readMap()));
-        ingestPipeline = in.readBoolean() ? Collections.unmodifiableMap(in.readMap()) : null;
+        mappings = Collections.unmodifiableSortedMap(new TreeMap<>(in.readGenericMap()));
+        ingestPipeline = in.readBoolean() ? Collections.unmodifiableMap(in.readGenericMap()) : null;
         fieldStats = Collections.unmodifiableSortedMap(new TreeMap<>(in.readMap(FieldStats::new)));
         explanation = in.readCollectionAsImmutableList(StreamInput::readString);
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/PreviewTransformAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/PreviewTransformAction.java
@@ -183,7 +183,7 @@ public class PreviewTransformAction extends ActionType<PreviewTransformAction.Re
             int size = in.readInt();
             this.docs = new ArrayList<>(size);
             for (int i = 0; i < size; i++) {
-                this.docs.add(in.readMap());
+                this.docs.add(in.readGenericMap());
             }
             this.generatedDestIndexSettings = new TransformDestIndexSettings(in);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/QueryConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/QueryConfig.java
@@ -61,7 +61,7 @@ public class QueryConfig implements SimpleDiffable<QueryConfig>, Writeable, ToXC
     }
 
     public QueryConfig(final StreamInput in) throws IOException {
-        this.source = in.readMap();
+        this.source = in.readGenericMap();
         this.query = in.readOptionalNamedWriteable(QueryBuilder.class);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/SourceConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/SourceConfig.java
@@ -111,7 +111,7 @@ public class SourceConfig implements Writeable, ToXContentObject {
     public SourceConfig(final StreamInput in) throws IOException {
         index = in.readStringArray();
         queryConfig = new QueryConfig(in);
-        runtimeMappings = in.readMap();
+        runtimeMappings = in.readGenericMap();
     }
 
     public String[] getIndex() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformCheckpoint.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformCheckpoint.java
@@ -128,7 +128,7 @@ public class TransformCheckpoint implements Writeable, ToXContentObject {
         this.transformId = in.readString();
         this.timestampMillis = in.readLong();
         this.checkpoint = in.readLong();
-        this.indicesCheckpoints = readCheckpoints(in.readMap());
+        this.indicesCheckpoints = readCheckpoints(in.readGenericMap());
         this.timeUpperBoundMillis = in.readLong();
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfig.java
@@ -257,7 +257,7 @@ public final class TransformConfig implements SimpleDiffable<TransformConfig>, W
         createTime = in.readOptionalInstant();
         transformVersion = in.readBoolean() ? TransformConfigVersion.readVersion(in) : null;
         settings = new SettingsConfig(in);
-        metadata = in.readMap();
+        metadata = in.readGenericMap();
         retentionPolicyConfig = in.readOptionalNamedWriteable(RetentionPolicyConfig.class);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfigUpdate.java
@@ -117,7 +117,7 @@ public final class TransformConfigUpdate implements Writeable {
             setHeaders(in.readMap(StreamInput::readString));
         }
         settings = in.readOptionalWriteable(SettingsConfig::new);
-        metadata = in.readMap();
+        metadata = in.readGenericMap();
         retentionPolicyConfig = in.readOptionalNamedWriteable(RetentionPolicyConfig.class);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformDestIndexSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformDestIndexSettings.java
@@ -75,7 +75,7 @@ public class TransformDestIndexSettings implements SimpleDiffable<TransformDestI
     }
 
     public TransformDestIndexSettings(StreamInput in) throws IOException {
-        mappings = in.readMap();
+        mappings = in.readGenericMap();
         settings = Settings.readSettingsFromStream(in);
         aliases = new HashSet<>(in.readCollectionAsList(Alias::new));
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformIndexerPosition.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformIndexerPosition.java
@@ -52,9 +52,9 @@ public class TransformIndexerPosition implements Writeable, ToXContentObject {
     }
 
     public TransformIndexerPosition(StreamInput in) throws IOException {
-        Map<String, Object> position = in.readMap();
+        Map<String, Object> position = in.readGenericMap();
         indexerPosition = position == null ? null : Collections.unmodifiableMap(position);
-        position = in.readMap();
+        position = in.readGenericMap();
         bucketPosition = position == null ? null : Collections.unmodifiableMap(position);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformState.java
@@ -134,7 +134,7 @@ public class TransformState implements Task.Status, PersistentTaskState {
         if (in.getTransportVersion().onOrAfter(TransportVersions.V_7_3_0)) {
             position = in.readOptionalWriteable(TransformIndexerPosition::new);
         } else {
-            Map<String, Object> pos = in.readMap();
+            Map<String, Object> pos = in.readGenericMap();
             position = new TransformIndexerPosition(pos, null);
         }
         checkpoint = in.readLong();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/pivot/AggregationConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/pivot/AggregationConfig.java
@@ -63,7 +63,7 @@ public class AggregationConfig implements Writeable, ToXContentObject {
     }
 
     public AggregationConfig(final StreamInput in) throws IOException {
-        source = in.readMap();
+        source = in.readGenericMap();
         aggregations = in.readOptionalWriteable(AggregatorFactories.Builder::new);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/pivot/GroupConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/pivot/GroupConfig.java
@@ -58,7 +58,7 @@ public class GroupConfig implements Writeable, ToXContentObject {
     }
 
     public GroupConfig(StreamInput in) throws IOException {
-        source = in.readMap();
+        source = in.readGenericMap();
         groups = in.readOrderedMap(StreamInput::readString, (stream) -> {
             SingleGroupSource.Type groupType = SingleGroupSource.Type.fromId(stream.readByte());
             return switch (groupType) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/pivot/ScriptConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/pivot/ScriptConfig.java
@@ -45,7 +45,7 @@ public class ScriptConfig implements SimpleDiffable<ScriptConfig>, Writeable, To
     }
 
     public ScriptConfig(final StreamInput in) throws IOException {
-        source = in.readMap();
+        source = in.readGenericMap();
         script = in.readOptionalWriteable(Script::new);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/WatcherFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/WatcherFeatureSetUsage.java
@@ -23,7 +23,7 @@ public class WatcherFeatureSetUsage extends XPackFeatureSet.Usage {
 
     public WatcherFeatureSetUsage(StreamInput in) throws IOException {
         super(in);
-        stats = in.readMap();
+        stats = in.readGenericMap();
     }
 
     public WatcherFeatureSetUsage(boolean available, boolean enabled, Map<String, Object> stats) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/execute/ExecuteWatchRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/execute/ExecuteWatchRequest.java
@@ -60,10 +60,10 @@ public class ExecuteWatchRequest extends ActionRequest {
         ignoreCondition = in.readBoolean();
         recordExecution = in.readBoolean();
         if (in.readBoolean()) {
-            alternativeInput = in.readMap();
+            alternativeInput = in.readGenericMap();
         }
         if (in.readBoolean()) {
-            triggerData = in.readMap();
+            triggerData = in.readGenericMap();
         }
         long actionModesCount = in.readLong();
         actionModes = new HashMap<>();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/put/UpdateWatcherSettingsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/put/UpdateWatcherSettingsAction.java
@@ -43,7 +43,7 @@ public class UpdateWatcherSettingsAction extends ActionType<AcknowledgedResponse
         }
 
         public Request(StreamInput in) throws IOException {
-            this.settings = in.readMap();
+            this.settings = in.readGenericMap();
         }
 
         @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRule.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRule.java
@@ -108,7 +108,7 @@ public class QueryRule implements Writeable, ToXContentObject {
         this.id = in.readString();
         this.type = QueryRuleType.queryRuleType(in.readString());
         this.criteria = in.readCollectionAsList(QueryRuleCriteria::new);
-        this.actions = in.readMap();
+        this.actions = in.readGenericMap();
 
         validate();
     }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/RuleQueryBuilder.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/RuleQueryBuilder.java
@@ -83,7 +83,7 @@ public class RuleQueryBuilder extends AbstractQueryBuilder<RuleQueryBuilder> {
     public RuleQueryBuilder(StreamInput in) throws IOException {
         super(in);
         organicQuery = in.readNamedWriteable(QueryBuilder.class);
-        matchCriteria = in.readMap();
+        matchCriteria = in.readGenericMap();
         rulesetId = in.readString();
         pinnedIds = in.readOptionalStringCollectionAsList();
         pinnedIdsSupplier = null;

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/SearchApplicationSearchRequest.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/SearchApplicationSearchRequest.java
@@ -42,7 +42,7 @@ public class SearchApplicationSearchRequest extends ActionRequest implements Ind
     public SearchApplicationSearchRequest(StreamInput in) throws IOException {
         super(in);
         this.name = in.readString();
-        this.queryParams = in.readMap();
+        this.queryParams = in.readGenericMap();
     }
 
     public SearchApplicationSearchRequest(String name) {

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchRequest.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchRequest.java
@@ -128,7 +128,7 @@ public class EqlSearchRequest extends ActionRequest implements IndicesRequest.Re
             if (in.readBoolean()) {
                 fetchFields = in.readCollectionAsList(FieldAndFormat::new);
             }
-            runtimeMappings = in.readMap();
+            runtimeMappings = in.readGenericMap();
         } else {
             runtimeMappings = emptyMap();
         }

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/sample/CircuitBreakerTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/sample/CircuitBreakerTests.java
@@ -293,7 +293,7 @@ public class CircuitBreakerTests extends ESTestCase {
                     }
 
                     @Override
-                    public Map<String, Object> readMap() throws IOException {
+                    public Map<String, Object> readGenericMap() throws IOException {
                         return emptyMap();
                     }
                 });

--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/action/SamlValidateAuthnRequestResponse.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/action/SamlValidateAuthnRequestResponse.java
@@ -26,7 +26,7 @@ public class SamlValidateAuthnRequestResponse extends ActionResponse {
         this.spEntityId = in.readString();
         this.assertionConsumerService = in.readString();
         this.forceAuthn = in.readBoolean();
-        this.authnState = in.readMap();
+        this.authnState = in.readGenericMap();
     }
 
     public SamlValidateAuthnRequestResponse(String spEntityId, String acs, boolean forceAuthn, Map<String, Object> authnState) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ltr/LearningToRankRescorerBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ltr/LearningToRankRescorerBuilder.java
@@ -89,7 +89,7 @@ public class LearningToRankRescorerBuilder extends RescorerBuilder<LearningToRan
     public LearningToRankRescorerBuilder(StreamInput input, LearningToRankService learningToRankService) throws IOException {
         super(input);
         this.modelId = input.readString();
-        this.params = input.readMap();
+        this.params = input.readGenericMap();
         this.learningToRankConfig = (LearningToRankConfig) input.readOptionalNamedWriteable(InferenceConfig.class);
         this.learningToRankService = learningToRankService;
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/UserToken.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/UserToken.java
@@ -74,7 +74,7 @@ public final class UserToken implements Writeable, ToXContentObject {
         this.id = input.readString();
         this.authentication = new Authentication(input);
         this.expirationTime = Instant.ofEpochSecond(input.readLong(), input.readInt());
-        this.metadata = input.readMap();
+        this.metadata = input.readGenericMap();
     }
 
     @Override

--- a/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/history/SnapshotHistoryItem.java
+++ b/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/history/SnapshotHistoryItem.java
@@ -168,7 +168,7 @@ public class SnapshotHistoryItem implements Writeable, ToXContentObject {
         this.snapshotName = in.readString();
         this.operation = in.readString();
         this.success = in.readBoolean();
-        this.snapshotConfiguration = in.readMap();
+        this.snapshotConfiguration = in.readGenericMap();
         this.errorDetails = in.readOptionalString();
     }
 

--- a/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/AbstractSqlQueryRequest.java
+++ b/x-pack/plugin/sql/sql-action/src/main/java/org/elasticsearch/xpack/sql/action/AbstractSqlQueryRequest.java
@@ -438,7 +438,7 @@ public abstract class AbstractSqlQueryRequest extends AbstractSqlRequest impleme
         pageTimeout = in.readTimeValue();
         filter = in.readOptionalNamedWriteable(QueryBuilder.class);
         if (in.getTransportVersion().onOrAfter(TransportVersions.V_7_13_0)) {
-            runtimeMappings = in.readMap();
+            runtimeMappings = in.readGenericMap();
         }
     }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/PivotCursor.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/PivotCursor.java
@@ -44,7 +44,7 @@ public class PivotCursor extends CompositeAggCursor {
 
     public PivotCursor(StreamInput in) throws IOException {
         super(in);
-        previousKey = in.readBoolean() ? in.readMap() : null;
+        previousKey = in.readBoolean() ? in.readGenericMap() : null;
     }
 
     @Override


### PR DESCRIPTION
`StreamInput#readMap()` is quite different from the other `readMap`
overloads, and pairs up with `StreamOutput#writeGenericMap`. This commit
renames it to avoid accidental misuse and so that the names line up
better between writer and reader.