### PR TITLE
ESQL: Update the use of some user-caused exceptions

### DIFF
--- a/docs/changelog/104046.yaml
+++ b/docs/changelog/104046.yaml
@@ -1,0 +1,5 @@
+pr: 104046
+summary: "ESQL: Update the use of some user-caused exceptions"
+area: ES|QL
+type: bug
+issues: []

--- a/docs/reference/esql/functions/to_integer.asciidoc
+++ b/docs/reference/esql/functions/to_integer.asciidoc
@@ -26,7 +26,7 @@ provide information on the source of the failure:
 
 A following header will contain the failure reason and the offending value:
 
-`"org.elasticsearch.xpack.ql.QlIllegalArgumentException: [501379200000] out of [integer] range"`
+`"org.elasticsearch.xpack.ql.InvalidArgumentException: [501379200000] out of [integer] range"`
 
 
 If the input parameter is of a date type, its value will be interpreted as

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLongFromDoubleEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLongFromDoubleEvaluator.java
@@ -14,7 +14,6 @@ import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
 import org.elasticsearch.xpack.ql.InvalidArgumentException;
-import org.elasticsearch.xpack.ql.QlIllegalArgumentException;
 import org.elasticsearch.xpack.ql.tree.Source;
 
 /**
@@ -39,7 +38,7 @@ public final class ToLongFromDoubleEvaluator extends AbstractConvertFunction.Abs
     if (vector.isConstant()) {
       try {
         return driverContext.blockFactory().newConstantLongBlockWith(evalValue(vector, 0), positionCount);
-      } catch (InvalidArgumentException | QlIllegalArgumentException  e) {
+      } catch (InvalidArgumentException  e) {
         registerException(e);
         return driverContext.blockFactory().newConstantNullBlock(positionCount);
       }
@@ -48,7 +47,7 @@ public final class ToLongFromDoubleEvaluator extends AbstractConvertFunction.Abs
       for (int p = 0; p < positionCount; p++) {
         try {
           builder.appendLong(evalValue(vector, p));
-        } catch (InvalidArgumentException | QlIllegalArgumentException  e) {
+        } catch (InvalidArgumentException  e) {
           registerException(e);
           builder.appendNull();
         }
@@ -82,7 +81,7 @@ public final class ToLongFromDoubleEvaluator extends AbstractConvertFunction.Abs
             }
             builder.appendLong(value);
             valuesAppended = true;
-          } catch (InvalidArgumentException | QlIllegalArgumentException  e) {
+          } catch (InvalidArgumentException  e) {
             registerException(e);
           }
         }

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLongFromUnsignedLongEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLongFromUnsignedLongEvaluator.java
@@ -13,7 +13,6 @@ import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
 import org.elasticsearch.xpack.ql.InvalidArgumentException;
-import org.elasticsearch.xpack.ql.QlIllegalArgumentException;
 import org.elasticsearch.xpack.ql.tree.Source;
 
 /**
@@ -38,7 +37,7 @@ public final class ToLongFromUnsignedLongEvaluator extends AbstractConvertFuncti
     if (vector.isConstant()) {
       try {
         return driverContext.blockFactory().newConstantLongBlockWith(evalValue(vector, 0), positionCount);
-      } catch (InvalidArgumentException | QlIllegalArgumentException  e) {
+      } catch (InvalidArgumentException  e) {
         registerException(e);
         return driverContext.blockFactory().newConstantNullBlock(positionCount);
       }
@@ -47,7 +46,7 @@ public final class ToLongFromUnsignedLongEvaluator extends AbstractConvertFuncti
       for (int p = 0; p < positionCount; p++) {
         try {
           builder.appendLong(evalValue(vector, p));
-        } catch (InvalidArgumentException | QlIllegalArgumentException  e) {
+        } catch (InvalidArgumentException  e) {
           registerException(e);
           builder.appendNull();
         }
@@ -81,7 +80,7 @@ public final class ToLongFromUnsignedLongEvaluator extends AbstractConvertFuncti
             }
             builder.appendLong(value);
             valuesAppended = true;
-          } catch (InvalidArgumentException | QlIllegalArgumentException  e) {
+          } catch (InvalidArgumentException  e) {
             registerException(e);
           }
         }

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToUnsignedLongFromDoubleEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToUnsignedLongFromDoubleEvaluator.java
@@ -14,7 +14,6 @@ import org.elasticsearch.compute.data.Vector;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
 import org.elasticsearch.xpack.ql.InvalidArgumentException;
-import org.elasticsearch.xpack.ql.QlIllegalArgumentException;
 import org.elasticsearch.xpack.ql.tree.Source;
 
 /**
@@ -39,7 +38,7 @@ public final class ToUnsignedLongFromDoubleEvaluator extends AbstractConvertFunc
     if (vector.isConstant()) {
       try {
         return driverContext.blockFactory().newConstantLongBlockWith(evalValue(vector, 0), positionCount);
-      } catch (InvalidArgumentException | QlIllegalArgumentException  e) {
+      } catch (InvalidArgumentException  e) {
         registerException(e);
         return driverContext.blockFactory().newConstantNullBlock(positionCount);
       }
@@ -48,7 +47,7 @@ public final class ToUnsignedLongFromDoubleEvaluator extends AbstractConvertFunc
       for (int p = 0; p < positionCount; p++) {
         try {
           builder.appendLong(evalValue(vector, p));
-        } catch (InvalidArgumentException | QlIllegalArgumentException  e) {
+        } catch (InvalidArgumentException  e) {
           registerException(e);
           builder.appendNull();
         }
@@ -82,7 +81,7 @@ public final class ToUnsignedLongFromDoubleEvaluator extends AbstractConvertFunc
             }
             builder.appendLong(value);
             valuesAppended = true;
-          } catch (InvalidArgumentException | QlIllegalArgumentException  e) {
+          } catch (InvalidArgumentException  e) {
             registerException(e);
           }
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLong.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToLong.java
@@ -12,7 +12,6 @@ import org.elasticsearch.compute.ann.ConvertEvaluator;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
 import org.elasticsearch.xpack.ql.InvalidArgumentException;
-import org.elasticsearch.xpack.ql.QlIllegalArgumentException;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.tree.NodeInfo;
 import org.elasticsearch.xpack.ql.tree.Source;
@@ -100,12 +99,12 @@ public class ToLong extends AbstractConvertFunction {
         }
     }
 
-    @ConvertEvaluator(extraName = "FromDouble", warnExceptions = { InvalidArgumentException.class, QlIllegalArgumentException.class })
+    @ConvertEvaluator(extraName = "FromDouble", warnExceptions = { InvalidArgumentException.class })
     static long fromDouble(double dbl) {
         return safeDoubleToLong(dbl);
     }
 
-    @ConvertEvaluator(extraName = "FromUnsignedLong", warnExceptions = { InvalidArgumentException.class, QlIllegalArgumentException.class })
+    @ConvertEvaluator(extraName = "FromUnsignedLong", warnExceptions = { InvalidArgumentException.class })
     static long fromUnsignedLong(long ul) {
         return safeToLong(unsignedLongAsNumber(ul));
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToUnsignedLong.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToUnsignedLong.java
@@ -12,7 +12,6 @@ import org.elasticsearch.compute.ann.ConvertEvaluator;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
 import org.elasticsearch.xpack.ql.InvalidArgumentException;
-import org.elasticsearch.xpack.ql.QlIllegalArgumentException;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.tree.NodeInfo;
 import org.elasticsearch.xpack.ql.tree.Source;
@@ -86,7 +85,7 @@ public class ToUnsignedLong extends AbstractConvertFunction {
         return asLongUnsigned(safeToUnsignedLong(asString));
     }
 
-    @ConvertEvaluator(extraName = "FromDouble", warnExceptions = { InvalidArgumentException.class, QlIllegalArgumentException.class })
+    @ConvertEvaluator(extraName = "FromDouble", warnExceptions = { InvalidArgumentException.class })
     static long fromDouble(double dbl) {
         return asLongUnsigned(safeToUnsignedLong(dbl));
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateExtract.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateExtract.java
@@ -12,8 +12,8 @@ import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.ann.Fixed;
 import org.elasticsearch.compute.operator.EvalOperator.ExpressionEvaluator;
-import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.evaluator.mapper.EvaluatorMapper;
+import org.elasticsearch.xpack.ql.InvalidArgumentException;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.TypeResolutions;
 import org.elasticsearch.xpack.ql.expression.function.scalar.ConfigurationFunction;
@@ -49,7 +49,7 @@ public class DateExtract extends ConfigurationFunction implements EvaluatorMappe
             ChronoField chrono = chronoField();
             if (chrono == null) {
                 BytesRef field = (BytesRef) children().get(0).fold();
-                throw new EsqlIllegalArgumentException("invalid date field for [{}]: {}", sourceText(), field.utf8ToString());
+                throw new InvalidArgumentException("invalid date field for [{}]: {}", sourceText(), field.utf8ToString());
             }
             return new DateExtractConstantEvaluator.Factory(source(), fieldEvaluator, chrono, configuration().zoneId());
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateParse.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateParse.java
@@ -16,6 +16,7 @@ import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.evaluator.mapper.EvaluatorMapper;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.ql.InvalidArgumentException;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.function.OptionalArgument;
 import org.elasticsearch.xpack.ql.expression.function.scalar.ScalarFunction;
@@ -114,7 +115,7 @@ public class DateParse extends ScalarFunction implements OptionalArgument, Evalu
                 DateFormatter formatter = toFormatter(format.fold(), zone);
                 return new DateParseConstantEvaluator.Factory(source(), fieldEvaluator, formatter);
             } catch (IllegalArgumentException e) {
-                throw new EsqlIllegalArgumentException(e, "invalid date pattern for [{}]: {}", sourceText(), e.getMessage());
+                throw new InvalidArgumentException(e, "invalid date pattern for [{}]: {}", sourceText(), e.getMessage());
             }
         }
         ExpressionEvaluator.Factory formatEvaluator = toEvaluator.apply(format);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateParse.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateParse.java
@@ -12,7 +12,6 @@ import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.ann.Fixed;
 import org.elasticsearch.compute.operator.EvalOperator.ExpressionEvaluator;
-import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.evaluator.mapper.EvaluatorMapper;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Cast.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Cast.java
@@ -11,7 +11,7 @@ import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.operator.EvalOperator;
 import org.elasticsearch.compute.operator.EvalOperator.ExpressionEvaluator;
 import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
-import org.elasticsearch.xpack.ql.QlIllegalArgumentException;
+import org.elasticsearch.xpack.ql.InvalidArgumentException;
 import org.elasticsearch.xpack.ql.tree.Source;
 import org.elasticsearch.xpack.ql.type.DataType;
 import org.elasticsearch.xpack.ql.type.DataTypes;
@@ -88,9 +88,10 @@ public class Cast {
     }
 
     @Evaluator(extraName = "LongToUnsignedLong")
+    // TODO: catch-to-null in evaluator?
     static long castLongToUnsignedLong(long v) {
         if (v < 0) {
-            throw new QlIllegalArgumentException("[" + v + "] out of [unsigned_long] range");
+            throw new InvalidArgumentException("[" + v + "] out of [unsigned_long] range");
         }
         return v;
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/Split.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/Split.java
@@ -13,7 +13,7 @@ import org.elasticsearch.compute.ann.Fixed;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.operator.EvalOperator.ExpressionEvaluator;
 import org.elasticsearch.xpack.esql.evaluator.mapper.EvaluatorMapper;
-import org.elasticsearch.xpack.ql.QlIllegalArgumentException;
+import org.elasticsearch.xpack.ql.InvalidArgumentException;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.function.scalar.BinaryScalarFunction;
 import org.elasticsearch.xpack.ql.tree.NodeInfo;
@@ -102,9 +102,7 @@ public class Split extends BinaryScalarFunction implements EvaluatorMapper {
         BytesRef delim,
         @Fixed(includeInToString = false, build = true) BytesRef scratch
     ) {
-        if (delim.length != 1) {
-            throw new QlIllegalArgumentException("delimiter must be single byte for now");
-        }
+        checkDelimiter(delim);
         process(builder, str, delim.bytes[delim.offset], scratch);
     }
 
@@ -125,9 +123,13 @@ public class Split extends BinaryScalarFunction implements EvaluatorMapper {
             return new SplitVariableEvaluator.Factory(source(), str, toEvaluator.apply(right()), context -> new BytesRef());
         }
         BytesRef delim = (BytesRef) right().fold();
-        if (delim.length != 1) {
-            throw new QlIllegalArgumentException("for now delimiter must be a single byte");
-        }
+        checkDelimiter(delim);
         return new SplitSingleByteEvaluator.Factory(source(), str, delim.bytes[delim.offset], context -> new BytesRef());
+    }
+
+    private static void checkDelimiter(BytesRef delim) {
+        if (delim.length != 1) {
+            throw new InvalidArgumentException("delimiter must be single byte for now");
+        }
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/ExpressionBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/ExpressionBuilder.java
@@ -103,9 +103,9 @@ public abstract class ExpressionBuilder extends IdentifierBuilder {
         String text = ctx.getText();
 
         try {
-            return new Literal(source, Double.valueOf(StringUtils.parseDouble(text)), DataTypes.DOUBLE);
-        } catch (QlIllegalArgumentException siae) {
-            throw new ParsingException(source, siae.getMessage());
+            return new Literal(source, StringUtils.parseDouble(text), DataTypes.DOUBLE);
+        } catch (InvalidArgumentException iae) {
+            throw new ParsingException(source, iae.getMessage());
         }
     }
 
@@ -121,7 +121,7 @@ public abstract class ExpressionBuilder extends IdentifierBuilder {
             // if it's too large, then quietly try to parse as a float instead
             try {
                 return new Literal(source, StringUtils.parseDouble(text), DataTypes.DOUBLE);
-            } catch (QlIllegalArgumentException ignored) {}
+            } catch (InvalidArgumentException ignored) {}
 
             throw new ParsingException(source, siae.getMessage());
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AbstractPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AbstractPhysicalOperationProviders.java
@@ -21,6 +21,7 @@ import org.elasticsearch.xpack.esql.expression.function.aggregate.Count;
 import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
 import org.elasticsearch.xpack.esql.planner.LocalExecutionPlanner.LocalExecutionPlannerContext;
 import org.elasticsearch.xpack.esql.planner.LocalExecutionPlanner.PhysicalOperation;
+import org.elasticsearch.xpack.ql.InvalidArgumentException;
 import org.elasticsearch.xpack.ql.expression.Alias;
 import org.elasticsearch.xpack.ql.expression.Attribute;
 import org.elasticsearch.xpack.ql.expression.Expression;
@@ -236,10 +237,10 @@ public abstract class AbstractPhysicalOperationProviders implements PhysicalOper
                         Expression field = aggregateFunction.field();
                         // Only count can now support literals - all the other aggs should be optimized away
                         if (field.foldable()) {
-                            if (aggregateFunction instanceof Count count) {
+                            if (aggregateFunction instanceof Count) {
                                 sourceAttr = emptyList();
                             } else {
-                                throw new EsqlIllegalArgumentException(
+                                throw new InvalidArgumentException(
                                     "Does not support yet aggregations over constants - [{}]",
                                     aggregateFunction.sourceText()
                                 );

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeConverter.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeConverter.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.type;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xpack.esql.parser.ParsingException;
+import org.elasticsearch.xpack.ql.InvalidArgumentException;
 import org.elasticsearch.xpack.ql.QlIllegalArgumentException;
 import org.elasticsearch.xpack.ql.tree.Source;
 import org.elasticsearch.xpack.ql.type.Converter;
@@ -130,8 +131,8 @@ public class EsqlDataTypeConverter {
         return DataTypeConverter.commonType(left, right);
     }
 
-    public static TemporalAmount parseTemporalAmout(Number value, String qualifier, Source source) throws QlIllegalArgumentException,
-        ArithmeticException {
+    public static TemporalAmount parseTemporalAmout(Number value, String qualifier, Source source) throws InvalidArgumentException,
+        ArithmeticException, ParsingException {
         return switch (qualifier) {
             case "millisecond", "milliseconds" -> Duration.ofMillis(safeToLong(value));
             case "second", "seconds" -> Duration.ofSeconds(safeToLong(value));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateExtractTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateExtractTests.java
@@ -11,9 +11,11 @@ import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.xpack.esql.EsqlTestUtils;
 import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
 import org.elasticsearch.xpack.esql.expression.function.scalar.AbstractScalarFunctionTestCase;
+import org.elasticsearch.xpack.ql.InvalidArgumentException;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.Literal;
 import org.elasticsearch.xpack.ql.tree.Source;
@@ -66,6 +68,15 @@ public class DateExtractTests extends AbstractScalarFunctionTestCase {
                 is(date.getLong(value))
             );
         }
+    }
+
+    public void testInvalidChrono() {
+        String chrono = randomAlphaOfLength(10);
+        DriverContext driverContext = driverContext();
+        InvalidArgumentException e = expectThrows(InvalidArgumentException.class, () -> evaluator(
+            new DateExtract(Source.EMPTY, new Literal(Source.EMPTY, new BytesRef(chrono), DataTypes.KEYWORD), field("str", DataTypes.DATETIME), null)
+        ).get(driverContext));
+        assertThat(e.getMessage(), equalTo("invalid date field for []: " + chrono));
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateExtractTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateExtractTests.java
@@ -73,9 +73,17 @@ public class DateExtractTests extends AbstractScalarFunctionTestCase {
     public void testInvalidChrono() {
         String chrono = randomAlphaOfLength(10);
         DriverContext driverContext = driverContext();
-        InvalidArgumentException e = expectThrows(InvalidArgumentException.class, () -> evaluator(
-            new DateExtract(Source.EMPTY, new Literal(Source.EMPTY, new BytesRef(chrono), DataTypes.KEYWORD), field("str", DataTypes.DATETIME), null)
-        ).get(driverContext));
+        InvalidArgumentException e = expectThrows(
+            InvalidArgumentException.class,
+            () -> evaluator(
+                new DateExtract(
+                    Source.EMPTY,
+                    new Literal(Source.EMPTY, new BytesRef(chrono), DataTypes.KEYWORD),
+                    field("str", DataTypes.DATETIME),
+                    null
+                )
+            ).get(driverContext)
+        );
         assertThat(e.getMessage(), equalTo("invalid date field for []: " + chrono));
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateParseTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateParseTests.java
@@ -67,9 +67,16 @@ public class DateParseTests extends AbstractScalarFunctionTestCase {
     public void testInvalidPattern() {
         String pattern = randomAlphaOfLength(10);
         DriverContext driverContext = driverContext();
-        InvalidArgumentException e = expectThrows(InvalidArgumentException.class, () -> evaluator(
-            new DateParse(Source.EMPTY, new Literal(Source.EMPTY, new BytesRef(pattern), DataTypes.KEYWORD), field("str", DataTypes.KEYWORD))
-        ).get(driverContext));
+        InvalidArgumentException e = expectThrows(
+            InvalidArgumentException.class,
+            () -> evaluator(
+                new DateParse(
+                    Source.EMPTY,
+                    new Literal(Source.EMPTY, new BytesRef(pattern), DataTypes.KEYWORD),
+                    field("str", DataTypes.KEYWORD)
+                )
+            ).get(driverContext)
+        );
         assertThat(e.getMessage(), startsWith("invalid date pattern for []: Invalid format: [" + pattern + "]"));
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateParseTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateParseTests.java
@@ -11,9 +11,12 @@ import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
 import org.elasticsearch.xpack.esql.expression.function.scalar.AbstractScalarFunctionTestCase;
+import org.elasticsearch.xpack.ql.InvalidArgumentException;
 import org.elasticsearch.xpack.ql.expression.Expression;
+import org.elasticsearch.xpack.ql.expression.Literal;
 import org.elasticsearch.xpack.ql.tree.Source;
 import org.elasticsearch.xpack.ql.type.DataType;
 import org.elasticsearch.xpack.ql.type.DataTypes;
@@ -22,6 +25,7 @@ import java.util.List;
 import java.util.function.Supplier;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.startsWith;
 
 public class DateParseTests extends AbstractScalarFunctionTestCase {
     public DateParseTests(@Name("TestCase") Supplier<TestCaseSupplier.TestCase> testCaseSupplier) {
@@ -58,6 +62,15 @@ public class DateParseTests extends AbstractScalarFunctionTestCase {
                 )
             )
         );
+    }
+
+    public void testInvalidPattern() {
+        String pattern = randomAlphaOfLength(10);
+        DriverContext driverContext = driverContext();
+        InvalidArgumentException e = expectThrows(InvalidArgumentException.class, () -> evaluator(
+            new DateParse(Source.EMPTY, new Literal(Source.EMPTY, new BytesRef(pattern), DataTypes.KEYWORD), field("str", DataTypes.KEYWORD))
+        ).get(driverContext));
+        assertThat(e.getMessage(), startsWith("invalid date pattern for []: Invalid format: [" + pattern + "]"));
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/SplitTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/SplitTests.java
@@ -25,7 +25,6 @@ import org.elasticsearch.xpack.ql.tree.Source;
 import org.elasticsearch.xpack.ql.type.DataType;
 import org.elasticsearch.xpack.ql.type.DataTypes;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -103,9 +102,16 @@ public class SplitTests extends AbstractScalarFunctionTestCase {
     public void testTooLongConstantDelimiter() {
         String delimiter = randomAlphaOfLength(2);
         DriverContext driverContext = driverContext();
-        InvalidArgumentException e = expectThrows(InvalidArgumentException.class, () -> evaluator(
-            new Split(Source.EMPTY, field("str", DataTypes.KEYWORD), new Literal(Source.EMPTY, new BytesRef(delimiter), DataTypes.KEYWORD))
-        ).get(driverContext));
+        InvalidArgumentException e = expectThrows(
+            InvalidArgumentException.class,
+            () -> evaluator(
+                new Split(
+                    Source.EMPTY,
+                    field("str", DataTypes.KEYWORD),
+                    new Literal(Source.EMPTY, new BytesRef(delimiter), DataTypes.KEYWORD)
+                )
+            ).get(driverContext)
+        );
         assertThat(e.getMessage(), equalTo("delimiter must be single byte for now"));
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/SplitTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/SplitTests.java
@@ -18,17 +18,16 @@ import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.EvalOperator;
 import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
 import org.elasticsearch.xpack.esql.expression.function.scalar.AbstractScalarFunctionTestCase;
+import org.elasticsearch.xpack.ql.InvalidArgumentException;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.Literal;
 import org.elasticsearch.xpack.ql.tree.Source;
 import org.elasticsearch.xpack.ql.type.DataType;
 import org.elasticsearch.xpack.ql.type.DataTypes;
-import org.hamcrest.Matcher;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -67,13 +66,6 @@ public class SplitTests extends AbstractScalarFunctionTestCase {
         return DataTypes.KEYWORD;
     }
 
-    private Matcher<Object> resultsMatcher(List<TestCaseSupplier.TypedData> typedData) {
-        String str = ((BytesRef) typedData.get(0).data()).utf8ToString();
-        String delim = ((BytesRef) typedData.get(1).data()).utf8ToString();
-        List<BytesRef> split = Arrays.stream(str.split(Pattern.quote(delim))).map(BytesRef::new).toList();
-        return equalTo(split.size() == 1 ? split.get(0) : split);
-    }
-
     @Override
     protected List<ArgumentSpec> argSpec() {
         return List.of(required(strings()), required(strings()));
@@ -106,5 +98,14 @@ public class SplitTests extends AbstractScalarFunctionTestCase {
                 page.releaseBlocks();
             }
         }
+    }
+
+    public void testTooLongConstantDelimiter() {
+        String delimiter = randomAlphaOfLength(2);
+        DriverContext driverContext = driverContext();
+        InvalidArgumentException e = expectThrows(InvalidArgumentException.class, () -> evaluator(
+            new Split(Source.EMPTY, field("str", DataTypes.KEYWORD), new Literal(Source.EMPTY, new BytesRef(delimiter), DataTypes.KEYWORD))
+        ).get(driverContext));
+        assertThat(e.getMessage(), equalTo("delimiter must be single byte for now"));
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/ExpressionTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/ExpressionTests.java
@@ -37,6 +37,8 @@ import java.time.Duration;
 import java.time.Period;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.as;
 import static org.elasticsearch.xpack.esql.type.EsqlDataTypes.DATE_PERIOD;
@@ -128,6 +130,12 @@ public class ExpressionTests extends ESTestCase {
         assertParsingException(
             () -> whereExpression("\"\"\"\"\"\" foo \"\"\"\" == abc"),
             "line 1:23: mismatched input 'foo' expecting {<EOF>,"
+        );
+
+        var number = "1" + IntStream.range(0, 309).mapToObj(ignored -> "0").collect(Collectors.joining());
+        assertParsingException(
+            () -> parse("row foo == " + number),
+            "line 1:13: Number [" + number + "] is too large"
         );
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/ExpressionTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/parser/ExpressionTests.java
@@ -133,10 +133,7 @@ public class ExpressionTests extends ESTestCase {
         );
 
         var number = "1" + IntStream.range(0, 309).mapToObj(ignored -> "0").collect(Collectors.joining());
-        assertParsingException(
-            () -> parse("row foo == " + number),
-            "line 1:13: Number [" + number + "] is too large"
-        );
+        assertParsingException(() -> parse("row foo == " + number), "line 1:13: Number [" + number + "] is too large");
     }
 
     public void testBooleanLiteralsCondition() {


### PR DESCRIPTION
This updates the use of the exceptions subclassed from `QlServerException` when the failure reason is user-caused. This ensures that a 400-class response is returned, instead of a 500-class one.

Related: #100918