### PR TITLE
[DOCS] Expands inference API docs

### DIFF
--- a/docs/reference/inference/delete-inference.asciidoc
+++ b/docs/reference/inference/delete-inference.asciidoc
@@ -6,10 +6,10 @@ experimental[]
 
 Deletes an {infer} model deployment.
 
-IMPORTANT: The {infer} service the following APIs provide enable you to use 
-certain services, such as ELSER or OpenAI, in your cluster. This is not the 
-same feature that you can use on an ML node with custom {ml} models. If you want 
-to train and use your own model, use the <<ml-df-trained-models-apis>>.
+IMPORTANT: The {infer} APIs enable you to use certain services, such as ELSER, 
+OpenAI, or Hugging Face, in your cluster. This is not the same feature that you 
+can use on an ML node with custom {ml} models. If you want to train and use your 
+own model, use the <<ml-df-trained-models-apis>>.
 
 
 [discrete]

--- a/docs/reference/inference/delete-inference.asciidoc
+++ b/docs/reference/inference/delete-inference.asciidoc
@@ -6,6 +6,11 @@ experimental[]
 
 Deletes an {infer} model deployment.
 
+IMPORTANT: The {infer} service the following APIs provide enable you to use 
+certain services, such as ELSER or OpenAI, in your cluster. This is not the 
+same feature that you can use on an ML node with custom {ml} models. If you want 
+to train and use your own model, use the <<ml-df-trained-models-apis>>.
+
 
 [discrete]
 [[delete-inference-api-request]]

--- a/docs/reference/inference/get-inference.asciidoc
+++ b/docs/reference/inference/get-inference.asciidoc
@@ -6,6 +6,12 @@ experimental[]
 
 Retrieves {infer} model information.
 
+IMPORTANT: The {infer} service the following APIs provide enable you to use 
+certain services, such as ELSER or OpenAI, in your cluster. This is not the 
+same feature that you can use on an ML node with custom {ml} models. If you want 
+to train and use your own model, use the <<ml-df-trained-models-apis>>.
+
+
 [discrete]
 [[get-inference-api-request]]
 ==== {api-request-title}

--- a/docs/reference/inference/get-inference.asciidoc
+++ b/docs/reference/inference/get-inference.asciidoc
@@ -6,10 +6,10 @@ experimental[]
 
 Retrieves {infer} model information.
 
-IMPORTANT: The {infer} service the following APIs provide enable you to use 
-certain services, such as ELSER or OpenAI, in your cluster. This is not the 
-same feature that you can use on an ML node with custom {ml} models. If you want 
-to train and use your own model, use the <<ml-df-trained-models-apis>>.
+IMPORTANT: The {infer} APIs enable you to use certain services, such as ELSER, 
+OpenAI, or Hugging Face, in your cluster. This is not the same feature that you 
+can use on an ML node with custom {ml} models. If you want to train and use your 
+own model, use the <<ml-df-trained-models-apis>>.
 
 
 [discrete]

--- a/docs/reference/inference/inference-apis.asciidoc
+++ b/docs/reference/inference/inference-apis.asciidoc
@@ -4,10 +4,10 @@
 
 experimental[]
 
-IMPORTANT: The {infer} service the following APIs provide enable you to use 
-certain services, such as ELSER or OpenAI, in your cluster. This is not the 
-same feature that you can use on an ML node with custom {ml} models. If you want 
-to train and use your own model, use the <<ml-df-trained-models-apis>>.
+IMPORTANT: The {infer} APIs enable you to use certain services, such as ELSER, 
+OpenAI, or Hugging Face, in your cluster. This is not the same feature that you 
+can use on an ML node with custom {ml} models. If you want to train and use your 
+own model, use the <<ml-df-trained-models-apis>>.
 
 You can use the following APIs to manage {infer} models and perform {infer}:
 

--- a/docs/reference/inference/inference-apis.asciidoc
+++ b/docs/reference/inference/inference-apis.asciidoc
@@ -4,6 +4,11 @@
 
 experimental[]
 
+IMPORTANT: The {infer} service the following APIs provide enable you to use 
+certain services, such as ELSER or OpenAI, in your cluster. This is not the 
+same feature that you can use on an ML node with custom {ml} models. If you want 
+to train and use your own model, use the <<ml-df-trained-models-apis>>.
+
 You can use the following APIs to manage {infer} models and perform {infer}:
 
 * <<delete-inference-api>>

--- a/docs/reference/inference/post-inference.asciidoc
+++ b/docs/reference/inference/post-inference.asciidoc
@@ -6,10 +6,10 @@ experimental[]
 
 Performs an inference task on an input text by using an {infer} model.
 
-IMPORTANT: The {infer} service the following APIs provide enable you to use 
-certain services, such as ELSER or OpenAI, in your cluster. This is not the 
-same feature that you can use on an ML node with custom {ml} models. If you want 
-to train and use your own model, use the <<ml-df-trained-models-apis>>.
+IMPORTANT: The {infer} APIs enable you to use certain services, such as ELSER, 
+OpenAI, or Hugging Face, in your cluster. This is not the same feature that you 
+can use on an ML node with custom {ml} models. If you want to train and use your 
+own model, use the <<ml-df-trained-models-apis>>.
 
 
 [discrete]

--- a/docs/reference/inference/post-inference.asciidoc
+++ b/docs/reference/inference/post-inference.asciidoc
@@ -6,6 +6,11 @@ experimental[]
 
 Performs an inference task on an input text by using an {infer} model.
 
+IMPORTANT: The {infer} service the following APIs provide enable you to use 
+certain services, such as ELSER or OpenAI, in your cluster. This is not the 
+same feature that you can use on an ML node with custom {ml} models. If you want 
+to train and use your own model, use the <<ml-df-trained-models-apis>>.
+
 
 [discrete]
 [[post-inference-api-request]]

--- a/docs/reference/inference/put-inference.asciidoc
+++ b/docs/reference/inference/put-inference.asciidoc
@@ -6,6 +6,11 @@ experimental[]
 
 Creates a model to perform an {infer} task.
 
+IMPORTANT: The {infer} service the following APIs provide enable you to use 
+certain services, such as ELSER or OpenAI, in your cluster. This is not the 
+same feature that you can use on an ML node with custom {ml} models. If you want 
+to train and use your own model, use the <<ml-df-trained-models-apis>>.
+
 
 [discrete]
 [[put-inference-api-request]]
@@ -26,6 +31,10 @@ Creates a model to perform an {infer} task.
 
 The create {infer} API enables you to create and configure an {infer} model to
 perform a specific {infer} task.
+
+The following services are available through the {infer} API:
+* ELSER
+* OpenAI
 
 
 [discrete]
@@ -52,8 +61,8 @@ The type of the {infer} task that the model will perform. Available task types:
 (Required, string)
 The type of service supported for the specified task type.
 Available services:
-* `elser`,
-* `openai`.
+* `elser`: specify the `sparse_embedding` task type to use the ELSER service.
+* `openai`: specify the `text_embedding` task type to use the OpenAI service.
 
 `service_settings`::
 (Required, object)

--- a/docs/reference/inference/put-inference.asciidoc
+++ b/docs/reference/inference/put-inference.asciidoc
@@ -6,10 +6,10 @@ experimental[]
 
 Creates a model to perform an {infer} task.
 
-IMPORTANT: The {infer} service the following APIs provide enable you to use 
-certain services, such as ELSER or OpenAI, in your cluster. This is not the 
-same feature that you can use on an ML node with custom {ml} models. If you want 
-to train and use your own model, use the <<ml-df-trained-models-apis>>.
+IMPORTANT: The {infer} APIs enable you to use certain services, such as ELSER, 
+OpenAI, or Hugging Face, in your cluster. This is not the same feature that you 
+can use on an ML node with custom {ml} models. If you want to train and use your 
+own model, use the <<ml-df-trained-models-apis>>.
 
 
 [discrete]

--- a/docs/reference/inference/put-inference.asciidoc
+++ b/docs/reference/inference/put-inference.asciidoc
@@ -35,7 +35,7 @@ perform a specific {infer} task.
 The following services are available through the {infer} API:
 * ELSER
 * OpenAI
-
+* Hugging Face
 
 [discrete]
 [[put-inference-api-path-params]]
@@ -63,6 +63,7 @@ The type of service supported for the specified task type.
 Available services:
 * `elser`: specify the `sparse_embedding` task type to use the ELSER service.
 * `openai`: specify the `text_embedding` task type to use the OpenAI service.
+* `hugging_face`: specify the `text_embedding` task type to use the Hugging Face service.
 
 `service_settings`::
 (Required, object)


### PR DESCRIPTION
## Overview

This PR: 
* adds an admonition about the difference between the inference API and the ML inference function,
* highlights that inference can use OpenAI,
* highlights when to specify `sparse_embedding` and `text_embedding`.


### Preview

[Inference APIs](https://elasticsearch_104047.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/inference-apis.html)
[PUT Inference API](https://elasticsearch_104047.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/put-inference-api.html)