### PR TITLE
[Transform] Fix NPE that is thrown by `_update` API

### DIFF
--- a/docs/changelog/104051.yaml
+++ b/docs/changelog/104051.yaml
@@ -1,0 +1,6 @@
+pr: 104051
+summary: Fix NPE that is thrown by `_update` API
+area: Transform
+type: bug
+issues:
+ - 104048

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformDestIndexIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformDestIndexIT.java
@@ -114,7 +114,15 @@ public class TransformDestIndexIT extends TransformRestTestCase {
         assertAliases(destIndex2, destAliasAll, destAliasLatest);
     }
 
-    public void testTransformDestIndexCreatedDuringUpdate() throws Exception {
+    public void testTransformDestIndexCreatedDuringUpdate_NoDeferValidation() throws Exception {
+        testTransformDestIndexCreatedDuringUpdate(false);
+    }
+
+    public void testTransformDestIndexCreatedDuringUpdate_DeferValidation() throws Exception {
+        testTransformDestIndexCreatedDuringUpdate(true);
+    }
+
+    private void testTransformDestIndexCreatedDuringUpdate(boolean deferValidation) throws Exception {
         String transformId = "test_dest_index_on_update";
         String destIndex = transformId + "-dest";
 
@@ -139,7 +147,8 @@ public class TransformDestIndexIT extends TransformRestTestCase {
         // Note that at this point the destination index could have already been created by the indexing process of the running transform
         // but the update code should cope with this situation.
         updateTransform(transformId, """
-            { "settings": { "max_page_search_size": 123 } }""");
+            { "settings": { "max_page_search_size": 123 } }""",
+            deferValidation);
 
         // Verify that the destination index now exists
         assertTrue(indexExists(destIndex));

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformDestIndexIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformDestIndexIT.java
@@ -123,7 +123,7 @@ public class TransformDestIndexIT extends TransformRestTestCase {
     }
 
     private void testTransformDestIndexCreatedDuringUpdate(boolean deferValidation) throws Exception {
-        String transformId = "test_dest_index_on_update";
+        String transformId = "test_dest_index_on_update" + (deferValidation ? "-defer" : "");
         String destIndex = transformId + "-dest";
 
         assertFalse(indexExists(destIndex));

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformDestIndexIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformDestIndexIT.java
@@ -147,8 +147,7 @@ public class TransformDestIndexIT extends TransformRestTestCase {
         // Note that at this point the destination index could have already been created by the indexing process of the running transform
         // but the update code should cope with this situation.
         updateTransform(transformId, """
-            { "settings": { "max_page_search_size": 123 } }""",
-            deferValidation);
+            { "settings": { "max_page_search_size": 123 } }""", deferValidation);
 
         // Verify that the destination index now exists
         assertTrue(indexExists(destIndex));

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
@@ -399,13 +399,16 @@ public abstract class TransformRestTestCase extends ESRestTestCase {
         createPivotReviewsTransform(transformId, transformIndex, query, pipeline, null, null, authHeader, null, REVIEWS_INDEX_NAME);
     }
 
-    protected void updateTransform(String transformId, String update) throws IOException {
+    protected void updateTransform(String transformId, String update, boolean deferValidation) throws IOException {
         final Request updateTransformRequest = createRequestWithSecondaryAuth(
             "POST",
             getTransformEndpoint() + transformId + "/_update",
             null,
             null
         );
+        if (deferValidation) {
+            updateTransformRequest.addParameter("defer_validation", String.valueOf(deferValidation));
+        }
         updateTransformRequest.setJsonEntity(update);
 
         client().performRequest(updateTransformRequest);

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportValidateTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportValidateTransformAction.java
@@ -38,6 +38,7 @@ import org.elasticsearch.xpack.transform.utils.SourceDestValidations;
 
 import java.util.Map;
 
+import static java.util.Collections.emptyMap;
 import static org.elasticsearch.core.Strings.format;
 
 public class TransportValidateTransformAction extends HandledTransportAction<Request, Response> {
@@ -127,7 +128,7 @@ public class TransportValidateTransformAction extends HandledTransportAction<Req
         // <4> Deduce destination index mappings
         ActionListener<Boolean> validateQueryListener = ActionListener.wrap(validateQueryResponse -> {
             if (request.isDeferValidation()) {
-                deduceMappingsListener.onResponse(null);
+                deduceMappingsListener.onResponse(emptyMap());
             } else {
                 function.deduceMappings(client, config.getHeaders(), config.getSource(), deduceMappingsListener);
             }


### PR DESCRIPTION
Currently, NPE is thrown when a running transform for which no destination index has been created yet is updated with `defer_validation` flag set to `true`.
This PR fixes the underlying NPE cause, i.e.: replaces `null` with `emptyMap()` when returning from `_validate` call.

Closes https://github.com/elastic/elasticsearch/issues/104048