### PR TITLE
[Transform] Integration test for chaining transforms

### DIFF
--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformChainIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformChainIT.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.transform.integration;
+
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.elasticsearch.rest.action.admin.indices.RestPutIndexTemplateAction;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+public class TransformChainIT extends TransformRestTestCase {
+
+    private static final String DEST_INDEX_TEMPLATE = """
+        {
+          "index_patterns": [ "my-transform-*-dest" ],
+          "mappings": {
+            "properties": {
+              "timestamp": {
+                "type": "date"
+              },
+              "user_id": {
+                "type": "keyword"
+              },
+              "stars": {
+                "type": "integer"
+              }
+            }
+          }
+        }""";
+
+    private static final String TRANSFORM_CONFIG_TEMPLATE = """
+        {
+          "source": {
+            "index": "%s"
+          },
+          "dest": {
+            "index": "%s"
+          },
+          "sync": {
+            "time": {
+              "field": "timestamp"
+            }
+          },
+          "frequency": "%s",
+          "pivot": {
+            "group_by": {
+              "timestamp": {
+                "date_histogram": {
+                  "field": "timestamp",
+                  "fixed_interval": "%s"
+                }
+              },
+              "user_id": {
+                "terms": {
+                  "field": "user_id"
+                }
+              }
+            },
+            "aggregations": {
+              "stars": {
+                "sum": {
+                  "field": "stars"
+                }
+              }
+            }
+          },
+          "settings": {
+            "unattended": true,
+            "deduce_mappings": %s
+          }
+        }""";
+
+    private TestThreadPool threadPool;
+
+    @Before
+    public void createThreadPool() {
+        threadPool = new TestThreadPool(getTestName());
+    }
+
+    @After
+    public void shutdownThreadPool() {
+        if (threadPool != null) {
+            threadPool.shutdown();
+        }
+    }
+
+    public void testChainedTransforms() throws Exception {
+        String reviewsIndexName = "reviews";
+        final int numDocs = 100;
+        createReviewsIndex(reviewsIndexName, numDocs, 100, TransformIT::getUserIdForRow, TransformIT::getDateStringForRow);
+
+        // Create destination index template. It will be used by all the transforms in this test.
+        Request createIndexTemplateRequest = new Request("PUT", "_template/test_dest_index_template");
+        createIndexTemplateRequest.setJsonEntity(DEST_INDEX_TEMPLATE);
+        createIndexTemplateRequest.setOptions(expectWarnings(RestPutIndexTemplateAction.DEPRECATION_WARNING));
+        assertAcknowledged(client().performRequest(createIndexTemplateRequest));
+
+        final int numberOfTransforms = 3;
+        List<String> transformIds = new ArrayList<>(numberOfTransforms);
+        // Create the chain of transforms. Previous transform's destination index becomes next transform's source index.
+        for (int i = 0; i < numberOfTransforms; ++i) {
+            String transformId = "my-transform-" + i;
+            transformIds.add(transformId);
+            // Set up the transform so that its source index is the destination index of the previous transform in the chain.
+            // The number of documents is expected to be the same in all the indices.
+            String sourceIndex = i == 0 ? reviewsIndexName : "my-transform-" + (i - 1) + "-dest";
+            String destIndex = transformId + "-dest";
+            assertFalse(indexExists(destIndex));
+
+            assertAcknowledged(putTransform(transformId, createTransformConfig(sourceIndex, destIndex), true, RequestOptions.DEFAULT));
+        }
+
+        List<String> transformIdsShuffled = new ArrayList<>(transformIds);
+        Collections.shuffle(transformIdsShuffled, random());
+        // Start all the transforms in random order so that sometimes the transform later in the chain needs to wait for its source index
+        // to become available.
+        for (String transformId : transformIdsShuffled) {
+            startTransform(transformId, RequestOptions.DEFAULT);
+        }
+
+        // Wait for the transforms to finish processing. Since the transforms are continuous, we cannot wait for them to be STOPPED.
+        // Instead, we wait for the expected number of processed documents.
+        assertBusy(() -> {
+            for (String transformId : transformIds) {
+                Map<?, ?> stats = getTransformStats(transformId);
+                // Verify that all the documents got processed.
+                assertThat(
+                    "Stats were: " + stats,
+                    XContentMapValues.extractValue(stats, "stats", "documents_processed"),
+                    is(equalTo(numDocs))
+                );
+            }
+        }, 60, TimeUnit.SECONDS);
+
+        // Stop all the transforms.
+        for (String transformId : transformIds) {
+            stopTransform(transformId);
+        }
+        // Delete all the transforms.
+        for (String transformId : transformIds) {
+            deleteTransform(transformId);
+        }
+    }
+
+    private static String createTransformConfig(String sourceIndex, String destIndex) {
+        return Strings.format(TRANSFORM_CONFIG_TEMPLATE, sourceIndex, destIndex, "1s", "1s", randomBoolean());
+    }
+}

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
@@ -164,15 +164,13 @@ public abstract class TransformRestTestCase extends ESRestTestCase {
         if (timeout != null) {
             stopTransformRequest.addParameter(TransformField.TIMEOUT.getPreferredName(), timeout.getStringRep());
         }
-        Map<String, Object> stopTransformResponse = entityAsMap(client().performRequest(stopTransformRequest));
-        assertThat(stopTransformResponse.get("acknowledged"), equalTo(Boolean.TRUE));
+        assertAcknowledged(client().performRequest(stopTransformRequest));
     }
 
     protected void startTransform(String id, RequestOptions options) throws IOException {
         Request startTransformRequest = new Request("POST", TRANSFORM_ENDPOINT + id + "/_start");
         startTransformRequest.setOptions(options);
-        Map<String, Object> startTransformResponse = entityAsMap(client().performRequest(startTransformRequest));
-        assertThat(startTransformResponse.get("acknowledged"), equalTo(Boolean.TRUE));
+        assertAcknowledged(client().performRequest(startTransformRequest));
     }
 
     // workaround for https://github.com/elastic/elasticsearch/issues/62204
@@ -221,16 +219,24 @@ public abstract class TransformRestTestCase extends ESRestTestCase {
         assertOK(adminClient().performRequest(request));
     }
 
-    protected void putTransform(String id, String config, RequestOptions options) throws IOException {
+    protected Response putTransform(String id, String config, RequestOptions options) throws IOException {
+        return putTransform(id, config, false, options);
+    }
+
+    protected Response putTransform(String id, String config, boolean deferValidation, RequestOptions options) throws IOException {
         if (createdTransformIds.contains(id)) {
             throw new IllegalArgumentException("transform [" + id + "] is already registered");
         }
 
-        Request put = new Request("PUT", TRANSFORM_ENDPOINT + id);
-        put.setJsonEntity(config);
-        put.setOptions(options);
-        assertOK(client().performRequest(put));
+        Request request = new Request("PUT", TRANSFORM_ENDPOINT + id);
+        request.setJsonEntity(config);
+        if (deferValidation) {
+            request.addParameter("defer_validation", "true");
+        }
+        request.setOptions(options);
+        Response response = assertOK(client().performRequest(request));
         createdTransformIds.add(id);
+        return response;
     }
 
     protected Map<String, Object> previewTransform(String transformConfig, RequestOptions options) throws IOException {
@@ -396,7 +402,14 @@ public abstract class TransformRestTestCase extends ESRestTestCase {
     }
 
     protected void updateConfig(String id, String update, RequestOptions options) throws Exception {
+        updateConfig(id, update, false, options);
+    }
+
+    protected void updateConfig(String id, String update, boolean deferValidation, RequestOptions options) throws Exception {
         Request updateRequest = new Request("POST", "_transform/" + id + "/_update");
+        if (deferValidation) {
+            updateRequest.addParameter("defer_validation", String.valueOf(deferValidation));
+        }
         updateRequest.setJsonEntity(update);
         updateRequest.setOptions(options);
         assertOK(client().performRequest(updateRequest));


### PR DESCRIPTION
Chained transforms are transforms for which the destination index of one transform is the source index of another transform.

This PR adds a test where 3 chained unattended transforms are started at the same time and it is expected that they finish processing without errors.

Closes https://github.com/elastic/elasticsearch/issues/103678