### PR TITLE
Add matchers for the return values of predicates

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/index/shard/IndexShardIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/shard/IndexShardIT.java
@@ -95,6 +95,8 @@ import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.NONE;
 import static org.elasticsearch.cluster.routing.TestShardRouting.newShardRouting;
 import static org.elasticsearch.index.shard.IndexShardTestCase.getTranslog;
 import static org.elasticsearch.index.shard.IndexShardTestCase.recoverFromStore;
+import static org.elasticsearch.test.LambdaMatchers.falseWith;
+import static org.elasticsearch.test.LambdaMatchers.trueWith;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFailures;
@@ -167,13 +169,13 @@ public class IndexShardIT extends ESSingleNodeTestCase {
             }
         };
         setDurability(shard, Translog.Durability.REQUEST);
-        assertFalse(needsSync.test(translog));
+        assertThat(needsSync, falseWith(translog));
         setDurability(shard, Translog.Durability.ASYNC);
         prepareIndex("test").setId("2").setSource("{}", XContentType.JSON).get();
-        assertTrue(needsSync.test(translog));
+        assertThat(needsSync, trueWith(translog));
         setDurability(shard, Translog.Durability.REQUEST);
         client().prepareDelete("test", "1").get();
-        assertFalse(needsSync.test(translog));
+        assertThat(needsSync, falseWith(translog));
 
         setDurability(shard, Translog.Durability.ASYNC);
         client().prepareDelete("test", "2").get();
@@ -185,7 +187,7 @@ public class IndexShardIT extends ESSingleNodeTestCase {
                 .add(client().prepareDelete("test", "1"))
                 .get()
         );
-        assertFalse(needsSync.test(translog));
+        assertThat(needsSync, falseWith(translog));
 
         setDurability(shard, Translog.Durability.ASYNC);
         assertNoFailures(
@@ -195,7 +197,7 @@ public class IndexShardIT extends ESSingleNodeTestCase {
                 .get()
         );
         setDurability(shard, Translog.Durability.REQUEST);
-        assertTrue(needsSync.test(translog));
+        assertThat(needsSync, trueWith(translog));
     }
 
     private void setDurability(IndexShard shard, Translog.Durability durability) {

--- a/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeRoleSettingTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeRoleSettingTests.java
@@ -14,6 +14,8 @@ import org.elasticsearch.test.ESTestCase;
 import java.util.Set;
 import java.util.function.Predicate;
 
+import static org.elasticsearch.test.LambdaMatchers.falseWith;
+import static org.elasticsearch.test.LambdaMatchers.trueWith;
 import static org.elasticsearch.test.NodeRoles.addRoles;
 import static org.elasticsearch.test.NodeRoles.nonDataNode;
 import static org.elasticsearch.test.NodeRoles.onlyRole;
@@ -40,10 +42,10 @@ public class DiscoveryNodeRoleSettingTests extends ESTestCase {
     }
 
     private void runRoleTest(final Predicate<Settings> predicate, final DiscoveryNodeRole role) {
-        assertTrue(predicate.test(onlyRole(role)));
+        assertThat(predicate, trueWith(onlyRole(role)));
         assertThat(DiscoveryNode.getRolesFromSettings(onlyRole(role)), hasItem(role));
 
-        assertFalse(predicate.test(removeRoles(Set.of(role))));
+        assertThat(predicate, falseWith(removeRoles(Set.of(role))));
         assertThat(DiscoveryNode.getRolesFromSettings(removeRoles(Set.of(role))), not(hasItem(role)));
     }
 

--- a/server/src/test/java/org/elasticsearch/common/regex/RegexTests.java
+++ b/server/src/test/java/org/elasticsearch/common/regex/RegexTests.java
@@ -16,6 +16,8 @@ import java.util.Locale;
 import java.util.Random;
 import java.util.regex.Pattern;
 
+import static org.elasticsearch.test.LambdaMatchers.falseWith;
+import static org.elasticsearch.test.LambdaMatchers.trueWith;
 import static org.hamcrest.Matchers.equalTo;
 
 public class RegexTests extends ESTestCase {
@@ -213,25 +215,25 @@ public class RegexTests extends ESTestCase {
     }
 
     public void testSimpleMatcher() {
-        assertFalse(Regex.simpleMatcher((String[]) null).test("abc"));
-        assertFalse(Regex.simpleMatcher().test("abc"));
-        assertTrue(Regex.simpleMatcher("abc").test("abc"));
-        assertFalse(Regex.simpleMatcher("abc").test("abd"));
+        assertThat(Regex.simpleMatcher((String[]) null), falseWith("abc"));
+        assertThat(Regex.simpleMatcher(), falseWith("abc"));
+        assertThat(Regex.simpleMatcher("abc"), trueWith("abc"));
+        assertThat(Regex.simpleMatcher("abc"), falseWith("abd"));
 
-        assertTrue(Regex.simpleMatcher("abc", "xyz").test("abc"));
-        assertTrue(Regex.simpleMatcher("abc", "xyz").test("xyz"));
-        assertFalse(Regex.simpleMatcher("abc", "xyz").test("abd"));
-        assertFalse(Regex.simpleMatcher("abc", "xyz").test("xyy"));
+        assertThat(Regex.simpleMatcher("abc", "xyz"), trueWith("abc"));
+        assertThat(Regex.simpleMatcher("abc", "xyz"), trueWith("xyz"));
+        assertThat(Regex.simpleMatcher("abc", "xyz"), falseWith("abd"));
+        assertThat(Regex.simpleMatcher("abc", "xyz"), falseWith("xyy"));
 
-        assertTrue(Regex.simpleMatcher("abc", "*").test("abc"));
-        assertTrue(Regex.simpleMatcher("abc", "*").test("abd"));
+        assertThat(Regex.simpleMatcher("abc", "*"), trueWith("abc"));
+        assertThat(Regex.simpleMatcher("abc", "*"), trueWith("abd"));
 
-        assertTrue(Regex.simpleMatcher("a*c").test("abc"));
-        assertFalse(Regex.simpleMatcher("a*c").test("abd"));
+        assertThat(Regex.simpleMatcher("a*c"), trueWith("abc"));
+        assertThat(Regex.simpleMatcher("a*c"), falseWith("abd"));
 
-        assertTrue(Regex.simpleMatcher("a*c", "x*z").test("abc"));
-        assertTrue(Regex.simpleMatcher("a*c", "x*z").test("xyz"));
-        assertFalse(Regex.simpleMatcher("a*c", "x*z").test("abd"));
-        assertFalse(Regex.simpleMatcher("a*c", "x*z").test("xyy"));
+        assertThat(Regex.simpleMatcher("a*c", "x*z"), trueWith("abc"));
+        assertThat(Regex.simpleMatcher("a*c", "x*z"), trueWith("xyz"));
+        assertThat(Regex.simpleMatcher("a*c", "x*z"), falseWith("abd"));
+        assertThat(Regex.simpleMatcher("a*c", "x*z"), falseWith("xyy"));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/query/SearchIndexNameMatcherTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/SearchIndexNameMatcherTests.java
@@ -19,6 +19,8 @@ import org.elasticsearch.indices.TestIndexNameExpressionResolver;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Before;
 
+import static org.elasticsearch.test.LambdaMatchers.falseWith;
+import static org.elasticsearch.test.LambdaMatchers.trueWith;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -46,31 +48,31 @@ public class SearchIndexNameMatcherTests extends ESTestCase {
     }
 
     public void testLocalIndex() {
-        assertTrue(matcher.test("index1"));
-        assertTrue(matcher.test("ind*x1"));
-        assertFalse(matcher.test("index2"));
+        assertThat(matcher, trueWith("index1"));
+        assertThat(matcher, trueWith("ind*x1"));
+        assertThat(matcher, falseWith("index2"));
 
-        assertTrue(matcher.test("alias"));
-        assertTrue(matcher.test("*lias"));
+        assertThat(matcher, trueWith("alias"));
+        assertThat(matcher, trueWith("*lias"));
 
-        assertFalse(matcher.test("cluster:index1"));
+        assertThat(matcher, falseWith("cluster:index1"));
     }
 
     public void testRemoteIndex() {
-        assertTrue(remoteMatcher.test("cluster:index1"));
-        assertTrue(remoteMatcher.test("cluster:ind*x1"));
-        assertTrue(remoteMatcher.test("*luster:ind*x1"));
-        assertFalse(remoteMatcher.test("cluster:index2"));
+        assertThat(remoteMatcher, trueWith("cluster:index1"));
+        assertThat(remoteMatcher, trueWith("cluster:ind*x1"));
+        assertThat(remoteMatcher, trueWith("*luster:ind*x1"));
+        assertThat(remoteMatcher, falseWith("cluster:index2"));
 
-        assertTrue(remoteMatcher.test("cluster:alias"));
-        assertTrue(remoteMatcher.test("cluster:*lias"));
+        assertThat(remoteMatcher, trueWith("cluster:alias"));
+        assertThat(remoteMatcher, trueWith("cluster:*lias"));
 
-        assertFalse(remoteMatcher.test("index1"));
-        assertFalse(remoteMatcher.test("alias"));
+        assertThat(remoteMatcher, falseWith("index1"));
+        assertThat(remoteMatcher, falseWith("alias"));
 
-        assertFalse(remoteMatcher.test("*index1"));
-        assertFalse(remoteMatcher.test("*alias"));
-        assertFalse(remoteMatcher.test("cluster*"));
-        assertFalse(remoteMatcher.test("cluster*index1"));
+        assertThat(remoteMatcher, falseWith("*index1"));
+        assertThat(remoteMatcher, falseWith("*alias"));
+        assertThat(remoteMatcher, falseWith("cluster*"));
+        assertThat(remoteMatcher, falseWith("cluster*index1"));
     }
 }

--- a/server/src/test/java/org/elasticsearch/indices/IndicesModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndicesModuleTests.java
@@ -45,6 +45,8 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import static org.elasticsearch.test.LambdaMatchers.falseWith;
+import static org.elasticsearch.test.LambdaMatchers.trueWith;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
@@ -239,7 +241,7 @@ public class IndicesModuleTests extends ESTestCase {
     }
 
     public void testGetFieldFilter() {
-        List<MapperPlugin> mapperPlugins = Arrays.asList(new MapperPlugin() {
+        List<MapperPlugin> mapperPlugins = List.of(new MapperPlugin() {
         }, new MapperPlugin() {
             @Override
             public Function<String, Predicate<String>> getFieldFilter() {
@@ -262,16 +264,16 @@ public class IndicesModuleTests extends ESTestCase {
         Function<String, Predicate<String>> fieldFilter = mapperRegistry.getFieldFilter();
         assertNotSame(MapperPlugin.NOOP_FIELD_FILTER, fieldFilter);
 
-        assertFalse(fieldFilter.apply("hidden_index").test(randomAlphaOfLengthBetween(3, 5)));
-        assertTrue(fieldFilter.apply(randomAlphaOfLengthBetween(3, 5)).test(randomAlphaOfLengthBetween(3, 5)));
+        assertThat(fieldFilter.apply("hidden_index"), falseWith(randomAlphaOfLengthBetween(3, 5)));
+        assertThat(fieldFilter.apply(randomAlphaOfLengthBetween(3, 5)), trueWith(randomAlphaOfLengthBetween(3, 5)));
 
-        assertFalse(fieldFilter.apply(randomAlphaOfLengthBetween(3, 5)).test("hidden_field"));
-        assertFalse(fieldFilter.apply("filtered").test(randomAlphaOfLengthBetween(3, 5)));
-        assertFalse(fieldFilter.apply("filtered").test("hidden_field"));
-        assertTrue(fieldFilter.apply("filtered").test("visible"));
-        assertFalse(fieldFilter.apply("hidden_index").test("visible"));
-        assertTrue(fieldFilter.apply(randomAlphaOfLengthBetween(3, 5)).test("visible"));
-        assertFalse(fieldFilter.apply("hidden_index").test("hidden_field"));
+        assertThat(fieldFilter.apply(randomAlphaOfLengthBetween(3, 5)), falseWith("hidden_field"));
+        assertThat(fieldFilter.apply("filtered"), falseWith(randomAlphaOfLengthBetween(3, 5)));
+        assertThat(fieldFilter.apply("filtered"), falseWith("hidden_field"));
+        assertThat(fieldFilter.apply("filtered"), trueWith("visible"));
+        assertThat(fieldFilter.apply("hidden_index"), falseWith("visible"));
+        assertThat(fieldFilter.apply(randomAlphaOfLengthBetween(3, 5)), trueWith("visible"));
+        assertThat(fieldFilter.apply("hidden_index"), falseWith("hidden_field"));
     }
 
     public void testDefaultFieldFilterIsNoOp() {

--- a/server/src/test/java/org/elasticsearch/transport/SniffConnectionStrategyTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/SniffConnectionStrategyTests.java
@@ -55,6 +55,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
+import static org.elasticsearch.test.LambdaMatchers.falseWith;
+import static org.elasticsearch.test.LambdaMatchers.trueWith;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.endsWith;
@@ -1063,7 +1065,7 @@ public class SniffConnectionStrategyTests extends ESTestCase {
         Predicate<DiscoveryNode> nodePredicate = SniffConnectionStrategy.getNodePredicate(Settings.EMPTY);
         {
             DiscoveryNode all = DiscoveryNodeUtils.create("id", address);
-            assertTrue(nodePredicate.test(all));
+            assertThat(nodePredicate, trueWith(all));
         }
         {
             DiscoveryNode dataMaster = DiscoveryNodeUtils.create(
@@ -1072,7 +1074,7 @@ public class SniffConnectionStrategyTests extends ESTestCase {
                 Collections.emptyMap(),
                 Set.of(DiscoveryNodeRole.DATA_ROLE, DiscoveryNodeRole.MASTER_ROLE)
             );
-            assertTrue(nodePredicate.test(dataMaster));
+            assertThat(nodePredicate, trueWith(dataMaster));
         }
         {
             DiscoveryNode dedicatedMaster = DiscoveryNodeUtils.create(
@@ -1081,7 +1083,7 @@ public class SniffConnectionStrategyTests extends ESTestCase {
                 Collections.emptyMap(),
                 Set.of(DiscoveryNodeRole.MASTER_ROLE)
             );
-            assertFalse(nodePredicate.test(dedicatedMaster));
+            assertThat(nodePredicate, falseWith(dedicatedMaster));
         }
         {
             DiscoveryNode dedicatedIngest = DiscoveryNodeUtils.create(
@@ -1090,7 +1092,7 @@ public class SniffConnectionStrategyTests extends ESTestCase {
                 Collections.emptyMap(),
                 Set.of(DiscoveryNodeRole.INGEST_ROLE)
             );
-            assertTrue(nodePredicate.test(dedicatedIngest));
+            assertThat(nodePredicate, trueWith(dedicatedIngest));
         }
         {
             DiscoveryNode masterIngest = DiscoveryNodeUtils.create(
@@ -1099,7 +1101,7 @@ public class SniffConnectionStrategyTests extends ESTestCase {
                 Collections.emptyMap(),
                 Set.of(DiscoveryNodeRole.INGEST_ROLE, DiscoveryNodeRole.MASTER_ROLE)
             );
-            assertTrue(nodePredicate.test(masterIngest));
+            assertThat(nodePredicate, trueWith(masterIngest));
         }
         {
             DiscoveryNode dedicatedData = DiscoveryNodeUtils.create(
@@ -1108,7 +1110,7 @@ public class SniffConnectionStrategyTests extends ESTestCase {
                 Collections.emptyMap(),
                 Set.of(DiscoveryNodeRole.DATA_ROLE)
             );
-            assertTrue(nodePredicate.test(dedicatedData));
+            assertThat(nodePredicate, trueWith(dedicatedData));
         }
         {
             DiscoveryNode ingestData = DiscoveryNodeUtils.create(
@@ -1117,11 +1119,11 @@ public class SniffConnectionStrategyTests extends ESTestCase {
                 Collections.emptyMap(),
                 Set.of(DiscoveryNodeRole.DATA_ROLE, DiscoveryNodeRole.INGEST_ROLE)
             );
-            assertTrue(nodePredicate.test(ingestData));
+            assertThat(nodePredicate, trueWith(ingestData));
         }
         {
             DiscoveryNode coordOnly = DiscoveryNodeUtils.create("id", address, Collections.emptyMap(), Set.of());
-            assertTrue(nodePredicate.test(coordOnly));
+            assertThat(nodePredicate, trueWith(coordOnly));
         }
     }
 
@@ -1143,18 +1145,18 @@ public class SniffConnectionStrategyTests extends ESTestCase {
         Predicate<DiscoveryNode> nodePredicate = SniffConnectionStrategy.getNodePredicate(settings);
         {
             DiscoveryNode nonGatewayNode = DiscoveryNodeUtils.create("id", address, Collections.singletonMap("gateway", "false"), roles);
-            assertFalse(nodePredicate.test(nonGatewayNode));
-            assertTrue(SniffConnectionStrategy.getNodePredicate(Settings.EMPTY).test(nonGatewayNode));
+            assertThat(nodePredicate, falseWith(nonGatewayNode));
+            assertThat(SniffConnectionStrategy.getNodePredicate(Settings.EMPTY), trueWith(nonGatewayNode));
         }
         {
             DiscoveryNode gatewayNode = DiscoveryNodeUtils.create("id", address, Collections.singletonMap("gateway", "true"), roles);
-            assertTrue(nodePredicate.test(gatewayNode));
-            assertTrue(SniffConnectionStrategy.getNodePredicate(Settings.EMPTY).test(gatewayNode));
+            assertThat(nodePredicate, trueWith(gatewayNode));
+            assertThat(SniffConnectionStrategy.getNodePredicate(Settings.EMPTY), trueWith(gatewayNode));
         }
         {
             DiscoveryNode noAttrNode = DiscoveryNodeUtils.create("id", address, Collections.emptyMap(), roles);
-            assertFalse(nodePredicate.test(noAttrNode));
-            assertTrue(SniffConnectionStrategy.getNodePredicate(Settings.EMPTY).test(noAttrNode));
+            assertThat(nodePredicate, falseWith(noAttrNode));
+            assertThat(SniffConnectionStrategy.getNodePredicate(Settings.EMPTY), trueWith(noAttrNode));
         }
     }
 
@@ -1171,7 +1173,7 @@ public class SniffConnectionStrategyTests extends ESTestCase {
                 Collections.singletonMap("gateway", "true"),
                 dedicatedMasterRoles
             );
-            assertFalse(nodePredicate.test(node));
+            assertThat(nodePredicate, falseWith(node));
         }
         {
             DiscoveryNode node = DiscoveryNodeUtils.create(
@@ -1180,7 +1182,7 @@ public class SniffConnectionStrategyTests extends ESTestCase {
                 Collections.singletonMap("gateway", "false"),
                 dedicatedMasterRoles
             );
-            assertFalse(nodePredicate.test(node));
+            assertThat(nodePredicate, falseWith(node));
         }
         {
             DiscoveryNode node = DiscoveryNodeUtils.create(
@@ -1189,11 +1191,11 @@ public class SniffConnectionStrategyTests extends ESTestCase {
                 Collections.singletonMap("gateway", "false"),
                 dedicatedMasterRoles
             );
-            assertFalse(nodePredicate.test(node));
+            assertThat(nodePredicate, falseWith(node));
         }
         {
             DiscoveryNode node = DiscoveryNodeUtils.create("id", address, Collections.singletonMap("gateway", "true"), allRoles);
-            assertTrue(nodePredicate.test(node));
+            assertThat(nodePredicate, trueWith(node));
         }
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/common/inject/ModuleTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/inject/ModuleTestCase.java
@@ -17,6 +17,8 @@ import java.lang.annotation.Annotation;
 import java.util.List;
 import java.util.function.Predicate;
 
+import static org.elasticsearch.test.LambdaMatchers.trueWith;
+
 /**
  * Base testcase for testing {@link Module} implementations.
  */
@@ -44,13 +46,13 @@ public abstract class ModuleTestCase extends ESTestCase {
             if (element instanceof InstanceBinding<?> binding) {
                 if (to.equals(binding.getKey().getTypeLiteral().getType())) {
                     if (annotation == null || annotation.equals(binding.getKey().getAnnotationType())) {
-                        assertTrue(tester.test(to.cast(binding.getInstance())));
+                        assertThat(tester, trueWith(to.cast(binding.getInstance())));
                         return;
                     }
                 }
             } else if (element instanceof ProviderInstanceBinding<?> binding) {
                 if (to.equals(binding.getKey().getTypeLiteral().getType())) {
-                    assertTrue(tester.test(to.cast(binding.getProviderInstance().get())));
+                    assertThat(tester, trueWith(to.cast(binding.getProviderInstance().get())));
                     return;
                 }
             }

--- a/test/framework/src/test/java/org/elasticsearch/test/LambdaMatchersTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/LambdaMatchersTests.java
@@ -13,9 +13,11 @@ import org.hamcrest.StringDescription;
 
 import java.util.List;
 
+import static org.elasticsearch.test.LambdaMatchers.falseWith;
 import static org.elasticsearch.test.LambdaMatchers.transformedArrayItemsMatch;
 import static org.elasticsearch.test.LambdaMatchers.transformedItemsMatch;
 import static org.elasticsearch.test.LambdaMatchers.transformedMatch;
+import static org.elasticsearch.test.LambdaMatchers.trueWith;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -95,6 +97,21 @@ public class LambdaMatchersTests extends ESTestCase {
             transformedArrayItemsMatch((A a) -> a.str, arrayContainingInAnyOrder("1")),
             equalTo("array with transformed items to match [\"1\"] in any order")
         );
+    }
+
+    public void testPredicateMatcher() {
+        assertThat(t -> true, trueWith(new Object()));
+        assertThat(t -> true, trueWith(null));
+        assertThat(t -> false, falseWith(new Object()));
+        assertThat(t -> false, falseWith(null));
+
+        assertMismatch(t -> false, trueWith("obj"), equalTo("predicate with argument \"obj\" evaluated to <false>"));
+        assertMismatch(t -> true, falseWith("obj"), equalTo("predicate with argument \"obj\" evaluated to <true>"));
+    }
+
+    public void testPredicateMatcherDescription() {
+        assertDescribeTo(trueWith("obj"), equalTo("predicate evaluates to <true> with argument \"obj\""));
+        assertDescribeTo(falseWith("obj"), equalTo("predicate evaluates to <false> with argument \"obj\""));
     }
 
     static <T> void assertMismatch(T v, Matcher<? super T> matcher, Matcher<String> mismatchDescriptionMatcher) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/rollup/action/RollupSearchActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/rollup/action/RollupSearchActionTests.java
@@ -11,9 +11,11 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.security.authz.privilege.IndexPrivilege;
 import org.elasticsearch.xpack.core.security.support.Automatons;
 
+import static org.elasticsearch.test.LambdaMatchers.trueWith;
+
 public class RollupSearchActionTests extends ESTestCase {
 
     public void testIndexReadPrivilegeCanPerformRollupSearchAction() {
-        assertTrue(Automatons.predicate(IndexPrivilege.READ.getAutomaton()).test(RollupSearchAction.NAME));
+        assertThat(Automatons.predicate(IndexPrivilege.READ.getAutomaton()), trueWith(RollupSearchAction.NAME));
     }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
@@ -123,6 +123,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Collections.emptyMap;
+import static org.elasticsearch.test.LambdaMatchers.falseWith;
+import static org.elasticsearch.test.LambdaMatchers.trueWith;
 import static org.elasticsearch.xpack.core.security.authc.RealmSettings.getFullSettingKey;
 import static org.elasticsearch.xpack.security.operator.OperatorPrivileges.NOOP_OPERATOR_PRIVILEGES_SERVICE;
 import static org.elasticsearch.xpack.security.operator.OperatorPrivileges.OPERATOR_PRIVILEGES_ENABLED;
@@ -483,10 +485,10 @@ public class SecurityTests extends ESTestCase {
         IndicesAccessControl indicesAccessControl = new IndicesAccessControl(true, permissionsMap);
         securityContext.putIndicesAccessControl(indicesAccessControl);
 
-        assertTrue(fieldFilter.apply("index_granted").test("field_granted"));
-        assertFalse(fieldFilter.apply("index_granted").test(randomAlphaOfLengthBetween(3, 10)));
+        assertThat(fieldFilter.apply("index_granted"), trueWith("field_granted"));
+        assertThat(fieldFilter.apply("index_granted"), falseWith(randomAlphaOfLengthBetween(3, 10)));
         assertEquals(MapperPlugin.NOOP_FIELD_PREDICATE, fieldFilter.apply("index_granted_all_permissions"));
-        assertTrue(fieldFilter.apply("index_granted_all_permissions").test(randomAlphaOfLengthBetween(3, 10)));
+        assertThat(fieldFilter.apply("index_granted_all_permissions"), trueWith(randomAlphaOfLengthBetween(3, 10)));
         assertEquals(MapperPlugin.NOOP_FIELD_PREDICATE, fieldFilter.apply("index_other"));
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/support/ApiKeyBoolQueryBuilderTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/support/ApiKeyBoolQueryBuilderTests.java
@@ -37,6 +37,8 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.function.Predicate;
 
+import static org.elasticsearch.test.LambdaMatchers.falseWith;
+import static org.elasticsearch.test.LambdaMatchers.trueWith;
 import static org.elasticsearch.xpack.security.support.ApiKeyFieldNameTranslators.FIELD_NAME_TRANSLATORS;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
@@ -318,10 +320,10 @@ public class ApiKeyBoolQueryBuilderTests extends ESTestCase {
             "metadata_flattened." + randomAlphaOfLengthBetween(1, 10),
             "creator." + randomAlphaOfLengthBetween(1, 10)
         );
-        assertTrue(predicate.test(allowedField));
+        assertThat(predicate, trueWith(allowedField));
 
         final String disallowedField = randomBoolean() ? (randomAlphaOfLengthBetween(1, 3) + allowedField) : (allowedField.substring(1));
-        assertFalse(predicate.test(disallowedField));
+        assertThat(predicate, falseWith(disallowedField));
     }
 
     private void assertCommonFilterQueries(ApiKeyBoolQueryBuilder qb, Authentication authentication) {


### PR DESCRIPTION
Add matchers for `Matcher<Predicate<T>>` to assert on the return values of predicates given specific arguments