### PR TITLE
[8.12] AsyncOperator#isFinished must never return true on failure (#104029)

### DIFF
--- a/docs/changelog/104029.yaml
+++ b/docs/changelog/104029.yaml
@@ -1,0 +1,5 @@
+pr: 104029
+summary: '`AsyncOperator#isFinished` must never return true on failure'
+area: ES|QL
+type: bug
+issues: []

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/AsyncOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/AsyncOperator.java
@@ -181,8 +181,12 @@ public abstract class AsyncOperator implements Operator {
 
     @Override
     public boolean isFinished() {
-        checkFailure();
-        return finished && checkpoint.getPersistedCheckpoint() == checkpoint.getMaxSeqNo();
+        if (finished && checkpoint.getPersistedCheckpoint() == checkpoint.getMaxSeqNo()) {
+            checkFailure();
+            return true;
+        } else {
+            return false;
+        }
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/AsyncOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/AsyncOperatorTests.java
@@ -43,6 +43,8 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.LongStream;
@@ -267,6 +269,53 @@ public class AsyncOperatorTests extends ESTestCase {
         } else {
             assertTrue(asyncOperator.isFinished());
             assertNull(asyncOperator.getOutput());
+        }
+    }
+
+    public void testIsFinished() {
+        int iters = iterations(10, 10_000);
+        BlockFactory blockFactory = blockFactory();
+        for (int i = 0; i < iters; i++) {
+            DriverContext driverContext = new DriverContext(blockFactory.bigArrays(), blockFactory);
+            CyclicBarrier barrier = new CyclicBarrier(2);
+            AsyncOperator asyncOperator = new AsyncOperator(driverContext, between(1, 10)) {
+                @Override
+                protected void performAsync(Page inputPage, ActionListener<Page> listener) {
+                    ActionRunnable<Page> command = new ActionRunnable<>(listener) {
+                        @Override
+                        protected void doRun() {
+                            try {
+                                barrier.await(10, TimeUnit.SECONDS);
+                            } catch (Exception e) {
+                                throw new AssertionError(e);
+                            }
+                            listener.onFailure(new ElasticsearchException("simulated"));
+                        }
+                    };
+                    threadPool.executor(ESQL_TEST_EXECUTOR).execute(command);
+                }
+
+                @Override
+                protected void doClose() {
+
+                }
+            };
+            asyncOperator.addInput(new Page(blockFactory.newConstantIntBlockWith(randomInt(), between(1, 10))));
+            asyncOperator.finish();
+            try {
+                barrier.await(10, TimeUnit.SECONDS);
+            } catch (Exception e) {
+                throw new AssertionError(e);
+            }
+            int numChecks = between(10, 100);
+            while (--numChecks >= 0) {
+                try {
+                    assertFalse("must not finished or failed", asyncOperator.isFinished());
+                } catch (ElasticsearchException e) {
+                    assertThat(e.getMessage(), equalTo("simulated"));
+                    break;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Backports the following commits to 8.12:
 - AsyncOperator#isFinished must never return true on failure (#104029)