### PR TITLE
Fix missing links in geo_point docs for ESQL

### DIFF
--- a/docs/reference/esql/esql-functions.asciidoc
+++ b/docs/reference/esql/esql-functions.asciidoc
@@ -61,9 +61,11 @@ these functions:
 * <<esql-tanh>>
 * <<esql-tau>>
 * <<esql-to_boolean>>
+* <<esql-to_cartesianpoint>>
 * <<esql-to_datetime>>
 * <<esql-to_degrees>>
 * <<esql-to_double>>
+* <<esql-to_geopoint>>
 * <<esql-to_integer>>
 * <<esql-to_ip>>
 * <<esql-to_long>>


### PR DESCRIPTION
The original PR at https://github.com/elastic/elasticsearch/pull/103207 did not add the functions to the main list