### PR TITLE
[ML] Retry updates to model snapshot ID on job config

### DIFF
--- a/docs/changelog/104077.yaml
+++ b/docs/changelog/104077.yaml
@@ -1,0 +1,5 @@
+pr: 104077
+summary: Retry updates to model snapshot ID on job config
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/RetryableUpdateModelSnapshotAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/RetryableUpdateModelSnapshotAction.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.job.process.autodetect.output;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.RetryableAction;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.xpack.core.ml.action.PutJobAction;
+import org.elasticsearch.xpack.core.ml.action.UpdateJobAction;
+import org.elasticsearch.xpack.ml.MachineLearning;
+
+import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
+import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
+
+/**
+ * Class to retry updates to the model snapshot ID on the job config after a new model snapshot result
+ * is seen. Prior to the introduction of this functionality we saw cases where this particular job config
+ * update would fail, so that the job would have persisted a perfectly valid model snapshot and yet it
+ * would not be used if the job failed over to another node, leading to wasted work rerunning from an
+ * older snapshot.
+ */
+public class RetryableUpdateModelSnapshotAction extends RetryableAction<PutJobAction.Response> {
+
+    private static final Logger logger = LogManager.getLogger(RetryableUpdateModelSnapshotAction.class);
+
+    private final Client client;
+    private final UpdateJobAction.Request updateRequest;
+    private volatile boolean hasFailedAtLeastOnce;
+
+    public RetryableUpdateModelSnapshotAction(
+        Client client,
+        UpdateJobAction.Request updateRequest,
+        ActionListener<PutJobAction.Response> listener
+    ) {
+        super(
+            logger,
+            client.threadPool(),
+            // First retry after 15 seconds
+            TimeValue.timeValueSeconds(15),
+            // Never wait more than 2 minutes between retries
+            TimeValue.timeValueMinutes(2),
+            // Retry for 5 minutes in total. If the node is shutting down then we cannot wait longer than 10
+            // minutes, and there is other work to do as well. If the node is not shutting down then persisting
+            // the snapshot is less important, as we'll try again if the node does shut down. Therefore, 5 minutes
+            // is a reasonable compromise between preventing excess rework on failover and delaying processing
+            // unnecessarily.
+            TimeValue.timeValueMinutes(5),
+            listener,
+            client.threadPool().executor(MachineLearning.UTILITY_THREAD_POOL_NAME)
+        );
+        this.client = client;
+        this.updateRequest = updateRequest;
+    }
+
+    @Override
+    public void tryAction(ActionListener<PutJobAction.Response> listener) {
+        executeAsyncWithOrigin(client, ML_ORIGIN, UpdateJobAction.INSTANCE, updateRequest, listener);
+    }
+
+    @Override
+    public boolean shouldRetry(Exception e) {
+        if (hasFailedAtLeastOnce == false) {
+            hasFailedAtLeastOnce = true;
+            logger.warn(() -> "[" + updateRequest.getJobId() + "] Failed to update job with new model snapshot id; attempting retry", e);
+        }
+        return true;
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectResultProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectResultProcessorTests.java
@@ -63,6 +63,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 
+import static org.elasticsearch.common.util.concurrent.EsExecutors.DIRECT_EXECUTOR_SERVICE;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
@@ -102,6 +103,7 @@ public class AutodetectResultProcessorTests extends ESTestCase {
         executor = new Scheduler.SafeScheduledThreadPoolExecutor(1);
         client = mock(Client.class);
         ThreadPool threadPool = mock(ThreadPool.class);
+        when(threadPool.executor(any())).thenReturn(DIRECT_EXECUTOR_SERVICE);
         when(client.threadPool()).thenReturn(threadPool);
         when(threadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
         auditor = mock(AnomalyDetectionAuditor.class);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/RetryableUpdateModelSnapshotActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/RetryableUpdateModelSnapshotActionTests.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.job.process.autodetect.output;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.ml.action.PutJobAction;
+import org.elasticsearch.xpack.core.ml.action.UpdateJobAction;
+import org.elasticsearch.xpack.core.ml.job.config.JobUpdate;
+import org.junit.Before;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.elasticsearch.common.util.concurrent.EsExecutors.DIRECT_EXECUTOR_SERVICE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class RetryableUpdateModelSnapshotActionTests extends ESTestCase {
+
+    private static final String JOB_ID = "valid_id";
+
+    private Client client;
+
+    private ThreadPool threadPool;
+
+    @Before
+    public void setUpMocks() {
+        client = mock(Client.class);
+        threadPool = mock(ThreadPool.class);
+        when(threadPool.executor(any())).thenReturn(DIRECT_EXECUTOR_SERVICE);
+        doAnswer(invocationOnMock -> {
+            Runnable runnable = (Runnable) invocationOnMock.getArguments()[0];
+            runnable.run();
+            return null;
+        }).when(threadPool).schedule(any(), any(), any());
+        when(client.threadPool()).thenReturn(threadPool);
+        when(threadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
+    }
+
+    public void testFirstTimeSuccess() {
+
+        PutJobAction.Response response = mock(PutJobAction.Response.class);
+        doAnswer(invocationOnMock -> {
+            @SuppressWarnings("unchecked")
+            ActionListener<PutJobAction.Response> listener = (ActionListener<PutJobAction.Response>) invocationOnMock.getArguments()[2];
+            listener.onResponse(response);
+            return null;
+        }).when(client).execute(any(), any(), any());
+
+        AtomicReference<PutJobAction.Response> storedResponse = new AtomicReference<>();
+
+        UpdateJobAction.Request updateRequest = new UpdateJobAction.Request(JOB_ID, new JobUpdate.Builder(JOB_ID).build());
+        RetryableUpdateModelSnapshotAction updateModelSnapshotAction = new RetryableUpdateModelSnapshotAction(
+            client,
+            updateRequest,
+            new ActionListener<>() {
+                @Override
+                public void onResponse(PutJobAction.Response response) {
+                    storedResponse.set(response);
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    fail(e);
+                }
+            }
+        );
+        updateModelSnapshotAction.run();
+
+        verify(threadPool, never()).schedule(any(), any(), any());
+        assertSame(response, storedResponse.get());
+    }
+
+    public void testRetriesNeeded() {
+
+        int numRetries = randomIntBetween(1, 5);
+
+        PutJobAction.Response response = mock(PutJobAction.Response.class);
+        AtomicInteger callCount = new AtomicInteger(0);
+        doAnswer(invocationOnMock -> {
+            @SuppressWarnings("unchecked")
+            ActionListener<PutJobAction.Response> listener = (ActionListener<PutJobAction.Response>) invocationOnMock.getArguments()[2];
+            if (callCount.incrementAndGet() > numRetries) {
+                listener.onResponse(response);
+            } else {
+                listener.onFailure(new Exception());
+            }
+            return null;
+        }).when(client).execute(any(), any(), any());
+
+        AtomicReference<PutJobAction.Response> storedResponse = new AtomicReference<>();
+
+        UpdateJobAction.Request updateRequest = new UpdateJobAction.Request(JOB_ID, new JobUpdate.Builder(JOB_ID).build());
+        RetryableUpdateModelSnapshotAction updateModelSnapshotAction = new RetryableUpdateModelSnapshotAction(
+            client,
+            updateRequest,
+            new ActionListener<>() {
+                @Override
+                public void onResponse(PutJobAction.Response response) {
+                    storedResponse.set(response);
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    fail(e);
+                }
+            }
+        );
+        updateModelSnapshotAction.run();
+
+        verify(threadPool, times(numRetries)).schedule(any(), any(), any());
+        assertSame(response, storedResponse.get());
+    }
+
+    public void testCompleteFailure() {
+
+        int numRetries = randomIntBetween(1, 5);
+
+        AtomicInteger callCount = new AtomicInteger(0);
+        AtomicLong relativeTimeMs = new AtomicLong(0);
+        doAnswer(invocationOnMock -> {
+            @SuppressWarnings("unchecked")
+            ActionListener<PutJobAction.Response> listener = (ActionListener<PutJobAction.Response>) invocationOnMock.getArguments()[2];
+            if (callCount.incrementAndGet() > numRetries) {
+                relativeTimeMs.set(TimeValue.timeValueMinutes(5).millis() + 1);
+            }
+            listener.onFailure(new Exception(Long.toString(relativeTimeMs.get())));
+            return null;
+        }).when(client).execute(any(), any(), any());
+        doAnswer(invocationOnMock -> relativeTimeMs.get()).when(threadPool).relativeTimeInMillis();
+
+        AtomicReference<Exception> storedFailure = new AtomicReference<>();
+
+        UpdateJobAction.Request updateRequest = new UpdateJobAction.Request(JOB_ID, new JobUpdate.Builder(JOB_ID).build());
+        RetryableUpdateModelSnapshotAction updateModelSnapshotAction = new RetryableUpdateModelSnapshotAction(
+            client,
+            updateRequest,
+            new ActionListener<>() {
+                @Override
+                public void onResponse(PutJobAction.Response response) {
+                    fail("this should not be called");
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    storedFailure.set(e);
+                }
+            }
+        );
+        updateModelSnapshotAction.run();
+
+        verify(threadPool, times(numRetries)).schedule(any(), any(), any());
+        assertEquals(Long.toString(relativeTimeMs.get()), storedFailure.get().getMessage());
+    }
+}


### PR DESCRIPTION
When an autodetect process produces a new model snapshot, we update the model snapshot ID on the corresponding job config. This means that the next time the job restarts it will load the most recent model snapshot.

We have seen a few occasions where this update to the job config has failed. Often this happens because the .ml-config index is temporarily inaccessible. This change adds a few retries of the config update. It is not completely catastrophic if we fail to update the model snapshot ID on the job config - it just means that the job will pick up from an earlier snapshot and redo work if it has to restart for any reason. But it's still better to attempt a few retries before giving up.