### PR TITLE
AsyncOperator#isFinished must never return true on failure (#104029)

### DIFF
--- a/docs/changelog/104029.yaml
+++ b/docs/changelog/104029.yaml
@@ -1,0 +1,5 @@
+pr: 104029
+summary: '`AsyncOperator#isFinished` must never return true on failure'
+area: ES|QL
+type: bug
+issues: []

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/AsyncOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/AsyncOperator.java
@@ -134,8 +134,12 @@ public abstract class AsyncOperator implements Operator {
 
     @Override
     public boolean isFinished() {
-        checkFailure();
-        return finished && checkpoint.getPersistedCheckpoint() == checkpoint.getMaxSeqNo();
+        if (finished && checkpoint.getPersistedCheckpoint() == checkpoint.getMaxSeqNo()) {
+            checkFailure();
+            return true;
+        } else {
+            return false;
+        }
     }
 
     @Override


### PR DESCRIPTION
Enrich IT tests can return OK with some missing results instead of Failure when the enrich lookup hits circuit breakers. This is due to a race condition in isFinished and onFailure within the AsyncOperator. When an async lookup fails, we set the exception and then discard pages. Unfortunately, in the isFinished method, we perform the checks in the same order: first, we check for failure, and then we check for outstanding pages. If there is a long pause between these steps, isFinished might not detect the failure but see no outstanding pages, leading it to return true despite the presence of a failure. This change swaps the order of the checks.

Backport of #104029 to 8.11