### PR TITLE
[dra] Trigger elasticsearch-hadoop dra build whenever we build a new staging artifact

### DIFF
--- a/.buildkite/pipelines/dra-workflow.yml
+++ b/.buildkite/pipelines/dra-workflow.yml
@@ -7,3 +7,13 @@ steps:
       image: family/elasticsearch-ubuntu-2204
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+  - wait
+  # The hadoop build depends on the ES artifact
+  # So let's trigger the hadoop build any time we build a new staging artifact
+  - trigger: elasticsearch-hadoop-dra-workflow
+    async: true
+    build:
+      branch: "${BUILDKITE_BRANCH}"
+      env:
+        DRA_WORKFLOW: staging
+    if: build.env('DRA_WORKFLOW') == 'staging'


### PR DESCRIPTION
`elasticsearch-hadoop` DRA workflow depends on the `elasticsearch` DRA artifact being built.

After a version bump, the `elasticsearch-hadoop` workflow will just fail until the first `elasticsearch` artifact exists for the next version.

Let's just trigger the `elasticsearch-hadoop` workflow whenever we build a new staging artifact, rather than having someone manually do it or waiting until it eventually becomes correct.

See ES-7249