### PR TITLE
[ML] Deprecate machine learning on Intel macOS

### DIFF
--- a/docs/changelog/104087.yaml
+++ b/docs/changelog/104087.yaml
@@ -1,0 +1,11 @@
+pr: 104087
+summary: Deprecate machine learning on Intel macOS
+area: Machine Learning
+type: deprecation
+issues: []
+deprecation:
+  title: Deprecate machine learning on Intel macOS
+  area: Machine Learning
+  details: Please describe the details of this change for the release notes. You can
+    use asciidoc.
+  impact: Please describe the impact of this change to users

--- a/docs/changelog/104087.yaml
+++ b/docs/changelog/104087.yaml
@@ -5,7 +5,9 @@ type: deprecation
 issues: []
 deprecation:
   title: Deprecate machine learning on Intel macOS
-  area: Machine Learning
-  details: Please describe the details of this change for the release notes. You can
-    use asciidoc.
-  impact: Please describe the impact of this change to users
+  area: Packaging
+  details: The machine learning plugin will be permanently disabled on macOS x86_64
+    in new minor versions released from December 2024 onwards.
+  impact: To continue to use machine learning functionality on macOS please switch to
+    an arm64 machine (Apple silicon). Alternatively, it will still be possible to run
+    Elasticsearch with machine learning enabled in a Docker container on macOS x86_64.

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -32,6 +32,8 @@ import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.logging.DeprecationCategory;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Setting;
@@ -68,6 +70,7 @@ import org.elasticsearch.plugins.ExtensiblePlugin;
 import org.elasticsearch.plugins.IngestPlugin;
 import org.elasticsearch.plugins.MapperPlugin;
 import org.elasticsearch.plugins.PersistentTaskPlugin;
+import org.elasticsearch.plugins.Platforms;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.plugins.ShutdownAwarePlugin;
@@ -753,6 +756,7 @@ public class MachineLearning extends Plugin
     public static final int MAX_LOW_PRIORITY_MODELS_PER_NODE = 100;
 
     private static final Logger logger = LogManager.getLogger(MachineLearning.class);
+    private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(MachineLearning.class);
 
     private final Settings settings;
     private final boolean enabled;
@@ -917,6 +921,15 @@ public class MachineLearning extends Plugin
             // Holders for @link(MachineLearningFeatureSetUsage) which needs access to job manager and ML extension,
             // both empty if ML is disabled
             return List.of(new JobManagerHolder(), new MachineLearningExtensionHolder());
+        }
+
+        if ("darwin-x86_64".equals(Platforms.PLATFORM_NAME)) {
+            String msg = "The machine learning plugin will be permanently disabled on macOS x86_64 in new minor versions released "
+                + "from December 2024 onwards. To continue to use machine learning functionality on macOS please switch to an arm64 "
+                + "machine (Apple silicon). Alternatively, it will still be possible to run Elasticsearch with machine learning "
+                + "enabled in a Docker container on macOS x86_64.";
+            logger.warn(msg);
+            deprecationLogger.warn(DeprecationCategory.PLUGINS, "ml-darwin-x86_64", msg);
         }
 
         machineLearningExtension.get().configure(environment.settings());


### PR DESCRIPTION
PyTorch is no longer going to provide macOS x86_64 builds after version 2.2. This doesn't instantly affect us, as we build PyTorch from source ourselves and they've said that they will not deliberately break macOS x86_64. They just won't build or test on that platform themselves. As a result it's inevitable that we'll have to make some tweaks to the PyTorch code to get it to build, and as the years go by it will become harder and harder to make the code compile on an unsupported platform. Since PyTorch is such a critical component of Elastic ML we won't be able to keep it running on macOS x86_64 for more than a few releases after PyTorch drops support. This change gives notice of our intentions.