### PR TITLE
Suppress this-escape for JDK21

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/NodesHotThreadsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/NodesHotThreadsResponse.java
@@ -29,10 +29,12 @@ import java.util.NoSuchElementException;
 
 public class NodesHotThreadsResponse extends BaseNodesResponse<NodeHotThreads> {
 
+    @SuppressWarnings("this-escape")
     private final RefCounted refs = LeakTracker.wrap(
         AbstractRefCounted.of(() -> Releasables.wrap(Iterators.map(getNodes().iterator(), n -> n::decRef)).close())
     );
 
+    @SuppressWarnings("this-escape")
     public NodesHotThreadsResponse(ClusterName clusterName, List<NodeHotThreads> nodes, List<FailedNodeException> failures) {
         super(clusterName, nodes, failures);
         for (NodeHotThreads nodeHotThreads : getNodes()) {

--- a/server/src/main/java/org/elasticsearch/action/support/single/instance/TransportInstanceSingleOperationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/single/instance/TransportInstanceSingleOperationAction.java
@@ -57,6 +57,7 @@ public abstract class TransportInstanceSingleOperationAction<
 
     final String shardActionName;
 
+    @SuppressWarnings("this-escape")
     protected TransportInstanceSingleOperationAction(
         String actionName,
         ThreadPool threadPool,


### PR DESCRIPTION
Suppress the `this-escape` warnings to allow running with JDK21.