### PR TITLE
Ingest geoip processor cache 'no results' from the database

### DIFF
--- a/docs/changelog/104092.yaml
+++ b/docs/changelog/104092.yaml
@@ -1,0 +1,5 @@
+pr: 104092
+summary: Ingest geoip processor cache 'no results' from the database
+area: Ingest Node
+type: enhancement
+issues: []

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpCache.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpCache.java
@@ -30,7 +30,8 @@ final class GeoIpCache {
      * this no-result we can distinguish between something not being in the cache because we haven't searched for that data yet, versus
      * something not being in the cache because the data doesn't exist in the database.
      */
-    private static final AbstractResponse NO_RESULT = new AbstractResponse() {
+    // visible for testing
+    static final AbstractResponse NO_RESULT = new AbstractResponse() {
         @Override
         public String toString() {
             return "AbstractResponse[NO_RESULT]";

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpCache.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpCache.java
@@ -18,7 +18,7 @@ import java.nio.file.Path;
 import java.util.function.Function;
 
 /**
- * The in-memory cache for the geoip data. There should only be 1 instance of this class..
+ * The in-memory cache for the geoip data. There should only be 1 instance of this class.
  * This cache differs from the maxmind's {@link NodeCache} such that this cache stores the deserialized Json objects to avoid the
  * cost of deserialization for each lookup (cached or not). This comes at slight expense of higher memory usage, but significant
  * reduction of CPU usage.

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpCache.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpCache.java
@@ -40,7 +40,6 @@ final class GeoIpCache {
         String databasePath,
         Function<InetAddress, AbstractResponse> retrieveFunction
     ) {
-
         // can't use cache.computeIfAbsent due to the elevated permissions for the jackson (run via the cache loader)
         CacheKey cacheKey = new CacheKey(ip, databasePath);
         // intentionally non-locking for simplicity...it's OK if we re-put the same key/value in the cache during a race condition.

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
@@ -172,10 +172,8 @@ public final class GeoIpProcessor extends AbstractProcessor {
             geoData = retrieveCityGeoData(geoIpDatabase, ipAddress);
         } else if (databaseType.endsWith(COUNTRY_DB_SUFFIX)) {
             geoData = retrieveCountryGeoData(geoIpDatabase, ipAddress);
-
         } else if (databaseType.endsWith(ASN_DB_SUFFIX)) {
             geoData = retrieveAsnGeoData(geoIpDatabase, ipAddress);
-
         } else {
             throw new ElasticsearchParseException(
                 "Unsupported database type [" + geoIpDatabase.getDatabaseType() + "]",


### PR DESCRIPTION
For my own future reference, here's some history of the geoip cache: it was originally added in #22231, rewritten for better performance in #33029, and tweaked for better performance in #80737 and #92372.

The maxmind `DatabaseReader`'s `tryCity`/`tryCountry`/`tryAsn` methods return an empty `Optional`  if you ask about an ip address for which the database doesn't have a record, and we very quickly convert that into a null value (see `DatabaseReaderLazyLoader#getResponse`).

Externally, the cache has two way logic: it either returns a response if there was one, or it returns null if there's nothing in the database for that ip address. That was true before this PR, and it remains true after this PR.

Internally, the cache used to have two way logic: it would A.) return a result from the cache if there was one, OR B.) it would hit the underlying database if it had either never seen the ip address before or if the ip address wasn't in the database.

After this pull request that logic changes to three way logic: it will A.) return a result from the cache if there is one, OR B.) return null 'from the cache' if there isn't a record of the ip address in the database, OR C.) hit the underlying database if it hasn't seen the ip address before.

Generally speaking, I don't expect the databases to have records for "private internets" (https://www.ietf.org/rfc/rfc1918.txt) so if you're feeding a lot of those sorts of ip addresses into the `geoip` processor, then this change will result in significantly better performance for you (since we'll cache 'no-result' rather than hitting the underlying database each time).

In some ad-hoc testing on my machine, a cache hit is about an order of magnitude cheaper than hitting the actual database, so the more we can exercise the cache, the faster we'll be.