### PR TITLE
[8.12] [dra] Trigger elasticsearch-hadoop dra build whenever we build a new staging artifact (#104084)

### DIFF
--- a/.buildkite/pipelines/dra-workflow.yml
+++ b/.buildkite/pipelines/dra-workflow.yml
@@ -7,3 +7,13 @@ steps:
       image: family/elasticsearch-ubuntu-2204
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+  - wait
+  # The hadoop build depends on the ES artifact
+  # So let's trigger the hadoop build any time we build a new staging artifact
+  - trigger: elasticsearch-hadoop-dra-workflow
+    async: true
+    build:
+      branch: "${BUILDKITE_BRANCH}"
+      env:
+        DRA_WORKFLOW: staging
+    if: build.env('DRA_WORKFLOW') == 'staging'


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.12`:
 - [[dra] Trigger elasticsearch-hadoop dra build whenever we build a new staging artifact (#104084)](https://github.com/elastic/elasticsearch/pull/104084)

<!--- Backport version: 9.2.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)