### PR TITLE
Fix `require_alias` implicit true value on presence

### DIFF
--- a/docs/changelog/104099.yaml
+++ b/docs/changelog/104099.yaml
@@ -1,0 +1,6 @@
+pr: 104099
+summary: Fix `require_alias` implicit true value on presence
+area: Indices APIs
+type: bug
+issues:
+ - 103945

--- a/qa/smoke-test-http/src/javaRestTest/java/org/elasticsearch/http/AutoCreateIndexIT.java
+++ b/qa/smoke-test-http/src/javaRestTest/java/org/elasticsearch/http/AutoCreateIndexIT.java
@@ -8,18 +8,22 @@
 
 package org.elasticsearch.http;
 
+import org.apache.http.util.EntityUtils;
 import org.elasticsearch.action.support.AutoCreateIndex;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.Streams;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.test.rest.ESRestTestCase;
+import org.elasticsearch.xcontent.ObjectPath;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.json.JsonXContent;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.util.Map;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.Matchers.containsString;
@@ -76,6 +80,22 @@ public class AutoCreateIndexIT extends ESRestTestCase {
         assertThat(
             Streams.copyToString(new InputStreamReader(responseException.getResponse().getEntity().getContent(), UTF_8)),
             containsString("no such index [composable template [recipe*] forbids index auto creation]")
+        );
+    }
+
+    public void testRequireAliasImplicitValueIsTrue() throws IOException {
+        final Request indexDocumentRequest = new Request("POST", "/_bulk?require_alias");
+        indexDocumentRequest.setJsonEntity("""
+            { "index" : { "_index" : "test", "_id" : "1" } }
+            { "field1" : "value1" }
+            """);
+        String resp = EntityUtils.toString(client().performRequest(indexDocumentRequest).getEntity());
+        Map<String, Object> respDoc = XContentHelper.convertToMap(JsonXContent.jsonXContent, resp, false);
+        assertTrue("there should be errors in the bulk response", ObjectPath.eval("errors", respDoc));
+        assertThat(
+            "there should be errors in the bulk response",
+            "" + ObjectPath.eval("items.0.index.error.reason", respDoc),
+            containsString("no such index [test] and [require_alias] request flag is [true] and [test] is not an alias")
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/rest/action/document/RestBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/document/RestBulkAction.java
@@ -79,7 +79,7 @@ public class RestBulkAction extends BaseRestHandler {
         if (waitForActiveShards != null) {
             bulkRequest.waitForActiveShards(ActiveShardCount.parseString(waitForActiveShards));
         }
-        Boolean defaultRequireAlias = request.paramAsBoolean(DocWriteRequest.REQUIRE_ALIAS, null);
+        Boolean defaultRequireAlias = request.paramAsBoolean(DocWriteRequest.REQUIRE_ALIAS, false);
         bulkRequest.timeout(request.paramAsTime("timeout", BulkShardRequest.DEFAULT_TIMEOUT));
         bulkRequest.setRefreshPolicy(request.param("refresh"));
         bulkRequest.add(


### PR DESCRIPTION
This commit brings the `require_alias` query-string parameter into line with the rest of our parameters where its presence indicates an implicit "true" value (so a user can do `POST /_bulk?require_alias` to enable the check).

Resolves #103945
