### PR TITLE
Ensure test clusters use keystore cli tool flag for reading from stdin

### DIFF
--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalClusterFactory.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalClusterFactory.java
@@ -472,7 +472,7 @@ public abstract class AbstractLocalClusterFactory<S extends LocalClusterSpec, H 
                     ? value
                     : spec.getKeystorePassword() + "\n" + value;
 
-                runToolScript("elasticsearch-keystore", input, "add", key);
+                runToolScript("elasticsearch-keystore", input, "add", "-x", key);
             });
         }
 


### PR DESCRIPTION
We've seen a large number of test failures due to errors adding secure settings to the keystore in test clusters when running on Java 22 (see https://github.com/elastic/elasticsearch/issues/103963). It seems we are having issues reading the secure setting value from stdin. Turns out, the `elasticsearch-keystore` CLI actually has an explicit flag (`-x`) for instructing it to read from stdin that we weren't using. I assume this incidentally worked since the when the flag is missing, it simply prompts the user to provide the value, then reads it from terminal anyway. There was likely always a race condition here and running on Java 22 has exacerbated it somehow.

This PR now explicitly passes this flag, which should resolve the issues on Java 22 and perhaps address instability when using security settings in tests on other runtimes as well.