### PR TITLE
Unmute DownsampleActionIT.testTsdbDataStreams() test

### DIFF
--- a/x-pack/plugin/ilm/qa/multi-node/build.gradle
+++ b/x-pack/plugin/ilm/qa/multi-node/build.gradle
@@ -38,6 +38,7 @@ testClusters.configureEach {
    * cached time. So the policy's action date is always after the snapshot's start.
    */
   setting 'thread_pool.estimated_time_interval', '0'
+  setting 'time_series.poll_interval', '10m'
 }
 
 if (BuildParams.inFipsJvm){

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/DownsampleActionIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/DownsampleActionIT.java
@@ -302,7 +302,6 @@ public class DownsampleActionIT extends ESRestTestCase {
         });
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/103439")
     public void testTsdbDataStreams() throws Exception {
         // Create the ILM policy
         DateHistogramInterval fixedInterval = ConfigTestHelpers.randomInterval();


### PR DESCRIPTION
- More logging was added this should give more insight in the next failure.
- Increased the `time_series.poll_interval` setting.  The time when the `index.time_series.end_time` index setting gets updated by `UpdateTimeSeriesRangeService` is the likely cause of the test failure.