### PR TITLE
Log rejection in SLMGetExpiredSnapshotsAction

### DIFF
--- a/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/SLMGetExpiredSnapshotsAction.java
+++ b/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/SLMGetExpiredSnapshotsAction.java
@@ -25,7 +25,6 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
-import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.repositories.GetSnapshotInfoContext;
 import org.elasticsearch.repositories.RepositoriesService;
@@ -69,7 +68,6 @@ public class SLMGetExpiredSnapshotsAction extends ActionType<SLMGetExpiredSnapsh
     public static class LocalAction extends TransportAction<Request, Response> {
         private final RepositoriesService repositoriesService;
         private final Executor retentionExecutor;
-        private final ThreadContext threadContext;
 
         private static final Logger logger = SLMGetExpiredSnapshotsAction.logger;
 
@@ -79,7 +77,6 @@ public class SLMGetExpiredSnapshotsAction extends ActionType<SLMGetExpiredSnapsh
             this.repositoriesService = repositoriesService;
             final var threadPool = transportService.getThreadPool();
             this.retentionExecutor = threadPool.executor(ThreadPool.Names.MANAGEMENT);
-            this.threadContext = threadPool.getThreadContext();
         }
 
         private static class ResultsBuilder {
@@ -120,34 +117,36 @@ public class SLMGetExpiredSnapshotsAction extends ActionType<SLMGetExpiredSnapsh
                         continue;
                     }
 
-                    retentionExecutor.execute(
-                        ActionRunnable.wrap(
-                            refs.acquireListener(),
-                            perRepositoryListener -> SubscribableListener
+                    retentionExecutor.execute(ActionRunnable.wrap(ActionListener.releaseAfter(new ActionListener<Void>() {
+                        @Override
+                        public void onResponse(Void unused) {}
 
-                                // Get repository data
-                                .<RepositoryData>newForked(l -> repository.getRepositoryData(retentionExecutor, l))
+                        @Override
+                        public void onFailure(Exception e) {
+                            logger.debug(Strings.format("[%s]: could not compute expired snapshots", repositoryName), e);
+                        }
+                    }, refs.acquire()),
+                        perRepositoryListener -> SubscribableListener
 
-                                // Collect snapshot details by policy, and get any missing details by reading SnapshotInfo
-                                .<SnapshotDetailsByPolicy>andThen(
-                                    (l, repositoryData) -> getSnapshotDetailsByPolicy(retentionExecutor, repository, repositoryData, l)
-                                )
+                            // Get repository data
+                            .<RepositoryData>newForked(l -> repository.getRepositoryData(retentionExecutor, l))
 
-                                // Compute snapshots to delete for each (relevant) policy
-                                .andThenAccept(snapshotDetailsByPolicy -> {
-                                    resultsBuilder.addResult(
-                                        repositoryName,
-                                        getSnapshotsToDelete(repositoryName, request.policies(), snapshotDetailsByPolicy)
-                                    );
-                                })
+                            // Collect snapshot details by policy, and get any missing details by reading SnapshotInfo
+                            .<SnapshotDetailsByPolicy>andThen(
+                                (l, repositoryData) -> getSnapshotDetailsByPolicy(retentionExecutor, repository, repositoryData, l)
+                            )
 
-                                // And notify this repository's listener on completion
-                                .addListener(perRepositoryListener.delegateResponse((l, e) -> {
-                                    logger.debug(Strings.format("[%s]: could not compute expired snapshots", repositoryName), e);
-                                    l.onResponse(null);
-                                }))
-                        )
-                    );
+                            // Compute snapshots to delete for each (relevant) policy
+                            .andThenAccept(snapshotDetailsByPolicy -> {
+                                resultsBuilder.addResult(
+                                    repositoryName,
+                                    getSnapshotsToDelete(repositoryName, request.policies(), snapshotDetailsByPolicy)
+                                );
+                            })
+
+                            // And notify this repository's listener on completion
+                            .addListener(perRepositoryListener)
+                    ));
                 }
             }
         }

--- a/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/SLMGetExpiredSnapshotsAction.java
+++ b/x-pack/plugin/slm/src/main/java/org/elasticsearch/xpack/slm/SLMGetExpiredSnapshotsAction.java
@@ -75,8 +75,7 @@ public class SLMGetExpiredSnapshotsAction extends ActionType<SLMGetExpiredSnapsh
         public LocalAction(TransportService transportService, RepositoriesService repositoriesService, ActionFilters actionFilters) {
             super(INSTANCE.name(), actionFilters, transportService.getTaskManager());
             this.repositoriesService = repositoriesService;
-            final var threadPool = transportService.getThreadPool();
-            this.retentionExecutor = threadPool.executor(ThreadPool.Names.MANAGEMENT);
+            this.retentionExecutor = transportService.getThreadPool().executor(ThreadPool.Names.MANAGEMENT);
         }
 
         private static class ResultsBuilder {


### PR DESCRIPTION
We log failures encountered while computing the expired snapshots, but
in principle we could fail to even execute that computation. This commit
moves the exception handling to the listener wrapped by the
`ActionRunnable` so that we get a log message on all failure paths.