### PR TITLE
Fix security apm metric names

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/metric/SecurityMetricType.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/metric/SecurityMetricType.java
@@ -14,8 +14,8 @@ public enum SecurityMetricType {
 
     AUTHC_API_KEY(
         SecurityMetricGroup.AUTHC,
-        new SecurityMetricInfo("es.security.authc.api_key.success.count", "Number of successful API key authentications.", "count"),
-        new SecurityMetricInfo("es.security.authc.api_key.failures.count", "Number of failed API key authentications.", "count"),
+        new SecurityMetricInfo("es.security.authc.api_key.success.total", "Number of successful API key authentications.", "count"),
+        new SecurityMetricInfo("es.security.authc.api_key.failures.total", "Number of failed API key authentications.", "count"),
         new SecurityMetricInfo("es.security.authc.api_key.time", "Time it took (in nanoseconds) to execute API key authentication.", "ns")
     ),
 


### PR DESCRIPTION
fix the metric names not adhering to the validation rules