### PR TITLE
ESQL: Use Point geometry in tests

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/geo/SpatialPointTests.java
+++ b/server/src/test/java/org/elasticsearch/common/geo/SpatialPointTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.common.geo;
 
+import org.apache.lucene.tests.geo.GeoTestUtil;
 import org.elasticsearch.test.ESTestCase;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -32,7 +33,7 @@ public class SpatialPointTests extends ESTestCase {
 
     public void testCompareTo() {
         for (int i = 0; i < 100; i++) {
-            SpatialPoint point = randomValueOtherThanMany(p -> p.getX() < -170 || p.getX() > 170, ESTestCase::randomGeoPoint);
+            SpatialPoint point = randomValueOtherThanMany(p -> p.getX() < -170 || p.getX() > 170, SpatialPointTests::randomGeoPoint);
             GeoPoint smaller = new GeoPoint(point.getY(), point.getX() - 1);
             GeoPoint bigger = new GeoPoint(point.getY(), point.getX() + 1);
             TestPoint testSmaller = new TestPoint(smaller);
@@ -56,6 +57,10 @@ public class SpatialPointTests extends ESTestCase {
         assertThat("Equals: " + message, a, not(equalTo(b)));
         assertThat("Hashcode: " + message, a.hashCode(), not(equalTo(b.hashCode())));
         assertThat("Compare: " + message, a.compareTo(b), not(equalTo(0)));
+    }
+
+    private static GeoPoint randomGeoPoint() {
+        return new GeoPoint(GeoTestUtil.nextLatitude(), GeoTestUtil.nextLongitude());
     }
 
     /**

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -51,8 +51,6 @@ import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.bytes.CompositeBytesReference;
-import org.elasticsearch.common.geo.GeoPoint;
-import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
@@ -1192,34 +1190,6 @@ public abstract class ESTestCase extends LuceneTestCase {
      */
     public static String randomDateFormatterPattern() {
         return randomFrom(FormatNames.values()).getName();
-    }
-
-    /**
-     * Generate a random valid point constrained to geographic ranges (lat, lon ranges).
-     */
-    public static SpatialPoint randomGeoPoint() {
-        double lat = randomDoubleBetween(-90, 90, true);
-        double lon = randomDoubleBetween(-180, 180, true);
-        return new GeoPoint(lat, lon);
-    }
-
-    /**
-     * Generate a random valid point constrained to cartesian ranges.
-     */
-    public static SpatialPoint randomCartesianPoint() {
-        double x = randomDoubleBetween(-Float.MAX_VALUE, Float.MAX_VALUE, true);
-        double y = randomDoubleBetween(-Float.MAX_VALUE, Float.MAX_VALUE, true);
-        return new SpatialPoint() {
-            @Override
-            public double getX() {
-                return x;
-            }
-
-            @Override
-            public double getY() {
-                return y;
-            }
-        };
     }
 
     /**

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicBlockTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicBlockTests.java
@@ -9,7 +9,6 @@ package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.breaker.CircuitBreaker;
-import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BitArray;
@@ -22,6 +21,9 @@ import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.core.RefCounted;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
+import org.elasticsearch.geo.GeometryTestUtils;
+import org.elasticsearch.geo.ShapeTestUtils;
+import org.elasticsearch.geometry.Point;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.After;
@@ -445,11 +447,11 @@ public class BasicBlockTests extends ESTestCase {
     }
 
     public void testBytesRefBlockOnGeoPoints() {
-        testBytesRefBlock(() -> GEO.pointAsWKB(randomGeoPoint()), false, GEO::wkbAsString);
+        testBytesRefBlock(() -> GEO.pointAsWKB(GeometryTestUtils.randomPoint()), false, GEO::wkbAsString);
     }
 
     public void testBytesRefBlockOnCartesianPoints() {
-        testBytesRefBlock(() -> CARTESIAN.pointAsWKB(randomCartesianPoint()), false, CARTESIAN::wkbAsString);
+        testBytesRefBlock(() -> CARTESIAN.pointAsWKB(ShapeTestUtils.randomPoint()), false, CARTESIAN::wkbAsString);
     }
 
     public void testBytesRefBlockBuilderWithNulls() {
@@ -895,7 +897,7 @@ public class BasicBlockTests extends ESTestCase {
         List<List<Object>> values = new ArrayList<>();
         try (var builder = elementType.newBlockBuilder(positionCount, blockFactory)) {
             boolean bytesRefFromPoints = randomBoolean();
-            Supplier<SpatialPoint> pointSupplier = randomBoolean() ? ESTestCase::randomGeoPoint : ESTestCase::randomCartesianPoint;
+            Supplier<Point> pointSupplier = randomBoolean() ? GeometryTestUtils::randomPoint : ShapeTestUtils::randomPoint;
             for (int p = 0; p < positionCount; p++) {
                 int valueCount = between(minValuesPerPosition, maxValuesPerPosition);
                 if (valueCount == 0 || nullAllowed && randomBoolean()) {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/TopNEncoderTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/topn/TopNEncoderTests.java
@@ -11,8 +11,9 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.apache.lucene.document.InetAddressPoint;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.compute.operator.BreakingBytesRefBuilder;
+import org.elasticsearch.geo.GeometryTestUtils;
+import org.elasticsearch.geo.ShapeTestUtils;
 import org.elasticsearch.geometry.Point;
 import org.elasticsearch.geometry.utils.WellKnownBinary;
 import org.elasticsearch.test.ESTestCase;
@@ -139,8 +140,8 @@ public class TopNEncoderTests extends ESTestCase {
     }
 
     static BytesRef randomPointAsWKB() {
-        SpatialPoint point = randomBoolean() ? randomGeoPoint() : randomCartesianPoint();
-        byte[] wkb = WellKnownBinary.toWKB(new Point(point.getX(), point.getY()), ByteOrder.LITTLE_ENDIAN);
+        Point point = randomBoolean() ? GeometryTestUtils.randomPoint() : ShapeTestUtils.randomPoint();
+        byte[] wkb = WellKnownBinary.toWKB(point, ByteOrder.LITTLE_ENDIAN);
         return new BytesRef(wkb);
     }
 }

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
@@ -12,7 +12,6 @@ import org.apache.http.HttpEntity;
 import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.ResponseException;
-import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
@@ -162,31 +161,7 @@ public abstract class EsqlSpecTestCase extends ESRestTestCase {
         Logger logger
     ) {
         assertMetadata(expected, actualColumns, logger);
-        assertData(expected, actualValues, testCase.ignoreOrder, logger, EsqlSpecTestCase::valueToString);
-    }
-
-    /**
-     * Unfortunately the GeoPoint.toString method returns the old format, but cannot be changed due to BWC.
-     * So we need to custom format GeoPoint as well as wrap Lists to ensure this custom conversion applies to multi-value fields
-     */
-    private static String valueToString(Object value) {
-        if (value == null) {
-            return "null";
-        } else if (value instanceof List<?> list) {
-            StringBuilder sb = new StringBuilder("[");
-            for (Object field : list) {
-                if (sb.length() > 1) {
-                    sb.append(", ");
-                }
-                sb.append(valueToString(field));
-            }
-            return sb.append("]").toString();
-        } else if (value instanceof SpatialPoint point) {
-            // Alternatively we could just change GeoPoint.toString() to use WKT, but that has other side-effects
-            return point.toWKT();
-        } else {
-            return value.toString();
-        }
+        assertData(expected, actualValues, testCase.ignoreOrder, logger, value -> value == null ? "null" : value.toString());
     }
 
     private Throwable reworkException(Throwable th) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponseTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponseTests.java
@@ -33,6 +33,8 @@ import org.elasticsearch.compute.operator.DriverProfile;
 import org.elasticsearch.compute.operator.DriverStatus;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasables;
+import org.elasticsearch.geo.GeometryTestUtils;
+import org.elasticsearch.geo.ShapeTestUtils;
 import org.elasticsearch.test.AbstractChunkedSerializingTestCase;
 import org.elasticsearch.xcontent.InstantiatingObjectParser;
 import org.elasticsearch.xcontent.ObjectParser;
@@ -148,8 +150,10 @@ public class EsqlQueryResponseTests extends AbstractChunkedSerializingTestCase<E
                     new BytesRef(UnsupportedValueSource.UNSUPPORTED_OUTPUT)
                 );
                 case "version" -> ((BytesRefBlock.Builder) builder).appendBytesRef(new Version(randomIdentifier()).toBytesRef());
-                case "geo_point" -> ((BytesRefBlock.Builder) builder).appendBytesRef(GEO.pointAsWKB(randomGeoPoint()));
-                case "cartesian_point" -> ((BytesRefBlock.Builder) builder).appendBytesRef(CARTESIAN.pointAsWKB(randomCartesianPoint()));
+                case "geo_point" -> ((BytesRefBlock.Builder) builder).appendBytesRef(GEO.pointAsWKB(GeometryTestUtils.randomPoint()));
+                case "cartesian_point" -> ((BytesRefBlock.Builder) builder).appendBytesRef(
+                    CARTESIAN.pointAsWKB(ShapeTestUtils.randomPoint())
+                );
                 case "null" -> builder.appendNull();
                 case "_source" -> {
                     try {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractFunctionTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractFunctionTestCase.java
@@ -28,6 +28,8 @@ import org.elasticsearch.compute.operator.EvalOperator;
 import org.elasticsearch.compute.operator.EvalOperator.ExpressionEvaluator;
 import org.elasticsearch.core.PathUtils;
 import org.elasticsearch.core.Releasables;
+import org.elasticsearch.geo.GeometryTestUtils;
+import org.elasticsearch.geo.ShapeTestUtils;
 import org.elasticsearch.indices.CrankyCircuitBreakerService;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.test.ESTestCase;
@@ -125,8 +127,8 @@ public abstract class AbstractFunctionTestCase extends ESTestCase {
             case "time_duration" -> Duration.ofMillis(randomLongBetween(-604800000L, 604800000L)); // plus/minus 7 days
             case "text" -> new BytesRef(randomAlphaOfLength(50));
             case "version" -> randomVersion().toBytesRef();
-            case "geo_point" -> GEO.pointAsWKB(randomGeoPoint());
-            case "cartesian_point" -> CARTESIAN.pointAsWKB(randomCartesianPoint());
+            case "geo_point" -> GEO.pointAsWKB(GeometryTestUtils.randomPoint());
+            case "cartesian_point" -> CARTESIAN.pointAsWKB(ShapeTestUtils.randomPoint());
             case "null" -> null;
             case "_source" -> {
                 try {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/TestCaseSupplier.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/TestCaseSupplier.java
@@ -10,6 +10,8 @@ package org.elasticsearch.xpack.esql.expression.function;
 import org.apache.lucene.document.InetAddressPoint;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.network.InetAddresses;
+import org.elasticsearch.geo.GeometryTestUtils;
+import org.elasticsearch.geo.ShapeTestUtils;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.test.ESTestCase;
@@ -41,8 +43,6 @@ import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
-import static org.elasticsearch.test.ESTestCase.randomCartesianPoint;
-import static org.elasticsearch.test.ESTestCase.randomGeoPoint;
 import static org.elasticsearch.xpack.ql.util.SpatialCoordinateTypes.CARTESIAN;
 import static org.elasticsearch.xpack.ql.util.SpatialCoordinateTypes.GEO;
 import static org.hamcrest.Matchers.equalTo;
@@ -913,12 +913,18 @@ public record TestCaseSupplier(String name, List<DataType> types, Supplier<TestC
     }
 
     private static List<TypedDataSupplier> geoPointCases() {
-        return List.of(new TypedDataSupplier("<geo_point>", () -> GEO.pointAsWKB(randomGeoPoint()), EsqlDataTypes.GEO_POINT));
+        return List.of(
+            new TypedDataSupplier("<geo_point>", () -> GEO.pointAsWKB(GeometryTestUtils.randomPoint()), EsqlDataTypes.GEO_POINT)
+        );
     }
 
     private static List<TypedDataSupplier> cartesianPointCases() {
         return List.of(
-            new TypedDataSupplier("<cartesian_point>", () -> CARTESIAN.pointAsWKB(randomCartesianPoint()), EsqlDataTypes.CARTESIAN_POINT)
+            new TypedDataSupplier(
+                "<cartesian_point>",
+                () -> CARTESIAN.pointAsWKB(ShapeTestUtils.randomPoint()),
+                EsqlDataTypes.CARTESIAN_POINT
+            )
         );
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToCartesianPointTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToCartesianPointTests.java
@@ -11,6 +11,7 @@ import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.geo.ShapeTestUtils;
 import org.elasticsearch.xpack.esql.expression.function.AbstractFunctionTestCase;
 import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
 import org.elasticsearch.xpack.esql.type.EsqlDataTypes;
@@ -76,7 +77,7 @@ public class ToCartesianPointTests extends AbstractFunctionTestCase {
             List.of(
                 new TestCaseSupplier.TypedDataSupplier(
                     "<cartesian point as string>",
-                    () -> new BytesRef(CARTESIAN.pointAsString(randomCartesianPoint())),
+                    () -> new BytesRef(CARTESIAN.pointAsString(ShapeTestUtils.randomPoint())),
                     DataTypes.KEYWORD
                 )
             ),

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToGeoPointTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/convert/ToGeoPointTests.java
@@ -11,6 +11,7 @@ import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.geo.GeometryTestUtils;
 import org.elasticsearch.xpack.esql.expression.function.AbstractFunctionTestCase;
 import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
 import org.elasticsearch.xpack.esql.type.EsqlDataTypes;
@@ -68,7 +69,7 @@ public class ToGeoPointTests extends AbstractFunctionTestCase {
             List.of(
                 new TestCaseSupplier.TypedDataSupplier(
                     "<geo point as string>",
-                    () -> new BytesRef(GEO.pointAsString(randomGeoPoint())),
+                    () -> new BytesRef(GEO.pointAsString(GeometryTestUtils.randomPoint())),
                     DataTypes.KEYWORD
                 )
             ),

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/AbstractMultivalueFunctionTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/AbstractMultivalueFunctionTestCase.java
@@ -8,8 +8,10 @@
 package org.elasticsearch.xpack.esql.expression.function.scalar.multivalue;
 
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.geo.GeometryTestUtils;
+import org.elasticsearch.geo.ShapeTestUtils;
+import org.elasticsearch.geometry.Point;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
 import org.elasticsearch.xpack.esql.expression.function.scalar.AbstractScalarFunctionTestCase;
@@ -413,7 +415,7 @@ public abstract class AbstractMultivalueFunctionTestCase extends AbstractScalarF
         DataType expectedDataType,
         BiFunction<Integer, Stream<BytesRef>, Matcher<Object>> matcher
     ) {
-        points(cases, name, evaluatorName, EsqlDataTypes.GEO_POINT, expectedDataType, GEO, ESTestCase::randomGeoPoint, matcher);
+        points(cases, name, evaluatorName, EsqlDataTypes.GEO_POINT, expectedDataType, GEO, GeometryTestUtils::randomPoint, matcher);
     }
 
     /**
@@ -448,7 +450,7 @@ public abstract class AbstractMultivalueFunctionTestCase extends AbstractScalarF
             EsqlDataTypes.CARTESIAN_POINT,
             expectedDataType,
             CARTESIAN,
-            ESTestCase::randomCartesianPoint,
+            ShapeTestUtils::randomPoint,
             matcher
         );
     }
@@ -463,12 +465,11 @@ public abstract class AbstractMultivalueFunctionTestCase extends AbstractScalarF
         DataType dataType,
         DataType expectedDataType,
         SpatialCoordinateTypes spatial,
-        Supplier<SpatialPoint> randomPoint,
+        Supplier<Point> randomPoint,
         BiFunction<Integer, Stream<BytesRef>, Matcher<Object>> matcher
     ) {
         cases.add(new TestCaseSupplier(name + "(" + dataType.typeName() + ")", List.of(dataType), () -> {
-            SpatialPoint point = randomPoint.get();
-            BytesRef wkb = spatial.pointAsWKB(point);
+            BytesRef wkb = spatial.pointAsWKB(randomPoint.get());
             return new TestCaseSupplier.TestCase(
                 List.of(new TestCaseSupplier.TypedData(List.of(wkb), dataType, "field")),
                 evaluatorName + "[field=Attribute[channel=0]]",

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/util/SpatialCoordinateTypes.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/util/SpatialCoordinateTypes.java
@@ -10,8 +10,6 @@ package org.elasticsearch.xpack.ql.util;
 import org.apache.lucene.geo.GeoEncodingUtils;
 import org.apache.lucene.geo.XYEncodingUtils;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.geo.GeoPoint;
-import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.Point;
 import org.elasticsearch.geometry.utils.GeometryValidator;
@@ -25,8 +23,8 @@ import static org.apache.lucene.geo.GeoEncodingUtils.encodeLongitude;
 
 public enum SpatialCoordinateTypes {
     GEO {
-        public SpatialPoint longAsPoint(long encoded) {
-            return new GeoPoint(GeoEncodingUtils.decodeLatitude((int) (encoded >>> 32)), GeoEncodingUtils.decodeLongitude((int) encoded));
+        public Point longAsPoint(long encoded) {
+            return new Point(GeoEncodingUtils.decodeLongitude((int) encoded), GeoEncodingUtils.decodeLatitude((int) (encoded >>> 32)));
         }
 
         public long pointAsLong(double x, double y) {
@@ -36,14 +34,8 @@ public enum SpatialCoordinateTypes {
         }
     },
     CARTESIAN {
-        public SpatialPoint longAsPoint(long encoded) {
-            try {
-                final double x = XYEncodingUtils.decode((int) (encoded >>> 32));
-                final double y = XYEncodingUtils.decode((int) (encoded & 0xFFFFFFFF));
-                return makePoint(x, y);
-            } catch (Error e) {
-                throw new IllegalArgumentException("Failed to convert invalid encoded value to cartesian point");
-            }
+        public Point longAsPoint(long encoded) {
+            return new Point(XYEncodingUtils.decode((int) (encoded >>> 32)), XYEncodingUtils.decode((int) (encoded & 0xFFFFFFFF)));
         }
 
         public long pointAsLong(double x, double y) {
@@ -51,70 +43,14 @@ public enum SpatialCoordinateTypes {
             final long yi = XYEncodingUtils.encode((float) y);
             return (yi & 0xFFFFFFFFL) | xi << 32;
         }
-
-        private SpatialPoint makePoint(double x, double y) {
-            return new SpatialPoint() {
-                @Override
-                public double getX() {
-                    return x;
-                }
-
-                @Override
-                public double getY() {
-                    return y;
-                }
-
-                @Override
-                public int hashCode() {
-                    return 31 * Double.hashCode(x) + Double.hashCode(y);
-                }
-
-                @Override
-                public boolean equals(Object obj) {
-                    if (obj == null) {
-                        return false;
-                    }
-                    if (obj instanceof SpatialPoint other) {
-                        return x == other.getX() && y == other.getY();
-                    }
-                    return false;
-                }
-
-                @Override
-                public String toString() {
-                    return toWKT();
-                }
-            };
-        }
     };
 
-    public abstract SpatialPoint longAsPoint(long encoded);
-
-    public long pointAsLong(SpatialPoint point) {
-        return pointAsLong(point.getX(), point.getY());
-    }
+    public abstract Point longAsPoint(long encoded);
 
     public abstract long pointAsLong(double x, double y);
 
-    public String pointAsString(SpatialPoint point) {
-        return point.toWKT();
-    }
-
-    public Point stringAsPoint(String string) {
-        try {
-            Geometry geometry = WellKnownText.fromWKT(GeometryValidator.NOOP, false, string);
-            if (geometry instanceof Point point) {
-                return point;
-            } else {
-                throw new IllegalArgumentException("Unsupported geometry type " + geometry.type());
-            }
-        } catch (Exception e) {
-            throw new IllegalArgumentException("Failed to parse WKT: " + e.getMessage(), e);
-        }
-    }
-
-    public BytesRef pointAsWKB(SpatialPoint point) {
-        return pointAsWKB(new Point(point.getX(), point.getY()));
+    public String pointAsString(Point point) {
+        return WellKnownText.toWKT(point);
     }
 
     public BytesRef pointAsWKB(Point point) {

--- a/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/util/SpatialCoordinateTypesTests.java
+++ b/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/util/SpatialCoordinateTypesTests.java
@@ -7,7 +7,8 @@
 
 package org.elasticsearch.xpack.ql.util;
 
-import org.elasticsearch.common.geo.SpatialPoint;
+import org.elasticsearch.geo.GeometryTestUtils;
+import org.elasticsearch.geo.ShapeTestUtils;
 import org.elasticsearch.geometry.Point;
 import org.elasticsearch.test.ESTestCase;
 
@@ -22,10 +23,10 @@ public class SpatialCoordinateTypesTests extends ESTestCase {
 
     private static final Map<SpatialCoordinateTypes, TestTypeFunctions> types = new LinkedHashMap<>();
     static {
-        types.put(SpatialCoordinateTypes.GEO, new TestTypeFunctions(ESTestCase::randomGeoPoint, v -> 1e-5));
+        types.put(SpatialCoordinateTypes.GEO, new TestTypeFunctions(GeometryTestUtils::randomPoint, v -> 1e-5));
         types.put(
             SpatialCoordinateTypes.CARTESIAN,
-            new TestTypeFunctions(ESTestCase::randomCartesianPoint, SpatialCoordinateTypesTests::cartesianError)
+            new TestTypeFunctions(ShapeTestUtils::randomPoint, SpatialCoordinateTypesTests::cartesianError)
         );
     }
 
@@ -34,15 +35,15 @@ public class SpatialCoordinateTypesTests extends ESTestCase {
         return (abs < 1) ? 1e-5 : abs / 1e7;
     }
 
-    record TestTypeFunctions(Supplier<SpatialPoint> randomPoint, Function<Double, Double> error) {}
+    record TestTypeFunctions(Supplier<Point> randomPoint, Function<Double, Double> error) {}
 
     public void testEncoding() {
         for (var type : types.entrySet()) {
             for (int i = 0; i < 10; i++) {
                 SpatialCoordinateTypes coordType = type.getKey();
-                SpatialPoint original = type.getValue().randomPoint().get();
+                Point original = type.getValue().randomPoint().get();
                 var error = type.getValue().error;
-                SpatialPoint point = coordType.longAsPoint(coordType.pointAsLong(original));
+                Point point = coordType.longAsPoint(coordType.pointAsLong(original.getX(), original.getY()));
                 assertThat(coordType + ": Y[" + i + "]", point.getY(), closeTo(original.getY(), error.apply(original.getY())));
                 assertThat(coordType + ": X[" + i + "]", point.getX(), closeTo(original.getX(), error.apply(original.getX())));
             }
@@ -53,10 +54,8 @@ public class SpatialCoordinateTypesTests extends ESTestCase {
         for (var type : types.entrySet()) {
             for (int i = 0; i < 10; i++) {
                 SpatialCoordinateTypes coordType = type.getKey();
-                SpatialPoint geoPoint = type.getValue().randomPoint.get();
-                Point point = coordType.stringAsPoint(coordType.pointAsString(geoPoint));
-                assertThat(coordType + ": Y[" + i + "]", point.getY(), closeTo(geoPoint.getY(), 1e-5));
-                assertThat(coordType + ": X[" + i + "]", point.getX(), closeTo(geoPoint.getX(), 1e-5));
+                Point point = type.getValue().randomPoint.get();
+                assertEquals(coordType.wkbAsString(coordType.pointAsWKB(point)), coordType.pointAsString(point));
             }
         }
     }


### PR DESCRIPTION
We are currently use the SpatialPoint abstraction on ES|QL geo test which makes it difficult to integrate with geo_shape. Therefore this PR changes the implementation to use Point geometries.