### PR TITLE
Expand uses of matchers for Optionals

### DIFF
--- a/libs/core/src/test/java/org/elasticsearch/core/internal/provider/EmbeddedModulePathTests.java
+++ b/libs/core/src/test/java/org/elasticsearch/core/internal/provider/EmbeddedModulePathTests.java
@@ -31,7 +31,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.elasticsearch.test.hamcrest.ModuleDescriptorMatchers.exportsOf;
 import static org.elasticsearch.test.hamcrest.ModuleDescriptorMatchers.opensOf;
 import static org.elasticsearch.test.hamcrest.OptionalMatchers.isEmpty;
-import static org.elasticsearch.test.hamcrest.OptionalMatchers.isPresent;
+import static org.elasticsearch.test.hamcrest.OptionalMatchers.isPresentWith;
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -51,16 +51,13 @@ public class EmbeddedModulePathTests extends ESTestCase {
         assertThat(over, isEmpty());
 
         over = EmbeddedModulePath.version("foo-1.2.jar");
-        assertThat(over, isPresent());
-        assertThat(over.get(), is(Version.parse("1.2")));
+        assertThat(over, isPresentWith(Version.parse("1.2")));
 
         over = EmbeddedModulePath.version("foo-bar-1.2.3-SNAPSHOT.jar");
-        assertThat(over, isPresent());
-        assertThat(over.get(), is(Version.parse("1.2.3-SNAPSHOT")));
+        assertThat(over, isPresentWith(Version.parse("1.2.3-SNAPSHOT")));
 
         over = EmbeddedModulePath.version("elasticsearch-8.3.0-SNAPSHOT.jar");
-        assertThat(over, isPresent());
-        assertThat(over.get(), is(Version.parse("8.3.0-SNAPSHOT")));
+        assertThat(over, isPresentWith(Version.parse("8.3.0-SNAPSHOT")));
 
         expectThrows(IAE, () -> EmbeddedModulePath.version(""));
         expectThrows(IAE, () -> EmbeddedModulePath.version("foo"));

--- a/modules/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureBlobContainerRetriesTests.java
+++ b/modules/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureBlobContainerRetriesTests.java
@@ -44,6 +44,7 @@ import java.util.stream.Collectors;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.elasticsearch.repositories.blobstore.BlobStoreTestUtil.randomPurpose;
 import static org.elasticsearch.repositories.blobstore.ESBlobStoreRepositoryIntegTestCase.randomBytes;
+import static org.elasticsearch.test.hamcrest.OptionalMatchers.isPresentWith;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -133,8 +134,7 @@ public class AzureBlobContainerRetriesTests extends AbstractAzureServerTestCase 
                         final int rangeStart = getRangeStart(exchange);
                         assertThat(rangeStart, lessThan(bytes.length));
                         final Optional<Integer> rangeEnd = getRangeEnd(exchange);
-                        assertThat(rangeEnd.isPresent(), is(true));
-                        assertThat(rangeEnd.get(), greaterThanOrEqualTo(rangeStart));
+                        assertThat(rangeEnd, isPresentWith(greaterThanOrEqualTo(rangeStart)));
                         final int length = (rangeEnd.get() - rangeStart) + 1;
                         assertThat(length, lessThanOrEqualTo(bytes.length - rangeStart));
                         exchange.getResponseHeaders().add("Content-Type", "application/octet-stream");

--- a/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobContainerRetriesTests.java
+++ b/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageBlobContainerRetriesTests.java
@@ -70,6 +70,7 @@ import static org.elasticsearch.repositories.gcs.GoogleCloudStorageClientSetting
 import static org.elasticsearch.repositories.gcs.GoogleCloudStorageClientSettings.ENDPOINT_SETTING;
 import static org.elasticsearch.repositories.gcs.GoogleCloudStorageClientSettings.READ_TIMEOUT_SETTING;
 import static org.elasticsearch.repositories.gcs.GoogleCloudStorageClientSettings.TOKEN_URI_SETTING;
+import static org.elasticsearch.test.hamcrest.OptionalMatchers.isPresent;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -203,7 +204,7 @@ public class GoogleCloudStorageBlobContainerRetriesTests extends AbstractBlobCon
             assertThat(exchange.getRequestURI().getQuery(), containsString("uploadType=multipart"));
             if (countDown.countDown()) {
                 Optional<Tuple<String, BytesReference>> content = parseMultipartRequestBody(exchange.getRequestBody());
-                assertThat(content.isPresent(), is(true));
+                assertThat(content, isPresent());
                 assertThat(content.get().v1(), equalTo(blobContainer.path().buildAsString() + "write_blob_max_retries"));
                 if (Objects.deepEquals(bytes, BytesReference.toBytes(content.get().v2()))) {
                     byte[] response = Strings.format("""

--- a/modules/systemd/src/test/java/org/elasticsearch/systemd/SystemdPluginTests.java
+++ b/modules/systemd/src/test/java/org/elasticsearch/systemd/SystemdPluginTests.java
@@ -25,6 +25,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 
+import static org.elasticsearch.test.hamcrest.OptionalMatchers.isPresentWith;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasToString;
@@ -110,12 +112,16 @@ public class SystemdPluginTests extends ESTestCase {
 
     public void testOnNodeStartedFailure() {
         final int rc = randomIntBetween(Integer.MIN_VALUE, -1);
-        runTestOnNodeStarted(Boolean.TRUE.toString(), rc, (maybe, plugin) -> {
-            assertThat(maybe, OptionalMatchers.isPresent());
-            // noinspection OptionalGetWithoutIsPresent
-            assertThat(maybe.get(), instanceOf(RuntimeException.class));
-            assertThat(maybe.get(), hasToString(containsString("sd_notify returned error [" + rc + "]")));
-        });
+        runTestOnNodeStarted(
+            Boolean.TRUE.toString(),
+            rc,
+            (maybe, plugin) -> assertThat(
+                maybe,
+                isPresentWith(
+                    allOf(instanceOf(RuntimeException.class), hasToString(containsString("sd_notify returned error [" + rc + "]")))
+                )
+            )
+        );
     }
 
     public void testOnNodeStartedNotEnabled() {

--- a/server/src/test/java/org/elasticsearch/action/RequestValidatorsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/RequestValidatorsTests.java
@@ -11,12 +11,16 @@ package org.elasticsearch.action;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
 import org.elasticsearch.common.Randomness;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.hamcrest.OptionalMatchers;
-import org.hamcrest.Matchers;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+
+import static org.elasticsearch.test.LambdaMatchers.transformedMatch;
+import static org.elasticsearch.test.hamcrest.OptionalMatchers.isEmpty;
+import static org.elasticsearch.test.hamcrest.OptionalMatchers.isPresent;
+import static org.elasticsearch.test.hamcrest.OptionalMatchers.isPresentWith;
+import static org.hamcrest.Matchers.arrayWithSize;
 
 public class RequestValidatorsTests extends ESTestCase {
 
@@ -32,17 +36,17 @@ public class RequestValidatorsTests extends ESTestCase {
             validators.add(EMPTY);
         }
         final RequestValidators<PutMappingRequest> requestValidators = new RequestValidators<>(validators);
-        assertThat(requestValidators.validateRequest(null, null, null), OptionalMatchers.isEmpty());
+        assertThat(requestValidators.validateRequest(null, null, null), isEmpty());
     }
 
     public void testFailure() {
         final RequestValidators<PutMappingRequest> validators = new RequestValidators<>(List.of(FAIL));
-        assertThat(validators.validateRequest(null, null, null), OptionalMatchers.isPresent());
+        assertThat(validators.validateRequest(null, null, null), isPresent());
     }
 
     public void testValidatesAfterFailure() {
         final RequestValidators<PutMappingRequest> validators = new RequestValidators<>(List.of(FAIL, EMPTY));
-        assertThat(validators.validateRequest(null, null, null), OptionalMatchers.isPresent());
+        assertThat(validators.validateRequest(null, null, null), isPresent());
     }
 
     public void testMultipleFailures() {
@@ -53,9 +57,7 @@ public class RequestValidatorsTests extends ESTestCase {
         }
         final RequestValidators<PutMappingRequest> requestValidators = new RequestValidators<>(validators);
         final Optional<Exception> e = requestValidators.validateRequest(null, null, null);
-        assertThat(e, OptionalMatchers.isPresent());
-        // noinspection OptionalGetWithoutIsPresent
-        assertThat(e.get().getSuppressed(), Matchers.arrayWithSize(numberOfFailures - 1));
+        assertThat(e, isPresentWith(transformedMatch(Exception::getSuppressed, arrayWithSize(numberOfFailures - 1))));
     }
 
     public void testRandom() {
@@ -74,11 +76,9 @@ public class RequestValidatorsTests extends ESTestCase {
         final RequestValidators<PutMappingRequest> requestValidators = new RequestValidators<>(validators);
         final Optional<Exception> e = requestValidators.validateRequest(null, null, null);
         if (numberOfFailures == 0) {
-            assertThat(e, OptionalMatchers.isEmpty());
+            assertThat(e, isEmpty());
         } else {
-            assertThat(e, OptionalMatchers.isPresent());
-            // noinspection OptionalGetWithoutIsPresent
-            assertThat(e.get().getSuppressed(), Matchers.arrayWithSize(numberOfFailures - 1));
+            assertThat(e, isPresentWith(transformedMatch(Exception::getSuppressed, arrayWithSize(numberOfFailures - 1))));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/common/network/NetworkUtilsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/network/NetworkUtilsTests.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.common.network;
 
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.hamcrest.OptionalMatchers;
 
 import java.net.InetAddress;
 import java.net.NetworkInterface;
@@ -17,6 +16,8 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.elasticsearch.common.network.NetworkUtils.getInterfaces;
+import static org.elasticsearch.test.LambdaMatchers.transformedMatch;
+import static org.elasticsearch.test.hamcrest.OptionalMatchers.isPresentWith;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -80,8 +81,7 @@ public class NetworkUtilsTests extends ESTestCase {
                 networkInterfaces,
                 netIf.getName()
             );
-            assertThat(maybeNetworkInterface, OptionalMatchers.isPresent());
-            assertThat(maybeNetworkInterface.get().getName(), equalTo(netIf.getName()));
+            assertThat(maybeNetworkInterface, isPresentWith(transformedMatch(NetworkInterface::getName, equalTo(netIf.getName()))));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -185,6 +185,7 @@ import static org.elasticsearch.index.engine.Engine.Operation.Origin.REPLICA;
 import static org.elasticsearch.index.seqno.SequenceNumbers.NO_OPS_PERFORMED;
 import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_PRIMARY_TERM;
 import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
+import static org.elasticsearch.test.hamcrest.OptionalMatchers.isPresent;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.Matchers.contains;
@@ -7719,7 +7720,7 @@ public class InternalEngineTests extends EngineTestCase {
 
     private static void releaseCommitRef(Map<IndexCommit, Engine.IndexCommitRef> commits, long generation) {
         var releasable = commits.keySet().stream().filter(c -> c.getGeneration() == generation).findFirst();
-        assertThat(releasable.isPresent(), is(true));
+        assertThat(releasable, isPresent());
         Engine.IndexCommitRef indexCommitRef = commits.get(releasable.get());
         try {
             indexCommitRef.close();

--- a/server/src/test/java/org/elasticsearch/plugins/ExtensionLoaderTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/ExtensionLoaderTests.java
@@ -23,9 +23,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.ServiceLoader;
 
+import static org.elasticsearch.test.hamcrest.OptionalMatchers.isEmpty;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -72,7 +72,7 @@ public class ExtensionLoaderTests extends ESTestCase {
 
     public void testNoProvider() {
         Optional<TestService> service = ExtensionLoader.loadSingleton(ServiceLoader.load(TestService.class));
-        assertThat(service.isEmpty(), is(true));
+        assertThat(service, isEmpty());
     }
 
     public void testOneProvider() throws Exception {

--- a/server/src/test/java/org/elasticsearch/plugins/PluginDescriptorTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/PluginDescriptorTests.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
+import static org.elasticsearch.test.hamcrest.OptionalMatchers.isEmpty;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
@@ -183,14 +184,14 @@ public class PluginDescriptorTests extends ESTestCase {
 
     public void testReadFromPropertiesModulenameFallback() throws Exception {
         PluginDescriptor info = mockInternalDescriptor("modulename", null);
-        assertThat(info.getModuleName().isPresent(), is(false));
+        assertThat(info.getModuleName(), isEmpty());
         assertThat(info.isModular(), is(false));
         assertThat(info.getExtendedPlugins(), empty());
     }
 
     public void testReadFromPropertiesModulenameEmpty() throws Exception {
         PluginDescriptor info = mockInternalDescriptor("modulename", " ");
-        assertThat(info.getModuleName().isPresent(), is(false));
+        assertThat(info.getModuleName(), isEmpty());
         assertThat(info.isModular(), is(false));
         assertThat(info.getExtendedPlugins(), empty());
     }

--- a/server/src/test/java/org/elasticsearch/transport/RemoteConnectionManagerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteConnectionManagerTests.java
@@ -28,10 +28,10 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
+import static org.elasticsearch.test.hamcrest.OptionalMatchers.isPresentWith;
 import static org.elasticsearch.transport.RemoteClusterService.REMOTE_CLUSTER_HANDSHAKE_ACTION_NAME;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
@@ -166,8 +166,7 @@ public class RemoteConnectionManagerTests extends ESTestCase {
         final Optional<RemoteConnectionManager.RemoteClusterAliasWithCredentials> actual = RemoteConnectionManager
             .resolveRemoteClusterAliasWithCredentials(wrappedConnection);
 
-        assertThat(actual.isPresent(), is(true));
-        assertThat(actual.get(), equalTo(new RemoteConnectionManager.RemoteClusterAliasWithCredentials(clusterAlias, credentials)));
+        assertThat(actual, isPresentWith(new RemoteConnectionManager.RemoteClusterAliasWithCredentials(clusterAlias, credentials)));
     }
 
     private static class TestRemoteConnection extends CloseableConnection {

--- a/test/framework/src/main/java/org/elasticsearch/test/hamcrest/OptionalMatchers.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/hamcrest/OptionalMatchers.java
@@ -28,12 +28,12 @@ public class OptionalMatchers {
 
         @Override
         protected void describeMismatchSafely(Optional<?> item, Description mismatchDescription) {
-            mismatchDescription.appendText("was not an empty optional");
+            mismatchDescription.appendText("a non-empty optional ").appendValue(item.get());
         }
 
         @Override
         public void describeTo(Description description) {
-            description.appendText("empty optional");
+            description.appendText("an empty optional");
         }
     }
 
@@ -56,18 +56,18 @@ public class OptionalMatchers {
 
         @Override
         public void describeTo(Description description) {
-            description.appendText("non-empty optional with item ").appendDescriptionOf(contents);
+            description.appendText("a non-empty optional ").appendDescriptionOf(contents);
         }
 
         @Override
         public void describeMismatch(Object item, Description description) {
             Optional<?> opt = (Optional<?>) item;
             if (opt.isEmpty()) {
-                description.appendText("empty optional");
+                description.appendText("an empty optional");
                 return;
             }
 
-            description.appendText("optional with ");
+            description.appendText("an optional ");
             contents.describeMismatch(opt.get(), description);
         }
     }

--- a/test/framework/src/main/java/org/elasticsearch/test/hamcrest/OptionalMatchers.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/hamcrest/OptionalMatchers.java
@@ -8,66 +8,79 @@
 
 package org.elasticsearch.test.hamcrest;
 
+import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
+import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 
 import java.util.Optional;
 
+import static org.hamcrest.Matchers.anything;
+import static org.hamcrest.Matchers.equalTo;
+
 public class OptionalMatchers {
 
     private static class IsEmptyMatcher extends TypeSafeMatcher<Optional<?>> {
-
         @Override
-        protected boolean matchesSafely(final Optional<?> item) {
-            // noinspection OptionalAssignedToNull
-            return item != null && item.isEmpty();
+        protected boolean matchesSafely(Optional<?> item) {
+            return item.isEmpty();
         }
 
         @Override
-        public void describeTo(final Description description) {
-            description.appendText("expected empty optional");
+        protected void describeMismatchSafely(Optional<?> item, Description mismatchDescription) {
+            mismatchDescription.appendText("was not an empty optional");
         }
 
         @Override
-        protected void describeMismatchSafely(final Optional<?> item, final Description mismatchDescription) {
-            if (item == null) {
-                mismatchDescription.appendText("was null");
-            } else {
-                mismatchDescription.appendText("was ").appendText(item.toString());
-            }
+        public void describeTo(Description description) {
+            description.appendText("empty optional");
         }
-
     }
 
-    public static IsEmptyMatcher isEmpty() {
+    public static Matcher<Optional<?>> isEmpty() {
         return new IsEmptyMatcher();
     }
 
-    private static class IsPresentMatcher extends TypeSafeMatcher<Optional<?>> {
+    private static class IsPresentMatcher<T> extends BaseMatcher<Optional<? extends T>> {
+        private final Matcher<? super T> contents;
 
-        @Override
-        protected boolean matchesSafely(final Optional<?> item) {
-            return item != null && item.isPresent();
+        private IsPresentMatcher(Matcher<? super T> contents) {
+            this.contents = contents;
         }
 
         @Override
-        public void describeTo(final Description description) {
-            description.appendText("expected non-empty optional");
+        public boolean matches(Object actual) {
+            Optional<?> opt = (Optional<?>) actual;
+            return opt.isPresent() && contents.matches(opt.get());
         }
 
         @Override
-        protected void describeMismatchSafely(final Optional<?> item, final Description mismatchDescription) {
-            if (item == null) {
-                mismatchDescription.appendText("was null");
-            } else {
-                mismatchDescription.appendText("was empty");
+        public void describeTo(Description description) {
+            description.appendText("non-empty optional with item ").appendDescriptionOf(contents);
+        }
+
+        @Override
+        public void describeMismatch(Object item, Description description) {
+            Optional<?> opt = (Optional<?>) item;
+            if (opt.isEmpty()) {
+                description.appendText("empty optional");
+                return;
             }
+
+            description.appendText("optional with ");
+            contents.describeMismatch(opt.get(), description);
         }
-
     }
 
-    public static IsPresentMatcher isPresent() {
-        return new IsPresentMatcher();
+    public static <T> Matcher<Optional<? extends T>> isPresent() {
+        return new IsPresentMatcher<>(anything());
     }
 
+    public static <T> Matcher<Optional<? extends T>> isPresentWith(T contents) {
+        return new IsPresentMatcher<>(equalTo(contents));
+    }
+
+    public static <T> Matcher<Optional<? extends T>> isPresentWith(Matcher<? super T> contents) {
+        return new IsPresentMatcher<>(contents);
+    }
 }

--- a/test/framework/src/test/java/org/elasticsearch/test/hamcrest/OptionalMatchersTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/hamcrest/OptionalMatchersTests.java
@@ -35,7 +35,6 @@ public class OptionalMatchersTests extends ESTestCase {
         assertThat(Optional.empty(), not(isPresent()));
 
         StringDescription desc = new StringDescription();
-
         isPresent().describeMismatch(Optional.empty(), desc);
         assertThat(desc.toString(), equalTo("an empty optional"));
     }

--- a/test/framework/src/test/java/org/elasticsearch/test/hamcrest/OptionalMatchersTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/hamcrest/OptionalMatchersTests.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.test.hamcrest;
+
+import org.elasticsearch.test.ESTestCase;
+import org.hamcrest.StringDescription;
+
+import java.util.Optional;
+
+import static org.elasticsearch.test.hamcrest.OptionalMatchers.isEmpty;
+import static org.elasticsearch.test.hamcrest.OptionalMatchers.isPresent;
+import static org.elasticsearch.test.hamcrest.OptionalMatchers.isPresentWith;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+
+public class OptionalMatchersTests extends ESTestCase {
+
+    public void testEmptyMatcher() {
+        assertThat(Optional.empty(), isEmpty());
+        assertThat(Optional.of(""), not(isEmpty()));
+
+        StringDescription desc = new StringDescription();
+        isEmpty().describeMismatch(Optional.of(""), desc);
+        assertThat(desc.toString(), equalTo("a non-empty optional \"\""));
+    }
+
+    public void testIsPresentMatcher() {
+        assertThat(Optional.of(""), isPresent());
+        assertThat(Optional.empty(), not(isPresent()));
+
+        StringDescription desc = new StringDescription();
+
+        isPresent().describeMismatch(Optional.empty(), desc);
+        assertThat(desc.toString(), equalTo("an empty optional"));
+    }
+
+    public void testIsPresentWithMatcher() {
+        assertThat(Optional.of(""), isPresentWith(""));
+        assertThat(Optional.of("foo"), not(isPresentWith("")));
+        assertThat(Optional.empty(), not(isPresentWith("")));
+
+        StringDescription desc = new StringDescription();
+        isPresentWith("foo").describeMismatch(Optional.empty(), desc);
+        assertThat(desc.toString(), equalTo("an empty optional"));
+
+        desc = new StringDescription();
+        isPresentWith("foo").describeMismatch(Optional.of(""), desc);
+        assertThat(desc.toString(), equalTo("an optional was \"\""));
+    }
+}

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/nodeinfo/AutoscalingNodesInfoServiceTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/nodeinfo/AutoscalingNodesInfoServiceTests.java
@@ -63,6 +63,9 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import static org.elasticsearch.test.hamcrest.OptionalMatchers.isEmpty;
+import static org.elasticsearch.test.hamcrest.OptionalMatchers.isPresent;
+import static org.elasticsearch.test.hamcrest.OptionalMatchers.isPresentWith;
 import static org.elasticsearch.xpack.autoscaling.capacity.nodeinfo.AutoscalingNodeInfoService.FETCH_TIMEOUT;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.equalTo;
@@ -148,8 +151,8 @@ public class AutoscalingNodesInfoServiceTests extends AutoscalingTestCase {
             );
             client.respondStats(response, () -> {
                 Sets.union(missingNodes, Sets.difference(previousNodes, nodes))
-                    .forEach(n -> assertThat(service.snapshot().get(n).isEmpty(), is(true)));
-                Sets.intersection(previousSucceededNodes, nodes).forEach(n -> assertThat(service.snapshot().get(n).isPresent(), is(true)));
+                    .forEach(n -> assertThat(service.snapshot().get(n), isEmpty()));
+                Sets.intersection(previousSucceededNodes, nodes).forEach(n -> assertThat(service.snapshot().get(n), isPresent()));
             });
             client.respondInfo(responseInfo, () -> {
 
@@ -159,7 +162,7 @@ public class AutoscalingNodesInfoServiceTests extends AutoscalingTestCase {
             client.assertNoResponder();
 
             assertMatchesResponse(succeedingNodes, response, responseInfo);
-            failingNodes.forEach(n -> assertThat(service.snapshot().get(n).isEmpty(), is(true)));
+            failingNodes.forEach(n -> assertThat(service.snapshot().get(n), isEmpty()));
 
             previousNodes.clear();
             previousNodes.addAll(nodes);
@@ -177,7 +180,7 @@ public class AutoscalingNodesInfoServiceTests extends AutoscalingTestCase {
         // client throws if called.
         service.onClusterChanged(new ClusterChangedEvent("test", state, ClusterState.EMPTY_STATE));
 
-        nodes.forEach(n -> assertThat(service.snapshot().get(n).isEmpty(), is(true)));
+        nodes.forEach(n -> assertThat(service.snapshot().get(n), isEmpty()));
     }
 
     public void testNoLongerMaster() {
@@ -208,7 +211,7 @@ public class AutoscalingNodesInfoServiceTests extends AutoscalingTestCase {
         // client throws if called.
         service.onClusterChanged(new ClusterChangedEvent("test", notMasterState, masterState));
 
-        nodes.forEach(n -> assertThat(service.snapshot().get(n).isEmpty(), is(true)));
+        nodes.forEach(n -> assertThat(service.snapshot().get(n), isEmpty()));
     }
 
     public void testStatsFails() {
@@ -218,7 +221,7 @@ public class AutoscalingNodesInfoServiceTests extends AutoscalingTestCase {
         client.respondStats((r, listener) -> listener.onFailure(randomFrom(new IllegalStateException(), new RejectedExecutionException())));
         service.onClusterChanged(new ClusterChangedEvent("test", state, ClusterState.EMPTY_STATE));
 
-        nodes.forEach(n -> assertThat(service.snapshot().get(n).isEmpty(), is(true)));
+        nodes.forEach(n -> assertThat(service.snapshot().get(n), isEmpty()));
 
         NodesStatsResponse response = new NodesStatsResponse(
             ClusterName.DEFAULT,
@@ -249,7 +252,7 @@ public class AutoscalingNodesInfoServiceTests extends AutoscalingTestCase {
         client.respondStats(response, () -> {});
         client.respondInfo((r, listener) -> listener.onFailure(randomFrom(new IllegalStateException(), new RejectedExecutionException())));
         service.onClusterChanged(new ClusterChangedEvent("test", state, ClusterState.EMPTY_STATE));
-        nodes.forEach(n -> assertThat(service.snapshot().get(n).isEmpty(), is(true)));
+        nodes.forEach(n -> assertThat(service.snapshot().get(n), isEmpty()));
         NodesInfoResponse responseInfo = new NodesInfoResponse(
             ClusterName.DEFAULT,
             nodes.stream().map(n -> infoForNode(n, randomIntBetween(1, 64))).collect(Collectors.toList()),
@@ -316,7 +319,7 @@ public class AutoscalingNodesInfoServiceTests extends AutoscalingTestCase {
         assertMatchesResponse(Sets.intersection(restartedNodes, nodes), response, responseInfo);
         assertMatchesResponse(Sets.difference(restartedNodes, nodes), restartedStatsResponse, restartedInfoResponse);
 
-        Sets.difference(nodes, restartedNodes).forEach(n -> assertThat(service.snapshot().get(n).isEmpty(), is(true)));
+        Sets.difference(nodes, restartedNodes).forEach(n -> assertThat(service.snapshot().get(n), isEmpty()));
     }
 
     public void testConcurrentStateUpdate() throws Exception {
@@ -396,10 +399,9 @@ public class AutoscalingNodesInfoServiceTests extends AutoscalingTestCase {
 
     public void assertMatchesResponse(Set<DiscoveryNode> nodes, NodesStatsResponse response, NodesInfoResponse infoResponse) {
         nodes.forEach(n -> {
-            assertThat(service.snapshot().get(n).isPresent(), is(true));
             assertThat(
-                service.snapshot().get(n).get(),
-                equalTo(
+                service.snapshot().get(n),
+                isPresentWith(
                     new AutoscalingNodeInfo(
                         response.getNodesMap().get(n.getId()).getOs().getMem().getAdjustedTotal().getBytes(),
                         Processors.of(infoResponse.getNodesMap().get(n.getId()).getInfo(OsInfo.class).getFractionalAllocatedProcessors())

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignmentTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignmentTests.java
@@ -25,6 +25,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Stream;
 
+import static org.elasticsearch.test.hamcrest.OptionalMatchers.isEmpty;
+import static org.elasticsearch.test.hamcrest.OptionalMatchers.isPresentWith;
 import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
@@ -112,8 +114,8 @@ public class TrainedModelAssignmentTests extends AbstractXContentSerializingTest
 
     public void testCalculateAllocationStatus_GivenNoAllocations() {
         assertThat(
-            TrainedModelAssignment.Builder.empty(randomTaskParams(5)).build().calculateAllocationStatus().get(),
-            equalTo(new AllocationStatus(0, 5))
+            TrainedModelAssignment.Builder.empty(randomTaskParams(5)).build().calculateAllocationStatus(),
+            isPresentWith(new AllocationStatus(0, 5))
         );
     }
 
@@ -121,7 +123,7 @@ public class TrainedModelAssignmentTests extends AbstractXContentSerializingTest
         TrainedModelAssignment.Builder builder = TrainedModelAssignment.Builder.empty(randomTaskParams(5));
         builder.addRoutingEntry("node-1", new RoutingInfo(1, 2, RoutingState.STARTED, ""));
         builder.addRoutingEntry("node-2", new RoutingInfo(2, 1, RoutingState.STARTED, ""));
-        assertThat(builder.stopAssignment("test").build().calculateAllocationStatus().isEmpty(), is(true));
+        assertThat(builder.stopAssignment("test").build().calculateAllocationStatus(), isEmpty());
     }
 
     public void testCalculateAllocationStatus_GivenPartiallyAllocated() {
@@ -129,14 +131,14 @@ public class TrainedModelAssignmentTests extends AbstractXContentSerializingTest
         builder.addRoutingEntry("node-1", new RoutingInfo(1, 2, RoutingState.STARTED, ""));
         builder.addRoutingEntry("node-2", new RoutingInfo(2, 1, RoutingState.STARTED, ""));
         builder.addRoutingEntry("node-3", new RoutingInfo(3, 3, RoutingState.STARTING, ""));
-        assertThat(builder.build().calculateAllocationStatus().get(), equalTo(new AllocationStatus(3, 5)));
+        assertThat(builder.build().calculateAllocationStatus(), isPresentWith(new AllocationStatus(3, 5)));
     }
 
     public void testCalculateAllocationStatus_GivenFullyAllocated() {
         TrainedModelAssignment.Builder builder = TrainedModelAssignment.Builder.empty(randomTaskParams(5));
         builder.addRoutingEntry("node-1", new RoutingInfo(4, 4, RoutingState.STARTED, ""));
         builder.addRoutingEntry("node-2", new RoutingInfo(1, 1, RoutingState.STARTED, ""));
-        assertThat(builder.build().calculateAllocationStatus().get(), equalTo(new AllocationStatus(5, 5)));
+        assertThat(builder.build().calculateAllocationStatus(), isPresentWith(new AllocationStatus(5, 5)));
     }
 
     public void testCalculateAssignmentState_GivenNoStartedAssignments() {
@@ -179,8 +181,7 @@ public class TrainedModelAssignmentTests extends AbstractXContentSerializingTest
 
         var nodes = assignment.selectRandomStartedNodesWeighedOnAllocationsForNRequests(1, RoutingState.STARTED);
 
-        assertThat(nodes, hasSize(1));
-        assertThat(nodes.get(0), equalTo(new Tuple<>("node-1", 1)));
+        assertThat(nodes, contains(new Tuple<>("node-1", 1)));
     }
 
     public void testselectRandomStartedNodeWeighedOnAllocationsForNRequests_GivenAShuttingDownRoute_ItReturnsNoNodes() {
@@ -200,8 +201,7 @@ public class TrainedModelAssignmentTests extends AbstractXContentSerializingTest
 
         var nodes = assignment.selectRandomStartedNodesWeighedOnAllocationsForNRequests(1, RoutingState.STOPPING);
 
-        assertThat(nodes, hasSize(1));
-        assertThat(nodes.get(0), equalTo(new Tuple<>("node-1", 1)));
+        assertThat(nodes, contains(new Tuple<>("node-1", 1)));
     }
 
     public void testSingleRequestWith2Nodes() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/JobTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/JobTests.java
@@ -48,6 +48,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.elasticsearch.test.hamcrest.OptionalMatchers.isEmpty;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -114,7 +115,7 @@ public class JobTests extends AbstractXContentSerializingTestCase<Job> {
         ) {
             Job parsedConfig = Job.LENIENT_PARSER.apply(parser, null).build();
             // When we are writing for internal storage, we do not include the datafeed config
-            assertThat(parsedConfig.getDatafeedConfig().isPresent(), is(false));
+            assertThat(parsedConfig.getDatafeedConfig(), isEmpty());
         }
     }
 

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/MlDeprecationCheckerTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/MlDeprecationCheckerTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 
 import java.util.Collections;
 
+import static org.elasticsearch.test.hamcrest.OptionalMatchers.isEmpty;
 import static org.hamcrest.Matchers.is;
 
 public class MlDeprecationCheckerTests extends ESTestCase {
@@ -47,7 +48,7 @@ public class MlDeprecationCheckerTests extends ESTestCase {
         DatafeedConfig.Builder goodDatafeed = new DatafeedConfig.Builder("good-df", "job-id");
         goodDatafeed.setIndices(Collections.singletonList("some-index"));
         goodDatafeed.setParsedQuery(QueryBuilders.termQuery("foo", "bar"));
-        assertThat(MlDeprecationChecker.checkDataFeedQuery(goodDatafeed.build(), xContentRegistry()).isPresent(), is(false));
+        assertThat(MlDeprecationChecker.checkDataFeedQuery(goodDatafeed.build(), xContentRegistry()), isEmpty());
 
         DatafeedConfig.Builder deprecatedDatafeed = new DatafeedConfig.Builder("df-with-deprecated-query", "job-id");
         deprecatedDatafeed.setIndices(Collections.singletonList("some-index"));

--- a/x-pack/plugin/enrich/src/internalClusterTest/java/org/elasticsearch/xpack/enrich/EnrichRestartIT.java
+++ b/x-pack/plugin/enrich/src/internalClusterTest/java/org/elasticsearch/xpack/enrich/EnrichRestartIT.java
@@ -19,13 +19,14 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
+import static org.elasticsearch.test.hamcrest.OptionalMatchers.isPresent;
 import static org.elasticsearch.xpack.enrich.AbstractEnrichTestCase.createSourceIndices;
 import static org.elasticsearch.xpack.enrich.EnrichMultiNodeIT.DECORATE_FIELDS;
 import static org.elasticsearch.xpack.enrich.EnrichMultiNodeIT.MATCH_FIELD;
 import static org.elasticsearch.xpack.enrich.EnrichMultiNodeIT.POLICY_NAME;
 import static org.elasticsearch.xpack.enrich.EnrichMultiNodeIT.SOURCE_INDEX_NAME;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.hasSize;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0, numClientNodes = 0)
 public class EnrichRestartIT extends ESIntegTestCase {
@@ -72,14 +73,14 @@ public class EnrichRestartIT extends ESIntegTestCase {
     private static void verifyPolicies(int numPolicies, EnrichPolicy enrichPolicy) {
         GetEnrichPolicyAction.Response response = client().execute(GetEnrichPolicyAction.INSTANCE, new GetEnrichPolicyAction.Request())
             .actionGet();
-        assertThat(response.getPolicies().size(), equalTo(numPolicies));
+        assertThat(response.getPolicies(), hasSize(numPolicies));
         for (int i = 0; i < numPolicies; i++) {
             String policyName = POLICY_NAME + i;
             Optional<EnrichPolicy.NamedPolicy> result = response.getPolicies()
                 .stream()
                 .filter(namedPolicy -> namedPolicy.getName().equals(policyName))
                 .findFirst();
-            assertThat(result.isPresent(), is(true));
+            assertThat(result, isPresent());
             assertThat(result.get().getPolicy(), equalTo(enrichPolicy));
         }
     }

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RegressionIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RegressionIT.java
@@ -33,6 +33,7 @@ import org.elasticsearch.xpack.core.ml.inference.preprocessing.PreProcessor;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ensemble.Ensemble;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.metadata.Hyperparameters;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.metadata.TrainedModelMetadata;
+import org.hamcrest.Matchers;
 import org.junit.After;
 
 import java.io.IOException;
@@ -47,11 +48,12 @@ import java.util.Set;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
-import static org.elasticsearch.test.hamcrest.OptionalMatchers.isPresent;
+import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
@@ -129,9 +131,9 @@ public class RegressionIT extends MlNativeDataFrameAnalyticsIntegTestCase {
                 // double predictionValue = (double) resultsObject.get(predictedClassField);
                 // assertThat(predictionValue, closeTo(10 * featureValue, 2.0));
 
-                assertThat(resultsObject.containsKey(predictedClassField), is(true));
-                assertThat(resultsObject.containsKey("is_training"), is(true));
-                assertThat(resultsObject.get("is_training"), is(destDoc.containsKey(DEPENDENT_VARIABLE_FIELD)));
+                assertThat(resultsObject, hasKey(predictedClassField));
+                assertThat(resultsObject, hasKey("is_training"));
+                assertThat(resultsObject, hasEntry("is_training", destDoc.containsKey(DEPENDENT_VARIABLE_FIELD)));
                 @SuppressWarnings("unchecked")
                 List<Map<String, Object>> importanceArray = (List<Map<String, Object>>) resultsObject.get("feature_importance");
 
@@ -144,15 +146,13 @@ public class RegressionIT extends MlNativeDataFrameAnalyticsIntegTestCase {
                     }
                 }
 
-                assertThat(importanceArray, hasSize(greaterThan(0)));
                 assertThat(
-                    importanceArray.stream()
-                        .filter(
-                            m -> NUMERICAL_FEATURE_FIELD.equals(m.get("feature_name"))
-                                || DISCRETE_NUMERICAL_FEATURE_FIELD.equals(m.get("feature_name"))
+                    importanceArray,
+                    hasItem(
+                        either(Matchers.<String, Object>hasEntry("feature_name", NUMERICAL_FEATURE_FIELD)).or(
+                            hasEntry("feature_name", DISCRETE_NUMERICAL_FEATURE_FIELD)
                         )
-                        .findAny(),
-                    isPresent()
+                    )
                 );
             }
 
@@ -504,20 +504,19 @@ public class RegressionIT extends MlNativeDataFrameAnalyticsIntegTestCase {
                 Map<String, Object> destDoc = getDestDoc(config, hit);
                 Map<String, Object> resultsObject = getMlResultsObjectFromDestDoc(destDoc);
 
-                assertThat(resultsObject.containsKey(predictedClassField), is(true));
-                assertThat(resultsObject.containsKey("is_training"), is(true));
-                assertThat(resultsObject.get("is_training"), is(destDoc.containsKey(DEPENDENT_VARIABLE_FIELD)));
+                assertThat(resultsObject, hasKey(predictedClassField));
+                assertThat(resultsObject, hasKey("is_training"));
+                assertThat(resultsObject, hasEntry("is_training", destDoc.containsKey(DEPENDENT_VARIABLE_FIELD)));
                 @SuppressWarnings("unchecked")
                 List<Map<String, Object>> importanceArray = (List<Map<String, Object>>) resultsObject.get("feature_importance");
-                assertThat(importanceArray, hasSize(greaterThan(0)));
+
                 assertThat(
-                    importanceArray.stream()
-                        .filter(
-                            m -> NUMERICAL_FEATURE_FIELD.equals(m.get("feature_name"))
-                                || DISCRETE_NUMERICAL_FEATURE_FIELD.equals(m.get("feature_name"))
+                    importanceArray,
+                    hasItem(
+                        either(Matchers.<String, Object>hasEntry("feature_name", NUMERICAL_FEATURE_FIELD)).or(
+                            hasEntry("feature_name", DISCRETE_NUMERICAL_FEATURE_FIELD)
                         )
-                        .findAny(),
-                    isPresent()
+                    )
                 );
             }
         });

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RegressionIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RegressionIT.java
@@ -132,7 +132,6 @@ public class RegressionIT extends MlNativeDataFrameAnalyticsIntegTestCase {
                 // assertThat(predictionValue, closeTo(10 * featureValue, 2.0));
 
                 assertThat(resultsObject, hasKey(predictedClassField));
-                assertThat(resultsObject, hasKey("is_training"));
                 assertThat(resultsObject, hasEntry("is_training", destDoc.containsKey(DEPENDENT_VARIABLE_FIELD)));
                 @SuppressWarnings("unchecked")
                 List<Map<String, Object>> importanceArray = (List<Map<String, Object>>) resultsObject.get("feature_importance");
@@ -505,7 +504,6 @@ public class RegressionIT extends MlNativeDataFrameAnalyticsIntegTestCase {
                 Map<String, Object> resultsObject = getMlResultsObjectFromDestDoc(destDoc);
 
                 assertThat(resultsObject, hasKey(predictedClassField));
-                assertThat(resultsObject, hasKey("is_training"));
                 assertThat(resultsObject, hasEntry("is_training", destDoc.containsKey(DEPENDENT_VARIABLE_FIELD)));
                 @SuppressWarnings("unchecked")
                 List<Map<String, Object>> importanceArray = (List<Map<String, Object>>) resultsObject.get("feature_importance");

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlMemoryAutoscalingDeciderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlMemoryAutoscalingDeciderTests.java
@@ -61,6 +61,8 @@ import java.util.Set;
 import java.util.function.LongSupplier;
 
 import static java.lang.Math.min;
+import static org.elasticsearch.test.hamcrest.OptionalMatchers.isEmpty;
+import static org.elasticsearch.test.hamcrest.OptionalMatchers.isPresent;
 import static org.elasticsearch.xpack.ml.MachineLearning.MACHINE_MEMORY_NODE_ATTR;
 import static org.elasticsearch.xpack.ml.MachineLearning.MAX_JVM_SIZE_NODE_ATTR;
 import static org.elasticsearch.xpack.ml.MachineLearning.NATIVE_EXECUTABLE_CODE_OVERHEAD;
@@ -72,7 +74,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.mockito.ArgumentMatchers.any;
@@ -978,7 +979,7 @@ public class MlMemoryAutoscalingDeciderTests extends ESTestCase {
                     ByteSizeValue.ofGb(5).getBytes() - PER_NODE_OVERHEAD
                 )
             );
-            assertThat(result.isEmpty(), is(false));
+            assertThat(result, isPresent());
             MlMemoryAutoscalingCapacity deciderResult = result.get();
             // Four times due to 25% ML memory
             assertThat(deciderResult.nodeSize().getBytes(), equalTo(4 * ByteSizeValue.ofGb(1).getBytes()));
@@ -1013,7 +1014,7 @@ public class MlMemoryAutoscalingDeciderTests extends ESTestCase {
                     ByteSizeValue.ofGb(1).getBytes() - PER_NODE_OVERHEAD
                 )
             );
-            assertThat(result.isEmpty(), is(false));
+            assertThat(result, isPresent());
             MlMemoryAutoscalingCapacity deciderResult = result.get();
             // Four times due to 25% ML memory
             assertThat(deciderResult.nodeSize().getBytes(), equalTo(4 * ByteSizeValue.ofMb(100).getBytes()));
@@ -1048,7 +1049,7 @@ public class MlMemoryAutoscalingDeciderTests extends ESTestCase {
                     ByteSizeValue.ofMb(100).getBytes() - PER_NODE_OVERHEAD
                 )
             );
-            assertThat(result.isEmpty(), is(true));
+            assertThat(result, isEmpty());
         }
     }
 
@@ -1210,7 +1211,7 @@ public class MlMemoryAutoscalingDeciderTests extends ESTestCase {
 
         Collection<DiscoveryNode> mlNodesInCluster = clusterState.getNodes().getNodes().values();
         Optional<NativeMemoryCapacity> nativeMemoryCapacity = decider.calculateFutureAvailableCapacity(mlNodesInCluster, clusterState);
-        assertThat(nativeMemoryCapacity.isEmpty(), is(false));
+        assertThat(nativeMemoryCapacity, isPresent());
         assertThat(nativeMemoryCapacity.get().getNodeMlNativeMemoryRequirementExcludingOverhead(), greaterThanOrEqualTo(TEST_JOB_SIZE));
         assertThat(
             nativeMemoryCapacity.get().getNodeMlNativeMemoryRequirementExcludingOverhead(),

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractorTests.java
@@ -49,6 +49,7 @@ import java.util.Queue;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.test.hamcrest.OptionalMatchers.isEmpty;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
@@ -134,7 +135,7 @@ public class DataFrameDataExtractorTests extends ESTestCase {
 
         // Third batch should return empty
         rows = dataExtractor.next();
-        assertThat(rows.isEmpty(), is(true));
+        assertThat(rows, isEmpty());
         assertThat(dataExtractor.hasNext(), is(false));
 
         // Now let's assert we're sending the expected search requests
@@ -223,7 +224,7 @@ public class DataFrameDataExtractorTests extends ESTestCase {
 
         // Next batch should return empty
         rows = dataExtractor.next();
-        assertThat(rows.isEmpty(), is(true));
+        assertThat(rows, isEmpty());
         assertThat(dataExtractor.hasNext(), is(false));
 
         // Notice we've done 4 searches
@@ -267,7 +268,7 @@ public class DataFrameDataExtractorTests extends ESTestCase {
         assertThat(rows.get().get(0).getValues(), equalTo(new String[] { "11", "21" }));
         assertThat(dataExtractor.hasNext(), is(true));
 
-        assertThat(dataExtractor.next().isEmpty(), is(true));
+        assertThat(dataExtractor.next(), isEmpty());
         assertThat(dataExtractor.hasNext(), is(false));
 
         assertThat(dataExtractor.capturedSearchRequests.size(), equalTo(2));
@@ -302,7 +303,7 @@ public class DataFrameDataExtractorTests extends ESTestCase {
         assertThat(rows.get().get(0).getValues(), equalTo(new String[] { "11", "21" }));
         assertThat(dataExtractor.hasNext(), is(true));
 
-        assertThat(dataExtractor.next().isEmpty(), is(true));
+        assertThat(dataExtractor.next(), isEmpty());
         assertThat(dataExtractor.hasNext(), is(false));
 
         assertThat(dataExtractor.capturedSearchRequests.size(), equalTo(2));
@@ -380,7 +381,7 @@ public class DataFrameDataExtractorTests extends ESTestCase {
 
         // Third batch should return empty
         rows = dataExtractor.next();
-        assertThat(rows.isEmpty(), is(true));
+        assertThat(rows, isEmpty());
         assertThat(dataExtractor.hasNext(), is(false));
     }
 
@@ -414,7 +415,7 @@ public class DataFrameDataExtractorTests extends ESTestCase {
 
         // Third batch should return empty
         rows = dataExtractor.next();
-        assertThat(rows.isEmpty(), is(true));
+        assertThat(rows, isEmpty());
         assertThat(dataExtractor.hasNext(), is(false));
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/planning/AssignmentPlannerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/planning/AssignmentPlannerTests.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.elasticsearch.test.hamcrest.OptionalMatchers.isEmpty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -43,7 +44,7 @@ public class AssignmentPlannerTests extends ESTestCase {
             List<Node> nodes = List.of(new Node("n_1", scaleNodeSize(50), 4));
             Deployment deployment = new AssignmentPlan.Deployment("m_1", ByteSizeValue.ofMb(51).getBytes(), 4, 1, Map.of(), 0, 0, 0);
             AssignmentPlan plan = new AssignmentPlanner(nodes, List.of(deployment)).computePlan();
-            assertThat(plan.assignments(deployment).isEmpty(), is(true));
+            assertThat(plan.assignments(deployment), isEmpty());
         }
         { // With perDeploymentMemory and perAllocationMemory specified
             List<Node> nodes = List.of(new Node("n_1", scaleNodeSize(55), 4));
@@ -58,7 +59,7 @@ public class AssignmentPlannerTests extends ESTestCase {
                 ByteSizeValue.ofMb(51).getBytes()
             );
             AssignmentPlan plan = new AssignmentPlanner(nodes, List.of(deployment)).computePlan();
-            assertThat(plan.assignments(deployment).isEmpty(), is(true));
+            assertThat(plan.assignments(deployment), isEmpty());
         }
     }
 
@@ -66,7 +67,7 @@ public class AssignmentPlannerTests extends ESTestCase {
         List<Node> nodes = List.of(new Node("n_1", scaleNodeSize(100), 4), new Node("n_2", scaleNodeSize(100), 5));
         Deployment deployment = new AssignmentPlan.Deployment("m_1", ByteSizeValue.ofMb(1).getBytes(), 1, 6, Map.of(), 0, 0, 0);
         AssignmentPlan plan = new AssignmentPlanner(nodes, List.of(deployment)).computePlan();
-        assertThat(plan.assignments(deployment).isEmpty(), is(true));
+        assertThat(plan.assignments(deployment), isEmpty());
     }
 
     public void testSingleModelThatFitsFullyOnSingleNode() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/planning/PreserveAllAllocationsTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/planning/PreserveAllAllocationsTests.java
@@ -15,9 +15,10 @@ import org.elasticsearch.xpack.ml.inference.assignment.planning.AssignmentPlan.N
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.test.hamcrest.OptionalMatchers.isEmpty;
+import static org.elasticsearch.test.hamcrest.OptionalMatchers.isPresentWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
 
 public class PreserveAllAllocationsTests extends ESTestCase {
 
@@ -89,12 +90,12 @@ public class PreserveAllAllocationsTests extends ESTestCase {
             AssignmentPlan plan = AssignmentPlan.builder(List.of(node1, node2), List.of(deployment1, deployment2))
                 .assignModelToNode(deployment1, node1, 2)
                 .build();
-            assertThat(plan.assignments(deployment1).get(), equalTo(Map.of(node1, 2)));
-            assertThat(plan.assignments(deployment2).isEmpty(), is(true));
+            assertThat(plan.assignments(deployment1), isPresentWith(Map.of(node1, 2)));
+            assertThat(plan.assignments(deployment2), isEmpty());
 
             plan = preserveAllAllocations.mergePreservedAllocations(plan);
-            assertThat(plan.assignments(deployment1).get(), equalTo(Map.of(node1, 3)));
-            assertThat(plan.assignments(deployment2).get(), equalTo(Map.of(node1, 1, node2, 2)));
+            assertThat(plan.assignments(deployment1), isPresentWith(Map.of(node1, 3)));
+            assertThat(plan.assignments(deployment2), isPresentWith(Map.of(node1, 1, node2, 2)));
 
             // Node 1 already had deployments 1 and 2 assigned to it so adding more allocation doesn't change memory usage.
             assertThat(plan.getRemainingNodeMemory("n_1"), equalTo(0L));
@@ -174,12 +175,12 @@ public class PreserveAllAllocationsTests extends ESTestCase {
             AssignmentPlan plan = AssignmentPlan.builder(List.of(node1, node2), List.of(deployment1, deployment2))
                 .assignModelToNode(deployment1, node1, 2)
                 .build();
-            assertThat(plan.assignments(deployment1).get(), equalTo(Map.of(node1, 2)));
-            assertThat(plan.assignments(deployment2).isEmpty(), is(true));
+            assertThat(plan.assignments(deployment1), isPresentWith(Map.of(node1, 2)));
+            assertThat(plan.assignments(deployment2), isEmpty());
 
             plan = preserveAllAllocations.mergePreservedAllocations(plan);
-            assertThat(plan.assignments(deployment1).get(), equalTo(Map.of(node1, 3)));
-            assertThat(plan.assignments(deployment2).get(), equalTo(Map.of(node1, 1, node2, 2)));
+            assertThat(plan.assignments(deployment1), isPresentWith(Map.of(node1, 3)));
+            assertThat(plan.assignments(deployment2), isPresentWith(Map.of(node1, 1, node2, 2)));
 
             // 1000 - ((30 + 300 + 3*10) + (50 + 300 + 10)) = 280 : deployments use 720 MB on the node 1
             assertThat(plan.getRemainingNodeMemory("n_1"), equalTo(ByteSizeValue.ofMb(280).getBytes()));
@@ -198,11 +199,10 @@ public class PreserveAllAllocationsTests extends ESTestCase {
         PreserveAllAllocations preserveAllAllocations = new PreserveAllAllocations(List.of(node), List.of(deployment));
 
         AssignmentPlan plan = AssignmentPlan.builder(List.of(node), List.of(deployment)).build();
-        assertThat(plan.assignments(deployment).isEmpty(), is(true));
+        assertThat(plan.assignments(deployment), isEmpty());
 
         plan = preserveAllAllocations.mergePreservedAllocations(plan);
-        assertThat(plan.assignments(deployment).isPresent(), is(true));
-        assertThat(plan.assignments(deployment).get(), equalTo(Map.of(node, 2)));
+        assertThat(plan.assignments(deployment), isPresentWith(Map.of(node, 2)));
         assertThat(plan.getRemainingNodeMemory("n_1"), equalTo(ByteSizeValue.ofMb(100).getBytes()));
         assertThat(plan.getRemainingNodeCores("n_1"), equalTo(0));
     }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/planning/PreserveOneAllocationTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/planning/PreserveOneAllocationTests.java
@@ -15,10 +15,11 @@ import org.elasticsearch.xpack.ml.inference.assignment.planning.AssignmentPlan.N
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.test.hamcrest.OptionalMatchers.isEmpty;
+import static org.elasticsearch.test.hamcrest.OptionalMatchers.isPresentWith;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
 
 public class PreserveOneAllocationTests extends ESTestCase {
 
@@ -202,11 +203,10 @@ public class PreserveOneAllocationTests extends ESTestCase {
             PreserveOneAllocation preserveOneAllocation = new PreserveOneAllocation(List.of(node), List.of(deployment));
 
             AssignmentPlan plan = AssignmentPlan.builder(List.of(node), List.of(deployment)).build();
-            assertThat(plan.assignments(deployment).isEmpty(), is(true));
+            assertThat(plan.assignments(deployment), isEmpty());
 
             plan = preserveOneAllocation.mergePreservedAllocations(plan);
-            assertThat(plan.assignments(deployment).isPresent(), is(true));
-            assertThat(plan.assignments(deployment).get(), equalTo(Map.of(node, 1)));
+            assertThat(plan.assignments(deployment), isPresentWith(Map.of(node, 1)));
             // 400 - (30*2 + 240) = 100 : deployments use 300MB on the node
             assertThat(plan.getRemainingNodeMemory("n_1"), equalTo(ByteSizeValue.ofMb(100).getBytes()));
             assertThat(plan.getRemainingNodeCores("n_1"), equalTo(2));
@@ -227,11 +227,10 @@ public class PreserveOneAllocationTests extends ESTestCase {
             PreserveOneAllocation preserveOneAllocation = new PreserveOneAllocation(List.of(node), List.of(deployment));
 
             AssignmentPlan plan = AssignmentPlan.builder(List.of(node), List.of(deployment)).build();
-            assertThat(plan.assignments(deployment).isEmpty(), is(true));
+            assertThat(plan.assignments(deployment), isEmpty());
 
             plan = preserveOneAllocation.mergePreservedAllocations(plan);
-            assertThat(plan.assignments(deployment).isPresent(), is(true));
-            assertThat(plan.assignments(deployment).get(), equalTo(Map.of(node, 1)));
+            assertThat(plan.assignments(deployment), isPresentWith(Map.of(node, 1)));
             // 400 - (30 + 300 + 10) = 60 : deployments use 340MB on the node
             assertThat(plan.getRemainingNodeMemory("n_1"), equalTo(ByteSizeValue.ofMb(60).getBytes()));
             assertThat(plan.getRemainingNodeCores("n_1"), equalTo(2));


### PR DESCRIPTION
We already have `OptionalMatchers` - expand the uses of this class, and create new methods to assert specific optional values