### PR TITLE
POC: Cap shard failure lists to a fixed small size

### DIFF
--- a/server/src/main/java/org/elasticsearch/ExceptionsHelper.java
+++ b/server/src/main/java/org/elasticsearch/ExceptionsHelper.java
@@ -262,6 +262,21 @@ public final class ExceptionsHelper {
         });
     }
 
+    // MP TODO: IDEA - implement this?
+    /**
+     * Deduplicate failures, returning the first 'max' number of deduplicated failures.
+     * If aggressive=false, failures will be deduplicated by message and index.
+     * If aggressive=true, failures will be deduplicated only by message
+     * @param failures
+     * @param max
+     * @param aggressive
+     * @return
+     */
+    public static ShardOperationFailedException[] groupByMessage(ShardOperationFailedException[] failures, int max, boolean aggressive) {
+        // MP TODO: IDEA: this could also add a final Exception (at the n-1) slot that summarizes all exceptions truncated (not included)
+        return null;
+    }
+
     /**
      * Deduplicate the failures by exception message and index.
      * @param failures array to deduplicate

--- a/server/src/main/java/org/elasticsearch/ExceptionsHelper.java
+++ b/server/src/main/java/org/elasticsearch/ExceptionsHelper.java
@@ -262,23 +262,44 @@ public final class ExceptionsHelper {
         });
     }
 
-    // MP TODO: IDEA - implement this?
     /**
      * Deduplicate failures, returning the first 'max' number of deduplicated failures.
-     * If aggressive=false, failures will be deduplicated by message and index.
-     * If aggressive=true, failures will be deduplicated only by message
-     * @param failures
-     * @param max
-     * @param aggressive
-     * @return
+     * If aggressive=false, failures will be deduplicated by message, index and cause.
+     * If aggressive=true, failures will be deduplicated only by message.
+     *
+     * @param failures array to deduplicate
+     * @param max limit on size of array returned (beyond that failures are discarded)
+     * @param aggressive how aggressively to deduplicate
+     * @return deduplicated array; if failures is null or empty, it will be returned without modification
      */
-    public static ShardOperationFailedException[] groupByMessage(ShardOperationFailedException[] failures, int max, boolean aggressive) {
-        // MP TODO: IDEA: this could also add a final Exception (at the n-1) slot that summarizes all exceptions truncated (not included)
-        return null;
+    public static ShardOperationFailedException[] groupBy(ShardOperationFailedException[] failures, int max, boolean aggressive) {
+        if (failures == null || failures.length == 0) {
+            return failures;
+        }
+
+        assert max > 0 : "max must be greater than zero";
+        if (failures.length >= max && aggressive == false) {
+            return groupBy(failures);
+        }
+
+        // MP TODO: IDEA: this could also add a final Exception (at the n-1 slot) that summarizes all exceptions truncated (not included)
+        List<ShardOperationFailedException> uniqueFailures = new ArrayList<>();
+        Set<GroupBy> reasons = new HashSet<>();
+        for (ShardOperationFailedException failure : failures) {
+            GroupBy reason = new GroupBy(failure, aggressive == false);
+            if (reasons.contains(reason) == false) {
+                reasons.add(reason);
+                uniqueFailures.add(failure);
+            }
+            if (uniqueFailures.size() >= max) {
+                break;
+            }
+        }
+        return uniqueFailures.toArray(new ShardOperationFailedException[0]);
     }
 
     /**
-     * Deduplicate the failures by exception message and index.
+     * Deduplicate the failures by exception message, index and cause.
      * @param failures array to deduplicate
      * @return deduplicated array; if failures is null or empty, it will be returned without modification
      */
@@ -289,7 +310,7 @@ public final class ExceptionsHelper {
         List<ShardOperationFailedException> uniqueFailures = new ArrayList<>();
         Set<GroupBy> reasons = new HashSet<>();
         for (ShardOperationFailedException failure : failures) {
-            GroupBy reason = new GroupBy(failure);
+            GroupBy reason = new GroupBy(failure, true);
             if (reasons.contains(reason) == false) {
                 reasons.add(reason);
                 uniqueFailures.add(failure);
@@ -321,8 +342,10 @@ public final class ExceptionsHelper {
         final String reason;
         final String index;
         final Class<? extends Throwable> causeType;
+        private final boolean groupByIndex;
 
-        GroupBy(ShardOperationFailedException failure) {
+        GroupBy(ShardOperationFailedException failure, boolean groupByIndex) {
+            this.groupByIndex = groupByIndex;
             Throwable cause = failure.getCause();
             // the index name from the failure contains the cluster alias when using CCS. Ideally failures should be grouped by
             // index name and cluster alias. That's why the failure index name has the precedence over the one coming from the cause,
@@ -350,14 +373,22 @@ public final class ExceptionsHelper {
                 return false;
             }
             GroupBy groupBy = (GroupBy) o;
-            return Objects.equals(reason, groupBy.reason)
-                && Objects.equals(index, groupBy.index)
-                && Objects.equals(causeType, groupBy.causeType);
+            if (groupByIndex) {
+                return Objects.equals(reason, groupBy.reason)
+                    && Objects.equals(index, groupBy.index)
+                    && Objects.equals(causeType, groupBy.causeType);
+            } else {
+                return Objects.equals(reason, groupBy.reason) && Objects.equals(causeType, groupBy.causeType);
+            }
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(reason, index, causeType);
+            if (groupByIndex) {
+                return Objects.hash(reason, index, causeType);
+            } else {
+                return Objects.hash(reason, causeType);
+            }
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -191,6 +191,7 @@ public class TransportVersions {
     public static final TransportVersion NESTED_KNN_MORE_INNER_HITS = def(8_577_00_0);
     public static final TransportVersion REQUIRE_DATA_STREAM_ADDED = def(8_578_00_0);
     public static final TransportVersion ML_INFERENCE_COHERE_EMBEDDINGS_ADDED = def(8_579_00_0);
+    public static final TransportVersion SEARCH_RESPONSE_FAILED_SHARD_COUNT_TRACKING = def(8_580_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/action/search/SearchPhaseExecutionException.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchPhaseExecutionException.java
@@ -65,6 +65,8 @@ public class SearchPhaseExecutionException extends ElasticsearchException {
         return cause;
     }
 
+    /// MP TODO: IDEA add status to the SearchShardFailures class and change this class to accept that class
+    /// MP TODO the logic below can go into that class
     @Override
     public RestStatus status() {
         if (shardFailures.length == 0) {

--- a/server/src/main/java/org/elasticsearch/action/search/ShardSearchFailures.java
+++ b/server/src/main/java/org/elasticsearch/action/search/ShardSearchFailures.java
@@ -16,6 +16,9 @@ public class ShardSearchFailures {  // TODO: convert to Record?
     private final int numFailures;
     private final ShardSearchFailure[] failures;
 
+    // MP TODO: IDEA: also accept the full list of failures as well as a truncated list
+    // MP TODO you would sift the truncated list to determine RestStatus and keep that as an instance var also
+
     public ShardSearchFailures(int numFailures, ShardSearchFailure[] failures) {
         this.numFailures = numFailures;
         this.failures = failures;

--- a/server/src/main/java/org/elasticsearch/action/search/ShardSearchFailures.java
+++ b/server/src/main/java/org/elasticsearch/action/search/ShardSearchFailures.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.search;
+
+/**
+ * TODO: DOCUMENT ME
+ */
+public class ShardSearchFailures {  // TODO: convert to Record?
+
+    private final int numFailures;
+    private final ShardSearchFailure[] failures;
+
+    public ShardSearchFailures(int numFailures, ShardSearchFailure[] failures) {
+        this.numFailures = numFailures;
+        this.failures = failures;
+    }
+
+    public int getNumFailures() {
+        return numFailures;
+    }
+
+    public ShardSearchFailure[] getFailures() {
+        return failures;
+    }
+}

--- a/server/src/test/java/org/elasticsearch/action/search/AbstractSearchAsyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/AbstractSearchAsyncActionTests.java
@@ -38,6 +38,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.instanceOf;
 
@@ -192,7 +193,9 @@ public class AbstractSearchAsyncActionTests extends ESTestCase {
         assertThat(exception.get(), instanceOf(SearchPhaseExecutionException.class));
         SearchPhaseExecutionException searchPhaseExecutionException = (SearchPhaseExecutionException) exception.get();
         assertEquals(0, searchPhaseExecutionException.getSuppressed().length);
-        assertEquals(numFailures, searchPhaseExecutionException.shardFailures().length);
+
+        assertThat(searchPhaseExecutionException.shardFailures().length, greaterThan(0));
+        // assertEquals(numFailures, searchPhaseExecutionException.shardFailures().length); -> restore if add getTotalNumFailures method
         for (ShardSearchFailure shardSearchFailure : searchPhaseExecutionException.shardFailures()) {
             assertThat(shardSearchFailure.getCause(), instanceOf(IllegalArgumentException.class));
         }

--- a/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncSearchSingleNodeTests.java
+++ b/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncSearchSingleNodeTests.java
@@ -35,6 +35,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResponse;
+import static org.hamcrest.Matchers.greaterThan;
 
 public class AsyncSearchSingleNodeTests extends ESSingleNodeTestCase {
 
@@ -106,12 +107,15 @@ public class AsyncSearchSingleNodeTests extends ESSingleNodeTestCase {
             assertEquals(10, searchResponse.getTotalShards());
             assertEquals(5, searchResponse.getSuccessfulShards());
             assertEquals(5, searchResponse.getFailedShards());
+            // since shard failures array can be truncated, the exact size may not match the total number of failed shards
+            // but there should be at least one entry since we expect 5 total failed shards in this test
+            assertThat(searchResponse.getShardFailures().length, greaterThan(0));
             assertEquals(10, searchResponse.getHits().getTotalHits().value);
             assertEquals(5, searchResponse.getHits().getHits().length);
             StringTerms terms = searchResponse.getAggregations().get("text");
             assertEquals(1, terms.getBuckets().size());
             assertEquals(10, terms.getBucketByKey("value").getDocCount());
-            assertEquals(5, searchResponse.getShardFailures().length);
+            assertEquals(5, searchResponse.getFailedShards());
             for (ShardSearchFailure shardFailure : searchResponse.getShardFailures()) {
                 assertEquals("boom", shardFailure.getCause().getMessage());
             }


### PR DESCRIPTION
This is a POC exploratory coding attempt to address https://github.com/elastic/elasticsearch/issues/103708 and https://github.com/elastic/elasticsearch/issues/99220

After some earlier exploratory code, I decided not to change the AtomicAtomic of ShardSearchFailures in `AbstractSearchAsyncAction`. Changing it really messes up the lock-free thread safety model of that class. In addition, other classes keep AtomicArray's of all shard results, so this is not the only offender.

Instead, I focused on reducing the number of failures reported in the SearchResponse. The SearchResponse does not track failed shard count independent of the ShardSearchFailure array, so that new field had to be added.

Most tests are passing, but need to do further work on those. Also CCS MRT=false is not yet truncating the number of failures in the _cluster/details/failures section so I need to track down where that occurs.