### PR TITLE
Wait for async actions in AsyncOperator tests

### DIFF
--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/AsyncOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/AsyncOperatorTests.java
@@ -316,6 +316,10 @@ public class AsyncOperatorTests extends ESTestCase {
                     break;
                 }
             }
+            driverContext.finish();
+            PlainActionFuture<Void> future = new PlainActionFuture<>();
+            driverContext.waitForAsyncActions(future);
+            future.actionGet(30, TimeUnit.SECONDS);
         }
     }
 


### PR DESCRIPTION
We must wait for the async lookups in AsyncOperator to complete before ending the test to ensure that all blocks are released.

Closes #104130