### PR TITLE
Muting testBlockLoader tests for TextFieldMapperTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
@@ -97,6 +97,30 @@ public class TextFieldMapperTests extends MapperTestCase {
         return "value";
     }
 
+    @Override
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/104152")
+    public void testBlockLoaderFromColumnReader() throws IOException {
+        super.testBlockLoaderFromColumnReader();
+    }
+
+    @Override
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/104152")
+    public void testBlockLoaderFromRowStrideReader() throws IOException {
+        super.testBlockLoaderFromRowStrideReader();
+    }
+
+    @Override
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/104152")
+    public void testBlockLoaderFromColumnReaderWithSyntheticSource() throws IOException {
+        super.testBlockLoaderFromColumnReaderWithSyntheticSource();
+    }
+
+    @Override
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/104152")
+    public void testBlockLoaderFromRowStrideReaderWithSyntheticSource() throws IOException {
+        super.testBlockLoaderFromRowStrideReaderWithSyntheticSource();
+    }
+
     public final void testExistsQueryIndexDisabled() throws IOException {
         MapperService mapperService = createMapperService(fieldMapping(b -> {
             minimalMapping(b);

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
@@ -1239,19 +1239,23 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
         assertNoDocValueLoader(b -> b.startArray("field").endArray());
     }
 
-    public final void testBlockLoaderFromColumnReader() throws IOException {
+    // TextFieldMapperTests @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/104152")
+    public void testBlockLoaderFromColumnReader() throws IOException {
         testBlockLoader(false, true);
     }
 
-    public final void testBlockLoaderFromRowStrideReader() throws IOException {
+    // TextFieldMapperTests @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/104152")
+    public void testBlockLoaderFromRowStrideReader() throws IOException {
         testBlockLoader(false, false);
     }
 
-    public final void testBlockLoaderFromColumnReaderWithSyntheticSource() throws IOException {
+    // TextFieldMapperTests @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/104152")
+    public void testBlockLoaderFromColumnReaderWithSyntheticSource() throws IOException {
         testBlockLoader(true, true);
     }
 
     // Removed 'final' to silence this test in GeoPointFieldMapperTests, which does not support synthetic source completely
+    // TextFieldMapperTests @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/104152")
     public void testBlockLoaderFromRowStrideReaderWithSyntheticSource() throws IOException {
         testBlockLoader(true, false);
     }


### PR DESCRIPTION
Muted all the testBlockLoader tests for TextFieldMapperTests. These methods should be returned to `final`. I didn't want to mute the entire `TextFieldMapperTests` as that blast radius was too high.

related to: https://github.com/elastic/elasticsearch/issues/104152