### PR TITLE
Reduce concurrency of execution for x-pack full cluster restart tests

### DIFF
--- a/x-pack/qa/full-cluster-restart/build.gradle
+++ b/x-pack/qa/full-cluster-restart/build.gradle
@@ -19,5 +19,6 @@ BuildParams.bwcVersions.withIndexCompatible { bwcVersion, baseName ->
   tasks.register(bwcTaskName(bwcVersion), StandaloneRestIntegTestTask) {
     usesBwcDistribution(bwcVersion)
     systemProperty("tests.old_cluster_version", bwcVersion)
+    maxParallelForks = 1
   }
 }


### PR DESCRIPTION
This suite has a number of tests, each spins up a 2 node cluster, and we often see timeouts here. This is likely due to resource contention of too many parallel nodes running. Let's just reduce the concurrency here until we have a better solution for shared clusters in upgrade tests. This is going to extend test execution but should improve stability.