### PR TITLE
[8.11] Reduce concurrency of execution for x-pack full cluster restart tests (#104166)

### DIFF
--- a/x-pack/qa/full-cluster-restart/build.gradle
+++ b/x-pack/qa/full-cluster-restart/build.gradle
@@ -19,5 +19,6 @@ BuildParams.bwcVersions.withIndexCompatible { bwcVersion, baseName ->
   tasks.register(bwcTaskName(bwcVersion), StandaloneRestIntegTestTask) {
     usesBwcDistribution(bwcVersion)
     systemProperty("tests.old_cluster_version", bwcVersion)
+    maxParallelForks = 1
   }
 }


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Reduce concurrency of execution for x-pack full cluster restart tests (#104166)