### PR TITLE
Lazily setup constants in DomainSplitFunction to save ~1M of memory

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/DomainSplitFunction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/DomainSplitFunction.java
@@ -25,77 +25,78 @@ import static java.util.Map.entry;
 
 public final class DomainSplitFunction {
 
-    private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(DomainSplitFunction.class);
+    private static final class ConstantHolder {
+        private static final Map<String, String> exact;
+        private static final Map<String, String> under = Map.ofEntries(
+            entry("bd", "i"),
+            entry("np", "i"),
+            entry("jm", "i"),
+            entry("fj", "i"),
+            entry("fk", "i"),
+            entry("ye", "i"),
+            entry("sch.uk", "i"),
+            entry("bn", "i"),
+            entry("kitakyushu.jp", "i"),
+            entry("kobe.jp", "i"),
+            entry("ke", "i"),
+            entry("sapporo.jp", "i"),
+            entry("kh", "i"),
+            entry("mm", "i"),
+            entry("il", "i"),
+            entry("yokohama.jp", "i"),
+            entry("ck", "i"),
+            entry("nagoya.jp", "i"),
+            entry("sendai.jp", "i"),
+            entry("kw", "i"),
+            entry("er", "i"),
+            entry("mz", "i"),
+            entry("platform.sh", "p"),
+            entry("gu", "i"),
+            entry("nom.br", "i"),
+            entry("zm", "i"),
+            entry("pg", "i"),
+            entry("ni", "i"),
+            entry("kawasaki.jp", "i"),
+            entry("zw", "i")
+        );
 
-    private static final int MAX_DOMAIN_PART_LENGTH = 63;
+        private static final Map<String, String> excluded = Map.of(
+            "city.yokohama.jp",
+            "i",
+            "teledata.mz",
+            "i",
+            "city.kobe.jp",
+            "i",
+            "city.sapporo.jp",
+            "i",
+            "city.kawasaki.jp",
+            "i",
+            "city.nagoya.jp",
+            "i",
+            "www.ck",
+            "i",
+            "city.sendai.jp",
+            "i",
+            "city.kitakyushu.jp",
+            "i"
+        );
 
-    private static final Map<String, String> exact;
-    private static final Map<String, String> under = Map.ofEntries(
-        entry("bd", "i"),
-        entry("np", "i"),
-        entry("jm", "i"),
-        entry("fj", "i"),
-        entry("fk", "i"),
-        entry("ye", "i"),
-        entry("sch.uk", "i"),
-        entry("bn", "i"),
-        entry("kitakyushu.jp", "i"),
-        entry("kobe.jp", "i"),
-        entry("ke", "i"),
-        entry("sapporo.jp", "i"),
-        entry("kh", "i"),
-        entry("mm", "i"),
-        entry("il", "i"),
-        entry("yokohama.jp", "i"),
-        entry("ck", "i"),
-        entry("nagoya.jp", "i"),
-        entry("sendai.jp", "i"),
-        entry("kw", "i"),
-        entry("er", "i"),
-        entry("mz", "i"),
-        entry("platform.sh", "p"),
-        entry("gu", "i"),
-        entry("nom.br", "i"),
-        entry("zm", "i"),
-        entry("pg", "i"),
-        entry("ni", "i"),
-        entry("kawasaki.jp", "i"),
-        entry("zw", "i")
-    );
-
-    private static final Map<String, String> excluded = Map.of(
-        "city.yokohama.jp",
-        "i",
-        "teledata.mz",
-        "i",
-        "city.kobe.jp",
-        "i",
-        "city.sapporo.jp",
-        "i",
-        "city.kawasaki.jp",
-        "i",
-        "city.nagoya.jp",
-        "i",
-        "www.ck",
-        "i",
-        "city.sendai.jp",
-        "i",
-        "city.kitakyushu.jp",
-        "i"
-    );
-
-    static {
-        try (
-            var stream = DomainSplitFunction.class.getClassLoader().getResourceAsStream("org/elasticsearch/xpack/ml/utils/exact.properties")
-        ) {
-            exact = Streams.readAllLines(stream)
-                .stream()
-                .map(line -> line.split("="))
-                .collect(Collectors.toUnmodifiableMap(split -> split[0], split -> split[1]));
-        } catch (final IOException e) {
-            throw new UncheckedIOException(e);
+        static {
+            try (
+                var stream = DomainSplitFunction.class.getClassLoader()
+                    .getResourceAsStream("org/elasticsearch/xpack/ml/utils/exact.properties")
+            ) {
+                exact = Streams.readAllLines(stream)
+                    .stream()
+                    .map(line -> line.split("="))
+                    .collect(Collectors.toUnmodifiableMap(split -> split[0].intern(), split -> split[1].intern()));
+            } catch (final IOException e) {
+                throw new UncheckedIOException(e);
+            }
         }
     }
+
+    private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(DomainSplitFunction.class);
 
     private DomainSplitFunction() {}
 
@@ -127,16 +128,16 @@ public final class DomainSplitFunction {
             }
             /* parts.subList(i, partsSize).each(joiner::add); */
             String ancestorName = joiner.toString();
-            if (exact.containsKey(ancestorName)) {
+            if (ConstantHolder.exact.containsKey(ancestorName)) {
                 return i;
             }
             /* Excluded domains (e.g. !nhs.uk) use the next highest
                domain as the effective public suffix (e.g. uk). */
-            if (excluded.containsKey(ancestorName)) {
+            if (ConstantHolder.excluded.containsKey(ancestorName)) {
                 return i + 1;
             }
             String[] pieces = ancestorName.split("\\.");
-            if (pieces.length >= 2 && under.containsKey(pieces[1])) {
+            if (pieces.length >= 2 && ConstantHolder.under.containsKey(pieces[1])) {
                 return i;
             }
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/DomainSplitFunction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/DomainSplitFunction.java
@@ -82,17 +82,21 @@ public final class DomainSplitFunction {
         );
 
         static {
-            try (
-                var stream = DomainSplitFunction.class.getClassLoader()
-                    .getResourceAsStream("org/elasticsearch/xpack/ml/utils/exact.properties")
-            ) {
-                exact = Streams.readAllLines(stream)
-                    .stream()
-                    .map(line -> line.split("="))
-                    .collect(Collectors.toUnmodifiableMap(split -> split[0].intern(), split -> split[1].intern()));
-            } catch (final IOException e) {
-                throw new UncheckedIOException(e);
-            }
+            exact = AccessController.doPrivileged((PrivilegedAction<Map<String, String>>) () -> {
+                try (
+                    var stream = DomainSplitFunction.class.getClassLoader()
+                        .getResourceAsStream("org/elasticsearch/xpack/ml/utils/exact.properties")
+                ) {
+                    return Streams.readAllLines(stream)
+                        .stream()
+                        .map(line -> line.split("="))
+                        .collect(
+                            Collectors.<String[], String, String>toUnmodifiableMap(split -> split[0].intern(), split -> split[1].intern())
+                        );
+                } catch (final IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            });
         }
     }
 


### PR DESCRIPTION
It seems the utilities in this class are only used from Painless. We should avoid eager loading these constants (and can make one of them far cheaper by string interning) since they cost almost 1M in mostly unused memory.
