### PR TITLE
[POC] Enhancement/metrics for search latencies

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -403,6 +403,7 @@ import org.elasticsearch.rest.action.search.RestKnnSearchAction;
 import org.elasticsearch.rest.action.search.RestMultiSearchAction;
 import org.elasticsearch.rest.action.search.RestSearchAction;
 import org.elasticsearch.rest.action.search.RestSearchScrollAction;
+import org.elasticsearch.rest.action.search.SearchRestMetrics;
 import org.elasticsearch.rest.action.synonyms.RestDeleteSynonymRuleAction;
 import org.elasticsearch.rest.action.synonyms.RestDeleteSynonymsAction;
 import org.elasticsearch.rest.action.synonyms.RestGetSynonymRuleAction;
@@ -463,6 +464,8 @@ public class ActionModule extends AbstractModule {
     private final ReservedClusterStateService reservedClusterStateService;
     private final RestExtension restExtension;
 
+    private final SearchRestMetrics searchRestMetrics;
+
     public ActionModule(
         Settings settings,
         IndexNameExpressionResolver indexNameExpressionResolver,
@@ -479,7 +482,8 @@ public class ActionModule extends AbstractModule {
         ClusterService clusterService,
         RerouteService rerouteService,
         List<ReservedClusterStateHandler<?>> reservedStateHandlers,
-        RestExtension restExtension
+        RestExtension restExtension,
+        SearchRestMetrics searchRestMetrics
     ) {
         this.settings = settings;
         this.indexNameExpressionResolver = indexNameExpressionResolver;
@@ -526,6 +530,7 @@ public class ActionModule extends AbstractModule {
         }
         reservedClusterStateService = new ReservedClusterStateService(clusterService, rerouteService, reservedStateHandlers);
         this.restExtension = restExtension;
+        this.searchRestMetrics = searchRestMetrics;
     }
 
     private static <T> T getRestServerComponent(
@@ -930,11 +935,11 @@ public class ActionModule extends AbstractModule {
         registerHandler.accept(new RestUpdateAction());
 
         registerHandler.accept(new RestSearchAction(restController.getSearchUsageHolder()));
-        registerHandler.accept(new RestSearchScrollAction());
+        registerHandler.accept(new RestSearchScrollAction(searchRestMetrics));
         registerHandler.accept(new RestClearScrollAction());
         registerHandler.accept(new RestOpenPointInTimeAction());
         registerHandler.accept(new RestClosePointInTimeAction());
-        registerHandler.accept(new RestMultiSearchAction(settings, restController.getSearchUsageHolder()));
+        registerHandler.accept(new RestMultiSearchAction(settings, restController.getSearchUsageHolder(), searchRestMetrics));
         registerHandler.accept(new RestKnnSearchAction());
 
         registerHandler.accept(new RestValidateQueryAction());

--- a/server/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
@@ -672,7 +672,7 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
             getNumShards(),
             numSuccess,
             skippedOps.get(),
-            buildTookInMillis(),
+            buildTookInMillis(),  // TODO: John here
             failures,
             clusters,
             searchContextId

--- a/server/src/main/java/org/elasticsearch/action/search/MultiSearchResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/MultiSearchResponse.java
@@ -23,6 +23,7 @@ import org.elasticsearch.core.AbstractRefCounted;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.RefCounted;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.rest.action.search.ReportsTookTime;
 import org.elasticsearch.transport.LeakTracker;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
@@ -39,7 +40,8 @@ import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg
 /**
  * A multi search response.
  */
-public class MultiSearchResponse extends ActionResponse implements Iterable<MultiSearchResponse.Item>, ChunkedToXContentObject {
+public class MultiSearchResponse extends ActionResponse implements Iterable<MultiSearchResponse.Item>, ChunkedToXContentObject, ReportsTookTime {
+    private static final String MetricIdentifier = "MultiSearchResponse";
 
     private static final ParseField RESPONSES = new ParseField(Fields.RESPONSES);
     private static final ParseField TOOK_IN_MILLIS = new ParseField("took");
@@ -52,6 +54,16 @@ public class MultiSearchResponse extends ActionResponse implements Iterable<Mult
     static {
         PARSER.declareObjectArray(constructorArg(), (p, c) -> itemFromXContent(p), RESPONSES);
         PARSER.declareLong(constructorArg(), TOOK_IN_MILLIS);
+    }
+
+    @Override
+    public long getTookMillis() {
+        return tookInMillis;
+    }
+
+    @Override
+    public String getIdentifier() {
+        return MetricIdentifier;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/search/MultiSearchResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/MultiSearchResponse.java
@@ -40,7 +40,11 @@ import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg
 /**
  * A multi search response.
  */
-public class MultiSearchResponse extends ActionResponse implements Iterable<MultiSearchResponse.Item>, ChunkedToXContentObject, ReportsTookTime {
+public class MultiSearchResponse extends ActionResponse
+    implements
+        Iterable<MultiSearchResponse.Item>,
+        ChunkedToXContentObject,
+        ReportsTookTime {
     private static final String MetricIdentifier = "MultiSearchResponse";
 
     private static final ParseField RESPONSES = new ParseField(Fields.RESPONSES);

--- a/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
@@ -24,6 +24,7 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.rest.action.RestActions;
+import org.elasticsearch.rest.action.search.ReportsTookTime;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.InternalAggregations;
@@ -56,11 +57,12 @@ import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpect
 /**
  * A response of a search request.
  */
-public class SearchResponse extends ActionResponse implements ChunkedToXContentObject {
+public class SearchResponse extends ActionResponse implements ChunkedToXContentObject, ReportsTookTime {
+    private static final String MetricIdentifier = "SearchResponse";
 
     private static final ParseField SCROLL_ID = new ParseField("_scroll_id");
     private static final ParseField POINT_IN_TIME_ID = new ParseField("pit_id");
-    private static final ParseField TOOK = new ParseField("took");
+    private static final ParseField TOOK = new ParseField("took"); // here
     private static final ParseField TIMED_OUT = new ParseField("timed_out");
     private static final ParseField TERMINATED_EARLY = new ParseField("terminated_early");
     private static final ParseField NUM_REDUCE_PHASES = new ParseField("num_reduce_phases");
@@ -79,7 +81,7 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
     private final int skippedShards;
     private final ShardSearchFailure[] shardFailures;
     private final Clusters clusters;
-    private final long tookInMillis;
+    private final long tookInMillis; // here
 
     public SearchResponse(StreamInput in) throws IOException {
         super(in);
@@ -120,7 +122,7 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
         int totalShards,
         int successfulShards,
         int skippedShards,
-        long tookInMillis,
+        long tookInMillis,  // TODO: John here
         ShardSearchFailure[] shardFailures,
         Clusters clusters
     ) {
@@ -149,7 +151,7 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
         int totalShards,
         int successfulShards,
         int skippedShards,
-        long tookInMillis,
+        long tookInMillis,  // TODO: John here
         ShardSearchFailure[] shardFailures,
         Clusters clusters,
         String pointInTimeId
@@ -185,7 +187,7 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
         int totalShards,
         int successfulShards,
         int skippedShards,
-        long tookInMillis,
+        long tookInMillis,  // TODO: John here
         ShardSearchFailure[] shardFailures,
         Clusters clusters,
         String pointInTimeId
@@ -538,6 +540,16 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
     @Override
     public String toString() {
         return Strings.toString(this);
+    }
+
+    @Override
+    public long getTookMillis() {
+        return tookInMillis;
+    }
+
+    @Override
+    public String getIdentifier() {
+        return MetricIdentifier;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/search/SearchResponseMerger.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchResponseMerger.java
@@ -223,7 +223,7 @@ final class SearchResponseMerger implements Releasable {
             totalShards,
             successfulShards,
             skippedShards,
-            tookInMillis,
+            tookInMillis,  // TODO: John here
             shardFailures,
             clusters,
             null

--- a/server/src/main/java/org/elasticsearch/action/search/SearchScrollAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchScrollAsyncAction.java
@@ -253,7 +253,7 @@ abstract class SearchScrollAsyncAction<T extends SearchPhaseResult> implements R
                     this.scrollId.getContext().length,
                     successfulOps.get(),
                     0,
-                    buildTookInMillis(),
+                    buildTookInMillis(),  // TODO: John here
                     buildShardFailures(),
                     SearchResponse.Clusters.EMPTY,
                     null

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -554,7 +554,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                             searchResponse.getTotalShards(),
                             searchResponse.getSuccessfulShards(),
                             searchResponse.getSkippedShards(),
-                            timeProvider.buildTookInMillis(),
+                            timeProvider.buildTookInMillis(), // TODO: John here
                             searchResponse.getShardFailures(),
                             clusters,
                             searchResponse.pointInTimeId()

--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -798,7 +798,8 @@ class NodeConstruction {
         terminationHandler = getSinglePlugin(terminationHandlers, TerminationHandler.class).orElse(null);
 
         final SearchRestMetrics searchRestMetrics = new SearchRestMetrics(telemetryProvider.getMeterRegistry());
-        ActionModule actionModule = new ActionModule( // here
+        ActionModule actionModule = new ActionModule(
+            // here
             settings,
             clusterModule.getIndexNameExpressionResolver(),
             settingsModule.getIndexScopedSettings(),

--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -167,6 +167,7 @@ import org.elasticsearch.reservedstate.ReservedClusterStateHandler;
 import org.elasticsearch.reservedstate.ReservedClusterStateHandlerProvider;
 import org.elasticsearch.reservedstate.action.ReservedClusterSettingsAction;
 import org.elasticsearch.reservedstate.service.FileSettingsService;
+import org.elasticsearch.rest.action.search.SearchRestMetrics;
 import org.elasticsearch.script.ScriptModule;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.SearchModule;
@@ -796,7 +797,8 @@ class NodeConstruction {
             .map(TerminationHandlerProvider::handler);
         terminationHandler = getSinglePlugin(terminationHandlers, TerminationHandler.class).orElse(null);
 
-        ActionModule actionModule = new ActionModule(
+        final SearchRestMetrics searchRestMetrics = new SearchRestMetrics(telemetryProvider.getMeterRegistry());
+        ActionModule actionModule = new ActionModule( // here
             settings,
             clusterModule.getIndexNameExpressionResolver(),
             settingsModule.getIndexScopedSettings(),
@@ -819,7 +821,8 @@ class NodeConstruction {
                 indexSettingProviders,
                 metadataCreateIndexService
             ),
-            pluginsService.loadSingletonServiceProvider(RestExtension.class, RestExtension::allowAll)
+            pluginsService.loadSingletonServiceProvider(RestExtension.class, RestExtension::allowAll),
+            searchRestMetrics
         );
         modules.add(actionModule);
 

--- a/server/src/main/java/org/elasticsearch/rest/action/RestActionListener.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/RestActionListener.java
@@ -32,7 +32,7 @@ public abstract class RestActionListener<Response> implements ActionListener<Res
     }
 
     @Override
-    public final void onResponse(Response response) {
+    public void onResponse(Response response) {
         try {
             ensureOpen();
             processResponse(response);

--- a/server/src/main/java/org/elasticsearch/rest/action/RestRefCountedChunkedToXContentInstrumentedListener.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/RestRefCountedChunkedToXContentInstrumentedListener.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.rest.action;
+
+import org.elasticsearch.common.xcontent.ChunkedToXContent;
+import org.elasticsearch.core.RefCounted;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.action.search.ReportsTookTime;
+import org.elasticsearch.rest.action.search.SearchRestMetrics;
+
+/**
+ * Same as {@link RestRefCountedChunkedToXContentListener} but recordings metrics of timing data of classes that implement ReportsTookTime.
+ */
+public class RestRefCountedChunkedToXContentInstrumentedListener<Response extends ChunkedToXContent & RefCounted & ReportsTookTime>
+    extends RestRefCountedChunkedToXContentListener<Response> {
+    SearchRestMetrics searchRestMetrics;
+
+    public RestRefCountedChunkedToXContentInstrumentedListener(RestChannel channel, SearchRestMetrics searchRestMetrics) {
+        super(channel);
+        this.searchRestMetrics = searchRestMetrics;
+    }
+
+    @Override
+    public void onResponse(Response response) {
+        searchRestMetrics.getSearchRequestCount().increment();
+        searchRestMetrics.getSearchDurationTotalMillisCount().incrementBy(response.getTookMillis());
+        searchRestMetrics.getSearchDurationsMillisHistogram().record(response.getTookMillis());
+        super.onResponse(response);
+    }
+}
+

--- a/server/src/main/java/org/elasticsearch/rest/action/RestRefCountedChunkedToXContentInstrumentedListener.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/RestRefCountedChunkedToXContentInstrumentedListener.java
@@ -17,8 +17,8 @@ import org.elasticsearch.rest.action.search.SearchRestMetrics;
 /**
  * Same as {@link RestRefCountedChunkedToXContentListener} but recordings metrics of timing data of classes that implement ReportsTookTime.
  */
-public class RestRefCountedChunkedToXContentInstrumentedListener<Response extends ChunkedToXContent & RefCounted & ReportsTookTime>
-    extends RestRefCountedChunkedToXContentListener<Response> {
+public class RestRefCountedChunkedToXContentInstrumentedListener<Response extends ChunkedToXContent & RefCounted & ReportsTookTime> extends
+    RestRefCountedChunkedToXContentListener<Response> {
     SearchRestMetrics searchRestMetrics;
 
     public RestRefCountedChunkedToXContentInstrumentedListener(RestChannel channel, SearchRestMetrics searchRestMetrics) {
@@ -34,4 +34,3 @@ public class RestRefCountedChunkedToXContentInstrumentedListener<Response extend
         super.onResponse(response);
     }
 }
-

--- a/server/src/main/java/org/elasticsearch/rest/action/RestRefCountedChunkedToXContentListener.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/RestRefCountedChunkedToXContentListener.java
@@ -30,3 +30,6 @@ public class RestRefCountedChunkedToXContentListener<Response extends ChunkedToX
         return Releasables.assertOnce(response::decRef);
     }
 }
+/*
+Subclass of this that extends search response so that I can report took.
+ */

--- a/server/src/main/java/org/elasticsearch/rest/action/search/ReportsTookTime.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/ReportsTookTime.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.rest.action.search;
+
+public interface ReportsTookTime {
+
+    long getTookMillis();
+
+    String getIdentifier();
+}

--- a/server/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
@@ -26,7 +26,7 @@ import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.Scope;
 import org.elasticsearch.rest.ServerlessScope;
 import org.elasticsearch.rest.action.RestCancellableNodeClient;
-import org.elasticsearch.rest.action.RestRefCountedChunkedToXContentListener;
+import org.elasticsearch.rest.action.RestRefCountedChunkedToXContentInstrumentedListener;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.usage.SearchUsageHolder;
 import org.elasticsearch.xcontent.XContent;
@@ -49,10 +49,12 @@ public class RestMultiSearchAction extends BaseRestHandler {
 
     private final boolean allowExplicitIndex;
     private final SearchUsageHolder searchUsageHolder;
+    private final SearchRestMetrics searchRestMetrics;
 
-    public RestMultiSearchAction(Settings settings, SearchUsageHolder searchUsageHolder) {
+    public RestMultiSearchAction(Settings settings, SearchUsageHolder searchUsageHolder, SearchRestMetrics searchRestMetrics) {
         this.allowExplicitIndex = MULTI_ALLOW_EXPLICIT_INDEX.get(settings);
         this.searchUsageHolder = searchUsageHolder;
+        this.searchRestMetrics = searchRestMetrics;
     }
 
     @Override
@@ -85,7 +87,7 @@ public class RestMultiSearchAction extends BaseRestHandler {
             cancellableClient.execute(
                 TransportMultiSearchAction.TYPE,
                 multiSearchRequest,
-                new RestRefCountedChunkedToXContentListener<>(channel)
+                new RestRefCountedChunkedToXContentInstrumentedListener<>(channel, searchRestMetrics)
             );
         };
     }

--- a/server/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
@@ -119,7 +119,7 @@ public class RestSearchAction extends BaseRestHandler {
 
         return channel -> {
             RestCancellableNodeClient cancelClient = new RestCancellableNodeClient(client, request.getHttpChannel());
-            cancelClient.execute(TransportSearchAction.TYPE, searchRequest, new RestRefCountedChunkedToXContentListener<>(channel));
+            cancelClient.execute(TransportSearchAction.TYPE, searchRequest, new RestRefCountedChunkedToXContentListener<>(channel)); // here, the listener.  Can wrap the listener?
         };
     }
 

--- a/server/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
@@ -119,7 +119,13 @@ public class RestSearchAction extends BaseRestHandler {
 
         return channel -> {
             RestCancellableNodeClient cancelClient = new RestCancellableNodeClient(client, request.getHttpChannel());
-            cancelClient.execute(TransportSearchAction.TYPE, searchRequest, new RestRefCountedChunkedToXContentListener<>(channel)); // here, the listener.  Can wrap the listener?
+            cancelClient.execute(TransportSearchAction.TYPE, searchRequest, new RestRefCountedChunkedToXContentListener<>(channel)); // here,
+                                                                                                                                     // the
+                                                                                                                                     // listener.
+                                                                                                                                     // Can
+                                                                                                                                     // wrap
+                                                                                                                                     // the
+                                                                                                                                     // listener?
         };
     }
 

--- a/server/src/main/java/org/elasticsearch/rest/action/search/RestSearchScrollAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/RestSearchScrollAction.java
@@ -33,7 +33,6 @@ public class RestSearchScrollAction extends BaseRestHandler {
 
     private final SearchRestMetrics searchRestMetrics;
 
-
     public RestSearchScrollAction(SearchRestMetrics searchRestMetrics) {
         this.searchRestMetrics = searchRestMetrics;
     }
@@ -73,7 +72,10 @@ public class RestSearchScrollAction extends BaseRestHandler {
                 }
             }
         });
-        return channel -> client.searchScroll(searchScrollRequest, new RestRefCountedChunkedToXContentInstrumentedListener<>(channel, searchRestMetrics));
+        return channel -> client.searchScroll(
+            searchScrollRequest,
+            new RestRefCountedChunkedToXContentInstrumentedListener<>(channel, searchRestMetrics)
+        );
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/rest/action/search/RestSearchScrollAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/RestSearchScrollAction.java
@@ -14,7 +14,7 @@ import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.Scope;
 import org.elasticsearch.rest.ServerlessScope;
-import org.elasticsearch.rest.action.RestRefCountedChunkedToXContentListener;
+import org.elasticsearch.rest.action.RestRefCountedChunkedToXContentInstrumentedListener;
 import org.elasticsearch.search.Scroll;
 import org.elasticsearch.xcontent.XContentParseException;
 
@@ -30,6 +30,13 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 @ServerlessScope(Scope.PUBLIC)
 public class RestSearchScrollAction extends BaseRestHandler {
     private static final Set<String> RESPONSE_PARAMS = Collections.singleton(RestSearchAction.TOTAL_HITS_AS_INT_PARAM);
+
+    private final SearchRestMetrics searchRestMetrics;
+
+
+    public RestSearchScrollAction(SearchRestMetrics searchRestMetrics) {
+        this.searchRestMetrics = searchRestMetrics;
+    }
 
     @Override
     public String getName() {
@@ -66,7 +73,7 @@ public class RestSearchScrollAction extends BaseRestHandler {
                 }
             }
         });
-        return channel -> client.searchScroll(searchScrollRequest, new RestRefCountedChunkedToXContentListener<>(channel));
+        return channel -> client.searchScroll(searchScrollRequest, new RestRefCountedChunkedToXContentInstrumentedListener<>(channel, searchRestMetrics));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/rest/action/search/SearchRestMetrics.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/SearchRestMetrics.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.rest.action.search;
+
+import org.elasticsearch.telemetry.TelemetryProvider;
+import org.elasticsearch.telemetry.metric.LongCounter;
+import org.elasticsearch.telemetry.metric.LongHistogram;
+import org.elasticsearch.telemetry.metric.MeterRegistry;
+
+public class SearchRestMetrics {
+    private final LongCounter searchRequestCount;
+    private final LongCounter searchDurationTotalMillisCount;
+    private final LongHistogram searchDurationsMillisHistogram;
+
+    public SearchRestMetrics(MeterRegistry meterRegistry) {
+        this(
+            meterRegistry.registerLongCounter(
+                "es.rest.search_requests.count",
+                "The total number of search requests expressed as a counter",
+                "count"
+            ),
+            meterRegistry.registerLongCounter(
+                "es.rest.search_requests_times.total",
+                "The total time of search requests in milliseconds expressed as a counter",
+                "millis"
+            ),
+            meterRegistry.registerLongHistogram(
+                "es.rest.search_requests_times.histogram",
+                "The timing percentiles of search requests in milliseconds expressed as a histogram",
+                "millis"
+            )
+        );
+    }
+
+    SearchRestMetrics(LongCounter searchRequestCount, LongCounter searchDurationTotalMillisCount, LongHistogram searchDurationsMillisHistogram) {
+        this.searchRequestCount = searchRequestCount;
+        this.searchDurationTotalMillisCount = searchDurationTotalMillisCount;
+        this.searchDurationsMillisHistogram = searchDurationsMillisHistogram;
+    }
+
+    public LongCounter getSearchRequestCount() {
+        return searchRequestCount;
+    }
+
+    public LongCounter getSearchDurationTotalMillisCount() {
+        return searchDurationTotalMillisCount;
+    }
+
+    public LongHistogram getSearchDurationsMillisHistogram() {
+        return searchDurationsMillisHistogram;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/rest/action/search/SearchRestMetrics.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/SearchRestMetrics.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.rest.action.search;
 
-import org.elasticsearch.telemetry.TelemetryProvider;
 import org.elasticsearch.telemetry.metric.LongCounter;
 import org.elasticsearch.telemetry.metric.LongHistogram;
 import org.elasticsearch.telemetry.metric.MeterRegistry;
@@ -37,7 +36,11 @@ public class SearchRestMetrics {
         );
     }
 
-    SearchRestMetrics(LongCounter searchRequestCount, LongCounter searchDurationTotalMillisCount, LongHistogram searchDurationsMillisHistogram) {
+    SearchRestMetrics(
+        LongCounter searchRequestCount,
+        LongCounter searchDurationTotalMillisCount,
+        LongHistogram searchDurationsMillisHistogram
+    ) {
         this.searchRequestCount = searchRequestCount;
         this.searchDurationTotalMillisCount = searchDurationTotalMillisCount;
         this.searchDurationsMillisHistogram = searchDurationsMillisHistogram;

--- a/server/src/test/java/org/elasticsearch/rest/action/search/RestMultiSearchActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/search/RestMultiSearchActionTests.java
@@ -33,7 +33,11 @@ public final class RestMultiSearchActionTests extends RestActionTestCase {
 
     @Before
     public void setUpAction() {
-        action = new RestMultiSearchAction(Settings.EMPTY, new UsageService().getSearchUsageHolder(), new SearchRestMetrics(TelemetryProvider.NOOP.getMeterRegistry()));
+        action = new RestMultiSearchAction(
+            Settings.EMPTY,
+            new UsageService().getSearchUsageHolder(),
+            new SearchRestMetrics(TelemetryProvider.NOOP.getMeterRegistry())
+        );
         controller().registerHandler(action);
         verifyingClient.setExecuteVerifier((actionType, request) -> Mockito.mock(MultiSearchResponse.class));
         verifyingClient.setExecuteLocallyVerifier((actionType, request) -> Mockito.mock(MultiSearchResponse.class));

--- a/server/src/test/java/org/elasticsearch/rest/action/search/RestMultiSearchActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/search/RestMultiSearchActionTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.telemetry.TelemetryProvider;
 import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.test.rest.RestActionTestCase;
 import org.elasticsearch.usage.UsageService;
@@ -32,7 +33,7 @@ public final class RestMultiSearchActionTests extends RestActionTestCase {
 
     @Before
     public void setUpAction() {
-        action = new RestMultiSearchAction(Settings.EMPTY, new UsageService().getSearchUsageHolder());
+        action = new RestMultiSearchAction(Settings.EMPTY, new UsageService().getSearchUsageHolder(), new SearchRestMetrics(TelemetryProvider.NOOP.getMeterRegistry()));
         controller().registerHandler(action);
         verifyingClient.setExecuteVerifier((actionType, request) -> Mockito.mock(MultiSearchResponse.class));
         verifyingClient.setExecuteLocallyVerifier((actionType, request) -> Mockito.mock(MultiSearchResponse.class));

--- a/server/src/test/java/org/elasticsearch/search/scroll/RestSearchScrollActionTests.java
+++ b/server/src/test/java/org/elasticsearch/search/scroll/RestSearchScrollActionTests.java
@@ -15,6 +15,8 @@ import org.elasticsearch.action.search.SearchScrollRequest;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.search.RestSearchScrollAction;
+import org.elasticsearch.rest.action.search.SearchRestMetrics;
+import org.elasticsearch.telemetry.TelemetryProvider;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.client.NoOpNodeClient;
 import org.elasticsearch.test.rest.FakeRestChannel;
@@ -29,7 +31,7 @@ import static org.hamcrest.Matchers.equalTo;
 public class RestSearchScrollActionTests extends ESTestCase {
 
     public void testParseSearchScrollRequestWithInvalidJsonThrowsException() throws Exception {
-        RestSearchScrollAction action = new RestSearchScrollAction();
+        RestSearchScrollAction action = new RestSearchScrollAction(new SearchRestMetrics(TelemetryProvider.NOOP.getMeterRegistry()));
         RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withContent(
             new BytesArray("{invalid_json}"),
             XContentType.JSON
@@ -49,7 +51,7 @@ public class RestSearchScrollActionTests extends ESTestCase {
                     assertThat(request.scroll().keepAlive().getStringRep(), equalTo("1m"));
                 }
             };
-            RestSearchScrollAction action = new RestSearchScrollAction();
+            RestSearchScrollAction action = new RestSearchScrollAction(new SearchRestMetrics(TelemetryProvider.NOOP.getMeterRegistry()));
             Map<String, String> params = new HashMap<>();
             params.put("scroll_id", "QUERY_STRING");
             params.put("scroll", "1000m");

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/AsyncSearch.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/AsyncSearch.java
@@ -52,7 +52,7 @@ public final class AsyncSearch extends Plugin implements ActionPlugin {
         Supplier<DiscoveryNodes> nodesInCluster
     ) {
         return Arrays.asList(
-            new RestSubmitAsyncSearchAction(restController.getSearchUsageHolder()),
+            new RestSubmitAsyncSearchAction(restController.getSearchUsageHolder(), searchRestMetrics),
             new RestGetAsyncSearchAction(),
             new RestGetAsyncStatusAction(),
             new RestDeleteAsyncSearchAction()

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/MutableSearchResponse.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/MutableSearchResponse.java
@@ -168,7 +168,7 @@ class MutableSearchResponse {
             totalShards,
             successfulShards,
             skippedShards,
-            tookInMillis,
+            tookInMillis,  // TODO: John here
             buildQueryFailures(),
             clusters
         );

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/RestSubmitAsyncSearchAction.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/RestSubmitAsyncSearchAction.java
@@ -37,7 +37,6 @@ public final class RestSubmitAsyncSearchAction extends BaseRestHandler {
     private final SearchUsageHolder searchUsageHolder;
     private final SearchRestMetrics searchRestMetrics;
 
-
     public RestSubmitAsyncSearchAction(SearchUsageHolder searchUsageHolder, SearchRestMetrics searchRestMetrics) {
         this.searchUsageHolder = searchUsageHolder;
         this.searchRestMetrics = searchRestMetrics;
@@ -83,12 +82,16 @@ public final class RestSubmitAsyncSearchAction extends BaseRestHandler {
         }
         return channel -> {
             RestCancellableNodeClient cancelClient = new RestCancellableNodeClient(client, request.getHttpChannel());
-            cancelClient.execute(SubmitAsyncSearchAction.INSTANCE, submit, new RestRefCountedChunkedToXContentInstrumentedListener<>(channel, searchRestMetrics) {
-                @Override
-                protected RestStatus getRestStatus(AsyncSearchResponse asyncSearchResponse) {
-                    return asyncSearchResponse.status();
+            cancelClient.execute(
+                SubmitAsyncSearchAction.INSTANCE,
+                submit,
+                new RestRefCountedChunkedToXContentInstrumentedListener<>(channel, searchRestMetrics) {
+                    @Override
+                    protected RestStatus getRestStatus(AsyncSearchResponse asyncSearchResponse) {
+                        return asyncSearchResponse.status();
+                    }
                 }
-            });
+            );
         };
     }
 

--- a/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/RestSubmitAsyncSearchActionTests.java
+++ b/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/RestSubmitAsyncSearchActionTests.java
@@ -33,7 +33,7 @@ public class RestSubmitAsyncSearchActionTests extends RestActionTestCase {
 
     @Before
     public void setUpAction() {
-        action = new RestSubmitAsyncSearchAction(new UsageService().getSearchUsageHolder());
+        action = new RestSubmitAsyncSearchAction(new UsageService().getSearchUsageHolder(), searchRestMetrics);
         controller().registerHandler(action);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/AsyncSearchResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/AsyncSearchResponse.java
@@ -18,6 +18,7 @@ import org.elasticsearch.common.xcontent.ChunkedToXContentObject;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.rest.action.search.ReportsTookTime;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xpack.core.async.AsyncResponse;
 
@@ -30,7 +31,9 @@ import static org.elasticsearch.rest.RestStatus.OK;
 /**
  * A response of an async search request.
  */
-public class AsyncSearchResponse extends ActionResponse implements ChunkedToXContentObject, AsyncResponse<AsyncSearchResponse> {
+public class AsyncSearchResponse extends ActionResponse implements ChunkedToXContentObject, AsyncResponse<AsyncSearchResponse>, ReportsTookTime {
+    private static final String MetricIdentifier = "AsyncSearchResponse";
+
     @Nullable
     private final String id;
     @Nullable
@@ -234,5 +237,15 @@ public class AsyncSearchResponse extends ActionResponse implements ChunkedToXCon
     public AsyncSearchResponse convertToFailure(Exception exc) {
         exc.setStackTrace(new StackTraceElement[0]); // we don't need to store stack traces
         return new AsyncSearchResponse(id, null, exc, isPartial, false, startTimeMillis, expirationTimeMillis);
+    }
+
+    @Override
+    public long getTookMillis() {
+        return searchResponse.getTookMillis();
+    }
+
+    @Override
+    public String getIdentifier() {
+        return MetricIdentifier;
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/AsyncSearchResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/AsyncSearchResponse.java
@@ -31,7 +31,11 @@ import static org.elasticsearch.rest.RestStatus.OK;
 /**
  * A response of an async search request.
  */
-public class AsyncSearchResponse extends ActionResponse implements ChunkedToXContentObject, AsyncResponse<AsyncSearchResponse>, ReportsTookTime {
+public class AsyncSearchResponse extends ActionResponse
+    implements
+        ChunkedToXContentObject,
+        AsyncResponse<AsyncSearchResponse>,
+        ReportsTookTime {
     private static final String MetricIdentifier = "AsyncSearchResponse";
 
     @Nullable


### PR DESCRIPTION
This is a POC of an approach to instrument the "took" metrics reported in by Rest responses.  This approach uses the REST layer, as opposed to the transport layer approach located here: https://github.com/elastic/elasticsearch/pull/104292

Due to issues with threading dependencies into plugins, I've decided to not move forward with this approach, and to instead focus on the transport layer.