### PR TITLE
Update security QA suite to allow running in Serverless

### DIFF
--- a/x-pack/plugin/esql/qa/security/build.gradle
+++ b/x-pack/plugin/esql/qa/security/build.gradle
@@ -1,4 +1,6 @@
 apply plugin: 'elasticsearch.internal-java-rest-test'
+// Necessary to use tests in Serverless
+apply plugin: 'elasticsearch.internal-test-artifact'
 
 tasks.named('javaRestTest') {
   usesDefaultDistribution()

--- a/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityIT.java
+++ b/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityIT.java
@@ -38,11 +38,10 @@ public class EsqlSecurityIT extends ESRestTestCase {
     @ClassRule
     public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
         .distribution(DistributionType.DEFAULT)
-        .nodes(2)
         .setting("xpack.license.self_generated.type", "trial")
         .setting("xpack.security.enabled", "true")
         .rolesFile(Resource.fromClasspath("roles.yml"))
-        .user("test-admin", "x-pack-test-password", "test-admin", false)
+        .user("test-admin", "x-pack-test-password", "test-admin", true)
         .user("user1", "x-pack-test-password", "user1", false)
         .user("user2", "x-pack-test-password", "user2", false)
         .user("user3", "x-pack-test-password", "user3", false)


### PR DESCRIPTION
This removes the node count setting from configuring the test cluster, adds the `internal-test-artifact` plugin to suite's config and sets the test admin role as operator (needed to allow querying for cluster's config when setting up the suite's test client).