### PR TITLE
Refactor RollupResponseTranslator slightly to ease ref-counting

### DIFF
--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/RollupResponseTranslator.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/RollupResponseTranslator.java
@@ -73,10 +73,10 @@ public class RollupResponseTranslator {
      * on the translation conventions
      */
     public static SearchResponse translateResponse(
-        MultiSearchResponse.Item[] rolledMsearch,
+        MultiSearchResponse mSearchResponse,
         AggregationReduceContext.Builder reduceContextBuilder
     ) throws Exception {
-
+        var rolledMsearch = mSearchResponse.getResponses();
         assert rolledMsearch.length > 0;
         List<SearchResponse> responses = new ArrayList<>();
         for (MultiSearchResponse.Item item : rolledMsearch) {
@@ -199,13 +199,13 @@ public class RollupResponseTranslator {
      * so that the final product looks like a regular aggregation response, allowing it to be
      * reduced/merged into the response from the un-rolled index
      *
-     * @param msearchResponses The responses from the msearch, where the first response is the live-index response
+     * @param mSearchResponse The response from the msearch, where the first response is the live-index response
      */
     public static SearchResponse combineResponses(
-        MultiSearchResponse.Item[] msearchResponses,
+        MultiSearchResponse mSearchResponse,
         AggregationReduceContext.Builder reduceContextBuilder
     ) throws Exception {
-
+        var msearchResponses = mSearchResponse.getResponses();
         assert msearchResponses.length >= 2;
 
         boolean first = true;
@@ -242,6 +242,7 @@ public class RollupResponseTranslator {
 
         // If we only have a live index left, just return it directly. We know it can't be an error already
         if (rolledResponses.isEmpty() && liveResponse != null) {
+            liveResponse.mustIncRef();
             return liveResponse;
         } else if (rolledResponses.isEmpty()) {
             throw new ResourceNotFoundException("No indices (live or rollup) found during rollup search");

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportRollupSearchAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportRollupSearchAction.java
@@ -154,14 +154,16 @@ public class TransportRollupSearchAction extends TransportAction<SearchRequest, 
     ) throws Exception {
         if (rollupContext.hasLiveIndices() && rollupContext.hasRollupIndices()) {
             // Both
-            return RollupResponseTranslator.combineResponses(msearchResponse.getResponses(), reduceContextBuilder);
+            return RollupResponseTranslator.combineResponses(msearchResponse, reduceContextBuilder);
         } else if (rollupContext.hasLiveIndices()) {
             // Only live
             assert msearchResponse.getResponses().length == 1;
-            return RollupResponseTranslator.verifyResponse(msearchResponse.getResponses()[0]);
+            var res = RollupResponseTranslator.verifyResponse(msearchResponse.getResponses()[0]);
+            res.mustIncRef();
+            return res;
         } else if (rollupContext.hasRollupIndices()) {
             // Only rollup
-            return RollupResponseTranslator.translateResponse(msearchResponse.getResponses(), reduceContextBuilder);
+            return RollupResponseTranslator.translateResponse(msearchResponse, reduceContextBuilder);
         }
         throw new RuntimeException("MSearch response was empty, cannot unroll RollupSearch results");
     }

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerIndexingTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerIndexingTests.java
@@ -43,6 +43,7 @@ import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.SearchExecutionContextHelper;
 import org.elasticsearch.script.ScriptCompiler;
+import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
 import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregation;
@@ -868,7 +869,7 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
             ActionListener.respondAndRelease(
                 listener,
                 new SearchResponse(
-                    null,
+                    SearchHits.EMPTY_WITH_TOTAL_HITS,
                     new Aggregations(Collections.singletonList(result)),
                     null,
                     false,


### PR DESCRIPTION
Work with the combined MSearchResponse here throughout to make ref-counting the full response-array in one possible.
... and adjust tests accordingly to not leak responses 