### PR TITLE
[ML] Ignore failed jobs in unassigned task logging

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsTaskState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsTaskState.java
@@ -110,6 +110,11 @@ public class DataFrameAnalyticsTaskState implements PersistentTaskState, MlTaskS
         return lastStateChangeTime;
     }
 
+    @Override
+    public boolean isFailed() {
+        return DataFrameAnalyticsState.FAILED.equals(state);
+    }
+
     public boolean isStatusStale(PersistentTasksCustomMetadata.PersistentTask<?> task) {
         return allocationId != task.getAllocationId();
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/JobTaskState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/JobTaskState.java
@@ -106,6 +106,11 @@ public class JobTaskState implements PersistentTaskState, MlTaskState {
         return lastStateChangeTime;
     }
 
+    @Override
+    public boolean isFailed() {
+        return JobState.FAILED.equals(state);
+    }
+
     /**
      * The job state stores the allocation ID at the time it was last set.
      * This method compares the allocation ID in the state with the allocation

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/MlTaskState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/MlTaskState.java
@@ -18,4 +18,9 @@ public interface MlTaskState {
      */
     @Nullable
     Instant getLastStateChangeTime();
+
+    /**
+     * @return Is the task in the <code>failed</code> state?
+     */
+    boolean isFailed();
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlAssignmentNotifier.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlAssignmentNotifier.java
@@ -24,6 +24,7 @@ import org.elasticsearch.xpack.core.ml.action.OpenJobAction;
 import org.elasticsearch.xpack.core.ml.action.StartDataFrameAnalyticsAction;
 import org.elasticsearch.xpack.core.ml.action.StartDatafeedAction;
 import org.elasticsearch.xpack.core.ml.utils.MlTaskParams;
+import org.elasticsearch.xpack.core.ml.utils.MlTaskState;
 import org.elasticsearch.xpack.ml.notifications.AnomalyDetectionAuditor;
 import org.elasticsearch.xpack.ml.notifications.DataFrameAnalyticsAuditor;
 
@@ -298,6 +299,10 @@ public class MlAssignmentNotifier implements ClusterStateListener {
             if (task.getExecutorNode() == null) {
                 final String taskName = task.getTaskName();
                 if (MlTasks.JOB_TASK_NAME.equals(taskName) || MlTasks.DATA_FRAME_ANALYTICS_TASK_NAME.equals(taskName)) {
+                    // Ignore failed tasks - they don't need to be assigned to a node
+                    if (((MlTaskState) task.getState()).isFailed()) {
+                        continue;
+                    }
                     final String mlId = ((MlTaskParams) task.getParams()).getMlId();
                     final TaskNameAndId key = new TaskNameAndId(taskName, mlId);
                     final UnassignedTimeAndReportTime previousInfo = oldUnassignedInfoByTask.get(key);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlAssignmentNotifierTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlAssignmentNotifierTests.java
@@ -253,6 +253,7 @@ public class MlAssignmentNotifierTests extends ESTestCase {
         Instant eightHoursAgo = now.minus(Duration.ofHours(8));
         Instant sevenHoursAgo = eightHoursAgo.plus(Duration.ofHours(1));
         Instant twoHoursAgo = sevenHoursAgo.plus(Duration.ofHours(5));
+        Instant tomorrow = now.plus(Duration.ofHours(24));
 
         PersistentTasksCustomMetadata.Builder tasksBuilder = PersistentTasksCustomMetadata.builder();
         addJobTask("job1", "node1", JobState.OPENED, tasksBuilder);
@@ -304,5 +305,16 @@ public class MlAssignmentNotifierTests extends ESTestCase {
                 "[xpack/ml/job]/[job3] unassigned for [28800] seconds"
             )
         );
+
+        tasksBuilder = PersistentTasksCustomMetadata.builder();
+        addJobTask("job1", null, JobState.FAILED, tasksBuilder);
+        addJobTask("job2", null, JobState.FAILED, tasksBuilder);
+        addJobTask("job3", null, JobState.FAILED, tasksBuilder);
+        addJobTask("job4", null, JobState.FAILED, tasksBuilder);
+        addJobTask("job5", "node1", JobState.FAILED, tasksBuilder);
+        itemsToReport = notifier.findLongTimeUnassignedTasks(tomorrow, tasksBuilder.build());
+        // We still have unassigned jobs, but now all the jobs are failed, so none should be reported as unassigned
+        // as it doesn't make any difference whether they're assigned or not and autoscaling will ignore them
+        assertThat(itemsToReport, empty());
     }
 }


### PR DESCRIPTION
The logging of unassigned tasks added in #100154 should ignore failed jobs. Failed jobs may or may not be assigned to a node, but if they cannot be assigned they will not trigger a scale up by autoscaling, so never will be assigned. Therefore it's wrong to consider the fact that they are unassigned as a problem. (The fact that they are _failed_ may be a problem, but that is monitored elsewhere.)