### PR TITLE
[8.12] Update nested knn search documentation about inner-hits (#104154)

### DIFF
--- a/docs/reference/search/search-your-data/knn-search.asciidoc
+++ b/docs/reference/search/search-your-data/knn-search.asciidoc
@@ -814,11 +814,18 @@ Now we have filtered based on the top level `"creation_time"` and only one docum
 ----
 // TESTRESPONSE[s/"took": 4/"took" : "$body.took"/]
 
+[discrete]
+[[nested-knn-search-inner-hits]]
+==== Nested kNN Search with Inner hits
+
 Additionally, if you wanted to extract the nearest passage for a matched document, you can supply <<inner-hits, inner_hits>>
 to the `knn` clause.
 
 NOTE: `inner_hits` for kNN will only ever return a single hit, the nearest passage vector.
 Setting `"size"` to any value greater than `1` will have no effect on the results.
+
+NOTE: When using `inner_hits` and multiple `knn` clauses, be sure to specify the <<inner-hits-options,`inner_hits.name`>>
+field. Otherwise, a naming clash can occur and fail the search request.
 
 [source,console]
 ----


### PR DESCRIPTION
Backports the following commits to 8.12:
 - Update nested knn search documentation about inner-hits (#104154)