### PR TITLE
Remove incorrect is-not-empty asserts in EsqlAsyncActionIT

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlAsyncActionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlAsyncActionIT.java
@@ -40,7 +40,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.hamcrest.core.IsNot.not;
 
 /**
  * Runs test scenarios from EsqlActionIT, with an extra level of indirection

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlAsyncActionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlAsyncActionIT.java
@@ -74,8 +74,6 @@ public class EsqlAsyncActionIT extends EsqlActionIT {
             String id = response.asyncExecutionId().get();
             if (response.isRunning() == false) {
                 assertThat(request.keepOnCompletion(), is(true));
-                assertThat(response.columns(), is(not(empty())));
-                assertThat(response.pages(), is(not(empty())));
                 initialColumns = List.copyOf(response.columns());
                 initialPages = deepCopyOf(response.pages(), TestBlockFactory.getNonBreakingInstance());
             } else {


### PR DESCRIPTION
This commit removes a couple of incorrect is-not-empty asserts in EsqlAsyncActionIT. 

The original intent of the asserts here was to try to ensure that the completed results are valid - there should be a result. However, there are some test scenarios where an empty list of columns and values is actually the expected and correct result. The asserts are not need, not correct, and should just be removed. The results will be asserted by the caller when the response is returned.

closes #104214