### PR TITLE
Enable feature flag in node shutdown full cluster restart tests

### DIFF
--- a/x-pack/plugin/shutdown/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
+++ b/x-pack/plugin/shutdown/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
@@ -64,6 +64,7 @@ public class FullClusterRestartIT extends ParameterizedFullClusterRestartTestCas
         .keystore("xpack.watcher.encryption_key", Resource.fromClasspath("system_key"))
         .keystore("xpack.security.transport.ssl.secure_key_passphrase", "testnode")
         .feature(FeatureFlag.TIME_SERIES_MODE)
+        .feature(FeatureFlag.FAILURE_STORE_ENABLED)
         .build();
 
     public FullClusterRestartIT(@Name("cluster") FullClusterRestartUpgradeStatus upgradeStatus) {


### PR DESCRIPTION
This should resolve test failures in release builds like [this one](https://gradle-enterprise.elastic.co/s/twbb3r777mhlo/tests/task/:x-pack:plugin:shutdown:qa:full-cluster-restart:v8.12.0%23bwcTest/details/org.elasticsearch.xpack.restart.FullClusterRestartIT/testNodeShutdown%20%7Bcluster%3DUPGRADED%7D?page=eyJvdXRwdXQiOnsiMCI6NX19&top-execution=1).