### PR TITLE
[ML] Unmute MLModelDeploymentsUpgradeIT testTrainedModelDeployment

### DIFF
--- a/x-pack/plugin/ml/build.gradle
+++ b/x-pack/plugin/ml/build.gradle
@@ -55,11 +55,7 @@ if (useDra == false) {
 
 configurations {
   nativeBundle {
-    // See https://github.com/elastic/elasticsearch/issues/104193#issuecomment-1885295733
-    // for an example of why we cannot safely cache locally. When all of the ml-cpp files
-    // were in the same zip it was possible, but now they're spread between two zips local
-    // caching can result in an inconsistency that causes hard-to-debug breakages.
-    resolutionStrategy.cacheChangingModulesFor 0, 'hours'
+    resolutionStrategy.cacheChangingModulesFor 2, 'hours'
   }
 }
 

--- a/x-pack/plugin/ml/build.gradle
+++ b/x-pack/plugin/ml/build.gradle
@@ -55,7 +55,11 @@ if (useDra == false) {
 
 configurations {
   nativeBundle {
-    resolutionStrategy.cacheChangingModulesFor 2, 'hours'
+    // See https://github.com/elastic/elasticsearch/issues/104193#issuecomment-1885295733
+    // for an example of why we cannot safely cache locally. When all of the ml-cpp files
+    // were in the same zip it was possible, but now they're spread between two zips local
+    // caching can result in an inconsistency that causes hard-to-debug breakages.
+    resolutionStrategy.cacheChangingModulesFor 0, 'hours'
   }
 }
 

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MLModelDeploymentsUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MLModelDeploymentsUpgradeIT.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.upgrades;
 
 import org.apache.http.util.EntityUtils;
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
@@ -32,7 +31,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.oneOf;
 
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/104193")
 public class MLModelDeploymentsUpgradeIT extends AbstractUpgradeTestCase {
 
     // See PyTorchModelIT for how this model was created


### PR DESCRIPTION
It seems that this test failure was purely down to inconsistency of ml-cpp dependencies, and not a real problem. Therefore the test can be unmuted.

Fixes #104193