### PR TITLE
[7.17] Disable BWC tests from "monolithic" CI jobs (#104221)

### DIFF
--- a/.buildkite/scripts/encryption-at-rest.sh
+++ b/.buildkite/scripts/encryption-at-rest.sh
@@ -20,4 +20,4 @@ touch .output.log
 rm -Rf "$WORKSPACE"
 ln -s "$PWD" "$WORKSPACE"
 
-.ci/scripts/run-gradle.sh -Dbwc.checkout.align=true check
+.ci/scripts/run-gradle.sh -Dbwc.checkout.align=true functionalTests

--- a/.buildkite/scripts/release-tests.sh
+++ b/.buildkite/scripts/release-tests.sh
@@ -9,4 +9,4 @@ mkdir -p ${ML_IVY_REPO}/maven/org/elasticsearch/ml/ml-cpp/${ES_VERSION}
 curl --fail -o "${ML_IVY_REPO}/maven/org/elasticsearch/ml/ml-cpp/${ES_VERSION}/ml-cpp-${ES_VERSION}.zip" https://artifacts-snapshot.elastic.co/ml-cpp/${ES_VERSION}-SNAPSHOT/downloads/ml-cpp/ml-cpp-${ES_VERSION}-SNAPSHOT.zip
 
 .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dbuild.snapshot=false -Dbuild.ml_cpp.repo=file://${ML_IVY_REPO} \
-  -Dtests.jvm.argline=-Dbuild.snapshot=false -Dlicense.key=${WORKSPACE}/x-pack/license-tools/src/test/resources/public.key -Dbuild.id=deadbeef build
+  -Dtests.jvm.argline=-Dbuild.snapshot=false -Dlicense.key=${WORKSPACE}/x-pack/license-tools/src/test/resources/public.key -Dbuild.id=deadbeef assemble functionalTests


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Disable BWC tests from "monolithic" CI jobs (#104221)