### PR TITLE
Skip heap attack tests in release builds

### DIFF
--- a/test/external-modules/esql-heap-attack/build.gradle
+++ b/test/external-modules/esql-heap-attack/build.gradle
@@ -5,10 +5,12 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
+import org.elasticsearch.gradle.internal.info.BuildParams
 
 apply plugin: 'elasticsearch.internal-java-rest-test'
 // Necessary to use tests in Serverless
 apply plugin: 'elasticsearch.internal-test-artifact'
+
 
 esplugin {
   description 'A test module that can trigger out of memory'

--- a/test/external-modules/esql-heap-attack/build.gradle
+++ b/test/external-modules/esql-heap-attack/build.gradle
@@ -17,4 +17,5 @@ esplugin {
 
 tasks.named('javaRestTest') {
   usesDefaultDistribution()
+  it.onlyIf("snapshot build") { BuildParams.isSnapshotBuild() }
 }


### PR DESCRIPTION
We need to add a test plugin in the heap attack tests. However, we are not loading test plugins in the release builds; hence, we need to skip this suite.