### PR TITLE
[ci] Add Amazon Linux 2 to platform support pipeline

### DIFF
--- a/.buildkite/pipelines/periodic-platform-support.yml
+++ b/.buildkite/pipelines/periodic-platform-support.yml
@@ -89,6 +89,7 @@ steps:
           setup:
             image:
               - amazonlinux-2023
+              - amazonlinux-2
         agents:
           provider: aws
           imagePrefix: elasticsearch-{{matrix.image}}


### PR DESCRIPTION
The issue preventing tests to run on amazonlinux-2 has been fixed separately, so this OS can be re-added to the platform support pipeline.