### PR TITLE
Simplify handling of runtime java for tests clusters

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.runtime-jdk-provision.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.runtime-jdk-provision.gradle
@@ -47,15 +47,6 @@ configure(allprojects) {
             }
         }
     }
-
-    project.plugins.withType(RestTestBasePlugin) {
-      tasks.withType(StandaloneRestIntegTestTask).configureEach {
-        if (BuildParams.getIsRuntimeJavaHomeSet() == false) {
-          nonInputProperties.systemProperty("tests.runtime.java", "${-> launcher.map { it.metadata.installationPath.asFile.path }.get()}")
-        }
-      }
-    }
-
     project.plugins.withType(ThirdPartyAuditPrecommitPlugin) {
       project.getTasks().withType(ThirdPartyAuditTask.class).configureEach {
         if (BuildParams.getIsRuntimeJavaHomeSet() == false) {

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/RestTestBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/RestTestBasePlugin.java
@@ -63,7 +63,6 @@ import javax.inject.Inject;
 public class RestTestBasePlugin implements Plugin<Project> {
 
     private static final String TESTS_MAX_PARALLEL_FORKS_SYSPROP = "tests.max.parallel.forks";
-    private static final String TESTS_RUNTIME_JAVA_SYSPROP = "tests.runtime.java";
     private static final String DEFAULT_DISTRIBUTION_SYSPROP = "tests.default.distribution";
     private static final String INTEG_TEST_DISTRIBUTION_SYSPROP = "tests.integ-test.distribution";
     private static final String BWC_SNAPSHOT_DISTRIBUTION_SYSPROP_PREFIX = "tests.snapshot.distribution.";
@@ -189,12 +188,6 @@ public class RestTestBasePlugin implements Plugin<Project> {
             // Wire up integ-test distribution by default for all test tasks
             FileCollection extracted = integTestDistro.getExtracted();
             nonInputSystemProperties.systemProperty(INTEG_TEST_DISTRIBUTION_SYSPROP, () -> extracted.getSingleFile().getPath());
-
-            // Pass the current test task runtime java home to test framework via system property
-            nonInputSystemProperties.systemProperty(
-                TESTS_RUNTIME_JAVA_SYSPROP,
-                task.getJavaLauncher().map(l -> l.getMetadata().getInstallationPath().getAsFile().getPath())
-            );
 
             // Add `usesDefaultDistribution()` extension method to test tasks to indicate they require the default distro
             task.getExtensions().getExtraProperties().set("usesDefaultDistribution", new Closure<Void>(task) {

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/RestTestBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/RestTestBasePlugin.java
@@ -189,7 +189,12 @@ public class RestTestBasePlugin implements Plugin<Project> {
             // Wire up integ-test distribution by default for all test tasks
             FileCollection extracted = integTestDistro.getExtracted();
             nonInputSystemProperties.systemProperty(INTEG_TEST_DISTRIBUTION_SYSPROP, () -> extracted.getSingleFile().getPath());
-            nonInputSystemProperties.systemProperty(TESTS_RUNTIME_JAVA_SYSPROP, BuildParams.getRuntimeJavaHome());
+
+            // Pass the current test task runtime java home to test framework via system property
+            nonInputSystemProperties.systemProperty(
+                TESTS_RUNTIME_JAVA_SYSPROP,
+                task.getJavaLauncher().map(l -> l.getMetadata().getInstallationPath().getAsFile().getPath())
+            );
 
             // Add `usesDefaultDistribution()` extension method to test tasks to indicate they require the default distro
             task.getExtensions().getExtraProperties().set("usesDefaultDistribution", new Closure<Void>(task) {

--- a/test/external-modules/die-with-dignity/src/javaRestTest/java/org/elasticsearch/qa/die_with_dignity/DieWithDignityIT.java
+++ b/test/external-modules/die-with-dignity/src/javaRestTest/java/org/elasticsearch/qa/die_with_dignity/DieWithDignityIT.java
@@ -77,7 +77,7 @@ public class DieWithDignityIT extends ESRestTestCase {
     }
 
     private Process startJcmd(long pid) throws IOException {
-        final String jcmdPath = PathUtils.get(System.getProperty("tests.runtime.java"), "bin/jcmd").toString();
+        final String jcmdPath = PathUtils.get(System.getProperty("java.home"), "bin/jcmd").toString();
         return new ProcessBuilder().command(jcmdPath, Long.toString(pid), "VM.command_line").redirectErrorStream(true).start();
     }
 

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultEnvironmentProvider.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultEnvironmentProvider.java
@@ -20,7 +20,6 @@ import java.util.TimeZone;
 public class DefaultEnvironmentProvider implements EnvironmentProvider {
     private static final String HOSTNAME_OVERRIDE = "LinuxDarwinHostname";
     private static final String COMPUTERNAME_OVERRIDE = "WindowsComputername";
-    private static final String TESTS_RUNTIME_JAVA_SYSPROP = "tests.runtime.java";
 
     @Override
     public Map<String, String> get(LocalNodeSpec nodeSpec) {
@@ -28,7 +27,7 @@ public class DefaultEnvironmentProvider implements EnvironmentProvider {
 
         // If we are testing the current version of Elasticsearch, use the configured runtime Java, otherwise use the bundled JDK
         if (nodeSpec.getDistributionType() == DistributionType.INTEG_TEST || nodeSpec.getVersion().equals(Version.CURRENT)) {
-            environment.put("ES_JAVA_HOME", System.getProperty(TESTS_RUNTIME_JAVA_SYSPROP));
+            environment.put("ES_JAVA_HOME", System.getProperty("java.home"));
         }
 
         // Override the system hostname variables for testing


### PR DESCRIPTION
This simplifies our test clusters runtime java handling to simply inherit from the parent test task.