### PR TITLE
Speed up resolving keep command

### DIFF
--- a/docs/changelog/104246.yaml
+++ b/docs/changelog/104246.yaml
@@ -1,0 +1,5 @@
+pr: 104246
+summary: Speed up resolving keep command
+area: ES|QL
+type: bug
+issues: []

--- a/docs/changelog/104246.yaml
+++ b/docs/changelog/104246.yaml
@@ -1,5 +1,0 @@
-pr: 104246
-summary: Speed up resolving keep command
-area: ES|QL
-type: bug
-issues: []

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -477,11 +477,13 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                         throw new IllegalStateException("unexpected projection: " + proj);
                     }
                     for (Attribute attr : resolved) {
-                        Integer previousPrio = priorities.get(attr);
-                        if (previousPrio == null || previousPrio >= priority) {
-                            priorities.remove(attr);
-                            priorities.put(attr, priority);
-                        }
+                        priorities.compute(attr, (k, prevPriority) -> {
+                            if (prevPriority == null || prevPriority >= priority) {
+                                return priority;
+                            } else {
+                                return prevPriority;
+                            }
+                        });
                     }
                 }
                 resolvedProjections = new ArrayList<>(priorities.keySet());

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -473,7 +473,8 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                         resolved = resolveAgainstList(ua, childOutput);
                         priority = Regex.isSimpleMatchPattern(ua.name()) ? 1 : 0;
                     } else {
-                        continue;
+                        assert false : "unexpected projection: " + proj;
+                        throw new IllegalStateException("unexpected projection: " + proj);
                     }
                     for (Attribute attr : resolved) {
                         Integer previousPrio = priorities.get(attr);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -463,7 +463,6 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
             // otherwise resolve them
             else {
                 Map<NamedExpression, Integer> priorities = new LinkedHashMap<>();
-                boolean hasUnresolvedProjects = false;
                 for (var proj : projections) {
                     final List<Attribute> resolved;
                     final int priority;
@@ -474,7 +473,6 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                         resolved = resolveAgainstList(ua, childOutput);
                         priority = Regex.isSimpleMatchPattern(ua.name()) ? 1 : 0;
                     } else {
-                        hasUnresolvedProjects = true;
                         continue;
                     }
                     for (Attribute attr : resolved) {
@@ -483,11 +481,6 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                             priorities.remove(attr);
                             priorities.put(attr, priority);
                         }
-                    }
-                }
-                if (hasUnresolvedProjects) {
-                    for (Attribute attribute : childOutput) {
-                        priorities.putIfAbsent(attribute, 0);
                     }
                 }
                 resolvedProjections = new ArrayList<>(priorities.keySet());

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -477,13 +477,11 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                         throw new IllegalStateException("unexpected projection: " + proj);
                     }
                     for (Attribute attr : resolved) {
-                        priorities.compute(attr, (k, prevPriority) -> {
-                            if (prevPriority == null || prevPriority >= priority) {
-                                return priority;
-                            } else {
-                                return prevPriority;
-                            }
-                        });
+                        Integer previousPrio = priorities.get(attr);
+                        if (previousPrio == null || previousPrio >= priority) {
+                            priorities.remove(attr);
+                            priorities.put(attr, priority);
+                        }
                     }
                 }
                 resolvedProjections = new ArrayList<>(priorities.keySet());


### PR DESCRIPTION
We accidentally have O(N^3) when resolving the keep command.

The first loop: https://github.com/elastic/elasticsearch/blob/8e3efae03df386dc80ab1a4ac3e620d16dc9828c/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java#L466
The second loop: https://github.com/elastic/elasticsearch/blob/8e3efae03df386dc80ab1a4ac3e620d16dc9828c/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java#L467
The third loop: https://github.com/elastic/elasticsearch/blob/8e3efae03df386dc80ab1a4ac3e620d16dc9828c/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/analyzer/AnalyzerRules.java#L160

Resolving 2000 fields can take 35 seconds on a fast machine and more than 5 minutes on a slow machine. Although I think we should try to make this linear if possible, this quick fix only changes the resolution to O(N^2). This reduces the resolution time from 35s to 170ms (200 times faster) for 2000 fields. This is good enough to re-enable the HeapAttack tests.

Relates #104240