### PR TITLE
Allow tests to specify "historical" (version-based) features even for new features

### DIFF
--- a/server/src/main/java/org/elasticsearch/features/FeatureData.java
+++ b/server/src/main/java/org/elasticsearch/features/FeatureData.java
@@ -35,7 +35,7 @@ public class FeatureData {
         this.nodeFeatures = nodeFeatures;
     }
 
-    public static FeatureData createFromSpecifications(List<? extends FeatureSpecification> specs) {
+    public static FeatureData createFromSpecifications(List<? extends FeatureSpecification> specs, boolean allowAllHistoricalFeatures) {
         Map<String, FeatureSpecification> allFeatures = new HashMap<>();
 
         NavigableMap<Version, Set<String>> historicalFeatures = new TreeMap<>();
@@ -50,7 +50,7 @@ public class FeatureData {
                     );
                 }
 
-                if (hfe.getValue().after(CLUSTER_FEATURES_ADDED_VERSION)) {
+                if (allowAllHistoricalFeatures == false && hfe.getValue().after(CLUSTER_FEATURES_ADDED_VERSION)) {
                     throw new IllegalArgumentException(
                         Strings.format(
                             "Historical feature [%s] declared by [%s] for version [%s] is not a historical version",

--- a/server/src/main/java/org/elasticsearch/features/FeatureService.java
+++ b/server/src/main/java/org/elasticsearch/features/FeatureService.java
@@ -38,7 +38,7 @@ public class FeatureService {
 
     public FeatureService(List<? extends FeatureSpecification> specs) {
 
-        var featureData = FeatureData.createFromSpecifications(specs);
+        var featureData = FeatureData.createFromSpecifications(specs, false);
         nodeFeatures = featureData.getNodeFeatures();
         historicalFeatures = featureData.getHistoricalFeatures();
 

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestFeatureService.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestFeatureService.java
@@ -30,7 +30,7 @@ class ESRestTestFeatureService implements TestFeatureService {
         Set<String> clusterStateFeatures
     ) {
         var minNodeVersion = nodeVersions.stream().min(Version::compareTo);
-        var featureData = FeatureData.createFromSpecifications(specs);
+        var featureData = FeatureData.createFromSpecifications(specs, true);
         var historicalFeatures = featureData.getHistoricalFeatures();
         var allHistoricalFeatures = historicalFeatures.lastEntry() == null ? Set.of() : historicalFeatures.lastEntry().getValue();
 


### PR DESCRIPTION
We (correctly) disallow devs to specify production features as "historical" for new versions (after `CLUSTER_FEATURES_ADDED_VERSION`, which is 8.12.0).
However, the use of "historical" features (version-based features) can still be useful in tests, for the case of "test-only" features.

-- this is still in draft state as I'm not sure it'll be useful - it came up during work to deprecate Version in DesiredNodes. I might find another way.
