### PR TITLE
[8.12] [Connector API] Fix bug in configuration validation parser (#104198)

### DIFF
--- a/docs/changelog/104198.yaml
+++ b/docs/changelog/104198.yaml
@@ -1,0 +1,5 @@
+pr: 104198
+summary: "[Connector API] Fix bug in configuration validation parser"
+area: Application
+type: bug
+issues: []

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/335_connector_update_configuration.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/335_connector_update_configuration.yml
@@ -72,8 +72,18 @@ setup:
               type: str
               ui_restrictions: [ ]
               validations:
+                - constraint: [123, 456, 789]
+                  type: included_in
+                - constraint: ["string 1", "string 2", "string 3"]
+                  type: included_in
                 - constraint: 0
                   type: greater_than
+                - constraint: 42
+                  type: less_than
+                - constraint: int
+                  type: list_type
+                - constraint: "\\d+"
+                  type: regex
               value: 456
 
   - match: { result: updated }
@@ -84,6 +94,18 @@ setup:
 
   - match: { configuration.some_field.value: 456 }
   - match: { status: configured }
+  - match: { configuration.some_field.validations.0.constraint: [123, 456, 789] }
+  - match: { configuration.some_field.validations.0.type: included_in }
+  - match: { configuration.some_field.validations.1.constraint: ["string 1", "string 2", "string 3"] }
+  - match: { configuration.some_field.validations.1.type: included_in }
+  - match: { configuration.some_field.validations.2.constraint: 0 }
+  - match: { configuration.some_field.validations.2.type: greater_than }
+  - match: { configuration.some_field.validations.3.constraint: 42 }
+  - match: { configuration.some_field.validations.3.type: less_than }
+  - match: { configuration.some_field.validations.4.constraint: int }
+  - match: { configuration.some_field.validations.4.type: list_type }
+  - match: { configuration.some_field.validations.5.constraint: "\\d+" }
+  - match: { configuration.some_field.validations.5.type: regex }
 
 ---
 "Update Connector Configuration with null tooltip":

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/configuration/ConfigurationValidationType.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/configuration/ConfigurationValidationType.java
@@ -14,8 +14,7 @@ public enum ConfigurationValidationType {
     GREATER_THAN,
     LIST_TYPE,
     INCLUDED_IN,
-    REGEX,
-    UNSET;
+    REGEX;
 
     @Override
     public String toString() {

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorConfigurationTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorConfigurationTests.java
@@ -85,6 +85,69 @@ public class ConnectorConfigurationTests extends ESTestCase {
         assertToXContentEquivalent(originalBytes, toXContent(parsed, XContentType.JSON, humanReadable), XContentType.JSON);
     }
 
+    public void testToXContentWithMultipleConstraintTypes() throws IOException {
+        String content = XContentHelper.stripWhitespace("""
+            {
+               "default_value": null,
+               "depends_on": [
+                 {
+                   "field": "some_field",
+                   "value": true
+                 }
+               ],
+               "display": "textbox",
+               "label": "Very important field",
+               "options": [],
+               "order": 4,
+               "required": true,
+               "sensitive": false,
+               "tooltip": "Wow, this tooltip is useful.",
+               "type": "str",
+               "ui_restrictions": [],
+               "validations": [
+                   {
+                       "constraint": 32,
+                       "type": "less_than"
+                   },
+                   {
+                       "constraint": "^\\\\\\\\d{4}-\\\\\\\\d{2}-\\\\\\\\d{2}$",
+                       "type": "regex"
+                   },
+                   {
+                       "constraint": "int",
+                       "type": "list_type"
+                   },
+                   {
+                       "constraint": [
+                           1,
+                           2,
+                           3
+                       ],
+                       "type": "included_in"
+                   },
+                   {
+                       "constraint": [
+                           "string_1",
+                           "string_2",
+                           "string_3"
+                       ],
+                       "type": "included_in"
+                   }
+               ],
+               "value": ""
+            }
+            """);
+
+        ConnectorConfiguration configuration = ConnectorConfiguration.fromXContentBytes(new BytesArray(content), XContentType.JSON);
+        boolean humanReadable = true;
+        BytesReference originalBytes = toShuffledXContent(configuration, XContentType.JSON, ToXContent.EMPTY_PARAMS, humanReadable);
+        ConnectorConfiguration parsed;
+        try (XContentParser parser = createParser(XContentType.JSON.xContent(), originalBytes)) {
+            parsed = ConnectorConfiguration.fromXContent(parser);
+        }
+        assertToXContentEquivalent(originalBytes, toXContent(parsed, XContentType.JSON, humanReadable), XContentType.JSON);
+    }
+
     private void assertTransportSerialization(ConnectorConfiguration testInstance) throws IOException {
         ConnectorConfiguration deserializedInstance = copyInstance(testInstance);
         assertNotSame(testInstance, deserializedInstance);


### PR DESCRIPTION
Backports the following commits to 8.12:
 - [Connector API] Fix bug in configuration validation parser (#104198)