### PR TITLE
Add names of "regular" cluster features to extracted feature metadata

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/TestFeatureService.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/TestFeatureService.java
@@ -8,8 +8,30 @@
 
 package org.elasticsearch.test.rest;
 
-public interface TestFeatureService {
-    boolean clusterHasFeature(String featureId);
+import org.elasticsearch.Version;
 
+import java.util.Collection;
+import java.util.NavigableMap;
+import java.util.Set;
+import java.util.function.Predicate;
+
+public interface TestFeatureService {
     TestFeatureService ALL_FEATURES = ignored -> true;
+
+    static Predicate<String> createHistoricalFeaturePredicate(
+        NavigableMap<Version, Set<String>> historicalFeatures,
+        Collection<Version> nodeVersions
+    ) {
+        var minNodeVersion = nodeVersions.stream().min(Version::compareTo);
+        return minNodeVersion.<Predicate<String>>map(
+            v -> featureId -> TestFeatureService.hasHistoricalFeature(historicalFeatures, v, featureId)
+        ).orElse(featureId -> true); // We can safely assume that new non-semantic versions (serverless) support all historical features
+    }
+
+    static boolean hasHistoricalFeature(NavigableMap<Version, Set<String>> historicalFeatures, Version version, String featureId) {
+        var features = historicalFeatures.floorEntry(version);
+        return features != null && features.getValue().contains(featureId);
+    }
+
+    boolean clusterHasFeature(String featureId);
 }


### PR DESCRIPTION
Today we extract all historical features to a JSON map that is parsed by ESRestTestCase to provide info about historical features. 
This PR adds to that map the list of all names (Ids) of regular features too, so we can reliably raise an error if a feature is not defined.

The logic we have today to detect if a feature is "off" or "non-existing" (wrong, non-existing id) is flawed and works only for historical features. This fixes it. The distinction works only for non-legacy tests; for legacy tests, we log a warning and skip the check.