### PR TITLE
[Docs] Add connectors links, cleanup connectors API docs

### DIFF
--- a/docs/reference/connector/apis/cancel-connector-sync-job-api.asciidoc
+++ b/docs/reference/connector/apis/cancel-connector-sync-job-api.asciidoc
@@ -4,6 +4,8 @@
 <titleabbrev>Cancel connector sync job</titleabbrev>
 ++++
 
+preview::[]
+
 Cancels a connector sync job.
 
 [[cancel-connector-sync-job-api-request]]

--- a/docs/reference/connector/apis/check-in-connector-api.asciidoc
+++ b/docs/reference/connector/apis/check-in-connector-api.asciidoc
@@ -1,11 +1,10 @@
 [[check-in-connector-api]]
 === Check in connector API
-
-preview::[]
-
 ++++
 <titleabbrev>Check in a connector</titleabbrev>
 ++++
+
+preview::[]
 
 Updates the `last_seen` field of a connector with current timestamp.
 

--- a/docs/reference/connector/apis/check-in-connector-sync-job-api.asciidoc
+++ b/docs/reference/connector/apis/check-in-connector-sync-job-api.asciidoc
@@ -4,6 +4,8 @@
 <titleabbrev>Check in connector sync job</titleabbrev>
 ++++
 
+preview::[]
+
 Checks in a connector sync job (updates `last_seen` to the current time).
 
 [[check-in-connector-sync-job-api-request]]

--- a/docs/reference/connector/apis/connector-apis.asciidoc
+++ b/docs/reference/connector/apis/connector-apis.asciidoc
@@ -10,7 +10,7 @@ validations and assertions to ensure that the state representation in the intern
 
 [TIP]
 ====
-Use our https://github.com/elastic/connectors/blob/main/docs/CLI.md[CLI] to manage connectors and sync jobs programmatically.
+We also have a command-line interface for Elastic connectors. Learn more in the https://github.com/elastic/connectors/blob/main/docs/CLI.md[elastic/connectors] repository.
 ====
 
 [discrete]

--- a/docs/reference/connector/apis/connector-apis.asciidoc
+++ b/docs/reference/connector/apis/connector-apis.asciidoc
@@ -3,16 +3,15 @@
 
 preview::[]
 
-++++
-<titleabbrev>Connector APIs</titleabbrev>
-++++
-
----
-
-The connector and sync jobs API provides a convenient way to create and manage Elastic connectors and sync jobs in an internal index.
+The connector and sync jobs API provides a convenient way to create and manage Elastic {enterprise-search-ref}/connectors.html[connectors^] and sync jobs in an internal index.
 
 This API provides an alternative to relying solely on {kib} UI for connector and sync job management. The API comes with a set of
 validations and assertions to ensure that the state representation in the internal index remains valid.
+
+[TIP]
+====
+Use our https://github.com/elastic/connectors/blob/main/docs/CLI.md[CLI] to manage connectors and sync jobs programmatically.
+====
 
 [discrete]
 [[elastic-connector-apis]]

--- a/docs/reference/connector/apis/create-connector-api.asciidoc
+++ b/docs/reference/connector/apis/create-connector-api.asciidoc
@@ -4,6 +4,8 @@
 <titleabbrev>Create connector</titleabbrev>
 ++++
 
+preview::[]
+
 Creates a connector.
 
 

--- a/docs/reference/connector/apis/create-connector-sync-job-api.asciidoc
+++ b/docs/reference/connector/apis/create-connector-sync-job-api.asciidoc
@@ -4,6 +4,9 @@
 <titleabbrev>Create connector sync job</titleabbrev>
 ++++
 
+preview::[]
+
+
 Creates a connector sync job.
 
 [source, console]

--- a/docs/reference/connector/apis/delete-connector-api.asciidoc
+++ b/docs/reference/connector/apis/delete-connector-api.asciidoc
@@ -1,11 +1,10 @@
 [[delete-connector-api]]
 === Delete connector API
-
-preview::[]
-
 ++++
 <titleabbrev>Delete connector</titleabbrev>
 ++++
+
+preview::[]
 
 Removes a connector and its associated data.
 This is a destructive action that is not recoverable.

--- a/docs/reference/connector/apis/delete-connector-sync-job-api.asciidoc
+++ b/docs/reference/connector/apis/delete-connector-sync-job-api.asciidoc
@@ -1,11 +1,10 @@
 [[delete-connector-sync-job-api]]
 === Delete connector sync job API
-
-preview::[]
-
 ++++
 <titleabbrev>Delete connector sync job</titleabbrev>
 ++++
+
+preview::[]
 
 Removes a connector sync job and its associated data.
 This is a destructive action that is not recoverable.

--- a/docs/reference/connector/apis/get-connector-api.asciidoc
+++ b/docs/reference/connector/apis/get-connector-api.asciidoc
@@ -1,9 +1,10 @@
 [[get-connector-api]]
 === Get connector API
-preview::[]
 ++++
 <titleabbrev>Get connector</titleabbrev>
 ++++
+
+preview::[]
 
 Retrieves the details about a connector.
 

--- a/docs/reference/connector/apis/get-connector-sync-job-api.asciidoc
+++ b/docs/reference/connector/apis/get-connector-sync-job-api.asciidoc
@@ -1,9 +1,10 @@
 [[get-connector-sync-job-api]]
 === Get connector sync job API
-preview::[]
 ++++
 <titleabbrev>Get connector sync job</titleabbrev>
 ++++
+
+preview::[]
 
 Retrieves the details about a connector sync job.
 

--- a/docs/reference/connector/apis/list-connector-sync-jobs-api.asciidoc
+++ b/docs/reference/connector/apis/list-connector-sync-jobs-api.asciidoc
@@ -1,12 +1,11 @@
 [role="xpack"]
 [[list-connector-sync-jobs-api]]
 === List connector sync jobs API
-
-preview::[]
-
 ++++
 <titleabbrev>List connector sync jobs</titleabbrev>
 ++++
+
+preview::[]
 
 Returns information about all stored connector sync jobs ordered by their creation date in ascending order.
 

--- a/docs/reference/connector/apis/list-connectors-api.asciidoc
+++ b/docs/reference/connector/apis/list-connectors-api.asciidoc
@@ -1,12 +1,11 @@
 [role="xpack"]
 [[list-connector-api]]
 === List connectors API
-
-preview::[]
-
 ++++
 <titleabbrev>List connectors</titleabbrev>
 ++++
+
+preview::[]
 
 Returns information about all stored connectors.
 

--- a/docs/reference/connector/apis/set-connector-sync-job-error-api.asciidoc
+++ b/docs/reference/connector/apis/set-connector-sync-job-error-api.asciidoc
@@ -4,6 +4,8 @@
 <titleabbrev>Set connector sync job error</titleabbrev>
 ++++
 
+preview::[]
+
 Sets a connector sync job error.
 
 [[set-connector-sync-job-error-api-request]]

--- a/docs/reference/connector/apis/set-connector-sync-job-stats-api.asciidoc
+++ b/docs/reference/connector/apis/set-connector-sync-job-stats-api.asciidoc
@@ -4,6 +4,8 @@
 <titleabbrev>Set connector sync job stats</titleabbrev>
 ++++
 
+preview::[]
+
 Sets connector sync job stats.
 
 [[set-connector-sync-job-stats-api-request]]

--- a/docs/reference/connector/apis/update-connector-configuration-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-configuration-api.asciidoc
@@ -1,11 +1,10 @@
 [[update-connector-configuration-api]]
 === Update connector configuration API
-
-preview::[]
-
 ++++
 <titleabbrev>Update connector configuration</titleabbrev>
 ++++
+
+preview::[]
 
 Updates the `configuration` of a connector.
 

--- a/docs/reference/connector/apis/update-connector-error-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-error-api.asciidoc
@@ -1,11 +1,10 @@
 [[update-connector-error-api]]
 === Update connector error API
-
-preview::[]
-
 ++++
 <titleabbrev>Update connector error</titleabbrev>
 ++++
+
+preview::[]
 
 Updates the `error` field of a connector.
 

--- a/docs/reference/connector/apis/update-connector-filtering-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-filtering-api.asciidoc
@@ -1,11 +1,11 @@
 [[update-connector-filtering-api]]
 === Update connector filtering API
-
-preview::[]
-
 ++++
 <titleabbrev>Update connector filtering</titleabbrev>
 ++++
+
+preview::[]
+
 
 Updates the `filtering` configuration of a connector. Learn more about filtering in the {enterprise-search-ref}/sync-rules.html[sync rules] documentation.
 

--- a/docs/reference/connector/apis/update-connector-last-sync-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-last-sync-api.asciidoc
@@ -1,11 +1,10 @@
 [[update-connector-last-sync-api]]
 === Update connector last sync stats API
-
-preview::[]
-
 ++++
 <titleabbrev>Update connector last sync stats</titleabbrev>
 ++++
+
+preview::[]
 
 Updates the fields related to the last sync of a connector.
 

--- a/docs/reference/connector/apis/update-connector-name-description-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-name-description-api.asciidoc
@@ -1,11 +1,11 @@
 [[update-connector-name-description-api]]
 === Update connector name and description API
-
-preview::[]
-
 ++++
 <titleabbrev>Update connector name and description</titleabbrev>
 ++++
+
+preview::[]
+
 
 Updates the `name` and `description` fields of a connector.
 

--- a/docs/reference/connector/apis/update-connector-pipeline-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-pipeline-api.asciidoc
@@ -1,11 +1,10 @@
 [[update-connector-pipeline-api]]
 === Update connector pipeline API
-
-preview::[]
-
 ++++
 <titleabbrev>Update connector pipeline</titleabbrev>
 ++++
+
+preview::[]
 
 Updates the `pipeline` configuration of a connector.
 

--- a/docs/reference/connector/apis/update-connector-scheduling-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-scheduling-api.asciidoc
@@ -1,11 +1,10 @@
 [[update-connector-scheduling-api]]
 === Update connector scheduling API
-
-preview::[]
-
 ++++
 <titleabbrev>Update connector scheduling</titleabbrev>
 ++++
+
+preview::[]
 
 Updates the `scheduling` configuration of a connector.
 


### PR DESCRIPTION
Add couple handy links. Anywhere else we'd like to point to?

🚗 [🧹 Cleanup abbreviations, add missing tech preview labels](https://github.com/elastic/elasticsearch/pull/104262/commits/5d5979ff4bbf97892c00b62cfc4533e1600b4b72)