### PR TITLE
[7.17] Fix cancellation order in CancellableRateLimitedFluxIterator (#104259)

### DIFF
--- a/docs/changelog/104259.yaml
+++ b/docs/changelog/104259.yaml
@@ -1,0 +1,6 @@
+pr: 104259
+summary: Fix cancellation order in `CancellableRateLimitedFluxIterator`
+area: Snapshot/Restore
+type: bug
+issues:
+ - 103054

--- a/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/CancellableRateLimitedFluxIterator.java
+++ b/plugins/repository-azure/src/main/java/org/elasticsearch/repositories/azure/CancellableRateLimitedFluxIterator.java
@@ -166,9 +166,9 @@ class CancellableRateLimitedFluxIterator<T> implements Subscriber<T>, Iterator<T
     }
 
     public void cancel() {
+        done = true;
         cancelSubscription();
         clearQueue();
-        done = true;
         // cancel should be called from the consumer
         // thread, but to avoid potential deadlocks
         // we just try to release a possibly blocked
@@ -178,9 +178,9 @@ class CancellableRateLimitedFluxIterator<T> implements Subscriber<T>, Iterator<T
 
     @Override
     public void onError(Throwable t) {
+        done = true;
         clearQueue();
         error = t;
-        done = true;
         signalConsumer();
     }
 


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Fix cancellation order in CancellableRateLimitedFluxIterator (#104259)