### PR TITLE
ESQL: Test all operators with breaker

### DIFF
--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/LimitOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/LimitOperatorTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.compute.operator;
 
-import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.compute.data.BasicBlockTests;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
@@ -47,12 +46,6 @@ public class LimitOperatorTests extends OperatorTestCase {
         int inputPositionCount = input.stream().mapToInt(p -> p.getPositionCount()).sum();
         int outputPositionCount = results.stream().mapToInt(p -> p.getPositionCount()).sum();
         assertThat(outputPositionCount, equalTo(Math.min(100, inputPositionCount)));
-    }
-
-    @Override
-    protected ByteSizeValue enoughMemoryForSimple() {
-        assumeFalse("doesn't allocate, just filters", true);
-        return null;
     }
 
     public void testStatus() {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/MvExpandOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/MvExpandOperatorTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.compute.operator;
 
-import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.ElementType;
@@ -197,12 +196,6 @@ public class MvExpandOperatorTests extends OperatorTestCase {
             }
         }
         assertThat(resultIter2.hasNext(), equalTo(false));
-    }
-
-    @Override
-    protected ByteSizeValue enoughMemoryForSimple() {
-        assumeFalse("doesn't throw in tests but probably should", true);
-        return ByteSizeValue.ofBytes(1);
     }
 
     public void testNoopStatus() {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/ProjectOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/ProjectOperatorTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.compute.operator;
 
-import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.IntBlock;
@@ -93,12 +92,6 @@ public class ProjectOperatorTests extends OperatorTestCase {
             }
         }
         assertThat(total, equalTo(input.stream().mapToInt(Page::getPositionCount).sum()));
-    }
-
-    @Override
-    protected ByteSizeValue enoughMemoryForSimple() {
-        assumeTrue("doesn't allocate", false);
-        return null;
     }
 
     public void testDescriptionOfMany() {


### PR DESCRIPTION
This modifies the operator tests to *always* test with a breaker without the ability to opt out. Previously three operations opted out:
1. mv_expand never through exceptions even though it should. It was using the block factory of the test blocks which didn't have a breaker. I modified the test blocks to take a breaker so now it properly breaks.
2. reading values was throwing strange exceptions when I first wrote these tests and I didn't have time to get it work. I don't 100% recall what those exceptions were but they seem to be gone now. Good fairies?
3. The "project" operator doesn't allocate much of anything - it just drops or shifts block around. But the work I did to move the test blocks under the limit makes it so the test itself can throw. That's good enough for this.
