### PR TITLE
Disable elser download test case in inf IT

### DIFF
--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceBaseRestTest.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceBaseRestTest.java
@@ -15,7 +15,6 @@ import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.inference.TaskType;
-import org.elasticsearch.plugins.Platforms;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.rest.ESRestTestCase;
@@ -63,25 +62,6 @@ public class InferenceBaseRestTest extends ESRestTestCase {
               }
             }
             """;
-    }
-
-    protected Map<String, Object> downloadElserBlocking() throws IOException {
-        String endpoint = "_ml/trained_models/.elser_model_2?wait_for_completion=true";
-        if ("linux-x86_64".equals(Platforms.PLATFORM_NAME)) {
-            endpoint = "_ml/trained_models/.elser_model_2_linux-x86_64?wait_for_completion=true";
-        }
-        String body = """
-            {
-                "input": {
-                "field_names": ["text_field"]
-                }
-            }
-            """;
-        var request = new Request("PUT", endpoint);
-        request.setJsonEntity(body);
-        var response = client().performRequest(request);
-        assertOkOrCreated(response);
-        return entityAsMap(response);
     }
 
     protected Map<String, Object> putModel(String modelId, String modelConfig, TaskType taskType) throws IOException {

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceCrudIT.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceCrudIT.java
@@ -18,7 +18,6 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.not;
 
 public class InferenceCrudIT extends InferenceBaseRestTest {
 
@@ -41,19 +40,9 @@ public class InferenceCrudIT extends InferenceBaseRestTest {
             expectThrows(ResponseException.class, () -> putModel(modelId, elserConfig, TaskType.SPARSE_EMBEDDING));
         }
 
-        downloadElserBlocking();
-
-        // Happy case
-        {
-            String modelId = randomAlphaOfLength(10).toLowerCase();
-            putModel(modelId, elserConfig, TaskType.SPARSE_EMBEDDING);
-            var models = getModels(modelId, TaskType.SPARSE_EMBEDDING);
-            assertThat(models.get("models").toString(), containsString("model_id=" + modelId));
-            deleteModel(modelId, TaskType.SPARSE_EMBEDDING);
-            expectThrows(ResponseException.class, () -> getModels(modelId, TaskType.SPARSE_EMBEDDING));
-            models = getTrainedModel("_all");
-            assertThat(models.toString(), not(containsString("deployment_id=" + modelId)));
-        }
+        // Happy Case
+        // We choose not to test the case where ELSER is downloaded to avoid causing excessive network traffic.
+        // This test case will be tested separately outside of CI
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
In https://github.com/elastic/elasticsearch/pull/104230 we created an integration test case for ELSER CRUD, but to avoid causing excessive network traffic and cost, in this PR we disable this test. We will look into re-adding this test outside of CI. 