### PR TITLE
ESQL: Harden async tests

### DIFF
--- a/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/EsqlClientYamlAsyncSubmitAndFetchIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/EsqlClientYamlAsyncSubmitAndFetchIT.java
@@ -31,6 +31,7 @@ public class EsqlClientYamlAsyncSubmitAndFetchIT extends AbstractEsqlClientYamlI
             ApiCallSection copy = doSection.getApiCallSection().copyWithNewApi("esql.async_query");
             for (Map<String, Object> body : copy.getBodies()) {
                 body.put("wait_for_completion_timeout", "0ms");
+                body.put("keep_on_completion", true);
             }
             doSection.setApiCallSection(copy);
 


### PR DESCRIPTION
I've seen errors in the async tests where they expect to return an `id` but the results come back too fast! Well, this forces us to return the `id` even if we have the results. Then the test can happily fetch by the `id` every time.

Closes #104251
