### PR TITLE
[8.12] Add 8.11.4 release notes (#104276)

### DIFF
--- a/docs/reference/release-notes.asciidoc
+++ b/docs/reference/release-notes.asciidoc
@@ -7,6 +7,7 @@
 This section summarizes the changes in each release.
 
 * <<release-notes-8.12.0>>
+* <<release-notes-8.11.4>>
 * <<release-notes-8.11.3>>
 * <<release-notes-8.11.2>>
 * <<release-notes-8.11.1>>
@@ -58,6 +59,7 @@ This section summarizes the changes in each release.
 --
 
 include::release-notes/8.12.0.asciidoc[]
+include::release-notes/8.11.4.asciidoc[]
 include::release-notes/8.11.3.asciidoc[]
 include::release-notes/8.11.2.asciidoc[]
 include::release-notes/8.11.1.asciidoc[]

--- a/docs/reference/release-notes/8.11.4.asciidoc
+++ b/docs/reference/release-notes/8.11.4.asciidoc
@@ -1,0 +1,31 @@
+[[release-notes-8.11.4]]
+== {es} version 8.11.4
+
+Also see <<breaking-changes-8.11,Breaking changes in 8.11>>.
+
+[[bug-8.11.4]]
+[float]
+=== Bug fixes
+
+EQL::
+* Fix NPE on missing event queries {es-pull}103611[#103611] (issue: {es-issue}103608[#103608])
+
+ES|QL::
+* Fix now in millis for ESQL search contexts {es-pull}103474[#103474] (issue: {es-issue}103455[#103455])
+* Fix the transport version of `PlanStreamOutput` {es-pull}103758[#103758]
+* `AsyncOperator#isFinished` must never return true on failure {es-pull}104029[#104029]
+
+Infra/Scripting::
+* Wrap painless explain error {es-pull}103151[#103151] (issue: {es-issue}103018[#103018])
+
+Mapping::
+* Revert change {es-pull}103865[#103865]
+
+Snapshot/Restore::
+* Decref `SharedBytes.IO` after read is done not before {es-pull}102848[#102848]
+* Restore `SharedBytes.IO` refcounting on reads & writes {es-pull}102843[#102843]
+
+Watcher::
+* Fix: Watcher REST API `GET /_watcher/settings` now includes product header {es-pull}103003[#103003] (issue: {es-issue}102928[#102928])
+
+


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.11` to `8.12`:
 - [Add 8.11.4 release notes (#104276)](https://github.com/elastic/elasticsearch/pull/104276)

<!--- Backport version: 9.2.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)