### PR TITLE
[8.12] [ci] Add Amazon Linux 2 to platform support pipeline (#104229)

### DIFF
--- a/.buildkite/pipelines/periodic-platform-support.yml
+++ b/.buildkite/pipelines/periodic-platform-support.yml
@@ -89,6 +89,7 @@ steps:
           setup:
             image:
               - amazonlinux-2023
+              - amazonlinux-2
         agents:
           provider: aws
           imagePrefix: elasticsearch-{{matrix.image}}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.12`:
 - [[ci] Add Amazon Linux 2 to platform support pipeline (#104229)](https://github.com/elastic/elasticsearch/pull/104229)

<!--- Backport version: 9.2.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)