### PR TITLE
Prefer new test cluster framework for new FIPS setting

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.fips.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.fips.gradle
@@ -79,7 +79,6 @@ if (BuildParams.inFipsJvm) {
           // with no x-pack. Tests having security explicitly enabled/disabled will override this setting
           setting 'xpack.security.enabled', 'false'
           setting 'xpack.security.fips_mode.enabled', 'true'
-          setting 'xpack.security.fips_mode.required_providers', '["BCFIPS", "BCJSSE"]'
           setting 'xpack.license.self_generated.type', 'trial'
           setting 'xpack.security.authc.password_hashing.algorithm', 'pbkdf2_stretch'
           keystorePassword 'keystore-password'

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/FipsEnabledClusterConfigProvider.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/FipsEnabledClusterConfigProvider.java
@@ -8,14 +8,9 @@
 
 package org.elasticsearch.test.cluster.local;
 
-
-import org.elasticsearch.test.cluster.util.Version;
 import org.elasticsearch.test.cluster.util.resource.Resource;
 
-import java.util.HashMap;
-
 public class FipsEnabledClusterConfigProvider implements LocalClusterConfigProvider {
-
 
     @Override
     public void apply(LocalClusterSpecBuilder<?> builder) {
@@ -38,14 +33,8 @@ public class FipsEnabledClusterConfigProvider implements LocalClusterConfigProvi
                 .setting("xpack.security.fips_mode.enabled", "true")
                 .setting("xpack.license.self_generated.type", "trial")
                 .setting("xpack.security.authc.password_hashing.algorithm", "pbkdf2_stretch")
-                .keystorePassword("keystore-password")
-                .settings(node -> {
-                    var settings = new HashMap<String, String>(1);
-                    if(node.getVersion().onOrAfter(Version.fromString("8.13.0"))){
-                        settings.put("xpack.security.fips_mode.required_providers", "[BCFIPS, BCJSSE]");
-                    }
-                    return settings;
-                });
+                .setting("xpack.security.fips_mode.required_providers", () -> "[BCFIPS, BCJSSE]", n -> n.getVersion().onOrAfter("8.13.0"))
+                .keystorePassword("keystore-password");
         }
     }
 

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/FipsEnabledClusterConfigProvider.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/FipsEnabledClusterConfigProvider.java
@@ -8,9 +8,14 @@
 
 package org.elasticsearch.test.cluster.local;
 
+
+import org.elasticsearch.test.cluster.util.Version;
 import org.elasticsearch.test.cluster.util.resource.Resource;
 
+import java.util.HashMap;
+
 public class FipsEnabledClusterConfigProvider implements LocalClusterConfigProvider {
+
 
     @Override
     public void apply(LocalClusterSpecBuilder<?> builder) {
@@ -33,7 +38,14 @@ public class FipsEnabledClusterConfigProvider implements LocalClusterConfigProvi
                 .setting("xpack.security.fips_mode.enabled", "true")
                 .setting("xpack.license.self_generated.type", "trial")
                 .setting("xpack.security.authc.password_hashing.algorithm", "pbkdf2_stretch")
-                .keystorePassword("keystore-password");
+                .keystorePassword("keystore-password")
+                .settings(node -> {
+                    var settings = new HashMap<String, String>(1);
+                    if(node.getVersion().onOrAfter(Version.fromString("8.13.0"))){
+                        settings.put("xpack.security.fips_mode.required_providers", "[BCFIPS, BCJSSE]");
+                    }
+                    return settings;
+                });
         }
     }
 

--- a/x-pack/plugin/ml/qa/multi-cluster-tests-with-security/build.gradle
+++ b/x-pack/plugin/ml/qa/multi-cluster-tests-with-security/build.gradle
@@ -50,29 +50,16 @@ testClusters.register('mixed-cluster') {
 tasks.register('remote-cluster', RestIntegTestTask) {
   mustRunAfter("precommit")
   systemProperty 'tests.rest.suite', 'remote_cluster'
-  maybeDisableForFips(it)
 }
 
 tasks.register('mixed-cluster', RestIntegTestTask) {
   dependsOn 'remote-cluster'
   useCluster remoteCluster
   systemProperty 'tests.rest.suite', 'multi_cluster'
-  maybeDisableForFips(it)
 }
 
 tasks.register("integTest") {
   dependsOn 'mixed-cluster'
-  maybeDisableForFips(it)
 }
 
 tasks.named("check").configure { dependsOn("integTest") }
-
-//TODO: remove with version 8.14. A new FIPS setting was added in 8.13. Since FIPS configures all test clusters and this specific integTest uses
-// the previous minor version, that setting is not available when running in FIPS until 8.14.
-def maybeDisableForFips(task) {
-  if (BuildParams.inFipsJvm) {
-    if(Version.fromString(project.version).before(Version.fromString('8.14.0'))) {
-      task.enabled = false
-    }
-  }
-}

--- a/x-pack/plugin/transform/qa/multi-cluster-tests-with-security/build.gradle
+++ b/x-pack/plugin/transform/qa/multi-cluster-tests-with-security/build.gradle
@@ -54,29 +54,17 @@ testClusters.register('mixed-cluster') {
 tasks.register('remote-cluster', RestIntegTestTask) {
   mustRunAfter("precommit")
   systemProperty 'tests.rest.suite', 'remote_cluster'
-  maybeDisableForFips(it)
 }
 
 tasks.register('mixed-cluster', RestIntegTestTask) {
   dependsOn 'remote-cluster'
   useCluster remoteCluster
   systemProperty 'tests.rest.suite', 'multi_cluster'
-  maybeDisableForFips(it)
 }
 
 tasks.register("integTest") {
   dependsOn 'mixed-cluster'
-  maybeDisableForFips(it)
 }
 
 tasks.named("check").configure { dependsOn("integTest") }
 
-//TODO: remove with version 8.14. A new FIPS setting was added in 8.13. Since FIPS configures all test clusters and this specific integTest uses
-// the previous minor version, that setting is not available when running in FIPS until 8.14.
-def maybeDisableForFips(task) {
-  if (BuildParams.inFipsJvm) {
-    if(Version.fromString(project.version).before(Version.fromString('8.14.0'))) {
-      task.enabled = false
-    }
-  }
-}


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/103483 introduced a new setting for FIPS only. 
Due to the way FIPS is configured with the elder gradle test cluster framework this setting
was getting applied to elder clusters in BWC tests that did not have the settting causing test failures. 

The new test framework has better semantics for version specific configuration. 
This commit updates applies the new setting via the new framework with a 
version specific condition. 

Adding this setting to the test clusters is a simple way to
test the setting (which will cause errors if the required providers are not found in the cluster). 
The pseudo test does not care which framework is used for configuration. 
Also, using the new framework allows to remove some hacky configuration previously needed
to handle some elder test cluster configuration that used elder versions. 

Fixes: https://github.com/elastic/elasticsearch/issues/104234