### PR TITLE
[8.12] [Test] Remove mocker appender before closing it (#104300)

### DIFF
--- a/server/src/test/java/org/elasticsearch/http/AbstractHttpServerTransportTests.java
+++ b/server/src/test/java/org/elasticsearch/http/AbstractHttpServerTransportTests.java
@@ -1388,8 +1388,8 @@ public class AbstractHttpServerTransportTests extends ESTestCase {
 
         @Override
         public void close() {
-            appender.stop();
             Loggers.removeAppender(mockLogger, appender);
+            appender.stop();
             if (checked == false) {
                 fail("did not check expectations matched in TimedOutLogExpectation");
             }


### PR DESCRIPTION
Backports the following commits to 8.12:
 - [Test] Remove mocker appender before closing it (#104300)