### PR TITLE
Backport update versions task to 7.17

### DIFF
--- a/build-tools-internal/build.gradle
+++ b/build-tools-internal/build.gradle
@@ -262,6 +262,9 @@ dependencies {
   api buildLibs.asm.tree
 
   compileOnly buildLibs.checkstyle
+
+  implementation 'com.github.javaparser:javaparser-core:3.18.0'
+
   runtimeOnly "org.elasticsearch.gradle:reaper:$version"
   testImplementation buildLibs.checkstyle
   testImplementation buildLibs.wiremock

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/ReleaseToolsPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/ReleaseToolsPlugin.java
@@ -45,6 +45,9 @@ public class ReleaseToolsPlugin implements Plugin<Project> {
 
         final Version version = VersionProperties.getElasticsearchVersion();
 
+        project.getTasks()
+            .register("updateVersions", UpdateVersionsTask.class, t -> project.getTasks().named("spotlessApply").get().mustRunAfter(t));
+
         final FileTree yamlFiles = projectDirectory.dir("docs/changelog")
             .getAsFileTree()
             .matching(new PatternSet().include("**/*.yml", "**/*.yaml"));

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/UpdateVersionsTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/UpdateVersionsTask.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.gradle.internal.release;
+
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.FieldDeclaration;
+import com.github.javaparser.ast.body.VariableDeclarator;
+import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter;
+import com.google.common.annotations.VisibleForTesting;
+
+import org.elasticsearch.gradle.Version;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.options.Option;
+import org.gradle.initialization.layout.BuildLayout;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+
+public class UpdateVersionsTask extends DefaultTask {
+    private static final Logger LOGGER = Logging.getLogger(UpdateVersionsTask.class);
+
+    static final String SERVER_MODULE_PATH = "server/src/main/java/";
+    static final String VERSION_FILE_PATH = SERVER_MODULE_PATH + "org/elasticsearch/Version.java";
+
+    static final Pattern VERSION_FIELD = Pattern.compile("V_(\\d+)_(\\d+)_(\\d+)(?:_(\\w+))?");
+
+    final Path rootDir;
+
+    @Nullable
+    private Version addVersion;
+    private boolean setCurrent;
+    @Nullable
+    private Version removeVersion;
+
+    @Inject
+    public UpdateVersionsTask(BuildLayout layout) {
+        rootDir = layout.getRootDirectory().toPath();
+    }
+
+    @Option(option = "add-version", description = "Specifies the version to add")
+    public void addVersion(String version) {
+        this.addVersion = Version.fromString(version);
+    }
+
+    @Option(option = "set-current", description = "Set the 'current' constant to the new version")
+    public void setCurrent(boolean setCurrent) {
+        this.setCurrent = setCurrent;
+    }
+
+    @Option(option = "remove-version", description = "Specifies the version to remove")
+    public void removeVersion(String version) {
+        this.removeVersion = Version.fromString(version);
+    }
+
+    static String toVersionField(Version version) {
+        return String.format("V_%d_%d_%d", version.getMajor(), version.getMinor(), version.getRevision());
+    }
+
+    static Optional<Version> parseVersionField(CharSequence field) {
+        Matcher m = VERSION_FIELD.matcher(field);
+        if (m.find() == false) return Optional.empty();
+
+        return Optional.of(
+            new Version(Integer.parseInt(m.group(1)), Integer.parseInt(m.group(2)), Integer.parseInt(m.group(3)), m.group(4))
+        );
+    }
+
+    @TaskAction
+    public void executeTask() throws IOException {
+        if (addVersion == null && removeVersion == null) {
+            throw new IllegalArgumentException("No versions to add or remove specified");
+        }
+        if (setCurrent && addVersion == null) {
+            throw new IllegalArgumentException("No new version added to set as the current version");
+        }
+        if (Objects.equals(addVersion, removeVersion)) {
+            throw new IllegalArgumentException("Same version specified to add and remove");
+        }
+
+        Path versionJava = rootDir.resolve(VERSION_FILE_PATH);
+        CompilationUnit file = LexicalPreservingPrinter.setup(StaticJavaParser.parse(versionJava));
+
+        Optional<CompilationUnit> modifiedFile = Optional.empty();
+        if (addVersion != null) {
+            LOGGER.lifecycle("Adding new version [{}] to [{}]", addVersion, versionJava);
+            var added = addVersionConstant(modifiedFile.orElse(file), addVersion, setCurrent);
+            if (added.isPresent()) {
+                modifiedFile = added;
+            }
+        }
+        if (removeVersion != null) {
+            LOGGER.lifecycle("Removing version [{}] from [{}]", removeVersion, versionJava);
+            var removed = removeVersionConstant(modifiedFile.orElse(file), removeVersion);
+            if (removed.isPresent()) {
+                modifiedFile = removed;
+            }
+        }
+
+        if (modifiedFile.isPresent()) {
+            writeOutNewContents(versionJava, modifiedFile.get());
+        }
+    }
+
+    @VisibleForTesting
+    static Optional<CompilationUnit> addVersionConstant(CompilationUnit versionJava, Version version, boolean updateCurrent) {
+        String newFieldName = toVersionField(version);
+
+        ClassOrInterfaceDeclaration versionClass = versionJava.getClassByName("Version").get();
+        if (versionClass.getFieldByName(newFieldName).isPresent()) {
+            LOGGER.lifecycle("New version constant [{}] already present, skipping", newFieldName);
+            return Optional.empty();
+        }
+
+        NavigableMap<Version, FieldDeclaration> versions = versionClass.getFields()
+            .stream()
+            .map(f -> Map.entry(f, parseVersionField(f.getVariable(0).getNameAsString())))
+            .filter(e -> e.getValue().isPresent())
+            .collect(Collectors.toMap(e -> e.getValue().get(), Map.Entry::getKey, (v1, v2) -> {
+                throw new IllegalArgumentException("Duplicate version constants " + v1);
+            }, TreeMap::new));
+
+        // find the version this should be inserted after
+        var previousVersion = versions.lowerEntry(version);
+        if (previousVersion == null) {
+            throw new IllegalStateException(String.format("Could not find previous version to [%s]", version));
+        }
+        FieldDeclaration newVersion = createNewVersionConstant(
+            previousVersion.getValue(),
+            newFieldName,
+            String.format("%d_%02d_%02d_99", version.getMajor(), version.getMinor(), version.getRevision())
+        );
+        versionClass.getMembers().addAfter(newVersion, previousVersion.getValue());
+
+        if (updateCurrent) {
+            versionClass.getFieldByName("CURRENT")
+                .orElseThrow(() -> new IllegalArgumentException("Could not find CURRENT constant"))
+                .getVariable(0)
+                .setInitializer(new NameExpr(newFieldName));
+        }
+
+        return Optional.of(versionJava);
+    }
+
+    private static FieldDeclaration createNewVersionConstant(FieldDeclaration lastVersion, String newName, String newExpr) {
+        return new FieldDeclaration(
+            new NodeList<>(lastVersion.getModifiers()),
+            new VariableDeclarator(
+                lastVersion.getCommonType(),
+                newName,
+                StaticJavaParser.parseExpression(String.format("new Version(%s)", newExpr))
+            )
+        );
+    }
+
+    @VisibleForTesting
+    static Optional<CompilationUnit> removeVersionConstant(CompilationUnit versionJava, Version version) {
+        String removeFieldName = toVersionField(version);
+
+        ClassOrInterfaceDeclaration versionClass = versionJava.getClassByName("Version").get();
+        var declaration = versionClass.getFieldByName(removeFieldName);
+        if (declaration.isEmpty()) {
+            LOGGER.lifecycle("Version constant [{}] not found, skipping", removeFieldName);
+            return Optional.empty();
+        }
+
+        // check if this is referenced by CURRENT
+        String currentReference = versionClass.getFieldByName("CURRENT")
+            .orElseThrow(() -> new IllegalArgumentException("Could not find CURRENT constant"))
+            .getVariable(0)
+            .getInitializer()
+            .get()
+            .asNameExpr()
+            .getNameAsString();
+        if (currentReference.equals(removeFieldName)) {
+            throw new IllegalArgumentException(String.format("Cannot remove version [%s], it is referenced by CURRENT", version));
+        }
+
+        declaration.get().remove();
+
+        return Optional.of(versionJava);
+    }
+
+    static void writeOutNewContents(Path file, CompilationUnit unit) throws IOException {
+        if (unit.containsData(LexicalPreservingPrinter.NODE_TEXT_DATA) == false) {
+            throw new IllegalArgumentException("CompilationUnit has no lexical information for output");
+        }
+        Files.writeString(file, LexicalPreservingPrinter.print(unit), StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING);
+    }
+}

--- a/build-tools-internal/src/test/java/org/elasticsearch/gradle/internal/release/UpdateVersionsTaskTests.java
+++ b/build-tools-internal/src/test/java/org/elasticsearch/gradle/internal/release/UpdateVersionsTaskTests.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.gradle.internal.release;
+
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.body.FieldDeclaration;
+import com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter;
+
+import org.elasticsearch.gradle.Version;
+import org.junit.Test;
+
+import java.io.StringWriter;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.hasToString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+
+public class UpdateVersionsTaskTests {
+
+    @Test
+    public void addVersion_versionExists() {
+        final String versionJava = """
+            public class Version {
+                public static final Version V_8_10_0 = new Version(8_10_00_99);
+                public static final Version V_8_10_1 = new Version(8_10_01_99);
+                public static final Version V_8_11_0 = new Version(8_11_00_99);
+                public static final Version CURRENT = V_8_11_0;
+            }""";
+
+        CompilationUnit unit = StaticJavaParser.parse(versionJava);
+
+        var newUnit = UpdateVersionsTask.addVersionConstant(unit, Version.fromString("8.10.1"), false);
+        assertThat(newUnit.isPresent(), is(false));
+    }
+
+    @Test
+    public void addVersion_oldVersion() {
+        final String versionJava = """
+            public class Version {
+                public static final Version V_8_10_0 = new Version(8_10_00_99);
+                public static final Version V_8_10_1 = new Version(8_10_01_99);
+                public static final Version V_8_11_0 = new Version(8_11_00_99);
+                public static final Version CURRENT = V_8_11_0;
+            }""";
+        final String updatedVersionJava = """
+            public class Version {
+
+                public static final Version V_8_10_0 = new Version(8_10_00_99);
+
+                public static final Version V_8_10_1 = new Version(8_10_01_99);
+
+                public static final Version V_8_10_2 = new Version(8_10_02_99);
+
+                public static final Version V_8_11_0 = new Version(8_11_00_99);
+
+                public static final Version CURRENT = V_8_11_0;
+            }
+            """;
+
+        CompilationUnit unit = StaticJavaParser.parse(versionJava);
+
+        UpdateVersionsTask.addVersionConstant(unit, Version.fromString("8.10.2"), false);
+
+        assertThat(unit, hasToString(updatedVersionJava));
+    }
+
+    @Test
+    public void addVersion_newVersion_current() {
+        final String versionJava = """
+            public class Version {
+                public static final Version V_8_10_0 = new Version(8_10_00_99);
+                public static final Version V_8_10_1 = new Version(8_10_01_99);
+                public static final Version V_8_11_0 = new Version(8_11_00_99);
+                public static final Version CURRENT = V_8_11_0;
+            }""";
+        final String updatedVersionJava = """
+            public class Version {
+
+                public static final Version V_8_10_0 = new Version(8_10_00_99);
+
+                public static final Version V_8_10_1 = new Version(8_10_01_99);
+
+                public static final Version V_8_11_0 = new Version(8_11_00_99);
+
+                public static final Version V_8_11_1 = new Version(8_11_01_99);
+
+                public static final Version CURRENT = V_8_11_1;
+            }
+            """;
+
+        CompilationUnit unit = StaticJavaParser.parse(versionJava);
+
+        UpdateVersionsTask.addVersionConstant(unit, Version.fromString("8.11.1"), true);
+
+        assertThat(unit, hasToString(updatedVersionJava));
+    }
+
+    @Test
+    public void removeVersion_versionDoesntExist() {
+        final String versionJava = """
+            public class Version {
+                public static final Version V_8_10_0 = new Version(8_10_00_99);
+                public static final Version V_8_10_1 = new Version(8_10_01_99);
+                public static final Version V_8_11_0 = new Version(8_11_00_99);
+                public static final Version CURRENT = V_8_11_0;
+            }""";
+
+        CompilationUnit unit = StaticJavaParser.parse(versionJava);
+
+        var newUnit = UpdateVersionsTask.removeVersionConstant(unit, Version.fromString("8.10.2"));
+        assertThat(newUnit.isPresent(), is(false));
+    }
+
+    @Test
+    public void removeVersion_versionIsCurrent() {
+        final String versionJava = """
+            public class Version {
+                public static final Version V_8_10_0 = new Version(8_10_00_99);
+                public static final Version V_8_10_1 = new Version(8_10_01_99);
+                public static final Version V_8_11_0 = new Version(8_11_00_99);
+                public static final Version CURRENT = V_8_11_0;
+            }""";
+
+        CompilationUnit unit = StaticJavaParser.parse(versionJava);
+
+        var ex = assertThrows(
+            IllegalArgumentException.class,
+            () -> UpdateVersionsTask.removeVersionConstant(unit, Version.fromString("8.11.0"))
+        );
+        assertThat(ex.getMessage(), equalTo("Cannot remove version [8.11.0], it is referenced by CURRENT"));
+    }
+
+    @Test
+    public void removeVersion() {
+        final String versionJava = """
+            public class Version {
+                public static final Version V_8_10_0 = new Version(8_10_00_99);
+                public static final Version V_8_10_1 = new Version(8_10_01_99);
+                public static final Version V_8_11_0 = new Version(8_11_00_99);
+                public static final Version CURRENT = V_8_11_0;
+            }""";
+        final String updatedVersionJava = """
+            public class Version {
+
+                public static final Version V_8_10_0 = new Version(8_10_00_99);
+
+                public static final Version V_8_11_0 = new Version(8_11_00_99);
+
+                public static final Version CURRENT = V_8_11_0;
+            }
+            """;
+
+        CompilationUnit unit = StaticJavaParser.parse(versionJava);
+
+        UpdateVersionsTask.removeVersionConstant(unit, Version.fromString("8.10.1"));
+
+        assertThat(unit, hasToString(updatedVersionJava));
+    }
+
+    @Test
+    public void updateVersionFile_addsCorrectly() throws Exception {
+        Version newVersion = new Version(50, 10, 20);
+        String versionField = UpdateVersionsTask.toVersionField(newVersion);
+
+        Path versionFile = Path.of("..", UpdateVersionsTask.VERSION_FILE_PATH);
+        CompilationUnit unit = LexicalPreservingPrinter.setup(StaticJavaParser.parse(versionFile));
+        assertFalse("Test version already exists in the file", findFirstField(unit, versionField).isPresent());
+
+        List<FieldDeclaration> existingFields = unit.findAll(FieldDeclaration.class);
+
+        var result = UpdateVersionsTask.addVersionConstant(unit, newVersion, true);
+        assertThat(result.isPresent(), is(true));
+
+        // write out & parse back in again
+        StringWriter writer = new StringWriter();
+        LexicalPreservingPrinter.print(unit, writer);
+        unit = StaticJavaParser.parse(writer.toString());
+
+        // a field has been added
+        assertThat(unit.findAll(FieldDeclaration.class), hasSize(existingFields.size() + 1));
+        // the field has the right name
+        var field = findFirstField(unit, versionField);
+        assertThat(field.isPresent(), is(true));
+        // the field has the right constant
+        assertThat(
+            field.get().getVariable(0).getInitializer().get(),
+            hasToString(
+                String.format("new Version(%d_%02d_%02d_99)", newVersion.getMajor(), newVersion.getMinor(), newVersion.getRevision())
+            )
+        );
+        // and CURRENT has been updated
+        var current = findFirstField(unit, "CURRENT");
+        assertThat(current.get().getVariable(0).getInitializer().get(), hasToString(versionField));
+    }
+
+    @Test
+    public void updateVersionFile_removesCorrectly() throws Exception {
+        Path versionFile = Path.of("..", UpdateVersionsTask.VERSION_FILE_PATH);
+        CompilationUnit unit = LexicalPreservingPrinter.setup(StaticJavaParser.parse(versionFile));
+
+        List<FieldDeclaration> existingFields = unit.findAll(FieldDeclaration.class);
+
+        var staticVersionFields = unit.findAll(
+            FieldDeclaration.class,
+            f -> f.isStatic() && f.getVariable(0).getTypeAsString().equals("Version")
+        );
+        // remove the last-but-two static version field (skip CURRENT and the latest version)
+        String constant = staticVersionFields.get(staticVersionFields.size() - 3).getVariable(0).getNameAsString();
+
+        Version versionToRemove = UpdateVersionsTask.parseVersionField(constant).orElseThrow(AssertionError::new);
+        var result = UpdateVersionsTask.removeVersionConstant(unit, versionToRemove);
+        assertThat(result.isPresent(), is(true));
+
+        // write out & parse back in again
+        StringWriter writer = new StringWriter();
+        LexicalPreservingPrinter.print(unit, writer);
+        unit = StaticJavaParser.parse(writer.toString());
+
+        // a field has been removed
+        assertThat(unit.findAll(FieldDeclaration.class), hasSize(existingFields.size() - 1));
+        // the removed field does not exist
+        var field = findFirstField(unit, constant);
+        assertThat(field.isPresent(), is(false));
+    }
+
+    private static Optional<FieldDeclaration> findFirstField(Node node, String name) {
+        return node.findFirst(FieldDeclaration.class, f -> f.getVariable(0).getName().getIdentifier().equals(name));
+    }
+}

--- a/build-tools-internal/src/test/java/org/elasticsearch/gradle/internal/release/UpdateVersionsTaskTests.java
+++ b/build-tools-internal/src/test/java/org/elasticsearch/gradle/internal/release/UpdateVersionsTaskTests.java
@@ -27,6 +27,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.matchesRegex;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 
@@ -36,15 +37,15 @@ public class UpdateVersionsTaskTests {
     public void addVersion_versionExists() {
         final String versionJava = """
             public class Version {
-                public static final Version V_8_10_0 = new Version(8_10_00_99);
-                public static final Version V_8_10_1 = new Version(8_10_01_99);
-                public static final Version V_8_11_0 = new Version(8_11_00_99);
-                public static final Version CURRENT = V_8_11_0;
+                public static final Version V_7_16_0 = new Version(7_16_00_99, org.apache.lucene.util.Version.LUCENE_8_10_1);
+                public static final Version V_7_16_1 = new Version(7_16_01_99, org.apache.lucene.util.Version.LUCENE_8_10_1);
+                public static final Version V_7_17_0 = new Version(7_17_00_99, org.apache.lucene.util.Version.LUCENE_8_11_1);
+                public static final Version CURRENT = V_7_17_0;
             }""";
 
         CompilationUnit unit = StaticJavaParser.parse(versionJava);
 
-        var newUnit = UpdateVersionsTask.addVersionConstant(unit, Version.fromString("8.10.1"), false);
+        var newUnit = UpdateVersionsTask.addVersionConstant(unit, Version.fromString("7.17.0"), false);
         assertThat(newUnit.isPresent(), is(false));
     }
 
@@ -52,29 +53,29 @@ public class UpdateVersionsTaskTests {
     public void addVersion_oldVersion() {
         final String versionJava = """
             public class Version {
-                public static final Version V_8_10_0 = new Version(8_10_00_99);
-                public static final Version V_8_10_1 = new Version(8_10_01_99);
-                public static final Version V_8_11_0 = new Version(8_11_00_99);
-                public static final Version CURRENT = V_8_11_0;
+                public static final Version V_7_16_0 = new Version(7_16_00_99, org.apache.lucene.util.Version.LUCENE_8_10_1);
+                public static final Version V_7_16_1 = new Version(7_16_01_99, org.apache.lucene.util.Version.LUCENE_8_10_1);
+                public static final Version V_7_17_0 = new Version(7_17_00_99, org.apache.lucene.util.Version.LUCENE_8_11_1);
+                public static final Version CURRENT = V_7_17_0;
             }""";
         final String updatedVersionJava = """
             public class Version {
 
-                public static final Version V_8_10_0 = new Version(8_10_00_99);
+                public static final Version V_7_16_0 = new Version(7_16_00_99, org.apache.lucene.util.Version.LUCENE_8_10_1);
 
-                public static final Version V_8_10_1 = new Version(8_10_01_99);
+                public static final Version V_7_16_1 = new Version(7_16_01_99, org.apache.lucene.util.Version.LUCENE_8_10_1);
 
-                public static final Version V_8_10_2 = new Version(8_10_02_99);
+                public static final Version V_7_16_2 = new Version(7_16_02_99, org.apache.lucene.util.Version.LUCENE_8_10_1);
 
-                public static final Version V_8_11_0 = new Version(8_11_00_99);
+                public static final Version V_7_17_0 = new Version(7_17_00_99, org.apache.lucene.util.Version.LUCENE_8_11_1);
 
-                public static final Version CURRENT = V_8_11_0;
+                public static final Version CURRENT = V_7_17_0;
             }
             """;
 
         CompilationUnit unit = StaticJavaParser.parse(versionJava);
 
-        UpdateVersionsTask.addVersionConstant(unit, Version.fromString("8.10.2"), false);
+        UpdateVersionsTask.addVersionConstant(unit, Version.fromString("7.16.2"), false);
 
         assertThat(unit, hasToString(updatedVersionJava));
     }
@@ -83,29 +84,29 @@ public class UpdateVersionsTaskTests {
     public void addVersion_newVersion_current() {
         final String versionJava = """
             public class Version {
-                public static final Version V_8_10_0 = new Version(8_10_00_99);
-                public static final Version V_8_10_1 = new Version(8_10_01_99);
-                public static final Version V_8_11_0 = new Version(8_11_00_99);
-                public static final Version CURRENT = V_8_11_0;
+                public static final Version V_7_16_0 = new Version(7_16_00_99, org.apache.lucene.util.Version.LUCENE_8_10_1);
+                public static final Version V_7_16_1 = new Version(7_16_01_99, org.apache.lucene.util.Version.LUCENE_8_10_1);
+                public static final Version V_7_17_0 = new Version(7_17_00_99, org.apache.lucene.util.Version.LUCENE_8_11_1);
+                public static final Version CURRENT = V_7_17_0;
             }""";
         final String updatedVersionJava = """
             public class Version {
 
-                public static final Version V_8_10_0 = new Version(8_10_00_99);
+                public static final Version V_7_16_0 = new Version(7_16_00_99, org.apache.lucene.util.Version.LUCENE_8_10_1);
 
-                public static final Version V_8_10_1 = new Version(8_10_01_99);
+                public static final Version V_7_16_1 = new Version(7_16_01_99, org.apache.lucene.util.Version.LUCENE_8_10_1);
 
-                public static final Version V_8_11_0 = new Version(8_11_00_99);
+                public static final Version V_7_17_0 = new Version(7_17_00_99, org.apache.lucene.util.Version.LUCENE_8_11_1);
 
-                public static final Version V_8_11_1 = new Version(8_11_01_99);
+                public static final Version V_7_17_1 = new Version(7_17_01_99, org.apache.lucene.util.Version.LUCENE_8_11_1);
 
-                public static final Version CURRENT = V_8_11_1;
+                public static final Version CURRENT = V_7_17_1;
             }
             """;
 
         CompilationUnit unit = StaticJavaParser.parse(versionJava);
 
-        UpdateVersionsTask.addVersionConstant(unit, Version.fromString("8.11.1"), true);
+        UpdateVersionsTask.addVersionConstant(unit, Version.fromString("7.17.1"), true);
 
         assertThat(unit, hasToString(updatedVersionJava));
     }
@@ -114,15 +115,15 @@ public class UpdateVersionsTaskTests {
     public void removeVersion_versionDoesntExist() {
         final String versionJava = """
             public class Version {
-                public static final Version V_8_10_0 = new Version(8_10_00_99);
-                public static final Version V_8_10_1 = new Version(8_10_01_99);
-                public static final Version V_8_11_0 = new Version(8_11_00_99);
-                public static final Version CURRENT = V_8_11_0;
+                public static final Version V_7_16_0 = new Version(7_16_00_99, org.apache.lucene.util.Version.LUCENE_8_10_1);
+                public static final Version V_7_16_1 = new Version(7_16_01_99, org.apache.lucene.util.Version.LUCENE_8_10_1);
+                public static final Version V_7_17_0 = new Version(7_17_00_99, org.apache.lucene.util.Version.LUCENE_8_11_1);
+                public static final Version CURRENT = V_7_17_0;
             }""";
 
         CompilationUnit unit = StaticJavaParser.parse(versionJava);
 
-        var newUnit = UpdateVersionsTask.removeVersionConstant(unit, Version.fromString("8.10.2"));
+        var newUnit = UpdateVersionsTask.removeVersionConstant(unit, Version.fromString("7.16.2"));
         assertThat(newUnit.isPresent(), is(false));
     }
 
@@ -130,44 +131,44 @@ public class UpdateVersionsTaskTests {
     public void removeVersion_versionIsCurrent() {
         final String versionJava = """
             public class Version {
-                public static final Version V_8_10_0 = new Version(8_10_00_99);
-                public static final Version V_8_10_1 = new Version(8_10_01_99);
-                public static final Version V_8_11_0 = new Version(8_11_00_99);
-                public static final Version CURRENT = V_8_11_0;
+                public static final Version V_7_16_0 = new Version(7_16_00_99, org.apache.lucene.util.Version.LUCENE_8_10_1);
+                public static final Version V_7_16_1 = new Version(7_16_01_99, org.apache.lucene.util.Version.LUCENE_8_10_1);
+                public static final Version V_7_17_0 = new Version(7_17_00_99, org.apache.lucene.util.Version.LUCENE_8_11_1);
+                public static final Version CURRENT = V_7_17_0;
             }""";
 
         CompilationUnit unit = StaticJavaParser.parse(versionJava);
 
         var ex = assertThrows(
             IllegalArgumentException.class,
-            () -> UpdateVersionsTask.removeVersionConstant(unit, Version.fromString("8.11.0"))
+            () -> UpdateVersionsTask.removeVersionConstant(unit, Version.fromString("7.17.0"))
         );
-        assertThat(ex.getMessage(), equalTo("Cannot remove version [8.11.0], it is referenced by CURRENT"));
+        assertThat(ex.getMessage(), equalTo("Cannot remove version [7.17.0], it is referenced by CURRENT"));
     }
 
     @Test
     public void removeVersion() {
         final String versionJava = """
             public class Version {
-                public static final Version V_8_10_0 = new Version(8_10_00_99);
-                public static final Version V_8_10_1 = new Version(8_10_01_99);
-                public static final Version V_8_11_0 = new Version(8_11_00_99);
-                public static final Version CURRENT = V_8_11_0;
+                public static final Version V_7_16_0 = new Version(7_16_00_99, org.apache.lucene.util.Version.LUCENE_8_10_1);
+                public static final Version V_7_16_1 = new Version(7_16_01_99, org.apache.lucene.util.Version.LUCENE_8_10_1);
+                public static final Version V_7_17_0 = new Version(7_17_00_99, org.apache.lucene.util.Version.LUCENE_8_11_1);
+                public static final Version CURRENT = V_7_17_0;
             }""";
         final String updatedVersionJava = """
             public class Version {
 
-                public static final Version V_8_10_0 = new Version(8_10_00_99);
+                public static final Version V_7_16_0 = new Version(7_16_00_99, org.apache.lucene.util.Version.LUCENE_8_10_1);
 
-                public static final Version V_8_11_0 = new Version(8_11_00_99);
+                public static final Version V_7_17_0 = new Version(7_17_00_99, org.apache.lucene.util.Version.LUCENE_8_11_1);
 
-                public static final Version CURRENT = V_8_11_0;
+                public static final Version CURRENT = V_7_17_0;
             }
             """;
 
         CompilationUnit unit = StaticJavaParser.parse(versionJava);
 
-        UpdateVersionsTask.removeVersionConstant(unit, Version.fromString("8.10.1"));
+        UpdateVersionsTask.removeVersionConstant(unit, Version.fromString("7.16.1"));
 
         assertThat(unit, hasToString(updatedVersionJava));
     }
@@ -200,7 +201,14 @@ public class UpdateVersionsTaskTests {
         assertThat(
             field.get().getVariable(0).getInitializer().get(),
             hasToString(
-                String.format("new Version(%d_%02d_%02d_99)", newVersion.getMajor(), newVersion.getMinor(), newVersion.getRevision())
+                matchesRegex(
+                    String.format(
+                        "new Version\\(%d_%02d_%02d_99, (org.apache.lucene.util.Version.)?LUCENE_[0-9_]+\\)",
+                        newVersion.getMajor(),
+                        newVersion.getMinor(),
+                        newVersion.getRevision()
+                    )
+                )
             )
         );
         // and CURRENT has been updated


### PR DESCRIPTION
Backport the update versions task from #103335 to 7.17, for future 7.17 patch releases using new release automation.

This modifies the update versions logic to also copy across the lucene version