### PR TITLE
Reduce contention in `CancellableTask#ensureNotCancelled`

### DIFF
--- a/server/src/main/java/org/elasticsearch/tasks/CancellableTask.java
+++ b/server/src/main/java/org/elasticsearch/tasks/CancellableTask.java
@@ -85,9 +85,11 @@ public class CancellableTask extends Task {
     /**
      * Throws a {@link TaskCancelledException} if this task has been cancelled, otherwise does nothing.
      */
-    public final synchronized void ensureNotCancelled() {
+    public final void ensureNotCancelled() {
         if (isCancelled()) {
-            throw getTaskCancelledException();
+            synchronized (this) {
+                throw getTaskCancelledException();
+            }
         }
     }
 


### PR DESCRIPTION
No need to acquire the mutex to read the volatile `isCancelled` field,
we can check that first to avoid contention.

Relates #104273