### PR TITLE
Remove some unused dependencies from Reindex transport actions

### DIFF
--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractAsyncBulkByScrollAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/AbstractAsyncBulkByScrollAction.java
@@ -23,7 +23,6 @@ import org.elasticsearch.action.bulk.Retry;
 import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.client.internal.ParentTaskAssigningClient;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
@@ -74,9 +73,7 @@ import static org.elasticsearch.search.sort.SortBuilders.fieldSort;
  * Abstract base for scrolling across a search and executing bulk actions on all results. All package private methods are package private so
  * their tests can use them. Most methods run in the listener thread pool because they are meant to be fast and don't expect to block.
  */
-public abstract class AbstractAsyncBulkByScrollAction<
-    Request extends AbstractBulkByScrollRequest<Request>,
-    Action extends TransportAction<Request, ?>> {
+public abstract class AbstractAsyncBulkByScrollAction<Request extends AbstractBulkByScrollRequest<Request>> {
 
     protected final Logger logger;
     protected final BulkByScrollTask task;
@@ -122,7 +119,6 @@ public abstract class AbstractAsyncBulkByScrollAction<
         boolean needsSourceDocumentSeqNoAndPrimaryTerm,
         Logger logger,
         ParentTaskAssigningClient client,
-        ThreadPool threadPool,
         Request mainRequest,
         ActionListener<BulkByScrollResponse> listener,
         @Nullable ScriptService scriptService,
@@ -135,7 +131,6 @@ public abstract class AbstractAsyncBulkByScrollAction<
             logger,
             client,
             client,
-            threadPool,
             mainRequest,
             listener,
             scriptService,
@@ -150,7 +145,6 @@ public abstract class AbstractAsyncBulkByScrollAction<
         Logger logger,
         ParentTaskAssigningClient searchClient,
         ParentTaskAssigningClient bulkClient,
-        ThreadPool threadPool,
         Request mainRequest,
         ActionListener<BulkByScrollResponse> listener,
         @Nullable ScriptService scriptService,
@@ -167,7 +161,7 @@ public abstract class AbstractAsyncBulkByScrollAction<
         this.logger = logger;
         this.searchClient = searchClient;
         this.bulkClient = bulkClient;
-        this.threadPool = threadPool;
+        this.threadPool = searchClient.threadPool();
         this.mainRequest = mainRequest;
         this.listener = listener;
         BackoffPolicy backoffPolicy = buildBackoffPolicy();

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/AsyncDeleteByQueryAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/AsyncDeleteByQueryAction.java
@@ -17,23 +17,21 @@ import org.elasticsearch.index.reindex.BulkByScrollTask;
 import org.elasticsearch.index.reindex.DeleteByQueryRequest;
 import org.elasticsearch.index.reindex.ScrollableHitSource;
 import org.elasticsearch.script.ScriptService;
-import org.elasticsearch.threadpool.ThreadPool;
 
 /**
  * Implementation of delete-by-query using scrolling and bulk.
  */
-public class AsyncDeleteByQueryAction extends AbstractAsyncBulkByScrollAction<DeleteByQueryRequest, TransportDeleteByQueryAction> {
+public class AsyncDeleteByQueryAction extends AbstractAsyncBulkByScrollAction<DeleteByQueryRequest> {
 
     public AsyncDeleteByQueryAction(
         BulkByScrollTask task,
         Logger logger,
         ParentTaskAssigningClient client,
-        ThreadPool threadPool,
         DeleteByQueryRequest request,
         ScriptService scriptService,
         ActionListener<BulkByScrollResponse> listener
     ) {
-        super(task, false, true, logger, client, threadPool, request, listener, scriptService, null);
+        super(task, false, true, logger, client, request, listener, scriptService, null);
     }
 
     @Override

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/Reindexer.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/Reindexer.java
@@ -79,20 +79,12 @@ public class Reindexer {
 
     private final ClusterService clusterService;
     private final Client client;
-    private final ThreadPool threadPool;
     private final ScriptService scriptService;
     private final ReindexSslConfig reindexSslConfig;
 
-    Reindexer(
-        ClusterService clusterService,
-        Client client,
-        ThreadPool threadPool,
-        ScriptService scriptService,
-        ReindexSslConfig reindexSslConfig
-    ) {
+    Reindexer(ClusterService clusterService, Client client, ScriptService scriptService, ReindexSslConfig reindexSslConfig) {
         this.clusterService = clusterService;
         this.client = client;
-        this.threadPool = threadPool;
         this.scriptService = scriptService;
         this.reindexSslConfig = reindexSslConfig;
     }
@@ -117,7 +109,6 @@ public class Reindexer {
                     logger,
                     assigningClient,
                     assigningBulkClient,
-                    threadPool,
                     scriptService,
                     clusterService.state(),
                     reindexSslConfig,
@@ -184,7 +175,7 @@ public class Reindexer {
      * but this makes no attempt to do any of them so it can be as simple
      * possible.
      */
-    static class AsyncIndexBySearchAction extends AbstractAsyncBulkByScrollAction<ReindexRequest, TransportReindexAction> {
+    static class AsyncIndexBySearchAction extends AbstractAsyncBulkByScrollAction<ReindexRequest> {
         /**
          * Mapper for the {@code _id} of the destination index used to
          * normalize {@code _id}s landing in the index.
@@ -204,7 +195,6 @@ public class Reindexer {
             Logger logger,
             ParentTaskAssigningClient searchClient,
             ParentTaskAssigningClient bulkClient,
-            ThreadPool threadPool,
             ScriptService scriptService,
             ClusterState state,
             ReindexSslConfig sslConfig,
@@ -222,7 +212,6 @@ public class Reindexer {
                 logger,
                 searchClient,
                 bulkClient,
-                threadPool,
                 request,
                 listener,
                 scriptService,

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/TransportDeleteByQueryAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/TransportDeleteByQueryAction.java
@@ -13,7 +13,6 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.ParentTaskAssigningClient;
-import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.index.reindex.BulkByScrollResponse;
@@ -22,30 +21,25 @@ import org.elasticsearch.index.reindex.DeleteByQueryAction;
 import org.elasticsearch.index.reindex.DeleteByQueryRequest;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.tasks.Task;
-import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
 public class TransportDeleteByQueryAction extends HandledTransportAction<DeleteByQueryRequest, BulkByScrollResponse> {
 
-    private final ThreadPool threadPool;
     private final Client client;
     private final ScriptService scriptService;
-    private final ClusterService clusterService;
+    private final TransportService transportService;
 
     @Inject
     public TransportDeleteByQueryAction(
-        ThreadPool threadPool,
         ActionFilters actionFilters,
         Client client,
         TransportService transportService,
-        ScriptService scriptService,
-        ClusterService clusterService
+        ScriptService scriptService
     ) {
         super(DeleteByQueryAction.NAME, transportService, actionFilters, DeleteByQueryRequest::new, EsExecutors.DIRECT_EXECUTOR_SERVICE);
-        this.threadPool = threadPool;
         this.client = client;
         this.scriptService = scriptService;
-        this.clusterService = clusterService;
+        this.transportService = transportService;
     }
 
     @Override
@@ -57,15 +51,14 @@ public class TransportDeleteByQueryAction extends HandledTransportAction<DeleteB
             DeleteByQueryAction.INSTANCE,
             listener,
             client,
-            clusterService.localNode(),
+            transportService.getLocalNode(),
             () -> {
                 ParentTaskAssigningClient assigningClient = new ParentTaskAssigningClient(
                     client,
-                    clusterService.localNode(),
+                    transportService.getLocalNode(),
                     bulkByScrollTask
                 );
-                new AsyncDeleteByQueryAction(bulkByScrollTask, logger, assigningClient, threadPool, request, scriptService, listener)
-                    .start();
+                new AsyncDeleteByQueryAction(bulkByScrollTask, logger, assigningClient, request, scriptService, listener).start();
             }
         );
     }

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/TransportReindexAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/TransportReindexAction.java
@@ -26,7 +26,6 @@ import org.elasticsearch.index.reindex.ReindexAction;
 import org.elasticsearch.index.reindex.ReindexRequest;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.tasks.Task;
-import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
 import java.util.List;
@@ -45,7 +44,6 @@ public class TransportReindexAction extends HandledTransportAction<ReindexReques
     @Inject
     public TransportReindexAction(
         Settings settings,
-        ThreadPool threadPool,
         ActionFilters actionFilters,
         IndexNameExpressionResolver indexNameExpressionResolver,
         ClusterService clusterService,
@@ -58,7 +56,6 @@ public class TransportReindexAction extends HandledTransportAction<ReindexReques
         this(
             ReindexAction.NAME,
             settings,
-            threadPool,
             actionFilters,
             indexNameExpressionResolver,
             clusterService,
@@ -73,7 +70,6 @@ public class TransportReindexAction extends HandledTransportAction<ReindexReques
     protected TransportReindexAction(
         String name,
         Settings settings,
-        ThreadPool threadPool,
         ActionFilters actionFilters,
         IndexNameExpressionResolver indexNameExpressionResolver,
         ClusterService clusterService,
@@ -86,7 +82,7 @@ public class TransportReindexAction extends HandledTransportAction<ReindexReques
         super(name, transportService, actionFilters, ReindexRequest::new, EsExecutors.DIRECT_EXECUTOR_SERVICE);
         this.client = client;
         this.reindexValidator = new ReindexValidator(settings, clusterService, indexNameExpressionResolver, autoCreateIndex);
-        this.reindexer = new Reindexer(clusterService, client, threadPool, scriptService, sslConfig);
+        this.reindexer = new Reindexer(clusterService, client, scriptService, sslConfig);
     }
 
     @Override

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/AbstractAsyncBulkByScrollActionMetadataTestCase.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/AbstractAsyncBulkByScrollActionMetadataTestCase.java
@@ -21,5 +21,5 @@ public abstract class AbstractAsyncBulkByScrollActionMetadataTestCase<
         return new ScrollableHitSource.BasicHit("index", "id", 0);
     }
 
-    protected abstract AbstractAsyncBulkByScrollAction<Request, ?> action();
+    protected abstract AbstractAsyncBulkByScrollAction<Request> action();
 }

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/AbstractAsyncBulkByScrollActionScriptTestCase.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/AbstractAsyncBulkByScrollActionScriptTestCase.java
@@ -72,7 +72,7 @@ public abstract class AbstractAsyncBulkByScrollActionScriptTestCase<
                 }
             }
         );
-        AbstractAsyncBulkByScrollAction<Request, ?> action = action(scriptService, request().setScript(mockScript("")));
+        AbstractAsyncBulkByScrollAction<Request> action = action(scriptService, request().setScript(mockScript("")));
         RequestWrapper<?> result = action.buildScriptApplier().apply(AbstractAsyncBulkByScrollAction.wrap(index), doc);
         return (result != null) ? (T) result.self() : null;
     }
@@ -109,5 +109,5 @@ public abstract class AbstractAsyncBulkByScrollActionScriptTestCase<
         assertThat(e.getMessage(), equalTo("[op] must be one of delete, index, noop, not [unknown]"));
     }
 
-    protected abstract AbstractAsyncBulkByScrollAction<Request, ?> action(ScriptService scriptService, Request request);
+    protected abstract AbstractAsyncBulkByScrollAction<Request> action(ScriptService scriptService, Request request);
 }

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/AsyncBulkByScrollActionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/AsyncBulkByScrollActionTests.java
@@ -948,9 +948,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         );
     }
 
-    private class DummyAsyncBulkByScrollAction extends AbstractAsyncBulkByScrollAction<
-        DummyAbstractBulkByScrollRequest,
-        DummyTransportAsyncBulkByScrollAction> {
+    private class DummyAsyncBulkByScrollAction extends AbstractAsyncBulkByScrollAction<DummyAbstractBulkByScrollRequest> {
         DummyAsyncBulkByScrollAction() {
             super(
                 testTask,
@@ -958,7 +956,6 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
                 randomBoolean(),
                 AsyncBulkByScrollActionTests.this.logger,
                 new ParentTaskAssigningClient(client, localNode, testTask),
-                client.threadPool(),
                 testRequest,
                 listener,
                 null,

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexIdTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexIdTests.java
@@ -8,6 +8,8 @@
 
 package org.elasticsearch.reindex;
 
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.client.internal.ParentTaskAssigningClient;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.ComponentTemplate;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
@@ -29,6 +31,8 @@ import java.util.List;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Reindex tests for picking ids.
@@ -100,6 +104,19 @@ public class ReindexIdTests extends AbstractAsyncBulkByScrollActionTestCase<Rein
     }
 
     private Reindexer.AsyncIndexBySearchAction action(ClusterState state) {
-        return new Reindexer.AsyncIndexBySearchAction(task, logger, null, null, threadPool, null, state, null, request(), listener());
+        var client = mock(Client.class);
+        when(client.threadPool()).thenReturn(threadPool);
+        var parentAssigningClient = new ParentTaskAssigningClient(client, null);
+        return new Reindexer.AsyncIndexBySearchAction(
+            task,
+            logger,
+            parentAssigningClient,
+            parentAssigningClient,
+            null,
+            state,
+            null,
+            request(),
+            listener()
+        );
     }
 }

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexMetadataTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexMetadataTests.java
@@ -9,10 +9,13 @@
 package org.elasticsearch.reindex;
 
 import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.client.internal.ParentTaskAssigningClient;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.index.reindex.BulkByScrollResponse;
 import org.elasticsearch.index.reindex.ReindexRequest;
 import org.elasticsearch.index.reindex.ScrollableHitSource.Hit;
+
+import static org.mockito.Mockito.mock;
 
 /**
  * Reindex test for routing.
@@ -73,9 +76,8 @@ public class ReindexMetadataTests extends AbstractAsyncBulkByScrollActionMetadat
             super(
                 ReindexMetadataTests.this.task,
                 ReindexMetadataTests.this.logger,
-                null,
-                null,
-                ReindexMetadataTests.this.threadPool,
+                mock(ParentTaskAssigningClient.class),
+                mock(ParentTaskAssigningClient.class),
                 null,
                 ClusterState.EMPTY_STATE,
                 null,

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexScriptTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexScriptTests.java
@@ -9,16 +9,19 @@
 package org.elasticsearch.reindex;
 
 import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.client.internal.ParentTaskAssigningClient;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.common.lucene.uid.Versions;
 import org.elasticsearch.index.reindex.BulkByScrollResponse;
 import org.elasticsearch.index.reindex.ReindexRequest;
 import org.elasticsearch.script.ScriptService;
-import org.mockito.Mockito;
 
 import java.util.Map;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests reindex with a script modifying the documents.
@@ -88,13 +91,15 @@ public class ReindexScriptTests extends AbstractAsyncBulkByScrollActionScriptTes
 
     @Override
     protected Reindexer.AsyncIndexBySearchAction action(ScriptService scriptService, ReindexRequest request) {
-        ReindexSslConfig sslConfig = Mockito.mock(ReindexSslConfig.class);
+        ReindexSslConfig sslConfig = mock(ReindexSslConfig.class);
+        Client client = mock(Client.class);
+        when(client.threadPool()).thenReturn(threadPool);
+        var parentTaskAssigningClient = new ParentTaskAssigningClient(client, null);
         return new Reindexer.AsyncIndexBySearchAction(
             task,
             logger,
-            null,
-            null,
-            threadPool,
+            parentTaskAssigningClient,
+            parentTaskAssigningClient,
             scriptService,
             ClusterState.EMPTY_STATE,
             sslConfig,

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/UpdateByQueryMetadataTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/UpdateByQueryMetadataTests.java
@@ -9,10 +9,12 @@
 package org.elasticsearch.reindex;
 
 import org.elasticsearch.action.index.IndexRequest;
-import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.client.internal.ParentTaskAssigningClient;
 import org.elasticsearch.index.reindex.BulkByScrollResponse;
 import org.elasticsearch.index.reindex.ScrollableHitSource.Hit;
 import org.elasticsearch.index.reindex.UpdateByQueryRequest;
+
+import static org.mockito.Mockito.mock;
 
 public class UpdateByQueryMetadataTests extends AbstractAsyncBulkByScrollActionMetadataTestCase<
     UpdateByQueryRequest,
@@ -39,11 +41,9 @@ public class UpdateByQueryMetadataTests extends AbstractAsyncBulkByScrollActionM
             super(
                 UpdateByQueryMetadataTests.this.task,
                 UpdateByQueryMetadataTests.this.logger,
-                null,
-                UpdateByQueryMetadataTests.this.threadPool,
+                mock(ParentTaskAssigningClient.class),
                 null,
                 request(),
-                ClusterState.EMPTY_STATE,
                 listener()
             );
         }

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/UpdateByQueryVersionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/UpdateByQueryVersionTests.java
@@ -8,10 +8,12 @@
 
 package org.elasticsearch.reindex;
 
-import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.client.internal.ParentTaskAssigningClient;
 import org.elasticsearch.index.reindex.BulkByScrollResponse;
 import org.elasticsearch.index.reindex.ScrollableHitSource.Hit;
 import org.elasticsearch.index.reindex.UpdateByQueryRequest;
+
+import static org.mockito.Mockito.mock;
 
 public class UpdateByQueryVersionTests extends AbstractAsyncBulkByScrollActionMetadataTestCase<UpdateByQueryRequest, BulkByScrollResponse> {
 
@@ -49,11 +51,9 @@ public class UpdateByQueryVersionTests extends AbstractAsyncBulkByScrollActionMe
             super(
                 UpdateByQueryVersionTests.this.task,
                 UpdateByQueryVersionTests.this.logger,
-                null,
-                UpdateByQueryVersionTests.this.threadPool,
+                mock(ParentTaskAssigningClient.class),
                 null,
                 request(),
-                ClusterState.EMPTY_STATE,
                 listener()
             );
         }

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/UpdateByQueryWithScriptTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/UpdateByQueryWithScriptTests.java
@@ -9,7 +9,8 @@
 package org.elasticsearch.reindex;
 
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.client.internal.ParentTaskAssigningClient;
 import org.elasticsearch.index.reindex.BulkByScrollResponse;
 import org.elasticsearch.index.reindex.UpdateByQueryRequest;
 import org.elasticsearch.script.ScriptService;
@@ -54,22 +55,20 @@ public class UpdateByQueryWithScriptTests extends AbstractAsyncBulkByScrollActio
         TransportService transportService = mock(TransportService.class);
         when(transportService.getThreadPool()).thenReturn(threadPool);
 
+        Client client = mock(Client.class);
+        when(client.threadPool()).thenReturn(threadPool);
         TransportUpdateByQueryAction transportAction = new TransportUpdateByQueryAction(
-            threadPool,
             new ActionFilters(Collections.emptySet()),
-            null,
+            client,
             transportService,
-            scriptService,
-            null
+            scriptService
         );
         return new TransportUpdateByQueryAction.AsyncIndexBySearchAction(
             task,
             logger,
-            null,
-            threadPool,
+            new ParentTaskAssigningClient(client, null),
             scriptService,
             request,
-            ClusterState.EMPTY_STATE,
             listener()
         );
     }

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/TransportEnrichReindexAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/TransportEnrichReindexAction.java
@@ -53,7 +53,6 @@ public class TransportEnrichReindexAction extends TransportReindexAction {
         super(
             EnrichReindexAction.NAME,
             settings,
-            threadPool,
             actionFilters,
             indexNameExpressionResolver,
             clusterService,


### PR DESCRIPTION
We didn't use the cluster state in one spot, from that it followed that we can do away with the clusterservice as a dependency in many spots. Also we already pass around clients that reference the thread-pool, no need to separately pass it around either.
