### PR TITLE
[LTR] FieldValueExtrator - Checking if fetched values is empty.

### DIFF
--- a/docs/changelog/104314.yaml
+++ b/docs/changelog/104314.yaml
@@ -1,0 +1,5 @@
+pr: 104314
+summary: "[LTR] `FieldValueExtrator` - Checking if fetched values is empty"
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ltr/FieldValueFeatureExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ltr/FieldValueFeatureExtractor.java
@@ -53,7 +53,10 @@ public class FieldValueFeatureExtractor implements FeatureExtractor {
     public void addFeatures(Map<String, Object> featureMap, int docId) throws IOException {
         Source source = sourceLookup.getSource(this.segmentContext, docId);
         for (FieldValueFetcher vf : this.valueFetcherList) {
-            featureMap.put(vf.fieldName(), vf.valueFetcher().fetchValues(source, docId, new ArrayList<>()).get(0));
+            List<Object> values = vf.valueFetcher().fetchValues(source, docId, new ArrayList<>());
+            if (values.isEmpty() == false) {
+                featureMap.put(vf.fieldName(), values.get(0));
+            }
         }
     }
 


### PR DESCRIPTION
The FieldValueExtractor does not check for the presence of a value, which can sometimes cause 500 errors when using the rescorer on a sparse field.