### PR TITLE
Temporarily tolerate tracing.apm.agent.global_labels.XYZ settings 

### DIFF
--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/APMAgentSettings.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/APMAgentSettings.java
@@ -228,7 +228,7 @@ public class APMAgentSettings {
             return new Setting<>(qualifiedKey, "", (value) -> {
                 if (qualifiedKey.equals("_na_") == false && PERMITTED_AGENT_KEYS.contains(key) == false) {
                     // TODO figure out why those settings are kept, these should be reformatted / removed by now
-                    if(key.startsWith("global_labels.")){
+                    if (key.startsWith("global_labels.")) {
                         return value;
                     }
                     throw new IllegalArgumentException("Configuration [" + qualifiedKey + "] is either prohibited or unknown.");

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/APMAgentSettings.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/APMAgentSettings.java
@@ -227,6 +227,10 @@ public class APMAgentSettings {
             final String key = parts[parts.length - 1];
             return new Setting<>(qualifiedKey, "", (value) -> {
                 if (qualifiedKey.equals("_na_") == false && PERMITTED_AGENT_KEYS.contains(key) == false) {
+                    // TODO figure out why those settings are kept, these should be reformatted / removed by now
+                    if(key.startsWith("global_labels.")){
+                        return value;
+                    }
                     throw new IllegalArgumentException("Configuration [" + qualifiedKey + "] is either prohibited or unknown.");
                 }
                 return value;


### PR DESCRIPTION
Temporarily tolerate `tracing.apm.agent.global_labels.XYZ` settings in `APMAgentSettings`.
It looks like these are currently not correctly filtered out in APMJvmOptions. I'll keep investigating the root cause.
