### PR TITLE
Fail fast on heap attack tests

### DIFF
--- a/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackIT.java
+++ b/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackIT.java
@@ -75,6 +75,11 @@ public class HeapAttackIT extends ESRestTestCase {
         return cluster.getHttpAddresses();
     }
 
+    @Before
+    public void skipOnAborted() {
+        assumeFalse("skip on aborted", SUITE_ABORTED);
+    }
+
     /**
      * This used to fail, but we've since compacted top n so it actually succeeds now.
      */
@@ -552,7 +557,9 @@ public class HeapAttackIT extends ESRestTestCase {
     @Before
     @After
     public void assertRequestBreakerEmpty() throws Exception {
-        assumeFalse("suite was aborted", SUITE_ABORTED);
+        if (SUITE_ABORTED) {
+            return;
+        }
         assertBusy(() -> {
             HttpEntity entity = adminClient().performRequest(new Request("GET", "/_nodes/stats")).getEntity();
             Map<?, ?> stats = XContentHelper.convertToMap(XContentType.JSON.xContent(), entity.getContent(), false);


### PR DESCRIPTION
We can't use `assume` after a test fails.