### PR TITLE
ESQL: Run async tests more carefully

### DIFF
--- a/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/ApiCallSection.java
+++ b/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/ApiCallSection.java
@@ -32,6 +32,10 @@ public class ApiCallSection {
         this.api = api;
     }
 
+    public String getApi() {
+        return api;
+    }
+
     public ApiCallSection copyWithNewApi(String api) {
         ApiCallSection copy = new ApiCallSection(api);
         for (var e : params.entrySet()) {
@@ -43,10 +47,6 @@ public class ApiCallSection {
         }
         copy.nodeSelector = nodeSelector;
         return copy;
-    }
-
-    public String getApi() {
-        return api;
     }
 
     public Map<String, String> getParams() {

--- a/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/EsqlClientYamlAsyncSubmitAndFetchIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/yamlRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/EsqlClientYamlAsyncSubmitAndFetchIT.java
@@ -9,19 +9,22 @@ package org.elasticsearch.xpack.esql.qa.single_node;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
-import org.elasticsearch.test.rest.yaml.section.ApiCallSection;
+import org.elasticsearch.test.rest.yaml.ClientYamlTestExecutionContext;
+import org.elasticsearch.test.rest.yaml.ClientYamlTestResponse;
+import org.elasticsearch.test.rest.yaml.ClientYamlTestResponseException;
 import org.elasticsearch.test.rest.yaml.section.DoSection;
+import org.elasticsearch.test.rest.yaml.section.ExecutableSection;
+import org.elasticsearch.xcontent.XContentLocation;
 
+import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Stream;
 
 /**
  * Run the ESQL yaml tests async and then fetch the results with a long wait time.
  */
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/104294")
 public class EsqlClientYamlAsyncSubmitAndFetchIT extends AbstractEsqlClientYamlIT {
     public EsqlClientYamlAsyncSubmitAndFetchIT(final ClientYamlTestCandidate testCandidate) {
         super(testCandidate);
@@ -29,34 +32,79 @@ public class EsqlClientYamlAsyncSubmitAndFetchIT extends AbstractEsqlClientYamlI
 
     @ParametersFactory
     public static Iterable<Object[]> parameters() throws Exception {
-        return EsqlClientYamlAsyncIT.parameters(doSection -> {
-            ApiCallSection copy = doSection.getApiCallSection().copyWithNewApi("esql.async_query");
-            for (Map<String, Object> body : copy.getBodies()) {
-                body.put("wait_for_completion_timeout", "0ms");
-                body.put("keep_on_completion", true);
+        return EsqlClientYamlAsyncIT.parameters(DoEsqlAsync::new);
+    }
+
+    private static class DoEsqlAsync implements ExecutableSection {
+        private final DoSection original;
+
+        private DoEsqlAsync(DoSection original) {
+            this.original = original;
+        }
+
+        @Override
+        public XContentLocation getLocation() {
+            return original.getLocation();
+        }
+
+        @Override
+        public void execute(ClientYamlTestExecutionContext executionContext) throws IOException {
+            try {
+                // Start the query
+                List<Map<String, Object>> bodies = original.getApiCallSection().getBodies().stream().map(m -> {
+                    Map<String, Object> body = new HashMap<>(m);
+                    if (randomBoolean()) {
+                        /*
+                         * Try to force the request to go async by setting the timeout to 0.
+                         * This doesn't *actually* force the request async - if it finishes
+                         * super duper faster it won't get async. But that's life.
+                         */
+                        body.put("wait_for_completion_timeout", "0ms");
+                    }
+                    return body;
+                }).toList();
+                ClientYamlTestResponse startResponse = executionContext.callApi(
+                    "esql.async_query",
+                    original.getApiCallSection().getParams(),
+                    bodies,
+                    original.getApiCallSection().getHeaders(),
+                    original.getApiCallSection().getNodeSelector()
+                );
+
+                String id = (String) startResponse.evaluate("id");
+                boolean finishedEarly = id == null;
+                if (finishedEarly) {
+                    /*
+                     * If we finished early, make sure we don't have a "catch"
+                     * param and expect and error. And make sure we match the
+                     * warnings folks have asked for.
+                     */
+                    original.failIfHasCatch(startResponse);
+                    original.checkWarningHeaders(startResponse.getWarningHeaders(), testPath(executionContext));
+                    return;
+                }
+
+                /*
+                 * Ok, we didn't finish before the timeout. Fine, let's fetch the result.
+                 */
+                ClientYamlTestResponse fetchResponse = executionContext.callApi(
+                    "esql.async_query_get",
+                    Map.of("wait_for_completion_timeout", "30m", "id", id),
+                    List.of(),
+                    original.getApiCallSection().getHeaders(),
+                    original.getApiCallSection().getNodeSelector()
+                );
+                original.failIfHasCatch(fetchResponse);
+                original.checkWarningHeaders(fetchResponse.getWarningHeaders(), testPath(executionContext));
+            } catch (ClientYamlTestResponseException e) {
+                original.checkResponseException(e, executionContext);
             }
-            doSection.setApiCallSection(copy);
+        }
 
-            DoSection fetch = new DoSection(doSection.getLocation());
-            fetch.setApiCallSection(new ApiCallSection("esql.async_query_get"));
-            fetch.getApiCallSection().addParam("wait_for_completion_timeout", "30m");
-            fetch.getApiCallSection().addParam("id", "$body.id");
-
-            /*
-             * The request to start the query doesn't make warnings or errors so shift
-             * those to the fetch.
-             */
-            fetch.setExpectedWarningHeaders(doSection.getExpectedWarningHeaders());
-            fetch.setExpectedWarningHeadersRegex(doSection.getExpectedWarningHeadersRegex());
-            fetch.setAllowedWarningHeaders(doSection.getAllowedWarningHeaders());
-            fetch.setAllowedWarningHeadersRegex(doSection.getAllowedWarningHeadersRegex());
-            fetch.setCatch(doSection.getCatch());
-            doSection.setExpectedWarningHeaders(List.of());
-            doSection.setExpectedWarningHeadersRegex(List.of());
-            doSection.setAllowedWarningHeaders(List.of());
-            doSection.setAllowedWarningHeadersRegex(List.of());
-            doSection.setCatch(null);
-            return Stream.of(doSection, fetch);
-        });
+        private String testPath(ClientYamlTestExecutionContext executionContext) {
+            return executionContext.getClientYamlTestCandidate() != null
+                ? executionContext.getClientYamlTestCandidate().getTestPath()
+                : null;
+        }
     }
 }


### PR DESCRIPTION
The ESQL async tests run the ESQL yaml tests two extra time - once under the async endpoint with the `wait_for_completion_timeout` set to a long time and *again* with `wait_for_completion_timeout` set to a short time, expecting to receive an `id` for the query.

That second way is tricky! Even with a `0ms` timeout sometimes the request will complete. That's great, but the tests didn't realize that was possible. And it's tricky to get the warnings and `catch` sections working properly with that. This reworks how we run these commands, breaking apart the way we run a single API and running it as two, taking into account that the "start the query" request could also complete the query.

Closes #104294
