### PR TITLE
[ML] Automatically download the ELSER model when PUT in _inference

### DIFF
--- a/docs/changelog/104334.yaml
+++ b/docs/changelog/104334.yaml
@@ -1,0 +1,5 @@
+pr: 104334
+summary: Automatically download the ELSER model when PUT in `_inference`
+area: Machine Learning
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/inference/InferenceService.java
+++ b/server/src/main/java/org/elasticsearch/inference/InferenceService.java
@@ -98,6 +98,17 @@ public interface InferenceService extends Closeable {
     }
 
     /**
+     * Put the model definition (if applicable)
+     * The main purpose of this function is to download ELSER
+     * The default action does nothing except acknowledge the request (true).
+     * @param modelVariant The configuration of the model variant to be downloaded
+     * @param listener The listener
+     */
+    default void putModel(Model modelVariant, ActionListener<Boolean> listener) {
+        listener.onResponse(true);
+    }
+
+    /**
      * Optionally test the new model configuration in the inference service.
      * This function should be called when the model is first created, the
      * default action is to do nothing.

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceBaseRestTest.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceBaseRestTest.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.inference.TaskType;
+import org.elasticsearch.plugins.Platforms;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.rest.ESRestTestCase;
@@ -62,6 +63,25 @@ public class InferenceBaseRestTest extends ESRestTestCase {
               }
             }
             """;
+    }
+
+    protected Map<String, Object> downloadElserBlocking() throws IOException {
+        String endpoint = "_ml/trained_models/.elser_model_2?wait_for_completion=true";
+        if ("linux-x86_64".equals(Platforms.PLATFORM_NAME)) {
+            endpoint = "_ml/trained_models/.elser_model_2_linux-x86_64?wait_for_completion=true";
+        }
+        String body = """
+            {
+                "input": {
+                "field_names": ["text_field"]
+                }
+            }
+            """;
+        var request = new Request("PUT", endpoint);
+        request.setJsonEntity(body);
+        var response = client().performRequest(request);
+        assertOkOrCreated(response);
+        return entityAsMap(response);
     }
 
     protected Map<String, Object> putModel(String modelId, String modelConfig, TaskType taskType) throws IOException {

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceBaseRestTest.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceBaseRestTest.java
@@ -64,37 +64,10 @@ public class InferenceBaseRestTest extends ESRestTestCase {
             """;
     }
 
-    protected Map<String, Object> putElserInference(String modelId, TaskType taskType) throws IOException {
-        var endpoint = Strings.format("_inference/%s/%s", taskType, modelId);
-        var request = new Request("PUT", endpoint);
-
-        request.setJsonEntity("""
-            {
-              "service": "elser",
-              "service_settings": {
-                "num_allocations": 1,
-                "num_threads": 1
-              },
-              "task_settings": {}
-            }
-            """);
-        var response = client().performRequest(request);
-        assertOkOrCreated(response);
-        return entityAsMap(response);
-    }
-
     protected Map<String, Object> putModel(String modelId, String modelConfig, TaskType taskType) throws IOException {
         String endpoint = Strings.format("_inference/%s/%s", taskType, modelId);
         var request = new Request("PUT", endpoint);
         request.setJsonEntity(modelConfig);
-        var response = client().performRequest(request);
-        assertOkOrCreated(response);
-        return entityAsMap(response);
-    }
-
-    protected Map<String, Object> deleteModel(String modelId, TaskType taskType) throws IOException {
-        var endpoint = Strings.format("_inference/%s/%s", taskType, modelId);
-        var request = new Request("DELETE", endpoint);
         var response = client().performRequest(request);
         assertOkOrCreated(response);
         return entityAsMap(response);
@@ -110,14 +83,6 @@ public class InferenceBaseRestTest extends ESRestTestCase {
 
     protected Map<String, Object> getAllModels() throws IOException {
         var endpoint = Strings.format("_inference/_all");
-        var request = new Request("GET", endpoint);
-        var response = client().performRequest(request);
-        assertOkOrCreated(response);
-        return entityAsMap(response);
-    }
-
-    protected Map<String, Object> getTrainedModel(String modelId) throws IOException {
-        var endpoint = Strings.format("_ml/trained_models/%s/_stats", modelId);
         var request = new Request("GET", endpoint);
         var response = client().performRequest(request);
         assertOkOrCreated(response);

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceBaseRestTest.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceBaseRestTest.java
@@ -15,7 +15,6 @@ import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.inference.TaskType;
-import org.elasticsearch.plugins.Platforms;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.rest.ESRestTestCase;
@@ -65,20 +64,20 @@ public class InferenceBaseRestTest extends ESRestTestCase {
             """;
     }
 
-    protected Map<String, Object> downloadElserBlocking() throws IOException {
-        String endpoint = "_ml/trained_models/.elser_model_2?wait_for_completion=true";
-        if ("linux-x86_64".equals(Platforms.PLATFORM_NAME)) {
-            endpoint = "_ml/trained_models/.elser_model_2_linux-x86_64?wait_for_completion=true";
-        }
-        String body = """
-            {
-                "input": {
-                "field_names": ["text_field"]
-                }
-            }
-            """;
+    protected Map<String, Object> putElserInference(String modelId, TaskType taskType) throws IOException {
+        var endpoint = Strings.format("_inference/%s/%s", taskType, modelId);
         var request = new Request("PUT", endpoint);
-        request.setJsonEntity(body);
+
+        request.setJsonEntity("""
+            {
+              "service": "elser",
+              "service_settings": {
+                "num_allocations": 1,
+                "num_threads": 1
+              },
+              "task_settings": {}
+            }
+            """);
         var response = client().performRequest(request);
         assertOkOrCreated(response);
         return entityAsMap(response);

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceCrudIT.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceCrudIT.java
@@ -18,53 +18,8 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.not;
 
 public class InferenceCrudIT extends InferenceBaseRestTest {
-
-    public void testElserCrud() throws IOException {
-
-        String elserConfig = """
-            {
-              "service": "elser",
-              "service_settings": {
-                "num_allocations": 1,
-                "num_threads": 1
-              },
-              "task_settings": {}
-            }
-            """;
-
-        // Model already downloaded
-        {
-            String modelId = randomAlphaOfLength(10).toLowerCase();
-            putModel(modelId, elserConfig, TaskType.SPARSE_EMBEDDING);
-            var models = getModels(modelId, TaskType.SPARSE_EMBEDDING);
-            assertThat(models.get("models").toString(), containsString("model_id=" + modelId));
-
-            deleteModel(modelId, TaskType.SPARSE_EMBEDDING);
-            expectThrows(ResponseException.class, () -> getModels(modelId, TaskType.SPARSE_EMBEDDING));
-            models = getTrainedModel("_all");
-            assertThat(models.toString(), not(containsString("deployment_id=" + modelId)));
-        }
-
-        // Model downloaded automatically & test infer
-        {
-            String modelId = randomAlphaOfLength(10).toLowerCase();
-            putElserInference(modelId, TaskType.SPARSE_EMBEDDING);
-            var models = getTrainedModel("_all");
-            assertThat(models.toString(), containsString("deployment_id=" + modelId));
-
-            Map<String, Object> results = inferOnMockService(
-                modelId,
-                TaskType.SPARSE_EMBEDDING,
-                List.of("hello world", "this is the second document")
-            );
-            System.out.println(results.toString());
-            assert (((Map) ((Map) ((List) results.get("sparse_embedding")).get(0)).get("embedding")).size() > 1); // there exists embeddings
-            assert (((Map) ((List) results.get("sparse_embedding")).get(0)).size() == 2); // there are two sets of embeddings
-        }
-    }
 
     @SuppressWarnings("unchecked")
     public void testGet() throws IOException {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportPutInferenceModelAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportPutInferenceModelAction.java
@@ -179,7 +179,6 @@ public class TransportPutInferenceModelAction extends TransportMasterNodeAction<
             model,
             listener.delegateFailureAndWrap(
                 // model is valid good to persist then start
-                // TODO insert call to put model
                 (delegate, verifiedModel) -> modelRegistry.storeModel(
                     verifiedModel,
                     delegate.delegateFailureAndWrap((l, r) -> startModel(service, verifiedModel, l))

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elser/ElserMlNodeService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elser/ElserMlNodeService.java
@@ -40,7 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
+import static org.elasticsearch.xpack.core.ClientHelper.INFERENCE_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
 import static org.elasticsearch.xpack.core.ml.inference.assignment.AllocationStatus.State.STARTED;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeFromMapOrThrowIfNull;
@@ -247,9 +247,15 @@ public class ElserMlNodeService implements InferenceService {
             var input = new TrainedModelInput(fieldNames);
             var config = TrainedModelConfig.builder().setInput(input).setModelId(modelVariant).build();
             PutTrainedModelAction.Request putRequest = new PutTrainedModelAction.Request(config, false, true);
-            executeAsyncWithOrigin(client, ML_ORIGIN, PutTrainedModelAction.INSTANCE, putRequest, listener.delegateFailure((l, r) -> {
-                l.onResponse(Boolean.TRUE);
-            }));
+            executeAsyncWithOrigin(
+                client,
+                INFERENCE_ORIGIN,
+                PutTrainedModelAction.INSTANCE,
+                putRequest,
+                listener.delegateFailure((l, r) -> {
+                    l.onResponse(Boolean.TRUE);
+                })
+            );
         }
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elser/ElserMlNodeService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elser/ElserMlNodeService.java
@@ -27,8 +27,11 @@ import org.elasticsearch.xpack.core.ClientHelper;
 import org.elasticsearch.xpack.core.inference.results.SparseEmbeddingResults;
 import org.elasticsearch.xpack.core.ml.action.CreateTrainedModelAssignmentAction;
 import org.elasticsearch.xpack.core.ml.action.InferTrainedModelDeploymentAction;
+import org.elasticsearch.xpack.core.ml.action.PutTrainedModelAction;
 import org.elasticsearch.xpack.core.ml.action.StartTrainedModelDeploymentAction;
 import org.elasticsearch.xpack.core.ml.action.StopTrainedModelDeploymentAction;
+import org.elasticsearch.xpack.core.ml.inference.TrainedModelConfig;
+import org.elasticsearch.xpack.core.ml.inference.TrainedModelInput;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TextExpansionConfigUpdate;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 
@@ -37,6 +40,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
+import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
 import static org.elasticsearch.xpack.core.ml.inference.assignment.AllocationStatus.State.STARTED;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeFromMapOrThrowIfNull;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.throwIfNotEmptyMap;
@@ -227,6 +232,25 @@ public class ElserMlNodeService implements InferenceService {
             request,
             listener.delegateFailureAndWrap((l, inferenceResult) -> l.onResponse(SparseEmbeddingResults.of(inferenceResult.getResults())))
         );
+    }
+
+    @Override
+    public void putModel(Model model, ActionListener<Boolean> listener) {
+        if (model instanceof ElserMlNodeModel == false) {
+            listener.onFailure(
+                new IllegalStateException("Error starting model, [" + model.getConfigurations().getModelId() + "] is not an elser model")
+            );
+            return;
+        } else {
+            String modelVariant = ((ElserMlNodeModel) model).getServiceSettings().getModelVariant();
+            var fieldNames = List.<String>of();
+            var input = new TrainedModelInput(fieldNames);
+            var config = TrainedModelConfig.builder().setInput(input).setModelId(modelVariant).build();
+            PutTrainedModelAction.Request putRequest = new PutTrainedModelAction.Request(config, false, true);
+            executeAsyncWithOrigin(client, ML_ORIGIN, PutTrainedModelAction.INSTANCE, putRequest, listener.delegateFailure((l, r) -> {
+                l.onResponse(Boolean.TRUE);
+            }));
+        }
     }
 
     private static ElserMlNodeTaskSettings taskSettingsFromMap(TaskType taskType, Map<String, Object> config) {


### PR DESCRIPTION
Closes https://github.com/elastic/ml-team/issues/1098

Previously, to be able to use the ELSER model, there were two steps: 1. Put (download) ELSER using the trained models API; 2. Put the ELSER model using the _inference API.

With this change, these two steps are combined, so now to install ELSER in _inference, all one has to do is PUT the ELSER model using the _inference API.

For example, 
```
curl -X PUT "localhost:9200/_inference/sparse_embedding/<model_id>" \
-H 'Content-Type: application/json' -u <user>:<password> \
-d'  
{
  "service": "elser",
  "service_settings": {
    "num_allocations": 1,
    "num_threads": 1
  },
  "task_settings": {}
}
'
```