### PR TITLE
Bump min target page size to 32

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/Operator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/Operator.java
@@ -39,7 +39,7 @@ public interface Operator extends Releasable {
      * non-trivial overhead and it's just not worth building even
      * smaller blocks without under normal circumstances.
      */
-    int MIN_TARGET_PAGE_SIZE = 10;
+    int MIN_TARGET_PAGE_SIZE = 32;
 
     /**
      * whether the given operator can accept more input pages


### PR DESCRIPTION
The current MIN_TARGET_PAGE_SIZE is set to 10, which may be too low. I think most of the optimizations in ESQL are focused on processing rows rather than pages. The overhead of processing many pages can be significant in some cases. For instance, the execution time of `HeapAttackIT#testGroupOnManyLongs` decreased from 52 seconds to 28 seconds when I increased MIN_TARGET_PAGE_SIZE from 10 to 32. Therefore, I propose raising the MIN_TARGET_PAGE_SIZE to 32.