### PR TITLE
Fix request timeout in HeapAttack tests

### DIFF
--- a/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackIT.java
+++ b/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackIT.java
@@ -309,7 +309,7 @@ public class HeapAttackIT extends ESRestTestCase {
         request.setJsonEntity(query.toString().replace("\n", "\\n"));
         request.setOptions(
             RequestOptions.DEFAULT.toBuilder()
-                .setRequestConfig(RequestConfig.custom().setSocketTimeout(Math.toIntExact(TimeValue.timeValueMinutes(5).millis())).build())
+                .setRequestConfig(RequestConfig.custom().setSocketTimeout(Math.toIntExact(TimeValue.timeValueMinutes(6).millis())).build())
                 .setWarningsHandler(WarningsHandler.PERMISSIVE)
         );
         logger.info("--> test {} started querying", getTestName());
@@ -329,6 +329,10 @@ public class HeapAttackIT extends ESRestTestCase {
                     TimeValue elapsed = TimeValue.timeValueNanos(System.nanoTime() - startedTimeInNanos);
                     logger.info("--> test {} triggering OOM after {}", getTestName(), elapsed);
                     Request triggerOOM = new Request("POST", "/_trigger_out_of_memory");
+                    RequestConfig requestConfig = RequestConfig.custom()
+                        .setSocketTimeout(Math.toIntExact(TimeValue.timeValueMinutes(2).millis()))
+                        .build();
+                    request.setOptions(RequestOptions.DEFAULT.toBuilder().setRequestConfig(requestConfig));
                     client().performRequest(triggerOOM);
                 }
             }, TimeValue.timeValueMinutes(5), testThreadPool.executor(ThreadPool.Names.GENERIC));


### PR DESCRIPTION
I noticed we're using 5 minutes for both query timeout and triggering the out-of-memory action in heap attack tests. This means when we're generating the heap dump, and some ESQL tasks might get canceled because the connection was disconnected. This PR increases the query timeout to 6 minutes instead.