### PR TITLE
[8.12] Bump min target page size to 32 (#104335)

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/Operator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/Operator.java
@@ -39,7 +39,7 @@ public interface Operator extends Releasable {
      * non-trivial overhead and it's just not worth building even
      * smaller blocks without under normal circumstances.
      */
-    int MIN_TARGET_PAGE_SIZE = 10;
+    int MIN_TARGET_PAGE_SIZE = 32;
 
     /**
      * whether the given operator can accept more input pages


### PR DESCRIPTION
Backports the following commits to 8.12:
 - Bump min target page size to 32 (#104335)