### PR TITLE
Deprecate LoggingTaskListener

### DIFF
--- a/docs/changelog/104353.yaml
+++ b/docs/changelog/104353.yaml
@@ -1,0 +1,22 @@
+pr: 104353
+summary: Deprecate `LoggingTaskListener`
+area: Task Management
+type: deprecation
+issues:
+ - 104278
+deprecation:
+  title: Deprecate `LoggingTaskListener`
+  area: Logging
+  details: >-
+    Logs from `org.elasticsearch.tasks.LoggingTaskListener` contain very little
+    information which makes them very hard to use. Moreover, the information it
+    reports is also available, and much easier to consume, when using the Task
+    Management APIs instead. This logger is deprecated, and will be removed in
+    the next major version.
+  impact: >-
+
+    * Use the task management APIs to obtain the status of long-running tasks.
+
+    * Set the `?log_task_completion=false` query parameter when calling the
+    affected APIs to disable the deprecated logger and suppress the deprecation
+    warning.

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/delete_by_query/10_basic.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/delete_by_query/10_basic.yml
@@ -38,6 +38,9 @@
 
 ---
 "wait_for_completion=false":
+  - skip:
+      features: allowed_warnings_regex
+
   - do:
       index:
         index:   test
@@ -49,6 +52,63 @@
   - do:
       delete_by_query:
         wait_for_completion: false
+        index: test
+        body:
+          query:
+            match_all: {}
+      allowed_warnings_regex:
+        - "Logging the completion of a task using .*LoggingTaskListener.* is deprecated.*"
+
+  - match: {task: '/.+:\d+/'}
+  - set: {task: task}
+  - is_false: version_conflicts
+  - is_false: batches
+  - is_false: failures
+  - is_false: noops
+  - is_false: took
+  - is_false: throttled_millis
+  - is_false: created
+  - is_false: updated
+  - is_false: deleted
+
+  - do:
+      tasks.get:
+        wait_for_completion: true
+        task_id: $task
+  - is_false: node_failures
+  # The task will be in the response even if it finished before we got here
+  # because of task persistence.
+  - is_true: task
+  - is_false: response.timed_out
+  - match: {response.deleted: 1}
+  - is_false: response.created
+  - is_false: response.updated
+  - match: {response.version_conflicts: 0}
+  - match: {response.batches: 1}
+  - match: {response.failures: []}
+  - match: {response.noops: 0}
+  - match: {response.throttled_millis: 0}
+  - gte: { response.took: 0 }
+  - is_false: response.task
+
+---
+"wait_for_completion=false and log_task_completion=false":
+  - skip:
+      version: " - 8.12.99"
+      reason: ?log_task_completion parameter introduced in 8.13
+
+  - do:
+      index:
+        index:   test
+        id:      "1"
+        body:    { "text": "test" }
+  - do:
+      indices.refresh: {}
+
+  - do:
+      delete_by_query:
+        wait_for_completion: false
+        log_task_completion: false
         index: test
         body:
           query:

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/delete_by_query/70_throttle.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/delete_by_query/70_throttle.yml
@@ -75,7 +75,10 @@
 ---
 "Rethrottle to -1 which turns off throttling":
   - skip:
-      features: warnings
+      features:
+        - warnings
+        - allowed_warnings_regex
+
   # Throttling happens between each scroll batch so we need to control the size of the batch by using a single shard
   # and a small batch size on the request
   - do:
@@ -109,6 +112,8 @@
         body:
           query:
             match_all: {}
+      allowed_warnings_regex:
+        - "Logging the completion of a task using .*LoggingTaskListener.* is deprecated.*"
 
   - match: {task: '/.+:\d+/'}
   - set: {task: task}
@@ -134,6 +139,9 @@
 
 ---
 "Rethrottle but not unlimited":
+  - skip:
+      features: allowed_warnings_regex
+
   # Throttling happens between each scroll batch so we need to control the size of the batch by using a single shard
   # and a small batch size on the request
   - do:
@@ -166,6 +174,8 @@
         body:
           query:
             match_all: {}
+      allowed_warnings_regex:
+        - "Logging the completion of a task using .*LoggingTaskListener.* is deprecated.*"
 
   - match: {task: '/.+:\d+/'}
   - set: {task: task}

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/delete_by_query/80_slices.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/delete_by_query/80_slices.yml
@@ -63,7 +63,9 @@
 ---
 "Multiple slices with wait_for_completion=false":
   - skip:
-      features: warnings
+      features:
+        - warnings
+        - allowed_warnings_regex
   - do:
       index:
         index:   test
@@ -95,6 +97,8 @@
         body:
           query:
             match_all: {}
+      allowed_warnings_regex:
+        - "Logging the completion of a task using .*LoggingTaskListener.* is deprecated.*"
   - is_false: timed_out
   - match: {task: '/.+:\d+/'}
   - set: {task: task}
@@ -173,7 +177,9 @@
 ---
 "Multiple slices with rethrottle":
   - skip:
-      features: warnings
+      features:
+        - warnings
+        - allowed_warnings_regex
   - do:
       index:
         index:   test
@@ -218,6 +224,8 @@
         body:
           query:
             match_all: {}
+      allowed_warnings_regex:
+        - "Logging the completion of a task using .*LoggingTaskListener.* is deprecated.*"
   - is_false: timed_out
   - match: {task: '/.+:\d+/'}
   - set: {task: task}

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/10_basic.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/10_basic.yml
@@ -73,6 +73,8 @@
 
 ---
 "wait_for_completion=false":
+  - skip:
+      features: allowed_warnings_regex
   - do:
       index:
         index:   source
@@ -84,6 +86,69 @@
   - do:
       reindex:
         wait_for_completion: false
+        body:
+          source:
+            index: source
+          dest:
+            index: dest
+      allowed_warnings_regex:
+        - "Logging the completion of a task using .*LoggingTaskListener.* is deprecated.*"
+  - is_false: timed_out
+  - match: {task: '/.+:\d+/'}
+  - set: {task: task}
+  - is_false: updated
+  - is_false: version_conflicts
+  - is_false: batches
+  - is_false: failures
+  - is_false: noops
+  - is_false: took
+  - is_false: throttled_millis
+  - is_false: created
+  - is_false: deleted
+
+  - do:
+      tasks.get:
+        wait_for_completion: true
+        task_id: $task
+  - is_false: node_failures
+  # The task will be in the response even if it finished before we got here
+  # because of task persistence.
+  - is_true: task
+  - match: {response.created: 1}
+  - match: {response.updated: 0}
+  - match: {response.version_conflicts: 0}
+  - match: {response.batches: 1}
+  - match: {response.failures: []}
+  - match: {response.throttled_millis: 0}
+  - gte: { response.took: 0 }
+  - is_false: response.task
+  - is_false: response.deleted
+
+  # Make sure reindex closed all the scroll contexts
+  - do:
+      indices.stats:
+        index: source
+        metric: search
+  - match: {indices.source.total.search.open_contexts: 0}
+
+---
+"wait_for_completion=false and log_task_completion=false":
+  - skip:
+      version: " - 8.12.99"
+      reason: ?log_task_completion parameter introduced in 8.13
+
+  - do:
+      index:
+        index:   source
+        id:      "1"
+        body:    { "text": "test" }
+  - do:
+      indices.refresh: {}
+
+  - do:
+      reindex:
+        wait_for_completion: false
+        log_task_completion: false
         body:
           source:
             index: source

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/30_search.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/30_search.yml
@@ -126,7 +126,10 @@
   - skip:
       version: " - 7.5.99"
       reason: "sort deprecated in 7.6"
-      features: "warnings"
+      features:
+        - warnings
+        - allowed_warnings_regex
+
 
   - do:
       index:
@@ -149,6 +152,8 @@
             sort: order
           dest:
             index: target
+      allowed_warnings_regex:
+        - "Logging the completion of a task using .*LoggingTaskListener.* is deprecated.*"
   - set: {task: task}
 
   - do:

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/70_throttle.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/70_throttle.yml
@@ -92,6 +92,9 @@
 
 ---
 "Rethrottle to -1 which turns off throttling":
+  - skip:
+      features: allowed_warnings_regex
+
   # Throttling happens between each scroll batch so we need to control the size of the batch by using a single shard
   # and a small batch size on the request
   - do:
@@ -129,6 +132,8 @@
             size: 1
           dest:
             index: dest
+      allowed_warnings_regex:
+        - "Logging the completion of a task using .*LoggingTaskListener.* is deprecated.*"
   - match: {task: '/.+:\d+/'}
   - set: {task: task}
 
@@ -144,6 +149,9 @@
 
 ---
 "Rethrottle but not unlimited":
+  - skip:
+      features: allowed_warnings_regex
+
   # Throttling happens between each scroll batch so we need to control the size of the batch by using a single shard
   # and a small batch size on the request
   - do:
@@ -181,6 +189,8 @@
             size: 1
           dest:
             index: dest
+      allowed_warnings_regex:
+        - "Logging the completion of a task using .*LoggingTaskListener.* is deprecated.*"
   - match: {task: '/.+:\d+/'}
   - set: {task: task}
 

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/80_slices.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/80_slices.yml
@@ -59,7 +59,9 @@
 ---
 "Multiple slices with wait_for_completion=false":
   - skip:
-      features: warnings
+      features:
+        - warnings
+        - allowed_warnings_regex
   - do:
       index:
         index:   source
@@ -92,6 +94,8 @@
             index: source
           dest:
             index: dest
+      allowed_warnings_regex:
+        - "Logging the completion of a task using .*LoggingTaskListener.* is deprecated.*"
   - is_false: timed_out
   - match: {task: '/.+:\d+/'}
   - set: {task: task}
@@ -178,7 +182,9 @@
 ---
 "Multiple slices with rethrottle":
   - skip:
-      features: warnings
+      features:
+        - warnings
+        - allowed_warnings_regex
   - do:
       index:
         index:   source
@@ -223,6 +229,8 @@
             index: source
           dest:
             index: dest
+      allowed_warnings_regex:
+        - "Logging the completion of a task using .*LoggingTaskListener.* is deprecated.*"
   - is_false: timed_out
   - match: {task: '/.+:\d+/'}
   - set: {task: task}

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/90_remote.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/reindex/90_remote.yml
@@ -385,6 +385,9 @@
 
 ---
 "Reindex from remote with rethrottle":
+  - skip:
+      features: allowed_warnings_regex
+
   # Throttling happens between each scroll batch so we need to control the size of the batch by using a single shard
   # and a small batch size on the request
   - do:
@@ -435,6 +438,8 @@
             size: 1
           dest:
             index: dest
+      allowed_warnings_regex:
+        - "Logging the completion of a task using .*LoggingTaskListener.* is deprecated.*"
   - match: {task: '/.+:\d+/'}
   - set: {task: task}
 

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/update_by_query/10_basic.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/update_by_query/10_basic.yml
@@ -26,6 +26,9 @@
 
 ---
 "wait_for_completion=false":
+  - skip:
+      features: allowed_warnings_regex
+
   - do:
       index:
         index:   test
@@ -37,6 +40,61 @@
   - do:
       update_by_query:
         wait_for_completion: false
+        index: test
+      allowed_warnings_regex:
+        - "Logging the completion of a task using .*LoggingTaskListener.* is deprecated.*"
+
+  - match: {task: '/.+:\d+/'}
+  - set: {task: task}
+  - is_false: updated
+  - is_false: version_conflicts
+  - is_false: batches
+  - is_false: failures
+  - is_false: noops
+  - is_false: took
+  - is_false: throttled_millis
+  - is_false: created
+  - is_false: deleted
+
+  - do:
+      tasks.get:
+        wait_for_completion: true
+        task_id: $task
+  - is_false: node_failures
+  # The task will be in the response even if it finished before we got here
+  # because of task persistence.
+  - is_true: task
+  - is_false: response.timed_out
+  - match: {response.updated: 1}
+  - match: {response.version_conflicts: 0}
+  - match: {response.batches: 1}
+  - match: {response.failures: []}
+  - match: {response.noops: 0}
+  - match: {response.throttled_millis: 0}
+  - gte: { response.took: 0 }
+  # Update by query can't create
+  - is_false: response.created
+  - is_false: response.task
+  - is_false: response.deleted
+
+---
+"wait_for_completion=false and log_task_completion=false":
+  - skip:
+      version: " - 8.12.99"
+      reason: ?log_task_completion parameter introduced in 8.13
+
+  - do:
+      index:
+        index:   test
+        id:      "1"
+        body:    { "text": "test" }
+  - do:
+      indices.refresh: {}
+
+  - do:
+      update_by_query:
+        wait_for_completion: false
+        log_task_completion: false
         index: test
   - match: {task: '/.+:\d+/'}
   - set: {task: task}

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/update_by_query/60_throttle.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/update_by_query/60_throttle.yml
@@ -66,6 +66,9 @@
 
 ---
 "Rethrottle to -1 which turns off throttling":
+  - skip:
+      features: allowed_warnings_regex
+
   # Throttling happens between each scroll batch so we need to control the size of the batch by using a single shard
   # and a small batch size on the request
   - do:
@@ -95,6 +98,8 @@
         wait_for_completion: false
         index: test
         scroll_size: 1
+      allowed_warnings_regex:
+        - "Logging the completion of a task using .*LoggingTaskListener.* is deprecated.*"
   - match: {task: '/.+:\d+/'}
   - set: {task: task}
 
@@ -110,6 +115,9 @@
 
 ---
 "Rethrottle but not unlimited":
+  - skip:
+      features: allowed_warnings_regex
+
   # Throttling happens between each scroll batch so we need to control the size of the batch by using a single shard
   # and a small batch size on the request
   - do:
@@ -139,6 +147,8 @@
         wait_for_completion: false
         index: test
         scroll_size: 1
+      allowed_warnings_regex:
+        - "Logging the completion of a task using .*LoggingTaskListener.* is deprecated.*"
   - match: {task: '/.+:\d+/'}
   - set: {task: task}
 

--- a/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/update_by_query/70_slices.yml
+++ b/modules/reindex/src/yamlRestTest/resources/rest-api-spec/test/update_by_query/70_slices.yml
@@ -55,7 +55,10 @@
 ---
 "Multiple slices with wait_for_completion=false":
   - skip:
-      features: warnings
+      features:
+        - warnings
+        - allowed_warnings_regex
+
   - do:
       index:
         index:   test
@@ -87,6 +90,8 @@
         body:
           query:
             match_all: {}
+      allowed_warnings_regex:
+        - "Logging the completion of a task using .*LoggingTaskListener.* is deprecated.*"
   - is_false: timed_out
   - match: {task: '/.+:\d+/'}
   - set: {task: task}
@@ -160,7 +165,10 @@
 ---
 "Multiple slices with rethrottle":
   - skip:
-      features: warnings
+      features:
+        - warnings
+        - allowed_warnings_regex
+
   - do:
       index:
         index:   test
@@ -204,6 +212,8 @@
         body:
           query:
             match_all: {}
+      allowed_warnings_regex:
+        - "Logging the completion of a task using .*LoggingTaskListener.* is deprecated.*"
   - is_false: timed_out
   - match: {task: '/.+:\d+/'}
   - set: {task: task}

--- a/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -17,6 +17,7 @@ import org.elasticsearch.Build;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.settings.RestClusterGetSettingsResponse;
 import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
@@ -41,6 +42,7 @@ import org.elasticsearch.test.cluster.FeatureFlag;
 import org.elasticsearch.test.cluster.local.LocalClusterConfigProvider;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.rest.ESRestTestCase;
+import org.elasticsearch.test.rest.LoggingTaskListenerWarningHandler;
 import org.elasticsearch.test.rest.ObjectPath;
 import org.elasticsearch.test.rest.RestTestLegacyFeatures;
 import org.elasticsearch.transport.Compression;
@@ -1660,6 +1662,7 @@ public class FullClusterRestartIT extends ParameterizedFullClusterRestartTestCas
                     .endObject()
             );
             reindex.addParameter("wait_for_completion", "false");
+            reindex.setOptions(RequestOptions.DEFAULT.toBuilder().setWarningsHandler(LoggingTaskListenerWarningHandler.INSTANCE));
             Map<String, Object> response = entityAsMap(client().performRequest(reindex));
             String taskId = (String) response.get("task");
 

--- a/qa/rolling-upgrade-legacy/src/test/resources/rest-api-spec/test/old_cluster/10_basic.yml
+++ b/qa/rolling-upgrade-legacy/src/test/resources/rest-api-spec/test/old_cluster/10_basic.yml
@@ -166,6 +166,9 @@
 
 ---
 "Create a task result record in the old cluster":
+  - skip:
+      features: allowed_warnings_regex
+
   - do:
       indices.create:
         index: reindexed_index
@@ -197,6 +200,8 @@
             size: 1
           dest:
             index: reindexed_index_copy
+      allowed_warnings_regex:
+        - "Logging the completion of a task using .*LoggingTaskListener.* is deprecated.*"
   - match: {task: '/.+:\d+/'}
   - set: {task: task}
 

--- a/qa/rolling-upgrade-legacy/src/test/resources/rest-api-spec/test/upgraded_cluster/10_basic.yml
+++ b/qa/rolling-upgrade-legacy/src/test/resources/rest-api-spec/test/upgraded_cluster/10_basic.yml
@@ -91,6 +91,7 @@
       features:
         - headers
         - warnings
+        - allowed_warnings_regex
 
   - do:
       warnings:
@@ -124,6 +125,8 @@
             size: 1
           dest:
             index: reindexed_index_another_copy
+      allowed_warnings_regex:
+        - "Logging the completion of a task using .*LoggingTaskListener.* is deprecated.*"
   - match: { task: '/.+:\d+/' }
   - set: { task: task_id }
 

--- a/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/FeatureUpgradeIT.java
+++ b/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/FeatureUpgradeIT.java
@@ -12,8 +12,10 @@ import com.carrotsearch.randomizedtesting.annotations.Name;
 
 import org.elasticsearch.action.admin.cluster.migration.TransportGetFeatureUpgradeStatusAction;
 import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.test.XContentTestUtils;
+import org.elasticsearch.test.rest.LoggingTaskListenerWarningHandler;
 
 import java.util.Collections;
 import java.util.List;
@@ -60,6 +62,7 @@ public class FeatureUpgradeIT extends ParameterizedRollingUpgradeTestCase {
                   }
                 }""");
             reindex.addParameter("wait_for_completion", "false");
+            reindex.setOptions(RequestOptions.DEFAULT.toBuilder().setWarningsHandler(LoggingTaskListenerWarningHandler.INSTANCE));
             Map<String, Object> response = entityAsMap(client().performRequest(reindex));
             String taskId = (String) response.get("task");
 

--- a/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/SystemIndicesUpgradeIT.java
+++ b/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/SystemIndicesUpgradeIT.java
@@ -11,9 +11,11 @@ package org.elasticsearch.upgrades;
 import com.carrotsearch.randomizedtesting.annotations.Name;
 
 import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.test.XContentTestUtils.JsonMapView;
+import org.elasticsearch.test.rest.LoggingTaskListenerWarningHandler;
 import org.elasticsearch.test.rest.RestTestLegacyFeatures;
 
 import java.util.Map;
@@ -59,6 +61,7 @@ public class SystemIndicesUpgradeIT extends ParameterizedRollingUpgradeTestCase 
                   }
                 }""");
             reindex.addParameter("wait_for_completion", "false");
+            reindex.setOptions(RequestOptions.DEFAULT.toBuilder().setWarningsHandler(LoggingTaskListenerWarningHandler.INSTANCE));
             Map<String, Object> response = entityAsMap(client().performRequest(reindex));
             String taskId = (String) response.get("task");
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query.json
@@ -169,6 +169,11 @@
         "type":"number|string",
         "default":1,
         "description":"The number of slices this task should be divided into. Defaults to 1, meaning the task isn't sliced into subtasks. Can be set to `auto`."
+      },
+      "log_task_completion":{
+        "type":"boolean",
+        "default":true,
+        "description":"If ?wait_for_completion is set, suppress the deprecated legacy completion message in the node logs."
       }
     },
     "body":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.forcemerge.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.forcemerge.json
@@ -68,6 +68,11 @@
         "type":"boolean",
         "default":true,
         "description":"Should the request wait until the force merge is completed."
+      },
+      "log_task_completion":{
+        "type":"boolean",
+        "default":true,
+        "description":"If ?wait_for_completion is set, suppress the deprecated legacy completion message in the node logs."
       }
     }
   }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/reindex.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/reindex.json
@@ -57,6 +57,11 @@
       "max_docs":{
         "type":"number",
         "description":"Maximum number of documents to process (default: all documents)"
+      },
+      "log_task_completion":{
+        "type":"boolean",
+        "default":true,
+        "description":"If ?wait_for_completion is set, suppress the deprecated legacy completion message in the node logs."
       }
     },
     "body":{

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query.json
@@ -177,6 +177,11 @@
         "type":"number|string",
         "default":1,
         "description":"The number of slices this task should be divided into. Defaults to 1, meaning the task isn't sliced into subtasks. Can be set to `auto`."
+      },
+      "log_task_completion":{
+        "type":"boolean",
+        "default":true,
+        "description":"If ?wait_for_completion is set, suppress the deprecated legacy completion message in the node logs."
       }
     },
     "body":{

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.forcemerge/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.forcemerge/10_basic.yml
@@ -33,6 +33,7 @@
 ---
 "Force merge with wait_for_completion parameter":
   - skip:
+      features: allowed_warnings_regex
       version: " - 8.0.99"
       reason: wait_for_completion is introduced since 8.1
 
@@ -44,6 +45,30 @@
       indices.forcemerge:
         max_num_segments: 1
         wait_for_completion: false
+      allowed_warnings_regex:
+        - "Logging the completion of a task using .*LoggingTaskListener.* is deprecated.*"
+  - match: { task: '/^\S+:\d+$/' }
+
+  - do:
+      tasks.list:
+        wait_for_completion: true
+
+---
+"Force merge with wait_for_completion and log_task_completion parameters":
+  - skip:
+      version: " - 8.12.99"
+      reason: ?log_task_completion parameter introduced in 8.13
+
+  - do:
+      indices.create:
+        index: test_index
+
+  - do:
+      indices.forcemerge:
+        max_num_segments: 1
+        wait_for_completion: false
+        log_task_completion: false
+
   - match: { task: '/^\S+:\d+$/' }
 
   - do:

--- a/server/src/main/java/org/elasticsearch/common/ReferenceDocs.java
+++ b/server/src/main/java/org/elasticsearch/common/ReferenceDocs.java
@@ -70,6 +70,7 @@ public enum ReferenceDocs {
     BOOTSTRAP_CHECK_TOKEN_SSL,
     BOOTSTRAP_CHECK_SECURITY_MINIMAL_SETUP,
     CONTACT_SUPPORT,
+    TASK_MANAGEMENT_API,
     // this comment keeps the ';' on the next line so every entry above has a trailing ',' which makes the diff for adding new links cleaner
     ;
 

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestForceMergeAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestForceMergeAction.java
@@ -12,7 +12,6 @@ import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.admin.indices.forcemerge.ForceMergeAction;
 import org.elasticsearch.action.admin.indices.forcemerge.ForceMergeRequest;
 import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.action.support.broadcast.BroadcastResponse;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.Strings;
@@ -65,10 +64,13 @@ public class RestForceMergeAction extends BaseRestHandler {
             if (validationException != null) {
                 throw validationException;
             }
-            final var responseListener = new SubscribableListener<BroadcastResponse>();
-            final var task = client.executeLocally(ForceMergeAction.INSTANCE, mergeRequest, responseListener);
-            responseListener.addListener(new LoggingTaskListener<>(task));
-            return sendTask(client.getLocalNodeId(), task);
+            return sendTask(
+                client.getLocalNodeId(),
+                LoggingTaskListener.<BroadcastResponse>runWithLoggingTaskListener(
+                    request.paramAsBoolean(LoggingTaskListener.LOGGING_ENABLED_QUERY_PARAMETER, true),
+                    l -> client.executeLocally(ForceMergeAction.INSTANCE, mergeRequest, l)
+                )
+            );
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/tasks/LoggingTaskListener.java
+++ b/server/src/main/java/org/elasticsearch/tasks/LoggingTaskListener.java
@@ -11,6 +11,13 @@ package org.elasticsearch.tasks;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.SubscribableListener;
+import org.elasticsearch.common.ReferenceDocs;
+import org.elasticsearch.common.logging.DeprecationCategory;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.core.UpdateForV9;
+
+import java.util.function.Function;
 
 import static org.elasticsearch.core.Strings.format;
 
@@ -20,11 +27,13 @@ import static org.elasticsearch.core.Strings.format;
  */
 public final class LoggingTaskListener<Response> implements ActionListener<Response> {
 
+    public static final String LOGGING_ENABLED_QUERY_PARAMETER = "log_task_completion";
     private static final Logger logger = LogManager.getLogger(LoggingTaskListener.class);
+    private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(LoggingTaskListener.class);
 
     private final Task task;
 
-    public LoggingTaskListener(Task task) {
+    private LoggingTaskListener(Task task) {
         this.task = task;
     }
 
@@ -36,5 +45,28 @@ public final class LoggingTaskListener<Response> implements ActionListener<Respo
     @Override
     public void onFailure(Exception e) {
         logger.warn(() -> format("%s failed with exception", task.getId()), e);
+    }
+
+    @UpdateForV9 // always just use noop() in v9
+    public static <Response> Task runWithLoggingTaskListener(boolean enabled, Function<ActionListener<Response>, Task> taskSupplier) {
+        if (enabled == false) {
+            return taskSupplier.apply(ActionListener.noop());
+        }
+
+        deprecationLogger.warn(
+            DeprecationCategory.OTHER,
+            "logging_task_listener",
+            """
+                Logging the completion of a task using [{}] is deprecated and will be removed in a future version. Instead, use the task \
+                management API [{}] to monitor long-running tasks for completion. To suppress this warning and opt-in to the future \
+                behaviour now, set [?{}=false] when calling the affected API.""",
+            LoggingTaskListener.class.getCanonicalName(),
+            ReferenceDocs.TASK_MANAGEMENT_API,
+            LOGGING_ENABLED_QUERY_PARAMETER
+        );
+        final var responseListener = new SubscribableListener<Response>();
+        final var task = taskSupplier.apply(responseListener);
+        responseListener.addListener(new LoggingTaskListener<>(task));
+        return task;
     }
 }

--- a/server/src/main/resources/org/elasticsearch/common/reference-docs-links.json
+++ b/server/src/main/resources/org/elasticsearch/common/reference-docs-links.json
@@ -30,5 +30,6 @@
   "BOOTSTRAP_CHECK_TLS": "bootstrap-checks-xpack.html#bootstrap-checks-tls",
   "BOOTSTRAP_CHECK_TOKEN_SSL": "bootstrap-checks-xpack.html#_token_ssl_check",
   "BOOTSTRAP_CHECK_SECURITY_MINIMAL_SETUP": "security-minimal-setup.html",
-  "CONTACT_SUPPORT": "troubleshooting.html#troubleshooting-contact-support"
+  "CONTACT_SUPPORT": "troubleshooting.html#troubleshooting-contact-support",
+  "TASK_MANAGEMENT_API": "tasks.html"
 }

--- a/server/src/test/java/org/elasticsearch/tasks/LoggingTaskListenerTests.java
+++ b/server/src/test/java/org/elasticsearch/tasks/LoggingTaskListenerTests.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.tasks;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.LogEvent;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.support.SubscribableListener;
+import org.elasticsearch.common.ReferenceDocs;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.core.UpdateForV9;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockLogAppender;
+
+import java.util.Map;
+
+@UpdateForV9 // this logging can be removed in v9
+public class LoggingTaskListenerTests extends ESTestCase {
+
+    private static Task createTask() {
+        return new Task(randomNonNegativeLong(), "test", "test:action", "", TaskId.EMPTY_TASK_ID, Map.of());
+    }
+
+    private static SubscribableListener<Void> runTask(Task task, boolean legacyLoggingEnabled) {
+        final var listeners = new SubscribableListener<Void>();
+        assertSame(task, LoggingTaskListener.<Void>runWithLoggingTaskListener(legacyLoggingEnabled, l -> {
+            listeners.addListener(l);
+            return task;
+        }));
+        return listeners;
+    }
+
+    private void assertDeprecationWarning() {
+        assertWarnings(Strings.format("""
+            Logging the completion of a task using [org.elasticsearch.tasks.LoggingTaskListener] is deprecated and will be \
+            removed in a future version. Instead, use the task management API [%s] to monitor long-running tasks for completion. \
+            To suppress this warning and opt-in to the future behaviour now, set [?log_task_completion=false] when calling the \
+            affected API.""", ReferenceDocs.TASK_MANAGEMENT_API));
+    }
+
+    public void testLogSuccess() {
+        final var task = createTask();
+        final var listeners = runTask(task, true);
+
+        assertDeprecationWarning();
+        MockLogAppender.assertThatLogger(
+            () -> listeners.onResponse(null),
+            LoggingTaskListener.class,
+            new MockLogAppender.SeenEventExpectation(
+                "completion",
+                LoggingTaskListener.class.getCanonicalName(),
+                Level.INFO,
+                task.getId() + " finished with response null"
+            )
+        );
+    }
+
+    public void testLogFailure() {
+        final var task = createTask();
+        final var listeners = runTask(task, true);
+
+        assertDeprecationWarning();
+        MockLogAppender.assertThatLogger(
+            () -> listeners.onFailure(new ElasticsearchException("simulated")),
+            LoggingTaskListener.class,
+            new MockLogAppender.SeenEventExpectation(
+                "completion",
+                LoggingTaskListener.class.getCanonicalName(),
+                Level.WARN,
+                task.getId() + " failed with exception"
+            )
+        );
+    }
+
+    public void testNoLogSuccess() {
+        final var task = createTask();
+        final var listeners = runTask(task, false);
+
+        MockLogAppender.assertThatLogger(
+            () -> listeners.onResponse(null),
+            LoggingTaskListener.class,
+            new MockLogAppender.LoggingExpectation() {
+                @Override
+                public void match(LogEvent event) {
+                    fail("should see no log messages");
+                }
+
+                @Override
+                public void assertMatched() {}
+            }
+        );
+    }
+
+    public void testNoLogFailure() {
+        final var task = createTask();
+        final var listeners = runTask(task, false);
+
+        MockLogAppender.assertThatLogger(
+            () -> listeners.onFailure(new ElasticsearchException("simulated")),
+            LoggingTaskListener.class,
+            new MockLogAppender.LoggingExpectation() {
+                @Override
+                public void match(LogEvent event) {
+                    fail("should see no log messages");
+                }
+
+                @Override
+                public void assertMatched() {}
+            }
+        );
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/LoggingTaskListenerWarningHandler.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/LoggingTaskListenerWarningHandler.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.test.rest;
+
+import org.elasticsearch.client.WarningsHandler;
+import org.elasticsearch.core.UpdateForV9;
+import org.elasticsearch.tasks.LoggingTaskListener;
+
+import java.util.List;
+
+@UpdateForV9 // this warning won't be emitted in v9 so this can be removed
+public class LoggingTaskListenerWarningHandler implements WarningsHandler {
+
+    public static final LoggingTaskListenerWarningHandler INSTANCE = new LoggingTaskListenerWarningHandler();
+
+    private LoggingTaskListenerWarningHandler() {}
+
+    @Override
+    public boolean warningsShouldFailRequest(List<String> warnings) {
+        return warnings.stream()
+            .anyMatch(
+                s -> s.startsWith(
+                    "Logging the completion of a task using ["
+                        + LoggingTaskListener.class.getCanonicalName()
+                        + "] is deprecated and will be removed in a future version."
+                ) == false
+            );
+    }
+}

--- a/x-pack/qa/reindex-tests-with-security/src/yamlRestTest/resources/rest-api-spec/test/10_reindex.yml
+++ b/x-pack/qa/reindex-tests-with-security/src/yamlRestTest/resources/rest-api-spec/test/10_reindex.yml
@@ -314,6 +314,9 @@ setup:
 
 ---
 "Reindex wait_for_completion=false as minimal with task API":
+  - skip:
+      features:
+        - allowed_warnings_regex
 
   - do:
       index:
@@ -333,6 +336,8 @@ setup:
             index: source
           dest:
             index: dest
+      allowed_warnings_regex:
+        - "Logging the completion of a task using .*LoggingTaskListener.* is deprecated.*"
   - set: {task: task}
 
   - do:


### PR DESCRIPTION
As noted in #104278 this logging is fairly unusable since it only
mentions the task ID. It dates back to the early days of the reindex
feature and was introduced before the task management APIs, but the task
management APIs are today the preferred mechanism for monitoring
long-running tasks. This commit deprecates the logger and introduces a
setting that allows it to be disabled, in preparation for its removal in
the next major version.

Closes #104278