### PR TITLE
Fix snapshot version in `createSnapshotLegacy`

### DIFF
--- a/docs/changelog/104354.yaml
+++ b/docs/changelog/104354.yaml
@@ -1,0 +1,6 @@
+pr: 104354
+summary: Fix snapshot version in `createSnapshotLegacy`
+area: Snapshot/Restore
+type: bug
+issues:
+ - 86889


### PR DESCRIPTION
We shouldn't use `Version#CURRENT` for the snapshot version anywhere,
but especially not on the legacy path.

Closes #86889