### PR TITLE
[Profiling] Extract properties faster from source

### DIFF
--- a/docs/changelog/104356.yaml
+++ b/docs/changelog/104356.yaml
@@ -1,0 +1,5 @@
+pr: 104356
+summary: "[Profiling] Extract properties faster from source"
+area: Application
+type: enhancement
+issues: []

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/StackTrace.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/StackTrace.java
@@ -20,6 +20,9 @@ import java.util.Objects;
 import java.util.function.Consumer;
 
 final class StackTrace implements ToXContentObject {
+    private static final String[] PATH_FRAME_IDS = new String[] { "Stacktrace", "frame", "ids" };
+    private static final String[] PATH_FRAME_TYPES = new String[] { "Stacktrace", "frame", "types" };
+
     static final int NATIVE_FRAME_TYPE = 3;
     static final int KERNEL_FRAME_TYPE = 4;
     List<Integer> addressOrLines;
@@ -188,8 +191,8 @@ final class StackTrace implements ToXContentObject {
     }
 
     public static StackTrace fromSource(Map<String, Object> source) {
-        String inputFrameIDs = ObjectPath.eval("Stacktrace.frame.ids", source);
-        String inputFrameTypes = ObjectPath.eval("Stacktrace.frame.types", source);
+        String inputFrameIDs = ObjectPath.eval(PATH_FRAME_IDS, source);
+        String inputFrameTypes = ObjectPath.eval(PATH_FRAME_TYPES, source);
         int countsFrameIDs = inputFrameIDs.length() / BASE64_FRAME_ID_LENGTH;
 
         List<String> fileIDs = new ArrayList<>(countsFrameIDs);

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStackTracesAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStackTracesAction.java
@@ -683,6 +683,7 @@ public class TransportGetStackTracesAction extends TransportAction<GetStackTrace
      * Collects stack trace details which are retrieved concurrently and sends a response only when all details are known.
      */
     private static class DetailsHandler {
+        private static final String[] PATH_FILE_NAME = new String[] { "Executable", "file", "name" };
         private final GetStackTracesResponseBuilder builder;
         private final ActionListener<GetStackTracesResponse> submitListener;
         private final Map<String, String> executables;
@@ -740,7 +741,7 @@ public class TransportGetStackTracesAction extends TransportAction<GetStackTrace
                 if (executable.getResponse().isExists()) {
                     // Duplicates are expected as we query multiple indices - do a quick pre-check before we deserialize a response
                     if (executables.containsKey(executable.getId()) == false) {
-                        String fileName = ObjectPath.eval("Executable.file.name", executable.getResponse().getSource());
+                        String fileName = ObjectPath.eval(PATH_FILE_NAME, executable.getResponse().getSource());
                         if (fileName != null) {
                             executables.putIfAbsent(executable.getId(), fileName);
                         } else {


### PR DESCRIPTION
Previously the extraction code for reading stacktrace and executable properties has used an implementation of `ObjectPath#eval()` that split the provided object path using a regex. As the object path is constant and known in advance we can directly provide the final object path avoiding this costly step.
