### PR TITLE
Account for shard count in profiling test timeout

### DIFF
--- a/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/CancellationIT.java
+++ b/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/CancellationIT.java
@@ -10,7 +10,6 @@ package org.elasticsearch.xpack.profiling;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.logging.log4j.LogManager;
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoResponse;
@@ -49,7 +48,6 @@ import static org.elasticsearch.action.support.ActionTestUtils.wrapAsRestRespons
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
 
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/103809")
 public class CancellationIT extends ProfilingTestCase {
     @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {

--- a/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/GetFlameGraphActionIT.java
+++ b/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/GetFlameGraphActionIT.java
@@ -7,9 +7,6 @@
 
 package org.elasticsearch.xpack.profiling;
 
-import org.apache.lucene.tests.util.LuceneTestCase;
-
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/103809")
 public class GetFlameGraphActionIT extends ProfilingTestCase {
     public void testGetStackTracesUnfiltered() throws Exception {
         GetStackTracesRequest request = new GetStackTracesRequest(1000, 600.0d, 1.0d, null, null, null, null, null, null, null, null);

--- a/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/GetStackTracesActionIT.java
+++ b/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/GetStackTracesActionIT.java
@@ -7,13 +7,11 @@
 
 package org.elasticsearch.xpack.profiling;
 
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.TermQueryBuilder;
 
 import java.util.List;
 
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/103809")
 public class GetStackTracesActionIT extends ProfilingTestCase {
     public void testGetStackTracesUnfiltered() throws Exception {
         GetStackTracesRequest request = new GetStackTracesRequest(1000, 600.0d, 1.0d, null, null, null, null, null, null, null, null);

--- a/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/ProfilingTestCase.java
+++ b/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/ProfilingTestCase.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.common.network.NetworkModule;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.datastreams.DataStreamsPlugin;
 import org.elasticsearch.license.LicenseSettings;
 import org.elasticsearch.plugins.Plugin;
@@ -127,7 +128,8 @@ public abstract class ProfilingTestCase extends ESIntegTestCase {
         );
         allIndices.add(apmTestIndex);
         waitForIndices(allIndices);
-        ensureGreen(allIndices.toArray(new String[0]));
+        // higher timeout since we have more shards than usual
+        ensureGreen(TimeValue.timeValueSeconds(120), allIndices.toArray(new String[0]));
 
         bulkIndex("data/profiling-events-all.ndjson");
         bulkIndex("data/profiling-stacktraces.ndjson");


### PR DESCRIPTION
With this commit we increase the timeout to wait for a green cluster state in the integration tests for the profiling plugin. We do this because the tests create all profiling-related indices with more shards than usual and that might take longer than usual until the cluster is green.

Closes #103809