### PR TITLE
Add .status to end of HealthPeriodicLogger metric names

### DIFF
--- a/server/src/main/java/org/elasticsearch/health/HealthPeriodicLogger.java
+++ b/server/src/main/java/org/elasticsearch/health/HealthPeriodicLogger.java
@@ -374,7 +374,7 @@ public class HealthPeriodicLogger implements ClusterStateListener, Closeable, Sc
                 if (metric == null) {
                     metric = LongGaugeMetric.create(
                         this.meterRegistry,
-                        String.format(Locale.ROOT, "es.health.%s.red", metricName),
+                        String.format(Locale.ROOT, "es.health.%s.red.status", metricName),
                         String.format(Locale.ROOT, "%s: Red", metricName),
                         "{cluster}"
                     );


### PR DESCRIPTION
This adds `.status` to the end of the APM metrics in `HealthPeriodicLogger`. PR https://github.com/elastic/elasticsearch/pull/103388 added the validation for the metric names.