### PR TITLE
[8.12] Don't throw error for remote shards that open PIT filtered out (#104288)

### DIFF
--- a/docs/changelog/104288.yaml
+++ b/docs/changelog/104288.yaml
@@ -1,0 +1,6 @@
+pr: 104288
+summary: Don't throw error for remote shards that open PIT filtered out
+area: Search
+type: bug
+issues:
+ - 102596

--- a/qa/ccs-common-rest/build.gradle
+++ b/qa/ccs-common-rest/build.gradle
@@ -40,8 +40,7 @@ tasks.named("yamlRestTest") {
       'search.aggregation/220_filters_bucket/cache hits', // node_selector?
       'search.aggregation/50_filter/Standard queries get cached',
       'search.aggregation/50_filter/Terms lookup gets cached', // terms lookup by "index" doesn't seem to work correctly
-      'search.aggregation/70_adjacency_matrix/Terms lookup', // terms lookup by "index" doesn't seem to work correctly
-      'search/350_point_in_time/point-in-time with index filter'
+      'search.aggregation/70_adjacency_matrix/Terms lookup' // terms lookup by "index" doesn't seem to work correctly
     ].join(',')
 }
 

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/350_point_in_time.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/350_point_in_time.yml
@@ -23,6 +23,10 @@ setup:
   - do:
       indices.create:
         index:  test2
+        body:
+          settings:
+            index:
+              number_of_shards: 2
 
   - do:
       index:

--- a/server/src/main/java/org/elasticsearch/action/search/TransportOpenPointInTimeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportOpenPointInTimeAction.java
@@ -132,6 +132,9 @@ public class TransportOpenPointInTimeAction extends HandledTransportAction<OpenP
             ThreadPool threadPool,
             SearchResponse.Clusters clusters
         ) {
+            // Note: remote shards are prefiltered via can match as part of search shards. They don't need additional pre-filtering and
+            // that is signaled to the local can match through the SearchShardIterator#prefiltered flag. Local shards do need to go
+            // through the local can match phase.
             if (SearchService.canRewriteToMatchNone(searchRequest.source())) {
                 return new CanMatchPreFilterSearchPhase(
                     logger,


### PR DESCRIPTION
Backports the following commits to 8.12:
 - Don't throw error for remote shards that open PIT filtered out (#104288)