### PR TITLE
Treat failed shard as no data in GetStatusActionIT

### DIFF
--- a/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/GetStatusActionIT.java
+++ b/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/GetStatusActionIT.java
@@ -52,10 +52,11 @@ public class GetStatusActionIT extends ProfilingTestCase {
         assertFalse(response.hasData());
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/104035")
     public void testWaitsUntilResourcesAreCreated() throws Exception {
         updateProfilingTemplatesEnabled(true);
         GetStatusAction.Request request = new GetStatusAction.Request();
+        // higher timeout since we have more shards than usual
+        request.timeout(TimeValue.timeValueSeconds(120));
         request.waitForResourcesCreated(true);
 
         GetStatusAction.Response response = client().execute(GetStatusAction.INSTANCE, request).get();

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStatusAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStatusAction.java
@@ -9,7 +9,9 @@ package org.elasticsearch.xpack.profiling;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -177,7 +179,17 @@ public class TransportGetStatusAction extends TransportMasterNodeAction<GetStatu
                     listener.onResponse(
                         new GetStatusAction.Response(pluginEnabled, resourceManagementEnabled, resourcesCreated, anyPre891Data, hasData)
                     );
-                }, listener::onFailure));
+                }, (e) -> {
+                    // no data yet
+                    if (e instanceof SearchPhaseExecutionException) {
+                        log.trace("Has data check has failed.", e);
+                        listener.onResponse(
+                            new GetStatusAction.Response(pluginEnabled, resourceManagementEnabled, resourcesCreated, anyPre891Data, false)
+                        );
+                    } else {
+                        listener.onFailure(e);
+                    }
+                }));
             } else {
                 listener.onResponse(new GetStatusAction.Response(pluginEnabled, resourceManagementEnabled, false, anyPre891Data, false));
             }

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStatusAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStatusAction.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.profiling;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchRequest;

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/profiling/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/profiling/10_basic.yml
@@ -1,10 +1,8 @@
 ---
 setup:
   - skip:
-      version: all
-      reason: AwaitsFix https://github.com/elastic/elasticsearch/issues/104038
-      # version: " - 8.12.99"
-      # reason: "Universal Profiling test infrastructure is available in 8.12+"
+      version: " - 8.12.99"
+      reason: "Universal Profiling test infrastructure is available in 8.12+"
 
   - do:
       cluster.put_settings:


### PR DESCRIPTION
Among other things, the profiling get status API checks whether a cluster contains any profiling-related data. It uses the search API for that internally since #103920. However, shards might not be ready shortly after index creation and consequently that search request will fail.

With this commit we check whether a search phase has failed and treat this as if the cluster contains no profiling-related data.

Closes #104035
Closes #104038