### PR TITLE
Fix CoreFullClusterRestartIT testRollover

### DIFF
--- a/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -605,7 +605,7 @@ public class FullClusterRestartIT extends ParameterizedFullClusterRestartTestCas
      *  <li>Make sure the document count is correct
      * </ol>
      */
-    public void testRollover() throws IOException {
+    public void testRollover() throws Exception {
         if (isRunningAgainstOldCluster()) {
             client().performRequest(
                 newXContentRequest(
@@ -637,9 +637,11 @@ public class FullClusterRestartIT extends ParameterizedFullClusterRestartTestCas
                 )
             );
 
-            assertThat(
-                EntityUtils.toString(client().performRequest(new Request("GET", "/_cat/indices?v")).getEntity()),
-                containsString("testrollover-000002")
+            assertBusy(
+                () -> assertThat(
+                    EntityUtils.toString(client().performRequest(new Request("GET", "/_cat/indices?v")).getEntity()),
+                    containsString("testrollover-000002")
+                )
             );
         }
 

--- a/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -637,6 +637,7 @@ public class FullClusterRestartIT extends ParameterizedFullClusterRestartTestCas
                 )
             );
 
+            // assertBusy to work around https://github.com/elastic/elasticsearch/issues/104371
             assertBusy(
                 () -> assertThat(
                     EntityUtils.toString(client().performRequest(new Request("GET", "/_cat/indices?v")).getEntity()),

--- a/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -640,7 +640,7 @@ public class FullClusterRestartIT extends ParameterizedFullClusterRestartTestCas
             // assertBusy to work around https://github.com/elastic/elasticsearch/issues/104371
             assertBusy(
                 () -> assertThat(
-                    EntityUtils.toString(client().performRequest(new Request("GET", "/_cat/indices?v")).getEntity()),
+                    EntityUtils.toString(client().performRequest(new Request("GET", "/_cat/indices?v&error_trace")).getEntity()),
                     containsString("testrollover-000002")
                 )
             );


### PR DESCRIPTION
Closes #97809

#104371 is the root issue here, and since the test in question isn't really primarily about testing the cat APIs specifically, I think it's fair to 'just' workaround the bug in the extremely rare case that it happens to come up.