### PR TITLE
Added more information to the "deprecation" log for `skip: feature`

### DIFF
--- a/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/ClientYamlTestSection.java
+++ b/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/ClientYamlTestSection.java
@@ -28,7 +28,7 @@ public class ClientYamlTestSection implements Comparable<ClientYamlTestSection> 
         List<ExecutableSection> executableSections = new ArrayList<>();
         try {
             parser.nextToken();
-            PrerequisiteSection prerequisiteSection = PrerequisiteSection.parseIfNext(parser);
+            PrerequisiteSection prerequisiteSection = PrerequisiteSection.parseIfNext(parser, sectionName);
             while (parser.currentToken() != XContentParser.Token.END_ARRAY) {
                 ParserUtils.advanceToFieldName(parser);
                 executableSections.add(ExecutableSection.parse(parser));

--- a/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/PrerequisiteSection.java
+++ b/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/PrerequisiteSection.java
@@ -183,8 +183,8 @@ public class PrerequisiteSection {
     /**
      * Parse a {@link PrerequisiteSection} if the next field is {@code skip}, otherwise returns {@link PrerequisiteSection#EMPTY}.
      */
-    public static PrerequisiteSection parseIfNext(XContentParser parser) throws IOException {
-        return parseInternal(parser).build();
+    public static PrerequisiteSection parseIfNext(XContentParser parser, String testName) throws IOException {
+        return parseInternal(parser, testName).build();
     }
 
     private static void maybeAdvanceToNextField(XContentParser parser) throws IOException {
@@ -194,14 +194,14 @@ public class PrerequisiteSection {
         }
     }
 
-    static PrerequisiteSectionBuilder parseInternal(XContentParser parser) throws IOException {
+    static PrerequisiteSectionBuilder parseInternal(XContentParser parser, String testName) throws IOException {
         PrerequisiteSectionBuilder builder = new PrerequisiteSectionBuilder();
         var hasPrerequisiteSection = false;
         var unknownFieldName = false;
         ParserUtils.advanceToFieldName(parser);
         while (unknownFieldName == false) {
             if ("skip".equals(parser.currentName())) {
-                parseSkipSection(parser, builder);
+                parseSkipSection(parser, builder, testName);
                 hasPrerequisiteSection = true;
                 maybeAdvanceToNextField(parser);
             } else if ("requires".equals(parser.currentName())) {
@@ -232,7 +232,7 @@ public class PrerequisiteSection {
     }
 
     // package private for tests
-    static void parseSkipSection(XContentParser parser, PrerequisiteSectionBuilder builder) throws IOException {
+    static void parseSkipSection(XContentParser parser, PrerequisiteSectionBuilder builder, String testName) throws IOException {
         if (parser.nextToken() != XContentParser.Token.START_OBJECT) {
             throw new IllegalArgumentException(
                 "Expected ["
@@ -256,8 +256,10 @@ public class PrerequisiteSection {
                 } else if ("features".equals(currentFieldName)) {
                     // TODO: legacy - remove
                     logger.warn(
-                        "[\"skip\": \"features\"] is deprecated and will be removed. Replace it with "
-                            + "[\"requires\": \"test_runner_features\"]"
+                        "[\"skip\": \"features\"] is deprecated. Replace it with "
+                            + "[\"requires\": \"test_runner_features\"]. Test [\"{}\"], Location: [{}]",
+                        testName,
+                        parser.getTokenLocation()
                     );
                     parseFeatureField(parser.text(), builder);
                 } else if ("os".equals(currentFieldName)) {
@@ -273,8 +275,10 @@ public class PrerequisiteSection {
             } else if (token == XContentParser.Token.START_ARRAY) {
                 // TODO: legacy - remove
                 logger.warn(
-                    "[\"skip\": \"features\"] is deprecated and will be removed. Replace it with "
-                        + "[\"requires\": \"test_runner_features\"]"
+                    "[\"skip\": \"features\"] is deprecated. Replace it with "
+                        + "[\"requires\": \"test_runner_features\"]. Test [\"{}\"], Location: [{}]",
+                    testName,
+                    parser.getTokenLocation()
                 );
                 if ("features".equals(currentFieldName)) {
                     while (parser.nextToken() != XContentParser.Token.END_ARRAY) {

--- a/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/SetupSection.java
+++ b/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/SetupSection.java
@@ -36,7 +36,7 @@ public class SetupSection {
     }
 
     public static SetupSection parse(XContentParser parser) throws IOException {
-        PrerequisiteSection prerequisiteSection = PrerequisiteSection.parseIfNext(parser);
+        PrerequisiteSection prerequisiteSection = PrerequisiteSection.parseIfNext(parser, "setup");
         List<ExecutableSection> executableSections = new ArrayList<>();
         while (parser.currentToken() != XContentParser.Token.END_ARRAY) {
             ParserUtils.advanceToFieldName(parser);

--- a/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/TeardownSection.java
+++ b/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/TeardownSection.java
@@ -35,7 +35,7 @@ public class TeardownSection {
     }
 
     public static TeardownSection parse(XContentParser parser) throws IOException {
-        PrerequisiteSection prerequisiteSection = PrerequisiteSection.parseIfNext(parser);
+        PrerequisiteSection prerequisiteSection = PrerequisiteSection.parseIfNext(parser, "teardown");
         List<ExecutableSection> executableSections = new ArrayList<>();
         while (parser.currentToken() != XContentParser.Token.END_ARRAY) {
             ParserUtils.advanceToFieldName(parser);

--- a/test/yaml-rest-runner/src/test/java/org/elasticsearch/test/rest/yaml/section/PrerequisiteSectionTests.java
+++ b/test/yaml-rest-runner/src/test/java/org/elasticsearch/test/rest/yaml/section/PrerequisiteSectionTests.java
@@ -210,7 +210,7 @@ public class PrerequisiteSectionTests extends AbstractClientYamlTestFragmentPars
             do:
                something
             """);
-        var skipSectionBuilder = PrerequisiteSection.parseInternal(parser);
+        var skipSectionBuilder = PrerequisiteSection.parseInternal(parser, "test");
         assertThat(skipSectionBuilder, notNullValue());
 
         var skipSection = skipSectionBuilder.build();
@@ -229,7 +229,7 @@ public class PrerequisiteSectionTests extends AbstractClientYamlTestFragmentPars
             reason:      Delete ignores the parent param""", version));
 
         var skipSectionBuilder = new PrerequisiteSection.PrerequisiteSectionBuilder();
-        PrerequisiteSection.parseSkipSection(parser, skipSectionBuilder);
+        PrerequisiteSection.parseSkipSection(parser, skipSectionBuilder, "test");
         assertThat(skipSectionBuilder, notNullValue());
         assertThat(skipSectionBuilder.skipVersionRange, not(emptyOrNullString()));
         assertThat(skipSectionBuilder.requiredYamlRunnerFeatures.size(), equalTo(0));
@@ -240,7 +240,7 @@ public class PrerequisiteSectionTests extends AbstractClientYamlTestFragmentPars
         parser = createParser(YamlXContent.yamlXContent, "features:     regex");
 
         var skipSectionBuilder = new PrerequisiteSection.PrerequisiteSectionBuilder();
-        PrerequisiteSection.parseSkipSection(parser, skipSectionBuilder);
+        PrerequisiteSection.parseSkipSection(parser, skipSectionBuilder, "test");
         assertThat(skipSectionBuilder, notNullValue());
         assertThat(skipSectionBuilder.skipVersionRange, emptyOrNullString());
         assertThat(skipSectionBuilder.requiredYamlRunnerFeatures, contains("regex"));
@@ -252,7 +252,7 @@ public class PrerequisiteSectionTests extends AbstractClientYamlTestFragmentPars
         parser = createParser(YamlXContent.yamlXContent, "features:     xpack");
 
         var skipSectionBuilder = new PrerequisiteSection.PrerequisiteSectionBuilder();
-        PrerequisiteSection.parseSkipSection(parser, skipSectionBuilder);
+        PrerequisiteSection.parseSkipSection(parser, skipSectionBuilder, "test");
         assertThat(skipSectionBuilder, notNullValue());
         assertThat(skipSectionBuilder.skipVersionRange, emptyOrNullString());
         assertThat(skipSectionBuilder.requiredYamlRunnerFeatures, empty());
@@ -264,7 +264,7 @@ public class PrerequisiteSectionTests extends AbstractClientYamlTestFragmentPars
         parser = createParser(YamlXContent.yamlXContent, "features:     no_xpack");
 
         var skipSectionBuilder = new PrerequisiteSection.PrerequisiteSectionBuilder();
-        PrerequisiteSection.parseSkipSection(parser, skipSectionBuilder);
+        PrerequisiteSection.parseSkipSection(parser, skipSectionBuilder, "test");
         assertThat(skipSectionBuilder, notNullValue());
         assertThat(skipSectionBuilder.skipVersionRange, emptyOrNullString());
         assertThat(skipSectionBuilder.requiredYamlRunnerFeatures, empty());
@@ -278,7 +278,7 @@ public class PrerequisiteSectionTests extends AbstractClientYamlTestFragmentPars
                features:     [xpack, no_xpack]
             """);
 
-        var e = expectThrows(ParsingException.class, () -> PrerequisiteSection.parseInternal(parser));
+        var e = expectThrows(ParsingException.class, () -> PrerequisiteSection.parseInternal(parser, "test"));
         assertThat(e.getMessage(), containsString("either [xpack] or [no_xpack] can be present, not both"));
     }
 
@@ -286,7 +286,7 @@ public class PrerequisiteSectionTests extends AbstractClientYamlTestFragmentPars
         parser = createParser(YamlXContent.yamlXContent, "features:     [regex1,regex2,regex3]");
 
         var skipSectionBuilder = new PrerequisiteSection.PrerequisiteSectionBuilder();
-        PrerequisiteSection.parseSkipSection(parser, skipSectionBuilder);
+        PrerequisiteSection.parseSkipSection(parser, skipSectionBuilder, "test");
         assertThat(skipSectionBuilder, notNullValue());
         assertThat(skipSectionBuilder.skipVersionRange, emptyOrNullString());
         assertThat(skipSectionBuilder.requiredYamlRunnerFeatures, contains("regex1", "regex2", "regex3"));
@@ -300,7 +300,7 @@ public class PrerequisiteSectionTests extends AbstractClientYamlTestFragmentPars
             reason:      Delete ignores the parent param""");
 
         var skipSectionBuilder = new PrerequisiteSection.PrerequisiteSectionBuilder();
-        PrerequisiteSection.parseSkipSection(parser, skipSectionBuilder);
+        PrerequisiteSection.parseSkipSection(parser, skipSectionBuilder, "test");
         assertThat(skipSectionBuilder.skipVersionRange, not(emptyOrNullString()));
         assertThat(skipSectionBuilder.requiredYamlRunnerFeatures, contains("regex"));
         assertThat(skipSectionBuilder.skipReason, equalTo("Delete ignores the parent param"));
@@ -312,7 +312,7 @@ public class PrerequisiteSectionTests extends AbstractClientYamlTestFragmentPars
                version: " - 0.90.2"
             """);
 
-        Exception e = expectThrows(ParsingException.class, () -> PrerequisiteSection.parseInternal(parser));
+        Exception e = expectThrows(ParsingException.class, () -> PrerequisiteSection.parseInternal(parser, "test"));
         assertThat(e.getMessage(), is("reason is mandatory within skip version section"));
     }
 
@@ -322,7 +322,7 @@ public class PrerequisiteSectionTests extends AbstractClientYamlTestFragmentPars
                reason:      Delete ignores the parent param
             """);
 
-        Exception e = expectThrows(ParsingException.class, () -> PrerequisiteSection.parseInternal(parser));
+        Exception e = expectThrows(ParsingException.class, () -> PrerequisiteSection.parseInternal(parser, "test"));
         assertThat(
             e.getMessage(),
             is("at least one criteria (version, cluster features, runner features, os) is mandatory within a skip section")
@@ -337,7 +337,7 @@ public class PrerequisiteSectionTests extends AbstractClientYamlTestFragmentPars
             """);
 
         var skipSectionBuilder = new PrerequisiteSection.PrerequisiteSectionBuilder();
-        PrerequisiteSection.parseSkipSection(parser, skipSectionBuilder);
+        PrerequisiteSection.parseSkipSection(parser, skipSectionBuilder, "test");
         assertThat(skipSectionBuilder, notNullValue());
         assertThat(skipSectionBuilder.skipVersionRange, emptyOrNullString());
         assertThat(skipSectionBuilder.requiredYamlRunnerFeatures, hasSize(2));
@@ -353,7 +353,7 @@ public class PrerequisiteSectionTests extends AbstractClientYamlTestFragmentPars
             """);
 
         var skipSectionBuilder = new PrerequisiteSection.PrerequisiteSectionBuilder();
-        PrerequisiteSection.parseSkipSection(parser, skipSectionBuilder);
+        PrerequisiteSection.parseSkipSection(parser, skipSectionBuilder, "test");
         assertThat(skipSectionBuilder, notNullValue());
         assertThat(skipSectionBuilder.skipVersionRange, emptyOrNullString());
         assertThat(skipSectionBuilder.requiredYamlRunnerFeatures, hasSize(1));
@@ -371,7 +371,7 @@ public class PrerequisiteSectionTests extends AbstractClientYamlTestFragmentPars
                reason:      see gh#xyz
             """);
 
-        var skipSectionBuilder = PrerequisiteSection.parseInternal(parser);
+        var skipSectionBuilder = PrerequisiteSection.parseInternal(parser, "test");
         assertThat(skipSectionBuilder, notNullValue());
         assertThat(skipSectionBuilder.skipVersionRange, emptyOrNullString());
         assertThat(skipSectionBuilder.requiredYamlRunnerFeatures, hasSize(1));
@@ -389,7 +389,7 @@ public class PrerequisiteSectionTests extends AbstractClientYamlTestFragmentPars
                reason:      memory accounting broken, see gh#xyz
             """);
 
-        Exception e = expectThrows(ParsingException.class, () -> PrerequisiteSection.parseInternal(parser));
+        Exception e = expectThrows(ParsingException.class, () -> PrerequisiteSection.parseInternal(parser, "test"));
         assertThat(e.getMessage(), is("if os is specified, test runner feature [skip_os] must be set"));
     }
 
@@ -414,7 +414,7 @@ public class PrerequisiteSectionTests extends AbstractClientYamlTestFragmentPars
             """);
 
         var skipSectionBuilder = new PrerequisiteSection.PrerequisiteSectionBuilder();
-        PrerequisiteSection.parseSkipSection(parser, skipSectionBuilder);
+        PrerequisiteSection.parseSkipSection(parser, skipSectionBuilder, "test");
         assertThat(skipSectionBuilder, notNullValue());
         assertThat(skipSectionBuilder.skipVersionRange, emptyOrNullString());
         assertThat(skipSectionBuilder.skipClusterFeatures, contains("undesired-feature"));
@@ -431,7 +431,7 @@ public class PrerequisiteSectionTests extends AbstractClientYamlTestFragmentPars
                reason:      test cannot run when undesired-feature are present
             """);
 
-        var skipSectionBuilder = PrerequisiteSection.parseInternal(parser);
+        var skipSectionBuilder = PrerequisiteSection.parseInternal(parser, "test");
         assertThat(skipSectionBuilder, notNullValue());
         assertThat(skipSectionBuilder.skipVersionRange, emptyOrNullString());
         assertThat(skipSectionBuilder.skipClusterFeatures, contains("undesired-feature"));
@@ -453,7 +453,7 @@ public class PrerequisiteSectionTests extends AbstractClientYamlTestFragmentPars
                 reason:      test cannot run when some are present
             """);
 
-        var skipSectionBuilder = PrerequisiteSection.parseInternal(parser);
+        var skipSectionBuilder = PrerequisiteSection.parseInternal(parser, "test");
         assertThat(skipSectionBuilder, notNullValue());
         assertThat(skipSectionBuilder.skipVersionRange, emptyOrNullString());
         assertThat(skipSectionBuilder.skipClusterFeatures, containsInAnyOrder("undesired-feature-1", "undesired-feature-2"));
@@ -475,7 +475,7 @@ public class PrerequisiteSectionTests extends AbstractClientYamlTestFragmentPars
                reason: test cannot run with some-feature
             """);
 
-        var e = expectThrows(ParsingException.class, () -> PrerequisiteSection.parseInternal(parser));
+        var e = expectThrows(ParsingException.class, () -> PrerequisiteSection.parseInternal(parser, "test"));
         assertThat(e.getMessage(), is("a cluster feature can be specified either in [requires] or [skip], not both"));
 
         assertThat(parser.currentToken(), equalTo(XContentParser.Token.END_ARRAY));


### PR DESCRIPTION
The log we introduced in https://github.com/elastic/elasticsearch/pull/104140 to warn about the deprecation of `skip: features` in favour of the less ambiguous `requires: test_runner_features` is not very useful on a test suite with many files and/or many tests (it just repeats the same message over and over again).

This PR changes the log to include the test name and the section location, so the info can be used to track down the exact place where to update the test.

For the reviewers: should I include other information, like the file name (or the test suite name)?
Or would it be better to keep the log message generic but include it just once per file/per test run?