### PR TITLE
Speedup testTasksWaitForAllTask

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/node/tasks/TasksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/node/tasks/TasksIT.java
@@ -722,7 +722,7 @@ public class TasksIT extends ESIntegTestCase {
             .map(PersistentTasksCustomMetadata.PersistentTask::getExecutorNode)
             .collect(Collectors.toSet());
         // Spin up a request to wait for all tasks in the cluster to make sure it doesn't cause an infinite loop
-        ListTasksResponse response = clusterAdmin().prepareListTasks().setWaitForCompletion(true).setTimeout(timeValueSeconds(10)).get();
+        ListTasksResponse response = clusterAdmin().prepareListTasks().setWaitForCompletion(true).setTimeout(timeValueSeconds(1)).get();
 
         // We expect the nodes that are running always-running-tasks to report FailedNodeException and fail to list their tasks
         assertThat(response.getNodeFailures().size(), equalTo(nodesRunningTasks.size()));


### PR DESCRIPTION
This test relies on testTasksWaitForAllTask expiring as task is always running. No need to wait for it 10 seconds.
