### PR TITLE
Set read timeout for fetching IMDSv2 token

### DIFF
--- a/docs/changelog/104407.yaml
+++ b/docs/changelog/104407.yaml
@@ -1,0 +1,6 @@
+pr: 104407
+summary: Set read timeout for fetching IMDSv2 token
+area: Discovery-Plugins
+type: enhancement
+issues:
+ - 104244

--- a/plugins/discovery-ec2/build.gradle
+++ b/plugins/discovery-ec2/build.gradle
@@ -102,6 +102,9 @@ tasks.named("test").configure {
   } else {
     nonInputProperties.systemProperty 'java.security.policy', "file://${buildDir}/tmp/java.policy"
   }
+  if (BuildParams.random.nextBoolean()) {
+    environment 'AWS_METADATA_SERVICE_TIMEOUT', '1'
+  }
 }
 
 tasks.named("check").configure {

--- a/plugins/discovery-ec2/build.gradle
+++ b/plugins/discovery-ec2/build.gradle
@@ -102,9 +102,6 @@ tasks.named("test").configure {
   } else {
     nonInputProperties.systemProperty 'java.security.policy', "file://${buildDir}/tmp/java.policy"
   }
-  if (BuildParams.random.nextBoolean()) {
-    environment 'AWS_METADATA_SERVICE_TIMEOUT', '1'
-  }
 }
 
 tasks.named("check").configure {


### PR DESCRIPTION
Resubmit of #104397 ~with the fixed signature of setting the environment variable in the build~ without setting `AWS_METADATA_SERVICE_TIMEOUT` randomly in the build.

> Use the timeout set by AWS_METADATA_SERVICE_TIMEOUT environment variable both as connect and read timeout analogous to the AWS SDK.
See https://docs.aws.amazon.com/sdkref/latest/guide/feature-ec2-instance-metadata.html


Resolves #104244