### PR TITLE
[7.17] Update ExecutorScalingQueue to workaround LinkedTransferQueue JDK bug (#104347)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
@@ -382,6 +382,29 @@ public class EsExecutors {
             }
         }
 
+        // Overridden to workaround a JDK bug introduced in JDK 21.0.2
+        // https://bugs.openjdk.org/browse/JDK-8323659
+        @Override
+        public void put(E e) {
+            // As the queue is unbounded, this method will always add to the queue.
+            super.offer(e);
+        }
+
+        // Overridden to workaround a JDK bug introduced in JDK 21.0.2
+        // https://bugs.openjdk.org/browse/JDK-8323659
+        @Override
+        public boolean add(E e) {
+            // As the queue is unbounded, this method will never return false.
+            return super.offer(e);
+        }
+
+        // Overridden to workaround a JDK bug introduced in JDK 21.0.2
+        // https://bugs.openjdk.org/browse/JDK-8323659
+        @Override
+        public boolean offer(E e, long timeout, TimeUnit unit) {
+            // As the queue is unbounded, this method will never return false.
+            return super.offer(e);
+        }
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/EsExecutorsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/EsExecutorsTests.java
@@ -442,7 +442,7 @@ public class EsExecutorsTests extends ESTestCase {
     // Specifically that ExecutorScalingQueue, which subclasses LinkedTransferQueue, correctly
     // tracks tasks submitted to the executor.
     public void testBasicTaskExecution() {
-        final var executorService = EsExecutors.newScaling(
+        final ThreadPoolExecutor executorService = EsExecutors.newScaling(
             "test",
             0,
             between(1, 5),
@@ -453,7 +453,7 @@ public class EsExecutorsTests extends ESTestCase {
             new ThreadContext(Settings.EMPTY)
         );
         try {
-            final var countDownLatch = new CountDownLatch(between(1, 10));
+            final CountDownLatch countDownLatch = new CountDownLatch(between(1, 10));
             class TestTask extends AbstractRunnable {
                 @Override
                 protected void doRun() {

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/EsExecutorsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/EsExecutorsTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.hamcrest.Matcher;
 
 import java.util.Locale;
@@ -437,4 +438,41 @@ public class EsExecutorsTests extends ESTestCase {
         assertSettingDeprecationsAndWarnings(deprecatedSettings, new DeprecationWarning(DeprecationLogger.CRITICAL, expectedWarning));
     }
 
+    // This test must complete to ensure that our basic infrastructure is working as expected.
+    // Specifically that ExecutorScalingQueue, which subclasses LinkedTransferQueue, correctly
+    // tracks tasks submitted to the executor.
+    public void testBasicTaskExecution() {
+        final var executorService = EsExecutors.newScaling(
+            "test",
+            0,
+            between(1, 5),
+            60,
+            TimeUnit.SECONDS,
+            randomBoolean(),
+            EsExecutors.daemonThreadFactory("test"),
+            new ThreadContext(Settings.EMPTY)
+        );
+        try {
+            final var countDownLatch = new CountDownLatch(between(1, 10));
+            class TestTask extends AbstractRunnable {
+                @Override
+                protected void doRun() {
+                    countDownLatch.countDown();
+                    if (countDownLatch.getCount() > 0) {
+                        executorService.execute(TestTask.this);
+                    }
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    fail(e);
+                }
+            }
+
+            executorService.execute(new TestTask());
+            safeAwait(countDownLatch);
+        } finally {
+            ThreadPool.terminate(executorService, 10, TimeUnit.SECONDS);
+        }
+    }
 }

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/EsExecutorsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/EsExecutorsTests.java
@@ -465,7 +465,7 @@ public class EsExecutorsTests extends ESTestCase {
 
                 @Override
                 public void onFailure(Exception e) {
-                    fail(e);
+                    fail(e.getMessage());
                 }
             }
 

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/ExecutorScalingQueueTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/ExecutorScalingQueueTests.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.common.util.concurrent;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.concurrent.TimeUnit;
+
+public class ExecutorScalingQueueTests extends ESTestCase {
+
+    public void testPut() {
+        var queue = new EsExecutors.ExecutorScalingQueue<>();
+        queue.put(new Object());
+        assertEquals(queue.size(), 1);
+    }
+
+    public void testAdd() {
+        var queue = new EsExecutors.ExecutorScalingQueue<>();
+        assertTrue(queue.add(new Object()));
+        assertEquals(queue.size(), 1);
+    }
+
+    public void testTimedOffer() {
+        var queue = new EsExecutors.ExecutorScalingQueue<>();
+        assertTrue(queue.offer(new Object(), 60, TimeUnit.SECONDS));
+        assertEquals(queue.size(), 1);
+    }
+
+}

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/ExecutorScalingQueueTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/ExecutorScalingQueueTests.java
@@ -15,19 +15,19 @@ import java.util.concurrent.TimeUnit;
 public class ExecutorScalingQueueTests extends ESTestCase {
 
     public void testPut() {
-        var queue = new EsExecutors.ExecutorScalingQueue<>();
+        LinkedTransferQueue queue = new EsExecutors.ExecutorScalingQueue<>();
         queue.put(new Object());
         assertEquals(queue.size(), 1);
     }
 
     public void testAdd() {
-        var queue = new EsExecutors.ExecutorScalingQueue<>();
+        LinkedTransferQueue queue = new EsExecutors.ExecutorScalingQueue<>();
         assertTrue(queue.add(new Object()));
         assertEquals(queue.size(), 1);
     }
 
     public void testTimedOffer() {
-        var queue = new EsExecutors.ExecutorScalingQueue<>();
+        LinkedTransferQueue queue = new EsExecutors.ExecutorScalingQueue<>();
         assertTrue(queue.offer(new Object(), 60, TimeUnit.SECONDS));
         assertEquals(queue.size(), 1);
     }

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/ExecutorScalingQueueTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/ExecutorScalingQueueTests.java
@@ -10,24 +10,25 @@ package org.elasticsearch.common.util.concurrent;
 
 import org.elasticsearch.test.ESTestCase;
 
+import java.util.concurrent.LinkedTransferQueue;
 import java.util.concurrent.TimeUnit;
 
 public class ExecutorScalingQueueTests extends ESTestCase {
 
     public void testPut() {
-        LinkedTransferQueue queue = new EsExecutors.ExecutorScalingQueue<>();
+        LinkedTransferQueue<Object> queue = new EsExecutors.ExecutorScalingQueue<>();
         queue.put(new Object());
         assertEquals(queue.size(), 1);
     }
 
     public void testAdd() {
-        LinkedTransferQueue queue = new EsExecutors.ExecutorScalingQueue<>();
+        LinkedTransferQueue<Object> queue = new EsExecutors.ExecutorScalingQueue<>();
         assertTrue(queue.add(new Object()));
         assertEquals(queue.size(), 1);
     }
 
     public void testTimedOffer() {
-        LinkedTransferQueue queue = new EsExecutors.ExecutorScalingQueue<>();
+        LinkedTransferQueue<Object> queue = new EsExecutors.ExecutorScalingQueue<>();
         assertTrue(queue.offer(new Object(), 60, TimeUnit.SECONDS));
         assertEquals(queue.size(), 1);
     }


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Update ExecutorScalingQueue to workaround LinkedTransferQueue JDK bug (#104347)