### PR TITLE
[8.12] Fix routing_path when template has multiple path_match and multi-fields (#104418)

### DIFF
--- a/docs/changelog/104418.yaml
+++ b/docs/changelog/104418.yaml
@@ -1,0 +1,6 @@
+pr: 104418
+summary: Fix `routing_path` when template has multiple `path_match` and multi-fields
+area: TSDB
+type: bug
+issues:
+ - 104400

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/DataStreamIndexSettingsProvider.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/DataStreamIndexSettingsProvider.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 
@@ -177,14 +177,18 @@ public class DataStreamIndexSettingsProvider implements IndexSettingProvider {
                 }
 
                 MappingParserContext parserContext = mapperService.parserContext();
-                for (String pathMatch : template.pathMatch()) {
+                for (Iterator<String> iterator = template.pathMatch().iterator(); iterator.hasNext();) {
                     var mapper = parserContext.typeParser(mappingSnippetType)
-                        // Since FieldMapper.parse modifies the Map passed in (removing entries for "type"), that means
-                        // that only the first pathMatch passed in gets recognized as a time_series_dimension. To counteract
-                        // that, we wrap the mappingSnippet in a new HashMap for each pathMatch instance.
-                        .parse(pathMatch, new HashMap<>(mappingSnippet), parserContext)
+                        .parse(iterator.next(), mappingSnippet, parserContext)
                         .build(MapperBuilderContext.root(false, false));
                     extractPath(routingPaths, mapper);
+                    if (iterator.hasNext()) {
+                        // Since FieldMapper.parse modifies the Map passed in (removing entries for "type"), that means
+                        // that only the first pathMatch passed in gets recognized as a time_series_dimension.
+                        // To avoid this, each parsing call uses a new mapping snippet.
+                        // Note that a shallow copy of the mappingSnippet map is not enough if there are multi-fields.
+                        mappingSnippet = template.mappingForName(templateName, KeywordFieldMapper.CONTENT_TYPE);
+                    }
                 }
             }
             return routingPaths;

--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/DataStreamIndexSettingsProviderTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/DataStreamIndexSettingsProviderTests.java
@@ -498,6 +498,55 @@ public class DataStreamIndexSettingsProviderTests extends ESTestCase {
         assertEquals(3, routingPathList.size());
     }
 
+    public void testGenerateRoutingPathFromDynamicTemplateWithMultiplePathMatchEntriesMultiFields() throws Exception {
+        Instant now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+        String mapping = """
+            {
+                "_doc": {
+                    "dynamic_templates": [
+                        {
+                            "labels": {
+                                "path_match": ["xprometheus.labels.*", "yprometheus.labels.*"],
+                                "mapping": {
+                                    "type": "keyword",
+                                    "time_series_dimension": true,
+                                    "fields": {
+                                      "text": {
+                                        "type": "text"
+                                      }
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "properties": {
+                        "host": {
+                            "properties": {
+                                "id": {
+                                    "type": "keyword",
+                                    "time_series_dimension": true
+                                }
+                            }
+                        },
+                        "another_field": {
+                            "type": "keyword"
+                        }
+                    }
+                }
+            }
+            """;
+        Settings result = generateTsdbSettings(mapping, now);
+        assertThat(result.size(), equalTo(3));
+        assertThat(IndexSettings.TIME_SERIES_START_TIME.get(result), equalTo(now.minusMillis(DEFAULT_LOOK_BACK_TIME.getMillis())));
+        assertThat(IndexSettings.TIME_SERIES_END_TIME.get(result), equalTo(now.plusMillis(DEFAULT_LOOK_AHEAD_TIME.getMillis())));
+        assertThat(
+            IndexMetadata.INDEX_ROUTING_PATH.get(result),
+            containsInAnyOrder("host.id", "xprometheus.labels.*", "yprometheus.labels.*")
+        );
+        List<String> routingPathList = IndexMetadata.INDEX_ROUTING_PATH.get(result);
+        assertEquals(3, routingPathList.size());
+    }
+
     public void testGenerateRoutingPathFromDynamicTemplate_templateWithNoPathMatch() throws Exception {
         Instant now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
         TimeValue lookAheadTime = TimeValue.timeValueHours(2); // default


### PR DESCRIPTION
Backports the following commits to 8.12:
 - Fix routing_path when template has multiple path_match and multi-fields (#104418)