### PR TITLE
Unmute testDesiredBalanceShouldConvergeInABigCluster

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputerTests.java
@@ -571,7 +571,6 @@ public class DesiredBalanceComputerTests extends ESAllocationTestCase {
         );
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/104343")
     public void testDesiredBalanceShouldConvergeInABigCluster() {
         var nodes = randomIntBetween(3, 7);
         var nodeIds = new ArrayList<String>(nodes);


### PR DESCRIPTION
This enables testDesiredBalanceShouldConvergeInABigCluster test in earlier branches as they are not susceptible to the test failure.

Related to: #104343