### PR TITLE
Mute failing 3rd-party-deployment test in fips mode

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/3rd_party_deployment.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/3rd_party_deployment.yml
@@ -219,8 +219,8 @@ setup:
 ---
 "Test start deployment fails while model download in progress":
   - skip:
-    cluster_features: fips_140
-    reason: "@AwaitsFix https://github.com/elastic/elasticsearch/issues/104414"
+      features: fips_140
+      reason: "@AwaitsFix https://github.com/elastic/elasticsearch/issues/104414"
   - do:
       ml.put_trained_model:
         model_id: .elser_model_2

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/3rd_party_deployment.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/3rd_party_deployment.yml
@@ -218,6 +218,9 @@ setup:
 
 ---
 "Test start deployment fails while model download in progress":
+  - skip:
+    cluster_features: fips_140
+    reason: "@AwaitsFix https://github.com/elastic/elasticsearch/issues/104414"
   - do:
       ml.put_trained_model:
         model_id: .elser_model_2


### PR DESCRIPTION
Muting test because it's failing in fips mode: https://github.com/elastic/elasticsearch/issues/104414