### PR TITLE
dyamically adjust node metrics cache expire

### DIFF
--- a/docs/changelog/104460.yaml
+++ b/docs/changelog/104460.yaml
@@ -1,0 +1,5 @@
+pr: 104460
+summary: Dyamically adjust node metrics cache expire
+area: Search
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/monitor/metrics/NodeMetrics.java
+++ b/server/src/main/java/org/elasticsearch/monitor/metrics/NodeMetrics.java
@@ -37,7 +37,7 @@ public class NodeMetrics extends AbstractLifecycleComponent {
     private final NodeService nodeService;
     private final List<AutoCloseable> metrics;
     private NodeStatsCache stats;
-    private TimeValue cacheExpiry;
+    private final TimeValue cacheExpiry;
 
     /**
      * Constructs a new NodeMetrics instance.

--- a/server/src/main/java/org/elasticsearch/monitor/metrics/NodeMetrics.java
+++ b/server/src/main/java/org/elasticsearch/monitor/metrics/NodeMetrics.java
@@ -37,17 +37,23 @@ public class NodeMetrics extends AbstractLifecycleComponent {
     private final NodeService nodeService;
     private final List<AutoCloseable> metrics;
     private NodeStatsCache stats;
+    private TimeValue cacheExpiry;
 
     /**
      * Constructs a new NodeMetrics instance.
      *
-     * @param meterRegistry The MeterRegistry used to register metrics.
-     * @param nodeService   The NodeService for interacting with the Elasticsearch node and extracting statistics.
-     */
-    public NodeMetrics(MeterRegistry meterRegistry, NodeService nodeService) {
+     * @param meterRegistry     The MeterRegistry used to register metrics.
+     * @param nodeService       The NodeService for interacting with the Elasticsearch node and extracting statistics.
+     * @param metricsInterval   The interval at which the agent sends metrics to the APM Server
+     * */
+    public NodeMetrics(MeterRegistry meterRegistry, NodeService nodeService, TimeValue metricsInterval) {
         this.registry = meterRegistry;
         this.nodeService = nodeService;
         this.metrics = new ArrayList<>(17);
+        // we set the cache to expire after half the interval at which the agent sends
+        // metrics to the APM Server so that there is enough time for the cache not
+        // update during the same poll period and that expires before a new poll period
+        this.cacheExpiry = new TimeValue(metricsInterval.getMillis() / 2);
     }
 
     /**
@@ -57,10 +63,7 @@ public class NodeMetrics extends AbstractLifecycleComponent {
      * @param registry The MeterRegistry used to register and collect metrics.
      */
     private void registerAsyncMetrics(MeterRegistry registry) {
-        // Agent should poll stats every 4 minutes and being this cache is lazy we need a
-        // number high enough so that the cache does not update during the same poll
-        // period and that expires before a new poll period, therefore we choose 1 minute.
-        this.stats = new NodeStatsCache(TimeValue.timeValueMinutes(1));
+        this.stats = new NodeStatsCache(cacheExpiry);
         metrics.add(
             registry.registerLongAsyncCounter(
                 "es.indices.get.total",

--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -967,7 +967,7 @@ class NodeConstruction {
             repositoryService
         );
 
-        TimeValue metricsInterval = settings.getAsTime("tracing.apm.agent.metrics_interval", TimeValue.timeValueSeconds(10));
+        final TimeValue metricsInterval = settings.getAsTime("tracing.apm.agent.metrics_interval", TimeValue.timeValueSeconds(10));
         final NodeMetrics nodeMetrics = new NodeMetrics(telemetryProvider.getMeterRegistry(), nodeService, metricsInterval);
 
         final SearchService searchService = serviceProvider.newSearchService(

--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -78,6 +78,7 @@ import org.elasticsearch.common.settings.SettingsModule;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.core.IOUtils;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.discovery.DiscoveryModule;
 import org.elasticsearch.env.Environment;
@@ -966,7 +967,8 @@ class NodeConstruction {
             repositoryService
         );
 
-        final NodeMetrics nodeMetrics = new NodeMetrics(telemetryProvider.getMeterRegistry(), nodeService);
+        TimeValue metricsInterval = settings.getAsTime("tracing.apm.agent.metrics_interval", TimeValue.timeValueSeconds(10));
+        final NodeMetrics nodeMetrics = new NodeMetrics(telemetryProvider.getMeterRegistry(), nodeService, metricsInterval);
 
         final SearchService searchService = serviceProvider.newSearchService(
             pluginsService,


### PR DESCRIPTION
Node metrics cache is now dynamically set to to expire after half the APM reporting interval.