### PR TITLE
Fix location for javaRestTest in :x-pack:ent-search:qa:full-cluster-restart

### DIFF
--- a/x-pack/plugin/ent-search/qa/full-cluster-restart/build.gradle
+++ b/x-pack/plugin/ent-search/qa/full-cluster-restart/build.gradle
@@ -30,10 +30,3 @@ BuildParams.bwcVersions.withWireCompatible(v -> v.after("8.8.0")) { bwcVersion, 
     systemProperty("tests.old_cluster_version", bwcVersion)
   }
 }
-
-
-testClusters.configureEach {
-  testDistribution = 'DEFAULT'
-  numberOfNodes = 1
-  setting 'xpack.license.self_generated.type', 'trial'
-}

--- a/x-pack/plugin/ent-search/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/application/FullClusterRestartIT.java
+++ b/x-pack/plugin/ent-search/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/application/FullClusterRestartIT.java
@@ -5,17 +5,11 @@
  * 2.0.
  */
 
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
- */
 package org.elasticsearch.xpack.application;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
@@ -27,6 +21,8 @@ import org.junit.ClassRule;
 
 import java.io.IOException;
 import java.util.List;
+
+import static org.elasticsearch.Version.V_8_12_0;
 
 public class FullClusterRestartIT extends ParameterizedFullClusterRestartTestCase {
 
@@ -57,7 +53,7 @@ public class FullClusterRestartIT extends ParameterizedFullClusterRestartTestCas
 
         assumeTrue(
             "Data retention changed by default to DSL in " + DSL_DEFAULT_RETENTION_VERSION,
-            getOldClusterTestVersion().before(DSL_DEFAULT_RETENTION_VERSION)
+            getOldClusterTestVersion().before(DSL_DEFAULT_RETENTION_VERSION.toString())
         );
 
         String legacyAnalyticsCollectionName = "oldstuff";

--- a/x-pack/plugin/ent-search/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/application/FullClusterRestartIT.java
+++ b/x-pack/plugin/ent-search/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/application/FullClusterRestartIT.java
@@ -18,12 +18,14 @@ import org.elasticsearch.test.rest.ObjectPath;
 import org.elasticsearch.upgrades.FullClusterRestartUpgradeStatus;
 import org.elasticsearch.upgrades.ParameterizedFullClusterRestartTestCase;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 
 import java.io.IOException;
 import java.util.List;
 
 import static org.elasticsearch.Version.V_8_12_0;
 
+@Ignore("https://github.com/elastic/elasticsearch/issues/104470")
 public class FullClusterRestartIT extends ParameterizedFullClusterRestartTestCase {
 
     private static final Version DSL_DEFAULT_RETENTION_VERSION = V_8_12_0;


### PR DESCRIPTION
This puts the test sources in the right directory as expected by javaRestTest plugin.
Seems that test never got executed since it was positioned in the wrong directory not
matching our javaRestTest conventions