### PR TITLE
x-pack/plugin/apm-data: download geoip DB on pipeline creation

### DIFF
--- a/docs/changelog/104501.yaml
+++ b/docs/changelog/104501.yaml
@@ -1,0 +1,5 @@
+pr: 104501
+summary: "X-pack/plugin/apm-data: download geoip DB on pipeline creation"
+area: Ingest Node
+type: bug
+issues: []

--- a/x-pack/plugin/apm-data/src/main/resources/ingest-pipelines/apm@pipeline.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/ingest-pipelines/apm@pipeline.yaml
@@ -14,7 +14,6 @@ processors:
     database_file: GeoLite2-City.mmdb
     field: client.ip
     target_field: client.geo
-    download_database_on_pipeline_creation: false
     ignore_missing: true
     on_failure:
     - remove:


### PR DESCRIPTION
When the ingest pipeline is created, download the geoIP pipeline. This brings the pipeline in line with the pipeline created by the APM integration package, and avoids missing enrichment in the initial documents.