### PR TITLE
[8.11] Unmute testDesiredBalanceShouldConvergeInABigCluster (#104445)

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputerTests.java
@@ -576,7 +576,6 @@ public class DesiredBalanceComputerTests extends ESTestCase {
         );
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/104343")
     public void testDesiredBalanceShouldConvergeInABigCluster() {
         var nodes = randomIntBetween(3, 7);
         var nodeIds = new ArrayList<String>(nodes);


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Unmute testDesiredBalanceShouldConvergeInABigCluster (#104445)