### PR TITLE
Revert "x-pack/plugin/apm-data: download geoip DB on pipeline creation"

### DIFF
--- a/docs/changelog/104501.yaml
+++ b/docs/changelog/104501.yaml
@@ -1,5 +1,0 @@
-pr: 104501
-summary: "X-pack/plugin/apm-data: download geoip DB on pipeline creation"
-area: Ingest Node
-type: bug
-issues: []

--- a/docs/changelog/104505.yaml
+++ b/docs/changelog/104505.yaml
@@ -1,0 +1,5 @@
+pr: 104505
+summary: "Revert \"x-pack/plugin/apm-data: download geoip DB on pipeline creation\""
+area: Ingest Node
+type: bug
+issues: []

--- a/x-pack/plugin/apm-data/src/main/resources/ingest-pipelines/apm@pipeline.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/ingest-pipelines/apm@pipeline.yaml
@@ -14,6 +14,7 @@ processors:
     database_file: GeoLite2-City.mmdb
     field: client.ip
     target_field: client.geo
+    download_database_on_pipeline_creation: false
     ignore_missing: true
     on_failure:
     - remove:


### PR DESCRIPTION
Reverts elastic/elasticsearch#104501

Per discussion Slack, we should avoid eagerly downloading this for all users. The plugin is disabled at the moment, but we intend to enable it by default at some point. This does mean that enrichment will be skipped for initial documents, but we consider this to be acceptable. If users want different behaviour, they can enable eager geoip DB downloads.