### PR TITLE
[Connectors API] Support updating either name or description only

### DIFF
--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/336_connector_update_name.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/336_connector_update_name.yml
@@ -31,6 +31,23 @@ setup:
   - match: { name: test-name }
 
 ---
+"Update Connector Description":
+  - do:
+      connector.update_name:
+        connector_id: test-connector
+        body:
+          description: test-description
+
+
+  - match: { result: updated }
+
+  - do:
+      connector.get:
+        connector_id: test-connector
+
+  - match: { description: test-description }
+
+---
 "Update Connector Name and Description":
   - do:
       connector.update_name:

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorNameAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorNameAction.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 import java.util.Objects;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
-import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
 
 public class UpdateConnectorNameAction extends ActionType<ConnectorUpdateActionResponse> {
@@ -84,8 +83,11 @@ public class UpdateConnectorNameAction extends ActionType<ConnectorUpdateActionR
             if (Strings.isNullOrEmpty(connectorId)) {
                 validationException = addValidationError("[connector_id] cannot be [null] or [\"\"].", validationException);
             }
-            if (Strings.isNullOrEmpty(name)) {
-                validationException = addValidationError("[name] cannot be [null] or [\"\"].", validationException);
+            if (name == null && description == null) {
+                validationException = addValidationError(
+                    "[name] and [description] cannot both be [null]. Please provide a value for at least one of them.",
+                    validationException
+                );
             }
 
             return validationException;
@@ -98,7 +100,7 @@ public class UpdateConnectorNameAction extends ActionType<ConnectorUpdateActionR
         );
 
         static {
-            PARSER.declareStringOrNull(constructorArg(), Connector.NAME_FIELD);
+            PARSER.declareStringOrNull(optionalConstructorArg(), Connector.NAME_FIELD);
             PARSER.declareStringOrNull(optionalConstructorArg(), Connector.DESCRIPTION_FIELD);
         }
 
@@ -122,7 +124,9 @@ public class UpdateConnectorNameAction extends ActionType<ConnectorUpdateActionR
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject();
             {
-                builder.field(Connector.NAME_FIELD.getPreferredName(), name);
+                if (name != null) {
+                    builder.field(Connector.NAME_FIELD.getPreferredName(), name);
+                }
                 if (description != null) {
                     builder.field(Connector.DESCRIPTION_FIELD.getPreferredName(), description);
                 }


### PR DESCRIPTION
## Changes
- Support updating either `name` or `description` only. Make `name` non-required param
- Reason, serverless kibana expects to be able to perform such an action: https://github.com/elastic/kibana/pull/175037
- Added yaml test to cover the case
