### PR TITLE
ESQL: Build big geometries for test less eagerly

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/AbstractMultivalueFunctionTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/AbstractMultivalueFunctionTestCase.java
@@ -474,7 +474,7 @@ public abstract class AbstractMultivalueFunctionTestCase extends AbstractScalarF
             EsqlDataTypes.GEO_SHAPE,
             expectedDataType,
             GEO,
-            () -> GeometryTestUtils.randomGeometry(randomBoolean()),
+            () -> rarely() ? GeometryTestUtils.randomGeometry(randomBoolean()) : GeometryTestUtils.randomPoint(),
             matcher
         );
     }
@@ -498,7 +498,7 @@ public abstract class AbstractMultivalueFunctionTestCase extends AbstractScalarF
             EsqlDataTypes.CARTESIAN_SHAPE,
             expectedDataType,
             CARTESIAN,
-            () -> ShapeTestUtils.randomGeometry(randomBoolean()),
+            () -> rarely() ? ShapeTestUtils.randomGeometry(randomBoolean()) : ShapeTestUtils.randomPoint(),
             matcher
         );
     }


### PR DESCRIPTION
GeoShapes and shapes test build random geometries for testing. Those geometries can be large so it seems it can cause memory errors are test expects not so big objects. Therefore we change the logic to generate geometries so we mainly generate points and rarely we generate a random geometry.

fixes https://github.com/elastic/elasticsearch/issues/104496