### PR TITLE
Mute HuggingFaceEmbeddingsModelTests testThrowsURISyntaxException_ForInvalidUrl in FIPS

### DIFF
--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/huggingface/embeddings/HuggingFaceEmbeddingsModelTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/huggingface/embeddings/HuggingFaceEmbeddingsModelTests.java
@@ -19,6 +19,7 @@ import static org.hamcrest.Matchers.is;
 public class HuggingFaceEmbeddingsModelTests extends ESTestCase {
 
     public void testThrowsURISyntaxException_ForInvalidUrl() {
+        assumeFalse("https://github.com/elastic/elasticsearch/issues/104513", inFipsJvm());
         var thrownException = expectThrows(IllegalArgumentException.class, () -> createModel("^^", "secret"));
         assertThat(thrownException.getMessage(), is("unable to parse url [^^]"));
     }


### PR DESCRIPTION
Mute for https://github.com/elastic/elasticsearch/issues/104513