### PR TITLE
[Transform] Increase timeout and unmute `TransformContinuousIT`

### DIFF
--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TransformContinuousIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TransformContinuousIT.java
@@ -83,7 +83,7 @@ import static org.hamcrest.Matchers.notNullValue;
  */
 public class TransformContinuousIT extends TransformRestTestCase {
 
-    public static final int MAX_WAIT_TIME_ONE_ITERATION_SECONDS = 60;
+    public static final int MAX_WAIT_TIME_ONE_ITERATION_SECONDS = 120;
     private List<ContinuousTestCase> transformTestCases = new ArrayList<>();
 
     @Before
@@ -136,7 +136,6 @@ public class TransformContinuousIT extends TransformRestTestCase {
         deletePipeline(ContinuousTestCase.INGEST_PIPELINE);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/97263")
     public void testContinuousEvents() throws Exception {
         String sourceIndexName = ContinuousTestCase.CONTINUOUS_EVENTS_SOURCE_INDEX;
         DecimalFormat numberFormat = new DecimalFormat("000", new DecimalFormatSymbols(Locale.ROOT));


### PR DESCRIPTION
This PR increases timeout (used while waiting for the transform to process new data) from 60s to 120s.
This should be enough to make the test pass on slower environments.

This PR will be backported to `8.12` once the test runs without failure for a week in `main`.

Relates https://github.com/elastic/elasticsearch/issues/97263