### PR TITLE
Ensure there's only one newline added with new version declarations

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/UpdateVersionsTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/UpdateVersionsTask.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.gradle.internal.release;
 
+import com.github.javaparser.GeneratedJavaParserConstants;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.NodeList;
@@ -15,6 +16,9 @@ import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.observer.ObservableProperty;
+import com.github.javaparser.printer.ConcreteSyntaxModel;
+import com.github.javaparser.printer.concretesyntaxmodel.CsmElement;
 import com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter;
 import com.google.common.annotations.VisibleForTesting;
 
@@ -27,6 +31,7 @@ import org.gradle.api.tasks.options.Option;
 import org.gradle.initialization.layout.BuildLayout;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -42,7 +47,84 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 
+import static com.github.javaparser.ast.observer.ObservableProperty.TYPE_PARAMETERS;
+import static com.github.javaparser.printer.concretesyntaxmodel.CsmConditional.Condition.FLAG;
+import static com.github.javaparser.printer.concretesyntaxmodel.CsmElement.block;
+import static com.github.javaparser.printer.concretesyntaxmodel.CsmElement.child;
+import static com.github.javaparser.printer.concretesyntaxmodel.CsmElement.comma;
+import static com.github.javaparser.printer.concretesyntaxmodel.CsmElement.comment;
+import static com.github.javaparser.printer.concretesyntaxmodel.CsmElement.conditional;
+import static com.github.javaparser.printer.concretesyntaxmodel.CsmElement.list;
+import static com.github.javaparser.printer.concretesyntaxmodel.CsmElement.newline;
+import static com.github.javaparser.printer.concretesyntaxmodel.CsmElement.none;
+import static com.github.javaparser.printer.concretesyntaxmodel.CsmElement.sequence;
+import static com.github.javaparser.printer.concretesyntaxmodel.CsmElement.space;
+import static com.github.javaparser.printer.concretesyntaxmodel.CsmElement.string;
+import static com.github.javaparser.printer.concretesyntaxmodel.CsmElement.token;
+
 public class UpdateVersionsTask extends DefaultTask {
+
+    static {
+        replaceDefaultJavaParserClassCsm();
+    }
+
+    /*
+     * The default JavaParser CSM which it uses to format any new declarations added to a class
+     * inserts two newlines after each declaration. Our version classes only have one newline.
+     * In order to get javaparser lexical printer to use our format, we have to completely replace
+     * the statically declared CSM pattern using hacky reflection
+     * to access the static map where these are stored, and insert a replacement that is identical
+     * apart from only one newline at the end of each member declaration, rather than two.
+     */
+    private static void replaceDefaultJavaParserClassCsm() {
+        try {
+            Field classCsms = ConcreteSyntaxModel.class.getDeclaredField("concreteSyntaxModelByClass");
+            classCsms.setAccessible(true);
+            @SuppressWarnings({ "unchecked", "rawtypes" })
+            Map<Class, CsmElement> csms = (Map) classCsms.get(null);
+
+            // copied from the static initializer in ConcreteSyntaxModel
+            csms.put(
+                ClassOrInterfaceDeclaration.class,
+                sequence(
+                    comment(),
+                    list(ObservableProperty.ANNOTATIONS, newline(), none(), newline()),
+                    list(ObservableProperty.MODIFIERS, space(), none(), space()),
+                    conditional(
+                        ObservableProperty.INTERFACE,
+                        FLAG,
+                        token(GeneratedJavaParserConstants.INTERFACE),
+                        token(GeneratedJavaParserConstants.CLASS)
+                    ),
+                    space(),
+                    child(ObservableProperty.NAME),
+                    list(
+                        TYPE_PARAMETERS,
+                        sequence(comma(), space()),
+                        string(GeneratedJavaParserConstants.LT),
+                        string(GeneratedJavaParserConstants.GT)
+                    ),
+                    list(
+                        ObservableProperty.EXTENDED_TYPES,
+                        sequence(string(GeneratedJavaParserConstants.COMMA), space()),
+                        sequence(space(), token(GeneratedJavaParserConstants.EXTENDS), space()),
+                        none()
+                    ),
+                    list(
+                        ObservableProperty.IMPLEMENTED_TYPES,
+                        sequence(string(GeneratedJavaParserConstants.COMMA), space()),
+                        sequence(space(), token(GeneratedJavaParserConstants.IMPLEMENTS), space()),
+                        none()
+                    ),
+                    space(),
+                    block(sequence(newline(), list(ObservableProperty.MEMBERS, sequence(newline()/*, newline()*/), newline(), newline())))
+                )
+            );
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError(e);
+        }
+    }
+
     private static final Logger LOGGER = Logging.getLogger(UpdateVersionsTask.class);
 
     static final String SERVER_MODULE_PATH = "server/src/main/java/";

--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -162,7 +162,6 @@ public class Version implements VersionId<Version>, ToXContentFragment {
     public static final Version V_8_11_4 = new Version(8_11_04_99);
     public static final Version V_8_12_0 = new Version(8_12_00_99);
     public static final Version V_8_12_1 = new Version(8_12_01_99);
-
     public static final Version V_8_13_0 = new Version(8_13_00_99);
     public static final Version CURRENT = V_8_13_0;
 


### PR DESCRIPTION
JavaParser by default adds two newlines to new member declarations, when lexical preserving printing is used. This is defined in the ConcreteSyntaxModel default formatting, within a (private) static map for each declaration type.

This replaces the default CSM format for class declarations with our own, that is virtually identical apart from having only one newline after each member declaration, rather than two. This ensures that JavaParser maintains our existing formatting style when adding new version members to Version.java