### PR TITLE
ESQL: minor heap-attack tests updates

### DIFF
--- a/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackIT.java
+++ b/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackIT.java
@@ -46,6 +46,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static org.elasticsearch.common.Strings.hasText;
 import static org.elasticsearch.test.ListMatcher.matchesList;
 import static org.elasticsearch.test.MapMatcher.assertMap;
 import static org.elasticsearch.test.MapMatcher.matchesMap;
@@ -281,7 +282,7 @@ public class HeapAttackIT extends ESRestTestCase {
 
     public void testTooManyEval() throws IOException {
         initManyLongs();
-        assertCircuitBreaks(() -> manyEval(1000));
+        assertCircuitBreaks(() -> manyEval(1500));
     }
 
     private Response manyEval(int evalLines) throws IOException {
@@ -434,8 +435,13 @@ public class HeapAttackIT extends ESRestTestCase {
                     }
                 }
             }
+            if (a == 0) {
+                initIndex("manylongs", bulk.toString());
+            } else {
+                bulk("manylongs", bulk.toString());
+            }
+            bulk.setLength(0);
         }
-        initIndex("manylongs", bulk.toString());
     }
 
     private void initSingleDocIndex() throws IOException {

--- a/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackIT.java
+++ b/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackIT.java
@@ -46,6 +46,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static org.elasticsearch.common.Strings.hasText;
 import static org.elasticsearch.test.ListMatcher.matchesList;
 import static org.elasticsearch.test.MapMatcher.assertMap;
 import static org.elasticsearch.test.MapMatcher.matchesMap;
@@ -434,13 +435,10 @@ public class HeapAttackIT extends ESRestTestCase {
                     }
                 }
             }
-            if (a == 0) {
-                initIndex("manylongs", bulk.toString());
-            } else {
-                bulk("manylongs", bulk.toString());
-            }
+            bulk("manylongs", bulk.toString());
             bulk.setLength(0);
         }
+        initIndex("manylongs", bulk.toString());
     }
 
     private void initSingleDocIndex() throws IOException {
@@ -536,7 +534,9 @@ public class HeapAttackIT extends ESRestTestCase {
     }
 
     private void initIndex(String name, String bulk) throws IOException {
-        bulk(name, bulk);
+        if (hasText(bulk)) {
+            bulk(name, bulk);
+        }
 
         Request request = new Request("POST", "/" + name + "/_refresh");
         Response response = client().performRequest(request);

--- a/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackIT.java
+++ b/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackIT.java
@@ -46,7 +46,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.elasticsearch.common.Strings.hasText;
 import static org.elasticsearch.test.ListMatcher.matchesList;
 import static org.elasticsearch.test.MapMatcher.assertMap;
 import static org.elasticsearch.test.MapMatcher.matchesMap;


### PR DESCRIPTION
This updates two tests: 
* it chunks the bulk loading of "many longs", which can "choke" some test environments otherwise.
* it increases the number of the "too many evals", which otherwise can be served in some environments and not trigger a breaker.