### PR TITLE
Make TransportResponse.Empty a singleton

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/TransportResponse.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportResponse.java
@@ -32,6 +32,8 @@ public abstract class TransportResponse extends TransportMessage {
     public static class Empty extends TransportResponse {
         public static final Empty INSTANCE = new Empty();
 
+        private Empty() {/* singleton */}
+
         @Override
         public String toString() {
             return "Empty{}";

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinTests.java
@@ -195,7 +195,7 @@ public class NodeJoinTests extends ESTestCase {
                     );
                 } else if (action.equals(JoinValidationService.JOIN_VALIDATE_ACTION_NAME)
                     || action.equals(JoinHelper.JOIN_PING_ACTION_NAME)) {
-                        handleResponse(requestId, new TransportResponse.Empty());
+                        handleResponse(requestId, TransportResponse.Empty.INSTANCE);
                     } else {
                         super.onSendRequest(requestId, action, request, destination);
                     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/ExchangeService.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/ExchangeService.java
@@ -169,7 +169,7 @@ public final class ExchangeService extends AbstractLifecycleComponent {
         @Override
         public void messageReceived(OpenExchangeRequest request, TransportChannel channel, Task task) throws Exception {
             createSinkHandler(request.sessionId, request.exchangeBuffer);
-            channel.sendResponse(new TransportResponse.Empty());
+            channel.sendResponse(TransportResponse.Empty.INSTANCE);
         }
     }
 


### PR DESCRIPTION
We use `TransportResponse.Empty.INSTANCE` almost everywhere anyway, but
there's a couple of places where we create new instances of this class
unnecessarily. This commit makes the constructor private so that
`INSTANCE` is the only possible instance.