### PR TITLE
Create extract/tag versions task for 7.17

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/ExtractCurrentVersionsTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/ExtractCurrentVersionsTask.java
@@ -8,11 +8,9 @@
 
 package org.elasticsearch.gradle.internal.release;
 
-
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.FieldDeclaration;
-
 import com.github.javaparser.ast.expr.IntegerLiteralExpr;
 
 import org.gradle.api.DefaultTask;
@@ -22,13 +20,14 @@ import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.options.Option;
 import org.gradle.initialization.layout.BuildLayout;
 
-import javax.inject.Inject;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.List;
 import java.util.function.Consumer;
+
+import javax.inject.Inject;
 
 public class ExtractCurrentVersionsTask extends DefaultTask {
     private static final Logger LOGGER = Logging.getLogger(ExtractCurrentVersionsTask.class);
@@ -63,7 +62,13 @@ public class ExtractCurrentVersionsTask extends DefaultTask {
         LOGGER.lifecycle("Version: {}", version);
 
         LOGGER.lifecycle("Writing version information to {}", outputFile);
-        Files.write(outputFile, List.of("Version:" + version), StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING);
+        Files.write(
+            outputFile,
+            List.of("Version:" + version),
+            StandardOpenOption.CREATE,
+            StandardOpenOption.WRITE,
+            StandardOpenOption.TRUNCATE_EXISTING
+        );
     }
 
     static class FieldIdExtractor implements Consumer<FieldDeclaration> {

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/ExtractCurrentVersionsTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/ExtractCurrentVersionsTask.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.gradle.internal.release;
+
+
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.FieldDeclaration;
+
+import com.github.javaparser.ast.expr.IntegerLiteralExpr;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.options.Option;
+import org.gradle.initialization.layout.BuildLayout;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+import java.util.function.Consumer;
+
+public class ExtractCurrentVersionsTask extends DefaultTask {
+    private static final Logger LOGGER = Logging.getLogger(ExtractCurrentVersionsTask.class);
+
+    static final String SERVER_MODULE_PATH = "server/src/main/java/";
+    static final String VERSION_FILE_PATH = SERVER_MODULE_PATH + "org/elasticsearch/Version.java";
+
+    final Path rootDir;
+
+    private Path outputFile;
+
+    @Inject
+    public ExtractCurrentVersionsTask(BuildLayout layout) {
+        rootDir = layout.getRootDirectory().toPath();
+    }
+
+    @Option(option = "output-file", description = "File to output tag information to")
+    public void outputFile(String file) {
+        this.outputFile = Path.of(file);
+    }
+
+    @TaskAction
+    public void executeTask() throws IOException {
+        if (outputFile == null) {
+            throw new IllegalArgumentException("Output file not specified");
+        }
+
+        LOGGER.lifecycle("Extracting latest version information");
+
+        // get the current version from Version.java
+        int version = readLatestVersion(rootDir.resolve(VERSION_FILE_PATH));
+        LOGGER.lifecycle("Version: {}", version);
+
+        LOGGER.lifecycle("Writing version information to {}", outputFile);
+        Files.write(outputFile, List.of("Version:" + version), StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING);
+    }
+
+    static class FieldIdExtractor implements Consumer<FieldDeclaration> {
+        private Integer highestVersionId;
+
+        Integer highestVersionId() {
+            return highestVersionId;
+        }
+
+        @Override
+        public void accept(FieldDeclaration fieldDeclaration) {
+            var ints = fieldDeclaration.findAll(IntegerLiteralExpr.class);
+            switch (ints.size()) {
+                case 0 -> {
+                    // No ints in the field declaration, ignore
+                }
+                case 1 -> {
+                    int id = ints.get(0).asNumber().intValue();
+                    if (highestVersionId != null && highestVersionId > id) {
+                        LOGGER.warn("Version ids [{}, {}] out of order", highestVersionId, id);
+                    } else {
+                        highestVersionId = id;
+                    }
+                }
+                default -> LOGGER.warn("Multiple integers found in version field declaration [{}]", fieldDeclaration); // and ignore it
+            }
+        }
+    }
+
+    private static int readLatestVersion(Path javaVersionsFile) throws IOException {
+        CompilationUnit java = StaticJavaParser.parse(javaVersionsFile);
+
+        FieldIdExtractor extractor = new FieldIdExtractor();
+        java.walk(FieldDeclaration.class, extractor);   // walks in code file order
+        if (extractor.highestVersionId == null) {
+            throw new IllegalArgumentException("No version ids found in " + javaVersionsFile);
+        }
+        return extractor.highestVersionId;
+    }
+}

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/ReleaseToolsPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/ReleaseToolsPlugin.java
@@ -48,6 +48,9 @@ public class ReleaseToolsPlugin implements Plugin<Project> {
         project.getTasks()
             .register("updateVersions", UpdateVersionsTask.class, t -> project.getTasks().named("spotlessApply").get().mustRunAfter(t));
 
+        project.getTasks().register("extractCurrentVersions", ExtractCurrentVersionsTask.class);
+        project.getTasks().register("tagVersions", TagVersionsTask.class);  // no-op, nothing to tag
+
         final FileTree yamlFiles = projectDirectory.dir("docs/changelog")
             .getAsFileTree()
             .matching(new PatternSet().include("**/*.yml", "**/*.yaml"));

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/TagVersionsTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/TagVersionsTask.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.gradle.internal.release;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.tasks.options.Option;
+
+import java.util.List;
+
+/**
+ * This is a no-op task that is only implemented for v8+
+ */
+public class TagVersionsTask extends DefaultTask {
+
+    @Option(option = "release", description = "Dummy option")
+    public void release(String version) {
+    }
+
+    @Option(option = "tag-version", description = "Dummy option")
+    public void tagVersions(List<String> version) {
+    }
+}

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/TagVersionsTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/TagVersionsTask.java
@@ -19,10 +19,8 @@ import java.util.List;
 public class TagVersionsTask extends DefaultTask {
 
     @Option(option = "release", description = "Dummy option")
-    public void release(String version) {
-    }
+    public void release(String version) {}
 
     @Option(option = "tag-version", description = "Dummy option")
-    public void tagVersions(List<String> version) {
-    }
+    public void tagVersions(List<String> version) {}
 }

--- a/build-tools-internal/src/test/java/org/elasticsearch/gradle/internal/release/ExtractCurrentVersionsTaskTests.java
+++ b/build-tools-internal/src/test/java/org/elasticsearch/gradle/internal/release/ExtractCurrentVersionsTaskTests.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.gradle.internal.release;
+
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.body.FieldDeclaration;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class ExtractCurrentVersionsTaskTests {
+
+    @Test
+    public void testFieldExtractor() {
+        var unit = StaticJavaParser.parse("""
+            public class Version {
+                public static final Version V_1 = def(1);
+                public static final Version V_2 = def(2);
+                public static final Version V_3 = def(3);
+
+                // ignore fields with no or more than one int
+                public static final Version REF = V_3;
+                public static final Version COMPUTED = compute(100, 200);
+            }""");
+
+        ExtractCurrentVersionsTask.FieldIdExtractor extractor = new ExtractCurrentVersionsTask.FieldIdExtractor();
+        unit.walk(FieldDeclaration.class, extractor);
+        assertThat(extractor.highestVersionId(), is(3));
+    }
+}


### PR DESCRIPTION
Create 7.17 implementations of #103627. Note that the tagVersions task is a no-op, as there is nothing to tag on 7.17. But we still need to extract version information to update v8 version info with.