### PR TITLE
[8.12] [ML] Add retry logic for 500 and 503 errors for OpenAI (#103819)

### DIFF
--- a/docs/changelog/103819.yaml
+++ b/docs/changelog/103819.yaml
@@ -1,0 +1,5 @@
+pr: 103819
+summary: Add retry logic for 500 and 503 errors for OpenAI
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/openai/OpenAiResponseHandlerTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/openai/OpenAiResponseHandlerTests.java
@@ -50,10 +50,28 @@ public class OpenAiResponseHandlerTests extends ESTestCase {
         // 503
         when(statusLine.getStatusCode()).thenReturn(503);
         var retryException = expectThrows(RetryException.class, () -> handler.checkForFailureStatusCode(httpRequest, httpResult));
+        assertTrue(retryException.shouldRetry());
+        assertThat(
+            retryException.getCause().getMessage(),
+            containsString("Received a server busy error status code for request [null] status [503]")
+        );
+        assertThat(((ElasticsearchStatusException) retryException.getCause()).status(), is(RestStatus.BAD_REQUEST));
+        // 501
+        when(statusLine.getStatusCode()).thenReturn(501);
+        retryException = expectThrows(RetryException.class, () -> handler.checkForFailureStatusCode(httpRequest, httpResult));
         assertFalse(retryException.shouldRetry());
         assertThat(
             retryException.getCause().getMessage(),
-            containsString("Received a server error status code for request [null] status [503]")
+            containsString("Received a server error status code for request [null] status [501]")
+        );
+        assertThat(((ElasticsearchStatusException) retryException.getCause()).status(), is(RestStatus.BAD_REQUEST));
+        // 500
+        when(statusLine.getStatusCode()).thenReturn(500);
+        retryException = expectThrows(RetryException.class, () -> handler.checkForFailureStatusCode(httpRequest, httpResult));
+        assertTrue(retryException.shouldRetry());
+        assertThat(
+            retryException.getCause().getMessage(),
+            containsString("Received a server error status code for request [null] status [500]")
         );
         assertThat(((ElasticsearchStatusException) retryException.getCause()).status(), is(RestStatus.BAD_REQUEST));
         // 429


### PR DESCRIPTION
Backports the following commits to 8.12:
 - [ML] Add retry logic for 500 and 503 errors for OpenAI (#103819)