### PR TITLE
Separate remote-cluster and local-cluster clients

### DIFF
--- a/server/src/main/java/org/elasticsearch/client/internal/Client.java
+++ b/server/src/main/java/org/elasticsearch/client/internal/Client.java
@@ -413,7 +413,7 @@ public interface Client extends ElasticsearchClient {
      * @throws IllegalArgumentException if the given clusterAlias doesn't exist
      * @throws UnsupportedOperationException if this functionality is not available on this client.
      */
-    default Client getRemoteClusterClient(String clusterAlias, Executor responseExecutor) {
+    default RemoteClusterClient getRemoteClusterClient(String clusterAlias, Executor responseExecutor) {
         throw new UnsupportedOperationException("this client doesn't support remote cluster connections");
     }
 }

--- a/server/src/main/java/org/elasticsearch/client/internal/FilterClient.java
+++ b/server/src/main/java/org/elasticsearch/client/internal/FilterClient.java
@@ -62,7 +62,7 @@ public abstract class FilterClient extends AbstractClient {
     }
 
     @Override
-    public Client getRemoteClusterClient(String clusterAlias, Executor responseExecutor) {
+    public RemoteClusterClient getRemoteClusterClient(String clusterAlias, Executor responseExecutor) {
         return in.getRemoteClusterClient(clusterAlias, responseExecutor);
     }
 }

--- a/server/src/main/java/org/elasticsearch/client/internal/ParentTaskAssigningClient.java
+++ b/server/src/main/java/org/elasticsearch/client/internal/ParentTaskAssigningClient.java
@@ -62,8 +62,18 @@ public class ParentTaskAssigningClient extends FilterClient {
     }
 
     @Override
-    public ParentTaskAssigningClient getRemoteClusterClient(String clusterAlias, Executor responseExecutor) {
-        Client remoteClient = super.getRemoteClusterClient(clusterAlias, responseExecutor);
-        return new ParentTaskAssigningClient(remoteClient, parentTask);
+    public RemoteClusterClient getRemoteClusterClient(String clusterAlias, Executor responseExecutor) {
+        final var delegate = super.getRemoteClusterClient(clusterAlias, responseExecutor);
+        return new RemoteClusterClient() {
+            @Override
+            public <Request extends ActionRequest, Response extends ActionResponse> void execute(
+                ActionType<Response> action,
+                Request request,
+                ActionListener<Response> listener
+            ) {
+                request.setParentTask(parentTask);
+                delegate.execute(action, request, listener);
+            }
+        };
     }
 }

--- a/server/src/main/java/org/elasticsearch/client/internal/RemoteClusterClient.java
+++ b/server/src/main/java/org/elasticsearch/client/internal/RemoteClusterClient.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.client.internal;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.ActionType;
+
+/**
+ * A client which can execute requests on a specific remote cluster.
+ */
+public interface RemoteClusterClient {
+    /**
+     * Executes an action, denoted by an {@link ActionType}, on the remote cluster.
+     *
+     * @param action           The action type to execute.
+     * @param request          The action request.
+     * @param listener         A listener for the response
+     * @param <Request>        The request type.
+     * @param <Response>       the response type.
+     */
+    <Request extends ActionRequest, Response extends ActionResponse> void execute(
+        ActionType<Response> action,
+        Request request,
+        ActionListener<Response> listener
+    );
+}

--- a/server/src/main/java/org/elasticsearch/client/internal/node/NodeClient.java
+++ b/server/src/main/java/org/elasticsearch/client/internal/node/NodeClient.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.client.internal.RemoteClusterClient;
 import org.elasticsearch.client.internal.support.AbstractClient;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.settings.Settings;
@@ -136,7 +137,7 @@ public class NodeClient extends AbstractClient {
     }
 
     @Override
-    public Client getRemoteClusterClient(String clusterAlias, Executor responseExecutor) {
+    public RemoteClusterClient getRemoteClusterClient(String clusterAlias, Executor responseExecutor) {
         return remoteClusterService.getRemoteClusterClient(threadPool(), clusterAlias, responseExecutor, true);
     }
 }

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterAwareClient.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterAwareClient.java
@@ -12,15 +12,12 @@ import org.elasticsearch.action.ActionListenerResponseHandler;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
-import org.elasticsearch.client.internal.Client;
-import org.elasticsearch.client.internal.support.AbstractClient;
+import org.elasticsearch.client.internal.RemoteClusterClient;
 import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.concurrent.Executor;
 
-final class RemoteClusterAwareClient extends AbstractClient {
+final class RemoteClusterAwareClient implements RemoteClusterClient {
 
     private final TransportService service;
     private final String clusterAlias;
@@ -28,15 +25,7 @@ final class RemoteClusterAwareClient extends AbstractClient {
     private final Executor responseExecutor;
     private final boolean ensureConnected;
 
-    RemoteClusterAwareClient(
-        Settings settings,
-        ThreadPool threadPool,
-        TransportService service,
-        String clusterAlias,
-        Executor responseExecutor,
-        boolean ensureConnected
-    ) {
-        super(settings, threadPool);
+    RemoteClusterAwareClient(TransportService service, String clusterAlias, Executor responseExecutor, boolean ensureConnected) {
         this.service = service;
         this.clusterAlias = clusterAlias;
         this.remoteClusterService = service.getRemoteClusterService();
@@ -45,7 +34,7 @@ final class RemoteClusterAwareClient extends AbstractClient {
     }
 
     @Override
-    protected <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
+    public <Request extends ActionRequest, Response extends ActionResponse> void execute(
         ActionType<Response> action,
         Request request,
         ActionListener<Response> listener
@@ -78,14 +67,9 @@ final class RemoteClusterAwareClient extends AbstractClient {
 
     private void maybeEnsureConnected(ActionListener<Void> ensureConnectedListener) {
         if (ensureConnected) {
-            remoteClusterService.ensureConnected(clusterAlias, ensureConnectedListener);
+            ActionListener.run(ensureConnectedListener, l -> remoteClusterService.ensureConnected(clusterAlias, l));
         } else {
             ensureConnectedListener.onResponse(null);
         }
-    }
-
-    @Override
-    public Client getRemoteClusterClient(String remoteClusterAlias, Executor responseExecutor) {
-        return remoteClusterService.getRemoteClusterClient(threadPool(), remoteClusterAlias, responseExecutor);
     }
 }

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
@@ -17,7 +17,7 @@ import org.elasticsearch.action.support.CountDownActionListener;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.RefCountingRunnable;
-import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.client.internal.RemoteClusterClient;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.common.Strings;
@@ -550,7 +550,12 @@ public final class RemoteClusterService extends RemoteClusterAware implements Cl
      * @param ensureConnected  whether requests should wait for a connection attempt when there isn't a connection available
      * @throws IllegalArgumentException if the given clusterAlias doesn't exist
      */
-    public Client getRemoteClusterClient(ThreadPool threadPool, String clusterAlias, Executor responseExecutor, boolean ensureConnected) {
+    public RemoteClusterClient getRemoteClusterClient(
+        ThreadPool threadPool,
+        String clusterAlias,
+        Executor responseExecutor,
+        boolean ensureConnected
+    ) {
         if (transportService.getRemoteClusterService().isEnabled() == false) {
             throw new IllegalArgumentException(
                 "this node does not have the " + DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE.roleName() + " role"
@@ -559,7 +564,7 @@ public final class RemoteClusterService extends RemoteClusterAware implements Cl
         if (transportService.getRemoteClusterService().getRemoteClusterNames().contains(clusterAlias) == false) {
             throw new NoSuchRemoteClusterException(clusterAlias);
         }
-        return new RemoteClusterAwareClient(settings, threadPool, transportService, clusterAlias, responseExecutor, ensureConnected);
+        return new RemoteClusterAwareClient(transportService, clusterAlias, responseExecutor, ensureConnected);
     }
 
     /**
@@ -570,7 +575,7 @@ public final class RemoteClusterService extends RemoteClusterAware implements Cl
      * @param responseExecutor the executor to use to process the response
      * @throws IllegalArgumentException if the given clusterAlias doesn't exist
      */
-    public Client getRemoteClusterClient(ThreadPool threadPool, String clusterAlias, Executor responseExecutor) {
+    public RemoteClusterClient getRemoteClusterClient(ThreadPool threadPool, String clusterAlias, Executor responseExecutor) {
         return getRemoteClusterClient(
             threadPool,
             clusterAlias,

--- a/server/src/test/java/org/elasticsearch/client/internal/ParentTaskAssigningClientTests.java
+++ b/server/src/test/java/org/elasticsearch/client/internal/ParentTaskAssigningClientTests.java
@@ -12,19 +12,19 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateAction;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.search.ClearScrollRequest;
 import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.client.NoOpClient;
 
 import java.util.concurrent.Executor;
-
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.mockito.Mockito.mock;
 
 public class ParentTaskAssigningClientTests extends ESTestCase {
     public void testSetsParentId() {
@@ -65,15 +65,31 @@ public class ParentTaskAssigningClientTests extends ESTestCase {
         try (var threadPool = createThreadPool()) {
             final var mockClient = new NoOpClient(threadPool) {
                 @Override
-                public Client getRemoteClusterClient(String clusterAlias, Executor responseExecutor) {
-                    return mock(Client.class);
+                public RemoteClusterClient getRemoteClusterClient(String clusterAlias, Executor responseExecutor) {
+                    return new RemoteClusterClient() {
+                        @Override
+                        public <Request extends ActionRequest, Response extends ActionResponse> void execute(
+                            ActionType<Response> action,
+                            Request request,
+                            ActionListener<Response> listener
+                        ) {
+                            assertSame(parentTaskId, request.getParentTask());
+                            listener.onFailure(new UnsupportedOperationException("fake remote-cluster client"));
+                        }
+                    };
                 }
             };
 
             final var client = new ParentTaskAssigningClient(mockClient, parentTaskId);
-            assertThat(
-                client.getRemoteClusterClient("remote-cluster", EsExecutors.DIRECT_EXECUTOR_SERVICE),
-                is(instanceOf(ParentTaskAssigningClient.class))
+            final var remoteClusterClient = client.getRemoteClusterClient("remote-cluster", EsExecutors.DIRECT_EXECUTOR_SERVICE);
+            assertEquals(
+                "fake remote-cluster client",
+                expectThrows(
+                    UnsupportedOperationException.class,
+                    () -> PlainActionFuture.<ClusterStateResponse, Exception>get(
+                        fut -> remoteClusterClient.execute(ClusterStateAction.INSTANCE, new ClusterStateRequest(), fut)
+                    )
+                ).getMessage()
             );
         }
     }

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterAwareClientTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterAwareClientTests.java
@@ -86,8 +86,6 @@ public class RemoteClusterAwareClientTests extends ESTestCase {
                 service.acceptIncomingRequests();
 
                 final var client = new RemoteClusterAwareClient(
-                    Settings.EMPTY,
-                    threadPool,
                     service,
                     "cluster1",
                     threadPool.executor(TEST_THREAD_POOL_NAME),
@@ -142,14 +140,7 @@ public class RemoteClusterAwareClientTests extends ESTestCase {
                 service.start();
                 service.acceptIncomingRequests();
 
-                final var client = new RemoteClusterAwareClient(
-                    Settings.EMPTY,
-                    threadPool,
-                    service,
-                    "cluster1",
-                    EsExecutors.DIRECT_EXECUTOR_SERVICE,
-                    randomBoolean()
-                );
+                final var client = new RemoteClusterAwareClient(service, "cluster1", EsExecutors.DIRECT_EXECUTOR_SERVICE, randomBoolean());
 
                 int numThreads = 10;
                 ExecutorService executorService = Executors.newFixedThreadPool(numThreads);

--- a/test/framework/src/main/java/org/elasticsearch/client/internal/RedirectToLocalClusterRemoteClusterClient.java
+++ b/test/framework/src/main/java/org/elasticsearch/client/internal/RedirectToLocalClusterRemoteClusterClient.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.client.internal;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.client.internal.node.NodeClient;
+
+/**
+ * A fake {@link RemoteClusterClient} which just runs actions on the local cluster, like a {@link NodeClient}, for use in tests.
+ */
+public class RedirectToLocalClusterRemoteClusterClient implements RemoteClusterClient {
+
+    private final ElasticsearchClient delegate;
+
+    public RedirectToLocalClusterRemoteClusterClient(ElasticsearchClient delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public <Request extends ActionRequest, Response extends ActionResponse> void execute(
+        ActionType<Response> action,
+        Request request,
+        ActionListener<Response> listener
+    ) {
+        delegate.execute(action, request, listener);
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/test/client/NoOpNodeClient.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/client/NoOpNodeClient.java
@@ -13,7 +13,7 @@ import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.TransportAction;
-import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.client.internal.RemoteClusterClient;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.tasks.Task;
@@ -79,7 +79,7 @@ public class NoOpNodeClient extends NodeClient {
     }
 
     @Override
-    public Client getRemoteClusterClient(String clusterAlias, Executor responseExecutor) {
+    public RemoteClusterClient getRemoteClusterClient(String clusterAlias, Executor responseExecutor) {
         return null;
     }
 }

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/CcrRetentionLeases.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/CcrRetentionLeases.java
@@ -10,7 +10,7 @@ package org.elasticsearch.xpack.ccr;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.support.PlainActionFuture;
-import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.client.internal.RemoteClusterClient;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.Index;
@@ -75,7 +75,7 @@ public class CcrRetentionLeases {
         final ShardId leaderShardId,
         final String retentionLeaseId,
         final long retainingSequenceNumber,
-        final Client remoteClient,
+        final RemoteClusterClient remoteClient,
         final TimeValue timeout
     ) {
         try {
@@ -103,7 +103,7 @@ public class CcrRetentionLeases {
         final ShardId leaderShardId,
         final String retentionLeaseId,
         final long retainingSequenceNumber,
-        final Client remoteClient,
+        final RemoteClusterClient remoteClient,
         final ActionListener<ActionResponse.Empty> listener
     ) {
         final RetentionLeaseActions.AddRequest request = new RetentionLeaseActions.AddRequest(
@@ -130,7 +130,7 @@ public class CcrRetentionLeases {
         final ShardId leaderShardId,
         final String retentionLeaseId,
         final long retainingSequenceNumber,
-        final Client remoteClient,
+        final RemoteClusterClient remoteClient,
         final TimeValue timeout
     ) {
         try {
@@ -158,7 +158,7 @@ public class CcrRetentionLeases {
         final ShardId leaderShardId,
         final String retentionLeaseId,
         final long retainingSequenceNumber,
-        final Client remoteClient,
+        final RemoteClusterClient remoteClient,
         final ActionListener<ActionResponse.Empty> listener
     ) {
         final RetentionLeaseActions.RenewRequest request = new RetentionLeaseActions.RenewRequest(
@@ -183,7 +183,7 @@ public class CcrRetentionLeases {
     public static void asyncRemoveRetentionLease(
         final ShardId leaderShardId,
         final String retentionLeaseId,
-        final Client remoteClient,
+        final RemoteClusterClient remoteClient,
         final ActionListener<ActionResponse.Empty> listener
     ) {
         final RetentionLeaseActions.RemoveRequest request = new RetentionLeaseActions.RemoveRequest(leaderShardId, retentionLeaseId);

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/CcrRequests.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/CcrRequests.java
@@ -13,7 +13,7 @@ import org.elasticsearch.action.admin.cluster.state.ClusterStateAction;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
-import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.client.internal.RemoteClusterClient;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
@@ -54,7 +54,7 @@ public final class CcrRequests {
      * must be at least the provided {@code mappingVersion} and {@code metadataVersion} respectively.
      */
     public static void getIndexMetadata(
-        Client client,
+        RemoteClusterClient client,
         Index index,
         long mappingVersion,
         long metadataVersion,

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowTasksExecutor.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowTasksExecutor.java
@@ -27,6 +27,7 @@ import org.elasticsearch.action.admin.indices.stats.IndicesStatsRequest;
 import org.elasticsearch.action.admin.indices.stats.ShardStats;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.client.internal.RemoteClusterClient;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -87,6 +88,7 @@ import java.util.function.Supplier;
 
 import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.ccr.CcrLicenseChecker.wrapClient;
+import static org.elasticsearch.xpack.ccr.CcrLicenseChecker.wrapRemoteClusterClient;
 import static org.elasticsearch.xpack.ccr.action.TransportResumeFollowAction.extractLeaderShardHistoryUUIDs;
 
 public final class ShardFollowTasksExecutor extends PersistentTasksExecutor<ShardFollowTask> {
@@ -559,9 +561,10 @@ public final class ShardFollowTasksExecutor extends PersistentTasksExecutor<Shar
         return recordedLeaderShardHistoryUUIDs[params.getLeaderShardId().id()];
     }
 
-    private Client remoteClient(ShardFollowTask params) {
+    private RemoteClusterClient remoteClient(ShardFollowTask params) {
         // TODO: do we need minNodeVersion here since it is for remote cluster
-        return wrapClient(
+        return wrapRemoteClusterClient(
+            client.threadPool().getThreadContext(),
             client.getRemoteClusterClient(
                 params.getRemoteCluster(),
                 // this client is only used for lightweight single-index metadata responses and for the shard-changes actions themselves

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportPutAutoFollowPatternAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportPutAutoFollowPatternAction.java
@@ -108,7 +108,7 @@ public class TransportPutAutoFollowPatternAction extends AcknowledgedTransportMa
 
         Consumer<ClusterStateResponse> consumer = remoteClusterState -> {
             String[] indices = request.getLeaderIndexPatterns().toArray(new String[0]);
-            ccrLicenseChecker.hasPrivilegesToFollowIndices(remoteClient, indices, e -> {
+            ccrLicenseChecker.hasPrivilegesToFollowIndices(client.threadPool().getThreadContext(), remoteClient, indices, e -> {
                 if (e == null) {
                     submitUnbatchedTask(
                         "put-auto-follow-pattern-" + request.getRemoteCluster(),

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportUnfollowAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportUnfollowAction.java
@@ -20,6 +20,7 @@ import org.elasticsearch.action.support.GroupedActionListener;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.support.master.AcknowledgedTransportMasterNodeAction;
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.client.internal.RemoteClusterClient;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -120,7 +121,7 @@ public class TransportUnfollowAction extends AcknowledgedTransportMasterNodeActi
                 );
                 final int numberOfShards = IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.get(indexMetadata.getSettings());
 
-                final Client remoteClient;
+                final RemoteClusterClient remoteClient;
                 try {
                     remoteClient = client.getRemoteClusterClient(remoteClusterName, remoteClientResponseExecutor);
                 } catch (Exception e) {
@@ -178,7 +179,7 @@ public class TransportUnfollowAction extends AcknowledgedTransportMasterNodeActi
                 final ShardId followerShardId,
                 final ShardId leaderShardId,
                 final String retentionLeaseId,
-                final Client remoteClient,
+                final RemoteClusterClient remoteClient,
                 final ActionListener<ActionResponse.Empty> listener
             ) {
                 logger.trace("{} removing retention lease [{}] while unfollowing leader index", followerShardId, retentionLeaseId);

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/repository/CcrRepository.java
@@ -26,6 +26,7 @@ import org.elasticsearch.action.support.ListenerTimeouts;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.ThreadedActionListener;
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.client.internal.RemoteClusterClient;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -177,7 +178,7 @@ public class CcrRepository extends AbstractLifecycleComponent implements Reposit
         return metadata;
     }
 
-    private Client getRemoteClusterClient() {
+    private RemoteClusterClient getRemoteClusterClient() {
         return client.getRemoteClusterClient(remoteClusterAlias, remoteClientResponseExecutor);
     }
 
@@ -454,7 +455,7 @@ public class CcrRepository extends AbstractLifecycleComponent implements Reposit
         final ShardId shardId,
         final String retentionLeaseId,
         final ShardId leaderShardId,
-        final Client remoteClient
+        final RemoteClusterClient remoteClient
     ) {
         logger.trace(() -> format("%s requesting leader to add retention lease [%s]", shardId, retentionLeaseId));
         final TimeValue timeout = ccrSettings.getRecoveryActionTimeout();
@@ -549,7 +550,7 @@ public class CcrRepository extends AbstractLifecycleComponent implements Reposit
     public void awaitIdle() {}
 
     private void updateMappings(
-        Client leaderClient,
+        RemoteClusterClient leaderClient,
         Index leaderIndex,
         long leaderMappingVersion,
         Client followerClient,
@@ -572,7 +573,7 @@ public class CcrRepository extends AbstractLifecycleComponent implements Reposit
 
     void openSession(
         String repositoryName,
-        Client remoteClient,
+        RemoteClusterClient remoteClient,
         ShardId leaderShardId,
         ShardId indexShardId,
         RecoveryState recoveryState,
@@ -611,7 +612,7 @@ public class CcrRepository extends AbstractLifecycleComponent implements Reposit
 
     private static class RestoreSession extends FileRestoreContext {
 
-        private final Client remoteClient;
+        private final RemoteClusterClient remoteClient;
         private final String sessionUUID;
         private final DiscoveryNode node;
         private final Store.MetadataSnapshot sourceMetadata;
@@ -624,7 +625,7 @@ public class CcrRepository extends AbstractLifecycleComponent implements Reposit
 
         RestoreSession(
             String repositoryName,
-            Client remoteClient,
+            RemoteClusterClient remoteClient,
             String sessionUUID,
             DiscoveryNode node,
             ShardId shardId,

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/CcrLicenseCheckerTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/CcrLicenseCheckerTests.java
@@ -7,10 +7,10 @@
 
 package org.elasticsearch.xpack.ccr;
 
-import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.client.internal.RemoteClusterClient;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.security.user.User;
 
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -19,7 +19,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class CcrLicenseCheckerTests extends ESTestCase {
 
@@ -34,13 +33,16 @@ public class CcrLicenseCheckerTests extends ESTestCase {
 
         };
         final AtomicBoolean invoked = new AtomicBoolean();
-        final var client = mock(Client.class);
-        when(client.threadPool()).thenReturn(mock(ThreadPool.class));
-        checker.hasPrivilegesToFollowIndices(client, new String[] { randomAlphaOfLength(8) }, e -> {
-            invoked.set(true);
-            assertThat(e, instanceOf(IllegalStateException.class));
-            assertThat(e, hasToString(containsString("missing or unable to read authentication info on request")));
-        });
+        checker.hasPrivilegesToFollowIndices(
+            new ThreadContext(Settings.EMPTY),
+            mock(RemoteClusterClient.class),
+            new String[] { randomAlphaOfLength(8) },
+            e -> {
+                invoked.set(true);
+                assertThat(e, instanceOf(IllegalStateException.class));
+                assertThat(e, hasToString(containsString("missing or unable to read authentication info on request")));
+            }
+        );
         assertTrue(invoked.get());
     }
 

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinatorTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinatorTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.ccr.action;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.action.support.replication.ClusterStateCreationUtils;
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.client.internal.RedirectToLocalClusterRemoteClusterClient;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.DataStream;
@@ -96,7 +97,7 @@ public class AutoFollowCoordinatorTests extends ESTestCase {
 
     public void testAutoFollower() {
         Client client = mock(Client.class);
-        when(client.getRemoteClusterClient(anyString(), any())).thenReturn(client);
+        when(client.getRemoteClusterClient(anyString(), any())).thenReturn(new RedirectToLocalClusterRemoteClusterClient(client));
 
         ClusterState remoteState = createRemoteClusterState("logs-20190101", true);
 
@@ -166,7 +167,7 @@ public class AutoFollowCoordinatorTests extends ESTestCase {
 
     public void testAutoFollower_dataStream() {
         Client client = mock(Client.class);
-        when(client.getRemoteClusterClient(anyString(), any())).thenReturn(client);
+        when(client.getRemoteClusterClient(anyString(), any())).thenReturn(new RedirectToLocalClusterRemoteClusterClient(client));
 
         ClusterState remoteState = createRemoteClusterStateWithDataStream("logs-foobar");
 
@@ -236,7 +237,7 @@ public class AutoFollowCoordinatorTests extends ESTestCase {
 
     public void testAutoFollowerClusterStateApiFailure() {
         Client client = mock(Client.class);
-        when(client.getRemoteClusterClient(anyString(), any())).thenReturn(client);
+        when(client.getRemoteClusterClient(anyString(), any())).thenReturn(new RedirectToLocalClusterRemoteClusterClient(client));
 
         AutoFollowPattern autoFollowPattern = createAutoFollowPattern("remote", "logs-*");
         Map<String, AutoFollowPattern> patterns = new HashMap<>();
@@ -285,7 +286,7 @@ public class AutoFollowCoordinatorTests extends ESTestCase {
 
     public void testAutoFollowerUpdateClusterStateFailure() {
         Client client = mock(Client.class);
-        when(client.getRemoteClusterClient(anyString(), any())).thenReturn(client);
+        when(client.getRemoteClusterClient(anyString(), any())).thenReturn(new RedirectToLocalClusterRemoteClusterClient(client));
         ClusterState remoteState = createRemoteClusterState("logs-20190101", true);
 
         AutoFollowPattern autoFollowPattern = createAutoFollowPattern("remote", "logs-*");
@@ -648,7 +649,7 @@ public class AutoFollowCoordinatorTests extends ESTestCase {
 
     public void testAutoFollowerCreateAndFollowApiCallFailure() {
         Client client = mock(Client.class);
-        when(client.getRemoteClusterClient(anyString(), any())).thenReturn(client);
+        when(client.getRemoteClusterClient(anyString(), any())).thenReturn(new RedirectToLocalClusterRemoteClusterClient(client));
         ClusterState remoteState = createRemoteClusterState("logs-20190101", true);
 
         AutoFollowPattern autoFollowPattern = createAutoFollowPattern("remote", "logs-*");
@@ -1673,7 +1674,7 @@ public class AutoFollowCoordinatorTests extends ESTestCase {
 
     public void testWaitForMetadataVersion() {
         Client client = mock(Client.class);
-        when(client.getRemoteClusterClient(anyString(), any())).thenReturn(client);
+        when(client.getRemoteClusterClient(anyString(), any())).thenReturn(new RedirectToLocalClusterRemoteClusterClient(client));
 
         AutoFollowPattern autoFollowPattern = createAutoFollowPattern("remote", "logs-*");
         Map<String, AutoFollowPattern> patterns = new HashMap<>();
@@ -1737,7 +1738,7 @@ public class AutoFollowCoordinatorTests extends ESTestCase {
 
     public void testWaitForTimeOut() {
         Client client = mock(Client.class);
-        when(client.getRemoteClusterClient(anyString(), any())).thenReturn(client);
+        when(client.getRemoteClusterClient(anyString(), any())).thenReturn(new RedirectToLocalClusterRemoteClusterClient(client));
 
         AutoFollowPattern autoFollowPattern = createAutoFollowPattern("remote", "logs-*");
         Map<String, AutoFollowPattern> patterns = new HashMap<>();
@@ -1789,7 +1790,7 @@ public class AutoFollowCoordinatorTests extends ESTestCase {
 
     public void testAutoFollowerSoftDeletesDisabled() {
         Client client = mock(Client.class);
-        when(client.getRemoteClusterClient(anyString(), any())).thenReturn(client);
+        when(client.getRemoteClusterClient(anyString(), any())).thenReturn(new RedirectToLocalClusterRemoteClusterClient(client));
 
         ClusterState remoteState = createRemoteClusterState("logs-20190101", false);
 
@@ -1855,7 +1856,7 @@ public class AutoFollowCoordinatorTests extends ESTestCase {
 
     public void testAutoFollowerFollowerIndexAlreadyExists() {
         Client client = mock(Client.class);
-        when(client.getRemoteClusterClient(anyString(), any())).thenReturn(client);
+        when(client.getRemoteClusterClient(anyString(), any())).thenReturn(new RedirectToLocalClusterRemoteClusterClient(client));
 
         ClusterState remoteState = createRemoteClusterState("logs-20190101", true);
 
@@ -2022,7 +2023,7 @@ public class AutoFollowCoordinatorTests extends ESTestCase {
 
     public void testClosedIndicesAreNotAutoFollowed() {
         final Client client = mock(Client.class);
-        when(client.getRemoteClusterClient(anyString(), any())).thenReturn(client);
+        when(client.getRemoteClusterClient(anyString(), any())).thenReturn(new RedirectToLocalClusterRemoteClusterClient(client));
 
         final String pattern = "pattern1";
         final ClusterState localState = ClusterState.builder(new ClusterName("local"))
@@ -2117,7 +2118,7 @@ public class AutoFollowCoordinatorTests extends ESTestCase {
 
     public void testExcludedPatternIndicesAreNotAutoFollowed() {
         final Client client = mock(Client.class);
-        when(client.getRemoteClusterClient(anyString(), any())).thenReturn(client);
+        when(client.getRemoteClusterClient(anyString(), any())).thenReturn(new RedirectToLocalClusterRemoteClusterClient(client));
 
         final String pattern = "pattern1";
         final ClusterState localState = ClusterState.builder(new ClusterName("local"))
@@ -2418,7 +2419,7 @@ public class AutoFollowCoordinatorTests extends ESTestCase {
         ClusterState finalRemoteState
     ) {
         final Client client = mock(Client.class);
-        when(client.getRemoteClusterClient(anyString(), any())).thenReturn(client);
+        when(client.getRemoteClusterClient(anyString(), any())).thenReturn(new RedirectToLocalClusterRemoteClusterClient(client));
 
         final String pattern = "pattern1";
         final ClusterState localState = ClusterState.builder(new ClusterName("local"))

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/repository/CcrRepositoryRetentionLeaseTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/repository/CcrRepositoryRetentionLeaseTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.client.internal.RemoteClusterClient;
 import org.elasticsearch.cluster.metadata.RepositoryMetadata;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
@@ -68,7 +69,7 @@ public class CcrRepositoryRetentionLeaseTests extends ESTestCase {
         );
 
         // simulate that the retention lease already exists on the leader, and verify that we attempt to renew it
-        final Client remoteClient = mock(Client.class);
+        final RemoteClusterClient remoteClient = mock(RemoteClusterClient.class);
         final ArgumentCaptor<RetentionLeaseActions.AddRequest> addRequestCaptor = ArgumentCaptor.forClass(
             RetentionLeaseActions.AddRequest.class
         );
@@ -139,7 +140,7 @@ public class CcrRepositoryRetentionLeaseTests extends ESTestCase {
         );
 
         // simulate that the retention lease already exists on the leader, expires before we renew, and verify that we attempt to add it
-        final Client remoteClient = mock(Client.class);
+        final RemoteClusterClient remoteClient = mock(RemoteClusterClient.class);
         final ArgumentCaptor<RetentionLeaseActions.AddRequest> addRequestCaptor = ArgumentCaptor.forClass(
             RetentionLeaseActions.AddRequest.class
         );

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ClientHelper.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ClientHelper.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.core;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
-import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.ContextPreservingActionListener;
@@ -210,7 +209,7 @@ public final class ClientHelper {
     /**
      * Executes a consumer after setting the origin and wrapping the listener so that the proper context is restored
      */
-    public static <Request extends ActionRequest, Response extends ActionResponse> void executeAsyncWithOrigin(
+    public static <Request, Response> void executeAsyncWithOrigin(
         ThreadContext threadContext,
         String origin,
         Request request,
@@ -227,21 +226,14 @@ public final class ClientHelper {
      * Executes an asynchronous action using the provided client. The origin is set in the context and the listener
      * is wrapped to ensure the proper context is restored
      */
-    public static <
-        Request extends ActionRequest,
-        Response extends ActionResponse,
-        RequestBuilder extends ActionRequestBuilder<Request, Response>> void executeAsyncWithOrigin(
-            Client client,
-            String origin,
-            ActionType<Response> action,
-            Request request,
-            ActionListener<Response> listener
-        ) {
-        final ThreadContext threadContext = client.threadPool().getThreadContext();
-        final Supplier<ThreadContext.StoredContext> supplier = threadContext.newRestorableContext(false);
-        try (ThreadContext.StoredContext ignore = threadContext.stashWithOrigin(origin)) {
-            client.execute(action, request, new ContextPreservingActionListener<>(supplier, listener));
-        }
+    public static <Request extends ActionRequest, Response extends ActionResponse> void executeAsyncWithOrigin(
+        Client client,
+        String origin,
+        ActionType<Response> action,
+        Request request,
+        ActionListener<Response> listener
+    ) {
+        executeAsyncWithOrigin(client.threadPool().getThreadContext(), origin, request, listener, (r, l) -> client.execute(action, r, l));
     }
 
     /**
@@ -304,17 +296,34 @@ public final class ClientHelper {
         Request request,
         ActionListener<Response> listener
     ) {
+        executeWithHeadersAsync(
+            client.threadPool().getThreadContext(),
+            headers,
+            origin,
+            request,
+            listener,
+            (r, l) -> client.execute(action, r, l)
+        );
+    }
+
+    public static <Request, Response> void executeWithHeadersAsync(
+        ThreadContext threadContext,
+        Map<String, String> headers,
+        String origin,
+        Request request,
+        ActionListener<Response> listener,
+        BiConsumer<Request, ActionListener<Response>> consumer
+    ) {
         // No need to rewrite authentication header because it will be handled by Security Interceptor
         final Map<String, String> filteredHeaders = filterSecurityHeaders(headers);
-        final ThreadContext threadContext = client.threadPool().getThreadContext();
         // No headers (e.g. security not installed/in use) so execute as origin
         if (filteredHeaders.isEmpty()) {
-            ClientHelper.executeAsyncWithOrigin(client, origin, action, request, listener);
+            executeAsyncWithOrigin(threadContext, origin, request, listener, consumer);
         } else {
             // Otherwise stash the context and copy in the saved headers before executing
             final Supplier<ThreadContext.StoredContext> supplier = threadContext.newRestorableContext(false);
             try (ThreadContext.StoredContext ignore = stashWithHeaders(threadContext, filteredHeaders)) {
-                client.execute(action, request, new ContextPreservingActionListener<>(supplier, listener));
+                consumer.accept(request, new ContextPreservingActionListener<>(supplier, listener));
             }
         }
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/validation/SourceDestValidatorTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/validation/SourceDestValidatorTests.java
@@ -14,6 +14,8 @@ import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.LatchedActionListener;
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.client.internal.RedirectToLocalClusterRemoteClusterClient;
+import org.elasticsearch.client.internal.RemoteClusterClient;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
@@ -162,8 +164,8 @@ public class SourceDestValidatorTests extends ESTestCase {
         }
 
         @Override
-        public Client getRemoteClusterClient(String clusterAlias, Executor responseExecutor) {
-            return this;
+        public RemoteClusterClient getRemoteClusterClient(String clusterAlias, Executor responseExecutor) {
+            return new RedirectToLocalClusterRemoteClusterClient(this);
         }
 
         @SuppressWarnings("unchecked")

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityFcActionAuthorizationIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityFcActionAuthorizationIT.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.remotecluster;
 
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.ElasticsearchSecurityException;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
@@ -20,7 +21,7 @@ import org.elasticsearch.action.fieldcaps.TransportFieldCapabilitiesAction;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
-import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.client.internal.RemoteClusterClient;
 import org.elasticsearch.cluster.node.VersionInformation;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.MockSecureSettings;
@@ -37,7 +38,6 @@ import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.RemoteClusterService;
 import org.elasticsearch.transport.RemoteConnectionInfo;
-import org.elasticsearch.transport.RemoteTransportException;
 import org.elasticsearch.xpack.ccr.action.repositories.ClearCcrRestoreSessionAction;
 import org.elasticsearch.xpack.ccr.action.repositories.ClearCcrRestoreSessionRequest;
 import org.elasticsearch.xpack.ccr.action.repositories.GetCcrRestoreFileChunkAction;
@@ -108,7 +108,7 @@ public class RemoteClusterSecurityFcActionAuthorizationIT extends ESRestTestCase
     }
 
     private static <Request extends ActionRequest, Response extends ActionResponse> Response executeRemote(
-        Client client,
+        RemoteClusterClient client,
         ActionType<Response> action,
         Request request
     ) throws Exception {
@@ -117,12 +117,7 @@ public class RemoteClusterSecurityFcActionAuthorizationIT extends ESRestTestCase
         try {
             return future.get(10, TimeUnit.SECONDS);
         } catch (ExecutionException e) {
-            if (e.getCause() instanceof RemoteTransportException remoteTransportException
-                && remoteTransportException.getCause() instanceof Exception cause) {
-                throw cause;
-            }
-
-            if (e.getCause() instanceof Exception cause) {
+            if (ExceptionsHelper.unwrapCause(e.getCause()) instanceof Exception cause) {
                 throw cause;
             }
 

--- a/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/checkpoint/TransformCCSCanMatchIT.java
+++ b/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/checkpoint/TransformCCSCanMatchIT.java
@@ -21,6 +21,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.engine.EngineConfig;
@@ -223,15 +224,18 @@ public class TransformCCSCanMatchIT extends AbstractMultiClustersTestCase {
     }
 
     public void testGetCheckpointAction_MatchAllQuery() throws InterruptedException {
+        final var threadContext = client().threadPool().getThreadContext();
         testGetCheckpointAction(
-            client(),
+            threadContext,
+            CheckpointClient.local(client()),
             null,
             new String[] { "local_*" },
             QueryBuilders.matchAllQuery(),
             Set.of("local_old_index", "local_new_index")
         );
         testGetCheckpointAction(
-            client().getRemoteClusterClient(REMOTE_CLUSTER, EsExecutors.DIRECT_EXECUTOR_SERVICE),
+            threadContext,
+            CheckpointClient.remote(client().getRemoteClusterClient(REMOTE_CLUSTER, EsExecutors.DIRECT_EXECUTOR_SERVICE)),
             REMOTE_CLUSTER,
             new String[] { "remote_*" },
             QueryBuilders.matchAllQuery(),
@@ -240,15 +244,18 @@ public class TransformCCSCanMatchIT extends AbstractMultiClustersTestCase {
     }
 
     public void testGetCheckpointAction_RangeQuery() throws InterruptedException {
+        final var threadContext = client().threadPool().getThreadContext();
         testGetCheckpointAction(
-            client(),
+            threadContext,
+            CheckpointClient.local(client()),
             null,
             new String[] { "local_*" },
             QueryBuilders.rangeQuery("@timestamp").from(timestamp),
             Set.of("local_new_index")
         );
         testGetCheckpointAction(
-            client().getRemoteClusterClient(REMOTE_CLUSTER, EsExecutors.DIRECT_EXECUTOR_SERVICE),
+            threadContext,
+            CheckpointClient.remote(client().getRemoteClusterClient(REMOTE_CLUSTER, EsExecutors.DIRECT_EXECUTOR_SERVICE)),
             REMOTE_CLUSTER,
             new String[] { "remote_*" },
             QueryBuilders.rangeQuery("@timestamp").from(timestamp),
@@ -257,15 +264,18 @@ public class TransformCCSCanMatchIT extends AbstractMultiClustersTestCase {
     }
 
     public void testGetCheckpointAction_RangeQueryThatMatchesNoShards() throws InterruptedException {
+        final var threadContext = client().threadPool().getThreadContext();
         testGetCheckpointAction(
-            client(),
+            threadContext,
+            CheckpointClient.local(client()),
             null,
             new String[] { "local_*" },
             QueryBuilders.rangeQuery("@timestamp").from(100_000_000),
             Set.of()
         );
         testGetCheckpointAction(
-            client().getRemoteClusterClient(REMOTE_CLUSTER, EsExecutors.DIRECT_EXECUTOR_SERVICE),
+            threadContext,
+            CheckpointClient.remote(client().getRemoteClusterClient(REMOTE_CLUSTER, EsExecutors.DIRECT_EXECUTOR_SERVICE)),
             REMOTE_CLUSTER,
             new String[] { "remote_*" },
             QueryBuilders.rangeQuery("@timestamp").from(100_000_000),
@@ -273,8 +283,14 @@ public class TransformCCSCanMatchIT extends AbstractMultiClustersTestCase {
         );
     }
 
-    private void testGetCheckpointAction(Client client, String cluster, String[] indices, QueryBuilder query, Set<String> expectedIndices)
-        throws InterruptedException {
+    private void testGetCheckpointAction(
+        ThreadContext threadContext,
+        CheckpointClient client,
+        String cluster,
+        String[] indices,
+        QueryBuilder query,
+        Set<String> expectedIndices
+    ) throws InterruptedException {
         final GetCheckpointAction.Request request = new GetCheckpointAction.Request(
             indices,
             IndicesOptions.LENIENT_EXPAND_OPEN,
@@ -286,19 +302,13 @@ public class TransformCCSCanMatchIT extends AbstractMultiClustersTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         SetOnce<GetCheckpointAction.Response> finalResponse = new SetOnce<>();
         SetOnce<Exception> finalException = new SetOnce<>();
-        ClientHelper.executeAsyncWithOrigin(
-            client,
-            TRANSFORM_ORIGIN,
-            GetCheckpointAction.INSTANCE,
-            request,
-            ActionListener.wrap(response -> {
-                finalResponse.set(response);
-                latch.countDown();
-            }, e -> {
-                finalException.set(e);
-                latch.countDown();
-            })
-        );
+        ClientHelper.executeAsyncWithOrigin(threadContext, TRANSFORM_ORIGIN, request, ActionListener.wrap(response -> {
+            finalResponse.set(response);
+            latch.countDown();
+        }, e -> {
+            finalException.set(e);
+            latch.countDown();
+        }), client::getCheckpoint);
         latch.await(10, TimeUnit.SECONDS);
 
         assertThat(finalException.get(), is(nullValue()));

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/checkpoint/CheckpointClient.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/checkpoint/CheckpointClient.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.transform.checkpoint;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.get.GetIndexAction;
+import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
+import org.elasticsearch.action.admin.indices.get.GetIndexResponse;
+import org.elasticsearch.action.admin.indices.stats.IndicesStatsAction;
+import org.elasticsearch.action.admin.indices.stats.IndicesStatsRequest;
+import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
+import org.elasticsearch.client.internal.ElasticsearchClient;
+import org.elasticsearch.client.internal.RemoteClusterClient;
+import org.elasticsearch.xpack.core.transform.action.GetCheckpointAction;
+
+/**
+ * Adapter interface so that the actions needed for {@link DefaultCheckpointProvider} can execute in the same way when using either an
+ * {@link ElasticsearchClient} (for local-cluster requests) and a {@link RemoteClusterClient} (for remote-cluster requests).
+ */
+interface CheckpointClient {
+
+    /**
+     * Execute {@link GetIndexAction}.
+     */
+    void getIndex(GetIndexRequest request, ActionListener<GetIndexResponse> listener);
+
+    /**
+     * Execute {@link IndicesStatsAction}.
+     */
+    void getIndicesStats(IndicesStatsRequest request, ActionListener<IndicesStatsResponse> listener);
+
+    /**
+     * Execute {@link GetCheckpointAction}.
+     */
+    void getCheckpoint(GetCheckpointAction.Request request, ActionListener<GetCheckpointAction.Response> listener);
+
+    /**
+     * Construct a {@link CheckpointClient} which executes its requests on the local cluster.
+     */
+    static CheckpointClient local(ElasticsearchClient client) {
+        return new CheckpointClient() {
+            @Override
+            public void getIndex(GetIndexRequest request, ActionListener<GetIndexResponse> listener) {
+                client.execute(GetIndexAction.INSTANCE, request, listener);
+            }
+
+            @Override
+            public void getIndicesStats(IndicesStatsRequest request, ActionListener<IndicesStatsResponse> listener) {
+                client.execute(IndicesStatsAction.INSTANCE, request, listener);
+            }
+
+            @Override
+            public void getCheckpoint(GetCheckpointAction.Request request, ActionListener<GetCheckpointAction.Response> listener) {
+                client.execute(GetCheckpointAction.INSTANCE, request, listener);
+            }
+        };
+    }
+
+    /**
+     * Construct a {@link CheckpointClient} which executes its requests on a remote cluster.
+     */
+    static CheckpointClient remote(RemoteClusterClient client) {
+        return new CheckpointClient() {
+            @Override
+            public void getIndex(GetIndexRequest request, ActionListener<GetIndexResponse> listener) {
+                client.execute(GetIndexAction.INSTANCE, request, listener);
+            }
+
+            @Override
+            public void getIndicesStats(IndicesStatsRequest request, ActionListener<IndicesStatsResponse> listener) {
+                client.execute(IndicesStatsAction.INSTANCE, request, listener);
+            }
+
+            @Override
+            public void getCheckpoint(GetCheckpointAction.Request request, ActionListener<GetCheckpointAction.Response> listener) {
+                client.execute(GetCheckpointAction.INSTANCE, request, listener);
+            }
+        };
+    }
+}

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/checkpoint/DefaultCheckpointProvider.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/checkpoint/DefaultCheckpointProvider.java
@@ -11,15 +11,14 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.admin.indices.get.GetIndexAction;
 import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
-import org.elasticsearch.action.admin.indices.stats.IndicesStatsAction;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsRequest;
 import org.elasticsearch.action.admin.indices.stats.ShardStats;
 import org.elasticsearch.action.support.GroupedActionListener;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.internal.ParentTaskAssigningClient;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.core.Strings;
 import org.elasticsearch.core.TimeValue;
@@ -129,9 +128,12 @@ class DefaultCheckpointProvider implements CheckpointProvider {
                 groupedListener = new GroupedActionListener<>(resolvedIndexes.numClusters(), mergeMapsListener);
             }
 
+            final var threadContext = client.threadPool().getThreadContext();
+
             if (resolvedIndexes.getLocalIndices().isEmpty() == false) {
                 getCheckpointsFromOneCluster(
-                    client,
+                    threadContext,
+                    CheckpointClient.local(client),
                     timeout,
                     transformConfig.getHeaders(),
                     resolvedIndexes.getLocalIndices().toArray(new String[0]),
@@ -143,12 +145,9 @@ class DefaultCheckpointProvider implements CheckpointProvider {
 
             for (Map.Entry<String, List<String>> remoteIndex : resolvedIndexes.getRemoteIndicesPerClusterAlias().entrySet()) {
                 String cluster = remoteIndex.getKey();
-                ParentTaskAssigningClient remoteClient = new ParentTaskAssigningClient(
-                    client.getRemoteClusterClient(cluster, EsExecutors.DIRECT_EXECUTOR_SERVICE),
-                    client.getParentTask()
-                );
                 getCheckpointsFromOneCluster(
-                    remoteClient,
+                    threadContext,
+                    CheckpointClient.remote(client.getRemoteClusterClient(cluster, EsExecutors.DIRECT_EXECUTOR_SERVICE)),
                     timeout,
                     transformConfig.getHeaders(),
                     remoteIndex.getValue().toArray(new String[0]),
@@ -163,7 +162,8 @@ class DefaultCheckpointProvider implements CheckpointProvider {
     }
 
     private void getCheckpointsFromOneCluster(
-        ParentTaskAssigningClient client,
+        ThreadContext threadContext,
+        CheckpointClient client,
         TimeValue timeout,
         Map<String, String> headers,
         String[] indices,
@@ -172,36 +172,46 @@ class DefaultCheckpointProvider implements CheckpointProvider {
         ActionListener<Map<String, long[]>> listener
     ) {
         if (fallbackToBWC.contains(cluster)) {
-            getCheckpointsFromOneClusterBWC(client, timeout, headers, indices, cluster, listener);
+            getCheckpointsFromOneClusterBWC(threadContext, client, timeout, headers, indices, cluster, listener);
         } else {
-            getCheckpointsFromOneClusterV2(client, timeout, headers, indices, query, cluster, ActionListener.wrap(response -> {
-                logger.debug(
-                    "[{}] Successfully retrieved checkpoints from cluster [{}] using transform checkpoint API",
-                    transformConfig.getId(),
-                    cluster
-                );
-                listener.onResponse(response);
-            }, e -> {
-                Throwable unwrappedException = ExceptionsHelper.unwrapCause(e);
-                if (unwrappedException instanceof ActionNotFoundTransportException) {
-                    // this is an implementation detail, so not necessary to audit or warn, but only report as debug
+            getCheckpointsFromOneClusterV2(
+                threadContext,
+                client,
+                timeout,
+                headers,
+                indices,
+                query,
+                cluster,
+                ActionListener.wrap(response -> {
                     logger.debug(
-                        "[{}] Cluster [{}] does not support transform checkpoint API, falling back to legacy checkpointing",
+                        "[{}] Successfully retrieved checkpoints from cluster [{}] using transform checkpoint API",
                         transformConfig.getId(),
                         cluster
                     );
+                    listener.onResponse(response);
+                }, e -> {
+                    Throwable unwrappedException = ExceptionsHelper.unwrapCause(e);
+                    if (unwrappedException instanceof ActionNotFoundTransportException) {
+                        // this is an implementation detail, so not necessary to audit or warn, but only report as debug
+                        logger.debug(
+                            "[{}] Cluster [{}] does not support transform checkpoint API, falling back to legacy checkpointing",
+                            transformConfig.getId(),
+                            cluster
+                        );
 
-                    fallbackToBWC.add(cluster);
-                    getCheckpointsFromOneClusterBWC(client, timeout, headers, indices, cluster, listener);
-                } else {
-                    listener.onFailure(e);
-                }
-            }));
+                        fallbackToBWC.add(cluster);
+                        getCheckpointsFromOneClusterBWC(threadContext, client, timeout, headers, indices, cluster, listener);
+                    } else {
+                        listener.onFailure(e);
+                    }
+                })
+            );
         }
     }
 
     private static void getCheckpointsFromOneClusterV2(
-        ParentTaskAssigningClient client,
+        ThreadContext threadContext,
+        CheckpointClient client,
         TimeValue timeout,
         Map<String, String> headers,
         String[] indices,
@@ -240,12 +250,12 @@ class DefaultCheckpointProvider implements CheckpointProvider {
         }
 
         ClientHelper.executeWithHeadersAsync(
+            threadContext,
             headers,
             ClientHelper.TRANSFORM_ORIGIN,
-            client,
-            GetCheckpointAction.INSTANCE,
             getCheckpointRequest,
-            checkpointListener
+            checkpointListener,
+            client::getCheckpoint
         );
     }
 
@@ -253,7 +263,8 @@ class DefaultCheckpointProvider implements CheckpointProvider {
      * BWC fallback for nodes/cluster older than 8.2
      */
     private static void getCheckpointsFromOneClusterBWC(
-        ParentTaskAssigningClient client,
+        ThreadContext threadContext,
+        CheckpointClient client,
         TimeValue timeout,
         Map<String, String> headers,
         String[] indices,
@@ -266,10 +277,9 @@ class DefaultCheckpointProvider implements CheckpointProvider {
             .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN);
 
         ClientHelper.executeWithHeadersAsync(
+            threadContext,
             headers,
             ClientHelper.TRANSFORM_ORIGIN,
-            client,
-            GetIndexAction.INSTANCE,
             getIndexRequest,
             ActionListener.wrap(getIndexResponse -> {
                 Set<String> userIndices = getIndexResponse.getIndices() != null
@@ -277,9 +287,8 @@ class DefaultCheckpointProvider implements CheckpointProvider {
                     : Collections.emptySet();
                 // 2nd get stats request
                 ClientHelper.executeAsyncWithOrigin(
-                    client,
+                    threadContext,
                     ClientHelper.TRANSFORM_ORIGIN,
-                    IndicesStatsAction.INSTANCE,
                     new IndicesStatsRequest().indices(indices).timeout(timeout).clear().indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN),
                     ActionListener.wrap(response -> {
                         if (response.getFailedShards() != 0) {
@@ -305,9 +314,11 @@ class DefaultCheckpointProvider implements CheckpointProvider {
                             return;
                         }
                         listener.onResponse(extractIndexCheckPoints(response.getShards(), userIndices, cluster));
-                    }, e -> listener.onFailure(new CheckpointException("Failed to create checkpoint", e)))
+                    }, e -> listener.onFailure(new CheckpointException("Failed to create checkpoint", e))),
+                    client::getIndicesStats
                 );
-            }, e -> listener.onFailure(new CheckpointException("Failed to create checkpoint", e)))
+            }, e -> listener.onFailure(new CheckpointException("Failed to create checkpoint", e))),
+            client::getIndex
         );
     }
 

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/checkpoint/DefaultCheckpointProviderTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/checkpoint/DefaultCheckpointProviderTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.ParentTaskAssigningClient;
+import org.elasticsearch.client.internal.RemoteClusterClient;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
@@ -71,9 +72,9 @@ public class DefaultCheckpointProviderTests extends ESTestCase {
     private Clock clock;
     private Client client;
     private ParentTaskAssigningClient parentTaskClient;
-    private Client remoteClient1;
-    private Client remoteClient2;
-    private Client remoteClient3;
+    private RemoteClusterClient remoteClient1;
+    private RemoteClusterClient remoteClient2;
+    private RemoteClusterClient remoteClient3;
     private IndexBasedTransformConfigManager transformConfigManager;
     private MockTransformAuditor transformAuditor;
 
@@ -85,12 +86,9 @@ public class DefaultCheckpointProviderTests extends ESTestCase {
         client = mock(Client.class);
         when(client.threadPool()).thenReturn(threadPool);
         parentTaskClient = new ParentTaskAssigningClient(client, new TaskId("dummy-node:123456"));
-        remoteClient1 = mock(Client.class);
-        when(remoteClient1.threadPool()).thenReturn(threadPool);
-        remoteClient2 = mock(Client.class);
-        when(remoteClient2.threadPool()).thenReturn(threadPool);
-        remoteClient3 = mock(Client.class);
-        when(remoteClient3.threadPool()).thenReturn(threadPool);
+        remoteClient1 = mock(RemoteClusterClient.class);
+        remoteClient2 = mock(RemoteClusterClient.class);
+        remoteClient3 = mock(RemoteClusterClient.class);
         when(client.getRemoteClusterClient(eq("remote-1"), any())).thenReturn(remoteClient1);
         when(client.getRemoteClusterClient(eq("remote-2"), any())).thenReturn(remoteClient2);
         when(client.getRemoteClusterClient(eq("remote-3"), any())).thenReturn(remoteClient3);


### PR DESCRIPTION
Today the general-purpose `Client` interface is used for interacting
with the local node and also with remote clusters. However, `Client`
includes a rich collection of utility methods, all of which are only
used on the local node. Many of these methods are untested, or
positively do not work, when targetting a remote cluster (see #100111).

This commit introduces a separate, simpler, interface for clients used
for remote-cluster interactions.