### PR TITLE
Reduce usage of Client utils with remote clusters

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessExecuteAction.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessExecuteAction.java
@@ -28,7 +28,6 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.single.shard.SingleShardRequest;
 import org.elasticsearch.action.support.single.shard.TransportSingleShardAction;
-import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
@@ -528,9 +527,9 @@ public class PainlessExecuteAction {
             } else {
                 // forward to remote cluster
                 String clusterAlias = request.getContextSetup().getClusterAlias();
-                Client remoteClusterClient = transportService.getRemoteClusterService()
-                    .getRemoteClusterClient(threadPool, clusterAlias, EsExecutors.DIRECT_EXECUTOR_SERVICE);
-                remoteClusterClient.admin().cluster().execute(PainlessExecuteAction.INSTANCE, request, listener);
+                transportService.getRemoteClusterService()
+                    .getRemoteClusterClient(threadPool, clusterAlias, EsExecutors.DIRECT_EXECUTOR_SERVICE)
+                    .execute(PainlessExecuteAction.INSTANCE, request, listener);
             }
         }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/ResolveIndexAction.java
@@ -18,7 +18,6 @@ import org.elasticsearch.action.OriginalIndices;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.IndexAbstraction;
@@ -493,13 +492,13 @@ public class ResolveIndexAction extends ActionType<ResolveIndexAction.Response> 
                 for (Map.Entry<String, OriginalIndices> remoteIndices : remoteClusterIndices.entrySet()) {
                     String clusterAlias = remoteIndices.getKey();
                     OriginalIndices originalIndices = remoteIndices.getValue();
-                    Client remoteClusterClient = remoteClusterService.getRemoteClusterClient(
+                    var remoteClusterClient = remoteClusterService.getRemoteClusterClient(
                         threadPool,
                         clusterAlias,
                         EsExecutors.DIRECT_EXECUTOR_SERVICE
                     );
                     Request remoteRequest = new Request(originalIndices.indices(), originalIndices.indicesOptions());
-                    remoteClusterClient.admin().indices().resolveIndex(remoteRequest, ActionListener.wrap(response -> {
+                    remoteClusterClient.execute(ResolveIndexAction.INSTANCE, remoteRequest, ActionListener.wrap(response -> {
                         remoteResponses.put(clusterAlias, response);
                         terminalHandler.run();
                     }, failure -> terminalHandler.run()));

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/TransportFieldCapabilitiesAction.java
@@ -18,7 +18,6 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.ChannelActionListener;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.action.support.RefCountingRunnable;
-import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
@@ -213,7 +212,7 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
             for (Map.Entry<String, OriginalIndices> remoteIndices : remoteClusterIndices.entrySet()) {
                 String clusterAlias = remoteIndices.getKey();
                 OriginalIndices originalIndices = remoteIndices.getValue();
-                Client remoteClusterClient = transportService.getRemoteClusterService()
+                var remoteClusterClient = transportService.getRemoteClusterService()
                     .getRemoteClusterClient(threadPool, clusterAlias, searchCoordinationExecutor);
                 FieldCapabilitiesRequest remoteRequest = prepareRemoteRequest(request, originalIndices, nowInMillis);
                 ActionListener<FieldCapabilitiesResponse> remoteListener = ActionListener.wrap(response -> {
@@ -234,7 +233,11 @@ public class TransportFieldCapabilitiesAction extends HandledTransportAction<Fie
                         handleIndexFailure.accept(RemoteClusterAware.buildRemoteIndexName(clusterAlias, index), ex);
                     }
                 });
-                remoteClusterClient.fieldCaps(remoteRequest, ActionListener.releaseAfter(remoteListener, refs.acquire()));
+                remoteClusterClient.execute(
+                    TransportFieldCapabilitiesAction.TYPE,
+                    remoteRequest,
+                    ActionListener.releaseAfter(remoteListener, refs.acquire())
+                );
             }
         }
     }

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -24,7 +24,6 @@ import org.elasticsearch.action.admin.cluster.shards.ClusterSearchShardsResponse
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
@@ -526,12 +525,8 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                 timeProvider.absoluteStartMillis(),
                 true
             );
-            Client remoteClusterClient = remoteClusterService.getRemoteClusterClient(
-                threadPool,
-                clusterAlias,
-                remoteClientResponseExecutor
-            );
-            remoteClusterClient.search(ccsSearchRequest, new ActionListener<>() {
+            var remoteClusterClient = remoteClusterService.getRemoteClusterClient(threadPool, clusterAlias, remoteClientResponseExecutor);
+            remoteClusterClient.execute(TransportSearchAction.TYPE, ccsSearchRequest, new ActionListener<>() {
                 @Override
                 public void onResponse(SearchResponse searchResponse) {
                     // overwrite the existing cluster entry with the updated one
@@ -609,12 +604,12 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                     task.getProgressListener(),
                     listener
                 );
-                Client remoteClusterClient = remoteClusterService.getRemoteClusterClient(
+                final var remoteClusterClient = remoteClusterService.getRemoteClusterClient(
                     threadPool,
                     clusterAlias,
                     remoteClientResponseExecutor
                 );
-                remoteClusterClient.search(ccsSearchRequest, ccsListener);
+                remoteClusterClient.execute(TransportSearchAction.TYPE, ccsSearchRequest, ccsListener);
             }
             if (localIndices != null) {
                 ActionListener<SearchResponse> ccsListener = createCCSListener(

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterClientTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterClientTests.java
@@ -9,9 +9,13 @@ package org.elasticsearch.transport;
 
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateAction;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchScrollRequest;
+import org.elasticsearch.action.search.TransportSearchScrollAction;
 import org.elasticsearch.action.support.PlainActionFuture;
-import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
@@ -90,22 +94,21 @@ public class RemoteClusterClientTests extends ESTestCase {
                 logger.info("now accepting incoming requests on local transport");
                 RemoteClusterService remoteClusterService = service.getRemoteClusterService();
                 assertTrue(remoteClusterService.isRemoteNodeConnected("test", remoteNode));
-                Client client = remoteClusterService.getRemoteClusterClient(
+                var client = remoteClusterService.getRemoteClusterClient(
                     threadPool,
                     "test",
                     threadPool.executor(TEST_THREAD_POOL_NAME),
                     randomBoolean()
                 );
                 ClusterStateResponse clusterStateResponse = PlainActionFuture.get(
-                    future -> client.admin()
-                        .cluster()
-                        .prepareState()
-                        .execute(
-                            ActionListener.runBefore(
-                                future,
-                                () -> assertTrue(Thread.currentThread().getName().contains('[' + TEST_THREAD_POOL_NAME + ']'))
-                            )
-                        ),
+                    future -> client.execute(
+                        ClusterStateAction.INSTANCE,
+                        new ClusterStateRequest(),
+                        ActionListener.runBefore(
+                            future,
+                            () -> assertTrue(Thread.currentThread().getName().contains('[' + TEST_THREAD_POOL_NAME + ']'))
+                        )
+                    ),
                     10,
                     TimeUnit.SECONDS
                 );
@@ -114,7 +117,9 @@ public class RemoteClusterClientTests extends ESTestCase {
                 // also test a failure, there is no handler for scroll registered
                 ActionNotFoundTransportException ex = expectThrows(
                     ActionNotFoundTransportException.class,
-                    () -> client.prepareSearchScroll("").get()
+                    () -> PlainActionFuture.<SearchResponse, RuntimeException>get(
+                        future -> client.execute(TransportSearchScrollAction.TYPE, new SearchScrollRequest(""), future)
+                    )
                 );
                 assertEquals("No handler for action [indices:data/read/scroll]", ex.getMessage());
             }
@@ -167,13 +172,10 @@ public class RemoteClusterClientTests extends ESTestCase {
                     connectionManager.disconnectFromNode(remoteNode);
                     closeFuture.get();
 
-                    Client client = remoteClusterService.getRemoteClusterClient(
-                        threadPool,
-                        "test",
-                        EsExecutors.DIRECT_EXECUTOR_SERVICE,
-                        true
+                    var client = remoteClusterService.getRemoteClusterClient(threadPool, "test", EsExecutors.DIRECT_EXECUTOR_SERVICE, true);
+                    ClusterStateResponse clusterStateResponse = PlainActionFuture.get(
+                        f -> client.execute(ClusterStateAction.INSTANCE, new ClusterStateRequest(), f)
                     );
-                    ClusterStateResponse clusterStateResponse = client.admin().cluster().prepareState().execute().get();
                     assertNotNull(clusterStateResponse);
                     assertEquals("foo_bar_cluster", clusterStateResponse.getState().getClusterName().value());
                     assertTrue(remoteClusterConnection.isNodeConnected(remoteNode));
@@ -241,7 +243,7 @@ public class RemoteClusterClientTests extends ESTestCase {
                 service.start();
                 service.acceptIncomingRequests();
                 RemoteClusterService remoteClusterService = service.getRemoteClusterService();
-                Client client = remoteClusterService.getRemoteClusterClient(threadPool, "test", EsExecutors.DIRECT_EXECUTOR_SERVICE);
+                var client = remoteClusterService.getRemoteClusterClient(threadPool, "test", EsExecutors.DIRECT_EXECUTOR_SERVICE);
 
                 try {
                     assertFalse(remoteClusterService.isRemoteNodeConnected("test", remoteNode));
@@ -249,7 +251,9 @@ public class RemoteClusterClientTests extends ESTestCase {
                     // check that we quickly fail
                     expectThrows(
                         NoSuchRemoteClusterException.class,
-                        () -> client.admin().cluster().prepareState().get(TimeValue.timeValueSeconds(10))
+                        () -> PlainActionFuture.<ClusterStateResponse, RuntimeException>get(
+                            f -> client.execute(ClusterStateAction.INSTANCE, new ClusterStateRequest(), f)
+                        )
                     );
                 } finally {
                     service.clearAllRules();
@@ -258,7 +262,9 @@ public class RemoteClusterClientTests extends ESTestCase {
 
                 assertBusy(() -> {
                     try {
-                        client.admin().cluster().prepareState().get();
+                        PlainActionFuture.<ClusterStateResponse, RuntimeException>get(
+                            f -> client.execute(ClusterStateAction.INSTANCE, new ClusterStateRequest(), f)
+                        );
                     } catch (NoSuchRemoteClusterException e) {
                         // keep retrying on this exception, the goal is to check that we eventually reconnect
                         throw new AssertionError(e);

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/CcrRequests.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/CcrRequests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.ccr.action;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.RequestValidators;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateAction;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
@@ -64,7 +65,7 @@ public final class CcrRequests {
         if (metadataVersion > 0) {
             request.waitForMetadataVersion(metadataVersion).waitForTimeout(timeoutSupplier.get());
         }
-        client.admin().cluster().state(request, listener.delegateFailureAndWrap((delegate, response) -> {
+        client.execute(ClusterStateAction.INSTANCE, request, listener.delegateFailureAndWrap((delegate, response) -> {
             if (response.getState() == null) { // timeout on wait_for_metadata_version
                 assert metadataVersion > 0 : metadataVersion;
                 if (timeoutSupplier.get().nanos() < 0) {

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowTasksExecutor.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowTasksExecutor.java
@@ -13,6 +13,7 @@ import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateAction;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
 import org.elasticsearch.action.admin.indices.close.CloseIndexRequest;
@@ -244,9 +245,11 @@ public final class ShardFollowTasksExecutor extends PersistentTasksExecutor<Shar
                     }
                 };
                 try {
-                    remoteClient(params).admin()
-                        .cluster()
-                        .state(CcrRequests.metadataRequest(leaderIndex.getName()), ActionListener.wrap(onResponse, errorHandler));
+                    remoteClient(params).execute(
+                        ClusterStateAction.INSTANCE,
+                        CcrRequests.metadataRequest(leaderIndex.getName()),
+                        ActionListener.wrap(onResponse, errorHandler)
+                    );
                 } catch (NoSuchRemoteClusterException e) {
                     errorHandler.accept(e);
                 }
@@ -371,9 +374,11 @@ public final class ShardFollowTasksExecutor extends PersistentTasksExecutor<Shar
                 };
 
                 try {
-                    remoteClient(params).admin()
-                        .cluster()
-                        .state(CcrRequests.metadataRequest(leaderIndex.getName()), ActionListener.wrap(onResponse, errorHandler));
+                    remoteClient(params).execute(
+                        ClusterStateAction.INSTANCE,
+                        CcrRequests.metadataRequest(leaderIndex.getName()),
+                        ActionListener.wrap(onResponse, errorHandler)
+                    );
                 } catch (final NoSuchRemoteClusterException e) {
                     errorHandler.accept(e);
                 }

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportPutAutoFollowPatternAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportPutAutoFollowPatternAction.java
@@ -100,7 +100,7 @@ public class TransportPutAutoFollowPatternAction extends AcknowledgedTransportMa
             listener.onFailure(new IllegalArgumentException(message));
             return;
         }
-        final Client remoteClient = client.getRemoteClusterClient(request.getRemoteCluster(), remoteClientResponseExecutor);
+        final var remoteClient = client.getRemoteClusterClient(request.getRemoteCluster(), remoteClientResponseExecutor);
         final Map<String, String> filteredHeaders = ClientHelper.getPersistableSafeSecurityHeaders(
             threadPool.getThreadContext(),
             clusterService.state()

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/CcrLicenseCheckerTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/CcrLicenseCheckerTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.ccr;
 
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.security.user.User;
 
@@ -25,7 +26,7 @@ public class CcrLicenseCheckerTests extends ESTestCase {
         final CcrLicenseChecker checker = new CcrLicenseChecker(() -> isCcrAllowed, () -> true) {
 
             @Override
-            User getUser(final Client remoteClient) {
+            User getUser(final ThreadContext threadContext) {
                 return null;
             }
 

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/CcrLicenseCheckerTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/CcrLicenseCheckerTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.ccr;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.security.user.User;
 
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -18,6 +19,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class CcrLicenseCheckerTests extends ESTestCase {
 
@@ -32,7 +34,9 @@ public class CcrLicenseCheckerTests extends ESTestCase {
 
         };
         final AtomicBoolean invoked = new AtomicBoolean();
-        checker.hasPrivilegesToFollowIndices(mock(Client.class), new String[] { randomAlphaOfLength(8) }, e -> {
+        final var client = mock(Client.class);
+        when(client.threadPool()).thenReturn(mock(ThreadPool.class));
+        checker.hasPrivilegesToFollowIndices(client, new String[] { randomAlphaOfLength(8) }, e -> {
             invoked.set(true);
             assertThat(e, instanceOf(IllegalStateException.class));
             assertThat(e, hasToString(containsString("missing or unable to read authentication info on request")));

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/action/TransportTermsEnumAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/action/TransportTermsEnumAction.java
@@ -19,7 +19,6 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.action.support.broadcast.BroadcastShardOperationFailedException;
-import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
@@ -625,7 +624,7 @@ public class TransportTermsEnumAction extends HandledTransportAction<TermsEnumRe
             try {
                 TermsEnumRequest req = new TermsEnumRequest(request).indices(remoteIndices.indices());
 
-                Client remoteClient = remoteClusterService.getRemoteClusterClient(
+                var remoteClient = remoteClusterService.getRemoteClusterClient(
                     transportService.getThreadPool(),
                     clusterAlias,
                     EsExecutors.DIRECT_EXECUTOR_SERVICE

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityFcActionAuthorizationIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityFcActionAuthorizationIT.java
@@ -9,10 +9,14 @@ package org.elasticsearch.xpack.remotecluster;
 
 import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.admin.cluster.remote.RemoteClusterNodesAction;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesRequest;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse;
 import org.elasticsearch.action.fieldcaps.TransportFieldCapabilitiesAction;
+import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.internal.Client;
@@ -32,6 +36,7 @@ import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.RemoteClusterService;
 import org.elasticsearch.transport.RemoteConnectionInfo;
+import org.elasticsearch.transport.RemoteTransportException;
 import org.elasticsearch.xpack.ccr.action.repositories.ClearCcrRestoreSessionAction;
 import org.elasticsearch.xpack.ccr.action.repositories.ClearCcrRestoreSessionRequest;
 import org.elasticsearch.xpack.ccr.action.repositories.GetCcrRestoreFileChunkAction;
@@ -50,6 +55,7 @@ import org.junit.ClassRule;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.xpack.remotecluster.AbstractRemoteClusterSecurityTestCase.PASS;
@@ -99,7 +105,32 @@ public class RemoteClusterSecurityFcActionAuthorizationIT extends ESRestTestCase
         ThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS);
     }
 
-    public void testIndicesPrivilegesAreEnforcedForCcrRestoreSessionActions() throws IOException {
+    private static <Request extends ActionRequest, Response extends ActionResponse> Response executeRemote(
+        Client client,
+        ActionType<Response> action,
+        Request request
+    ) throws Exception {
+        final var future = new PlainActionFuture<Response>();
+        client.execute(action, request, future);
+        try {
+            return future.get(10, TimeUnit.SECONDS);
+        } catch (ExecutionException e) {
+            if (e.getCause() instanceof RemoteTransportException remoteTransportException
+                && remoteTransportException.getCause() instanceof Exception cause) {
+                throw cause;
+            }
+
+            if (e.getCause() instanceof Exception cause) {
+                throw cause;
+            }
+
+            throw new AssertionError(e);
+        } catch (Exception e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    public void testIndicesPrivilegesAreEnforcedForCcrRestoreSessionActions() throws Exception {
         final Map<String, Object> crossClusterApiKeyMap = createCrossClusterAccessApiKey(adminClient(), """
             {
               "replication": [
@@ -141,7 +172,7 @@ public class RemoteClusterSecurityFcActionAuthorizationIT extends ESRestTestCase
             assertThat(remoteConnectionInfos, hasSize(1));
             assertThat(remoteConnectionInfos.get(0).isConnected(), is(true));
 
-            final Client remoteClusterClient = remoteClusterService.getRemoteClusterClient(
+            final var remoteClusterClient = remoteClusterService.getRemoteClusterClient(
                 threadPool,
                 "my_remote_cluster",
                 threadPool.generic()
@@ -152,7 +183,7 @@ public class RemoteClusterSecurityFcActionAuthorizationIT extends ESRestTestCase
             final PutCcrRestoreSessionRequest request = new PutCcrRestoreSessionRequest(UUIDs.randomBase64UUID(), privateShardId);
             final ElasticsearchSecurityException e = expectThrows(
                 ElasticsearchSecurityException.class,
-                () -> remoteClusterClient.execute(PutCcrRestoreSessionAction.INSTANCE, request).actionGet()
+                () -> executeRemote(remoteClusterClient, PutCcrRestoreSessionAction.INSTANCE, request)
             );
             assertThat(
                 e.getMessage(),
@@ -169,30 +200,33 @@ public class RemoteClusterSecurityFcActionAuthorizationIT extends ESRestTestCase
             final String sessionUUID1 = UUIDs.randomBase64UUID();
             final ShardId shardId1 = new ShardId("leader-index-1", leaderIndex1UUID, 0);
             final PutCcrRestoreSessionRequest request1 = new PutCcrRestoreSessionRequest(sessionUUID1, shardId1);
-            final PutCcrRestoreSessionAction.PutCcrRestoreSessionResponse response1 = remoteClusterClient.execute(
+            final PutCcrRestoreSessionAction.PutCcrRestoreSessionResponse response1 = executeRemote(
+                remoteClusterClient,
                 PutCcrRestoreSessionAction.INSTANCE,
                 request1
-            ).actionGet();
+            );
             assertThat(response1.getStoreFileMetadata().fileMetadataMap().keySet(), hasSize(greaterThanOrEqualTo(1)));
             final String leaderIndex1FileName = response1.getStoreFileMetadata().fileMetadataMap().keySet().iterator().next();
 
             final String sessionUUID2 = UUIDs.randomBase64UUID();
             final ShardId shardId2 = new ShardId("leader-index-2", leaderIndex2UUID, 0);
             final PutCcrRestoreSessionRequest request2 = new PutCcrRestoreSessionRequest(sessionUUID2, shardId2);
-            final PutCcrRestoreSessionAction.PutCcrRestoreSessionResponse response2 = remoteClusterClient.execute(
+            final PutCcrRestoreSessionAction.PutCcrRestoreSessionResponse response2 = executeRemote(
+                remoteClusterClient,
                 PutCcrRestoreSessionAction.INSTANCE,
                 request2
-            ).actionGet();
+            );
             assertThat(response2.getStoreFileMetadata().fileMetadataMap().keySet(), hasSize(greaterThanOrEqualTo(1)));
             final String leaderIndex2FileName = response2.getStoreFileMetadata().fileMetadataMap().keySet().iterator().next();
 
             // Get file chuck fails if requested index is not authorized
             final var e1 = expectThrows(
                 ElasticsearchSecurityException.class,
-                () -> remoteClusterClient.execute(
+                () -> executeRemote(
+                    remoteClusterClient,
                     GetCcrRestoreFileChunkAction.INSTANCE,
                     new GetCcrRestoreFileChunkRequest(response1.getNode(), sessionUUID1, leaderIndex1FileName, 1, privateShardId)
-                ).actionGet()
+                )
             );
             assertThat(
                 e1.getMessage(),
@@ -202,17 +236,19 @@ public class RemoteClusterSecurityFcActionAuthorizationIT extends ESRestTestCase
             // Get file chunk fails if requested index does not match session index
             final var e2 = expectThrows(
                 IllegalArgumentException.class,
-                () -> remoteClusterClient.execute(
+                () -> executeRemote(
+                    remoteClusterClient,
                     GetCcrRestoreFileChunkAction.INSTANCE,
                     new GetCcrRestoreFileChunkRequest(response1.getNode(), sessionUUID1, leaderIndex1FileName, 1, shardId2)
-                ).actionGet()
+                )
             );
             assertThat(e2.getMessage(), containsString("does not match requested shardId"));
 
             // Get file chunk fails if requested file is not part of the session
             final var e3 = expectThrows(
                 IllegalArgumentException.class,
-                () -> remoteClusterClient.execute(
+                () -> executeRemote(
+                    remoteClusterClient,
                     GetCcrRestoreFileChunkAction.INSTANCE,
                     new GetCcrRestoreFileChunkRequest(
                         response1.getNode(),
@@ -221,24 +257,26 @@ public class RemoteClusterSecurityFcActionAuthorizationIT extends ESRestTestCase
                         1,
                         shardId1
                     )
-                ).actionGet()
+                )
             );
             assertThat(e3.getMessage(), containsString("invalid file name"));
 
             // Get file chunk succeeds
-            final GetCcrRestoreFileChunkAction.GetCcrRestoreFileChunkResponse getChunkResponse = remoteClusterClient.execute(
+            final GetCcrRestoreFileChunkAction.GetCcrRestoreFileChunkResponse getChunkResponse = executeRemote(
+                remoteClusterClient,
                 GetCcrRestoreFileChunkAction.INSTANCE,
                 new GetCcrRestoreFileChunkRequest(response2.getNode(), sessionUUID2, leaderIndex2FileName, 1, shardId2)
-            ).actionGet();
+            );
             assertThat(getChunkResponse.getChunk().length(), equalTo(1));
 
             // Clear restore session fails if index is unauthorized
             final var e4 = expectThrows(
                 ElasticsearchSecurityException.class,
-                () -> remoteClusterClient.execute(
+                () -> executeRemote(
+                    remoteClusterClient,
                     ClearCcrRestoreSessionAction.INSTANCE,
                     new ClearCcrRestoreSessionRequest(sessionUUID1, response1.getNode(), privateShardId)
-                ).actionGet()
+                )
             );
             assertThat(
                 e4.getMessage(),
@@ -248,22 +286,25 @@ public class RemoteClusterSecurityFcActionAuthorizationIT extends ESRestTestCase
             // Clear restore session fails if requested index does not match session index
             final var e5 = expectThrows(
                 IllegalArgumentException.class,
-                () -> remoteClusterClient.execute(
+                () -> executeRemote(
+                    remoteClusterClient,
                     ClearCcrRestoreSessionAction.INSTANCE,
                     new ClearCcrRestoreSessionRequest(sessionUUID1, response1.getNode(), shardId2)
-                ).actionGet()
+                )
             );
             assertThat(e5.getMessage(), containsString("does not match requested shardId"));
 
             // Clear restore sessions succeed
-            remoteClusterClient.execute(
+            executeRemote(
+                remoteClusterClient,
                 ClearCcrRestoreSessionAction.INSTANCE,
                 new ClearCcrRestoreSessionRequest(sessionUUID1, response1.getNode(), shardId1)
-            ).actionGet();
-            remoteClusterClient.execute(
+            );
+            executeRemote(
+                remoteClusterClient,
                 ClearCcrRestoreSessionAction.INSTANCE,
                 new ClearCcrRestoreSessionRequest(sessionUUID2, response2.getNode(), shardId2)
-            ).actionGet();
+            );
         }
     }
 
@@ -278,7 +319,7 @@ public class RemoteClusterSecurityFcActionAuthorizationIT extends ESRestTestCase
         final Map<String, Object> apiKeyMap = responseAsMap(createApiKeyResponse);
         try (MockTransportService service = startTransport("node", threadPool, (String) apiKeyMap.get("encoded"))) {
             final RemoteClusterService remoteClusterService = service.getRemoteClusterService();
-            final Client remoteClusterClient = remoteClusterService.getRemoteClusterClient(
+            final var remoteClusterClient = remoteClusterService.getRemoteClusterClient(
                 threadPool,
                 "my_remote_cluster",
                 EsExecutors.DIRECT_EXECUTOR_SERVICE
@@ -286,10 +327,11 @@ public class RemoteClusterSecurityFcActionAuthorizationIT extends ESRestTestCase
 
             final ElasticsearchSecurityException e = expectThrows(
                 ElasticsearchSecurityException.class,
-                () -> remoteClusterClient.execute(
+                () -> executeRemote(
+                    remoteClusterClient,
                     RemoteClusterNodesAction.TYPE,
                     RemoteClusterNodesAction.Request.REMOTE_CLUSTER_SERVER_NODES
-                ).actionGet()
+                )
             );
             assertThat(
                 e.getMessage(),
@@ -300,7 +342,7 @@ public class RemoteClusterSecurityFcActionAuthorizationIT extends ESRestTestCase
         }
     }
 
-    public void testUpdateCrossClusterApiKey() throws IOException {
+    public void testUpdateCrossClusterApiKey() throws Exception {
         final Map<String, Object> crossClusterApiKeyMap = createCrossClusterAccessApiKey(adminClient(), """
             {
               "search": [
@@ -351,7 +393,7 @@ public class RemoteClusterSecurityFcActionAuthorizationIT extends ESRestTestCase
             final List<RemoteConnectionInfo> remoteConnectionInfos = remoteClusterService.getRemoteConnectionInfos().toList();
             assertThat(remoteConnectionInfos, hasSize(1));
             assertThat(remoteConnectionInfos.get(0).isConnected(), is(true));
-            final Client remoteClusterClient = remoteClusterService.getRemoteClusterClient(
+            final var remoteClusterClient = remoteClusterService.getRemoteClusterClient(
                 threadPool,
                 "my_remote_cluster",
                 EsExecutors.DIRECT_EXECUTOR_SERVICE
@@ -360,7 +402,7 @@ public class RemoteClusterSecurityFcActionAuthorizationIT extends ESRestTestCase
             // 1. Not accessible because API key does not grant the access
             final ElasticsearchSecurityException e1 = expectThrows(
                 ElasticsearchSecurityException.class,
-                () -> remoteClusterClient.execute(TransportFieldCapabilitiesAction.TYPE, request).actionGet()
+                () -> executeRemote(remoteClusterClient, TransportFieldCapabilitiesAction.TYPE, request)
             );
             assertThat(
                 e1.getMessage(),
@@ -386,10 +428,11 @@ public class RemoteClusterSecurityFcActionAuthorizationIT extends ESRestTestCase
                   }
                 }""");
             assertOK(performRequestWithAdminUser(adminClient(), updateApiKeyRequest));
-            final FieldCapabilitiesResponse fieldCapabilitiesResponse = remoteClusterClient.execute(
+            final FieldCapabilitiesResponse fieldCapabilitiesResponse = executeRemote(
+                remoteClusterClient,
                 TransportFieldCapabilitiesAction.TYPE,
                 request
-            ).actionGet();
+            );
             assertThat(fieldCapabilitiesResponse.getIndices(), arrayContaining("index"));
 
             // 3. Update the API key again to remove access
@@ -407,7 +450,7 @@ public class RemoteClusterSecurityFcActionAuthorizationIT extends ESRestTestCase
             assertOK(performRequestWithAdminUser(adminClient(), updateApiKeyRequest));
             final ElasticsearchSecurityException e2 = expectThrows(
                 ElasticsearchSecurityException.class,
-                () -> remoteClusterClient.execute(TransportFieldCapabilitiesAction.TYPE, request).actionGet()
+                () -> executeRemote(remoteClusterClient, TransportFieldCapabilitiesAction.TYPE, request)
             );
             assertThat(
                 e2.getMessage(),


### PR DESCRIPTION
In practice almost all of the utility methods on `Client` are only used
on the local node, and many of them are untested, or positively do not
work, when targetting a remote cluster (see #100111). This commit
removes most of the remaining usages of these utility methods against
remote clusters as a step towards separating the remote-cluster client
from the local-node client.

Relates #104536