### PR TITLE
ESQL: Fix bug in testing text field loading

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
@@ -710,7 +710,8 @@ public class KeywordFieldMapperTests extends MapperTestCase {
             List<String> outList = store ? outPrimary : new HashSet<>(outPrimary).stream().sorted().collect(Collectors.toList());
             List<String> loadBlock;
             if (loadBlockFromSource) {
-                loadBlock = in;
+                // The block loader infrastructure will never return nulls. Just zap them all.
+                loadBlock = in.stream().filter(m -> m != null).toList();
             } else if (docValues) {
                 loadBlock = new HashSet<>(outPrimary).stream().sorted().collect(Collectors.toList());
             } else {

--- a/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
@@ -1120,12 +1120,11 @@ public class TextFieldMapperTests extends MapperTestCase {
         assumeFalse("ignore_malformed not supported", ignoreMalformed);
         boolean storeTextField = randomBoolean();
         boolean storedKeywordField = storeTextField || randomBoolean();
-        String nullValue = storeTextField || usually() ? null : randomAlphaOfLength(2);
         Integer ignoreAbove = randomBoolean() ? null : between(10, 100);
         KeywordFieldMapperTests.KeywordSyntheticSourceSupport keywordSupport = new KeywordFieldMapperTests.KeywordSyntheticSourceSupport(
             ignoreAbove,
             storedKeywordField,
-            nullValue,
+            null,
             false == storeTextField
         );
         return new SyntheticSourceSupport() {


### PR DESCRIPTION
Our text field loader tests were accidentally using `nullValue` which isn't supported by text fields. And the expected values for `null` values in the source wasn't being calculated correctly. In `_source` you can have null values in a list like this: `[1, 2, null, 3]` but block loaders don't do this - they only emit `null` if there aren't any values in the block at all.

Closes #104158
