### PR TITLE
[8.12] Grant SocketPermission in FIPS ITs to the FIPS JSSE implementation lib (#104465)

### DIFF
--- a/build-tools-internal/src/main/resources/fips_java.policy
+++ b/build-tools-internal/src/main/resources/fips_java.policy
@@ -18,3 +18,8 @@ grant {
      permission org.bouncycastle.crypto.CryptoServicesPermission "exportPrivateKey";
      permission java.io.FilePermission "${javax.net.ssl.trustStore}", "read";
 };
+
+// rely on the caller's socket permissions, the JSSE TLS implementation here is always allowed to connect
+grant codeBase "file:${jdk.module.path}/bctls-fips-1.0.17.jar" {
+  permission java.net.SocketPermission "*", "connect";
+};

--- a/test/test-clusters/src/main/resources/fips/fips_java.policy
+++ b/test/test-clusters/src/main/resources/fips/fips_java.policy
@@ -18,3 +18,8 @@ grant {
      permission org.bouncycastle.crypto.CryptoServicesPermission "exportPrivateKey";
      permission java.io.FilePermission "${javax.net.ssl.trustStore}", "read";
 };
+
+// rely on the caller's socket permissions, the JSSE TLS implementation here is always allowed to connect
+grant codeBase "file:${jdk.module.path}/bctls-fips-1.0.17.jar" {
+  permission java.net.SocketPermission "*", "connect";
+};


### PR DESCRIPTION
Backports the following commits to 8.12:
 - Grant SocketPermission in FIPS ITs to the FIPS JSSE implementation lib (#104465)