### PR TITLE
ESQL: Allow grouping by null blocks (#104523)

### DIFF
--- a/docs/changelog/104523.yaml
+++ b/docs/changelog/104523.yaml
@@ -1,0 +1,5 @@
+pr: 104523
+summary: "ESQL: Allow grouping by null blocks"
+area: ES|QL
+type: bug
+issues: []

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BlockHash.java
@@ -34,7 +34,7 @@ import java.util.List;
  */
 public abstract sealed class BlockHash implements Releasable, SeenGroupIds //
     permits BooleanBlockHash, BytesRefBlockHash, DoubleBlockHash, IntBlockHash, LongBlockHash,//
-    PackedValuesBlockHash, BytesRefLongBlockHash, LongLongBlockHash {
+    NullBlockHash, PackedValuesBlockHash, BytesRefLongBlockHash, LongLongBlockHash {
 
     protected final BigArrays bigArrays;
     protected final BlockFactory blockFactory;
@@ -107,6 +107,7 @@ public abstract sealed class BlockHash implements Releasable, SeenGroupIds //
      */
     private static BlockHash newForElementType(int channel, ElementType type, DriverContext driverContext) {
         return switch (type) {
+            case NULL -> new NullBlockHash(channel, driverContext);
             case BOOLEAN -> new BooleanBlockHash(channel, driverContext);
             case INT -> new IntBlockHash(channel, driverContext);
             case LONG -> new LongBlockHash(channel, driverContext);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BooleanBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BooleanBlockHash.java
@@ -100,6 +100,7 @@ final class BooleanBlockHash extends BlockHash {
         }
     }
 
+    @Override
     public BitArray seenGroupIds(BigArrays bigArrays) {
         BitArray seen = new BitArray(everSeen.length, bigArrays);
         for (int i = 0; i < everSeen.length; i++) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/NullBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/NullBlockHash.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation.blockhash;
+
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.BitArray;
+import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+
+/**
+ * Maps a {@link BooleanBlock} column to group ids. Assigns group
+ * {@code 0} to {@code false} and group {@code 1} to {@code true}.
+ */
+final class NullBlockHash extends BlockHash {
+    private final int channel;
+    private boolean seenNull = false;
+
+    NullBlockHash(int channel, DriverContext driverContext) {
+        super(driverContext);
+        this.channel = channel;
+    }
+
+    @Override
+    public void add(Page page, GroupingAggregatorFunction.AddInput addInput) {
+        var block = page.getBlock(channel);
+        if (block.areAllValuesNull()) {
+            seenNull = true;
+            try (IntVector groupIds = blockFactory.newConstantIntVector(0, block.getPositionCount())) {
+                addInput.add(0, groupIds);
+            }
+        } else {
+            throw new IllegalArgumentException("can't use NullBlockHash for non-null blocks");
+        }
+    }
+
+    @Override
+    public Block[] getKeys() {
+        return new Block[] { blockFactory.newConstantNullBlock(seenNull ? 1 : 0) };
+    }
+
+    @Override
+    public IntVector nonEmpty() {
+        return blockFactory.newConstantIntVector(0, seenNull ? 1 : 0);
+    }
+
+    @Override
+    public BitArray seenGroupIds(BigArrays bigArrays) {
+        BitArray seen = new BitArray(1, bigArrays);
+        if (seenNull) {
+            seen.set(0);
+        }
+        return seen;
+    }
+
+    @Override
+    public void close() {
+        // Nothing to close
+    }
+
+    @Override
+    public String toString() {
+        return "NullBlockHash{channel=" + channel + ", seenNull=" + seenNull + '}';
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/BatchEncoder.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/BatchEncoder.java
@@ -49,7 +49,8 @@ public abstract class BatchEncoder implements Accountable {
             case DOUBLE -> new DoublesDecoder();
             case BYTES_REF -> new BytesRefsDecoder();
             case BOOLEAN -> new BooleansDecoder();
-            default -> throw new IllegalArgumentException("can't encode " + elementType);
+            case NULL -> new NullsDecoder();
+            default -> throw new IllegalArgumentException("can't decode " + elementType);
         };
     }
 
@@ -649,6 +650,19 @@ public abstract class BatchEncoder implements Accountable {
         protected int readValueAtBlockIndex(int valueIndex, BytesRefBuilder dst) {
             assert false : "all positions all nulls";
             throw new IllegalStateException("all positions all nulls");
+        }
+    }
+
+    private static class NullsDecoder implements Decoder {
+        @Override
+        public void decode(Block.Builder builder, IsNull isNull, BytesRef[] encoded, int count) {
+            for (int i = 0; i < count; i++) {
+                if (isNull.isNull(i)) {
+                    builder.appendNull();
+                } else {
+                    throw new IllegalArgumentException("NullsDecoder requires that all positions are null");
+                }
+            }
         }
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/MultivalueDedupe.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/MultivalueDedupe.java
@@ -35,6 +35,7 @@ public final class MultivalueDedupe {
             case INT -> new MultivalueDedupeInt((IntBlock) block).dedupeToBlockAdaptive(blockFactory);
             case LONG -> new MultivalueDedupeLong((LongBlock) block).dedupeToBlockAdaptive(blockFactory);
             case DOUBLE -> new MultivalueDedupeDouble((DoubleBlock) block).dedupeToBlockAdaptive(blockFactory);
+            case NULL -> block;
             default -> throw new IllegalArgumentException();
         };
     }
@@ -52,6 +53,7 @@ public final class MultivalueDedupe {
             case INT -> new MultivalueDedupeInt((IntBlock) block).dedupeToBlockUsingCopyMissing(blockFactory);
             case LONG -> new MultivalueDedupeLong((LongBlock) block).dedupeToBlockUsingCopyMissing(blockFactory);
             case DOUBLE -> new MultivalueDedupeDouble((DoubleBlock) block).dedupeToBlockUsingCopyMissing(blockFactory);
+            case NULL -> block;
             default -> throw new IllegalArgumentException();
         };
     }
@@ -71,6 +73,7 @@ public final class MultivalueDedupe {
             case INT -> new MultivalueDedupeInt((IntBlock) block).dedupeToBlockUsingCopyAndSort(blockFactory);
             case LONG -> new MultivalueDedupeLong((LongBlock) block).dedupeToBlockUsingCopyAndSort(blockFactory);
             case DOUBLE -> new MultivalueDedupeDouble((DoubleBlock) block).dedupeToBlockUsingCopyAndSort(blockFactory);
+            case NULL -> block;
             default -> throw new IllegalArgumentException();
         };
     }
@@ -118,6 +121,9 @@ public final class MultivalueDedupe {
      */
     public static BatchEncoder batchEncoder(Block block, int batchSize, boolean allowDirectEncoder) {
         if (block.areAllValuesNull()) {
+            if (allowDirectEncoder == false) {
+                throw new IllegalArgumentException("null blocks can only be directly encoded");
+            }
             return new BatchEncoder.DirectNulls(block);
         }
         var elementType = block.elementType();

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashRandomizedTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashRandomizedTests.java
@@ -140,7 +140,7 @@ public class BlockHashRandomizedTests extends ESTestCase {
                     randomBlocks[g] = BasicBlockTests.randomBlock(
                         types.get(g),
                         positionCount,
-                        randomBoolean(),
+                        types.get(g) == ElementType.NULL ? true : randomBoolean(),
                         1,
                         maxValuesPerPosition,
                         0,

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashTests.java
@@ -604,6 +604,20 @@ public class BlockHashTests extends ESTestCase {
         }
     }
 
+    public void testNullHash() {
+        Object[] values = new Object[] { null, null, null, null };
+        hash(ordsAndKeys -> {
+            if (forcePackedHash) {
+                assertThat(ordsAndKeys.description, startsWith("PackedValuesBlockHash{groups=[0:NULL], entries=1, size="));
+            } else {
+                assertThat(ordsAndKeys.description, equalTo("NullBlockHash{channel=0, seenNull=true}"));
+            }
+            assertOrds(ordsAndKeys.ords, 0, 0, 0, 0);
+            assertThat(ordsAndKeys.nonEmpty, equalTo(BlockFactory.getNonBreakingInstance().newConstantIntVector(0, 1)));
+            assertKeys(ordsAndKeys.keys, new Object[][] { new Object[] { null } });
+        }, blockFactory.newConstantNullBlock(values.length));
+    }
+
     public void testLongLongHash() {
         long[] values1 = new long[] { 0, 1, 0, 1, 0, 1 };
         long[] values2 = new long[] { 0, 0, 0, 1, 1, 1 };
@@ -1081,6 +1095,22 @@ public class BlockHashTests extends ESTestCase {
 
             assertThat("misconfigured test", expectedEntries[0], greaterThan(0));
         }
+    }
+
+    public void testLongNull() {
+        long[] values = new long[] { 0, 1, 0, 2, 3, 1 };
+        hash(ordsAndKeys -> {
+            Object[][] expectedKeys = {
+                new Object[] { 0L, null },
+                new Object[] { 1L, null },
+                new Object[] { 2L, null },
+                new Object[] { 3L, null } };
+
+            assertThat(ordsAndKeys.description, startsWith("PackedValuesBlockHash{groups=[0:LONG, 1:NULL], entries=4, size="));
+            assertOrds(ordsAndKeys.ords, 0, 1, 0, 2, 3, 1);
+            assertKeys(ordsAndKeys.keys, expectedKeys);
+            assertThat(ordsAndKeys.nonEmpty, equalTo(intRange(0, 4)));
+        }, blockFactory.newLongArrayVector(values, values.length).asBlock(), blockFactory.newConstantNullBlock(values.length));
     }
 
     record OrdsAndKeys(String description, int positionOffset, IntBlock ords, Block[] keys, IntVector nonEmpty) {}

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicBlockTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicBlockTests.java
@@ -870,6 +870,12 @@ public class BasicBlockTests extends ESTestCase {
         List<List<Object>> values = new ArrayList<>();
         try (var builder = elementType.newBlockBuilder(positionCount, blockFactory)) {
             for (int p = 0; p < positionCount; p++) {
+                if (elementType == ElementType.NULL) {
+                    assert nullAllowed;
+                    values.add(null);
+                    builder.appendNull();
+                    continue;
+                }
                 int valueCount = between(minValuesPerPosition, maxValuesPerPosition);
                 if (valueCount == 0 || nullAllowed && randomBoolean()) {
                     values.add(null);

--- a/x-pack/plugin/esql/qa/server/multi-node/build.gradle
+++ b/x-pack/plugin/esql/qa/server/multi-node/build.gradle
@@ -1,11 +1,27 @@
 apply plugin: 'elasticsearch.internal-java-rest-test'
+apply plugin: 'elasticsearch.internal-yaml-rest-test'
 
 dependencies {
   javaRestTestImplementation project(xpackModule('esql:qa:testFixtures'))
   javaRestTestImplementation project(xpackModule('esql:qa:server'))
+  yamlRestTestImplementation project(xpackModule('esql:qa:server'))
 }
 
 
 tasks.named('javaRestTest') {
   usesDefaultDistribution()
+}
+
+restResources {
+  restApi {
+    include '_common', 'bulk', 'get', 'indices', 'esql', 'xpack', 'enrich', 'cluster'
+  }
+  restTests {
+    includeXpack 'esql'
+  }
+}
+
+tasks.named('yamlRestTest') {
+  usesDefaultDistribution()
+  maxParallelForks = 1
 }

--- a/x-pack/plugin/esql/qa/server/multi-node/src/yamlRestTest/java/org/elasticsearch/xpack/esql/qa/multi_node/EsqlClientYamlIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-node/src/yamlRestTest/java/org/elasticsearch/xpack/esql/qa/multi_node/EsqlClientYamlIT.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.qa.mixed;
+
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.local.distribution.DistributionType;
+import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
+import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
+import org.elasticsearch.xpack.esql.qa.rest.EsqlSpecTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+
+public class EsqlClientYamlIT extends ESClientYamlSuiteTestCase {
+    @ClassRule
+    public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
+        .distribution(DistributionType.DEFAULT)
+        .nodes(2)
+        .setting("xpack.security.enabled", "false")
+        .setting("xpack.license.self_generated.type", "trial")
+        .build();
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
+    }
+
+    public EsqlClientYamlIT(final ClientYamlTestCandidate testCandidate) {
+        super(testCandidate);
+    }
+
+    @ParametersFactory
+    public static Iterable<Object[]> parameters() throws Exception {
+        return createParameters();
+    }
+
+    @Before
+    @After
+    public void assertRequestBreakerEmpty() throws Exception {
+        EsqlSpecTestCase.assertRequestBreakerEmpty();
+    }
+}

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -879,3 +879,43 @@ AVG(salary):double | avg_salary_rounded:double
 48248.55           | 48249.0
 // end::statsUnnamedColumnEval-result[]
 ;
+
+groupByNull#[skip:-8.12.0,reason:bug fixed in 8.12.1]
+ROW a = 1, c = null
+| STATS COUNT(a) BY c;
+
+COUNT(a):long | c:null
+            1 | null
+;
+
+groupByNullAndString#[skip:-8.12.0,reason:bug fixed in 8.12.1]
+ROW a = 1, b = "foo", c = null
+| STATS COUNT(a) BY c, b;
+
+COUNT(a):long | c:null | b:keyword
+            1 | null   | foo
+;
+
+groupByStringAndNull#[skip:-8.12.0,reason:bug fixed in 8.12.1]
+ROW a = 1, b = "foo", c = null
+| STATS COUNT(a) BY b, c;
+
+COUNT(a):long | b:keyword | c:null
+            1 | foo       | null
+;
+
+countNull#[skip:-8.12.0,reason:bug fixed in 8.12.1]
+ROW a = 1, c = null
+| STATS COUNT(c) BY a;
+
+COUNT(c):long | a:integer
+            0 | 1
+;
+
+countDistinctNull#[skip:-8.99.99,reason:not yet fixed]
+ROW a = 1, c = null
+| STATS COUNT_DISTINCT(c) BY a;
+
+COUNT(c):long | a:integer
+            0 | 1
+;

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/25_aggs_on_null.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/25_aggs_on_null.yml
@@ -1,0 +1,157 @@
+---
+setup:
+  - skip:
+      version: " - 8.12.99"
+      reason: "fixed in 8.13"
+      features: warnings
+  - do:
+      indices.create:
+        index:  test
+        body:
+          settings:
+            number_of_shards: 5
+          mappings:
+            properties:
+              always_null:
+                type: long
+              sometimes_null:
+                type: long
+              never_null:
+                type: long
+  - do:
+      bulk:
+        index: test
+        refresh: true
+        body:
+          - { "index": {} }
+          - { "sometimes_null": 1, "never_null": 1 }
+          - { "index": {} }
+          - { "sometimes_null": 1, "never_null": 1 }
+          - { "index": {} }
+          - { "never_null": 2 }
+          - { "index": {} }
+          - { "never_null": 2 }
+
+---
+group on null:
+  - do:
+      esql.query:
+        body:
+          query: 'FROM test | STATS med=median(never_null) BY always_null | LIMIT 1'
+          columnar: true
+  - match: {columns.0.name: "med"}
+  - match: {columns.0.type: "double"}
+  - match: {columns.1.name: "always_null"}
+  - match: {columns.1.type: "long"}
+  - length: {values: 2}
+  - match: {values.0: [1.5]}
+  - match: {values.1: [null]}
+
+---
+group on null, long:
+  - do:
+      esql.query:
+        body:
+          query: 'FROM test | STATS med=median(sometimes_null) BY always_null, never_null | SORT always_null, never_null | LIMIT 10'
+          columnar: true
+  - match: {columns.0.name: "med"}
+  - match: {columns.0.type: "double"}
+  - match: {columns.1.name: "always_null"}
+  - match: {columns.1.type: "long"}
+  - match: {columns.2.name: "never_null"}
+  - match: {columns.2.type: "long"}
+  - length: {values: 3}
+  - match: {values.0: [1.0, null]}
+  - match: {values.1: [null, null]}
+  - match: {values.2: [1, 2]}
+
+---
+agg on null:
+  - do:
+      esql.query:
+        body:
+          query: 'FROM test | STATS med=median(always_null) | LIMIT 1'
+          columnar: true
+  - match: {columns.0.name: "med"}
+  - match: {columns.0.type: "double"}
+  - length: {values: 1}
+  - match: {values.0: [null]}
+
+---
+agg on missing:
+  - do:
+      catch: bad_request
+      esql.query:
+        body:
+          query: 'FROM test | STATS med=median(missing) | LIMIT 1'
+          columnar: true
+
+---
+group on missing:
+  - do:
+      catch: bad_request
+      esql.query:
+        body:
+          query: 'FROM test | STATS med=median(never_null) BY missing | LIMIT 1'
+          columnar: true
+
+---
+agg on half missing:
+  - do:
+      indices.create:
+        index:  test2
+        body:
+          settings:
+            number_of_shards: 5
+          mappings:
+            properties:
+              always_null:
+                type: long
+              sometimes_null:
+                type: long
+              never_null:
+                type: long
+              missing:
+                type: long
+
+  - do:
+      esql.query:
+        body:
+          query: 'FROM test* | STATS med=median(missing) | LIMIT 1'
+          columnar: true
+  - match: {columns.0.name: "med"}
+  - match: {columns.0.type: "double"}
+  - length: {values: 1}
+  - match: {values.0: [null]}
+
+---
+group on half missing:
+  - do:
+      indices.create:
+        index:  test2
+        body:
+          settings:
+            number_of_shards: 5
+          mappings:
+            properties:
+              always_null:
+                type: long
+              sometimes_null:
+                type: long
+              never_null:
+                type: long
+              missing:
+                type: long
+
+  - do:
+      esql.query:
+        body:
+          query: 'FROM test,test2 | STATS med=median(never_null) BY missing | LIMIT 1'
+          columnar: true
+  - match: {columns.0.name: "med"}
+  - match: {columns.0.type: "double"}
+  - match: {columns.1.name: "missing"}
+  - match: {columns.1.type: "long"}
+  - length: {values: 2}
+  - match: {values.0: [1.5]}
+  - match: {values.1: [null]}


### PR DESCRIPTION
This fixes a bug in `STATS` where if you grouped by values that are always `null` it'd fail because we don't know how to group on `null` columns. It's kind of easy to group on `null` columns - assign `null` to the ordinal `0`. That's it. This does that.

Relates to #104430
