### PR TITLE
Fix `RemoteClusterSecurityFcActionAuthorizationIT`

### DIFF
--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityFcActionAuthorizationIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityFcActionAuthorizationIT.java
@@ -7,8 +7,8 @@
 
 package org.elasticsearch.xpack.remotecluster;
 
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.ElasticsearchSecurityException;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
@@ -37,7 +37,6 @@ import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.RemoteClusterService;
 import org.elasticsearch.transport.RemoteConnectionInfo;
-import org.elasticsearch.transport.RemoteTransportException;
 import org.elasticsearch.xpack.ccr.action.repositories.ClearCcrRestoreSessionAction;
 import org.elasticsearch.xpack.ccr.action.repositories.ClearCcrRestoreSessionRequest;
 import org.elasticsearch.xpack.ccr.action.repositories.GetCcrRestoreFileChunkAction;
@@ -70,7 +69,6 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/104567")
 public class RemoteClusterSecurityFcActionAuthorizationIT extends ESRestTestCase {
 
     @ClassRule
@@ -117,12 +115,7 @@ public class RemoteClusterSecurityFcActionAuthorizationIT extends ESRestTestCase
         try {
             return future.get(10, TimeUnit.SECONDS);
         } catch (ExecutionException e) {
-            if (e.getCause() instanceof RemoteTransportException remoteTransportException
-                && remoteTransportException.getCause() instanceof Exception cause) {
-                throw cause;
-            }
-
-            if (e.getCause() instanceof Exception cause) {
+            if (ExceptionsHelper.unwrapCause(e.getCause()) instanceof Exception cause) {
                 throw cause;
             }
 


### PR DESCRIPTION
There may be multiple layers of `RemoteTransportException` to unwrap it
seems. Use `ExceptionsHelper#unwrapCause` rather than just manually
unwrapping one layer.

Closes #104567