### PR TITLE
Fixing IndexTemplateRegistryTests race condition (#103999)

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/template/IndexTemplateRegistryTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/template/IndexTemplateRegistryTests.java
@@ -396,15 +396,16 @@ public class IndexTemplateRegistryTests extends ESTestCase {
         assertBusy(() -> assertThat(rolloverCounter.get(), equalTo(2)));
         AtomicReference<Collection<RolloverResponse>> rolloverResponsesRef = registry.getRolloverResponses();
         assertBusy(() -> assertNotNull(rolloverResponsesRef.get()));
-        Collection<RolloverResponse> rolloverResponses = rolloverResponsesRef.get();
-        assertThat(rolloverResponses, hasSize(2));
+        assertThat(rolloverResponsesRef.get(), hasSize(2));
 
         // test again, to verify that the per-index-template creation lock gets released for reuse
         putIndexTemplateCounter.set(0);
         rolloverCounter.set(0);
+        rolloverResponsesRef.set(Collections.emptySet());
         registry.clusterChanged(event);
         assertBusy(() -> assertThat(putIndexTemplateCounter.get(), equalTo(1)));
         assertBusy(() -> assertThat(rolloverCounter.get(), equalTo(2)));
+        assertBusy(() -> assertThat(rolloverResponsesRef.get(), hasSize(2)));
 
         // test rollover failures
         putIndexTemplateCounter.set(0);


### PR DESCRIPTION
IndexTemplateRegistryTests has a race condition where it can unintentionally run IndexTemplateRegistry::clusterChanged while a previous call to IndexTemplateRegistry::clusterChanged is still running asynchronously. More detail is at https://github.com/elastic/elasticsearch/issues/103969#issuecomment-1878962306. This changes the test to wait until work is complete before making the next call.