### PR TITLE
QL: Introduce Alias.unwrap method

### DIFF
--- a/docs/changelog/104575.yaml
+++ b/docs/changelog/104575.yaml
@@ -1,5 +1,5 @@
 pr: 104575
 summary: Introduce Alias.unwrap method
-area: "ES|QL, SQL"
+area: "Query Languages"
 type: enhancement
 issues: []

--- a/docs/changelog/104575.yaml
+++ b/docs/changelog/104575.yaml
@@ -1,0 +1,5 @@
+pr: 104575
+summary: Introduce Alias.unwrap method
+area: "ES|QL, SQL"
+type: enhancement
+issues: []

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Verifier.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Verifier.java
@@ -83,7 +83,7 @@ public class Verifier {
             if (p instanceof Aggregate aggregate) {
                 for (NamedExpression agg : aggregate.aggregates()) {
                     var child = Alias.unwrap(agg);
-                    if (child instanceof UnresolvedAttribute u) {
+                    if (child instanceof UnresolvedAttribute) {
                         failures.add(fail(child, "invalid stats declaration; [{}] is not an aggregate function", child.sourceText()));
                     }
                 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Verifier.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Verifier.java
@@ -82,11 +82,9 @@ public class Verifier {
             // handle aggregate first to disambiguate between missing fields or incorrect function declaration
             if (p instanceof Aggregate aggregate) {
                 for (NamedExpression agg : aggregate.aggregates()) {
-                    if (agg instanceof Alias as) {
-                        var child = as.child();
-                        if (child instanceof UnresolvedAttribute u) {
-                            failures.add(fail(child, "invalid stats declaration; [{}] is not an aggregate function", child.sourceText()));
-                        }
+                    var child = Alias.unwrap(agg);
+                    if (child instanceof UnresolvedAttribute u) {
+                        failures.add(fail(child, "invalid stats declaration; [{}] is not an aggregate function", child.sourceText()));
                     }
                 }
             }
@@ -149,16 +147,13 @@ public class Verifier {
         if (p instanceof Aggregate agg) {
             // check aggregates
             agg.aggregates().forEach(e -> {
-                var exp = e instanceof Alias a ? a.child() : e;
+                var exp = Alias.unwrap(e);
                 if (exp instanceof AggregateFunction af) {
                     af.field().forEachDown(AggregateFunction.class, f -> {
                         failures.add(fail(f, "nested aggregations [{}] not allowed inside other aggregations [{}]", f, af));
                     });
                 } else {
-                    if (Expressions.match(agg.groupings(), g -> {
-                        Expression to = g instanceof Alias al ? al.child() : g;
-                        return to.semanticEquals(exp);
-                    }) == false) {
+                    if (Expressions.match(agg.groupings(), g -> Alias.unwrap(g).semanticEquals(exp)) == false) {
                         failures.add(
                             fail(
                                 exp,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizer.java
@@ -216,11 +216,7 @@ public class LocalLogicalPlanOptimizer extends ParameterizedRuleExecutor<Logical
             var aggs = aggregate.aggregates();
             Set<Expression> nonNullAggFields = Sets.newLinkedHashSetWithExpectedSize(aggs.size());
             for (var agg : aggs) {
-                Expression expr = agg;
-                if (agg instanceof Alias as) {
-                    expr = as.child();
-                }
-                if (expr instanceof AggregateFunction af) {
+                if (Alias.unwrap(agg) instanceof AggregateFunction af) {
                     Expression field = af.field();
                     // ignore literals (e.g. COUNT(1))
                     // make sure the field exists at the source and is indexed (not runtime)

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
@@ -184,14 +184,14 @@ public class LogicalPlanOptimizer extends ParameterizedRuleExecutor<LogicalPlan,
 
             // first pass to check existing aggregates (to avoid duplication and alias waste)
             for (NamedExpression agg : aggs) {
-                if (agg instanceof Alias a && a.child() instanceof AggregateFunction af && af instanceof SurrogateExpression == false) {
-                    aggFuncToAttr.put(af, a.toAttribute());
+                if (Alias.unwrap(agg) instanceof AggregateFunction af && af instanceof SurrogateExpression == false) {
+                    aggFuncToAttr.put(af, agg.toAttribute());
                 }
             }
 
             // 0. check list of surrogate expressions
             for (NamedExpression agg : aggs) {
-                Expression e = agg instanceof Alias a ? a.child() : agg;
+                Expression e = Alias.unwrap(agg);
                 if (e instanceof SurrogateExpression sf) {
                     changed = true;
                     Expression s = sf.surrogate();
@@ -661,7 +661,7 @@ public class LogicalPlanOptimizer extends ParameterizedRuleExecutor<LogicalPlan,
             int i = 0;
             for (var agg : aggs) {
                 // there needs to be an alias
-                if (agg instanceof Alias a && a.child() instanceof AggregateFunction aggFunc) {
+                if (Alias.unwrap(agg) instanceof AggregateFunction aggFunc) {
                     aggOutput(agg, aggFunc, blockFactory, blocks);
                 } else {
                     throw new EsqlIllegalArgumentException("Did not expect a non-aliased aggregation {}", agg);
@@ -1286,20 +1286,19 @@ public class LogicalPlanOptimizer extends ParameterizedRuleExecutor<LogicalPlan,
         private static LogicalPlan normalize(Aggregate aggregate, AttributeMap<Expression> aliases) {
             var aggs = aggregate.aggregates();
             List<NamedExpression> newAggs = new ArrayList<>(aggs.size());
-            boolean changed = false;
+            final Holder<Boolean> changed = new Holder<>(false);
 
             for (NamedExpression agg : aggs) {
-                if (agg instanceof Alias as && as.child() instanceof AggregateFunction af) {
+                var newAgg = (NamedExpression) agg.transformDown(AggregateFunction.class, af -> {
                     // replace field reference
                     if (af.field() instanceof NamedExpression ne) {
                         Attribute attr = ne.toAttribute();
                         var resolved = aliases.resolve(attr, attr);
                         if (resolved != attr) {
-                            changed = true;
+                            changed.set(true);
                             var newChildren = CollectionUtils.combine(Collections.singletonList(resolved), af.parameters());
                             // update the reference so Count can pick it up
                             af = (AggregateFunction) af.replaceChildren(newChildren);
-                            agg = as.replaceChild(af);
                         }
                     }
                     // handle Count(*)
@@ -1308,16 +1307,17 @@ public class LogicalPlanOptimizer extends ParameterizedRuleExecutor<LogicalPlan,
                         if (field.foldable()) {
                             var fold = field.fold();
                             if (fold != null && StringUtils.WILDCARD.equals(fold) == false) {
-                                changed = true;
+                                changed.set(true);
                                 var source = count.source();
-                                agg = as.replaceChild(new Count(source, new Literal(source, StringUtils.WILDCARD, DataTypes.KEYWORD)));
+                                af = new Count(source, new Literal(source, StringUtils.WILDCARD, DataTypes.KEYWORD));
                             }
                         }
                     }
-                }
-                newAggs.add(agg);
+                    return af;
+                });
+                newAggs.add(newAgg);
             }
-            return changed ? new Aggregate(aggregate.source(), aggregate.child(), aggregate.groupings(), newAggs) : aggregate;
+            return changed.get() ? new Aggregate(aggregate.source(), aggregate.child(), aggregate.groupings(), newAggs) : aggregate;
         }
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/LogicalPlanBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/LogicalPlanBuilder.java
@@ -1,4 +1,3 @@
-
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/LogicalPlanBuilder.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/parser/LogicalPlanBuilder.java
@@ -1,3 +1,4 @@
+
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
@@ -208,7 +209,7 @@ public class LogicalPlanBuilder extends ExpressionBuilder {
             var groupNames = new LinkedHashSet<>(Expressions.names(Expressions.references(groupings)));
 
             for (NamedExpression aggregate : aggregates) {
-                if (aggregate instanceof Alias a && a.child() instanceof UnresolvedAttribute ua && groupNames.contains(ua.name())) {
+                if (Alias.unwrap(aggregate) instanceof UnresolvedAttribute ua && groupNames.contains(ua.name())) {
                     throw new ParsingException(ua.source(), "Cannot specify grouping expression [{}] as an aggregate", ua.name());
                 }
             }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AbstractPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AbstractPhysicalOperationProviders.java
@@ -125,8 +125,8 @@ public abstract class AbstractPhysicalOperationProviders implements PhysicalOper
 
             if (mode == AggregateExec.Mode.FINAL) {
                 for (var agg : aggregates) {
-                    if (agg instanceof Alias alias && alias.child() instanceof AggregateFunction) {
-                        layout.append(alias);
+                    if (Alias.unwrap(agg) instanceof AggregateFunction) {
+                        layout.append(agg);
                     }
                 }
             } else {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AggregateMapper.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AggregateMapper.java
@@ -103,7 +103,7 @@ public class AggregateMapper {
     }
 
     private Stream<? extends NamedExpression> map(Expression aggregate, boolean grouping) {
-        aggregate = unwrapAlias(aggregate);
+        aggregate = Alias.unwrap(aggregate);
         return cache.computeIfAbsent(aggregate, aggKey -> computeEntryForAgg(aggKey, grouping)).stream();
     }
 
@@ -230,10 +230,5 @@ public class AggregateMapper {
         } else {
             throw new EsqlIllegalArgumentException("illegal agg type: " + type.typeName());
         }
-    }
-
-    static Expression unwrapAlias(Expression expression) {
-        if (expression instanceof Alias alias) return alias.child();
-        return expression;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -512,7 +512,7 @@ public class LocalExecutionPlanner {
         for (int index = 0, size = projections.size(); index < size; index++) {
             NamedExpression ne = projections.get(index);
 
-            NameId inputId;
+            NameId inputId = null;
             if (ne instanceof Alias a) {
                 inputId = ((NamedExpression) a.child()).id();
             } else {

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/Alias.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/Alias.java
@@ -106,4 +106,11 @@ public class Alias extends NamedExpression {
     public String nodeString() {
         return child.nodeString() + " AS " + name();
     }
+
+    /**
+     * If the given expression is an alias, return its child - otherwise return as is.
+     */
+    public static Expression unwrap(Expression e) {
+        return e instanceof Alias as ? as.child() : e;
+    }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
@@ -927,9 +927,7 @@ public final class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, Analy
         protected LogicalPlan rule(Filter f) {
             if (f.child() instanceof Project p) {
                 for (Expression n : p.projections()) {
-                    if (n instanceof Alias) {
-                        n = ((Alias) n).child();
-                    }
+                    n = Alias.unwrap(n);
                     // no literal or aggregates - it's a 'regular' projection
                     if (n.foldable() == false && Functions.isAggregate(n) == false
                     // folding might not work (it might wait for the optimizer)
@@ -1014,12 +1012,7 @@ public final class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, Analy
             Set<NamedExpression> missing = new LinkedHashSet<>();
 
             for (Expression filterAgg : from.collect(Functions::isAggregate)) {
-                if (Expressions.anyMatch(target.aggregates(), a -> {
-                    if (a instanceof Alias) {
-                        a = ((Alias) a).child();
-                    }
-                    return a.equals(filterAgg);
-                }) == false) {
+                if (Expressions.anyMatch(target.aggregates(), a -> Alias.unwrap(a).equals(filterAgg)) == false) {
                     missing.add(Expressions.wrapAsNamed(filterAgg));
                 }
             }
@@ -1066,12 +1059,7 @@ public final class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, Analy
                     List<NamedExpression> missing = new ArrayList<>();
 
                     for (Expression orderedAgg : aggs) {
-                        if (Expressions.anyMatch(a.aggregates(), e -> {
-                            if (e instanceof Alias) {
-                                e = ((Alias) e).child();
-                            }
-                            return e.equals(orderedAgg);
-                        }) == false) {
+                        if (Expressions.anyMatch(a.aggregates(), e -> Alias.unwrap(e).equals(orderedAgg) == false)) {
                             missing.add(Expressions.wrapAsNamed(orderedAgg));
                         }
                     }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Analyzer.java
@@ -1059,7 +1059,7 @@ public final class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, Analy
                     List<NamedExpression> missing = new ArrayList<>();
 
                     for (Expression orderedAgg : aggs) {
-                        if (Expressions.anyMatch(a.aggregates(), e -> Alias.unwrap(e).equals(orderedAgg) == false)) {
+                        if (Expressions.anyMatch(a.aggregates(), e -> Alias.unwrap(e).equals(orderedAgg)) == false) {
                             missing.add(Expressions.wrapAsNamed(orderedAgg));
                         }
                     }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Verifier.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/analysis/analyzer/Verifier.java
@@ -918,7 +918,7 @@ public final class Verifier {
             DataType colType = pv.column().dataType();
             for (NamedExpression v : pv.values()) {
                 // check all values are foldable
-                Expression ex = v instanceof Alias ? ((Alias) v).child() : v;
+                Expression ex = Alias.unwrap(v);
                 if (ex instanceof Literal == false) {
                     localFailures.add(fail(v, "Non-literal [{}] found inside PIVOT values", v.name()));
                 } else if (ex.foldable() && ex.fold() == null) {

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/optimizer/Optimizer.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/optimizer/Optimizer.java
@@ -1211,10 +1211,7 @@ public class Optimizer extends RuleExecutor<LogicalPlan> {
         }
 
         private static boolean foldable(Expression e) {
-            if (e instanceof Alias) {
-                e = ((Alias) e).child();
-            }
-            return e.foldable();
+            return Alias.unwrap(e).foldable();
         }
 
     }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/QueryFolder.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/QueryFolder.java
@@ -493,7 +493,10 @@ class QueryFolder extends RuleExecutor<PhysicalPlan> {
                 Expression target = ne;
 
                 // unwrap aliases since it's the children we are interested in
-                target = Alias.unwrap(ne);
+                if (ne instanceof Alias) {
+                    target = ((Alias) ne).child();
+                }
+
                 id = Expressions.id(target);
 
                 // literal

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/QueryFolder.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/planner/QueryFolder.java
@@ -493,10 +493,7 @@ class QueryFolder extends RuleExecutor<PhysicalPlan> {
                 Expression target = ne;
 
                 // unwrap aliases since it's the children we are interested in
-                if (ne instanceof Alias) {
-                    target = ((Alias) ne).child();
-                }
-
+                target = Alias.unwrap(ne);
                 id = Expressions.id(target);
 
                 // literal


### PR DESCRIPTION
Utility method for a common pattern through-out the code base -
 unwrapping a given expression if it's an Alias otherwise return it as
 is.