### PR TITLE
Reduce Footprint of KeyedLock

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/KeyedLock.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/KeyedLock.java
@@ -132,7 +132,7 @@ public final class KeyedLock<T> {
             }
         }
 
-        @SuppressWarnings("FieldMayBeFinal") // updated via VH_REFCOUNT_FIELD (and _only_ via VH_REFCOUNT_FIELD)
+        @SuppressWarnings("FieldMayBeFinal") // updated via VH_COUNT_FIELD (and _only_ via VH_COUNT_FIELD)
         private volatile int count = 1;
 
         KeyLock() {

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/KeyedLock.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/KeyedLock.java
@@ -10,9 +10,10 @@ package org.elasticsearch.common.util.concurrent;
 
 import org.elasticsearch.core.Releasable;
 
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
@@ -40,8 +41,8 @@ public final class KeyedLock<T> {
                     return newLock;
                 }
             } else {
-                int i = perNodeLock.count.get();
-                if (i > 0 && perNodeLock.count.compareAndSet(i, i + 1)) {
+                int i = perNodeLock.count;
+                if (i > 0 && perNodeLock.tryIncCount(i)) {
                     perNodeLock.lock();
                     return new ReleasableLock(key, perNodeLock);
                 }
@@ -59,11 +60,11 @@ public final class KeyedLock<T> {
         }
         if (perNodeLock.tryLock()) { // ok we got it - make sure we increment it accordingly otherwise release it again
             int i;
-            while ((i = perNodeLock.count.get()) > 0) {
+            while ((i = perNodeLock.count) > 0) {
                 // we have to do this in a loop here since even if the count is > 0
                 // there could be a concurrent blocking acquire that changes the count and then this CAS fails. Since we already got
                 // the lock we should retry and see if we can still get it or if the count is 0. If that is the case and we give up.
-                if (perNodeLock.count.compareAndSet(i, i + 1)) {
+                if (perNodeLock.tryIncCount(i)) {
                     return new ReleasableLock(key, perNodeLock);
                 }
             }
@@ -95,7 +96,7 @@ public final class KeyedLock<T> {
 
     private void release(T key, KeyLock lock) {
         assert lock == map.get(key);
-        final int decrementAndGet = lock.count.decrementAndGet();
+        final int decrementAndGet = lock.decCountAndGet();
         lock.unlock();
         if (decrementAndGet == 0) {
             map.remove(key, lock);
@@ -103,30 +104,54 @@ public final class KeyedLock<T> {
         assert decrementAndGet >= 0 : decrementAndGet + " must be >= 0 but wasn't";
     }
 
-    private final class ReleasableLock extends AtomicBoolean implements Releasable {
-        final T key;
+    private final class ReleasableLock extends AtomicReference<T> implements Releasable {
         final KeyLock lock;
 
         private ReleasableLock(T key, KeyLock lock) {
-            this.key = key;
+            super(key);
             this.lock = lock;
         }
 
         @Override
         public void close() {
-            if (compareAndSet(false, true)) {
-                release(key, lock);
+            T k = getAndSet(null);
+            if (k != null) {
+                release(k, lock);
             }
         }
     }
 
-    @SuppressWarnings("serial")
     private static final class KeyLock extends ReentrantLock {
+        private static final VarHandle VH_COUNT_FIELD;
+
+        static {
+            try {
+                VH_COUNT_FIELD = MethodHandles.lookup().in(KeyLock.class).findVarHandle(KeyLock.class, "count", int.class);
+            } catch (NoSuchFieldException | IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @SuppressWarnings("FieldMayBeFinal") // updated via VH_REFCOUNT_FIELD (and _only_ via VH_REFCOUNT_FIELD)
+        private volatile int count = 1;
+
         KeyLock() {
             super();
         }
 
-        private final AtomicInteger count = new AtomicInteger(1);
+        int decCountAndGet() {
+            do {
+                int i = count;
+                int newCount = i - 1;
+                if (VH_COUNT_FIELD.weakCompareAndSet(this, i, newCount)) {
+                    return newCount;
+                }
+            } while (true);
+        }
+
+        boolean tryIncCount(int expectedCount) {
+            return VH_COUNT_FIELD.compareAndSet(this, expectedCount, expectedCount + 1);
+        }
     }
 
     /**


### PR DESCRIPTION
We can save the redundant atomic-boolean extension on the releasable lock and the atomic integer indirection on the keyed lock. Motivated by the fact that these instances account or more than 1% of total allocations and cache-misses in indexing benchmarks so saving some indirection here can't hurt.