### PR TITLE
Fix bogus assertion tripped by force-executed tasks

### DIFF
--- a/docs/changelog/104581.yaml
+++ b/docs/changelog/104581.yaml
@@ -2,4 +2,5 @@ pr: 104581
 summary: Fix bogus assertion tripped by force-executed tasks
 area: Infra/Core
 type: bug
-issues: []
+issues:
+ - 104580

--- a/docs/changelog/104581.yaml
+++ b/docs/changelog/104581.yaml
@@ -1,0 +1,5 @@
+pr: 104581
+summary: Fix bogus assertion tripped by force-executed tasks
+area: Infra/Core
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/EsAbortPolicy.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/EsAbortPolicy.java
@@ -8,26 +8,27 @@
 
 package org.elasticsearch.common.util.concurrent;
 
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 
 public class EsAbortPolicy extends EsRejectedExecutionHandler {
 
     @Override
     public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
-        if (r instanceof AbstractRunnable) {
-            if (((AbstractRunnable) r).isForceExecution()) {
-                BlockingQueue<Runnable> queue = executor.getQueue();
-                if ((queue instanceof SizeBlockingQueue) == false) {
-                    throw new IllegalStateException("forced execution, but expected a size queue");
+        if (r instanceof AbstractRunnable abstractRunnable) {
+            if (abstractRunnable.isForceExecution()) {
+                if (executor.getQueue() instanceof SizeBlockingQueue<Runnable> sizeBlockingQueue) {
+                    try {
+                        sizeBlockingQueue.forcePut(r);
+                        return;
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new IllegalStateException("forced execution, but got interrupted", e);
+                    }
                 }
-                try {
-                    ((SizeBlockingQueue<Runnable>) queue).forcePut(r);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    throw new IllegalStateException("forced execution, but got interrupted", e);
+
+                if (executor.isShutdown() == false) {
+                    throw new IllegalStateException("should only be rejected from unbounded executor when shut-down, not " + executor);
                 }
-                return;
             }
         }
         incrementRejections();

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/EsAbortPolicy.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/EsAbortPolicy.java
@@ -19,15 +19,15 @@ public class EsAbortPolicy extends EsRejectedExecutionHandler {
                 if (executor.getQueue() instanceof SizeBlockingQueue<Runnable> sizeBlockingQueue) {
                     try {
                         sizeBlockingQueue.forcePut(r);
-                        return;
                     } catch (InterruptedException e) {
                         Thread.currentThread().interrupt();
                         throw new IllegalStateException("forced execution, but got interrupted", e);
                     }
-                }
-
-                if (executor.isShutdown() == false) {
-                    throw new IllegalStateException("should only be rejected from unbounded executor when shut-down, not " + executor);
+                    if ((executor.isShutdown() && sizeBlockingQueue.remove(r)) == false) {
+                        return;
+                    } // else fall through and reject the task since the executor is shut down
+                } else {
+                    throw new IllegalStateException("expected but did not find SizeBlockingQueue: " + executor);
                 }
             }
         }

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
@@ -126,11 +126,14 @@ public class EsExecutors {
         ThreadContext contextHolder,
         TaskTrackingConfig config
     ) {
-        BlockingQueue<Runnable> queue;
+        final BlockingQueue<Runnable> queue;
+        final EsRejectedExecutionHandler rejectedExecutionHandler;
         if (queueCapacity < 0) {
             queue = ConcurrentCollections.newBlockingQueue();
+            rejectedExecutionHandler = new RejectOnShutdownOnlyPolicy();
         } else {
             queue = new SizeBlockingQueue<>(ConcurrentCollections.<Runnable>newBlockingQueue(), queueCapacity);
+            rejectedExecutionHandler = new EsAbortPolicy();
         }
         if (config.trackExecutionTime()) {
             return new TaskExecutionTimeTrackingEsThreadPoolExecutor(
@@ -142,7 +145,7 @@ public class EsExecutors {
                 queue,
                 TimedRunnable::new,
                 threadFactory,
-                new EsAbortPolicy(),
+                rejectedExecutionHandler,
                 contextHolder,
                 config
             );
@@ -155,7 +158,7 @@ public class EsExecutors {
                 TimeUnit.MILLISECONDS,
                 queue,
                 threadFactory,
-                new EsAbortPolicy(),
+                rejectedExecutionHandler,
                 contextHolder
             );
         }
@@ -406,6 +409,15 @@ public class EsExecutors {
         }
 
         private void reject(ThreadPoolExecutor executor, Runnable task) {
+            incrementRejections();
+            throw newRejectedException(task, executor, true);
+        }
+    }
+
+    static class RejectOnShutdownOnlyPolicy extends EsRejectedExecutionHandler {
+        @Override
+        public void rejectedExecution(Runnable task, ThreadPoolExecutor executor) {
+            assert executor.isShutdown() : executor;
             incrementRejections();
             throw newRejectedException(task, executor, true);
         }

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/EsExecutorsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/EsExecutorsTests.java
@@ -600,7 +600,6 @@ public class EsExecutorsTests extends ESTestCase {
         );
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/104580")
     public void testFixedBoundedRejectOnShutdown() {
         runRejectOnShutdownTest(
             EsExecutors.newFixed(

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/EsExecutorsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/EsExecutorsTests.java
@@ -8,6 +8,8 @@
 
 package org.elasticsearch.common.util.concurrent;
 
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.Processors;
@@ -18,6 +20,8 @@ import org.hamcrest.Matcher;
 import java.util.Locale;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -538,5 +542,132 @@ public class EsExecutorsTests extends ESTestCase {
         } finally {
             ThreadPool.terminate(executorService, 10, TimeUnit.SECONDS);
         }
+    }
+
+    public void testScalingDropOnShutdown() {
+        final var executor = EsExecutors.newScaling(
+            getName(),
+            0,
+            between(1, 5),
+            60,
+            TimeUnit.SECONDS,
+            false,
+            EsExecutors.daemonThreadFactory(getName()),
+            new ThreadContext(Settings.EMPTY)
+        );
+        ThreadPool.terminate(executor, 10, TimeUnit.SECONDS);
+        executor.execute(() -> fail("should not run")); // no-op
+        executor.execute(new AbstractRunnable() {
+            @Override
+            public void onFailure(Exception e) {
+                fail("should not call onFailure");
+            }
+
+            @Override
+            protected void doRun() {
+                fail("should not call doRun");
+            }
+
+            @Override
+            public boolean isForceExecution() {
+                return randomBoolean();
+            }
+
+            @Override
+            public void onRejection(Exception e) {
+                fail("should not call onRejection");
+            }
+
+            @Override
+            public void onAfter() {
+                fail("should not call onAfter");
+            }
+        });
+    }
+
+    public void testScalingRejectOnShutdown() {
+        runRejectOnShutdownTest(
+            EsExecutors.newScaling(
+                getName(),
+                0,
+                between(1, 5),
+                60,
+                TimeUnit.SECONDS,
+                true,
+                EsExecutors.daemonThreadFactory(getName()),
+                new ThreadContext(Settings.EMPTY)
+            )
+        );
+    }
+
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/104580")
+    public void testFixedBoundedRejectOnShutdown() {
+        runRejectOnShutdownTest(
+            EsExecutors.newFixed(
+                getName(),
+                between(1, 5),
+                between(1, 5),
+                EsExecutors.daemonThreadFactory(getName()),
+                threadContext,
+                randomFrom(DEFAULT, DO_NOT_TRACK)
+            )
+        );
+    }
+
+    public void testFixedUnboundedRejectOnShutdown() {
+        runRejectOnShutdownTest(
+            EsExecutors.newFixed(
+                getName(),
+                between(1, 5),
+                -1,
+                EsExecutors.daemonThreadFactory(getName()),
+                threadContext,
+                randomFrom(DEFAULT, DO_NOT_TRACK)
+            )
+        );
+    }
+
+    private static void runRejectOnShutdownTest(ExecutorService executor) {
+        for (int i = between(0, 10); i > 0; i--) {
+            final var delayMillis = between(0, 100);
+            executor.execute(ActionRunnable.wrap(ActionListener.noop(), l -> safeSleep(delayMillis)));
+        }
+        try {
+            executor.shutdown();
+            assertShutdownAndRejectingTasks(executor);
+        } finally {
+            ThreadPool.terminate(executor, 10, TimeUnit.SECONDS);
+        }
+        assertShutdownAndRejectingTasks(executor);
+    }
+
+    private static void assertShutdownAndRejectingTasks(Executor executor) {
+        final var rejected = new AtomicBoolean();
+        final var shouldBeRejected = new AbstractRunnable() {
+            @Override
+            public void onFailure(Exception e) {
+                fail("should not call onFailure");
+            }
+
+            @Override
+            protected void doRun() {
+                fail("should not call doRun");
+            }
+
+            @Override
+            public boolean isForceExecution() {
+                return randomBoolean();
+            }
+
+            @Override
+            public void onRejection(Exception e) {
+                assertTrue(asInstanceOf(EsRejectedExecutionException.class, e).isExecutorShutdown());
+                assertTrue(rejected.compareAndSet(false, true));
+            }
+        };
+        assertTrue(expectThrows(EsRejectedExecutionException.class, () -> executor.execute(shouldBeRejected::doRun)).isExecutorShutdown());
+        rejected.set(false);
+        executor.execute(shouldBeRejected);
+        assertTrue(rejected.get());
     }
 }

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/EsExecutorsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/EsExecutorsTests.java
@@ -666,7 +666,6 @@ public class EsExecutorsTests extends ESTestCase {
             }
         };
         assertTrue(expectThrows(EsRejectedExecutionException.class, () -> executor.execute(shouldBeRejected::doRun)).isExecutorShutdown());
-        rejected.set(false);
         executor.execute(shouldBeRejected);
         assertTrue(rejected.get());
     }


### PR DESCRIPTION
Today if you submit a force-executing task to a fixed executor with an
unbounded queue after the executor has been shut down then the
`EsAbortPolicy` will incorrectly throw an `IllegalStateException` which
ends up tripping an assertion. This is a legitimate thing to happen, so
this commit introduces a different rejection handler to deal with it. It
also introduces a check for a shut-down bounded-queue executor on
rejection to make sure we don't force the task onto a queue that's never
going to be processed.

Closes #104580