### PR TITLE
Edge case tests for ObjectPathTests.java and StashTests.java

### DIFF
--- a/test/yaml-rest-runner/src/test/java/org/elasticsearch/test/rest/yaml/ObjectPathTests.java
+++ b/test/yaml-rest-runner/src/test/java/org/elasticsearch/test/rest/yaml/ObjectPathTests.java
@@ -375,4 +375,37 @@ public class ObjectPathTests extends ESTestCase {
 
         assertEquals(Set.of("key1", "key2", "key3"), objectPath.evaluateMapKeys("test-object"));
     }
+
+    public void testEvaluateBoolean() throws Exception {
+        XContentBuilder xContentBuilder = randomXContentBuilder();
+        xContentBuilder.startObject();
+        xContentBuilder.startObject("field1");
+        xContentBuilder.field("field2", true);
+        xContentBuilder.endObject();
+        xContentBuilder.endObject();
+        ObjectPath objectPath = ObjectPath.createFromXContent(
+            xContentBuilder.contentType().xContent(),
+            BytesReference.bytes(xContentBuilder)
+        );
+        Object object = objectPath.evaluate("field1.field2");
+        assertThat(object, instanceOf(Boolean.class));
+        assertThat(object, equalTo(true));
+    }
+
+    public void testEvaluateEmptyObject() throws Exception {
+        XContentBuilder xContentBuilder = randomXContentBuilder();
+        xContentBuilder.startObject();
+        xContentBuilder.startObject("field1");
+        xContentBuilder.startObject("field2");
+        xContentBuilder.endObject();
+        xContentBuilder.endObject();
+        xContentBuilder.endObject();
+        ObjectPath objectPath = ObjectPath.createFromXContent(
+            xContentBuilder.contentType().xContent(),
+            BytesReference.bytes(xContentBuilder)
+        );
+        Object object = objectPath.evaluate("field1.field2");
+        assertThat(object, instanceOf(Map.class));
+        assertThat(((Map)object).isEmpty(), equalTo(true));
+    }
 }

--- a/test/yaml-rest-runner/src/test/java/org/elasticsearch/test/rest/yaml/StashTests.java
+++ b/test/yaml-rest-runner/src/test/java/org/elasticsearch/test/rest/yaml/StashTests.java
@@ -182,4 +182,34 @@ public class StashTests extends ESTestCase {
         assertThat(stash.getValue("$body.$backing_index.mappings"), equalTo(Map.of()));
     }
 
+    public void testReplaceNonExistentStashedValue() throws IOException {
+        Stash stash = new Stash();
+    
+        Map<String, Object> map = new HashMap<>();
+        map.put("key", "foo${nonExistentStashValue}");
+    
+        Exception e = expectThrows(IllegalArgumentException.class, () -> stash.replaceStashedValues(map));
+        assertEquals("Stashed value not found for key [nonExistentStashValue]", e.getMessage());
+    }
+
+    public void testStashNullValue() {
+        Stash stash = new Stash();
+    
+        Exception e = expectThrows(IllegalArgumentException.class, () -> stash.stashValue("nullValue", null));
+        assertEquals("Cannot stash null value", e.getMessage());
+    }
+
+    public void testReplaceStashedValueWithComplexObject() throws IOException {
+        Stash stash = new Stash();
+        Map<String, Object> complexObject = new HashMap<>();
+        complexObject.put("innerKey", "innerValue");
+    
+        stash.stashValue("complex", complexObject);
+        Map<String, Object> map = new HashMap<>();
+        map.put("key", "$complex");
+    
+        Map<String, Object> actual = stash.replaceStashedValues(map);
+        assertEquals(complexObject, actual.get("key"));
+        assertThat(actual, not(sameInstance(map)));
+    }
 }


### PR DESCRIPTION
In this PR, I added testing for a variety of null and empty input cases for the ObjectPathTests.java and StashTests.java 