### PR TITLE
[Profiling] Query in parallel on content nodes

### DIFF
--- a/docs/changelog/104600.yaml
+++ b/docs/changelog/104600.yaml
@@ -1,0 +1,5 @@
+pr: 104600
+summary: "[Profiling] Query in parallel on content nodes"
+area: Application
+type: bug
+issues: []

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/IndexAllocation.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/IndexAllocation.java
@@ -55,6 +55,11 @@ final class IndexAllocation {
      * @return <code>true</code> iff at least one index is allocated to either a warm or cold data node.
      */
     static boolean isAnyOnWarmOrColdTier(ClusterState state, List<Index> indices) {
-        return isAnyAssignedToNode(state, indices, n -> DataTier.isWarmNode(n) || DataTier.isColdNode(n));
+        return isAnyAssignedToNode(
+            state,
+            indices,
+            // a content node is never considered a warm or cold node
+            n -> DataTier.isContentNode(n) == false && (DataTier.isWarmNode(n) || DataTier.isColdNode(n))
+        );
     }
 }


### PR DESCRIPTION
In order to take advantage of inherent parallelism of modern SSDs, we slice keys and issue multiple mgets concurrently. In #103061 we have introduced an additional heuristic to disable that behavior on the warm and cold tier which usually use spinning disks. We have unintentionally also disabled the behavior on content nodes, i.e. on any clusters which do not use data tiers. With this commit we explicitly exclude content nodes from the heuristic so they can benefit from speedups due to concurrent mgets.

Relates #103061