### PR TITLE
rewrite term query to range query to optimize the performance of number and date field type

### DIFF
--- a/docs/changelog/104601.yaml
+++ b/docs/changelog/104601.yaml
@@ -1,0 +1,5 @@
+pr: 104601
+summary: rewrite term query to range query to optimize the performance of number and date field type
+area: Search
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/TermQueryBuilder.java
@@ -17,7 +17,9 @@ import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.mapper.ConstantFieldType;
+import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.NumberFieldMapper;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
@@ -191,6 +193,8 @@ public class TermQueryBuilder extends BaseTermQueryBuilder<TermQueryBuilder> {
             } else {
                 assert false : "Constant fields must produce match-all or match-none queries, got " + query;
             }
+        } else if (fieldType instanceof NumberFieldMapper.NumberFieldType || fieldType instanceof DateFieldMapper.DateFieldType) {
+            return QueryBuilders.rangeQuery(this.fieldName).gte(value).lte(value);
         }
         return this;
     }


### PR DESCRIPTION
1. Reasons why term number is slow:
In order to solve the problem of slow rangeQuery, after version 5.x, ES optimized the number type rangeQuery and used a block k-d tree. Simply put, a k-d tree is similar to a b-tree. The k-d tree will split the sequential data. The difference is that the k-d tree is multi-dimensional. Each time, the data will be split in dimensions with large variance and large number. If there is only one dimension, then it is a structure similar to b-tree. It is worth noting that the k-d leaf node is a block. Each block stores 512-1024 values. The block data is compact on the disk, which can reduce random IO and achieve fast scanning results. It can be quickly positioned by searching the k-d tree. Go to the approximate block location and find the set of the corresponding docId through disk sequence io. Note: The biggest difference between the found docId set and the Posting List is that the docId set is unordered, so there is no skip list structure.
Because the number structure is a block k-d tree structure, which is different from the term Dictionary, the term number will actually be converted into a single-point range query. However, because the docId set is obtained instead of the Posting List containing the skip list structure, we are merging When obtaining the results of each sub-item, a BitSet needs to be constructed to store the docId set, so as to iterate on the bitSet set.
At this time, if the docId range of the bitset set is small, the cost is not large. If the number of documents is large, the construction of the bitset will cost a lot, and constructing the bitset and iterating will also take a lot of time.

2. Reasons why rangQuery number is fast:
Above, we introduced the reason why term number is slow. In the final analysis, it is because too many docIds are obtained, which causes the cost of forming a bitset. Therefore, there are related optimizations in rangeQuery.
In fact, when the data is large, rangeQuery will perform the second query method-using Doc values query. If the term Dictionary is an inverted index, then Doc values is a forward index, and is usually based on docId. As the primary key, value stores the corresponding document content. Then the merge strategy at this time is as follows: ES will get a minimum set from other query conditions, iterate on this minimum cost set, and take the iterating docId to Doc values to check the document id corresponding to it. The document content is used to determine whether it matches the remaining conditions. If they all match, the docId is calculated into the collection of returned results. This method avoids the large overhead of constructing a large bitset when there are many documents.

This optimization can improve query performance by more than 5 times