### PR TITLE
[Transform] Fix bug when `latest` transform is used together with `from` parameter

### DIFF
--- a/docs/changelog/104606.yaml
+++ b/docs/changelog/104606.yaml
@@ -1,0 +1,6 @@
+pr: 104606
+summary: Fix bug when `latest` transform is used together with `from` parameter
+area: Transform
+type: bug
+issues:
+ - 104543

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
@@ -1177,7 +1177,7 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
     }
 
     private RunState determineRunStateAtStart() {
-        if (context.from() != null) {
+        if (context.from() != null && changeCollector.queryForChanges()) {
             return RunState.IDENTIFY_CHANGES;
         }
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
@@ -1177,7 +1177,7 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
     }
 
     private RunState determineRunStateAtStart() {
-        if (context.from() != null && changeCollector.queryForChanges()) {
+        if (context.from() != null && changeCollector != null && changeCollector.queryForChanges()) {
             return RunState.IDENTIFY_CHANGES;
         }
 


### PR DESCRIPTION
Currently, when `latest` transform is used together with `from` parameter, the `java.lang.UnsupportedOperationException` is being thrown by the indexer.
This PR fixes it so that no error is thrown and results are as expected.

Closes https://github.com/elastic/elasticsearch/issues/104543