### PR TITLE
[8.12] [Profiling] Query in parallel on content nodes (#104600)

### DIFF
--- a/docs/changelog/104600.yaml
+++ b/docs/changelog/104600.yaml
@@ -1,0 +1,5 @@
+pr: 104600
+summary: "[Profiling] Query in parallel on content nodes"
+area: Application
+type: bug
+issues: []

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/IndexAllocation.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/IndexAllocation.java
@@ -55,6 +55,11 @@ final class IndexAllocation {
      * @return <code>true</code> iff at least one index is allocated to either a warm or cold data node.
      */
     static boolean isAnyOnWarmOrColdTier(ClusterState state, List<Index> indices) {
-        return isAnyAssignedToNode(state, indices, n -> DataTier.isWarmNode(n) || DataTier.isColdNode(n));
+        return isAnyAssignedToNode(
+            state,
+            indices,
+            // a content node is never considered a warm or cold node
+            n -> DataTier.isContentNode(n) == false && (DataTier.isWarmNode(n) || DataTier.isColdNode(n))
+        );
     }
 }


### PR DESCRIPTION
Backports the following commits to 8.12:
 - [Profiling] Query in parallel on content nodes (#104600)