### PR TITLE
[Connector API] Make update configuration action non-additive

### DIFF
--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/335_connector_update_configuration.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/335_connector_update_configuration.yml
@@ -57,7 +57,7 @@ setup:
         connector_id: test-connector
         body:
           configuration:
-            some_field:
+            some_new_field:
               default_value: null
               depends_on:
                 - field: some_field
@@ -92,20 +92,22 @@ setup:
       connector.get:
         connector_id: test-connector
 
-  - match: { configuration.some_field.value: 456 }
+  - is_false:  configuration.some_field  # configuration.some_field doesn't exist
+
+  - match: { configuration.some_new_field.value: 456 }
   - match: { status: configured }
-  - match: { configuration.some_field.validations.0.constraint: [123, 456, 789] }
-  - match: { configuration.some_field.validations.0.type: included_in }
-  - match: { configuration.some_field.validations.1.constraint: ["string 1", "string 2", "string 3"] }
-  - match: { configuration.some_field.validations.1.type: included_in }
-  - match: { configuration.some_field.validations.2.constraint: 0 }
-  - match: { configuration.some_field.validations.2.type: greater_than }
-  - match: { configuration.some_field.validations.3.constraint: 42 }
-  - match: { configuration.some_field.validations.3.type: less_than }
-  - match: { configuration.some_field.validations.4.constraint: int }
-  - match: { configuration.some_field.validations.4.type: list_type }
-  - match: { configuration.some_field.validations.5.constraint: "\\d+" }
-  - match: { configuration.some_field.validations.5.type: regex }
+  - match: { configuration.some_new_field.validations.0.constraint: [123, 456, 789] }
+  - match: { configuration.some_new_field.validations.0.type: included_in }
+  - match: { configuration.some_new_field.validations.1.constraint: ["string 1", "string 2", "string 3"] }
+  - match: { configuration.some_new_field.validations.1.type: included_in }
+  - match: { configuration.some_new_field.validations.2.constraint: 0 }
+  - match: { configuration.some_new_field.validations.2.type: greater_than }
+  - match: { configuration.some_new_field.validations.3.constraint: 42 }
+  - match: { configuration.some_new_field.validations.3.type: less_than }
+  - match: { configuration.some_new_field.validations.4.constraint: int }
+  - match: { configuration.some_new_field.validations.4.type: list_type }
+  - match: { configuration.some_new_field.validations.5.constraint: "\\d+" }
+  - match: { configuration.some_new_field.validations.5.type: regex }
 
 ---
 "Update Connector Configuration with null tooltip":

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorIndexServiceTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorIndexServiceTests.java
@@ -12,7 +12,14 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.update.UpdateResponse;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.script.MockScriptEngine;
+import org.elasticsearch.script.MockScriptPlugin;
+import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.script.ScriptEngine;
+import org.elasticsearch.script.UpdateScript;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.elasticsearch.xpack.application.connector.action.PostConnectorAction;
 import org.elasticsearch.xpack.application.connector.action.PutConnectorAction;
@@ -27,11 +34,14 @@ import org.elasticsearch.xpack.application.connector.action.UpdateConnectorSched
 import org.junit.Before;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -47,6 +57,13 @@ public class ConnectorIndexServiceTests extends ESSingleNodeTestCase {
     @Before
     public void setup() {
         this.connectorIndexService = new ConnectorIndexService(client());
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        List<Class<? extends Plugin>> plugins = new ArrayList<>(super.getPlugins());
+        plugins.add(MockPainlessScriptEngine.TestPlugin.class);
+        return plugins;
     }
 
     public void testPutConnector() throws Exception {
@@ -90,21 +107,16 @@ public class ConnectorIndexServiceTests extends ESSingleNodeTestCase {
         DocWriteResponse resp = buildRequestAndAwaitPutConnector(connectorId, connector);
         assertThat(resp.status(), anyOf(equalTo(RestStatus.CREATED), equalTo(RestStatus.OK)));
 
-        Map<String, ConnectorConfiguration> connectorConfiguration = connector.getConfiguration()
-            .entrySet()
-            .stream()
-            .collect(Collectors.toMap(Map.Entry::getKey, entry -> ConnectorTestUtils.getRandomConnectorConfigurationField()));
-
         UpdateConnectorConfigurationAction.Request updateConfigurationRequest = new UpdateConnectorConfigurationAction.Request(
             connectorId,
-            connectorConfiguration
+            connector.getConfiguration()
         );
 
         DocWriteResponse updateResponse = awaitUpdateConnectorConfiguration(updateConfigurationRequest);
         assertThat(updateResponse.status(), equalTo(RestStatus.OK));
-        Connector indexedConnector = awaitGetConnector(connectorId);
-        assertThat(connectorConfiguration, equalTo(indexedConnector.getConfiguration()));
-        assertThat(indexedConnector.getStatus(), equalTo(ConnectorStatus.CONFIGURED));
+
+        // Configuration update is handled via painless script. ScriptEngine is mocked for unit tests.
+        // More comprehensive tests are defined in yamlRestTest.
     }
 
     public void testUpdateConnectorPipeline() throws Exception {
@@ -606,6 +618,46 @@ public class ConnectorIndexServiceTests extends ESSingleNodeTestCase {
         }
         assertNotNull("Received null response from update error request", resp.get());
         return resp.get();
+    }
+
+    /**
+     * Update configuration action is handled via painless script. This implementation mocks the painless script engine
+     * for unit tests.
+     */
+    private static class MockPainlessScriptEngine extends MockScriptEngine {
+
+        public static final String NAME = "painless";
+
+        public static class TestPlugin extends MockScriptPlugin {
+            @Override
+            public ScriptEngine getScriptEngine(Settings settings, Collection<ScriptContext<?>> contexts) {
+                return new ConnectorIndexServiceTests.MockPainlessScriptEngine();
+            }
+
+            @Override
+            protected Map<String, Function<Map<String, Object>, Object>> pluginScripts() {
+                return Collections.emptyMap();
+            }
+        }
+
+        @Override
+        public String getType() {
+            return NAME;
+        }
+
+        @Override
+        public <T> T compile(String name, String script, ScriptContext<T> context, Map<String, String> options) {
+            if (context.instanceClazz.equals(UpdateScript.class)) {
+                UpdateScript.Factory factory = (params, ctx) -> new UpdateScript(params, ctx) {
+                    @Override
+                    public void execute() {
+
+                    }
+                };
+                return context.factoryClazz.cast(factory);
+            }
+            throw new IllegalArgumentException("mock painless does not know how to handle context [" + context.name + "]");
+        }
     }
 
 }


### PR DESCRIPTION
## Changes

- Make update configuration action non-additive with a painless script
- Current configuration uses default `update` ES logic, therefore updating configuration (which is a `string, {...}>` mapping) with new values will keep old key-value pairs in doc source, reproduction scenario:
  - Create new connector
  - Update configuration with `{field1: {...}, field2: {...}}`
  - Update configuration again with `{field2: {...}, field3: {...}}`
  - The resulting state of configuration would contain `field1`, `field2` and `field3`
- This change would results only in `field2` and `field3` being present in the configuration field. The `configuration` field gets overridden completely

### Testing
- Tested locally
- Added scenario in Yaml test
- Adapted unit tests, script engine needs to be mocked for unit tests, therefore I test the "non-additive" property in yaml tests only
