### PR TITLE
Allow to disable CFS usage in tests

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/engine/EngineConfig.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/EngineConfig.java
@@ -73,6 +73,7 @@ public final class EngineConfig {
     private final LongSupplier globalCheckpointSupplier;
     private final Supplier<RetentionLeases> retentionLeasesSupplier;
     private final Comparator<LeafReader> leafSorter;
+    private final boolean useCompoundFile;
 
     /**
      * A supplier of the outstanding retention leases. This is used during merged operations to determine which operations that have been
@@ -107,6 +108,9 @@ public final class EngineConfig {
                 return s;
         }
     }, Property.IndexScope, Property.NodeScope, Property.ServerlessPublic);
+
+    // don't convert to Setting<> and register... we only set this in tests and register via a test plugin
+    public static final String USE_COMPOUND_FILE = "index.use_compound_file";
 
     /**
      * Legacy index setting, kept for 7.x BWC compatibility. This setting has no effect in 8.x. Do not use.
@@ -202,6 +206,8 @@ public final class EngineConfig {
         this.relativeTimeInNanosSupplier = relativeTimeInNanosSupplier;
         this.indexCommitListener = indexCommitListener;
         this.promotableToPrimary = promotableToPrimary;
+        // always use compound on flush - reduces # of file-handles on refresh
+        this.useCompoundFile = indexSettings.getSettings().getAsBoolean(USE_COMPOUND_FILE, true);
     }
 
     /**
@@ -422,5 +428,12 @@ public final class EngineConfig {
      */
     public boolean isPromotableToPrimary() {
         return promotableToPrimary;
+    }
+
+    /**
+     * @return whether the Engine's index writer should pack newly written segments in a compound file. Default is true.
+     */
+    public boolean getUseCompoundFile() {
+        return useCompoundFile;
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -2697,7 +2697,14 @@ public class InternalEngine extends Engine {
         iwc.setSimilarity(engineConfig.getSimilarity());
         iwc.setRAMBufferSizeMB(engineConfig.getIndexingBufferSize().getMbFrac());
         iwc.setCodec(engineConfig.getCodec());
-        iwc.setUseCompoundFile(true); // always use compound on flush - reduces # of file-handles on refresh
+        boolean useCompoundFile = engineConfig.getUseCompoundFile();
+        iwc.setUseCompoundFile(useCompoundFile);
+        if (useCompoundFile == false) {
+            logger.warn(
+                "[{}] is set to false, this should only be used in tests and can cause serious problems in production environments",
+                EngineConfig.USE_COMPOUND_FILE
+            );
+        }
         if (config().getIndexSort() != null) {
             iwc.setIndexSort(config().getIndexSort());
         }

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalSettingsPlugin.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalSettingsPlugin.java
@@ -14,6 +14,7 @@ import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.index.engine.EngineConfig;
 import org.elasticsearch.monitor.fs.FsService;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.transport.RemoteConnectionStrategy;
@@ -31,6 +32,12 @@ public final class InternalSettingsPlugin extends Plugin {
     );
     public static final Setting<Boolean> MERGE_ENABLED = Setting.boolSetting(
         "index.merge.enabled",
+        true,
+        Property.IndexScope,
+        Property.NodeScope
+    );
+    public static final Setting<Boolean> USE_COMPOUND_FILE = Setting.boolSetting(
+        EngineConfig.USE_COMPOUND_FILE,
         true,
         Property.IndexScope,
         Property.NodeScope
@@ -54,6 +61,7 @@ public final class InternalSettingsPlugin extends Plugin {
     public List<Setting<?>> getSettings() {
         return Arrays.asList(
             MERGE_ENABLED,
+            USE_COMPOUND_FILE,
             INDEX_CREATION_DATE_SETTING,
             PROVIDED_NAME_SETTING,
             TRANSLOG_RETENTION_CHECK_INTERVAL_SETTING,


### PR DESCRIPTION
This change allows to disable CFS usage in tests using a test-only index setting. This can be useful for tests that do not support CFS format.