### PR TITLE
[8.12] [Transform] Fix bug when `latest` transform is used together with `from` parameter (#104606)

### DIFF
--- a/docs/changelog/104606.yaml
+++ b/docs/changelog/104606.yaml
@@ -1,0 +1,6 @@
+pr: 104606
+summary: Fix bug when `latest` transform is used together with `from` parameter
+area: Transform
+type: bug
+issues:
+ - 104543

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
@@ -1165,7 +1165,7 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
     }
 
     private RunState determineRunStateAtStart() {
-        if (context.from() != null) {
+        if (context.from() != null && changeCollector != null && changeCollector.queryForChanges()) {
             return RunState.IDENTIFY_CHANGES;
         }
 


### PR DESCRIPTION
Backports the following commits to 8.12:
 - [Transform] Fix bug when `latest` transform is used together with `from` parameter (#104606)