### PR TITLE
[Enterprise Search] Disable broken BA template in BwC test

### DIFF
--- a/x-pack/plugin/ent-search/qa/full-cluster-restart/build.gradle
+++ b/x-pack/plugin/ent-search/qa/full-cluster-restart/build.gradle
@@ -30,10 +30,3 @@ BuildParams.bwcVersions.withWireCompatible(v -> v.after("8.8.0")) { bwcVersion, 
     systemProperty("tests.old_cluster_version", bwcVersion)
   }
 }
-
-
-testClusters.configureEach {
-  testDistribution = 'DEFAULT'
-  numberOfNodes = 1
-  setting 'xpack.license.self_generated.type', 'trial'
-}

--- a/x-pack/plugin/ent-search/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/application/FullClusterRestartIT.java
+++ b/x-pack/plugin/ent-search/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/application/FullClusterRestartIT.java
@@ -17,6 +17,7 @@ import org.elasticsearch.test.rest.ObjectPath;
 import org.elasticsearch.upgrades.FullClusterRestartUpgradeStatus;
 import org.elasticsearch.upgrades.ParameterizedFullClusterRestartTestCase;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 
 import java.io.IOException;
 import java.util.List;
@@ -48,6 +49,7 @@ public class FullClusterRestartIT extends ParameterizedFullClusterRestartTestCas
         return cluster;
     }
 
+    @Ignore("https://github.com/elastic/elasticsearch/issues/104470")
     public void testBehavioralAnalyticsDataRetention() throws Exception {
         assumeTrue(
             "Data retention changed by default to DSL in " + DSL_DEFAULT_RETENTION_VERSION,

--- a/x-pack/plugin/ent-search/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/application/FullClusterRestartIT.java
+++ b/x-pack/plugin/ent-search/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/application/FullClusterRestartIT.java
@@ -17,7 +17,6 @@ import org.elasticsearch.test.rest.ObjectPath;
 import org.elasticsearch.upgrades.FullClusterRestartUpgradeStatus;
 import org.elasticsearch.upgrades.ParameterizedFullClusterRestartTestCase;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 
 import java.io.IOException;
 import java.util.List;
@@ -49,7 +48,7 @@ public class FullClusterRestartIT extends ParameterizedFullClusterRestartTestCas
         return cluster;
     }
 
-    @Ignore("https://github.com/elastic/elasticsearch/issues/104470")
+    @AwaitsFix(bugUrl="https://github.com/elastic/elasticsearch/issues/104470")
     public void testBehavioralAnalyticsDataRetention() throws Exception {
         assumeTrue(
             "Data retention changed by default to DSL in " + DSL_DEFAULT_RETENTION_VERSION,

--- a/x-pack/plugin/ent-search/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/application/FullClusterRestartIT.java
+++ b/x-pack/plugin/ent-search/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/application/FullClusterRestartIT.java
@@ -4,18 +4,11 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
- */
 package org.elasticsearch.xpack.application;
 
 import com.carrotsearch.randomizedtesting.annotations.Name;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
@@ -27,6 +20,8 @@ import org.junit.ClassRule;
 
 import java.io.IOException;
 import java.util.List;
+
+import static org.elasticsearch.Version.V_8_12_0;
 
 public class FullClusterRestartIT extends ParameterizedFullClusterRestartTestCase {
 
@@ -54,15 +49,16 @@ public class FullClusterRestartIT extends ParameterizedFullClusterRestartTestCas
     }
 
     public void testBehavioralAnalyticsDataRetention() throws Exception {
-
+        System.out.println("TEST START");
         assumeTrue(
             "Data retention changed by default to DSL in " + DSL_DEFAULT_RETENTION_VERSION,
-            getOldClusterTestVersion().before(DSL_DEFAULT_RETENTION_VERSION)
+            getOldClusterTestVersion().before(DSL_DEFAULT_RETENTION_VERSION.toString())
         );
 
         String legacyAnalyticsCollectionName = "oldstuff";
         String newAnalyticsCollectionName = "newstuff";
 
+        System.out.println("INDEX TEMPLATE1: " + client().performRequest(new Request("GET", "_index_template/behav*")).toString());
         if (isRunningAgainstOldCluster()) {
             // Create an analytics collection
             Request legacyPutRequest = new Request("PUT", "_application/analytics/" + legacyAnalyticsCollectionName);

--- a/x-pack/plugin/ent-search/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/application/FullClusterRestartIT.java
+++ b/x-pack/plugin/ent-search/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/application/FullClusterRestartIT.java
@@ -49,7 +49,6 @@ public class FullClusterRestartIT extends ParameterizedFullClusterRestartTestCas
     }
 
     public void testBehavioralAnalyticsDataRetention() throws Exception {
-        System.out.println("TEST START");
         assumeTrue(
             "Data retention changed by default to DSL in " + DSL_DEFAULT_RETENTION_VERSION,
             getOldClusterTestVersion().before(DSL_DEFAULT_RETENTION_VERSION.toString())
@@ -58,7 +57,6 @@ public class FullClusterRestartIT extends ParameterizedFullClusterRestartTestCas
         String legacyAnalyticsCollectionName = "oldstuff";
         String newAnalyticsCollectionName = "newstuff";
 
-        System.out.println("INDEX TEMPLATE1: " + client().performRequest(new Request("GET", "_index_template/behav*")).toString());
         if (isRunningAgainstOldCluster()) {
             // Create an analytics collection
             Request legacyPutRequest = new Request("PUT", "_application/analytics/" + legacyAnalyticsCollectionName);

--- a/x-pack/plugin/ent-search/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/application/FullClusterRestartIT.java
+++ b/x-pack/plugin/ent-search/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/application/FullClusterRestartIT.java
@@ -48,7 +48,7 @@ public class FullClusterRestartIT extends ParameterizedFullClusterRestartTestCas
         return cluster;
     }
 
-    @AwaitsFix(bugUrl="https://github.com/elastic/elasticsearch/issues/104470")
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/104470")
     public void testBehavioralAnalyticsDataRetention() throws Exception {
         assumeTrue(
             "Data retention changed by default to DSL in " + DSL_DEFAULT_RETENTION_VERSION,

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearch.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearch.java
@@ -17,7 +17,6 @@ import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsFilter;
-import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.indices.SystemIndexDescriptor;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.logging.LogManager;
@@ -368,12 +367,10 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
             return Collections.emptyList();
         }
 
-        FeatureService featureService = new FeatureService(List.of(new EnterpriseSearchFeatures()));
-
         // Behavioral analytics components
         final AnalyticsTemplateRegistry analyticsTemplateRegistry = new AnalyticsTemplateRegistry(
             services.clusterService(),
-            featureService,
+            services.featureService(),
             services.threadPool(),
             services.client(),
             services.xContentRegistry()
@@ -383,7 +380,7 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
         // Connector components
         final ConnectorTemplateRegistry connectorTemplateRegistry = new ConnectorTemplateRegistry(
             services.clusterService(),
-            featureService,
+            services.featureService(),
             services.threadPool(),
             services.client(),
             services.xContentRegistry()

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearch.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearch.java
@@ -17,6 +17,7 @@ import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsFilter;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.indices.SystemIndexDescriptor;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.logging.LogManager;
@@ -367,10 +368,12 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
             return Collections.emptyList();
         }
 
+        FeatureService featureService = new FeatureService(List.of(new EnterpriseSearchFeatures()));
+
         // Behavioral analytics components
         final AnalyticsTemplateRegistry analyticsTemplateRegistry = new AnalyticsTemplateRegistry(
             services.clusterService(),
-            services.featureService(),
+            featureService,
             services.threadPool(),
             services.client(),
             services.xContentRegistry()
@@ -380,7 +383,7 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
         // Connector components
         final ConnectorTemplateRegistry connectorTemplateRegistry = new ConnectorTemplateRegistry(
             services.clusterService(),
-            services.featureService(),
+            featureService,
             services.threadPool(),
             services.client(),
             services.xContentRegistry()


### PR DESCRIPTION
This PR disables the broken BWC test `org.elasticsearch.xpack.application.FullClusterRestartIT`. It applies changes from  https://github.com/elastic/elasticsearch/pull/104463 (cc @breskeby) after rebasing to `main`.
