### PR TITLE
[WIP] Indices Options Refactor

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/IndexResolutionContext.java
+++ b/server/src/main/java/org/elasticsearch/action/support/IndexResolutionContext.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.support;
+
+public record IndexResolutionContext(IndicesOptions delegate) {
+    /**
+     * @return True if the requested indices should include open indices.
+     */
+    public boolean includeOpen() {
+        return delegate.expandWildcardsOpen();
+    }
+
+    /**
+     * @return True if the requested indices should include closed indices.
+     */
+    public boolean includeClosed() {
+        return delegate.expandWildcardsClosed();
+    }
+
+    /**
+     * @return If this is false, the indices options prevent any indices from being resolved.
+     */
+    public boolean anyIndicesIncluded() {
+        return includeOpen() || includeClosed();
+    }
+
+    /**
+     * @return True if wildcards should be expanded to include aliases, and then those aliases resolved to concrete
+     * indices. False if aliases should be ignored.
+     */
+    public boolean resolveAliases() {
+        return delegate.ignoreAliases() == false;
+    }
+
+    /**
+     * @return True if throttled indices should be removed from the final list, false if they should be included.
+     */
+    public boolean removeThrottled() {
+        return delegate.ignoreThrottled();
+    }
+
+    /**
+     * @return True if hidden indices should be removed from the final list, false if they should be included.
+     */
+    public boolean removeHidden() {
+        return delegate.expandWildcardsHidden() == false;
+    }
+
+    /**
+     * @return If this is false, an exception will be thrown if any of the resolved indices are unavailable.
+     */
+    public boolean allowUnavailable() {
+        return delegate.ignoreUnavailable();
+    }
+
+    /**
+     * @return If this is false, an exception will be thrown if any of the resolved indices are closed.
+     */
+    public boolean allowClosedIndices() {
+        return delegate.forbidClosedIndices() == false;
+    }
+
+    /**
+     * @return If this is false, an exception will be thrown if the list of resolved indices is empty.
+     */
+    public boolean allowNoIndices() {
+        return delegate.allowNoIndices();
+    }
+
+    /**
+     * @return If this is false, an exception will be thrown if the alias is resolved to multiple indices.
+     */
+    public boolean allowAliasesToMultipleIndices() {
+        return delegate.allowAliasesToMultipleIndices();
+    }
+
+}

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/ExpressionListTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/ExpressionListTests.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.cluster.metadata;
 
 import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.action.support.IndexResolutionContext;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.Context;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.ExpressionList;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.ExpressionList.Expression;
@@ -302,7 +303,7 @@ public class ExpressionListTests extends ESTestCase {
 
     private Context getContextWithOptions(IndicesOptions indicesOptions) {
         Context context = mock(Context.class);
-        when(context.getOptions()).thenReturn(indicesOptions);
+        when(context.getOptions()).thenReturn(new IndexResolutionContext(indicesOptions));
         return context;
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
@@ -1483,9 +1483,9 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
             IndicesOptions.fromOptions(
                 true,
                 contextICE.getOptions().allowNoIndices(),
-                contextICE.getOptions().expandWildcardsOpen(),
-                contextICE.getOptions().expandWildcardsClosed(),
-                contextICE.getOptions()
+                contextICE.getOptions().delegate().expandWildcardsOpen(),
+                contextICE.getOptions().delegate().expandWildcardsClosed(),
+                contextICE.getOptions().delegate()
             ),
             SystemIndexAccessLevel.NONE
         );
@@ -1522,9 +1522,9 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
             IndicesOptions.fromOptions(
                 true,
                 context.getOptions().allowNoIndices(),
-                context.getOptions().expandWildcardsOpen(),
-                context.getOptions().expandWildcardsClosed(),
-                context.getOptions()
+                context.getOptions().delegate().expandWildcardsOpen(),
+                context.getOptions().delegate().expandWildcardsClosed(),
+                context.getOptions().delegate()
             ),
             SystemIndexAccessLevel.NONE
         );

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/WildcardExpressionResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/WildcardExpressionResolverTests.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.cluster.metadata;
 
 import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.action.support.IndexResolutionContext;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata.State;
@@ -560,7 +561,7 @@ public class WildcardExpressionResolverTests extends ESTestCase {
         }
 
         {
-            IndicesOptions indicesAndAliasesOptions = IndicesOptions.fromOptions(
+            IndexResolutionContext indicesAndAliasesOptions = new IndexResolutionContext(IndicesOptions.fromOptions(
                 randomBoolean(),
                 randomBoolean(),
                 true,
@@ -569,7 +570,7 @@ public class WildcardExpressionResolverTests extends ESTestCase {
                 false,
                 false,
                 false
-            );
+            ));
             IndexNameExpressionResolver.Context indicesAliasesAndDataStreamsContext = new IndexNameExpressionResolver.Context(
                 state,
                 indicesAndAliasesOptions,
@@ -616,7 +617,7 @@ public class WildcardExpressionResolverTests extends ESTestCase {
         }
 
         {
-            IndicesOptions indicesAliasesAndExpandHiddenOptions = IndicesOptions.fromOptions(
+            IndexResolutionContext indicesAliasesAndExpandHiddenOptions = new IndexResolutionContext(IndicesOptions.fromOptions(
                 randomBoolean(),
                 randomBoolean(),
                 true,
@@ -626,7 +627,7 @@ public class WildcardExpressionResolverTests extends ESTestCase {
                 false,
                 false,
                 false
-            );
+            ));
             IndexNameExpressionResolver.Context indicesAliasesDataStreamsAndHiddenIndices = new IndexNameExpressionResolver.Context(
                 state,
                 indicesAliasesAndExpandHiddenOptions,


### PR DESCRIPTION
This PR is a WIP of a refactoring of `IndicesOptions` with the high-level goal of reducing mental overhead of using or making changes to index name resolution. To accomplish this, this PR has the following goals specific goals:

- Align all flags to positive logic (e.g. `resolveAliases` instead of `ignoreAliases`)
- Categorize flags to be more descriptive of their function (e.g. `removeHidden` instead of `expandWildcardsHidden`)
- Centralize index resolution options into one place (?)

---

The current state of this PR (very, very much a work in progress - this is mostly here to facilitate discussion) makes a stab at the first two points by introducing a thin layer over the existing `IndicesOptions` class. I expect that future iteration on this will expand that layer to be able to exist on its own, rather than requiring a delegate `IndicesOptions`. I also expect this new layer to grow to take over most of the duties of `IndexNameExpressionResolver.Context`, though I would be open to discussion on that point.