### PR TITLE
Remove `ActionType#responseReader`

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/ActionType.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionType.java
@@ -28,7 +28,6 @@ import org.elasticsearch.transport.TransportService;
 public class ActionType<Response extends ActionResponse> {
 
     private final String name;
-    private final Writeable.Reader<Response> responseReader;
 
     /**
      * Construct an {@link ActionType} which callers can execute on the local node (using {@link NodeClient}).
@@ -57,12 +56,9 @@ public class ActionType<Response extends ActionResponse> {
      * several utilities that help implement such an action, including {@link TransportNodesAction} or {@link TransportMasterNodeAction}.
      *
      * @param name           The name of the action, which must be unique across actions.
-     * @param responseReader Defines how to deserialize responses received from executions of this action on remote clusters. Effectively
-     *                       unused.
      */
-    public ActionType(String name, Writeable.Reader<Response> responseReader) {
+    public ActionType(String name, Writeable.Reader<Response> ignored) {
         this.name = name;
-        this.responseReader = responseReader;
     }
 
     /**
@@ -70,13 +66,6 @@ public class ActionType<Response extends ActionResponse> {
      */
     public String name() {
         return this.name;
-    }
-
-    /**
-     * Get a reader that can read a response from a {@link org.elasticsearch.common.io.stream.StreamInput}.
-     */
-    public Writeable.Reader<Response> getResponseReader() {
-        return responseReader;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/ingest/IngestActionForwarder.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/IngestActionForwarder.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionListenerResponseHandler;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterStateApplier;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -38,12 +39,12 @@ public final class IngestActionForwarder implements ClusterStateApplier {
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    public void forwardIngestRequest(ActionType<?> action, ActionRequest request, ActionListener<?> listener) {
+    public void forwardIngestRequest(ActionType<BulkResponse> action, ActionRequest request, ActionListener<?> listener) {
         transportService.sendRequest(
             randomIngestNode(),
             action.name(),
             request,
-            new ActionListenerResponseHandler(listener, action.getResponseReader(), TransportResponseHandler.TRANSPORT_WORKER)
+            new ActionListenerResponseHandler(listener, BulkResponse::new, TransportResponseHandler.TRANSPORT_WORKER)
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/action/ingest/SimulatePipelineTransportAction.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/SimulatePipelineTransportAction.java
@@ -118,7 +118,7 @@ public class SimulatePipelineTransportAction extends HandledTransportAction<Simu
                 logger.trace("forwarding request [{}] to ingest node [{}]", actionName, ingestNode);
                 ActionListenerResponseHandler<SimulatePipelineResponse> handler = new ActionListenerResponseHandler<>(
                     listener,
-                    SimulatePipelineAction.INSTANCE.getResponseReader(),
+                    SimulatePipelineResponse::new,
                     TransportResponseHandler.TRANSPORT_WORKER
                 );
                 if (task == null) {

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/TransportEqlSearchAction.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/plugin/TransportEqlSearchAction.java
@@ -210,7 +210,7 @@ public final class TransportEqlSearchAction extends HandledTransportAction<EqlSe
                         r -> listener.onResponse(qualifyHits(r, clusterAlias)),
                         e -> listener.onFailure(qualifyException(e, remoteIndices, clusterAlias))
                     ),
-                    EqlSearchAction.INSTANCE.getResponseReader(),
+                    EqlSearchResponse::new,
                     TransportResponseHandler.TRANSPORT_WORKER
                 )
             );


### PR DESCRIPTION
This field is only used in places where we aren't executing a client
action, so we shouldn't really be using an `ActionType` at all. This
commit fixes up those usages and removes the now-unused field.