### PR TITLE
[Profiling] More waiting in REST tests

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/profiling/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/profiling/10_basic.yml
@@ -13,10 +13,11 @@ setup:
   - do:
       profiling.status:
         wait_for_resources_created: true
+        timeout: "1m"
 
   - do:
       bulk:
-        refresh: true
+        refresh: wait_for
         body:
           - {"create": {"_index": "profiling-events-all"}}
           - {"Stacktrace.count": [1], "profiling.project.id": ["100"], "os.kernel": ["9.9.9-0"], "tags": ["environment:qa", "region:eu-west-1"], "host.ip": ["192.168.1.2"], "@timestamp": ["1700504427"], "container.name": ["instance-0000000010"], "ecs.version": ["1.12.0"], "Stacktrace.id": ["S07KmaoGhvNte78xwwRbZQ"], "agent.version": ["head-be593ef3-1688111067"], "host.name": ["ip-192-168-1-2"], "host.id": ["8457605156473051743"], "process.thread.name": ["497295213074376"]}


### PR DESCRIPTION
Universal Profiling creates a lot of indices upon startup. On slower systems it might take longer than usual which leads to sporadic test failures. With this commit we:

* Increase the initial timeout when waiting for resources to be created
* Wait for a refresh after bulk-indexing data