### PR TITLE
[Profiling] Speed up processing of stacktraces

### DIFF
--- a/docs/changelog/104674.yaml
+++ b/docs/changelog/104674.yaml
@@ -1,0 +1,5 @@
+pr: 104674
+summary: "[Profiling] Speed up processing of stacktraces"
+area: Application
+type: enhancement
+issues: []

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStackTracesAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStackTracesAction.java
@@ -59,7 +59,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;


### PR DESCRIPTION
So far we kept track of stack frame and executable ids that are associated to stack traces in a sorted collection. The rationale behind this was that the mget should be faster. However, we have seen in benchmarks that the contrary is the case: Not the mgets are the bottleneck but rather insertion is so slow that it defers further processing internally by several hundred milliseconds. When we change to an unsorted (and pre-sized) collection we reduce median response time from ~ 1200ms to 1000ms (or 17%).