### PR TITLE
[ML] Fix occasional NPE when calculating ML metrics for APM

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManager.java
@@ -1073,7 +1073,7 @@ public class AutodetectProcessManager implements ClusterStateListener {
                 ModelSizeStats modelSizeStats = processContext.getAutodetectCommunicator().getModelSizeStats();
                 ModelSizeStats.AssignmentMemoryBasis basis = modelSizeStats.getAssignmentMemoryBasis();
                 memoryUsedBytes += switch (basis != null ? basis : ModelSizeStats.AssignmentMemoryBasis.MODEL_MEMORY_LIMIT) {
-                    case MODEL_MEMORY_LIMIT -> modelSizeStats.getModelBytesMemoryLimit();
+                    case MODEL_MEMORY_LIMIT -> Optional.ofNullable(modelSizeStats.getModelBytesMemoryLimit()).orElse(0L);
                     case CURRENT_MODEL_BYTES -> modelSizeStats.getModelBytes();
                     case PEAK_MODEL_BYTES -> Optional.ofNullable(modelSizeStats.getPeakModelBytes()).orElse(modelSizeStats.getModelBytes());
                 };


### PR DESCRIPTION
There is a very short period of time when a job first starts up when its model size stats do not contain its model memory limit. This period only lasts a second or two, and it's when the job first starts, so it's reasonable in this case to add 0 to the memory usage reported in the metrics.