### PR TITLE
Ensure there's only one newline added with new version declarations in 7.17

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/UpdateVersionsTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/UpdateVersionsTask.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.gradle.internal.release;
 
+import com.github.javaparser.GeneratedJavaParserConstants;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.NodeList;
@@ -16,6 +17,9 @@ import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.expr.FieldAccessExpr;
 import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.observer.ObservableProperty;
+import com.github.javaparser.printer.ConcreteSyntaxModel;
+import com.github.javaparser.printer.concretesyntaxmodel.CsmElement;
 import com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter;
 import com.google.common.annotations.VisibleForTesting;
 
@@ -28,6 +32,7 @@ import org.gradle.api.tasks.options.Option;
 import org.gradle.initialization.layout.BuildLayout;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -43,7 +48,84 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 
+import static com.github.javaparser.ast.observer.ObservableProperty.TYPE_PARAMETERS;
+import static com.github.javaparser.printer.concretesyntaxmodel.CsmConditional.Condition.FLAG;
+import static com.github.javaparser.printer.concretesyntaxmodel.CsmElement.block;
+import static com.github.javaparser.printer.concretesyntaxmodel.CsmElement.child;
+import static com.github.javaparser.printer.concretesyntaxmodel.CsmElement.comma;
+import static com.github.javaparser.printer.concretesyntaxmodel.CsmElement.comment;
+import static com.github.javaparser.printer.concretesyntaxmodel.CsmElement.conditional;
+import static com.github.javaparser.printer.concretesyntaxmodel.CsmElement.list;
+import static com.github.javaparser.printer.concretesyntaxmodel.CsmElement.newline;
+import static com.github.javaparser.printer.concretesyntaxmodel.CsmElement.none;
+import static com.github.javaparser.printer.concretesyntaxmodel.CsmElement.sequence;
+import static com.github.javaparser.printer.concretesyntaxmodel.CsmElement.space;
+import static com.github.javaparser.printer.concretesyntaxmodel.CsmElement.string;
+import static com.github.javaparser.printer.concretesyntaxmodel.CsmElement.token;
+
 public class UpdateVersionsTask extends DefaultTask {
+
+    static {
+        replaceDefaultJavaParserClassCsm();
+    }
+
+    /*
+     * The default JavaParser CSM which it uses to format any new declarations added to a class
+     * inserts two newlines after each declaration. Our version classes only have one newline.
+     * In order to get javaparser lexical printer to use our format, we have to completely replace
+     * the statically declared CSM pattern using hacky reflection
+     * to access the static map where these are stored, and insert a replacement that is identical
+     * apart from only one newline at the end of each member declaration, rather than two.
+     */
+    private static void replaceDefaultJavaParserClassCsm() {
+        try {
+            Field classCsms = ConcreteSyntaxModel.class.getDeclaredField("concreteSyntaxModelByClass");
+            classCsms.setAccessible(true);
+            @SuppressWarnings({ "unchecked", "rawtypes" })
+            Map<Class, CsmElement> csms = (Map) classCsms.get(null);
+
+            // copied from the static initializer in ConcreteSyntaxModel
+            csms.put(
+                ClassOrInterfaceDeclaration.class,
+                sequence(
+                    comment(),
+                    list(ObservableProperty.ANNOTATIONS, newline(), none(), newline()),
+                    list(ObservableProperty.MODIFIERS, space(), none(), space()),
+                    conditional(
+                        ObservableProperty.INTERFACE,
+                        FLAG,
+                        token(GeneratedJavaParserConstants.INTERFACE),
+                        token(GeneratedJavaParserConstants.CLASS)
+                    ),
+                    space(),
+                    child(ObservableProperty.NAME),
+                    list(
+                        TYPE_PARAMETERS,
+                        sequence(comma(), space()),
+                        string(GeneratedJavaParserConstants.LT),
+                        string(GeneratedJavaParserConstants.GT)
+                    ),
+                    list(
+                        ObservableProperty.EXTENDED_TYPES,
+                        sequence(string(GeneratedJavaParserConstants.COMMA), space()),
+                        sequence(space(), token(GeneratedJavaParserConstants.EXTENDS), space()),
+                        none()
+                    ),
+                    list(
+                        ObservableProperty.IMPLEMENTED_TYPES,
+                        sequence(string(GeneratedJavaParserConstants.COMMA), space()),
+                        sequence(space(), token(GeneratedJavaParserConstants.IMPLEMENTS), space()),
+                        none()
+                    ),
+                    space(),
+                    block(sequence(newline(), list(ObservableProperty.MEMBERS, sequence(newline()/*, newline()*/), newline(), newline())))
+                )
+            );
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError(e);
+        }
+    }
+
     private static final Logger LOGGER = Logging.getLogger(UpdateVersionsTask.class);
 
     static final String SERVER_MODULE_PATH = "server/src/main/java/";

--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -177,7 +177,6 @@ public class Version implements Comparable<Version>, ToXContentFragment {
     public static final Version V_7_17_16 = new Version(7_17_16_99, org.apache.lucene.util.Version.LUCENE_8_11_1);
     public static final Version V_7_17_17 = new Version(7_17_17_99, org.apache.lucene.util.Version.LUCENE_8_11_1);
     public static final Version V_7_17_18 = new Version(7_17_18_99, org.apache.lucene.util.Version.LUCENE_8_11_1);
-
     public static final Version CURRENT = V_7_17_18;
 
     private static final ImmutableOpenIntMap<Version> idToVersion;


### PR DESCRIPTION
Backport https://github.com/elastic/elasticsearch/pull/104519 to 7.17