### PR TITLE
Blob-cache get remove false negatives

### DIFF
--- a/docs/changelog/104696.yaml
+++ b/docs/changelog/104696.yaml
@@ -1,0 +1,5 @@
+pr: 104696
+summary: Blob-cache get remove false negatives
+area: Snapshot/Restore
+type: enhancement
+issues: []

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
@@ -860,11 +860,11 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
             return new AbstractRunnable() {
                 @Override
                 protected void doRun() throws Exception {
-                    ensureOpen();
                     if (cacheFileRegion.tryIncRef() == false) {
                         throw new AlreadyClosedException("File chunk [" + cacheFileRegion.regionKey + "] has been released");
                     }
                     try {
+                        ensureOpen();
                         final int start = Math.toIntExact(gap.start());
                         var ioRef = io;
                         assert regionOwners.get(ioRef) == cacheFileRegion;

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
@@ -712,6 +712,7 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
 
             return false;
         }
+
         public boolean forceEvict() {
             assert Thread.holdsLock(SharedBlobCacheService.this) : "must hold lock when evicting";
             if (evict()) {
@@ -1434,6 +1435,7 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
             // give up
             return null;
         }
+
         /**
          * This method tries to evict the least used {@link LFUCacheEntry}. Only entries with the lowest possible frequency are considered
          * for eviction.

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
@@ -1415,6 +1415,7 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
                             if (ioRef != null) {
                                 try {
                                     if (entry.chunk.refCount() == 1) {
+                                        // we own that one refcount (since we CAS'ed evicted to 1)
                                         // grab io, rely on incref'ers also checking evicted field.
                                         entry.chunk.io = null;
                                         assert regionOwners.remove(ioRef) == entry.chunk;

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
@@ -311,6 +311,8 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
 
     private final BlobCacheMetrics blobCacheMetrics;
 
+    private final Runnable evictIncrementer;
+
     private final LongSupplier relativeTimeInMillisSupplier;
 
     public SharedBlobCacheService(
@@ -373,6 +375,7 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
 
         this.blobCacheMetrics = blobCacheMetrics;
         this.relativeTimeInMillisSupplier = relativeTimeInMillisSupplier;
+        this.evictIncrementer = blobCacheMetrics.getEvictedCountNonZeroFrequency()::increment;
     }
 
     public static long calculateCacheSize(Settings settings, long totalFsSize) {
@@ -1252,7 +1255,7 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
                 // need to evict something
                 SharedBytes.IO io;
                 synchronized (SharedBlobCacheService.this) {
-                    io = maybeEvictAndTake(blobCacheMetrics.getEvictedCountNonZeroFrequency()::increment);
+                    io = maybeEvictAndTake(evictIncrementer);
                 }
                 if (io == null) {
                     io = freeRegions.poll();

--- a/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBlobCacheServiceTests.java
+++ b/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBlobCacheServiceTests.java
@@ -325,10 +325,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
         final boolean allowAlreadyClosed = regionCount < threads;
         Settings settings = Settings.builder()
             .put(NODE_NAME_SETTING.getKey(), "node")
-            .put(
-                SharedBlobCacheService.SHARED_CACHE_SIZE_SETTING.getKey(),
-                ByteSizeValue.ofBytes(size(regionCount * 100L)).getStringRep()
-            )
+            .put(SharedBlobCacheService.SHARED_CACHE_SIZE_SETTING.getKey(), ByteSizeValue.ofBytes(size(regionCount * 100L)).getStringRep())
             .put(SharedBlobCacheService.SHARED_CACHE_REGION_SIZE_SETTING.getKey(), ByteSizeValue.ofBytes(size(100)).getStringRep())
             .put(SharedBlobCacheService.SHARED_CACHE_MIN_TIME_DELTA_SETTING.getKey(), randomFrom("0", "1ms", "10s"))
             .put("path.home", createTempDir())
@@ -360,13 +357,9 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
                             try {
                                 SharedBlobCacheService<String>.CacheFileRegion cacheFileRegion;
                                 try {
-                                    cacheFileRegion = cacheService.get(
-                                        cacheKeys[i],
-                                        fileLength,
-                                        regions[i]
-                                    );
+                                    cacheFileRegion = cacheService.get(cacheKeys[i], fileLength, regions[i]);
                                 } catch (AlreadyClosedException e) {
-                                    assert allowAlreadyClosed || e.getMessage().equals("evicted during free region allocation"): e;
+                                    assert allowAlreadyClosed || e.getMessage().equals("evicted during free region allocation") : e;
                                     throw e;
                                 }
                                 if (cacheFileRegion.tryIncRef()) {


### PR DESCRIPTION
The blob cache would sometimes respond with an already closed exception even though regions could be made available. Fixed to only do so when there really are no available regions (which should never happen with region count >= thread count, i.e., normally).
One exception is explicit evict, which only happens on explicit clear cache or corruptions.

Marked DRAFT for now to get input on approach, check that tests succeed and perhaps add a bit more testing.