### PR TITLE
ESQL: Lower the number of evaluations in `testTooManyEval()`

### DIFF
--- a/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackIT.java
+++ b/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackIT.java
@@ -280,10 +280,9 @@ public class HeapAttackIT extends ESRestTestCase {
         assertMap(map, matchesMap().entry("columns", columns).entry("values", hasSize(10_000)));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/104694")
     public void testTooManyEval() throws IOException {
         initManyLongs();
-        assertCircuitBreaks(() -> manyEval(1500));
+        assertCircuitBreaks(() -> manyEval(1000));
     }
 
     private Response manyEval(int evalLines) throws IOException {


### PR DESCRIPTION
This reverts the increase in #104521, which causes the parser to sometimes stack overflow.

Fixes #104694.
