### PR TITLE
Prune segments that don't intersect with the query time range.

### DIFF
--- a/docs/changelog/104705.yaml
+++ b/docs/changelog/104705.yaml
@@ -1,0 +1,6 @@
+pr: 104705
+summary: Prune segments that don't intersect with the query time range
+area: Search
+type: enhancement
+issues:
+ - 104556


### PR DESCRIPTION
When computing the intersection between multiple clauses, Lucene doesn't have a deterministic order for calling `Weight#scorer` in order to create scorers for each clause. This isn't a problem in general, except when filtering by a narrow time range and an expensive query (e.g. wildcard query). In this case, Lucene may perform expensive operations to evaluate matches of the `wildcard` query, before noticing that the segment doesn't have any matches for the filter on the time range.

In order to work around this, we proactively exclude segments from being searched if they don't match the filter on the time range. Note that this implementation only handles queries that do expensive operations in `Weight#create` such as `prefix`, `wildcard` or `range` queries, but not queries that perform expensive work in their rewrite phase, such as `fuzzy` and `vector` queries.

This should especially help alerting use-cases, that typically filter on a narrow time range, by making sure that we won't spent time creating scorers on the bigger segments that don't intersect with the query time range.

Closes #104556