### PR TITLE
Fix testRestoreSnapshotAllocationDoesNotExceedWatermarkWithMultipleShards

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderIT.java
@@ -196,7 +196,7 @@ public class DiskThresholdDeciderIT extends DiskUsageIntegTestCase {
 
         // reduce disk size of node 0 so that only 1 of 2 smallest shards can be allocated
         var usableSpace = shardSizes.sizes().get(1).size();
-        getTestFileStore(dataNodeName).setTotalSpace(usableSpace + WATERMARK_BYTES + 1L);
+        getTestFileStore(dataNodeName).setTotalSpace(usableSpace + WATERMARK_BYTES);
         refreshDiskUsage();
 
         final RestoreSnapshotResponse restoreSnapshotResponse = clusterAdmin().prepareRestoreSnapshot("repo", "snap")


### PR DESCRIPTION
Remove +1L that allows the third-smallest shard to be also allocated on the node in case it is only 1b bigger than second-smallest.

Closes: #104703
