### PR TITLE
Also allow test_grok_pattern's content passed by query param

### DIFF
--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/rest/RestTestGrokPatternAction.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/rest/RestTestGrokPatternAction.java
@@ -14,7 +14,6 @@ import org.elasticsearch.rest.Scope;
 import org.elasticsearch.rest.ServerlessScope;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xcontent.XContentParser;
-import org.elasticsearch.xpack.core.textstructure.action.FindStructureAction;
 import org.elasticsearch.xpack.core.textstructure.action.TestGrokPatternAction;
 
 import java.io.IOException;
@@ -40,8 +39,8 @@ public class RestTestGrokPatternAction extends BaseRestHandler {
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
         TestGrokPatternAction.Request request;
-        String ecsCompatibility = restRequest.param(FindStructureAction.Request.ECS_COMPATIBILITY.getPreferredName());
-        try (XContentParser parser = restRequest.contentParser()) {
+        String ecsCompatibility = restRequest.param(TestGrokPatternAction.Request.ECS_COMPATIBILITY.getPreferredName());
+        try (XContentParser parser = restRequest.contentOrSourceParamParser()) {
             request = TestGrokPatternAction.Request.parseRequest(ecsCompatibility, parser);
         }
 


### PR DESCRIPTION
Fixes: https://github.com/elastic/elasticsearch/issues/104708