### PR TITLE
Remove unused code from earlier GeoPoint ESQL work

### DIFF
--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
@@ -12,7 +12,6 @@ import org.apache.http.HttpEntity;
 import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.ResponseException;
-import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.Point;

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
@@ -181,9 +181,6 @@ public abstract class EsqlSpecTestCase extends ESRestTestCase {
         }
         if (type == CsvTestUtils.Type.GEO_POINT || type == CsvTestUtils.Type.CARTESIAN_POINT) {
             // Point tests are failing in clustered integration tests because of tiny precision differences at very small scales
-            if (value instanceof GeoPoint point) {
-                return normalizedGeoPoint(point.getX(), point.getY());
-            }
             if (value instanceof String wkt) {
                 try {
                     Geometry geometry = WellKnownText.fromWKT(GeometryValidator.NOOP, false, wkt);


### PR DESCRIPTION
This code made sense in earlier versions of the GeoPoint work, but is no longer meaningful since #104053

> Ignacio Vera* 2024-01-08, 17:33 ESQL: Simplify how we transform WKB to WKT in response (#104053)
