### PR TITLE
ESQL: Fix replacement of nested expressions in aggs with multiple parameters

### DIFF
--- a/docs/changelog/104718.yaml
+++ b/docs/changelog/104718.yaml
@@ -1,0 +1,6 @@
+pr: 104718
+summary: "ESQL: Fix replacement of nested expressions in aggs with multiple parameters"
+area: ES|QL
+type: bug
+issues:
+ - 104706

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -929,6 +929,21 @@ sum(sal):l | sum(salary + 10000):l | left(first_name, 1):s  | concat(gender,   t
 43370      | 43370                  |  B                    | F2
 ;
 
+nestedExpressionMultipleParams#[skip:-8.12.99,reason:supported in 8.13+]
+FROM employees
+| STATS p = percentile(emp_no + 10, 50), m = median(emp_no + 10) BY languages
+| SORT languages
+;
+
+p:double     | m:double      | languages:integer
+10053.0      | 10053.0       | 1
+10069.0      | 10069.0       | 2
+10068.0      | 10068.0       | 3
+10060.5      | 10060.5       | 4
+10076.0      | 10076.0       | 5
+10034.5      | 10034.5       | null
+;
+
 groupByNull#[skip:-8.12.99,reason:bug fixed in 8.13+]
 ROW a = 1, c = null
 | STATS COUNT(a) BY c;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats_count_distinct.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats_count_distinct.csv-spec
@@ -152,3 +152,16 @@ m:long  | languages:i
 20   | 5
 10   | null
 ;
+
+
+countDistinctWithGroupPrecisionAndNestedExpression
+from employees | stats m = count_distinct(height + 5, 9876) by languages | sort languages;
+
+m:long  | languages:i
+13   | 1
+16   | 2
+14   | 3
+15   | 4
+20   | 5
+10   | null
+;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats_count_distinct.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats_count_distinct.csv-spec
@@ -154,7 +154,7 @@ m:long  | languages:i
 ;
 
 
-countDistinctWithGroupPrecisionAndNestedExpression
+countDistinctWithGroupPrecisionAndNestedExpression#[skip:-8.12.99,reason:supported in 8.13+]
 from employees | stats m = count_distinct(height + 5, 9876) by languages | sort languages;
 
 m:long  | languages:i

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
@@ -1141,7 +1141,9 @@ public class LogicalPlanOptimizer extends ParameterizedRuleExecutor<LogicalPlan,
                                 return newAlias.toAttribute();
                             });
                             // replace field with attribute
-                            result = af.replaceChildren(Collections.singletonList(attr));
+                            List<Expression> newChildren = new ArrayList<>(af.children());
+                            newChildren.set(0, attr);
+                            result = af.replaceChildren(newChildren);
                         }
                         return result;
                     });


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/104706

Fixing a small regression after https://github.com/elastic/elasticsearch/pull/104387

The rule that extracts nested expressions from aggs did not take extra params into consideration, resulting in an IndexOutOfBoundsException for functions like `percentile()` that have more than one input parameter.