### PR TITLE
Add default rollover conditions to ILM explain API response

### DIFF
--- a/docs/changelog/104721.yaml
+++ b/docs/changelog/104721.yaml
@@ -1,0 +1,6 @@
+pr: 104721
+summary: Add default rollover conditions to ILM explain API response
+area: ILM+SLM
+type: enhancement
+issues:
+ - 103395

--- a/docs/reference/ilm/apis/explain.asciidoc
+++ b/docs/reference/ilm/apis/explain.asciidoc
@@ -181,7 +181,7 @@ phase completes.
             }
           }
         },
-        "version": 3, <4>
+        "version": 3, <3>
         "modified_date": "2018-10-15T13:21:41.576Z", <4>
         "modified_date_in_millis": 1539609701576 <5>
       }

--- a/docs/reference/ilm/apis/explain.asciidoc
+++ b/docs/reference/ilm/apis/explain.asciidoc
@@ -175,13 +175,15 @@ phase completes.
           "min_age": "0ms",
           "actions": {
             "rollover": {
-              "max_age": "30s"
+              "max_age": "30s",
+              "max_primary_shard_docs": 200000000, <2>
+              "min_docs": 1
             }
           }
         },
-        "version": 3, <2>
-        "modified_date": "2018-10-15T13:21:41.576Z", <3>
-        "modified_date_in_millis": 1539609701576 <4>
+        "version": 3, <4>
+        "modified_date": "2018-10-15T13:21:41.576Z", <4>
+        "modified_date_in_millis": 1539609701576 <5>
       }
     }
   }
@@ -191,9 +193,10 @@ phase completes.
 
 <1> The JSON phase definition loaded from the specified policy when the index
 entered this phase
-<2> The version of the policy that was loaded
-<3> The date the loaded policy was last modified
-<4> The epoch time when the loaded policy was last modified
+<2> The rollover action includes the default `max_primary_shard_docs` and `min_docs` conditions. See <<ilm-rollover-options,ILM Rollover Options>> for more information.
+<3> The version of the policy that was loaded
+<4> The date the loaded policy was last modified
+<5> The epoch time when the loaded policy was last modified
 
 If {ilm-init} is waiting for a step to complete, the response includes status
 information for the step that's being performed on the index.

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ExplainLifecycleResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ExplainLifecycleResponse.java
@@ -84,8 +84,6 @@ public class ExplainLifecycleResponse extends ActionResponse implements ToXConte
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        // Add human-readable (nested) time fields.
-        builder.humanReadable(true);
         builder.startObject();
         builder.startObject(INDICES_FIELD.getPreferredName());
         for (IndexLifecycleExplainResponse indexResponse : indexResponses.values()) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ExplainLifecycleResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ExplainLifecycleResponse.java
@@ -84,6 +84,8 @@ public class ExplainLifecycleResponse extends ActionResponse implements ToXConte
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        // Add human-readable (nested) time fields.
+        builder.humanReadable(true);
         builder.startObject();
         builder.startObject(INDICES_FIELD.getPreferredName());
         for (IndexLifecycleExplainResponse indexResponse : indexResponses.values()) {

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportExplainLifecycleAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportExplainLifecycleAction.java
@@ -33,7 +33,9 @@ import org.elasticsearch.xpack.core.ilm.ErrorStep;
 import org.elasticsearch.xpack.core.ilm.ExplainLifecycleRequest;
 import org.elasticsearch.xpack.core.ilm.ExplainLifecycleResponse;
 import org.elasticsearch.xpack.core.ilm.IndexLifecycleExplainResponse;
+import org.elasticsearch.xpack.core.ilm.LifecycleSettings;
 import org.elasticsearch.xpack.core.ilm.PhaseExecutionInfo;
+import org.elasticsearch.xpack.core.ilm.RolloverAction;
 import org.elasticsearch.xpack.core.ilm.action.ExplainLifecycleAction;
 import org.elasticsearch.xpack.ilm.IndexLifecycleService;
 
@@ -42,6 +44,7 @@ import java.util.Map;
 import java.util.TreeMap;
 
 import static org.elasticsearch.index.IndexSettings.LIFECYCLE_ORIGINATION_DATE;
+import static org.elasticsearch.xpack.core.ilm.WaitForRolloverReadyStep.applyDefaultConditions;
 
 public class TransportExplainLifecycleAction extends TransportClusterInfoAction<ExplainLifecycleRequest, ExplainLifecycleResponse> {
 
@@ -80,6 +83,8 @@ public class TransportExplainLifecycleAction extends TransportClusterInfoAction<
         ClusterState state,
         ActionListener<ExplainLifecycleResponse> listener
     ) {
+        boolean rolloverOnlyIfHasDocuments = LifecycleSettings.LIFECYCLE_ROLLOVER_ONLY_IF_HAS_DOCUMENTS_SETTING
+            .get(state.metadata().settings());
         Map<String, IndexLifecycleExplainResponse> indexResponses = new TreeMap<>();
         for (String index : concreteIndices) {
             final IndexLifecycleExplainResponse indexResponse;
@@ -90,7 +95,8 @@ public class TransportExplainLifecycleAction extends TransportClusterInfoAction<
                     request.onlyErrors(),
                     request.onlyManaged(),
                     indexLifecycleService,
-                    xContentRegistry
+                    xContentRegistry,
+                    rolloverOnlyIfHasDocuments
                 );
             } catch (IOException e) {
                 listener.onFailure(new ElasticsearchParseException("failed to parse phase definition for index [" + index + "]", e));
@@ -111,7 +117,8 @@ public class TransportExplainLifecycleAction extends TransportClusterInfoAction<
         boolean onlyErrors,
         boolean onlyManaged,
         IndexLifecycleService indexLifecycleService,
-        NamedXContentRegistry xContentRegistry
+        NamedXContentRegistry xContentRegistry,
+        boolean rolloverOnlyIfHasDocuments
     ) throws IOException {
         IndexMetadata indexMetadata = metadata.index(indexName);
         Settings idxSettings = indexMetadata.getSettings();
@@ -136,6 +143,13 @@ public class TransportExplainLifecycleAction extends TransportClusterInfoAction<
                 )
             ) {
                 phaseExecutionInfo = PhaseExecutionInfo.parse(parser, currentPhase);
+
+                // Try to add default rollover conditions to the response.
+                var rolloverAction = (RolloverAction) phaseExecutionInfo.getPhase().getActions().get(RolloverAction.NAME);
+                if (rolloverAction != null) {
+                    var conditions = applyDefaultConditions(rolloverAction.getConditions(), rolloverOnlyIfHasDocuments);
+                    phaseExecutionInfo.getPhase().getActions().put(RolloverAction.NAME, new RolloverAction(conditions));
+                }
             }
         }
 

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportExplainLifecycleAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportExplainLifecycleAction.java
@@ -84,8 +84,9 @@ public class TransportExplainLifecycleAction extends TransportClusterInfoAction<
         ClusterState state,
         ActionListener<ExplainLifecycleResponse> listener
     ) {
-        boolean rolloverOnlyIfHasDocuments = LifecycleSettings.LIFECYCLE_ROLLOVER_ONLY_IF_HAS_DOCUMENTS_SETTING
-            .get(state.metadata().settings());
+        boolean rolloverOnlyIfHasDocuments = LifecycleSettings.LIFECYCLE_ROLLOVER_ONLY_IF_HAS_DOCUMENTS_SETTING.get(
+            state.metadata().settings()
+        );
         Map<String, IndexLifecycleExplainResponse> indexResponses = new TreeMap<>();
         for (String index : concreteIndices) {
             final IndexLifecycleExplainResponse indexResponse;

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportExplainLifecycleAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportExplainLifecycleAction.java
@@ -34,6 +34,7 @@ import org.elasticsearch.xpack.core.ilm.ExplainLifecycleRequest;
 import org.elasticsearch.xpack.core.ilm.ExplainLifecycleResponse;
 import org.elasticsearch.xpack.core.ilm.IndexLifecycleExplainResponse;
 import org.elasticsearch.xpack.core.ilm.LifecycleSettings;
+import org.elasticsearch.xpack.core.ilm.Phase;
 import org.elasticsearch.xpack.core.ilm.PhaseExecutionInfo;
 import org.elasticsearch.xpack.core.ilm.RolloverAction;
 import org.elasticsearch.xpack.core.ilm.action.ExplainLifecycleAction;
@@ -145,10 +146,13 @@ public class TransportExplainLifecycleAction extends TransportClusterInfoAction<
                 phaseExecutionInfo = PhaseExecutionInfo.parse(parser, currentPhase);
 
                 // Try to add default rollover conditions to the response.
-                var rolloverAction = (RolloverAction) phaseExecutionInfo.getPhase().getActions().get(RolloverAction.NAME);
-                if (rolloverAction != null) {
-                    var conditions = applyDefaultConditions(rolloverAction.getConditions(), rolloverOnlyIfHasDocuments);
-                    phaseExecutionInfo.getPhase().getActions().put(RolloverAction.NAME, new RolloverAction(conditions));
+                var phase = phaseExecutionInfo.getPhase();
+                if (phase != null) {
+                    var rolloverAction = (RolloverAction) phase.getActions().get(RolloverAction.NAME);
+                    if (rolloverAction != null) {
+                        var conditions = applyDefaultConditions(rolloverAction.getConditions(), rolloverOnlyIfHasDocuments);
+                        phase.getActions().put(RolloverAction.NAME, new RolloverAction(conditions));
+                    }
                 }
             }
         }

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportExplainLifecycleAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/TransportExplainLifecycleAction.java
@@ -34,7 +34,6 @@ import org.elasticsearch.xpack.core.ilm.ExplainLifecycleRequest;
 import org.elasticsearch.xpack.core.ilm.ExplainLifecycleResponse;
 import org.elasticsearch.xpack.core.ilm.IndexLifecycleExplainResponse;
 import org.elasticsearch.xpack.core.ilm.LifecycleSettings;
-import org.elasticsearch.xpack.core.ilm.Phase;
 import org.elasticsearch.xpack.core.ilm.PhaseExecutionInfo;
 import org.elasticsearch.xpack.core.ilm.RolloverAction;
 import org.elasticsearch.xpack.core.ilm.action.ExplainLifecycleAction;

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/action/TransportExplainLifecycleActionTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/action/TransportExplainLifecycleActionTests.java
@@ -85,7 +85,8 @@ public class TransportExplainLifecycleActionTests extends ESTestCase {
                 true,
                 true,
                 indexLifecycleService,
-                REGISTRY
+                REGISTRY,
+                false
             );
             assertThat(onlyErrorsResponse, notNullValue());
             assertThat(onlyErrorsResponse.getIndex(), is(indexInErrorStep));
@@ -118,7 +119,8 @@ public class TransportExplainLifecycleActionTests extends ESTestCase {
                 true,
                 true,
                 indexLifecycleService,
-                REGISTRY
+                REGISTRY,
+                false
             );
             assertThat(onlyErrorsResponse, nullValue());
 
@@ -128,7 +130,8 @@ public class TransportExplainLifecycleActionTests extends ESTestCase {
                 false,
                 true,
                 indexLifecycleService,
-                REGISTRY
+                REGISTRY,
+                false
             );
             assertThat(allManagedResponse, notNullValue());
             assertThat(allManagedResponse.getIndex(), is(indexInCheckRolloverStep));
@@ -154,7 +157,8 @@ public class TransportExplainLifecycleActionTests extends ESTestCase {
                 true,
                 true,
                 indexLifecycleService,
-                REGISTRY
+                REGISTRY,
+                false
             );
             assertThat(onlyErrorsResponse, notNullValue());
             assertThat(onlyErrorsResponse.getPolicyName(), is("random-policy"));
@@ -179,7 +183,8 @@ public class TransportExplainLifecycleActionTests extends ESTestCase {
                 false,
                 true,
                 indexLifecycleService,
-                REGISTRY
+                REGISTRY,
+                false
             );
             assertThat(onlyManaged, nullValue());
         }

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/action/TransportExplainLifecycleActionTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/action/TransportExplainLifecycleActionTests.java
@@ -86,7 +86,7 @@ public class TransportExplainLifecycleActionTests extends ESTestCase {
                 true,
                 indexLifecycleService,
                 REGISTRY,
-                false
+                randomBoolean()
             );
             assertThat(onlyErrorsResponse, notNullValue());
             assertThat(onlyErrorsResponse.getIndex(), is(indexInErrorStep));
@@ -120,7 +120,7 @@ public class TransportExplainLifecycleActionTests extends ESTestCase {
                 true,
                 indexLifecycleService,
                 REGISTRY,
-                false
+                randomBoolean()
             );
             assertThat(onlyErrorsResponse, nullValue());
 
@@ -131,7 +131,7 @@ public class TransportExplainLifecycleActionTests extends ESTestCase {
                 true,
                 indexLifecycleService,
                 REGISTRY,
-                false
+                randomBoolean()
             );
             assertThat(allManagedResponse, notNullValue());
             assertThat(allManagedResponse.getIndex(), is(indexInCheckRolloverStep));
@@ -158,7 +158,7 @@ public class TransportExplainLifecycleActionTests extends ESTestCase {
                 true,
                 indexLifecycleService,
                 REGISTRY,
-                false
+                randomBoolean()
             );
             assertThat(onlyErrorsResponse, notNullValue());
             assertThat(onlyErrorsResponse.getPolicyName(), is("random-policy"));
@@ -184,9 +184,42 @@ public class TransportExplainLifecycleActionTests extends ESTestCase {
                 true,
                 indexLifecycleService,
                 REGISTRY,
-                false
+                randomBoolean()
             );
             assertThat(onlyManaged, nullValue());
+        }
+
+        {
+            // validate addition of default condition with `rolloverOnlyIfHasDocuments` true
+            IndexLifecycleService indexLifecycleService = mock(IndexLifecycleService.class);
+            when(indexLifecycleService.policyExists("my-policy")).thenReturn(true);
+
+            LifecycleExecutionState.Builder checkRolloverReadyStepState = LifecycleExecutionState.builder()
+                .setPhase("hot")
+                .setAction("rollover")
+                .setStep(WaitForRolloverReadyStep.NAME)
+                .setPhaseDefinition(PHASE_DEFINITION);
+            String indexInCheckRolloverStep = "index_in_check_rollover";
+            IndexMetadata indexMetadata = IndexMetadata.builder(indexInCheckRolloverStep)
+                .settings(settings(IndexVersion.current()).put(LifecycleSettings.LIFECYCLE_NAME, "my-policy"))
+                .numberOfShards(randomIntBetween(1, 5))
+                .numberOfReplicas(randomIntBetween(0, 5))
+                .putCustom(ILM_CUSTOM_METADATA_KEY, checkRolloverReadyStepState.build().asMap())
+                .build();
+            Metadata metadata = Metadata.builder().put(indexMetadata, true).build();
+
+            IndexLifecycleExplainResponse response = getIndexLifecycleExplainResponse(
+                indexInCheckRolloverStep,
+                metadata,
+                false,
+                true,
+                indexLifecycleService,
+                REGISTRY,
+                true
+            );
+            var rolloverAction = ((RolloverAction) response.getPhaseExecutionInfo().getPhase().getActions().get(RolloverAction.NAME));
+            assertThat(rolloverAction, notNullValue());
+            assertThat(rolloverAction.getConditions().getMinDocs(), is(1L));
         }
     }
 }


### PR DESCRIPTION
ILM implicitly configures a few rollover conditions (like `min_docs` and `max_primary_shard_docs` [source](https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-rollover.html#ilm-rollover-options)).
The ILM `_explain` API displays the user-configured rollover action with the user-defined rollover conditions. However, the implicit conditions are not visible anywhere (except in the documentation and some debug-level logging).

This PR should make it easier for users to understand the exact reasons why an index got rolled over (or not).

Fixes #103395