### PR TITLE
[ML] Add an important note about a gotcha with the delayed data check

### DIFF
--- a/docs/reference/ml/anomaly-detection/ml-delayed-data-detection.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-delayed-data-detection.asciidoc
@@ -54,10 +54,13 @@ image::images/ml-annotations.png["Delayed data annotations in the Single Metric 
 
 IMPORTANT: Because we are comparing `doc_count` from an aggregation with the
 job's bucket results, the delayed data check will not work correctly if the
-job has a `summary_count_field` other than `doc_count`. If your job's datafeed
-is using aggregations then it's highly likely that your `summary_count_field`
-should be `doc_count`. If `summary_count_field` is set at all, and is _not_ set
-to `doc_count`, then you must disable the delayed data check for that job.
+job's datafeed is using aggregations and its `analysis_config` does not have
+its `summary_count_field_name` set to `doc_count`, or if your job is _not_
+using aggregations and `summary_count_field_name` is set to anything. If your
+job's datafeed is using aggregations then it's highly likely that your
+`summary_count_field_name` should be `doc_count`. If `summary_count_field_name`
+is set at all, and is _not_ set to `doc_count`, then you must disable the
+delayed data check for that job.
 
 There is another tool for visualizing the delayed data on the *Annotations* tab
 in the {anomaly-detect} job management page:

--- a/docs/reference/ml/anomaly-detection/ml-delayed-data-detection.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-delayed-data-detection.asciidoc
@@ -55,17 +55,18 @@ image::images/ml-annotations.png["Delayed data annotations in the Single Metric 
 [IMPORTANT]
 ====
 As the `doc_count` from an aggregation is compared with the
-bucket results of the job, the delayed data check will not work correctly in the 
+bucket results of the job, the delayed data check will not work correctly in the
 following cases:
-* if the datafeed uses aggregations and its `analysis_config` does not have its 
+
+* if the datafeed uses aggregations and the job's `analysis_config` does not have its
 `summary_count_field_name` set to `doc_count`,
-* if your job is _not_ using aggregations and `summary_count_field_name` is set to 
+* if the datafeed is _not_ using aggregations and `summary_count_field_name` is set to
 any value.
 
-If the datafeed is using aggregations then it's highly likely that the
-`summary_count_field_name` should be set to `doc_count`. If 
-`summary_count_field_name` is set to any value other than `doc_count`, the 
-delayed data check for that job must be disabled.
+If the datafeed is using aggregations then it's highly likely that the job's
+`summary_count_field_name` should be set to `doc_count`. If
+`summary_count_field_name` is set to any value other than `doc_count`, the
+delayed data check for the datafeed must be disabled.
 ====
 There is another tool for visualizing the delayed data on the *Annotations* tab
 in the {anomaly-detect} job management page:

--- a/docs/reference/ml/anomaly-detection/ml-delayed-data-detection.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-delayed-data-detection.asciidoc
@@ -52,16 +52,21 @@ for the periods where these delays occur:
 [role="screenshot"]
 image::images/ml-annotations.png["Delayed data annotations in the Single Metric Viewer"]
 
-IMPORTANT: Because we are comparing `doc_count` from an aggregation with the
-job's bucket results, the delayed data check will not work correctly if the
-job's datafeed is using aggregations and its `analysis_config` does not have
-its `summary_count_field_name` set to `doc_count`, or if your job is _not_
-using aggregations and `summary_count_field_name` is set to anything. If your
-job's datafeed is using aggregations then it's highly likely that your
-`summary_count_field_name` should be `doc_count`. If `summary_count_field_name`
-is set at all, and is _not_ set to `doc_count`, then you must disable the
-delayed data check for that job.
+[IMPORTANT]
+====
+As the `doc_count` from an aggregation is compared with the
+bucket results of the job, the delayed data check will not work correctly in the 
+following cases:
+* if the datafeed uses aggregations and its `analysis_config` does not have its 
+`summary_count_field_name` set to `doc_count`,
+* if your job is _not_ using aggregations and `summary_count_field_name` is set to 
+any value.
 
+If the datafeed is using aggregations then it's highly likely that the
+`summary_count_field_name` should be set to `doc_count`. If 
+`summary_count_field_name` is set to any value other than `doc_count`, the 
+delayed data check for that job must be disabled.
+====
 There is another tool for visualizing the delayed data on the *Annotations* tab
 in the {anomaly-detect} job management page:
 

--- a/docs/reference/ml/anomaly-detection/ml-delayed-data-detection.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-delayed-data-detection.asciidoc
@@ -52,6 +52,13 @@ for the periods where these delays occur:
 [role="screenshot"]
 image::images/ml-annotations.png["Delayed data annotations in the Single Metric Viewer"]
 
+IMPORTANT: Because we are comparing `doc_count` from an aggregation with the
+job's bucket results, the delayed data check will not work correctly if the
+job has a `summary_count_field` other than `doc_count`. If your job's datafeed
+is using aggregations then it's highly likely that your `summary_count_field`
+should be `doc_count`. If `summary_count_field` is set at all, and is _not_ set
+to `doc_count`, then you must disable the delayed data check for that job.
+
 There is another tool for visualizing the delayed data on the *Annotations* tab
 in the {anomaly-detect} job management page:
 


### PR DESCRIPTION
Recently a user saw spurious delayed data warnings. These turned out to be due to accidentally setting `summary_count_field` to a field that was always zero. This meant that every document was considered delayed.