### PR TITLE
[CI] Ensure large response can fit into 3 messages

### DIFF
--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpPipeliningHandlerTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpPipeliningHandlerTests.java
@@ -232,14 +232,13 @@ public class Netty4HttpPipeliningHandlerTests extends ESTestCase {
         assertSame(response, messagesSeen.get(0));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/104728")
     public void testLargeFullResponsesAreSplit() {
         final List<Object> messagesSeen = new ArrayList<>();
         final var embeddedChannel = new EmbeddedChannel(capturingHandler(messagesSeen), getTestHttpHandler());
         embeddedChannel.writeInbound(createHttpRequest("/test"));
         final Netty4HttpRequest request = embeddedChannel.readInbound();
         final var minSize = (int) NettyAllocator.suggestedMaxAllocationSize();
-        final var content = new ZeroBytesReference(between(minSize, minSize * 2));
+        final var content = new ZeroBytesReference(between(minSize, (int) (minSize * 1.5)));
         final var response = request.createResponse(RestStatus.OK, content);
         assertThat(response, instanceOf(FullHttpResponse.class));
         final var promise = embeddedChannel.newPromise();


### PR DESCRIPTION
Lower the upper bound of large response size from
2 times of suggestedMaxAllocationSize to 1.5 so that it be sent over with 3 messages. This is because the split threshold is 0.99 of suggestedMaxAllocationSize.

Resolves: #104728
