### PR TITLE
Export random sampler agg from server

### DIFF
--- a/server/src/main/java/module-info.java
+++ b/server/src/main/java/module-info.java
@@ -333,6 +333,7 @@ module org.elasticsearch.server {
     exports org.elasticsearch.search.aggregations.bucket.nested;
     exports org.elasticsearch.search.aggregations.bucket.range;
     exports org.elasticsearch.search.aggregations.bucket.sampler;
+    exports org.elasticsearch.search.aggregations.bucket.sampler.random;
     exports org.elasticsearch.search.aggregations.bucket.terms;
     exports org.elasticsearch.search.aggregations.bucket.terms.heuristic;
     exports org.elasticsearch.search.aggregations.metrics;


### PR DESCRIPTION
The server module exports the classes needed to use most aggregations, but the random sampler aggregation was missed. (I think it's because the PRs to add random sampler and to add modularization in general were both long-running and were in flight around the same time.) This PR adds an export for the random sampler agg, so that it can be used from plugins.