### PR TITLE
Make RestResponse releasable

### DIFF
--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpPipeliningHandlerTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpPipeliningHandlerTests.java
@@ -522,9 +522,6 @@ public class Netty4HttpPipeliningHandlerTests extends ESTestCase {
             public String getResponseContentTypeString() {
                 return "application/octet-stream";
             }
-
-            @Override
-            public void close() {}
         };
     }
 

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerTransportTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerTransportTests.java
@@ -614,7 +614,7 @@ public class Netty4HttpServerTransportTests extends AbstractHttpServerTransportT
                     channel.sendResponse(
                         RestResponse.chunked(OK, ChunkedRestResponseBody.fromXContent(ignored -> Iterators.single((builder, params) -> {
                             throw new AssertionError("should not be called for HEAD REQUEST");
-                        }), ToXContent.EMPTY_PARAMS, channel, null))
+                        }), ToXContent.EMPTY_PARAMS, channel), null)
                     );
                 } catch (IOException e) {
                     throw new AssertionError(e);

--- a/server/src/main/java/org/elasticsearch/rest/ChunkedRestResponseBody.java
+++ b/server/src/main/java/org/elasticsearch/rest/ChunkedRestResponseBody.java
@@ -15,8 +15,6 @@ import org.elasticsearch.common.recycler.Recycler;
 import org.elasticsearch.common.xcontent.ChunkedToXContent;
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.core.IOUtils;
-import org.elasticsearch.core.Nullable;
-import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.core.Streams;
@@ -36,7 +34,7 @@ import java.util.Iterator;
  * The body of a rest response that uses chunked HTTP encoding. Implementations are used to avoid materializing full responses on heap and
  * instead serialize only as much of the response as can be flushed to the network right away.
  */
-public interface ChunkedRestResponseBody extends Releasable {
+public interface ChunkedRestResponseBody {
 
     Logger logger = LogManager.getLogger(ChunkedRestResponseBody.class);
 
@@ -67,15 +65,10 @@ public interface ChunkedRestResponseBody extends Releasable {
      * @param chunkedToXContent chunked x-content instance to serialize
      * @param params parameters to use for serialization
      * @param channel channel the response will be written to
-     * @param releasable resource to release when the response is fully sent, or {@code null} if nothing to release
      * @return chunked rest response body
      */
-    static ChunkedRestResponseBody fromXContent(
-        ChunkedToXContent chunkedToXContent,
-        ToXContent.Params params,
-        RestChannel channel,
-        @Nullable Releasable releasable
-    ) throws IOException {
+    static ChunkedRestResponseBody fromXContent(ChunkedToXContent chunkedToXContent, ToXContent.Params params, RestChannel channel)
+        throws IOException {
 
         return new ChunkedRestResponseBody() {
 
@@ -146,11 +139,6 @@ public interface ChunkedRestResponseBody extends Releasable {
             public String getResponseContentTypeString() {
                 return builder.getResponseContentTypeString();
             }
-
-            @Override
-            public void close() {
-                Releasables.closeExpectNoException(releasable);
-            }
         };
     }
 
@@ -158,11 +146,7 @@ public interface ChunkedRestResponseBody extends Releasable {
      * Create a chunked response body to be written to a specific {@link RestChannel} from a stream of text chunks, each represented as a
      * consumer of a {@link Writer}. The last chunk that the iterator yields must write at least one byte.
      */
-    static ChunkedRestResponseBody fromTextChunks(
-        String contentType,
-        Iterator<CheckedConsumer<Writer, IOException>> chunkIterator,
-        @Nullable Releasable releasable
-    ) {
+    static ChunkedRestResponseBody fromTextChunks(String contentType, Iterator<CheckedConsumer<Writer, IOException>> chunkIterator) {
         return new ChunkedRestResponseBody() {
             private RecyclerBytesStreamOutput currentOutput;
             private final Writer writer = new OutputStreamWriter(new OutputStream() {
@@ -234,11 +218,6 @@ public interface ChunkedRestResponseBody extends Releasable {
             @Override
             public String getResponseContentTypeString() {
                 return contentType;
-            }
-
-            @Override
-            public void close() {
-                Releasables.closeExpectNoException(releasable);
             }
         };
     }

--- a/server/src/main/java/org/elasticsearch/rest/LoggingChunkedRestResponseBody.java
+++ b/server/src/main/java/org/elasticsearch/rest/LoggingChunkedRestResponseBody.java
@@ -46,9 +46,4 @@ public class LoggingChunkedRestResponseBody implements ChunkedRestResponseBody {
     public String getResponseContentTypeString() {
         return inner.getResponseContentTypeString();
     }
-
-    @Override
-    public void close() {
-        inner.close();
-    }
 }

--- a/server/src/main/java/org/elasticsearch/rest/RestResponse.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestResponse.java
@@ -15,9 +15,10 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
 
@@ -33,7 +34,7 @@ import static java.util.Collections.singletonMap;
 import static org.elasticsearch.ElasticsearchException.REST_EXCEPTION_SKIP_STACK_TRACE;
 import static org.elasticsearch.rest.RestController.ELASTIC_PRODUCT_HTTP_HEADER;
 
-public final class RestResponse {
+public final class RestResponse implements Releasable {
 
     public static final String TEXT_CONTENT_TYPE = "text/plain; charset=UTF-8";
 
@@ -50,6 +51,9 @@ public final class RestResponse {
     private final ChunkedRestResponseBody chunkedResponseBody;
     private final String responseMediaType;
     private Map<String, List<String>> customHeaders;
+
+    @Nullable
+    private final Releasable releasable;
 
     /**
      * Creates a new response based on {@link XContentBuilder}.
@@ -73,18 +77,18 @@ public final class RestResponse {
     }
 
     public RestResponse(RestStatus status, String responseMediaType, BytesReference content) {
-        this(status, responseMediaType, content, null);
+        this(status, responseMediaType, content, null, null);
     }
 
-    public static RestResponse chunked(RestStatus restStatus, ChunkedRestResponseBody content) {
+    private RestResponse(RestStatus status, String responseMediaType, BytesReference content, @Nullable Releasable releasable) {
+        this(status, responseMediaType, content, null, releasable);
+    }
+
+    public static RestResponse chunked(RestStatus restStatus, ChunkedRestResponseBody content, @Nullable Releasable releasable) {
         if (content.isDone()) {
-            return new RestResponse(
-                restStatus,
-                content.getResponseContentTypeString(),
-                new ReleasableBytesReference(BytesArray.EMPTY, content)
-            );
+            return new RestResponse(restStatus, content.getResponseContentTypeString(), BytesArray.EMPTY, releasable);
         } else {
-            return new RestResponse(restStatus, content.getResponseContentTypeString(), null, content);
+            return new RestResponse(restStatus, content.getResponseContentTypeString(), null, content, releasable);
         }
     }
 
@@ -95,12 +99,14 @@ public final class RestResponse {
         RestStatus status,
         String responseMediaType,
         @Nullable BytesReference content,
-        @Nullable ChunkedRestResponseBody chunkedResponseBody
+        @Nullable ChunkedRestResponseBody chunkedResponseBody,
+        @Nullable Releasable releasable
     ) {
         this.status = status;
         this.content = content;
         this.responseMediaType = responseMediaType;
         this.chunkedResponseBody = chunkedResponseBody;
+        this.releasable = releasable;
         assert (content == null) != (chunkedResponseBody == null);
     }
 
@@ -142,6 +148,7 @@ public final class RestResponse {
             copyHeaders(((ElasticsearchException) e));
         }
         this.chunkedResponseBody = null;
+        this.releasable = null;
     }
 
     public String contentType() {
@@ -223,5 +230,10 @@ public final class RestResponse {
             }
         }
         return headers;
+    }
+
+    @Override
+    public void close() {
+        Releasables.closeExpectNoException(releasable);
     }
 }

--- a/server/src/main/java/org/elasticsearch/rest/action/RestChunkedToXContentListener.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/RestChunkedToXContentListener.java
@@ -40,7 +40,8 @@ public class RestChunkedToXContentListener<Response extends ChunkedToXContent> e
         channel.sendResponse(
             RestResponse.chunked(
                 getRestStatus(response),
-                ChunkedRestResponseBody.fromXContent(response, params, channel, releasableFromResponse(response))
+                ChunkedRestResponseBody.fromXContent(response, params, channel),
+                releasableFromResponse(response)
             )
         );
     }

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesHotThreadsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesHotThreadsAction.java
@@ -117,7 +117,7 @@ public class RestNodesHotThreadsAction extends BaseRestHandler {
             @Override
             public RestResponse buildResponse(NodesHotThreadsResponse response) {
                 response.mustIncRef();
-                return RestResponse.chunked(RestStatus.OK, fromTextChunks(TEXT_CONTENT_TYPE, response.getTextChunks(), response::decRef));
+                return RestResponse.chunked(RestStatus.OK, fromTextChunks(TEXT_CONTENT_TYPE, response.getTextChunks()), response::decRef);
             }
         });
     }

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestTable.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestTable.java
@@ -77,9 +77,9 @@ public class RestTable {
                     Iterators.single((builder, params) -> builder.endArray())
                 ),
                 ToXContent.EMPTY_PARAMS,
-                channel,
-                null
-            )
+                channel
+            ),
+            null
         );
     }
 
@@ -127,9 +127,9 @@ public class RestTable {
                         }
                         writer.append("\n");
                     })
-                ),
-                null
-            )
+                )
+            ),
+            null
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/rest/action/info/RestClusterInfoAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/info/RestClusterInfoAction.java
@@ -130,9 +130,9 @@ public class RestClusterInfoAction extends BaseRestHandler {
                                 ChunkedToXContentHelper.endObject()
                             ),
                             EMPTY_PARAMS,
-                            channel,
-                            null
-                        )
+                            channel
+                        ),
+                        null
                     );
                 }
             });

--- a/server/src/test/java/org/elasticsearch/http/DefaultRestChannelTests.java
+++ b/server/src/test/java/org/elasticsearch/http/DefaultRestChannelTests.java
@@ -543,12 +543,7 @@ public class DefaultRestChannelTests extends ESTestCase {
                 public String getResponseContentTypeString() {
                     return RestResponse.TEXT_CONTENT_TYPE;
                 }
-
-                @Override
-                public void close() {
-                    assertTrue(isClosed.compareAndSet(false, true));
-                }
-            }));
+            }, () -> assertTrue(isClosed.compareAndSet(false, true))));
             @SuppressWarnings("unchecked")
             Class<ActionListener<Void>> listenerClass = (Class<ActionListener<Void>>) (Class<?>) ActionListener.class;
             ArgumentCaptor<ActionListener<Void>> listenerCaptor = ArgumentCaptor.forClass(listenerClass);
@@ -750,12 +745,7 @@ public class DefaultRestChannelTests extends ESTestCase {
                     public String getResponseContentTypeString() {
                         return RestResponse.TEXT_CONTENT_TYPE;
                     }
-
-                    @Override
-                    public void close() {
-                        assertTrue(isClosed.compareAndSet(false, true));
-                    }
-                }))
+                }, () -> assertTrue(isClosed.compareAndSet(false, true))))
             )
         );
 

--- a/server/src/test/java/org/elasticsearch/rest/ChunkedRestResponseBodyTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/ChunkedRestResponseBodyTests.java
@@ -29,7 +29,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 public class ChunkedRestResponseBodyTests extends ESTestCase {
 
@@ -51,59 +50,39 @@ public class ChunkedRestResponseBodyTests extends ESTestCase {
         }
         final var bytesDirect = BytesReference.bytes(builderDirect);
 
-        final var isClosed = new AtomicBoolean();
-        try (
-            var chunkedResponse = ChunkedRestResponseBody.fromXContent(
-                chunkedToXContent,
-                ToXContent.EMPTY_PARAMS,
-                new FakeRestChannel(
-                    new FakeRestRequest.Builder(xContentRegistry()).withContent(BytesArray.EMPTY, randomXContent.type()).build(),
-                    randomBoolean(),
-                    1
-                ),
-                () -> assertTrue(isClosed.compareAndSet(false, true))
+        var chunkedResponse = ChunkedRestResponseBody.fromXContent(
+            chunkedToXContent,
+            ToXContent.EMPTY_PARAMS,
+            new FakeRestChannel(
+                new FakeRestRequest.Builder(xContentRegistry()).withContent(BytesArray.EMPTY, randomXContent.type()).build(),
+                randomBoolean(),
+                1
             )
-        ) {
+        );
 
-            final List<BytesReference> refsGenerated = new ArrayList<>();
-            while (chunkedResponse.isDone() == false) {
-                refsGenerated.add(chunkedResponse.encodeChunk(randomIntBetween(2, 10), BytesRefRecycler.NON_RECYCLING_INSTANCE));
-            }
-
-            assertEquals(bytesDirect, CompositeBytesReference.of(refsGenerated.toArray(new BytesReference[0])));
-            assertFalse(isClosed.get());
+        final List<BytesReference> refsGenerated = new ArrayList<>();
+        while (chunkedResponse.isDone() == false) {
+            refsGenerated.add(chunkedResponse.encodeChunk(randomIntBetween(2, 10), BytesRefRecycler.NON_RECYCLING_INSTANCE));
         }
-        assertTrue(isClosed.get());
+
+        assertEquals(bytesDirect, CompositeBytesReference.of(refsGenerated.toArray(new BytesReference[0])));
     }
 
     public void testFromTextChunks() throws IOException {
         final var chunks = randomList(1000, () -> randomUnicodeOfLengthBetween(1, 100));
-        final var isClosed = new AtomicBoolean();
-        try (
-            var body = ChunkedRestResponseBody.fromTextChunks(
-                "text/plain",
-                Iterators.map(chunks.iterator(), s -> w -> w.write(s)),
-                () -> assertTrue(isClosed.compareAndSet(false, true))
-            )
-        ) {
-            final List<BytesReference> refsGenerated = new ArrayList<>();
-            while (body.isDone() == false) {
-                refsGenerated.add(body.encodeChunk(randomIntBetween(2, 10), BytesRefRecycler.NON_RECYCLING_INSTANCE));
-            }
-            final BytesReference chunkedBytes = CompositeBytesReference.of(refsGenerated.toArray(new BytesReference[0]));
-
-            try (
-                var outputStream = new ByteArrayOutputStream();
-                var writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8)
-            ) {
-                for (final var chunk : chunks) {
-                    writer.write(chunk);
-                }
-                writer.flush();
-                assertEquals(new BytesArray(outputStream.toByteArray()), chunkedBytes);
-            }
-            assertFalse(isClosed.get());
+        var body = ChunkedRestResponseBody.fromTextChunks("text/plain", Iterators.map(chunks.iterator(), s -> w -> w.write(s)));
+        final List<BytesReference> refsGenerated = new ArrayList<>();
+        while (body.isDone() == false) {
+            refsGenerated.add(body.encodeChunk(randomIntBetween(2, 10), BytesRefRecycler.NON_RECYCLING_INSTANCE));
         }
-        assertTrue(isClosed.get());
+        final BytesReference chunkedBytes = CompositeBytesReference.of(refsGenerated.toArray(new BytesReference[0]));
+
+        try (var outputStream = new ByteArrayOutputStream(); var writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8)) {
+            for (final var chunk : chunks) {
+                writer.write(chunk);
+            }
+            writer.flush();
+            assertEquals(new BytesArray(outputStream.toByteArray()), chunkedBytes);
+        }
     }
 }

--- a/server/src/test/java/org/elasticsearch/rest/RestResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/RestResponseTests.java
@@ -97,7 +97,8 @@ public class RestResponseTests extends ESTestCase {
     public void testEmptyChunkedBody() {
         RestResponse response = RestResponse.chunked(
             RestStatus.OK,
-            ChunkedRestResponseBody.fromTextChunks(RestResponse.TEXT_CONTENT_TYPE, Collections.emptyIterator(), null)
+            ChunkedRestResponseBody.fromTextChunks(RestResponse.TEXT_CONTENT_TYPE, Collections.emptyIterator()),
+            null
         );
         assertFalse(response.isChunked());
         assertNotNull(response.content());

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlResponseListener.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlResponseListener.java
@@ -132,16 +132,14 @@ public final class EsqlResponseListener extends RestRefCountedChunkedToXContentL
             if (mediaType instanceof TextFormat format) {
                 restResponse = RestResponse.chunked(
                     RestStatus.OK,
-                    ChunkedRestResponseBody.fromTextChunks(
-                        format.contentType(restRequest),
-                        format.format(restRequest, esqlResponse),
-                        releasable
-                    )
+                    ChunkedRestResponseBody.fromTextChunks(format.contentType(restRequest), format.format(restRequest, esqlResponse)),
+                    releasable
                 );
             } else {
                 restResponse = RestResponse.chunked(
                     RestStatus.OK,
-                    ChunkedRestResponseBody.fromXContent(esqlResponse, channel.request(), channel, releasable)
+                    ChunkedRestResponseBody.fromXContent(esqlResponse, channel.request(), channel),
+                    releasable
                 );
             }
             long tookNanos = stopWatch.stop().getNanos();


### PR DESCRIPTION
On reflection is was probably a mistake to give each
`ChunkedRestResponseBody` a nontrivial lifecycle in #99871. The
lifecycle really belongs to the whole containing `RestResponse`. This
commit moves it there.