### PR TITLE
[Enterprise Search] Remove unnecessary extra arguments

### DIFF
--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/secrets/action/GetConnectorSecretAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/secrets/action/GetConnectorSecretAction.java
@@ -16,6 +16,6 @@ public class GetConnectorSecretAction extends ActionType<GetConnectorSecretRespo
     public static final GetConnectorSecretAction INSTANCE = new GetConnectorSecretAction();
 
     private GetConnectorSecretAction() {
-        super(NAME, GetConnectorSecretResponse::new);
+        super(NAME);
     }
 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/secrets/action/PostConnectorSecretAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/secrets/action/PostConnectorSecretAction.java
@@ -16,6 +16,6 @@ public class PostConnectorSecretAction extends ActionType<PostConnectorSecretRes
     public static final PostConnectorSecretAction INSTANCE = new PostConnectorSecretAction();
 
     private PostConnectorSecretAction() {
-        super(NAME, PostConnectorSecretResponse::new);
+        super(NAME);
     }
 }


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/103683 introduced a merge conflict that wasn't picked up by git, which is causing CI failures. This PR fixes that.