### PR TITLE
[Transform] Unmute TestFeatureResetIT and include more debug information

### DIFF
--- a/docs/changelog/104763.yaml
+++ b/docs/changelog/104763.yaml
@@ -1,5 +1,0 @@
-pr: 104763
-summary: Unmute `TestFeatureResetIT` and include more debug information
-area: Transform
-type: bug
-issues: []

--- a/docs/changelog/104763.yaml
+++ b/docs/changelog/104763.yaml
@@ -1,0 +1,5 @@
+pr: 104763
+summary: Unmute `TestFeatureResetIT` and include more debug information
+area: Transform
+type: bug
+issues: []

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TestFeatureResetIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TestFeatureResetIT.java
@@ -90,7 +90,8 @@ public class TestFeatureResetIT extends TransformRestTestCase {
 
         putTransform(continuousTransformId, Strings.toString(config), RequestOptions.DEFAULT);
         startTransform(continuousTransformId, RequestOptions.DEFAULT);
-        client().performRequest(new Request(HttpPost.METHOD_NAME, "/_features/_reset"));
+
+        assertOK(client().performRequest(new Request(HttpPost.METHOD_NAME, "/_features/_reset")));
 
         Response response = adminClient().performRequest(new Request("GET", "/_cluster/state?metric=metadata"));
         Map<String, Object> metadata = (Map<String, Object>) ESRestTestCase.entityAsMap(response).get("metadata");

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TestFeatureResetIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TestFeatureResetIT.java
@@ -58,7 +58,6 @@ public class TestFeatureResetIT extends TransformRestTestCase {
     }
 
     @SuppressWarnings("unchecked")
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/100596")
     public void testTransformFeatureReset() throws Exception {
         String indexName = "basic-crud-reviews";
         String transformId = "batch-transform-feature-reset";
@@ -118,5 +117,4 @@ public class TestFeatureResetIT extends TransformRestTestCase {
         Map<String, Object> transformIndices = ESRestTestCase.entityAsMap(adminClient().performRequest(new Request("GET", ".transform-*")));
         assertThat("Indices were: " + transformIndices, transformIndices, is(anEmptyMap()));
     }
-
 }


### PR DESCRIPTION
This PR unmutes `TestFeatureResetIT` with more logs to help with debugging.

Relates https://github.com/elastic/elasticsearch/issues/100596