### PR TITLE
Fix compute decay to iterate over all entries per freq

### DIFF
--- a/docs/changelog/104765.yaml
+++ b/docs/changelog/104765.yaml
@@ -1,0 +1,5 @@
+pr: 104765
+summary: Fix compute decay to iterate over all entries per freq
+area: Snapshot/Restore
+type: bug
+issues: []

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
@@ -1408,7 +1408,8 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
             synchronized (SharedBlobCacheService.this) {
                 long now = relativeTimeInMillis();
                 for (int i = 0; i < maxFreq; i++) {
-                    for (LFUCacheEntry entry = freqs[i]; entry != null; entry = entry.next) {
+                    for (LFUCacheEntry entry = freqs[i], next = null; entry != null; entry = next) {
+                        next = entry.next; // captured before unlink
                         if (entry.freq > 0 && now - entry.lastAccessed >= 2 * minTimeDelta) {
                             unlink(entry);
                             entry.freq--;


### PR DESCRIPTION
The compute decay method should iterate over all entries per frequency. Note that it only fixes the bug and tests, but the overall execution time of the compute decay method is not capped, but that might be fixed by #104746.