### PR TITLE
Avoid execute ESQL planning on refresh thread (#104591)

### DIFF
--- a/docs/changelog/104591.yaml
+++ b/docs/changelog/104591.yaml
@@ -1,0 +1,5 @@
+pr: 104591
+summary: Avoid execute ESQL planning on refresh thread
+area: ES|QL
+type: bug
+issues: []


### PR DESCRIPTION
A recent report shows that we can perform ESQL planning on the refresh thread pool after waiting for refreshes from search-idle shards. While the planning process is generally lightweight, it may become expensive at times. Therefore, we should fork off the refresh thread pool immediately upon resuming ESQL execution. Another place where we should fork off is after field_caps. I will look into that later.
