### PR TITLE
Adding a RequestBuilder interface

### DIFF
--- a/docs/changelog/104778.yaml
+++ b/docs/changelog/104778.yaml
@@ -1,0 +1,5 @@
+pr: 104778
+summary: Adding a `RequestBuilder` interface
+area: Ingest Node
+type: enhancement
+issues: []

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
@@ -11,9 +11,9 @@ import org.apache.logging.log4j.core.util.Throwables;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionFuture;
-import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.DocWriteResponse;
+import org.elasticsearch.action.RequestBuilder;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
 import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
@@ -1831,16 +1831,11 @@ public class DataStreamIT extends ESIntegTestCase {
         assertThat(indicesStatsResponse.getIndices().size(), equalTo(2));
     }
 
-    private static void verifyResolvability(String dataStream, ActionRequestBuilder<?, ?> requestBuilder, boolean fail) {
+    private static void verifyResolvability(String dataStream, RequestBuilder<?, ?> requestBuilder, boolean fail) {
         verifyResolvability(dataStream, requestBuilder, fail, 0);
     }
 
-    private static void verifyResolvability(
-        String dataStream,
-        ActionRequestBuilder<?, ?> requestBuilder,
-        boolean fail,
-        long expectedCount
-    ) {
+    private static void verifyResolvability(String dataStream, RequestBuilder<?, ?> requestBuilder, boolean fail, long expectedCount) {
         if (fail) {
             String expectedErrorMessage = "no such index [" + dataStream + "]";
             if (requestBuilder instanceof MultiSearchRequestBuilder) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/NoMasterNodeIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/NoMasterNodeIT.java
@@ -8,7 +8,7 @@
 
 package org.elasticsearch.cluster;
 
-import org.elasticsearch.action.ActionRequestBuilder;
+import org.elasticsearch.action.RequestBuilder;
 import org.elasticsearch.action.admin.cluster.configuration.AddVotingConfigExclusionsRequest;
 import org.elasticsearch.action.admin.cluster.configuration.TransportAddVotingConfigExclusionsAction;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
@@ -189,7 +189,7 @@ public class NoMasterNodeIT extends ESIntegTestCase {
         internalCluster().clearDisruptionScheme(true);
     }
 
-    void checkUpdateAction(boolean autoCreateIndex, TimeValue timeout, ActionRequestBuilder<?, ?> builder) {
+    void checkUpdateAction(boolean autoCreateIndex, TimeValue timeout, RequestBuilder<?, ?> builder) {
         // we clean the metadata when loosing a master, therefore all operations on indices will auto create it, if allowed
         try {
             builder.get();
@@ -204,7 +204,7 @@ public class NoMasterNodeIT extends ESIntegTestCase {
         }
     }
 
-    void checkWriteAction(ActionRequestBuilder<?, ?> builder) {
+    void checkWriteAction(RequestBuilder<?, ?> builder) {
         try {
             builder.get();
             fail("Expected ClusterBlockException");

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/RareClusterStateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/RareClusterStateIT.java
@@ -12,9 +12,9 @@ import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
-import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.DocWriteResponse;
+import org.elasticsearch.action.RequestBuilder;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
@@ -130,7 +130,7 @@ public class RareClusterStateIT extends ESIntegTestCase {
     }
 
     private <Req extends ActionRequest, Res extends ActionResponse> ActionFuture<Res> executeAndCancelCommittedPublication(
-        ActionRequestBuilder<Req, Res> req
+        RequestBuilder<Req, Res> req
     ) throws Exception {
         // Wait for no publication in progress to not accidentally cancel a publication different from the one triggered by the given
         // request.

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/DateMathIndexExpressionsIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/DateMathIndexExpressionsIntegrationIT.java
@@ -9,9 +9,9 @@
 package org.elasticsearch.indices;
 
 import org.elasticsearch.action.ActionRequest;
-import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.DocWriteResponse;
+import org.elasticsearch.action.RequestBuilder;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.index.IndexNotFoundException;
@@ -47,10 +47,7 @@ public class DateMathIndexExpressionsIntegrationIT extends ESIntegTestCase {
      * of failing when index resolution with `now` is one day off, this method wraps calls with the assumption that
      * the day did not change during the test run.
      */
-    public <Q extends ActionRequest, R extends ActionResponse> void dateSensitiveGet(
-        ActionRequestBuilder<Q, R> builder,
-        Consumer<R> consumer
-    ) {
+    public <Q extends ActionRequest, R extends ActionResponse> void dateSensitiveGet(RequestBuilder<Q, R> builder, Consumer<R> consumer) {
         Runnable dayChangeAssumption = () -> assumeTrue(
             "day changed between requests",
             ZonedDateTime.now(ZoneOffset.UTC).getDayOfYear() == now.getDayOfYear()

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/settings/UpdateSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/settings/UpdateSettingsIT.java
@@ -8,7 +8,7 @@
 
 package org.elasticsearch.indices.settings;
 
-import org.elasticsearch.action.ActionRequestBuilder;
+import org.elasticsearch.action.RequestBuilder;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
 import org.elasticsearch.cluster.ClusterState;
@@ -378,10 +378,7 @@ public class UpdateSettingsIT extends ESIntegTestCase {
         prepareIndex("test").setId("1").setSource("f", 1).setVersionType(VersionType.EXTERNAL).setVersion(1).get();
         client().prepareDelete("test", "1").setVersionType(VersionType.EXTERNAL).setVersion(2).get();
         // delete is still in cache this should fail
-        ActionRequestBuilder<?, ?> builder = prepareIndex("test").setId("1")
-            .setSource("f", 3)
-            .setVersionType(VersionType.EXTERNAL)
-            .setVersion(1);
+        RequestBuilder<?, ?> builder = prepareIndex("test").setId("1").setSource("f", 3).setVersionType(VersionType.EXTERNAL).setVersion(1);
         expectThrows(VersionConflictEngineException.class, builder);
 
         assertAcked(indicesAdmin().prepareUpdateSettings("test").setSettings(Settings.builder().put("index.gc_deletes", 0)));

--- a/server/src/internalClusterTest/java/org/elasticsearch/versioning/SimpleVersioningIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/versioning/SimpleVersioningIT.java
@@ -8,10 +8,10 @@
 package org.elasticsearch.versioning;
 
 import org.apache.lucene.tests.util.TestUtil;
-import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.DocWriteResponse;
+import org.elasticsearch.action.RequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.get.GetResponse;
@@ -88,7 +88,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
             .get();
         assertThat(indexResponse.getVersion(), equalTo(14L));
 
-        ActionRequestBuilder<?, ?> builder1 = prepareIndex("test").setId("1")
+        RequestBuilder<?, ?> builder1 = prepareIndex("test").setId("1")
             .setSource("field1", "value1_1")
             .setVersion(13)
             .setVersionType(VersionType.EXTERNAL_GTE);
@@ -103,7 +103,7 @@ public class SimpleVersioningIT extends ESIntegTestCase {
         }
 
         // deleting with a lower version fails.
-        ActionRequestBuilder<?, ?> builder = client().prepareDelete("test", "1").setVersion(2).setVersionType(VersionType.EXTERNAL_GTE);
+        RequestBuilder<?, ?> builder = client().prepareDelete("test", "1").setVersion(2).setVersionType(VersionType.EXTERNAL_GTE);
         expectThrows(VersionConflictEngineException.class, builder);
 
         // Delete with a higher or equal version deletes all versions up to the given one.
@@ -259,11 +259,11 @@ public class SimpleVersioningIT extends ESIntegTestCase {
             VersionConflictEngineException.class
         );
 
-        ActionRequestBuilder<?, ?> builder6 = client().prepareDelete("test", "1").setIfSeqNo(10).setIfPrimaryTerm(1);
+        RequestBuilder<?, ?> builder6 = client().prepareDelete("test", "1").setIfSeqNo(10).setIfPrimaryTerm(1);
         expectThrows(VersionConflictEngineException.class, builder6);
-        ActionRequestBuilder<?, ?> builder5 = client().prepareDelete("test", "1").setIfSeqNo(10).setIfPrimaryTerm(2);
+        RequestBuilder<?, ?> builder5 = client().prepareDelete("test", "1").setIfSeqNo(10).setIfPrimaryTerm(2);
         expectThrows(VersionConflictEngineException.class, builder5);
-        ActionRequestBuilder<?, ?> builder4 = client().prepareDelete("test", "1").setIfSeqNo(1).setIfPrimaryTerm(2);
+        RequestBuilder<?, ?> builder4 = client().prepareDelete("test", "1").setIfSeqNo(1).setIfPrimaryTerm(2);
         expectThrows(VersionConflictEngineException.class, builder4);
 
         client().admin().indices().prepareRefresh().get();
@@ -295,15 +295,15 @@ public class SimpleVersioningIT extends ESIntegTestCase {
         assertThat(deleteResponse.getSeqNo(), equalTo(2L));
         assertThat(deleteResponse.getPrimaryTerm(), equalTo(1L));
 
-        ActionRequestBuilder<?, ?> builder3 = client().prepareDelete("test", "1").setIfSeqNo(1).setIfPrimaryTerm(1);
+        RequestBuilder<?, ?> builder3 = client().prepareDelete("test", "1").setIfSeqNo(1).setIfPrimaryTerm(1);
         expectThrows(VersionConflictEngineException.class, builder3);
-        ActionRequestBuilder<?, ?> builder2 = client().prepareDelete("test", "1").setIfSeqNo(3).setIfPrimaryTerm(12);
+        RequestBuilder<?, ?> builder2 = client().prepareDelete("test", "1").setIfSeqNo(3).setIfPrimaryTerm(12);
         expectThrows(VersionConflictEngineException.class, builder2);
-        ActionRequestBuilder<?, ?> builder1 = client().prepareDelete("test", "1").setIfSeqNo(1).setIfPrimaryTerm(2);
+        RequestBuilder<?, ?> builder1 = client().prepareDelete("test", "1").setIfSeqNo(1).setIfPrimaryTerm(2);
         expectThrows(VersionConflictEngineException.class, builder1);
 
         // the doc is deleted. Even when we hit the deleted seqNo, a conditional delete should fail.
-        ActionRequestBuilder<?, ?> builder = client().prepareDelete("test", "1").setIfSeqNo(2).setIfPrimaryTerm(1);
+        RequestBuilder<?, ?> builder = client().prepareDelete("test", "1").setIfSeqNo(2).setIfPrimaryTerm(1);
         expectThrows(VersionConflictEngineException.class, builder);
     }
 
@@ -319,16 +319,13 @@ public class SimpleVersioningIT extends ESIntegTestCase {
         assertThat(indexResponse.getSeqNo(), equalTo(1L));
 
         client().admin().indices().prepareFlush().get();
-        ActionRequestBuilder<?, ?> builder2 = prepareIndex("test").setId("1")
-            .setSource("field1", "value1_1")
-            .setIfSeqNo(0)
-            .setIfPrimaryTerm(1);
+        RequestBuilder<?, ?> builder2 = prepareIndex("test").setId("1").setSource("field1", "value1_1").setIfSeqNo(0).setIfPrimaryTerm(1);
         expectThrows(VersionConflictEngineException.class, builder2);
 
-        ActionRequestBuilder<?, ?> builder1 = prepareIndex("test").setId("1").setCreate(true).setSource("field1", "value1_1");
+        RequestBuilder<?, ?> builder1 = prepareIndex("test").setId("1").setCreate(true).setSource("field1", "value1_1");
         expectThrows(VersionConflictEngineException.class, builder1);
 
-        ActionRequestBuilder<?, ?> builder = client().prepareDelete("test", "1").setIfSeqNo(0).setIfPrimaryTerm(1);
+        RequestBuilder<?, ?> builder = client().prepareDelete("test", "1").setIfSeqNo(0).setIfPrimaryTerm(1);
         expectThrows(VersionConflictEngineException.class, builder);
 
         for (int i = 0; i < 10; i++) {

--- a/server/src/main/java/org/elasticsearch/action/ActionRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionRequestBuilder.java
@@ -13,7 +13,9 @@ import org.elasticsearch.core.TimeValue;
 
 import java.util.Objects;
 
-public abstract class ActionRequestBuilder<Request extends ActionRequest, Response extends ActionResponse> {
+public abstract class ActionRequestBuilder<Request extends ActionRequest, Response extends ActionResponse>
+    implements
+        RequestBuilder<Request, Response> {
 
     protected final ActionType<Response> action;
     protected final Request request;

--- a/server/src/main/java/org/elasticsearch/action/RequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/RequestBuilder.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action;
+
+import org.elasticsearch.core.RefCounted;
+import org.elasticsearch.core.TimeValue;
+
+public interface RequestBuilder<Request, Response extends RefCounted> {
+    /**
+     * This method returns the request that this builder builds. Depending on the implementation, it might return a new request with each
+     * call or the same request with each call.
+     */
+    Request request();
+
+    ActionFuture<Response> execute();
+
+    Response get();
+
+    Response get(TimeValue timeout);
+
+    void execute(ActionListener<Response> listener);
+}

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -40,7 +40,7 @@ import org.apache.lucene.tests.util.TimeUnits;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.action.ActionFuture;
-import org.elasticsearch.action.ActionRequestBuilder;
+import org.elasticsearch.action.RequestBuilder;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.bootstrap.BootstrapForTesting;
@@ -2145,7 +2145,7 @@ public abstract class ESTestCase extends LuceneTestCase {
         );
     }
 
-    public static <T extends Throwable> T expectThrows(Class<T> expectedType, ActionRequestBuilder<?, ?> builder) {
+    public static <T extends Throwable> T expectThrows(Class<T> expectedType, RequestBuilder<?, ?> builder) {
         return expectThrows(
             expectedType,
             "Expected exception " + expectedType.getSimpleName() + " but no exception was thrown",

--- a/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/hamcrest/ElasticsearchAssertions.java
@@ -14,8 +14,8 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.ActionRequest;
-import org.elasticsearch.action.ActionRequestBuilder;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.RequestBuilder;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequestBuilder;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
@@ -99,7 +99,7 @@ import static org.junit.Assert.fail;
 
 public class ElasticsearchAssertions {
 
-    public static void assertAcked(ActionRequestBuilder<?, ? extends IsAcknowledgedSupplier> builder) {
+    public static void assertAcked(RequestBuilder<?, ? extends IsAcknowledgedSupplier> builder) {
         assertAcked(builder, TimeValue.timeValueSeconds(30));
     }
 
@@ -107,7 +107,7 @@ public class ElasticsearchAssertions {
         assertAcked(future.actionGet());
     }
 
-    public static void assertAcked(ActionRequestBuilder<?, ? extends IsAcknowledgedSupplier> builder, TimeValue timeValue) {
+    public static void assertAcked(RequestBuilder<?, ? extends IsAcknowledgedSupplier> builder, TimeValue timeValue) {
         assertAcked(builder.get(timeValue));
     }
 
@@ -141,7 +141,7 @@ public class ElasticsearchAssertions {
      *
      * @param builder the request builder
      */
-    public static void assertBlocked(ActionRequestBuilder<?, ?> builder) {
+    public static void assertBlocked(RequestBuilder<?, ?> builder) {
         assertBlocked(builder, (ClusterBlock) null);
     }
 
@@ -179,7 +179,7 @@ public class ElasticsearchAssertions {
      * @param builder the request builder
      * @param expectedBlockId the expected block id
      */
-    public static void assertBlocked(final ActionRequestBuilder<?, ?> builder, @Nullable final Integer expectedBlockId) {
+    public static void assertBlocked(final RequestBuilder<?, ?> builder, @Nullable final Integer expectedBlockId) {
         var e = ESTestCase.expectThrows(ClusterBlockException.class, builder);
         assertThat(e.blocks(), not(empty()));
         RestStatus status = checkRetryableBlock(e.blocks()) ? RestStatus.TOO_MANY_REQUESTS : RestStatus.FORBIDDEN;
@@ -200,7 +200,7 @@ public class ElasticsearchAssertions {
      * @param builder the request builder
      * @param expectedBlock the expected block
      */
-    public static void assertBlocked(final ActionRequestBuilder<?, ?> builder, @Nullable final ClusterBlock expectedBlock) {
+    public static void assertBlocked(final RequestBuilder<?, ?> builder, @Nullable final ClusterBlock expectedBlock) {
         assertBlocked(builder, expectedBlock != null ? expectedBlock.id() : null);
     }
 
@@ -340,12 +340,12 @@ public class ElasticsearchAssertions {
         assertThat(searchResponse.getHits().getAt(number - 1), matcher);
     }
 
-    public static void assertNoFailures(ActionRequestBuilder<?, SearchResponse> searchRequestBuilder) {
+    public static void assertNoFailures(RequestBuilder<? extends ActionRequest, SearchResponse> searchRequestBuilder) {
         assertNoFailuresAndResponse(searchRequestBuilder, r -> {});
     }
 
     public static void assertNoFailuresAndResponse(
-        ActionRequestBuilder<?, SearchResponse> searchRequestBuilder,
+        RequestBuilder<? extends ActionRequest, SearchResponse> searchRequestBuilder,
         Consumer<SearchResponse> consumer
     ) {
         assertResponse(searchRequestBuilder, res -> {
@@ -366,7 +366,7 @@ public class ElasticsearchAssertions {
     }
 
     public static <Q extends ActionRequest, R extends ActionResponse> void assertResponse(
-        ActionRequestBuilder<Q, R> searchRequestBuilder,
+        RequestBuilder<Q, R> searchRequestBuilder,
         Consumer<R> consumer
     ) {
         var res = searchRequestBuilder.get();
@@ -430,7 +430,7 @@ public class ElasticsearchAssertions {
     }
 
     public static void assertCheckedResponse(
-        ActionRequestBuilder<?, SearchResponse> searchRequestBuilder,
+        RequestBuilder<?, SearchResponse> searchRequestBuilder,
         CheckedConsumer<SearchResponse, IOException> consumer
     ) throws IOException {
         var res = searchRequestBuilder.get();
@@ -692,7 +692,7 @@ public class ElasticsearchAssertions {
      * Run the request from a given builder and check that it throws an exception of the right type, with a given {@link RestStatus}
      */
     public static <E extends Throwable> void assertRequestBuilderThrows(
-        ActionRequestBuilder<?, ?> builder,
+        RequestBuilder<?, ?> builder,
         Class<E> exceptionClass,
         RestStatus status
     ) {
@@ -705,7 +705,7 @@ public class ElasticsearchAssertions {
      * @param extraInfo extra information to add to the failure message
      */
     public static <E extends Throwable> void assertRequestBuilderThrows(
-        ActionRequestBuilder<?, ?> builder,
+        RequestBuilder<?, ?> builder,
         Class<E> exceptionClass,
         String extraInfo
     ) {
@@ -767,11 +767,11 @@ public class ElasticsearchAssertions {
         }
     }
 
-    public static void assertRequestBuilderThrows(ActionRequestBuilder<?, ?> builder, RestStatus status) {
+    public static void assertRequestBuilderThrows(RequestBuilder<?, ?> builder, RestStatus status) {
         assertFutureThrows(builder.execute(), status);
     }
 
-    public static void assertRequestBuilderThrows(ActionRequestBuilder<?, ?> builder, RestStatus status, String extraInfo) {
+    public static void assertRequestBuilderThrows(RequestBuilder<?, ?> builder, RestStatus status, String extraInfo) {
         assertFutureThrows(builder.execute(), status, extraInfo);
     }
 


### PR DESCRIPTION
Right now all of our builders for ActionRequests create the request upfront, and mutate it as methods on the builder is called. I plan to introduce more traditional builders for ingest requests (currently in draft form at #104636) that do not build the object until it is asked for. Modifying all requests at once would be an enormous change, so that PR only deals with ingest-related requests, and does not change any search-related requests. This PR introduces a new interface that can be shared between the current builders and new builders (in a future PR) so that everything does not have to be switched over all at once (or ever, if there is no need for the search builders).
Note that this PR only updates tests and test helper methods that might ingest-related requests. 