### PR TITLE
Add troubleshooting docs link to PeerFinder logs

### DIFF
--- a/docs/changelog/104787.yaml
+++ b/docs/changelog/104787.yaml
@@ -1,0 +1,5 @@
+pr: 104787
+summary: Add troubleshooting docs link to `PeerFinder` logs
+area: Cluster Coordination
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/discovery/PeerFinder.java
+++ b/server/src/main/java/org/elasticsearch/discovery/PeerFinder.java
@@ -12,9 +12,11 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.cluster.coordination.ClusterFormationFailureHelper;
 import org.elasticsearch.cluster.coordination.PeersResponse;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.common.ReferenceDocs;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
@@ -470,7 +472,14 @@ public abstract class PeerFinder {
                             final String message = messageBuilder.length() < 1024
                                 ? messageBuilder.toString()
                                 : (messageBuilder.substring(0, 1023) + "...");
-                            logger.warn("{}{} discovery result{}", Peer.this, believedMasterBy, message);
+                            logger.warn(
+                                "{}{} discovery result{}; for summary, see logs from {}; for troubleshooting guidance, see {}",
+                                Peer.this,
+                                believedMasterBy,
+                                message,
+                                ClusterFormationFailureHelper.class.getCanonicalName(),
+                                ReferenceDocs.DISCOVERY_TROUBLESHOOTING
+                            );
                         }
                     } else {
                         logger.debug(() -> format("%s discovery result", Peer.this), e);

--- a/server/src/test/java/org/elasticsearch/discovery/PeerFinderTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/PeerFinderTests.java
@@ -914,7 +914,9 @@ public class PeerFinderTests extends ESTestCase {
                 "discovery result",
                 "org.elasticsearch.discovery.PeerFinder",
                 Level.WARN,
-                "address [" + unreachableMaster.getAddress() + "]* [current master according to *node-from-hosts-list*"
+                "address ["
+                    + unreachableMaster.getAddress()
+                    + "]* [current master according to *node-from-hosts-list*ClusterFormationFailureHelper*discovery-troubleshooting.html*"
             )
         );
 


### PR DESCRIPTION
If a node is having persistent discovery problems then the `PeerFinder`
reports each issue it encounters. The `ClusterFormationFailureHelper`
also reports a summary every 10s, including a link to the
troubleshooting docs, but this is typically much less frequent so is
easy to miss. This commit makes the `PeerFinder` messages a little more
actionable by pointing to the `ClusterFormationFailureHelper` logs and
also linking to the troubleshooting docs.