### PR TITLE
Remove ParsedAggregation from tests

### DIFF
--- a/modules/aggregations/src/test/java/org/elasticsearch/aggregations/bucket/AggregationMultiBucketAggregationTestCase.java
+++ b/modules/aggregations/src/test/java/org/elasticsearch/aggregations/bucket/AggregationMultiBucketAggregationTestCase.java
@@ -9,18 +9,10 @@
 package org.elasticsearch.aggregations.bucket;
 
 import org.elasticsearch.aggregations.AggregationsPlugin;
-import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.plugins.SearchPlugin;
-import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
 import org.elasticsearch.test.InternalMultiBucketAggregationTestCase;
-import org.elasticsearch.xcontent.ContextParser;
-import org.elasticsearch.xcontent.NamedXContentRegistry;
-import org.elasticsearch.xcontent.ParseField;
-
-import java.util.List;
-import java.util.Map;
 
 /**
  * Base class for unit testing multi bucket aggregation's bucket implementations that reside in aggregations module.
@@ -34,16 +26,5 @@ public abstract class AggregationMultiBucketAggregationTestCase<T extends Intern
     protected SearchPlugin registerPlugin() {
         return new AggregationsPlugin();
     }
-
-    @Override
-    protected List<NamedXContentRegistry.Entry> getNamedXContents() {
-        var entry = getParser();
-        return CollectionUtils.appendToCopy(
-            getDefaultNamedXContents(),
-            new NamedXContentRegistry.Entry(Aggregation.class, new ParseField(entry.getKey()), entry.getValue())
-        );
-    }
-
-    protected abstract Map.Entry<String, ContextParser<Object, Aggregation>> getParser();
 
 }

--- a/modules/aggregations/src/test/java/org/elasticsearch/aggregations/bucket/adjacency/InternalAdjacencyMatrixTests.java
+++ b/modules/aggregations/src/test/java/org/elasticsearch/aggregations/bucket/adjacency/InternalAdjacencyMatrixTests.java
@@ -10,9 +10,7 @@ package org.elasticsearch.aggregations.bucket.adjacency;
 
 import org.elasticsearch.aggregations.bucket.AggregationMultiBucketAggregationTestCase;
 import org.elasticsearch.common.util.Maps;
-import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
-import org.elasticsearch.xcontent.ContextParser;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -21,11 +19,6 @@ import java.util.Map;
 import java.util.TreeMap;
 
 public class InternalAdjacencyMatrixTests extends AggregationMultiBucketAggregationTestCase<InternalAdjacencyMatrix> {
-
-    @Override
-    protected Map.Entry<String, ContextParser<Object, Aggregation>> getParser() {
-        return Map.entry(AdjacencyMatrixAggregationBuilder.NAME, (p, c) -> ParsedAdjacencyMatrix.fromXContent(p, (String) c));
-    }
 
     private List<String> keys;
 
@@ -92,11 +85,6 @@ public class InternalAdjacencyMatrixTests extends AggregationMultiBucketAggregat
             actualCounts.compute(bucket.getKeyAsString(), (key, oldValue) -> (oldValue == null ? 0 : oldValue) + bucket.getDocCount());
         }
         assertEquals(expectedCounts, actualCounts);
-    }
-
-    @Override
-    protected Class<ParsedAdjacencyMatrix> implementationClass() {
-        return ParsedAdjacencyMatrix.class;
     }
 
     @Override

--- a/modules/aggregations/src/test/java/org/elasticsearch/aggregations/bucket/histogram/InternalAutoDateHistogramTests.java
+++ b/modules/aggregations/src/test/java/org/elasticsearch/aggregations/bucket/histogram/InternalAutoDateHistogramTests.java
@@ -21,14 +21,12 @@ import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.search.DocValueFormat;
-import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.test.TransportVersionUtils;
-import org.elasticsearch.xcontent.ContextParser;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -54,11 +52,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Mockito.mock;
 
 public class InternalAutoDateHistogramTests extends AggregationMultiBucketAggregationTestCase<InternalAutoDateHistogram> {
-
-    @Override
-    protected Map.Entry<String, ContextParser<Object, Aggregation>> getParser() {
-        return Map.entry(AutoDateHistogramAggregationBuilder.NAME, (p, c) -> ParsedAutoDateHistogram.fromXContent(p, (String) c));
-    }
 
     protected InternalAutoDateHistogram createTestInstance(
         String name,
@@ -272,11 +265,6 @@ public class InternalAutoDateHistogramTests extends AggregationMultiBucketAggreg
             bucketCount++;
         }
         return bucketCount;
-    }
-
-    @Override
-    protected Class<ParsedAutoDateHistogram> implementationClass() {
-        return ParsedAutoDateHistogram.class;
     }
 
     @Override

--- a/modules/aggregations/src/test/java/org/elasticsearch/aggregations/bucket/timeseries/InternalTimeSeriesTests.java
+++ b/modules/aggregations/src/test/java/org/elasticsearch/aggregations/bucket/timeseries/InternalTimeSeriesTests.java
@@ -16,11 +16,9 @@ import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.common.util.MockPageCacheRecycler;
 import org.elasticsearch.index.mapper.TimeSeriesIdFieldMapper;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
-import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.AggregationReduceContext;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
-import org.elasticsearch.xcontent.ContextParser;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -30,17 +28,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.function.Predicate;
 
 import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 
 public class InternalTimeSeriesTests extends AggregationMultiBucketAggregationTestCase<InternalTimeSeries> {
-
-    @Override
-    protected Map.Entry<String, ContextParser<Object, Aggregation>> getParser() {
-        return Map.entry(TimeSeriesAggregationBuilder.NAME, (p, c) -> ParsedTimeSeries.fromXContent(p, (String) c));
-    }
 
     private List<InternalBucket> randomBuckets(boolean keyed, InternalAggregations aggregations) {
         int numberOfBuckets = randomNumberOfBuckets();
@@ -106,16 +98,6 @@ public class InternalTimeSeriesTests extends AggregationMultiBucketAggregationTe
             reduced.getBuckets().stream().map(InternalBucket::getKey).toArray(Object[]::new),
             arrayContainingInAnyOrder(keys.keySet().toArray(Object[]::new))
         );
-    }
-
-    @Override
-    protected Class<ParsedTimeSeries> implementationClass() {
-        return ParsedTimeSeries.class;
-    }
-
-    @Override
-    protected Predicate<String> excludePathsFromXContentInsertion() {
-        return s -> s.endsWith(".key");
     }
 
     public void testReduceSimple() {

--- a/modules/aggregations/src/test/java/org/elasticsearch/aggregations/metric/InternalMatrixStatsTests.java
+++ b/modules/aggregations/src/test/java/org/elasticsearch/aggregations/metric/InternalMatrixStatsTests.java
@@ -8,34 +8,25 @@
 package org.elasticsearch.aggregations.metric;
 
 import org.elasticsearch.aggregations.AggregationsPlugin;
-import org.elasticsearch.aggregations.metric.InternalMatrixStats.Fields;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.common.util.MockPageCacheRecycler;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.script.ScriptService;
-import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationReduceContext;
 import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator.PipelineTree;
 import org.elasticsearch.test.InternalAggregationTestCase;
-import org.elasticsearch.xcontent.ContextParser;
-import org.elasticsearch.xcontent.NamedXContentRegistry;
-import org.elasticsearch.xcontent.ParseField;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Predicate;
 
 import static org.mockito.Mockito.mock;
 
@@ -58,15 +49,6 @@ public class InternalMatrixStatsTests extends InternalAggregationTestCase<Intern
         for (int i = 0; i < numFields; i++) {
             fields[i] = "field_" + i;
         }
-    }
-
-    @Override
-    protected List<NamedXContentRegistry.Entry> getNamedXContents() {
-        ContextParser<Object, Aggregation> parser = (p, c) -> ParsedMatrixStats.fromXContent(p, (String) c);
-        return CollectionUtils.appendToCopy(
-            super.getNamedXContents(),
-            new NamedXContentRegistry.Entry(Aggregation.class, new ParseField(MatrixStatsAggregationBuilder.NAME), parser)
-        );
     }
 
     @Override
@@ -173,49 +155,5 @@ public class InternalMatrixStatsTests extends InternalAggregationTestCase<Intern
     @Override
     protected void assertReduced(InternalMatrixStats reduced, List<InternalMatrixStats> inputs) {
         throw new UnsupportedOperationException();
-    }
-
-    @Override
-    protected void assertFromXContent(InternalMatrixStats expected, ParsedAggregation parsedAggregation) throws IOException {
-        assertTrue(parsedAggregation instanceof ParsedMatrixStats);
-        ParsedMatrixStats actual = (ParsedMatrixStats) parsedAggregation;
-
-        assertEquals(expected.getDocCount(), actual.getDocCount());
-
-        for (String field : fields) {
-            assertEquals(expected.getFieldCount(field), actual.getFieldCount(field));
-            assertEquals(expected.getMean(field), actual.getMean(field), 0.0);
-            assertEquals(expected.getVariance(field), actual.getVariance(field), 0.0);
-            assertEquals(expected.getSkewness(field), actual.getSkewness(field), 0.0);
-            assertEquals(expected.getKurtosis(field), actual.getKurtosis(field), 0.0);
-
-            for (String other : fields) {
-                assertEquals(expected.getCovariance(field, other), actual.getCovariance(field, other), 0.0);
-                assertEquals(expected.getCorrelation(field, other), actual.getCorrelation(field, other), 0.0);
-            }
-        }
-
-        String unknownField = randomAlphaOfLength(3);
-        String other = randomValueOtherThan(unknownField, () -> randomAlphaOfLength(3));
-        // getFieldCount returns 0 for unknown fields
-        assertEquals(0.0, actual.getFieldCount(unknownField), 0.0);
-
-        expectThrows(IllegalArgumentException.class, () -> actual.getMean(unknownField));
-        expectThrows(IllegalArgumentException.class, () -> actual.getVariance(unknownField));
-        expectThrows(IllegalArgumentException.class, () -> actual.getSkewness(unknownField));
-        expectThrows(IllegalArgumentException.class, () -> actual.getKurtosis(unknownField));
-
-        expectThrows(IllegalArgumentException.class, () -> actual.getCovariance(unknownField, unknownField));
-        expectThrows(IllegalArgumentException.class, () -> actual.getCovariance(unknownField, other));
-        expectThrows(IllegalArgumentException.class, () -> actual.getCovariance(other, unknownField));
-
-        assertEquals(1.0, actual.getCorrelation(unknownField, unknownField), 0.0);
-        expectThrows(IllegalArgumentException.class, () -> actual.getCorrelation(unknownField, other));
-        expectThrows(IllegalArgumentException.class, () -> actual.getCorrelation(other, unknownField));
-    }
-
-    @Override
-    protected Predicate<String> excludePathsFromXContentInsertion() {
-        return path -> path.endsWith(Fields.CORRELATION) || path.endsWith(Fields.COVARIANCE);
     }
 }

--- a/modules/aggregations/src/test/java/org/elasticsearch/aggregations/pipeline/DerivativeResultTests.java
+++ b/modules/aggregations/src/test/java/org/elasticsearch/aggregations/pipeline/DerivativeResultTests.java
@@ -12,36 +12,16 @@ import org.elasticsearch.aggregations.AggregationsPlugin;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.search.DocValueFormat;
-import org.elasticsearch.search.aggregations.Aggregation;
-import org.elasticsearch.search.aggregations.ParsedAggregation;
-import org.elasticsearch.search.aggregations.pipeline.ParsedDerivative;
 import org.elasticsearch.test.InternalAggregationTestCase;
-import org.elasticsearch.xcontent.NamedXContentRegistry;
-import org.elasticsearch.xcontent.ParseField;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Stream;
 
 public class DerivativeResultTests extends InternalAggregationTestCase<Derivative> {
     @Override
     protected SearchPlugin registerPlugin() {
         return new AggregationsPlugin();
-    }
-
-    @Override
-    protected List<NamedXContentRegistry.Entry> getNamedXContents() {
-        return Stream.concat(
-            super.getNamedXContents().stream(),
-            Stream.of(
-                new NamedXContentRegistry.Entry(
-                    Aggregation.class,
-                    new ParseField(DerivativePipelineAggregationBuilder.NAME),
-                    (p, c) -> ParsedDerivative.fromXContent(p, (String) c)
-                )
-            )
-        ).toList();
     }
 
     @Override
@@ -62,19 +42,6 @@ public class DerivativeResultTests extends InternalAggregationTestCase<Derivativ
     @Override
     protected void assertReduced(Derivative reduced, List<Derivative> inputs) {
         // no test since reduce operation is unsupported
-    }
-
-    @Override
-    protected void assertFromXContent(Derivative derivative, ParsedAggregation parsedAggregation) {
-        ParsedDerivative parsed = ((ParsedDerivative) parsedAggregation);
-        if (Double.isInfinite(derivative.getValue()) == false && Double.isNaN(derivative.getValue()) == false) {
-            assertEquals(derivative.getValue(), parsed.value(), Double.MIN_VALUE);
-            assertEquals(derivative.getValueAsString(), parsed.getValueAsString());
-        } else {
-            // we write Double.NEGATIVE_INFINITY, Double.POSITIVE amd Double.NAN to xContent as 'null', so we
-            // cannot differentiate between them. Also we cannot recreate the exact String representation
-            assertEquals(parsed.value(), Double.NaN, Double.MIN_VALUE);
-        }
     }
 
     @Override

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/aggregations/InternalChildrenTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/aggregations/InternalChildrenTests.java
@@ -8,15 +8,10 @@
 
 package org.elasticsearch.join.aggregations;
 
-import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.join.ParentJoinPlugin;
 import org.elasticsearch.plugins.SearchPlugin;
-import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalSingleBucketAggregationTestCase;
-import org.elasticsearch.search.aggregations.bucket.ParsedSingleBucketAggregation;
-import org.elasticsearch.xcontent.NamedXContentRegistry;
-import org.elasticsearch.xcontent.ParseField;
 
 import java.util.List;
 import java.util.Map;
@@ -26,18 +21,6 @@ public class InternalChildrenTests extends InternalSingleBucketAggregationTestCa
     @Override
     protected SearchPlugin registerPlugin() {
         return new ParentJoinPlugin();
-    }
-
-    @Override
-    protected List<NamedXContentRegistry.Entry> getNamedXContents() {
-        return CollectionUtils.appendToCopy(
-            super.getNamedXContents(),
-            new NamedXContentRegistry.Entry(
-                Aggregation.class,
-                new ParseField(ChildrenAggregationBuilder.NAME),
-                (p, c) -> ParsedChildren.fromXContent(p, (String) c)
-            )
-        );
     }
 
     @Override
@@ -53,10 +36,5 @@ public class InternalChildrenTests extends InternalSingleBucketAggregationTestCa
     @Override
     protected void extraAssertReduced(InternalChildren reduced, List<InternalChildren> inputs) {
         // Nothing extra to assert
-    }
-
-    @Override
-    protected Class<? extends ParsedSingleBucketAggregation> implementationClass() {
-        return ParsedChildren.class;
     }
 }

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/aggregations/InternalParentTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/aggregations/InternalParentTests.java
@@ -8,15 +8,10 @@
 
 package org.elasticsearch.join.aggregations;
 
-import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.join.ParentJoinPlugin;
 import org.elasticsearch.plugins.SearchPlugin;
-import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalSingleBucketAggregationTestCase;
-import org.elasticsearch.search.aggregations.bucket.ParsedSingleBucketAggregation;
-import org.elasticsearch.xcontent.NamedXContentRegistry.Entry;
-import org.elasticsearch.xcontent.ParseField;
 
 import java.util.List;
 import java.util.Map;
@@ -26,14 +21,6 @@ public class InternalParentTests extends InternalSingleBucketAggregationTestCase
     @Override
     protected SearchPlugin registerPlugin() {
         return new ParentJoinPlugin();
-    }
-
-    @Override
-    protected List<Entry> getNamedXContents() {
-        return CollectionUtils.appendToCopy(
-            super.getNamedXContents(),
-            new Entry(Aggregation.class, new ParseField(ParentAggregationBuilder.NAME), (p, c) -> ParsedParent.fromXContent(p, (String) c))
-        );
     }
 
     @Override
@@ -49,10 +36,5 @@ public class InternalParentTests extends InternalSingleBucketAggregationTestCase
     @Override
     protected void extraAssertReduced(InternalParent reduced, List<InternalParent> inputs) {
         // Nothing extra to assert
-    }
-
-    @Override
-    protected Class<? extends ParsedSingleBucketAggregation> implementationClass() {
-        return ParsedParent.class;
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/search/SearchResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchResponseTests.java
@@ -26,21 +26,16 @@ import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.SearchHitsTests;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.search.SearchResponseUtils;
-import org.elasticsearch.search.aggregations.AggregationsTests;
-import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.profile.SearchProfileResults;
 import org.elasticsearch.search.profile.SearchProfileResultsTests;
 import org.elasticsearch.search.suggest.Suggest;
 import org.elasticsearch.search.suggest.SuggestTests;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.InternalAggregationTestCase;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentType;
-import org.junit.After;
-import org.junit.Before;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -59,25 +54,13 @@ public class SearchResponseTests extends ESTestCase {
 
     private static final NamedXContentRegistry xContentRegistry;
     static {
-        List<NamedXContentRegistry.Entry> namedXContents = new ArrayList<>(InternalAggregationTestCase.getDefaultNamedXContents());
-        namedXContents.addAll(SuggestTests.getDefaultNamedXContents());
+        List<NamedXContentRegistry.Entry> namedXContents = new ArrayList<>(SuggestTests.getDefaultNamedXContents());
         xContentRegistry = new NamedXContentRegistry(namedXContents);
     }
 
     private final NamedWriteableRegistry namedWriteableRegistry = new NamedWriteableRegistry(
         new SearchModule(Settings.EMPTY, emptyList()).getNamedWriteables()
     );
-    private AggregationsTests aggregationsTests = new AggregationsTests();
-
-    @Before
-    public void init() throws Exception {
-        aggregationsTests.init();
-    }
-
-    @After
-    public void cleanUp() throws Exception {
-        aggregationsTests.cleanUp();
-    }
 
     @Override
     protected NamedXContentRegistry xContentRegistry() {
@@ -116,12 +99,11 @@ public class SearchResponseTests extends ESTestCase {
         if (minimal == false) {
             SearchHits hits = SearchHitsTests.createTestItem(true, true);
             try {
-                InternalAggregations aggregations = aggregationsTests.createTestInstance();
                 Suggest suggest = SuggestTests.createTestItem();
                 SearchProfileResults profileResults = SearchProfileResultsTests.createTestItem();
                 return new SearchResponse(
                     hits,
-                    aggregations,
+                    null,
                     suggest,
                     timedOut,
                     terminatedEarly,

--- a/server/src/test/java/org/elasticsearch/plugins/spi/NamedXContentProviderTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/spi/NamedXContentProviderTests.java
@@ -9,9 +9,8 @@
 package org.elasticsearch.plugins.spi;
 
 import org.elasticsearch.common.io.Streams;
-import org.elasticsearch.search.aggregations.Aggregation;
-import org.elasticsearch.search.aggregations.pipeline.ParsedSimpleValue;
 import org.elasticsearch.search.suggest.Suggest;
+import org.elasticsearch.search.suggest.phrase.PhraseSuggestion;
 import org.elasticsearch.search.suggest.term.TermSuggestion;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
@@ -47,7 +46,7 @@ public class NamedXContentProviderTests extends ESTestCase {
         assertEquals(2, namedXContents.size());
 
         List<Predicate<NamedXContentRegistry.Entry>> predicates = new ArrayList<>(2);
-        predicates.add(e -> Aggregation.class.equals(e.categoryClass) && "test_aggregation".equals(e.name.getPreferredName()));
+        predicates.add(e -> Suggest.Suggestion.class.equals(e.categoryClass) && "phrase_aggregation".equals(e.name.getPreferredName()));
         predicates.add(e -> Suggest.Suggestion.class.equals(e.categoryClass) && "test_suggestion".equals(e.name.getPreferredName()));
         predicates.forEach(predicate -> assertEquals(1, namedXContents.stream().filter(predicate).count()));
     }
@@ -60,9 +59,9 @@ public class NamedXContentProviderTests extends ESTestCase {
         public List<NamedXContentRegistry.Entry> getNamedXContentParsers() {
             return Arrays.asList(
                 new NamedXContentRegistry.Entry(
-                    Aggregation.class,
-                    new ParseField("test_aggregation"),
-                    (parser, context) -> ParsedSimpleValue.fromXContent(parser, (String) context)
+                    Suggest.Suggestion.class,
+                    new ParseField("phrase_aggregation"),
+                    (parser, context) -> PhraseSuggestion.fromXContent(parser, (String) context)
                 ),
                 new NamedXContentRegistry.Entry(
                     Suggest.Suggestion.class,

--- a/server/src/test/java/org/elasticsearch/search/aggregations/AggregationsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/AggregationsTests.java
@@ -8,11 +8,6 @@
 
 package org.elasticsearch.search.aggregations;
 
-import org.elasticsearch.common.ParsingException;
-import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.xcontent.XContentHelper;
-import org.elasticsearch.rest.action.search.RestSearchAction;
-import org.elasticsearch.search.aggregations.Aggregation.CommonFields;
 import org.elasticsearch.search.aggregations.bucket.composite.InternalCompositeTests;
 import org.elasticsearch.search.aggregations.bucket.filter.InternalFilterTests;
 import org.elasticsearch.search.aggregations.bucket.filter.InternalFiltersTests;
@@ -63,26 +58,11 @@ import org.elasticsearch.search.aggregations.pipeline.InternalSimpleValueTests;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.InternalAggregationTestCase;
 import org.elasticsearch.test.InternalMultiBucketAggregationTestCase;
-import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
-import org.elasticsearch.xcontent.NamedXContentRegistry;
-import org.elasticsearch.xcontent.ToXContent;
-import org.elasticsearch.xcontent.XContent;
-import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xcontent.XContentFactory;
-import org.elasticsearch.xcontent.XContentParser;
-import org.elasticsearch.xcontent.XContentType;
 import org.junit.After;
 import org.junit.Before;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-
-import static java.util.Collections.singletonMap;
-import static org.elasticsearch.test.XContentTestUtils.insertRandomFields;
 
 /**
  * This class tests that aggregations parsing works properly. It checks that we can parse
@@ -141,11 +121,6 @@ public class AggregationsTests extends ESTestCase {
         new InternalMedianAbsoluteDeviationTests()
     );
 
-    @Override
-    protected NamedXContentRegistry xContentRegistry() {
-        return new NamedXContentRegistry(InternalAggregationTestCase.getDefaultNamedXContents());
-    }
-
     @Before
     public void init() throws Exception {
         for (InternalAggregationTestCase<?> aggsTest : aggsTests) {
@@ -162,99 +137,6 @@ public class AggregationsTests extends ESTestCase {
     public void cleanUp() throws Exception {
         for (InternalAggregationTestCase<?> aggsTest : aggsTests) {
             aggsTest.tearDown();
-        }
-    }
-
-    public void testAllAggsAreBeingTested() {
-        assertEquals(InternalAggregationTestCase.getDefaultNamedXContents().size(), aggsTests.size());
-        Set<String> aggs = aggsTests.stream().map((testCase) -> testCase.createTestInstance().getType()).collect(Collectors.toSet());
-        for (NamedXContentRegistry.Entry entry : InternalAggregationTestCase.getDefaultNamedXContents()) {
-            assertTrue(aggs.contains(entry.name.getPreferredName()));
-        }
-    }
-
-    public void testFromXContent() throws IOException {
-        parseAndAssert(false);
-    }
-
-    public void testFromXContentWithRandomFields() throws IOException {
-        parseAndAssert(true);
-    }
-
-    /**
-     * Test that parsing works for a randomly created Aggregations object with a
-     * randomized aggregation tree. The test randomly chooses an
-     * {@link XContentType}, randomizes the order of the {@link XContent} fields
-     * and randomly sets the `humanReadable` flag when rendering the
-     * {@link XContent}.
-     *
-     * @param addRandomFields
-     *            if set, this will also add random {@link XContent} fields to
-     *            tests that the parsers are lenient to future additions to rest
-     *            responses
-     */
-    private void parseAndAssert(boolean addRandomFields) throws IOException {
-        XContentType xContentType = randomFrom(XContentType.values());
-        final ToXContent.Params params = new ToXContent.MapParams(singletonMap(RestSearchAction.TYPED_KEYS_PARAM, "true"));
-        Aggregations aggregations = createTestInstance();
-        BytesReference originalBytes = toShuffledXContent(aggregations, xContentType, params, randomBoolean());
-        BytesReference mutated;
-        if (addRandomFields) {
-            /*
-             * - don't insert into the root object because it should only contain the named aggregations to test
-             *
-             * - don't insert into the "meta" object, because we pass on everything we find there
-             *
-             * - we don't want to directly insert anything random into "buckets"  objects, they are used with
-             * "keyed" aggregations and contain named bucket objects. Any new named object on this level should
-             * also be a bucket and be parsed as such.
-             *
-             * - we cannot insert randomly into VALUE or VALUES objects e.g. in Percentiles, the keys need to be numeric there
-             *
-             * - we cannot insert into ExtendedMatrixStats "covariance" or "correlation" fields, their syntax is strict
-             *
-             * - we cannot insert random values in top_hits, as all unknown fields
-             * on a root level of SearchHit are interpreted as meta-fields and will be kept
-             *
-             * - exclude "key", it can be an array of objects and we need strict values
-             */
-            Predicate<String> excludes = path -> (path.isEmpty()
-                || path.endsWith("aggregations")
-                || path.endsWith(Aggregation.CommonFields.META.getPreferredName())
-                || path.endsWith(Aggregation.CommonFields.BUCKETS.getPreferredName())
-                || path.endsWith(CommonFields.VALUES.getPreferredName())
-                || path.endsWith("covariance")
-                || path.endsWith("correlation")
-                || path.contains(CommonFields.VALUE.getPreferredName())
-                || path.endsWith(CommonFields.KEY.getPreferredName())) || path.contains("top_hits");
-            mutated = insertRandomFields(xContentType, originalBytes, excludes, random());
-        } else {
-            mutated = originalBytes;
-        }
-        try (XContentParser parser = createParser(xContentType.xContent(), mutated)) {
-            assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
-            assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
-            assertEquals(Aggregations.AGGREGATIONS_FIELD, parser.currentName());
-            assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
-            Aggregations parsedAggregations = Aggregations.fromXContent(parser);
-            BytesReference parsedBytes = XContentHelper.toXContent(parsedAggregations, xContentType, randomBoolean());
-            ElasticsearchAssertions.assertToXContentEquivalent(originalBytes, parsedBytes, xContentType);
-        }
-    }
-
-    public void testParsingExceptionOnUnknownAggregation() throws IOException {
-        XContentBuilder builder = XContentFactory.jsonBuilder();
-        builder.startObject();
-        {
-            builder.startObject("unknownAggregation");
-            builder.endObject();
-        }
-        builder.endObject();
-        BytesReference originalBytes = BytesReference.bytes(builder);
-        try (XContentParser parser = createParser(builder.contentType().xContent(), originalBytes)) {
-            assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
-            ParsingException ex = expectThrows(ParsingException.class, () -> Aggregations.fromXContent(parser));
-            assertEquals("Could not parse aggregation keyed as [unknownAggregation]", ex.getMessage());
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/InternalCompositeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/InternalCompositeTests.java
@@ -15,7 +15,6 @@ import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
-import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.test.InternalMultiBucketAggregationTestCase;
 import org.junit.After;
 
@@ -103,19 +102,6 @@ public class InternalCompositeTests extends InternalMultiBucketAggregationTestCa
         reverseMuls = null;
         missingOrders = null;
         types = null;
-    }
-
-    @Override
-    protected Class<ParsedComposite> implementationClass() {
-        return ParsedComposite.class;
-    }
-
-    protected <P extends ParsedAggregation> P parseAndAssert(
-        final InternalAggregation aggregation,
-        final boolean shuffled,
-        final boolean addRandomFields
-    ) throws IOException {
-        return super.parseAndAssert(aggregation, false, false);
     }
 
     private CompositeKey createCompositeKey() {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/filter/InternalFilterTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/filter/InternalFilterTests.java
@@ -12,7 +12,6 @@ import org.elasticsearch.search.aggregations.AggregationReduceContext;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalSingleBucketAggregationTestCase;
-import org.elasticsearch.search.aggregations.bucket.ParsedSingleBucketAggregation;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator.PipelineTree;
 import org.elasticsearch.search.aggregations.support.SamplingContext;
@@ -49,11 +48,6 @@ public class InternalFilterTests extends InternalSingleBucketAggregationTestCase
     @Override
     protected void extraAssertReduced(InternalFilter reduced, List<InternalFilter> inputs) {
         // Nothing extra to assert
-    }
-
-    @Override
-    protected Class<? extends ParsedSingleBucketAggregation> implementationClass() {
-        return ParsedFilter.class;
     }
 
     public void testReducePipelinesReturnsSameInstanceWithoutPipelines() {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/filter/InternalFiltersTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/filter/InternalFiltersTests.java
@@ -85,11 +85,6 @@ public class InternalFiltersTests extends InternalMultiBucketAggregationTestCase
     }
 
     @Override
-    protected Class<ParsedFilters> implementationClass() {
-        return ParsedFilters.class;
-    }
-
-    @Override
     protected InternalFilters mutateInstance(InternalFilters instance) {
         String name = instance.getName();
         List<InternalBucket> buckets = instance.getBuckets();

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/global/InternalGlobalTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/global/InternalGlobalTests.java
@@ -10,7 +10,6 @@ package org.elasticsearch.search.aggregations.bucket.global;
 
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalSingleBucketAggregationTestCase;
-import org.elasticsearch.search.aggregations.bucket.ParsedSingleBucketAggregation;
 
 import java.util.List;
 import java.util.Map;
@@ -29,10 +28,5 @@ public class InternalGlobalTests extends InternalSingleBucketAggregationTestCase
     @Override
     protected void extraAssertReduced(InternalGlobal reduced, List<InternalGlobal> inputs) {
         // Nothing extra to assert
-    }
-
-    @Override
-    protected Class<? extends ParsedSingleBucketAggregation> implementationClass() {
-        return ParsedGlobal.class;
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogramTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogramTests.java
@@ -167,11 +167,6 @@ public class InternalDateHistogramTests extends InternalMultiBucketAggregationTe
     }
 
     @Override
-    protected Class<ParsedDateHistogram> implementationClass() {
-        return ParsedDateHistogram.class;
-    }
-
-    @Override
     protected InternalDateHistogram mutateInstance(InternalDateHistogram instance) {
         String name = instance.getName();
         List<InternalDateHistogram.Bucket> buckets = instance.getBuckets();

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogramTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogramTests.java
@@ -159,11 +159,6 @@ public class InternalHistogramTests extends InternalMultiBucketAggregationTestCa
     }
 
     @Override
-    protected Class<ParsedHistogram> implementationClass() {
-        return ParsedHistogram.class;
-    }
-
-    @Override
     protected InternalHistogram mutateInstance(InternalHistogram instance) {
         String name = instance.getName();
         List<InternalHistogram.Bucket> buckets = instance.getBuckets();

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalVariableWidthHistogramTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalVariableWidthHistogramTests.java
@@ -93,11 +93,6 @@ public class InternalVariableWidthHistogramTests extends InternalMultiBucketAggr
     }
 
     @Override
-    protected Class<ParsedVariableWidthHistogram> implementationClass() {
-        return ParsedVariableWidthHistogram.class;
-    }
-
-    @Override
     protected InternalVariableWidthHistogram mutateInstance(InternalVariableWidthHistogram instance) {
         String name = instance.getName();
         List<InternalVariableWidthHistogram.Bucket> buckets = instance.getBuckets();

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/missing/InternalMissingTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/missing/InternalMissingTests.java
@@ -10,7 +10,6 @@ package org.elasticsearch.search.aggregations.bucket.missing;
 
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalSingleBucketAggregationTestCase;
-import org.elasticsearch.search.aggregations.bucket.ParsedSingleBucketAggregation;
 
 import java.util.List;
 import java.util.Map;
@@ -29,10 +28,5 @@ public class InternalMissingTests extends InternalSingleBucketAggregationTestCas
     @Override
     protected void extraAssertReduced(InternalMissing reduced, List<InternalMissing> inputs) {
         // Nothing extra to assert
-    }
-
-    @Override
-    protected Class<? extends ParsedSingleBucketAggregation> implementationClass() {
-        return ParsedMissing.class;
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/InternalNestedTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/InternalNestedTests.java
@@ -10,10 +10,7 @@ package org.elasticsearch.search.aggregations.bucket.nested;
 
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalSingleBucketAggregationTestCase;
-import org.elasticsearch.search.aggregations.ParsedAggregation;
-import org.elasticsearch.search.aggregations.bucket.ParsedSingleBucketAggregation;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
@@ -31,16 +28,5 @@ public class InternalNestedTests extends InternalSingleBucketAggregationTestCase
     @Override
     protected void extraAssertReduced(InternalNested reduced, List<InternalNested> inputs) {
         // Nothing extra to assert
-    }
-
-    @Override
-    protected Class<? extends ParsedSingleBucketAggregation> implementationClass() {
-        return ParsedNested.class;
-    }
-
-    @Override
-    protected void assertFromXContent(InternalNested aggregation, ParsedAggregation parsedAggregation) throws IOException {
-        super.assertFromXContent(aggregation, parsedAggregation);
-        assertTrue(parsedAggregation instanceof Nested);
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/InternalReverseNestedTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/InternalReverseNestedTests.java
@@ -10,10 +10,7 @@ package org.elasticsearch.search.aggregations.bucket.nested;
 
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalSingleBucketAggregationTestCase;
-import org.elasticsearch.search.aggregations.ParsedAggregation;
-import org.elasticsearch.search.aggregations.bucket.ParsedSingleBucketAggregation;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
@@ -31,16 +28,5 @@ public class InternalReverseNestedTests extends InternalSingleBucketAggregationT
     @Override
     protected void extraAssertReduced(InternalReverseNested reduced, List<InternalReverseNested> inputs) {
         // Nothing extra to assert
-    }
-
-    @Override
-    protected Class<? extends ParsedSingleBucketAggregation> implementationClass() {
-        return ParsedReverseNested.class;
-    }
-
-    @Override
-    protected void assertFromXContent(InternalReverseNested aggregation, ParsedAggregation parsedAggregation) throws IOException {
-        super.assertFromXContent(aggregation, parsedAggregation);
-        assertTrue(parsedAggregation instanceof ReverseNested);
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/prefix/InternalIpPrefixTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/prefix/InternalIpPrefixTests.java
@@ -13,7 +13,6 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.InternalAggregations;
-import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
 import org.elasticsearch.test.InternalMultiBucketAggregationTestCase;
 import org.elasticsearch.test.MapMatcher;
 
@@ -36,12 +35,6 @@ public class InternalIpPrefixTests extends InternalMultiBucketAggregationTestCas
     @Override
     protected InternalIpPrefix createTestInstance(String name, Map<String, Object> metadata, InternalAggregations aggregations) {
         return createTestInstance(name, metadata, aggregations, randomPrefixLength(), randomMinDocCount());
-    }
-
-    @Override
-    protected Class<? extends ParsedMultiBucketAggregation<?>> implementationClass() {
-        // Deprecated high level rest client not supported
-        return null;
     }
 
     private int randomPrefixLength() {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalBinaryRangeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalBinaryRangeTests.java
@@ -13,7 +13,6 @@ import org.elasticsearch.core.Tuple;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
-import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -96,11 +95,6 @@ public class InternalBinaryRangeTests extends InternalRangeTestCase<InternalBina
     @Override
     protected Class<? extends InternalMultiBucketAggregation.InternalBucket> internalRangeBucketClass() {
         return InternalBinaryRange.Bucket.class;
-    }
-
-    @Override
-    protected Class<? extends ParsedMultiBucketAggregation.ParsedBucket> parsedRangeBucketClass() {
-        return ParsedBinaryRange.ParsedBucket.class;
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalBinaryRangeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalBinaryRangeTests.java
@@ -78,11 +78,6 @@ public class InternalBinaryRangeTests extends InternalRangeTestCase<InternalBina
     }
 
     @Override
-    protected Class<ParsedBinaryRange> implementationClass() {
-        return ParsedBinaryRange.class;
-    }
-
-    @Override
     protected void assertReduced(InternalBinaryRange reduced, List<InternalBinaryRange> inputs) {
         int pos = 0;
         for (InternalBinaryRange input : inputs) {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalDateRangeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalDateRangeTests.java
@@ -87,11 +87,6 @@ public class InternalDateRangeTests extends InternalRangeTestCase<InternalDateRa
     }
 
     @Override
-    protected Class<ParsedDateRange> implementationClass() {
-        return ParsedDateRange.class;
-    }
-
-    @Override
     protected Class<? extends InternalMultiBucketAggregation.InternalBucket> internalRangeBucketClass() {
         return InternalDateRange.Bucket.class;
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalDateRangeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalDateRangeTests.java
@@ -13,7 +13,6 @@ import org.elasticsearch.core.Tuple;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
-import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
 
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -89,11 +88,6 @@ public class InternalDateRangeTests extends InternalRangeTestCase<InternalDateRa
     @Override
     protected Class<? extends InternalMultiBucketAggregation.InternalBucket> internalRangeBucketClass() {
         return InternalDateRange.Bucket.class;
-    }
-
-    @Override
-    protected Class<? extends ParsedMultiBucketAggregation.ParsedBucket> parsedRangeBucketClass() {
-        return ParsedDateRange.ParsedBucket.class;
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalGeoDistanceTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalGeoDistanceTests.java
@@ -69,11 +69,6 @@ public class InternalGeoDistanceTests extends InternalRangeTestCase<InternalGeoD
     }
 
     @Override
-    protected Class<ParsedGeoDistance> implementationClass() {
-        return ParsedGeoDistance.class;
-    }
-
-    @Override
     protected Class<? extends InternalMultiBucketAggregation.InternalBucket> internalRangeBucketClass() {
         return InternalGeoDistance.Bucket.class;
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalGeoDistanceTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalGeoDistanceTests.java
@@ -12,7 +12,6 @@ import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
-import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -71,11 +70,6 @@ public class InternalGeoDistanceTests extends InternalRangeTestCase<InternalGeoD
     @Override
     protected Class<? extends InternalMultiBucketAggregation.InternalBucket> internalRangeBucketClass() {
         return InternalGeoDistance.Bucket.class;
-    }
-
-    @Override
-    protected Class<? extends ParsedMultiBucketAggregation.ParsedBucket> parsedRangeBucketClass() {
-        return ParsedGeoDistance.ParsedBucket.class;
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalRangeTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalRangeTestCase.java
@@ -11,7 +11,6 @@ package org.elasticsearch.search.aggregations.bucket.range;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
-import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
 import org.elasticsearch.test.InternalMultiBucketAggregationTestCase;
 
@@ -68,10 +67,6 @@ public abstract class InternalRangeTestCase<T extends InternalAggregation & Rang
         assertNotNull("Internal bucket class must not be null", internalBucketClass);
         assertTrue(internalBucketClass.isInstance(expected));
 
-        Class<?> parsedBucketClass = parsedRangeBucketClass();
-        assertNotNull("Parsed bucket class must not be null", parsedBucketClass);
-        assertTrue(parsedBucketClass.isInstance(actual));
-
         Range.Bucket expectedRange = (Range.Bucket) expected;
         Range.Bucket actualRange = (Range.Bucket) actual;
 
@@ -82,6 +77,4 @@ public abstract class InternalRangeTestCase<T extends InternalAggregation & Rang
     }
 
     protected abstract Class<? extends InternalMultiBucketAggregation.InternalBucket> internalRangeBucketClass();
-
-    protected abstract Class<? extends ParsedMultiBucketAggregation.ParsedBucket> parsedRangeBucketClass();
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalRangeTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalRangeTestCase.java
@@ -11,7 +11,6 @@ package org.elasticsearch.search.aggregations.bucket.range;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
-import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
 import org.elasticsearch.test.InternalMultiBucketAggregationTestCase;
 
 import java.util.List;
@@ -57,23 +56,6 @@ public abstract class InternalRangeTestCase<T extends InternalAggregation & Rang
             actualCounts.compute(bucket.getKeyAsString(), (key, oldValue) -> (oldValue == null ? 0 : oldValue) + bucket.getDocCount());
         }
         assertEquals(expectedCounts, actualCounts);
-    }
-
-    @Override
-    protected final void assertBucket(MultiBucketsAggregation.Bucket expected, MultiBucketsAggregation.Bucket actual, boolean checkOrder) {
-        super.assertBucket(expected, actual, checkOrder);
-
-        Class<?> internalBucketClass = internalRangeBucketClass();
-        assertNotNull("Internal bucket class must not be null", internalBucketClass);
-        assertTrue(internalBucketClass.isInstance(expected));
-
-        Range.Bucket expectedRange = (Range.Bucket) expected;
-        Range.Bucket actualRange = (Range.Bucket) actual;
-
-        assertEquals(expectedRange.getFrom(), actualRange.getFrom());
-        assertEquals(expectedRange.getFromAsString(), actualRange.getFromAsString());
-        assertEquals(expectedRange.getTo(), actualRange.getTo());
-        assertEquals(expectedRange.getToAsString(), actualRange.getToAsString());
     }
 
     protected abstract Class<? extends InternalMultiBucketAggregation.InternalBucket> internalRangeBucketClass();

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalRangeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalRangeTests.java
@@ -13,7 +13,6 @@ import org.elasticsearch.core.Tuple;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
-import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -84,11 +83,6 @@ public class InternalRangeTests extends InternalRangeTestCase<InternalRange<Inte
     @Override
     protected Class<? extends InternalMultiBucketAggregation.InternalBucket> internalRangeBucketClass() {
         return InternalRange.Bucket.class;
-    }
-
-    @Override
-    protected Class<? extends ParsedMultiBucketAggregation.ParsedBucket> parsedRangeBucketClass() {
-        return ParsedRange.ParsedBucket.class;
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalRangeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalRangeTests.java
@@ -82,11 +82,6 @@ public class InternalRangeTests extends InternalRangeTestCase<InternalRange<Inte
     }
 
     @Override
-    protected Class<ParsedRange> implementationClass() {
-        return ParsedRange.class;
-    }
-
-    @Override
     protected Class<? extends InternalMultiBucketAggregation.InternalBucket> internalRangeBucketClass() {
         return InternalRange.Bucket.class;
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/sampler/InternalSamplerTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/sampler/InternalSamplerTests.java
@@ -9,7 +9,6 @@ package org.elasticsearch.search.aggregations.bucket.sampler;
 
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalSingleBucketAggregationTestCase;
-import org.elasticsearch.search.aggregations.bucket.ParsedSingleBucketAggregation;
 
 import java.util.List;
 import java.util.Map;
@@ -28,10 +27,5 @@ public class InternalSamplerTests extends InternalSingleBucketAggregationTestCas
     @Override
     protected void extraAssertReduced(InternalSampler reduced, List<InternalSampler> inputs) {
         // Nothing extra to assert
-    }
-
-    @Override
-    protected Class<? extends ParsedSingleBucketAggregation> implementationClass() {
-        return ParsedSampler.class;
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTermsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTermsTests.java
@@ -64,11 +64,6 @@ public class DoubleTermsTests extends InternalTermsTestCase {
     }
 
     @Override
-    protected Class<ParsedDoubleTerms> implementationClass() {
-        return ParsedDoubleTerms.class;
-    }
-
-    @Override
     protected InternalTerms<?, ?> mutateInstance(InternalTerms<?, ?> instance) {
         if (instance instanceof DoubleTerms doubleTerms) {
             String name = doubleTerms.getName();

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/InternalSignificantTermsTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/InternalSignificantTermsTestCase.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.search.aggregations.bucket.terms;
 
 import org.elasticsearch.search.aggregations.InternalAggregations;
-import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
 import org.elasticsearch.search.aggregations.bucket.terms.heuristic.ChiSquare;
 import org.elasticsearch.search.aggregations.bucket.terms.heuristic.GND;
 import org.elasticsearch.search.aggregations.bucket.terms.heuristic.JLHScore;
@@ -142,42 +141,6 @@ public abstract class InternalSignificantTermsTestCase extends InternalMultiBuck
             expectedReducedCounts.keySet().retainAll(reducedCounts.keySet());
             assertEquals(expectedReducedCounts, reducedCounts);
         }
-    }
-
-    @Override
-    protected void assertMultiBucketsAggregation(MultiBucketsAggregation expected, MultiBucketsAggregation actual, boolean checkOrder) {
-        super.assertMultiBucketsAggregation(expected, actual, checkOrder);
-
-        assertTrue(expected instanceof InternalSignificantTerms);
-        assertTrue(actual instanceof ParsedSignificantTerms);
-
-        InternalSignificantTerms<?, ?> expectedSigTerms = (InternalSignificantTerms<?, ?>) expected;
-        ParsedSignificantTerms actualSigTerms = (ParsedSignificantTerms) actual;
-        assertEquals(expectedSigTerms.getSubsetSize(), actualSigTerms.getSubsetSize());
-        assertEquals(expectedSigTerms.getSupersetSize(), actualSigTerms.getSupersetSize());
-
-        for (SignificantTerms.Bucket bucket : (SignificantTerms) expected) {
-            String key = bucket.getKeyAsString();
-            assertBucket(expectedSigTerms.getBucketByKey(key), actualSigTerms.getBucketByKey(key), checkOrder);
-        }
-    }
-
-    @Override
-    protected void assertBucket(MultiBucketsAggregation.Bucket expected, MultiBucketsAggregation.Bucket actual, boolean checkOrder) {
-        super.assertBucket(expected, actual, checkOrder);
-
-        assertTrue(expected instanceof InternalSignificantTerms.Bucket);
-        assertTrue(actual instanceof ParsedSignificantTerms.ParsedBucket);
-
-        SignificantTerms.Bucket expectedSigTerm = (SignificantTerms.Bucket) expected;
-        SignificantTerms.Bucket actualSigTerm = (SignificantTerms.Bucket) actual;
-
-        assertEquals(expectedSigTerm.getSignificanceScore(), actualSigTerm.getSignificanceScore(), 0.0);
-        assertEquals(expectedSigTerm.getSubsetDf(), actualSigTerm.getSubsetDf());
-        assertEquals(expectedSigTerm.getDocCount(), actualSigTerm.getSubsetDf());
-        assertEquals(expectedSigTerm.getSupersetDf(), actualSigTerm.getSupersetDf());
-        assertEquals(expectedSigTerm.getSubsetSize(), actualSigTerm.getSubsetSize());
-        assertEquals(expectedSigTerm.getSupersetSize(), actualSigTerm.getSupersetSize());
     }
 
     private static Map<Object, Long> toCounts(

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/LongRareTermsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/LongRareTermsTests.java
@@ -43,11 +43,6 @@ public class LongRareTermsTests extends InternalRareTermsTestCase {
     }
 
     @Override
-    protected Class<ParsedLongRareTerms> implementationClass() {
-        return ParsedLongRareTerms.class;
-    }
-
-    @Override
     protected InternalRareTerms<?, ?> mutateInstance(InternalRareTerms<?, ?> instance) {
         if (instance instanceof LongRareTerms longRareTerms) {
             String name = longRareTerms.getName();

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/LongTermsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/LongTermsTests.java
@@ -64,11 +64,6 @@ public class LongTermsTests extends InternalTermsTestCase {
     }
 
     @Override
-    protected Class<ParsedLongTerms> implementationClass() {
-        return ParsedLongTerms.class;
-    }
-
-    @Override
     protected InternalTerms<?, ?> mutateInstance(InternalTerms<?, ?> instance) {
         if (instance instanceof LongTerms longTerms) {
             String name = longTerms.getName();

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantLongTermsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantLongTermsTests.java
@@ -65,11 +65,6 @@ public class SignificantLongTermsTests extends InternalSignificantTermsTestCase 
     }
 
     @Override
-    protected Class<ParsedSignificantLongTerms> implementationClass() {
-        return ParsedSignificantLongTerms.class;
-    }
-
-    @Override
     protected InternalSignificantTerms<?, ?> mutateInstance(InternalSignificantTerms<?, ?> instance) {
         if (instance instanceof SignificantLongTerms longTerms) {
             String name = longTerms.getName();

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantStringTermsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantStringTermsTests.java
@@ -68,11 +68,6 @@ public class SignificantStringTermsTests extends InternalSignificantTermsTestCas
     }
 
     @Override
-    protected Class<ParsedSignificantStringTerms> implementationClass() {
-        return ParsedSignificantStringTerms.class;
-    }
-
-    @Override
     protected InternalSignificantTerms<?, ?> mutateInstance(InternalSignificantTerms<?, ?> instance) {
         if (instance instanceof SignificantStringTerms stringTerms) {
             String name = stringTerms.getName();

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/StringRareTermsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/StringRareTermsTests.java
@@ -47,11 +47,6 @@ public class StringRareTermsTests extends InternalRareTermsTestCase {
     }
 
     @Override
-    protected Class<ParsedStringRareTerms> implementationClass() {
-        return ParsedStringRareTerms.class;
-    }
-
-    @Override
     protected InternalRareTerms<?, ?> mutateInstance(InternalRareTerms<?, ?> instance) {
         if (instance instanceof StringRareTerms stringRareTerms) {
             String name = stringRareTerms.getName();

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsTests.java
@@ -46,11 +46,6 @@ public class StringTermsTests extends InternalTermsTestCase {
     }
 
     @Override
-    protected Class<ParsedStringTerms> implementationClass() {
-        return ParsedStringTerms.class;
-    }
-
-    @Override
     protected InternalTerms<?, ?> mutateInstance(InternalTerms<?, ?> instance) {
         if (instance instanceof StringTerms stringTerms) {
             String name = stringTerms.getName();

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/AbstractPercentilesTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/AbstractPercentilesTestCase.java
@@ -10,7 +10,6 @@ package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.search.DocValueFormat;
-import org.elasticsearch.search.aggregations.Aggregation.CommonFields;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.test.InternalAggregationTestCase;
@@ -25,7 +24,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import static java.util.Collections.emptyMap;
@@ -72,17 +70,6 @@ public abstract class AbstractPercentilesTestCase<T extends InternalAggregation 
 
     protected abstract Class<? extends ParsedPercentiles> implementationClass();
 
-    public void testPercentilesIterators() throws IOException {
-        final T aggregation = createTestInstance();
-        final Iterable<Percentile> parsedAggregation = parseAndAssert(aggregation, false, false);
-
-        Iterator<Percentile> it = aggregation.iterator();
-        Iterator<Percentile> parsedIt = parsedAggregation.iterator();
-        while (it.hasNext()) {
-            assertEquals(it.next(), parsedIt.next());
-        }
-    }
-
     public static double[] randomPercents(boolean sorted) {
         List<Double> randomCdfValues = randomSubsetOf(randomIntBetween(1, 7), 0.01d, 0.05d, 0.25d, 0.50d, 0.75d, 0.95d, 0.99d);
         double[] percents = new double[randomCdfValues.size()];
@@ -93,11 +80,6 @@ public abstract class AbstractPercentilesTestCase<T extends InternalAggregation 
             Arrays.sort(percents);
         }
         return percents;
-    }
-
-    @Override
-    protected Predicate<String> excludePathsFromXContentInsertion() {
-        return path -> path.endsWith(CommonFields.VALUES.getPreferredName());
     }
 
     protected abstract void assertPercentile(T agg, Double value);

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/AbstractPercentilesTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/AbstractPercentilesTestCase.java
@@ -68,8 +68,6 @@ public abstract class AbstractPercentilesTestCase<T extends InternalAggregation 
         boolean empty
     );
 
-    protected abstract Class<? extends ParsedPercentiles> implementationClass();
-
     public static double[] randomPercents(boolean sorted) {
         List<Double> randomCdfValues = randomSubsetOf(randomIntBetween(1, 7), 0.01d, 0.05d, 0.25d, 0.50d, 0.75d, 0.95d, 0.99d);
         double[] percents = new double[randomCdfValues.size()];

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalAvgTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalAvgTests.java
@@ -11,7 +11,6 @@ package org.elasticsearch.search.aggregations.metrics;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.search.aggregations.support.SamplingContext;
 import org.elasticsearch.test.InternalAggregationTestCase;
 
@@ -89,16 +88,6 @@ public class InternalAvgTests extends InternalAggregationTestCase<InternalAvg> {
         InternalAvg internalAvg = new InternalAvg("dummy2", 0, 0, null, null);
         InternalAvg reduced = internalAvg.reduce(aggregations, null);
         assertEquals(expected, reduced.getValue(), delta);
-    }
-
-    @Override
-    protected void assertFromXContent(InternalAvg avg, ParsedAggregation parsedAggregation) {
-        ParsedAvg parsed = ((ParsedAvg) parsedAggregation);
-        assertEquals(avg.getValue(), parsed.getValue(), Double.MIN_VALUE);
-        // we don't print out VALUE_AS_STRING for avg.getCount() == 0, so we cannot get the exact same value back
-        if (avg.getCount() != 0) {
-            assertEquals(avg.getValueAsString(), parsed.getValueAsString());
-        }
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalCardinalityTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalCardinalityTests.java
@@ -16,7 +16,6 @@ import org.elasticsearch.common.util.MockPageCacheRecycler;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
-import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.test.InternalAggregationTestCase;
 import org.junit.After;
 
@@ -84,15 +83,6 @@ public class InternalCardinalityTests extends InternalAggregationTestCase<Intern
             }
             assertEquals(result.cardinality(0), reduced.value(), 0);
         }
-    }
-
-    @Override
-    protected void assertFromXContent(InternalCardinality aggregation, ParsedAggregation parsedAggregation) {
-        assertTrue(parsedAggregation instanceof ParsedCardinality);
-        ParsedCardinality parsed = (ParsedCardinality) parsedAggregation;
-
-        assertEquals(aggregation.getValue(), parsed.getValue(), Double.MIN_VALUE);
-        assertEquals(aggregation.getValueAsString(), parsed.getValueAsString());
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalExtendedStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalExtendedStatsTests.java
@@ -11,8 +11,6 @@ package org.elasticsearch.search.aggregations.metrics;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.ParsedAggregation;
-import org.elasticsearch.search.aggregations.metrics.ExtendedStats.Bounds;
 import org.elasticsearch.search.aggregations.support.SamplingContext;
 import org.elasticsearch.test.InternalAggregationTestCase;
 
@@ -99,73 +97,6 @@ public class InternalExtendedStatsTests extends InternalAggregationTestCase<Inte
         assertEquals(sampled.getMax(), reduced.getMax(), 0d);
         assertEquals(sampled.getMin(), reduced.getMin(), 0d);
         assertEquals(sampled.getSumOfSquares(), samplingContext.scaleUp(reduced.getSumOfSquares()), 0);
-    }
-
-    @Override
-    protected void assertFromXContent(InternalExtendedStats aggregation, ParsedAggregation parsedAggregation) {
-        assertTrue(parsedAggregation instanceof ParsedExtendedStats);
-        ParsedExtendedStats parsed = (ParsedExtendedStats) parsedAggregation;
-        InternalStatsTests.assertStats(aggregation, parsed);
-
-        long count = aggregation.getCount();
-        // for count == 0, fields are rendered as `null`, so we test that we parse to default values used also in the reduce phase
-        assertEquals(count > 0 ? aggregation.getSumOfSquares() : 0, parsed.getSumOfSquares(), 0);
-        assertEquals(count > 0 ? aggregation.getVariance() : 0, parsed.getVariance(), 0);
-        assertEquals(count > 0 ? aggregation.getVariancePopulation() : 0, parsed.getVariancePopulation(), 0);
-        assertEquals(count > 0 ? aggregation.getVarianceSampling() : 0, parsed.getVarianceSampling(), 0);
-        assertEquals(count > 0 ? aggregation.getStdDeviation() : 0, parsed.getStdDeviation(), 0);
-        assertEquals(count > 0 ? aggregation.getStdDeviationPopulation() : 0, parsed.getStdDeviationPopulation(), 0);
-        assertEquals(count > 0 ? aggregation.getStdDeviationSampling() : 0, parsed.getStdDeviationSampling(), 0);
-        assertEquals(count > 0 ? aggregation.getStdDeviationBound(Bounds.LOWER) : 0, parsed.getStdDeviationBound(Bounds.LOWER), 0);
-        assertEquals(count > 0 ? aggregation.getStdDeviationBound(Bounds.UPPER) : 0, parsed.getStdDeviationBound(Bounds.UPPER), 0);
-        assertEquals(
-            count > 0 ? aggregation.getStdDeviationBound(Bounds.LOWER_POPULATION) : 0,
-            parsed.getStdDeviationBound(Bounds.LOWER_POPULATION),
-            0
-        );
-        assertEquals(
-            count > 0 ? aggregation.getStdDeviationBound(Bounds.UPPER_POPULATION) : 0,
-            parsed.getStdDeviationBound(Bounds.UPPER_POPULATION),
-            0
-        );
-        assertEquals(
-            count > 0 ? aggregation.getStdDeviationBound(Bounds.LOWER_SAMPLING) : 0,
-            parsed.getStdDeviationBound(Bounds.LOWER_SAMPLING),
-            0
-        );
-        assertEquals(
-            count > 0 ? aggregation.getStdDeviationBound(Bounds.UPPER_SAMPLING) : 0,
-            parsed.getStdDeviationBound(Bounds.UPPER_SAMPLING),
-            0
-        );
-        // also as_string values are only rendered for count != 0
-        if (count > 0) {
-            assertEquals(aggregation.getSumOfSquaresAsString(), parsed.getSumOfSquaresAsString());
-            assertEquals(aggregation.getVarianceAsString(), parsed.getVarianceAsString());
-            assertEquals(aggregation.getVariancePopulationAsString(), parsed.getVariancePopulationAsString());
-            assertEquals(aggregation.getVarianceSamplingAsString(), parsed.getVarianceSamplingAsString());
-            assertEquals(aggregation.getStdDeviationAsString(), parsed.getStdDeviationAsString());
-            assertEquals(aggregation.getStdDeviationPopulationAsString(), parsed.getStdDeviationPopulationAsString());
-            assertEquals(aggregation.getStdDeviationSamplingAsString(), parsed.getStdDeviationSamplingAsString());
-            assertEquals(aggregation.getStdDeviationBoundAsString(Bounds.LOWER), parsed.getStdDeviationBoundAsString(Bounds.LOWER));
-            assertEquals(aggregation.getStdDeviationBoundAsString(Bounds.UPPER), parsed.getStdDeviationBoundAsString(Bounds.UPPER));
-            assertEquals(
-                aggregation.getStdDeviationBoundAsString(Bounds.LOWER_POPULATION),
-                parsed.getStdDeviationBoundAsString(Bounds.LOWER_POPULATION)
-            );
-            assertEquals(
-                aggregation.getStdDeviationBoundAsString(Bounds.UPPER_POPULATION),
-                parsed.getStdDeviationBoundAsString(Bounds.UPPER_POPULATION)
-            );
-            assertEquals(
-                aggregation.getStdDeviationBoundAsString(Bounds.LOWER_SAMPLING),
-                parsed.getStdDeviationBoundAsString(Bounds.LOWER_SAMPLING)
-            );
-            assertEquals(
-                aggregation.getStdDeviationBoundAsString(Bounds.UPPER_SAMPLING),
-                parsed.getStdDeviationBoundAsString(Bounds.UPPER_SAMPLING)
-            );
-        }
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalGeoBoundsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalGeoBoundsTests.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.common.util.Maps;
-import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.search.aggregations.support.SamplingContext;
 import org.elasticsearch.test.InternalAggregationTestCase;
 
@@ -97,15 +96,6 @@ public class InternalGeoBoundsTests extends InternalAggregationTestCase<Internal
         assertValueClose(sampled.posRight, reduced.posRight);
         assertValueClose(sampled.negLeft, reduced.negLeft);
         assertValueClose(sampled.negRight, reduced.negRight);
-    }
-
-    @Override
-    protected void assertFromXContent(InternalGeoBounds aggregation, ParsedAggregation parsedAggregation) {
-        assertTrue(parsedAggregation instanceof ParsedGeoBounds);
-        ParsedGeoBounds parsed = (ParsedGeoBounds) parsedAggregation;
-
-        assertEquals(aggregation.topLeft(), parsed.topLeft());
-        assertEquals(aggregation.bottomRight(), parsed.bottomRight());
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalGeoCentroidTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalGeoCentroidTests.java
@@ -11,7 +11,6 @@ import org.apache.lucene.geo.GeoEncodingUtils;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.SpatialPoint;
 import org.elasticsearch.common.util.Maps;
-import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.search.aggregations.support.SamplingContext;
 import org.elasticsearch.test.InternalAggregationTestCase;
 import org.elasticsearch.test.geo.RandomGeoGenerator;
@@ -84,15 +83,6 @@ public class InternalGeoCentroidTests extends InternalAggregationTestCase<Intern
         );
         InternalCentroid reducedGeoCentroid = maxValueGeoCentroid.reduce(Collections.singletonList(maxValueGeoCentroid), null);
         assertThat(reducedGeoCentroid.count(), equalTo(Long.MAX_VALUE));
-    }
-
-    @Override
-    protected void assertFromXContent(InternalGeoCentroid aggregation, ParsedAggregation parsedAggregation) {
-        assertTrue(parsedAggregation instanceof ParsedGeoCentroid);
-        ParsedGeoCentroid parsed = (ParsedGeoCentroid) parsedAggregation;
-
-        assertEquals(aggregation.centroid(), parsed.centroid());
-        assertEquals(aggregation.count(), parsed.count());
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalHDRPercentilesRanksTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalHDRPercentilesRanksTests.java
@@ -68,11 +68,6 @@ public class InternalHDRPercentilesRanksTests extends InternalPercentilesRanksTe
     }
 
     @Override
-    protected Class<? extends ParsedPercentiles> implementationClass() {
-        return ParsedHDRPercentileRanks.class;
-    }
-
-    @Override
     protected InternalHDRPercentileRanks mutateInstance(InternalHDRPercentileRanks instance) {
         String name = instance.getName();
         double[] percents = instance.keys;

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalHDRPercentilesTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalHDRPercentilesTests.java
@@ -69,11 +69,6 @@ public class InternalHDRPercentilesTests extends InternalPercentilesTestCase<Int
         }
     }
 
-    @Override
-    protected Class<? extends ParsedPercentiles> implementationClass() {
-        return ParsedHDRPercentiles.class;
-    }
-
     public void testIterator() {
         final double[] percents = randomPercents(false);
         final double[] values = new double[frequently() ? randomIntBetween(1, 10) : 0];

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalMedianAbsoluteDeviationTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalMedianAbsoluteDeviationTests.java
@@ -9,11 +9,9 @@
 package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.common.util.Maps;
-import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.search.aggregations.support.SamplingContext;
 import org.elasticsearch.test.InternalAggregationTestCase;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -62,14 +60,6 @@ public class InternalMedianAbsoluteDeviationTests extends InternalAggregationTes
         SamplingContext samplingContext
     ) {
         assertThat(sampled.getMedianAbsoluteDeviation(), equalTo(reduced.getMedianAbsoluteDeviation()));
-    }
-
-    @Override
-    protected void assertFromXContent(InternalMedianAbsoluteDeviation internalMAD, ParsedAggregation parsedAggregation) throws IOException {
-        assertTrue(parsedAggregation instanceof ParsedMedianAbsoluteDeviation);
-        ParsedMedianAbsoluteDeviation parsedMAD = (ParsedMedianAbsoluteDeviation) parsedAggregation;
-        // Double.compare handles NaN, which we use for no result
-        assertEquals(internalMAD.getMedianAbsoluteDeviation(), parsedMAD.getMedianAbsoluteDeviation(), 0);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalPercentilesRanksTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalPercentilesRanksTestCase.java
@@ -9,27 +9,11 @@
 package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.ParsedAggregation;
 
 import static org.hamcrest.Matchers.equalTo;
 
 public abstract class InternalPercentilesRanksTestCase<T extends InternalAggregation & PercentileRanks> extends AbstractPercentilesTestCase<
     T> {
-
-    @Override
-    protected final void assertFromXContent(T aggregation, ParsedAggregation parsedAggregation) {
-        assertTrue(parsedAggregation instanceof PercentileRanks);
-        PercentileRanks parsedPercentileRanks = (PercentileRanks) parsedAggregation;
-
-        for (Percentile percentile : aggregation) {
-            Double value = percentile.value();
-            assertEquals(aggregation.percent(value), parsedPercentileRanks.percent(value), 0);
-            assertEquals(aggregation.percentAsString(value), parsedPercentileRanks.percentAsString(value));
-        }
-
-        Class<? extends ParsedPercentiles> parsedClass = implementationClass();
-        assertTrue(parsedClass != null && parsedClass.isInstance(parsedAggregation));
-    }
 
     @Override
     protected void assertPercentile(T agg, Double value) {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalPercentilesTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalPercentilesTestCase.java
@@ -9,28 +9,12 @@
 package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.ParsedAggregation;
 
 import java.util.List;
 
 import static org.hamcrest.Matchers.equalTo;
 
 public abstract class InternalPercentilesTestCase<T extends InternalAggregation & Percentiles> extends AbstractPercentilesTestCase<T> {
-
-    @Override
-    protected final void assertFromXContent(T aggregation, ParsedAggregation parsedAggregation) {
-        assertTrue(parsedAggregation instanceof Percentiles);
-        Percentiles parsedPercentiles = (Percentiles) parsedAggregation;
-
-        for (Percentile percentile : aggregation) {
-            Double percent = percentile.percent();
-            assertEquals(aggregation.percentile(percent), parsedPercentiles.percentile(percent), 0);
-            assertEquals(aggregation.percentileAsString(percent), parsedPercentiles.percentileAsString(percent));
-        }
-
-        Class<? extends ParsedPercentiles> parsedClass = implementationClass();
-        assertTrue(parsedClass != null && parsedClass.isInstance(parsedAggregation));
-    }
 
     public static double[] randomPercents() {
         List<Double> randomCdfValues = randomSubsetOf(randomIntBetween(1, 7), 0.01d, 0.05d, 0.25d, 0.50d, 0.75d, 0.95d, 0.99d);

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalScriptedMetricTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalScriptedMetricTests.java
@@ -17,10 +17,8 @@ import org.elasticsearch.script.ScriptEngine;
 import org.elasticsearch.script.ScriptModule;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.script.ScriptType;
-import org.elasticsearch.search.aggregations.Aggregation.CommonFields;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationReduceContext;
-import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator.PipelineTree;
 import org.elasticsearch.search.aggregations.support.SamplingContext;
 import org.elasticsearch.test.InternalAggregationTestCase;
@@ -31,7 +29,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import static java.util.Collections.singletonList;
@@ -183,14 +180,6 @@ public class InternalScriptedMetricTests extends InternalAggregationTestCase<Int
         );
     }
 
-    @Override
-    protected void assertFromXContent(InternalScriptedMetric aggregation, ParsedAggregation parsedAggregation) {
-        assertTrue(parsedAggregation instanceof ParsedScriptedMetric);
-        ParsedScriptedMetric parsed = (ParsedScriptedMetric) parsedAggregation;
-
-        assertValues(aggregation.aggregation(), parsed.aggregation());
-    }
-
     private static void assertValues(Object expected, Object actual) {
         if (expected instanceof Long) {
             // longs that fit into the integer range are parsed back as integer
@@ -234,11 +223,6 @@ public class InternalScriptedMetricTests extends InternalAggregationTestCase<Int
         } else {
             assertEquals(expected, actual);
         }
-    }
-
-    @Override
-    protected Predicate<String> excludePathsFromXContentInsertion() {
-        return path -> path.contains(CommonFields.VALUE.getPreferredName());
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalStatsBucketTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalStatsBucketTests.java
@@ -9,9 +9,7 @@
 package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.search.DocValueFormat;
-import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.search.aggregations.pipeline.InternalStatsBucket;
-import org.elasticsearch.search.aggregations.pipeline.ParsedStatsBucket;
 
 import java.util.List;
 import java.util.Map;
@@ -39,11 +37,5 @@ public class InternalStatsBucketTests extends InternalStatsTests {
     @Override
     protected void assertReduced(InternalStats reduced, List<InternalStats> inputs) {
         // no test since reduce operation is unsupported
-    }
-
-    @Override
-    protected void assertFromXContent(InternalStats aggregation, ParsedAggregation parsedAggregation) {
-        super.assertFromXContent(aggregation, parsedAggregation);
-        assertTrue(parsedAggregation instanceof ParsedStatsBucket);
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalStatsTests.java
@@ -134,23 +134,6 @@ public class InternalStatsTests extends InternalAggregationTestCase<InternalStat
         assertEquals(max, reduced.getMax(), 0d);
     }
 
-    static void assertStats(InternalStats aggregation, ParsedStats parsed) {
-        long count = aggregation.getCount();
-        assertEquals(count, parsed.getCount());
-        // for count == 0, fields are rendered as `null`, so we test that we parse to default values used also in the reduce phase
-        assertEquals(count > 0 ? aggregation.getMin() : Double.POSITIVE_INFINITY, parsed.getMin(), 0);
-        assertEquals(count > 0 ? aggregation.getMax() : Double.NEGATIVE_INFINITY, parsed.getMax(), 0);
-        assertEquals(count > 0 ? aggregation.getSum() : 0, parsed.getSum(), 0);
-        assertEquals(count > 0 ? aggregation.getAvg() : 0, parsed.getAvg(), 0);
-        // also as_string values are only rendered for count != 0
-        if (count > 0) {
-            assertEquals(aggregation.getMinAsString(), parsed.getMinAsString());
-            assertEquals(aggregation.getMaxAsString(), parsed.getMaxAsString());
-            assertEquals(aggregation.getSumAsString(), parsed.getSumAsString());
-            assertEquals(aggregation.getAvgAsString(), parsed.getAvgAsString());
-        }
-    }
-
     @Override
     protected InternalStats mutateInstance(InternalStats instance) {
         String name = instance.getName();

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalStatsTests.java
@@ -12,7 +12,6 @@ import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.search.aggregations.support.SamplingContext;
 import org.elasticsearch.test.InternalAggregationTestCase;
 import org.elasticsearch.xcontent.ToXContent;
@@ -133,13 +132,6 @@ public class InternalStatsTests extends InternalAggregationTestCase<InternalStat
         assertEquals(expectedAvg, reduced.getAvg(), delta);
         assertEquals(min, reduced.getMin(), 0d);
         assertEquals(max, reduced.getMax(), 0d);
-    }
-
-    @Override
-    protected void assertFromXContent(InternalStats aggregation, ParsedAggregation parsedAggregation) {
-        assertTrue(parsedAggregation instanceof ParsedStats);
-        ParsedStats parsed = (ParsedStats) parsedAggregation;
-        assertStats(aggregation, parsed);
     }
 
     static void assertStats(InternalStats aggregation, ParsedStats parsed) {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalTDigestPercentilesRanksTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalTDigestPercentilesRanksTests.java
@@ -83,11 +83,6 @@ public class InternalTDigestPercentilesRanksTests extends InternalPercentilesRan
     }
 
     @Override
-    protected Class<? extends ParsedPercentiles> implementationClass() {
-        return ParsedTDigestPercentileRanks.class;
-    }
-
-    @Override
     protected InternalTDigestPercentileRanks mutateInstance(InternalTDigestPercentileRanks instance) {
         String name = instance.getName();
         double[] percents = instance.keys;

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalTDigestPercentilesTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalTDigestPercentilesTests.java
@@ -75,11 +75,6 @@ public class InternalTDigestPercentilesTests extends InternalPercentilesTestCase
     }
 
     @Override
-    protected Class<? extends ParsedPercentiles> implementationClass() {
-        return ParsedTDigestPercentiles.class;
-    }
-
-    @Override
     protected InternalTDigestPercentiles mutateInstance(InternalTDigestPercentiles instance) {
         String name = instance.getName();
         double[] percents = instance.keys;

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalTopHitsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalTopHitsTests.java
@@ -29,7 +29,6 @@ import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
-import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.search.aggregations.support.SamplingContext;
 import org.elasticsearch.search.lookup.Source;
 import org.elasticsearch.test.ESTestCase;
@@ -42,7 +41,6 @@ import org.elasticsearch.xcontent.json.JsonXContent;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -186,35 +184,6 @@ public class InternalTopHitsTests extends InternalAggregationTestCase<InternalTo
         for (int i = 0; i < searchHits.length; i++) {
             searchHits[i] = hitScores.get(i).v1();
             scoreDocs[i] = hitScores.get(i).v2();
-        }
-    }
-
-    @Override
-    protected void assertFromXContent(InternalTopHits aggregation, ParsedAggregation parsedAggregation) throws IOException {
-        final SearchHits expectedSearchHits = aggregation.getHits();
-
-        assertTrue(parsedAggregation instanceof ParsedTopHits);
-        ParsedTopHits parsed = (ParsedTopHits) parsedAggregation;
-        final SearchHits actualSearchHits = parsed.getHits();
-
-        assertEquals(expectedSearchHits.getTotalHits().value, actualSearchHits.getTotalHits().value);
-        assertEquals(expectedSearchHits.getTotalHits().relation, actualSearchHits.getTotalHits().relation);
-        assertEquals(expectedSearchHits.getMaxScore(), actualSearchHits.getMaxScore(), 0.0f);
-
-        List<SearchHit> expectedHits = Arrays.asList(expectedSearchHits.getHits());
-        List<SearchHit> actualHits = Arrays.asList(actualSearchHits.getHits());
-
-        assertEquals(expectedHits.size(), actualHits.size());
-        for (int i = 0; i < expectedHits.size(); i++) {
-            SearchHit expected = expectedHits.get(i);
-            SearchHit actual = actualHits.get(i);
-
-            assertEquals(expected.getIndex(), actual.getIndex());
-            assertEquals(expected.getId(), actual.getId());
-            assertEquals(expected.getVersion(), actual.getVersion());
-            assertEquals(expected.getScore(), actual.getScore(), 0.0f);
-            assertEquals(expected.getFields(), actual.getFields());
-            assertEquals(expected.getSourceAsMap(), actual.getSourceAsMap());
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalValueCountTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalValueCountTests.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.common.util.Maps;
-import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.search.aggregations.support.SamplingContext;
 import org.elasticsearch.test.InternalAggregationTestCase;
 
@@ -39,12 +38,6 @@ public class InternalValueCountTests extends InternalAggregationTestCase<Interna
     @Override
     protected void assertSampled(InternalValueCount sampled, InternalValueCount reduced, SamplingContext samplingContext) {
         assertThat(sampled.getValue(), equalTo(samplingContext.scaleUp(reduced.getValue())));
-    }
-
-    @Override
-    protected void assertFromXContent(InternalValueCount valueCount, ParsedAggregation parsedAggregation) {
-        assertEquals(valueCount.getValue(), ((ParsedValueCount) parsedAggregation).getValue(), 0);
-        assertEquals(valueCount.getValueAsString(), ((ParsedValueCount) parsedAggregation).getValueAsString());
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalWeightedAvgTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalWeightedAvgTests.java
@@ -10,7 +10,6 @@ package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.DocValueFormat;
-import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.search.aggregations.support.SamplingContext;
 import org.elasticsearch.test.InternalAggregationTestCase;
 
@@ -55,16 +54,6 @@ public class InternalWeightedAvgTests extends InternalAggregationTestCase<Intern
     @Override
     protected void assertSampled(InternalWeightedAvg sampled, InternalWeightedAvg reduced, SamplingContext samplingContext) {
         assertThat(sampled.getValue(), equalTo(reduced.getValue()));
-    }
-
-    @Override
-    protected void assertFromXContent(InternalWeightedAvg avg, ParsedAggregation parsedAggregation) {
-        ParsedWeightedAvg parsed = ((ParsedWeightedAvg) parsedAggregation);
-        assertEquals(avg.getValue(), parsed.getValue(), Double.MIN_VALUE);
-        // we don't print out VALUE_AS_STRING for avg.getCount() == 0, so we cannot get the exact same value back
-        if (avg.getWeight() != 0) {
-            assertEquals(avg.getValueAsString(), parsed.getValueAsString());
-        }
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/MaxTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/MaxTests.java
@@ -10,7 +10,6 @@ package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.DocValueFormat;
-import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.search.aggregations.support.SamplingContext;
 import org.elasticsearch.test.InternalAggregationTestCase;
 
@@ -42,19 +41,6 @@ public class MaxTests extends InternalAggregationTestCase<Max> {
     @Override
     protected void assertSampled(Max sampled, Max reduced, SamplingContext samplingContext) {
         assertThat(sampled.value(), equalTo(reduced.value()));
-    }
-
-    @Override
-    protected void assertFromXContent(Max max, ParsedAggregation parsedAggregation) {
-        ParsedMax parsed = ((ParsedMax) parsedAggregation);
-        if (Double.isInfinite(max.value()) == false) {
-            assertEquals(max.value(), parsed.value(), Double.MIN_VALUE);
-            assertEquals(max.getValueAsString(), parsed.getValueAsString());
-        } else {
-            // we write Double.NEGATIVE_INFINITY and Double.POSITIVE_INFINITY to xContent as 'null', so we
-            // cannot differentiate between them. Also we cannot recreate the exact String representation
-            assertEquals(parsed.value(), Double.NEGATIVE_INFINITY, 0);
-        }
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/MinTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/MinTests.java
@@ -10,7 +10,6 @@ package org.elasticsearch.search.aggregations.metrics;
 
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.DocValueFormat;
-import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.search.aggregations.support.SamplingContext;
 import org.elasticsearch.test.InternalAggregationTestCase;
 
@@ -41,19 +40,6 @@ public class MinTests extends InternalAggregationTestCase<Min> {
     @Override
     protected void assertSampled(Min sampled, Min reduced, SamplingContext samplingContext) {
         assertThat(sampled.value(), equalTo(reduced.value()));
-    }
-
-    @Override
-    protected void assertFromXContent(Min min, ParsedAggregation parsedAggregation) {
-        ParsedMin parsed = ((ParsedMin) parsedAggregation);
-        if (Double.isInfinite(min.value()) == false) {
-            assertEquals(min.value(), parsed.value(), Double.MIN_VALUE);
-            assertEquals(min.getValueAsString(), parsed.getValueAsString());
-        } else {
-            // we write Double.NEGATIVE_INFINITY and Double.POSITIVE_INFINITY to xContent as 'null', so we
-            // cannot differentiate between them. Also we cannot recreate the exact String representation
-            assertEquals(parsed.value(), Double.POSITIVE_INFINITY, 0);
-        }
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/SumTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/SumTests.java
@@ -10,7 +10,6 @@ package org.elasticsearch.search.aggregations.metrics;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.search.aggregations.support.SamplingContext;
 import org.elasticsearch.test.InternalAggregationTestCase;
 
@@ -82,13 +81,6 @@ public class SumTests extends InternalAggregationTestCase<Sum> {
         Sum internalSum = new Sum("dummy", 0, null, null);
         Sum reduced = internalSum.reduce(aggregations, null);
         assertEquals(expected, reduced.value(), delta);
-    }
-
-    @Override
-    protected void assertFromXContent(Sum sum, ParsedAggregation parsedAggregation) {
-        ParsedSum parsed = ((ParsedSum) parsedAggregation);
-        assertEquals(sum.value(), parsed.value(), Double.MIN_VALUE);
-        assertEquals(sum.getValueAsString(), parsed.getValueAsString());
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/InternalBucketMetricValueTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/InternalBucketMetricValueTests.java
@@ -10,7 +10,6 @@ package org.elasticsearch.search.aggregations.pipeline;
 
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.DocValueFormat;
-import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.test.InternalAggregationTestCase;
 
 import java.util.Arrays;
@@ -40,20 +39,6 @@ public class InternalBucketMetricValueTests extends InternalAggregationTestCase<
     @Override
     protected void assertReduced(InternalBucketMetricValue reduced, List<InternalBucketMetricValue> inputs) {
         // no test since reduce operation is unsupported
-    }
-
-    @Override
-    protected void assertFromXContent(InternalBucketMetricValue bucketMetricValue, ParsedAggregation parsedAggregation) {
-        BucketMetricValue parsed = ((BucketMetricValue) parsedAggregation);
-        assertArrayEquals(bucketMetricValue.keys(), parsed.keys());
-        if (Double.isInfinite(bucketMetricValue.value()) == false) {
-            assertEquals(bucketMetricValue.value(), parsed.value(), 0);
-            assertEquals(bucketMetricValue.getValueAsString(), parsed.getValueAsString());
-        } else {
-            // we write Double.NEGATIVE_INFINITY and Double.POSITIVE_INFINITY to xContent as 'null', so we
-            // cannot differentiate between them. Also we cannot recreate the exact String representation
-            assertEquals(parsed.value(), Double.NEGATIVE_INFINITY, 0);
-        }
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/InternalExtendedStatsBucketTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/InternalExtendedStatsBucketTests.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.search.aggregations.pipeline;
 
 import org.elasticsearch.search.DocValueFormat;
-import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.search.aggregations.metrics.InternalExtendedStats;
 import org.elasticsearch.search.aggregations.metrics.InternalExtendedStatsTests;
 
@@ -41,11 +40,5 @@ public class InternalExtendedStatsBucketTests extends InternalExtendedStatsTests
     @Override
     protected void assertReduced(InternalExtendedStats reduced, List<InternalExtendedStats> inputs) {
         // no test since reduce operation is unsupported
-    }
-
-    @Override
-    protected void assertFromXContent(InternalExtendedStats aggregation, ParsedAggregation parsedAggregation) {
-        super.assertFromXContent(aggregation, parsedAggregation);
-        assertTrue(parsedAggregation instanceof ParsedExtendedStatsBucket);
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/InternalPercentilesBucketTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/InternalPercentilesBucketTests.java
@@ -11,8 +11,6 @@ package org.elasticsearch.search.aggregations.pipeline;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.DocValueFormat;
-import org.elasticsearch.search.aggregations.Aggregation.CommonFields;
-import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.search.aggregations.metrics.Percentile;
 import org.elasticsearch.test.InternalAggregationTestCase;
 import org.elasticsearch.xcontent.ToXContent;
@@ -27,7 +25,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Predicate;
 
 import static org.elasticsearch.search.aggregations.metrics.InternalPercentilesTestCase.randomPercents;
 import static org.hamcrest.Matchers.equalTo;
@@ -73,22 +70,6 @@ public class InternalPercentilesBucketTests extends InternalAggregationTestCase<
         // no test since reduce operation is unsupported
     }
 
-    @Override
-    protected final void assertFromXContent(InternalPercentilesBucket aggregation, ParsedAggregation parsedAggregation) {
-        assertTrue(parsedAggregation instanceof ParsedPercentilesBucket);
-        ParsedPercentilesBucket parsedPercentiles = (ParsedPercentilesBucket) parsedAggregation;
-
-        for (Percentile percentile : aggregation) {
-            Double percent = percentile.percent();
-            assertEquals(aggregation.percentile(percent), parsedPercentiles.percentile(percent), 0);
-            // we cannot ensure we get the same as_string output for Double.NaN values since they are rendered as
-            // null and we don't have a formatted string representation in the rest output
-            if (Double.isNaN(aggregation.percentile(percent)) == false) {
-                assertEquals(aggregation.percentileAsString(percent), parsedPercentiles.percentileAsString(percent));
-            }
-        }
-    }
-
     /**
      * check that we don't rely on the percent array order and that the iterator returns the values in the original order
      */
@@ -124,16 +105,6 @@ public class InternalPercentilesBucketTests extends InternalAggregationTestCase<
             "The number of provided percents and percentiles didn't match. percents: [0.1, 0.2, 0.3], percentiles: [0.1, 0.2]",
             e.getMessage()
         );
-    }
-
-    public void testParsedAggregationIteratorOrder() throws IOException {
-        final InternalPercentilesBucket aggregation = createTestInstance();
-        final Iterable<Percentile> parsedAggregation = parseAndAssert(aggregation, false, false);
-        Iterator<Percentile> it = aggregation.iterator();
-        Iterator<Percentile> parsedIt = parsedAggregation.iterator();
-        while (it.hasNext()) {
-            assertEquals(it.next(), parsedIt.next());
-        }
     }
 
     public void testEmptyRanksXContent() throws IOException {
@@ -181,11 +152,6 @@ public class InternalPercentilesBucketTests extends InternalAggregationTestCase<
         }
 
         assertThat(Strings.toString(builder), equalTo(expected));
-    }
-
-    @Override
-    protected Predicate<String> excludePathsFromXContentInsertion() {
-        return path -> path.endsWith(CommonFields.VALUES.getPreferredName());
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/InternalSimpleValueTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/InternalSimpleValueTests.java
@@ -10,7 +10,6 @@ package org.elasticsearch.search.aggregations.pipeline;
 
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.search.DocValueFormat;
-import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.test.InternalAggregationTestCase;
 
 import java.util.HashMap;
@@ -36,19 +35,6 @@ public class InternalSimpleValueTests extends InternalAggregationTestCase<Intern
     @Override
     protected void assertReduced(InternalSimpleValue reduced, List<InternalSimpleValue> inputs) {
         // no test since reduce operation is unsupported
-    }
-
-    @Override
-    protected void assertFromXContent(InternalSimpleValue simpleValue, ParsedAggregation parsedAggregation) {
-        ParsedSimpleValue parsed = ((ParsedSimpleValue) parsedAggregation);
-        if (Double.isInfinite(simpleValue.getValue()) == false && Double.isNaN(simpleValue.getValue()) == false) {
-            assertEquals(simpleValue.getValue(), parsed.value(), 0);
-            assertEquals(simpleValue.getValueAsString(), parsed.getValueAsString());
-        } else {
-            // we write Double.NEGATIVE_INFINITY, Double.POSITIVE amd Double.NAN to xContent as 'null', so we
-            // cannot differentiate between them. Also we cannot recreate the exact String representation
-            assertEquals(parsed.value(), Double.NaN, 0);
-        }
     }
 
     @Override

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/InternalSingleBucketAggregationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/InternalSingleBucketAggregationTestCase.java
@@ -8,18 +8,12 @@
 
 package org.elasticsearch.search.aggregations;
 
-import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.util.Maps;
-import org.elasticsearch.rest.action.search.RestSearchAction;
 import org.elasticsearch.search.aggregations.bucket.InternalSingleBucketAggregation;
-import org.elasticsearch.search.aggregations.bucket.ParsedSingleBucketAggregation;
 import org.elasticsearch.search.aggregations.metrics.Max;
 import org.elasticsearch.search.aggregations.metrics.Min;
 import org.elasticsearch.test.InternalAggregationTestCase;
-import org.elasticsearch.xcontent.ToXContent;
-import org.elasticsearch.xcontent.XContentType;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -27,9 +21,6 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 import static java.util.Collections.emptyMap;
-import static java.util.Collections.singletonMap;
-import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
 
 public abstract class InternalSingleBucketAggregationTestCase<T extends InternalSingleBucketAggregation> extends
     InternalAggregationTestCase<T> {
@@ -115,38 +106,4 @@ public abstract class InternalSingleBucketAggregationTestCase<T extends Internal
         }
         extraAssertReduced(reduced, inputs);
     }
-
-    @Override
-    protected void assertFromXContent(T aggregation, ParsedAggregation parsedAggregation) throws IOException {
-        assertTrue(parsedAggregation instanceof ParsedSingleBucketAggregation);
-        ParsedSingleBucketAggregation parsed = (ParsedSingleBucketAggregation) parsedAggregation;
-
-        assertEquals(aggregation.getDocCount(), parsed.getDocCount());
-        InternalAggregations aggregations = aggregation.getAggregations();
-        Map<String, Aggregation> expectedAggregations = new HashMap<>();
-        int expectedNumberOfAggregations = 0;
-        for (Aggregation expectedAggregation : aggregations) {
-            // since we shuffle xContent, we cannot rely on the order of the original inner aggregations for comparison
-            assertTrue(expectedAggregation instanceof InternalAggregation);
-            expectedAggregations.put(expectedAggregation.getName(), expectedAggregation);
-            expectedNumberOfAggregations++;
-        }
-        int parsedNumberOfAggregations = 0;
-        for (Aggregation parsedAgg : parsed.getAggregations()) {
-            assertTrue(parsedAgg instanceof ParsedAggregation);
-            assertTrue(expectedAggregations.keySet().contains(parsedAgg.getName()));
-            Aggregation expectedInternalAggregation = expectedAggregations.get(parsedAgg.getName());
-            final XContentType xContentType = randomFrom(XContentType.values());
-            final ToXContent.Params params = new ToXContent.MapParams(singletonMap(RestSearchAction.TYPED_KEYS_PARAM, "true"));
-            BytesReference expectedBytes = toXContent(expectedInternalAggregation, xContentType, params, false);
-            BytesReference actualBytes = toXContent(parsedAgg, xContentType, params, false);
-            assertToXContentEquivalent(expectedBytes, actualBytes, xContentType);
-            parsedNumberOfAggregations++;
-        }
-        assertEquals(expectedNumberOfAggregations, parsedNumberOfAggregations);
-        Class<? extends ParsedSingleBucketAggregation> parsedClass = implementationClass();
-        assertTrue(parsedClass != null && parsedClass.isInstance(parsedAggregation));
-    }
-
-    protected abstract Class<? extends ParsedSingleBucketAggregation> implementationClass();
 }

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoGridTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoGridTestCase.java
@@ -119,11 +119,6 @@ public abstract class GeoGridTestCase<B extends InternalGeoGridBucket, T extends
     }
 
     @Override
-    protected Class<ParsedGeoGrid> implementationClass() {
-        return ParsedGeoGrid.class;
-    }
-
-    @Override
     protected T mutateInstance(T instance) {
         String name = instance.getName();
         int size = instance.getRequiredSize();

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalAggregationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalAggregationTestCase.java
@@ -18,14 +18,12 @@ import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.common.util.MockPageCacheRecycler;
-import org.elasticsearch.common.xcontent.ChunkedToXContent;
 import org.elasticsearch.index.mapper.DateFieldMapper.Resolution;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.DocValueFormat;
-import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
 import org.elasticsearch.search.aggregations.Aggregation;
@@ -37,16 +35,10 @@ import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.MultiBucketConsumerService;
 import org.elasticsearch.search.aggregations.MultiBucketConsumerService.MultiBucketConsumer;
-import org.elasticsearch.search.aggregations.ParsedAggregation;
-import org.elasticsearch.search.aggregations.metrics.TopHits;
-import org.elasticsearch.search.aggregations.metrics.TopHitsAggregationBuilder;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator.PipelineTree;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.SamplingContext;
-import org.elasticsearch.xcontent.ObjectParser;
-import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -433,47 +425,6 @@ public abstract class InternalAggregationTestCase<T extends InternalAggregation>
         @Override
         public TransportVersion getMinimalSupportedVersion() {
             return TransportVersions.ZERO;
-        }
-    }
-
-    protected static class ParsedTopHits extends ParsedAggregation implements TopHits {
-
-        private SearchHits searchHits;
-
-        @Override
-        public String getType() {
-            return TopHitsAggregationBuilder.NAME;
-        }
-
-        @Override
-        public SearchHits getHits() {
-            return searchHits;
-        }
-
-        @Override
-        protected XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
-            return ChunkedToXContent.wrapAsToXContent(searchHits).toXContent(builder, params);
-        }
-
-        private static final ObjectParser<ParsedTopHits, Void> PARSER = new ObjectParser<>(
-            ParsedTopHits.class.getSimpleName(),
-            true,
-            ParsedTopHits::new
-        );
-
-        static {
-            declareAggregationFields(PARSER);
-            PARSER.declareObject(
-                (topHit, searchHits) -> topHit.searchHits = searchHits,
-                (parser, context) -> SearchHits.fromXContent(parser),
-                new ParseField(SearchHits.Fields.HITS)
-            );
-        }
-
-        public static ParsedTopHits fromXContent(XContentParser parser, String name) throws IOException {
-            ParsedTopHits aggregation = PARSER.parse(parser, null);
-            aggregation.setName(name);
-            return aggregation;
         }
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalAggregationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalAggregationTestCase.java
@@ -8,12 +8,9 @@
 
 package org.elasticsearch.test;
 
-import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.breaker.CircuitBreaker;
-import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
@@ -22,12 +19,10 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.common.util.MockPageCacheRecycler;
 import org.elasticsearch.common.xcontent.ChunkedToXContent;
-import org.elasticsearch.common.xcontent.XContentParserUtils;
 import org.elasticsearch.index.mapper.DateFieldMapper.Resolution;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.SearchPlugin;
-import org.elasticsearch.rest.action.search.RestSearchAction;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.SearchHits;
@@ -43,111 +38,15 @@ import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.MultiBucketConsumerService;
 import org.elasticsearch.search.aggregations.MultiBucketConsumerService.MultiBucketConsumer;
 import org.elasticsearch.search.aggregations.ParsedAggregation;
-import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregationBuilder;
-import org.elasticsearch.search.aggregations.bucket.composite.ParsedComposite;
-import org.elasticsearch.search.aggregations.bucket.filter.FilterAggregationBuilder;
-import org.elasticsearch.search.aggregations.bucket.filter.FiltersAggregationBuilder;
-import org.elasticsearch.search.aggregations.bucket.filter.ParsedFilter;
-import org.elasticsearch.search.aggregations.bucket.filter.ParsedFilters;
-import org.elasticsearch.search.aggregations.bucket.geogrid.GeoHashGridAggregationBuilder;
-import org.elasticsearch.search.aggregations.bucket.geogrid.GeoTileGridAggregationBuilder;
-import org.elasticsearch.search.aggregations.bucket.geogrid.ParsedGeoHashGrid;
-import org.elasticsearch.search.aggregations.bucket.geogrid.ParsedGeoTileGrid;
-import org.elasticsearch.search.aggregations.bucket.global.GlobalAggregationBuilder;
-import org.elasticsearch.search.aggregations.bucket.global.ParsedGlobal;
-import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramAggregationBuilder;
-import org.elasticsearch.search.aggregations.bucket.histogram.HistogramAggregationBuilder;
-import org.elasticsearch.search.aggregations.bucket.histogram.ParsedDateHistogram;
-import org.elasticsearch.search.aggregations.bucket.histogram.ParsedHistogram;
-import org.elasticsearch.search.aggregations.bucket.histogram.ParsedVariableWidthHistogram;
-import org.elasticsearch.search.aggregations.bucket.histogram.VariableWidthHistogramAggregationBuilder;
-import org.elasticsearch.search.aggregations.bucket.missing.MissingAggregationBuilder;
-import org.elasticsearch.search.aggregations.bucket.missing.ParsedMissing;
-import org.elasticsearch.search.aggregations.bucket.nested.NestedAggregationBuilder;
-import org.elasticsearch.search.aggregations.bucket.nested.ParsedNested;
-import org.elasticsearch.search.aggregations.bucket.nested.ParsedReverseNested;
-import org.elasticsearch.search.aggregations.bucket.nested.ReverseNestedAggregationBuilder;
-import org.elasticsearch.search.aggregations.bucket.range.DateRangeAggregationBuilder;
-import org.elasticsearch.search.aggregations.bucket.range.GeoDistanceAggregationBuilder;
-import org.elasticsearch.search.aggregations.bucket.range.IpRangeAggregationBuilder;
-import org.elasticsearch.search.aggregations.bucket.range.ParsedBinaryRange;
-import org.elasticsearch.search.aggregations.bucket.range.ParsedDateRange;
-import org.elasticsearch.search.aggregations.bucket.range.ParsedGeoDistance;
-import org.elasticsearch.search.aggregations.bucket.range.ParsedRange;
-import org.elasticsearch.search.aggregations.bucket.range.RangeAggregationBuilder;
-import org.elasticsearch.search.aggregations.bucket.sampler.InternalSampler;
-import org.elasticsearch.search.aggregations.bucket.sampler.ParsedSampler;
-import org.elasticsearch.search.aggregations.bucket.terms.DoubleTerms;
-import org.elasticsearch.search.aggregations.bucket.terms.LongRareTerms;
-import org.elasticsearch.search.aggregations.bucket.terms.LongTerms;
-import org.elasticsearch.search.aggregations.bucket.terms.ParsedDoubleTerms;
-import org.elasticsearch.search.aggregations.bucket.terms.ParsedLongRareTerms;
-import org.elasticsearch.search.aggregations.bucket.terms.ParsedLongTerms;
-import org.elasticsearch.search.aggregations.bucket.terms.ParsedSignificantLongTerms;
-import org.elasticsearch.search.aggregations.bucket.terms.ParsedSignificantStringTerms;
-import org.elasticsearch.search.aggregations.bucket.terms.ParsedStringRareTerms;
-import org.elasticsearch.search.aggregations.bucket.terms.ParsedStringTerms;
-import org.elasticsearch.search.aggregations.bucket.terms.SignificantLongTerms;
-import org.elasticsearch.search.aggregations.bucket.terms.SignificantStringTerms;
-import org.elasticsearch.search.aggregations.bucket.terms.StringRareTerms;
-import org.elasticsearch.search.aggregations.bucket.terms.StringTerms;
-import org.elasticsearch.search.aggregations.metrics.AvgAggregationBuilder;
-import org.elasticsearch.search.aggregations.metrics.CardinalityAggregationBuilder;
-import org.elasticsearch.search.aggregations.metrics.ExtendedStatsAggregationBuilder;
-import org.elasticsearch.search.aggregations.metrics.GeoBoundsAggregationBuilder;
-import org.elasticsearch.search.aggregations.metrics.GeoCentroidAggregationBuilder;
-import org.elasticsearch.search.aggregations.metrics.InternalHDRPercentileRanks;
-import org.elasticsearch.search.aggregations.metrics.InternalHDRPercentiles;
-import org.elasticsearch.search.aggregations.metrics.InternalTDigestPercentileRanks;
-import org.elasticsearch.search.aggregations.metrics.InternalTDigestPercentiles;
-import org.elasticsearch.search.aggregations.metrics.MaxAggregationBuilder;
-import org.elasticsearch.search.aggregations.metrics.MedianAbsoluteDeviationAggregationBuilder;
-import org.elasticsearch.search.aggregations.metrics.MinAggregationBuilder;
-import org.elasticsearch.search.aggregations.metrics.ParsedAvg;
-import org.elasticsearch.search.aggregations.metrics.ParsedCardinality;
-import org.elasticsearch.search.aggregations.metrics.ParsedExtendedStats;
-import org.elasticsearch.search.aggregations.metrics.ParsedGeoBounds;
-import org.elasticsearch.search.aggregations.metrics.ParsedGeoCentroid;
-import org.elasticsearch.search.aggregations.metrics.ParsedHDRPercentileRanks;
-import org.elasticsearch.search.aggregations.metrics.ParsedHDRPercentiles;
-import org.elasticsearch.search.aggregations.metrics.ParsedMax;
-import org.elasticsearch.search.aggregations.metrics.ParsedMedianAbsoluteDeviation;
-import org.elasticsearch.search.aggregations.metrics.ParsedMin;
-import org.elasticsearch.search.aggregations.metrics.ParsedScriptedMetric;
-import org.elasticsearch.search.aggregations.metrics.ParsedStats;
-import org.elasticsearch.search.aggregations.metrics.ParsedSum;
-import org.elasticsearch.search.aggregations.metrics.ParsedTDigestPercentileRanks;
-import org.elasticsearch.search.aggregations.metrics.ParsedTDigestPercentiles;
-import org.elasticsearch.search.aggregations.metrics.ParsedValueCount;
-import org.elasticsearch.search.aggregations.metrics.ParsedWeightedAvg;
-import org.elasticsearch.search.aggregations.metrics.ScriptedMetricAggregationBuilder;
-import org.elasticsearch.search.aggregations.metrics.StatsAggregationBuilder;
-import org.elasticsearch.search.aggregations.metrics.SumAggregationBuilder;
 import org.elasticsearch.search.aggregations.metrics.TopHits;
 import org.elasticsearch.search.aggregations.metrics.TopHitsAggregationBuilder;
-import org.elasticsearch.search.aggregations.metrics.ValueCountAggregationBuilder;
-import org.elasticsearch.search.aggregations.metrics.WeightedAvgAggregationBuilder;
-import org.elasticsearch.search.aggregations.pipeline.ExtendedStatsBucketPipelineAggregationBuilder;
-import org.elasticsearch.search.aggregations.pipeline.InternalBucketMetricValue;
-import org.elasticsearch.search.aggregations.pipeline.InternalSimpleValue;
-import org.elasticsearch.search.aggregations.pipeline.ParsedBucketMetricValue;
-import org.elasticsearch.search.aggregations.pipeline.ParsedExtendedStatsBucket;
-import org.elasticsearch.search.aggregations.pipeline.ParsedPercentilesBucket;
-import org.elasticsearch.search.aggregations.pipeline.ParsedSimpleValue;
-import org.elasticsearch.search.aggregations.pipeline.ParsedStatsBucket;
-import org.elasticsearch.search.aggregations.pipeline.PercentilesBucketPipelineAggregationBuilder;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator.PipelineTree;
-import org.elasticsearch.search.aggregations.pipeline.StatsBucketPipelineAggregationBuilder;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.SamplingContext;
-import org.elasticsearch.xcontent.ContextParser;
-import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ParseField;
-import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
-import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -156,17 +55,10 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
-import java.util.function.Predicate;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonMap;
-import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
 import static org.elasticsearch.search.aggregations.InternalMultiBucketAggregation.countInnerBucket;
-import static org.elasticsearch.test.XContentTestUtils.insertRandomFields;
-import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
@@ -243,79 +135,6 @@ public abstract class InternalAggregationTestCase<T extends InternalAggregation>
 
     @SuppressWarnings("this-escape")
     private final NamedWriteableRegistry namedWriteableRegistry = new NamedWriteableRegistry(getNamedWriteables());
-
-    @SuppressWarnings("this-escape")
-    private final NamedXContentRegistry namedXContentRegistry = new NamedXContentRegistry(getNamedXContents());
-
-    private static final List<NamedXContentRegistry.Entry> namedXContents;
-    static {
-        Map<String, ContextParser<Object, ? extends Aggregation>> map = new HashMap<>();
-        map.put(CardinalityAggregationBuilder.NAME, (p, c) -> ParsedCardinality.fromXContent(p, (String) c));
-        map.put(InternalHDRPercentiles.NAME, (p, c) -> ParsedHDRPercentiles.fromXContent(p, (String) c));
-        map.put(InternalHDRPercentileRanks.NAME, (p, c) -> ParsedHDRPercentileRanks.fromXContent(p, (String) c));
-        map.put(InternalTDigestPercentiles.NAME, (p, c) -> ParsedTDigestPercentiles.fromXContent(p, (String) c));
-        map.put(InternalTDigestPercentileRanks.NAME, (p, c) -> ParsedTDigestPercentileRanks.fromXContent(p, (String) c));
-        map.put(PercentilesBucketPipelineAggregationBuilder.NAME, (p, c) -> ParsedPercentilesBucket.fromXContent(p, (String) c));
-        map.put(MedianAbsoluteDeviationAggregationBuilder.NAME, (p, c) -> ParsedMedianAbsoluteDeviation.fromXContent(p, (String) c));
-        map.put(MinAggregationBuilder.NAME, (p, c) -> ParsedMin.fromXContent(p, (String) c));
-        map.put(MaxAggregationBuilder.NAME, (p, c) -> ParsedMax.fromXContent(p, (String) c));
-        map.put(SumAggregationBuilder.NAME, (p, c) -> ParsedSum.fromXContent(p, (String) c));
-        map.put(AvgAggregationBuilder.NAME, (p, c) -> ParsedAvg.fromXContent(p, (String) c));
-        map.put(WeightedAvgAggregationBuilder.NAME, (p, c) -> ParsedWeightedAvg.fromXContent(p, (String) c));
-        map.put(ValueCountAggregationBuilder.NAME, (p, c) -> ParsedValueCount.fromXContent(p, (String) c));
-        map.put(InternalSimpleValue.NAME, (p, c) -> ParsedSimpleValue.fromXContent(p, (String) c));
-        map.put(InternalBucketMetricValue.NAME, (p, c) -> ParsedBucketMetricValue.fromXContent(p, (String) c));
-        map.put(StatsAggregationBuilder.NAME, (p, c) -> ParsedStats.fromXContent(p, (String) c));
-        map.put(StatsBucketPipelineAggregationBuilder.NAME, (p, c) -> ParsedStatsBucket.fromXContent(p, (String) c));
-        map.put(ExtendedStatsAggregationBuilder.NAME, (p, c) -> ParsedExtendedStats.fromXContent(p, (String) c));
-        map.put(ExtendedStatsBucketPipelineAggregationBuilder.NAME, (p, c) -> ParsedExtendedStatsBucket.fromXContent(p, (String) c));
-        map.put(GeoBoundsAggregationBuilder.NAME, (p, c) -> ParsedGeoBounds.fromXContent(p, (String) c));
-        map.put(GeoCentroidAggregationBuilder.NAME, (p, c) -> ParsedGeoCentroid.fromXContent(p, (String) c));
-        map.put(HistogramAggregationBuilder.NAME, (p, c) -> ParsedHistogram.fromXContent(p, (String) c));
-        map.put(DateHistogramAggregationBuilder.NAME, (p, c) -> ParsedDateHistogram.fromXContent(p, (String) c));
-        map.put(VariableWidthHistogramAggregationBuilder.NAME, (p, c) -> ParsedVariableWidthHistogram.fromXContent(p, (String) c));
-        map.put(StringTerms.NAME, (p, c) -> ParsedStringTerms.fromXContent(p, (String) c));
-        map.put(LongTerms.NAME, (p, c) -> ParsedLongTerms.fromXContent(p, (String) c));
-        map.put(DoubleTerms.NAME, (p, c) -> ParsedDoubleTerms.fromXContent(p, (String) c));
-        map.put(LongRareTerms.NAME, (p, c) -> ParsedLongRareTerms.fromXContent(p, (String) c));
-        map.put(StringRareTerms.NAME, (p, c) -> ParsedStringRareTerms.fromXContent(p, (String) c));
-        map.put(MissingAggregationBuilder.NAME, (p, c) -> ParsedMissing.fromXContent(p, (String) c));
-        map.put(NestedAggregationBuilder.NAME, (p, c) -> ParsedNested.fromXContent(p, (String) c));
-        map.put(ReverseNestedAggregationBuilder.NAME, (p, c) -> ParsedReverseNested.fromXContent(p, (String) c));
-        map.put(GlobalAggregationBuilder.NAME, (p, c) -> ParsedGlobal.fromXContent(p, (String) c));
-        map.put(FilterAggregationBuilder.NAME, (p, c) -> ParsedFilter.fromXContent(p, (String) c));
-        map.put(InternalSampler.PARSER_NAME, (p, c) -> ParsedSampler.fromXContent(p, (String) c));
-        map.put(GeoHashGridAggregationBuilder.NAME, (p, c) -> ParsedGeoHashGrid.fromXContent(p, (String) c));
-        map.put(GeoTileGridAggregationBuilder.NAME, (p, c) -> ParsedGeoTileGrid.fromXContent(p, (String) c));
-        map.put(RangeAggregationBuilder.NAME, (p, c) -> ParsedRange.fromXContent(p, (String) c));
-        map.put(DateRangeAggregationBuilder.NAME, (p, c) -> ParsedDateRange.fromXContent(p, (String) c));
-        map.put(GeoDistanceAggregationBuilder.NAME, (p, c) -> ParsedGeoDistance.fromXContent(p, (String) c));
-        map.put(FiltersAggregationBuilder.NAME, (p, c) -> ParsedFilters.fromXContent(p, (String) c));
-        map.put(SignificantLongTerms.NAME, (p, c) -> ParsedSignificantLongTerms.fromXContent(p, (String) c));
-        map.put(SignificantStringTerms.NAME, (p, c) -> ParsedSignificantStringTerms.fromXContent(p, (String) c));
-        map.put(ScriptedMetricAggregationBuilder.NAME, (p, c) -> ParsedScriptedMetric.fromXContent(p, (String) c));
-        map.put(IpRangeAggregationBuilder.NAME, (p, c) -> ParsedBinaryRange.fromXContent(p, (String) c));
-        map.put(TopHitsAggregationBuilder.NAME, (p, c) -> ParsedTopHits.fromXContent(p, (String) c));
-        map.put(CompositeAggregationBuilder.NAME, (p, c) -> ParsedComposite.fromXContent(p, (String) c));
-
-        namedXContents = map.entrySet()
-            .stream()
-            .map(entry -> new NamedXContentRegistry.Entry(Aggregation.class, new ParseField(entry.getKey()), entry.getValue()))
-            .collect(Collectors.toList());
-    }
-
-    public static List<NamedXContentRegistry.Entry> getDefaultNamedXContents() {
-        return namedXContents;
-    }
-
-    protected List<NamedXContentRegistry.Entry> getNamedXContents() {
-        return namedXContents;
-    }
-
-    @Override
-    protected NamedXContentRegistry xContentRegistry() {
-        return namedXContentRegistry;
-    }
 
     @Override
     protected final NamedWriteableRegistry getNamedWriteableRegistry() {
@@ -538,130 +357,6 @@ public abstract class InternalAggregationTestCase<T extends InternalAggregation>
 
     public T createTestInstanceForXContent() {
         return createTestInstance();
-    }
-
-    public final void testFromXContent() throws IOException {
-        final T aggregation = createTestInstanceForXContent();
-        final ParsedAggregation parsedAggregation = parseAndAssert(aggregation, randomBoolean(), false);
-        assertFromXContent(aggregation, parsedAggregation);
-    }
-
-    public final void testFromXContentWithRandomFields() throws IOException {
-        final T aggregation = createTestInstanceForXContent();
-        final ParsedAggregation parsedAggregation = parseAndAssert(aggregation, randomBoolean(), true);
-        assertFromXContent(aggregation, parsedAggregation);
-    }
-
-    protected abstract void assertFromXContent(T aggregation, ParsedAggregation parsedAggregation) throws IOException;
-
-    /**
-     * Calls {@link ToXContent#toXContent} on many threads and verifies that
-     * they produce the same result. Async search sometimes does this to
-     * aggregation responses and, in general, we think it's reasonable for
-     * everything that can convert itself to json to be able to do so
-     * concurrently.
-     */
-    public final void testConcurrentToXContent() throws IOException, InterruptedException, ExecutionException {
-        T testInstance = createTestInstanceForXContent();
-        ToXContent.Params params = new ToXContent.MapParams(singletonMap(RestSearchAction.TYPED_KEYS_PARAM, "true"));
-        XContentType xContentType = randomFrom(XContentType.values());
-        boolean humanReadable = randomBoolean();
-        BytesRef firstTimeBytes = toXContent(testInstance, xContentType, params, humanReadable).toBytesRef();
-
-        /*
-         * 500 rounds seems to consistently reproduce the issue on Nik's
-         * laptop. Larger numbers are going to be slower but more likely
-         * to reproduce the issue.
-         */
-        int rounds = scaledRandomIntBetween(300, 5000);
-        concurrentTest(() -> {
-            try {
-                for (int r = 0; r < rounds; r++) {
-                    assertEquals(firstTimeBytes, toXContent(testInstance, xContentType, params, humanReadable).toBytesRef());
-                }
-            } catch (IOException e) {
-                throw new AssertionError(e);
-            }
-        });
-    }
-
-    @SuppressWarnings("unchecked")
-    protected <P extends ParsedAggregation> P parseAndAssert(
-        final InternalAggregation aggregation,
-        final boolean shuffled,
-        final boolean addRandomFields
-    ) throws IOException {
-
-        final ToXContent.Params params = new ToXContent.MapParams(singletonMap(RestSearchAction.TYPED_KEYS_PARAM, "true"));
-        final XContentType xContentType = randomFrom(XContentType.values());
-        final boolean humanReadable = randomBoolean();
-
-        final BytesReference originalBytes;
-        try {
-            if (shuffled) {
-                originalBytes = toShuffledXContent(aggregation, xContentType, params, humanReadable);
-            } else {
-                originalBytes = toXContent(aggregation, xContentType, params, humanReadable);
-            }
-        } catch (IOException e) {
-            throw new IOException("error converting " + aggregation, e);
-        }
-        BytesReference mutated;
-        if (addRandomFields) {
-            /*
-             * - we don't add to the root object because it should only contain
-             * the named aggregation to test - we don't want to insert into the
-             * "meta" object, because we pass on everything we find there
-             *
-             * - we don't want to directly insert anything random into "buckets"
-             * objects, they are used with "keyed" aggregations and contain
-             * named bucket objects. Any new named object on this level should
-             * also be a bucket and be parsed as such.
-             *
-             * we also exclude top_hits that contain SearchHits, as all unknown fields
-             * on a root level of SearchHit are interpreted as meta-fields and will be kept.
-             */
-            Predicate<String> basicExcludes = path -> path.isEmpty()
-                || path.endsWith(Aggregation.CommonFields.META.getPreferredName())
-                || path.endsWith(Aggregation.CommonFields.BUCKETS.getPreferredName())
-                || path.contains("top_hits");
-            Predicate<String> excludes = basicExcludes.or(excludePathsFromXContentInsertion());
-            mutated = insertRandomFields(xContentType, originalBytes, excludes, random());
-        } else {
-            mutated = originalBytes;
-        }
-
-        SetOnce<Aggregation> parsedAggregation = new SetOnce<>();
-        try (XContentParser parser = createParser(xContentType.xContent(), mutated)) {
-            assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
-            assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
-            assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
-            XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Aggregation.class, parsedAggregation::set);
-
-            assertEquals(XContentParser.Token.END_OBJECT, parser.currentToken());
-            assertEquals(XContentParser.Token.END_OBJECT, parser.nextToken());
-            assertNull(parser.nextToken());
-
-            Aggregation agg = parsedAggregation.get();
-            assertEquals(aggregation.getName(), agg.getName());
-            assertEquals(aggregation.getMetadata(), agg.getMetadata());
-
-            assertTrue(agg instanceof ParsedAggregation);
-            assertEquals(aggregation.getType(), agg.getType());
-
-            BytesReference parsedBytes = toXContent(agg, xContentType, params, humanReadable);
-            assertToXContentEquivalent(originalBytes, parsedBytes, xContentType);
-
-            return (P) agg;
-        }
-
-    }
-
-    /**
-     * Overwrite this in your test if other than the basic xContent paths should be excluded during insertion of random fields
-     */
-    protected Predicate<String> excludePathsFromXContentInsertion() {
-        return path -> false;
     }
 
     /**

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalMultiBucketAggregationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalMultiBucketAggregationTestCase.java
@@ -22,7 +22,6 @@ import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
 import org.elasticsearch.search.aggregations.MultiBucketConsumerService;
-import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator.PipelineTree;
 import org.elasticsearch.search.aggregations.support.SamplingContext;
@@ -173,7 +172,7 @@ public abstract class InternalMultiBucketAggregationTestCase<T extends InternalA
 
     protected void assertBucket(MultiBucketsAggregation.Bucket expected, MultiBucketsAggregation.Bucket actual, boolean checkOrder) {
         assertTrue(expected instanceof InternalMultiBucketAggregation.InternalBucket);
-        assertTrue(actual instanceof ParsedMultiBucketAggregation.ParsedBucket);
+        assertTrue(actual instanceof InternalMultiBucketAggregation.InternalBucket);
 
         assertEquals(expected.getKey(), actual.getKey());
         assertEquals(expected.getKeyAsString(), actual.getKeyAsString());

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalMultiBucketAggregationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalMultiBucketAggregationTestCase.java
@@ -22,13 +22,11 @@ import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
 import org.elasticsearch.search.aggregations.MultiBucketConsumerService;
-import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator.PipelineTree;
 import org.elasticsearch.search.aggregations.support.SamplingContext;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -100,18 +98,6 @@ public abstract class InternalMultiBucketAggregationTestCase<T extends InternalA
 
     protected abstract T createTestInstance(String name, Map<String, Object> metadata, InternalAggregations aggregations);
 
-    /**
-     * The parsed version used by the deprecated high level rest client or
-     * {@code null} if the deprecated high level rest client isn't supported
-     * by this agg.
-     */
-    protected abstract Class<? extends ParsedMultiBucketAggregation<?>> implementationClass();
-
-    @Override
-    protected final void assertFromXContent(T aggregation, ParsedAggregation parsedAggregation) {
-        assertMultiBucketsAggregations(aggregation, parsedAggregation, false);
-    }
-
     @Override
     public final T createTestInstanceForXContent() {
         return createTestInstanceForXContent(randomAlphaOfLength(5), createTestMetadata(), createSubAggregations());
@@ -119,18 +105,6 @@ public abstract class InternalMultiBucketAggregationTestCase<T extends InternalA
 
     protected T createTestInstanceForXContent(String name, Map<String, Object> metadata, InternalAggregations subAggs) {
         return createTestInstance(name, metadata, subAggs);
-    }
-
-    public void testIterators() throws IOException {
-        final T aggregation = createTestInstanceForXContent();
-        assertMultiBucketsAggregations(aggregation, parseAndAssert(aggregation, false, false), true);
-    }
-
-    @Override
-    protected <P extends ParsedAggregation> P parseAndAssert(InternalAggregation aggregation, boolean shuffled, boolean addRandomFields)
-        throws IOException {
-        assumeFalse("deprecated high level rest client not supported", implementationClass() == null);
-        return super.parseAndAssert(aggregation, shuffled, addRandomFields);
     }
 
     @Override
@@ -191,13 +165,6 @@ public abstract class InternalMultiBucketAggregationTestCase<T extends InternalA
     }
 
     protected void assertMultiBucketsAggregation(MultiBucketsAggregation expected, MultiBucketsAggregation actual, boolean checkOrder) {
-        Class<? extends ParsedMultiBucketAggregation<?>> parsedClass = implementationClass();
-        assertNotNull("Parsed aggregation class must not be null", parsedClass);
-        assertTrue(
-            "Unexpected parsed class, expected instance of: " + actual + ", but was: " + parsedClass,
-            parsedClass.isInstance(actual)
-        );
-
         assertTrue(expected instanceof InternalAggregation);
         assertEquals(expected.getName(), actual.getName());
         assertEquals(expected.getMetadata(), actual.getMetadata());

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/boxplot/InternalBoxplotTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/boxplot/InternalBoxplotTests.java
@@ -10,15 +10,11 @@ package org.elasticsearch.xpack.analytics.boxplot;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.search.DocValueFormat;
-import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.metrics.TDigestState;
 import org.elasticsearch.test.InternalAggregationTestCase;
-import org.elasticsearch.xcontent.NamedXContentRegistry;
-import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xpack.analytics.AnalyticsPlugin;
 
 import java.io.IOException;
@@ -88,17 +84,6 @@ public class InternalBoxplotTests extends InternalAggregationTestCase<InternalBo
             default -> throw new AssertionError("Illegal randomisation branch");
         }
         return new InternalBoxplot(name, state, formatter, metadata);
-    }
-
-    @Override
-    protected List<NamedXContentRegistry.Entry> getNamedXContents() {
-        return CollectionUtils.appendToCopy(
-            super.getNamedXContents(),
-            new NamedXContentRegistry.Entry(Aggregation.class, new ParseField(BoxplotAggregationBuilder.NAME), (p, c) -> {
-                assumeTrue("There is no ParsedBoxlot yet", false);
-                return null;
-            })
-        );
     }
 
     public void testIQR() {

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/boxplot/InternalBoxplotTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/boxplot/InternalBoxplotTests.java
@@ -15,7 +15,6 @@ import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.Aggregation;
-import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.search.aggregations.metrics.TDigestState;
 import org.elasticsearch.test.InternalAggregationTestCase;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
@@ -59,11 +58,6 @@ public class InternalBoxplotTests extends InternalAggregationTestCase<InternalBo
         assertNotNull(expected);
         assertEquals(expected.getMax(), reduced.getMax(), 0);
         assertEquals(expected.getMin(), reduced.getMin(), 0);
-    }
-
-    @Override
-    protected void assertFromXContent(InternalBoxplot min, ParsedAggregation parsedAggregation) {
-        // There is no ParsedBoxplot yet so we cannot test it here
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/multiterms/InternalMultiTermsTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/multiterms/InternalMultiTermsTests.java
@@ -10,7 +10,6 @@ package org.elasticsearch.xpack.analytics.multiterms;
 import org.apache.lucene.document.InetAddressPoint;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.common.util.MockPageCacheRecycler;
@@ -18,15 +17,12 @@ import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.DocValueFormat;
-import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationReduceContext;
 import org.elasticsearch.search.aggregations.BucketOrder;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.support.SamplingContext;
 import org.elasticsearch.test.InternalAggregationTestCase;
-import org.elasticsearch.xcontent.NamedXContentRegistry;
-import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xpack.analytics.AnalyticsPlugin;
 
 import java.util.ArrayList;
@@ -296,17 +292,6 @@ public class InternalMultiTermsTests extends InternalAggregationTestCase<Interna
             instance.formats,
             instance.keyConverters,
             metadata
-        );
-    }
-
-    @Override
-    protected List<NamedXContentRegistry.Entry> getNamedXContents() {
-        return CollectionUtils.appendToCopy(
-            super.getNamedXContents(),
-            new NamedXContentRegistry.Entry(Aggregation.class, new ParseField(MultiTermsAggregationBuilder.NAME), (p, c) -> {
-                assumeTrue("There is no ParsedMultiTerms yet", false);
-                return null;
-            })
         );
     }
 

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/multiterms/InternalMultiTermsTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/multiterms/InternalMultiTermsTests.java
@@ -23,7 +23,6 @@ import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationReduceContext;
 import org.elasticsearch.search.aggregations.BucketOrder;
 import org.elasticsearch.search.aggregations.InternalAggregations;
-import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.search.aggregations.support.SamplingContext;
 import org.elasticsearch.test.InternalAggregationTestCase;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
@@ -263,11 +262,6 @@ public class InternalMultiTermsTests extends InternalAggregationTestCase<Interna
             assertThat(bucketCounts.keySet(), hasItem(equalTo(key)));
             assertThat(bucketCounts.get(key), equalTo(bucket.docCount));
         }
-    }
-
-    @Override
-    protected void assertFromXContent(InternalMultiTerms min, ParsedAggregation parsedAggregation) {
-        // There is no ParsedMultiTerms yet so we cannot test it here
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/rate/InternalRateTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/rate/InternalRateTests.java
@@ -13,7 +13,6 @@ import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
-import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.search.aggregations.support.SamplingContext;
 import org.elasticsearch.test.InternalAggregationTestCase;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
@@ -69,11 +68,6 @@ public class InternalRateTests extends InternalAggregationTestCase<InternalRate>
     protected void assertReduced(InternalRate reduced, List<InternalRate> inputs) {
         double expected = inputs.stream().mapToDouble(a -> a.sum).sum() / reduced.divisor;
         assertEquals(expected, reduced.getValue(), 0.00001);
-    }
-
-    @Override
-    protected void assertFromXContent(InternalRate min, ParsedAggregation parsedAggregation) {
-        // There is no ParsedRate yet so we cannot test it here
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/rate/InternalRateTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/rate/InternalRateTests.java
@@ -7,16 +7,12 @@
 
 package org.elasticsearch.xpack.analytics.rate;
 
-import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.search.DocValueFormat;
-import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.support.SamplingContext;
 import org.elasticsearch.test.InternalAggregationTestCase;
-import org.elasticsearch.xcontent.NamedXContentRegistry;
-import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xpack.analytics.AnalyticsPlugin;
 
 import java.util.ArrayList;
@@ -92,16 +88,5 @@ public class InternalRateTests extends InternalAggregationTestCase<InternalRate>
             default -> throw new AssertionError("Illegal randomisation branch");
         }
         return new InternalRate(name, sum, divider, formatter, metadata);
-    }
-
-    @Override
-    protected List<NamedXContentRegistry.Entry> getNamedXContents() {
-        return CollectionUtils.appendToCopy(
-            super.getNamedXContents(),
-            new NamedXContentRegistry.Entry(Aggregation.class, new ParseField(RateAggregationBuilder.NAME), (p, c) -> {
-                assumeTrue("There is no ParsedRate yet", false);
-                return null;
-            })
-        );
     }
 }

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/rate/InternalResetTrackingRateTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/rate/InternalResetTrackingRateTests.java
@@ -12,13 +12,11 @@ import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.test.InternalAggregationTestCase;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xpack.analytics.AnalyticsPlugin;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -139,11 +137,6 @@ public class InternalResetTrackingRateTests extends InternalAggregationTestCase<
         }
         internalRates.add(rate(startValue, currentValue, startTime, endTime, resetComp, Rounding.DateTimeUnit.SECOND_OF_MINUTE));
         return new BuilderAndToReduce<>(mock(RateAggregationBuilder.class), internalRates);
-    }
-
-    @Override
-    protected void assertFromXContent(InternalResetTrackingRate aggregation, ParsedAggregation parsedAggregation) throws IOException {
-
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/rate/InternalResetTrackingRateTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/rate/InternalResetTrackingRateTests.java
@@ -8,13 +8,9 @@
 package org.elasticsearch.xpack.analytics.rate;
 
 import org.elasticsearch.common.Rounding;
-import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.plugins.SearchPlugin;
-import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.test.InternalAggregationTestCase;
-import org.elasticsearch.xcontent.NamedXContentRegistry;
-import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xpack.analytics.AnalyticsPlugin;
 
 import java.util.ArrayList;
@@ -137,17 +133,6 @@ public class InternalResetTrackingRateTests extends InternalAggregationTestCase<
         }
         internalRates.add(rate(startValue, currentValue, startTime, endTime, resetComp, Rounding.DateTimeUnit.SECOND_OF_MINUTE));
         return new BuilderAndToReduce<>(mock(RateAggregationBuilder.class), internalRates);
-    }
-
-    @Override
-    protected List<NamedXContentRegistry.Entry> getNamedXContents() {
-        return CollectionUtils.appendToCopy(
-            super.getNamedXContents(),
-            new NamedXContentRegistry.Entry(Aggregation.class, new ParseField(InternalResetTrackingRate.NAME), (p, c) -> {
-                assumeTrue("There is no ParsedRate yet", false);
-                return null;
-            })
-        );
     }
 
     public void testIncludes() {

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/stringstats/InternalStringStatsTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/stringstats/InternalStringStatsTests.java
@@ -13,24 +13,20 @@ import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
-import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.InternalAggregationTestCase;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xpack.analytics.AnalyticsPlugin;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import static java.util.Collections.emptyMap;
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.mock;
 
 public class InternalStringStatsTests extends InternalAggregationTestCase<InternalStringStats> {
@@ -121,36 +117,6 @@ public class InternalStringStatsTests extends InternalAggregationTestCase<Intern
             DocValueFormat.RAW,
             instance.getMetadata()
         );
-    }
-
-    @Override
-    protected void assertFromXContent(InternalStringStats aggregation, ParsedAggregation parsedAggregation) throws IOException {
-        ParsedStringStats parsed = (ParsedStringStats) parsedAggregation;
-        assertThat(parsed.getName(), equalTo(aggregation.getName()));
-        if (aggregation.getCount() == 0) {
-            assertThat(parsed.getCount(), equalTo(0L));
-            assertThat(parsed.getMinLength(), equalTo(0));
-            assertThat(parsed.getMaxLength(), equalTo(0));
-            assertThat(parsed.getAvgLength(), equalTo(0d));
-            assertThat(parsed.getEntropy(), equalTo(0d));
-            assertThat(parsed.getDistribution(), nullValue());
-            return;
-        }
-        assertThat(parsed.getCount(), equalTo(aggregation.getCount()));
-        assertThat(parsed.getMinLength(), equalTo(aggregation.getMinLength()));
-        assertThat(parsed.getMaxLength(), equalTo(aggregation.getMaxLength()));
-        assertThat(parsed.getAvgLength(), equalTo(aggregation.getAvgLength()));
-        assertThat(parsed.getEntropy(), equalTo(aggregation.getEntropy()));
-        if (aggregation.getShowDistribution()) {
-            assertThat(parsed.getDistribution(), equalTo(aggregation.getDistribution()));
-        } else {
-            assertThat(parsed.getDistribution(), nullValue());
-        }
-    }
-
-    @Override
-    protected Predicate<String> excludePathsFromXContentInsertion() {
-        return path -> path.endsWith(".distribution");
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/stringstats/InternalStringStatsTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/stringstats/InternalStringStatsTests.java
@@ -7,16 +7,11 @@
 
 package org.elasticsearch.xpack.analytics.stringstats;
 
-import org.elasticsearch.client.analytics.ParsedStringStats;
-import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.search.DocValueFormat;
-import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.InternalAggregationTestCase;
-import org.elasticsearch.xcontent.NamedXContentRegistry;
-import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xpack.analytics.AnalyticsPlugin;
 
 import java.util.HashMap;
@@ -34,18 +29,6 @@ public class InternalStringStatsTests extends InternalAggregationTestCase<Intern
     @Override
     protected SearchPlugin registerPlugin() {
         return new AnalyticsPlugin();
-    }
-
-    @Override
-    protected List<NamedXContentRegistry.Entry> getNamedXContents() {
-        return CollectionUtils.appendToCopy(
-            super.getNamedXContents(),
-            new NamedXContentRegistry.Entry(
-                Aggregation.class,
-                new ParseField(StringStatsAggregationBuilder.NAME),
-                (p, c) -> ParsedStringStats.PARSER.parse(p, (String) c)
-            )
-        );
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetricsTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/topmetrics/InternalTopMetricsTests.java
@@ -8,23 +8,18 @@
 package org.elasticsearch.xpack.analytics.topmetrics;
 
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.client.analytics.ParsedTopMetrics;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.time.DateUtils;
-import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.search.DocValueFormat;
-import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.support.SamplingContext;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.search.sort.SortValue;
 import org.elasticsearch.test.InternalAggregationTestCase;
-import org.elasticsearch.xcontent.NamedXContentRegistry;
-import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xpack.analytics.AnalyticsPlugin;
 import org.elasticsearch.xpack.analytics.topmetrics.InternalTopMetrics.MetricValue;
 
@@ -274,18 +269,6 @@ public class InternalTopMetricsTests extends InternalAggregationTestCase<Interna
                 )
             ),
             null
-        );
-    }
-
-    @Override
-    protected List<NamedXContentRegistry.Entry> getNamedXContents() {
-        return CollectionUtils.appendToCopy(
-            super.getNamedXContents(),
-            new NamedXContentRegistry.Entry(
-                Aggregation.class,
-                new ParseField(TopMetricsAggregationBuilder.NAME),
-                (p, c) -> ParsedTopMetrics.PARSER.parse(p, (String) c)
-            )
         );
     }
 

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/ttest/InternalTTestTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/ttest/InternalTTestTests.java
@@ -10,16 +10,12 @@ package org.elasticsearch.xpack.analytics.ttest;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.search.DocValueFormat;
-import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.support.SamplingContext;
 import org.elasticsearch.test.InternalAggregationTestCase;
-import org.elasticsearch.xcontent.NamedXContentRegistry;
-import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xpack.analytics.AnalyticsPlugin;
 
 import java.io.IOException;
@@ -115,16 +111,5 @@ public class InternalTTestTests extends InternalAggregationTestCase<InternalTTes
             default -> throw new AssertionError("Illegal randomisation branch");
         }
         return new InternalTTest(name, state, formatter, metadata);
-    }
-
-    @Override
-    protected List<NamedXContentRegistry.Entry> getNamedXContents() {
-        return CollectionUtils.appendToCopy(
-            super.getNamedXContents(),
-            new NamedXContentRegistry.Entry(Aggregation.class, new ParseField(TTestAggregationBuilder.NAME), (p, c) -> {
-                assumeTrue("There is no ParsedTTest yet", false);
-                return null;
-            })
-        );
     }
 }

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/ttest/InternalTTestTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/ttest/InternalTTestTests.java
@@ -16,7 +16,6 @@ import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
-import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.search.aggregations.support.SamplingContext;
 import org.elasticsearch.test.InternalAggregationTestCase;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
@@ -86,11 +85,6 @@ public class InternalTTestTests extends InternalAggregationTestCase<InternalTTes
     @Override
     protected boolean supportsSampling() {
         return true;
-    }
-
-    @Override
-    protected void assertFromXContent(InternalTTest min, ParsedAggregation parsedAggregation) {
-        // There is no ParsedTTest yet so we cannot test it here
     }
 
     @Override

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/categorization/InternalCategorizationAggregationTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/categorization/InternalCategorizationAggregationTests.java
@@ -10,13 +10,9 @@ package org.elasticsearch.xpack.ml.aggs.categorization;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BytesRefHash;
-import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.plugins.SearchPlugin;
-import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.test.InternalMultiBucketAggregationTestCase;
-import org.elasticsearch.xcontent.NamedXContentRegistry;
-import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xpack.ml.MachineLearningTests;
 import org.junit.After;
 import org.junit.Before;
@@ -48,18 +44,6 @@ public class InternalCategorizationAggregationTests extends InternalMultiBucketA
     @Override
     protected SearchPlugin registerPlugin() {
         return MachineLearningTests.createTrialLicensedMachineLearning(Settings.EMPTY);
-    }
-
-    @Override
-    protected List<NamedXContentRegistry.Entry> getNamedXContents() {
-        return CollectionUtils.appendToCopy(
-            super.getNamedXContents(),
-            new NamedXContentRegistry.Entry(
-                Aggregation.class,
-                new ParseField(CategorizeTextAggregationBuilder.NAME),
-                (p, c) -> ParsedCategorization.fromXContent(p, (String) c)
-            )
-        );
     }
 
     @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/87240")

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/categorization/InternalCategorizationAggregationTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/categorization/InternalCategorizationAggregationTests.java
@@ -14,7 +14,6 @@ import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
-import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
 import org.elasticsearch.test.InternalMultiBucketAggregationTestCase;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.ParseField;
@@ -27,7 +26,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -81,11 +79,6 @@ public class InternalCategorizationAggregationTests extends InternalMultiBucketA
     }
 
     @Override
-    protected Predicate<String> excludePathsFromXContentInsertion() {
-        return p -> p.contains("key");
-    }
-
-    @Override
     protected InternalCategorizationAggregation createTestInstance(
         String name,
         Map<String, Object> metadata,
@@ -107,11 +100,6 @@ public class InternalCategorizationAggregationTests extends InternalMultiBucketA
             metadata,
             buckets
         );
-    }
-
-    @Override
-    protected Class<? extends ParsedMultiBucketAggregation<?>> implementationClass() {
-        return ParsedCategorization.class;
     }
 
     private static Map<Object, Long> toCounts(Stream<? extends InternalCategorizationAggregation.Bucket> buckets) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/mr/InternalItemSetMapReduceAggregationTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/mr/InternalItemSetMapReduceAggregationTests.java
@@ -13,7 +13,6 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.search.DocValueFormat;
@@ -21,8 +20,6 @@ import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.test.InternalAggregationTestCase;
-import org.elasticsearch.xcontent.NamedXContentRegistry;
-import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
@@ -234,18 +231,6 @@ public class InternalItemSetMapReduceAggregationTests extends InternalAggregatio
     }
 
     @Override
-    protected void assertFromXContent(
-        InternalItemSetMapReduceAggregation<WordCounts, WordCounts, WordCounts, WordCounts> aggregation,
-        ParsedAggregation parsedAggregation
-    ) throws IOException {
-        ParsedWordCountMapReduceAggregation parsed = (ParsedWordCountMapReduceAggregation) parsedAggregation;
-        assertThat(parsed.getName(), equalTo(aggregation.getName()));
-
-        WordCountMapReducer.WordCounts wc = aggregation.getMapReduceResult();
-        assertMapEquals(wc.frequencies, parsed.getFrequencies());
-    }
-
-    @Override
     protected SearchPlugin registerPlugin() {
         return MachineLearningTests.createTrialLicensedMachineLearning(Settings.EMPTY);
     }
@@ -266,18 +251,6 @@ public class InternalItemSetMapReduceAggregationTests extends InternalAggregatio
         );
 
         return namedWritables;
-    }
-
-    @Override
-    protected List<NamedXContentRegistry.Entry> getNamedXContents() {
-        return CollectionUtils.appendToCopy(
-            super.getNamedXContents(),
-            new NamedXContentRegistry.Entry(
-                Aggregation.class,
-                new ParseField(WordCountMapReducer.AGG_NAME),
-                (p, c) -> ParsedWordCountMapReduceAggregation.fromXContent(p, (String) c)
-            )
-        );
     }
 
     private static void assertMapEquals(Map<String, Long> expected, Map<String, Long> actual) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/mr/InternalItemSetMapReduceAggregationTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/mr/InternalItemSetMapReduceAggregationTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.ml.aggs.frequentitemsets.mr;
 
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -16,6 +17,7 @@ import org.elasticsearch.core.Tuple;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.Aggregation;
+import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.test.InternalAggregationTestCase;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -185,6 +187,24 @@ public class InternalItemSetMapReduceAggregationTests extends InternalAggregatio
     @Override
     protected SearchPlugin registerPlugin() {
         return MachineLearningTests.createTrialLicensedMachineLearning(Settings.EMPTY);
+    }
+
+    @Override
+    protected List<NamedWriteableRegistry.Entry> getNamedWriteables() {
+        List<NamedWriteableRegistry.Entry> namedWritables = new ArrayList<>(super.getNamedWriteables());
+
+        namedWritables.add(
+            new NamedWriteableRegistry.Entry(
+                InternalAggregation.class,
+                WordCountMapReducer.AGG_NAME,
+                in -> new InternalItemSetMapReduceAggregation<>(in, (mapReducerReader) -> {
+                    in.readString();
+                    return new WordCountMapReducer(mapReducerReader);
+                })
+            )
+        );
+
+        return namedWritables;
     }
 
     private static void assertMapEquals(Map<String, Long> expected, Map<String, Long> actual) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/inference/InternalInferenceAggregationTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/inference/InternalInferenceAggregationTests.java
@@ -8,22 +8,14 @@
 package org.elasticsearch.xpack.ml.aggs.inference;
 
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.inference.InferenceResults;
 import org.elasticsearch.plugins.SearchPlugin;
-import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.InvalidAggregationPathException;
-import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.test.InternalAggregationTestCase;
-import org.elasticsearch.xcontent.NamedXContentRegistry;
-import org.elasticsearch.xcontent.ParseField;
-import org.elasticsearch.xpack.core.ml.inference.results.ClassificationFeatureImportance;
 import org.elasticsearch.xpack.core.ml.inference.results.ClassificationInferenceResults;
 import org.elasticsearch.xpack.core.ml.inference.results.ClassificationInferenceResultsTests;
-import org.elasticsearch.xpack.core.ml.inference.results.RegressionFeatureImportance;
 import org.elasticsearch.xpack.core.ml.inference.results.RegressionInferenceResults;
 import org.elasticsearch.xpack.core.ml.inference.results.RegressionInferenceResultsTests;
-import org.elasticsearch.xpack.core.ml.inference.results.TopClassEntry;
 import org.elasticsearch.xpack.core.ml.inference.results.WarningInferenceResults;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ClassificationConfig;
 import org.elasticsearch.xpack.ml.MachineLearningTests;
@@ -32,7 +24,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Predicate;
 
 import static org.hamcrest.Matchers.sameInstance;
 
@@ -41,23 +32,6 @@ public class InternalInferenceAggregationTests extends InternalAggregationTestCa
     @Override
     protected SearchPlugin registerPlugin() {
         return MachineLearningTests.createTrialLicensedMachineLearning(Settings.EMPTY);
-    }
-
-    @Override
-    protected List<NamedXContentRegistry.Entry> getNamedXContents() {
-        return CollectionUtils.appendToCopy(
-            super.getNamedXContents(),
-            new NamedXContentRegistry.Entry(
-                Aggregation.class,
-                new ParseField(InferencePipelineAggregationBuilder.NAME),
-                (p, c) -> ParsedInference.fromXContent(p, (String) c)
-            )
-        );
-    }
-
-    @Override
-    protected Predicate<String> excludePathsFromXContentInsertion() {
-        return p -> p.contains("top_classes") || p.contains("feature_importance");
     }
 
     @Override
@@ -95,37 +69,6 @@ public class InternalInferenceAggregationTests extends InternalAggregationTestCa
     @Override
     protected void assertReduced(InternalInferenceAggregation reduced, List<InternalInferenceAggregation> inputs) {
         // no test since reduce operation is unsupported
-    }
-
-    @Override
-    protected void assertFromXContent(InternalInferenceAggregation agg, ParsedAggregation parsedAggregation) {
-        ParsedInference parsed = ((ParsedInference) parsedAggregation);
-
-        InferenceResults result = agg.getInferenceResult();
-        if (result instanceof WarningInferenceResults warning) {
-            assertEquals(warning.getWarning(), parsed.getWarning());
-        } else if (result instanceof RegressionInferenceResults regression) {
-            assertEquals(regression.value(), parsed.getValue());
-            List<RegressionFeatureImportance> featureImportance = regression.getFeatureImportance();
-            if (featureImportance.isEmpty()) {
-                featureImportance = null;
-            }
-            assertEquals(featureImportance, parsed.getFeatureImportance());
-        } else if (result instanceof ClassificationInferenceResults classification) {
-            assertEquals(classification.predictedValue(), parsed.getValue());
-
-            List<ClassificationFeatureImportance> featureImportance = classification.getFeatureImportance();
-            if (featureImportance.isEmpty()) {
-                featureImportance = null;
-            }
-            assertEquals(featureImportance, parsed.getFeatureImportance());
-
-            List<TopClassEntry> topClasses = classification.getTopClasses();
-            if (topClasses.isEmpty()) {
-                topClasses = null;
-            }
-            assertEquals(topClasses, parsed.getTopClasses());
-        }
     }
 
     public void testGetProperty_givenEmptyPath() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/kstest/InternalKSTestAggregationTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/kstest/InternalKSTestAggregationTests.java
@@ -8,12 +8,8 @@
 package org.elasticsearch.xpack.ml.aggs.kstest;
 
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.plugins.SearchPlugin;
-import org.elasticsearch.search.aggregations.Aggregation;
-import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.test.InternalAggregationTestCase;
-import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.ml.MachineLearningTests;
 
 import java.util.Arrays;
@@ -22,25 +18,11 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static org.hamcrest.Matchers.equalTo;
-
 public class InternalKSTestAggregationTests extends InternalAggregationTestCase<InternalKSTestAggregation> {
 
     @Override
     protected SearchPlugin registerPlugin() {
         return MachineLearningTests.createTrialLicensedMachineLearning(Settings.EMPTY);
-    }
-
-    @Override
-    protected List<NamedXContentRegistry.Entry> getNamedXContents() {
-        return CollectionUtils.appendToCopy(
-            super.getNamedXContents(),
-            new NamedXContentRegistry.Entry(
-                Aggregation.class,
-                BucketCountKSTestAggregationBuilder.NAME,
-                (p, c) -> ParsedKSTest.fromXContent(p, (String) c)
-            )
-        );
     }
 
     @Override
@@ -61,12 +43,6 @@ public class InternalKSTestAggregationTests extends InternalAggregationTestCase<
     @Override
     public void testReduceRandom() {
         expectThrows(UnsupportedOperationException.class, () -> createTestInstance("name", null).reduce(null, null));
-    }
-
-    @Override
-    protected void assertFromXContent(InternalKSTestAggregation aggregation, ParsedAggregation parsedAggregation) {
-        ParsedKSTest ks = (ParsedKSTest) parsedAggregation;
-        assertThat(ks.getModes(), equalTo(aggregation.getModeValues()));
     }
 
     @Override

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/InternalGeoLineTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/InternalGeoLineTests.java
@@ -11,14 +11,12 @@ import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
-import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.InternalAggregationTestCase;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xpack.spatial.SpatialPlugin;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -136,11 +134,6 @@ public class InternalGeoLineTests extends InternalAggregationTestCase<InternalGe
 
         assertArrayEquals(finalCappedSortVals, reduced.sortVals(), 0d);
         assertArrayEquals(finalCappedPoints, reduced.line());
-    }
-
-    @Override
-    protected void assertFromXContent(InternalGeoLine aggregation, ParsedAggregation parsedAggregation) throws IOException {
-        // There is no ParsedGeoLine yet so we cannot test it here
     }
 
     @Override

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/InternalGeoLineTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/InternalGeoLineTests.java
@@ -6,15 +6,11 @@
  */
 package org.elasticsearch.xpack.spatial.search.aggregations;
 
-import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.plugins.SearchPlugin;
-import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.InternalAggregationTestCase;
-import org.elasticsearch.xcontent.NamedXContentRegistry;
-import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xpack.spatial.SpatialPlugin;
 
 import java.util.ArrayList;
@@ -134,16 +130,5 @@ public class InternalGeoLineTests extends InternalAggregationTestCase<InternalGe
 
         assertArrayEquals(finalCappedSortVals, reduced.sortVals(), 0d);
         assertArrayEquals(finalCappedPoints, reduced.line());
-    }
-
-    @Override
-    protected List<NamedXContentRegistry.Entry> getNamedXContents() {
-        return CollectionUtils.appendToCopy(
-            super.getNamedXContents(),
-            new NamedXContentRegistry.Entry(Aggregation.class, new ParseField(GeoLineAggregationBuilder.NAME), (p, c) -> {
-                assumeTrue("There is no ParsedGeoLine yet", false);
-                return null;
-            })
-        );
     }
 }

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoHexGridTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoHexGridTests.java
@@ -6,15 +6,11 @@
  */
 package org.elasticsearch.xpack.spatial.search.aggregations.bucket.geogrid;
 
-import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.h3.H3;
 import org.elasticsearch.plugins.SearchPlugin;
-import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.bucket.geogrid.GeoGridTestCase;
 import org.elasticsearch.search.aggregations.bucket.geogrid.InternalGeoGridBucket;
-import org.elasticsearch.xcontent.NamedXContentRegistry;
-import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xpack.spatial.LocalStateSpatialPlugin;
 
 import java.util.List;
@@ -25,18 +21,6 @@ public class GeoHexGridTests extends GeoGridTestCase<InternalGeoHexGridBucket, I
     @Override
     protected SearchPlugin registerPlugin() {
         return new LocalStateSpatialPlugin();
-    }
-
-    @Override
-    protected List<NamedXContentRegistry.Entry> getNamedXContents() {
-        return CollectionUtils.appendToCopy(
-            super.getNamedXContents(),
-            new NamedXContentRegistry.Entry(
-                Aggregation.class,
-                new ParseField(GeoHexGridAggregationBuilder.NAME),
-                (p, c) -> ParsedGeoHexGrid.fromXContent(p, (String) c)
-            )
-        );
     }
 
     @Override

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/InternalCartesianBoundsTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/InternalCartesianBoundsTests.java
@@ -7,15 +7,10 @@
 
 package org.elasticsearch.xpack.spatial.search.aggregations.metrics;
 
-import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.plugins.SearchPlugin;
-import org.elasticsearch.search.aggregations.Aggregation;
-import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.search.aggregations.support.SamplingContext;
 import org.elasticsearch.test.InternalAggregationTestCase;
-import org.elasticsearch.xcontent.NamedXContentRegistry;
-import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xpack.spatial.LocalStateSpatialPlugin;
 
 import java.util.HashMap;
@@ -32,18 +27,6 @@ public class InternalCartesianBoundsTests extends InternalAggregationTestCase<In
     @Override
     protected SearchPlugin registerPlugin() {
         return new LocalStateSpatialPlugin();
-    }
-
-    @Override
-    protected List<NamedXContentRegistry.Entry> getNamedXContents() {
-        return CollectionUtils.appendToCopy(
-            super.getNamedXContents(),
-            new NamedXContentRegistry.Entry(
-                Aggregation.class,
-                new ParseField(CartesianBoundsAggregationBuilder.NAME),
-                (p, c) -> ParsedCartesianBounds.fromXContent(p, (String) c)
-            )
-        );
     }
 
     @Override
@@ -90,15 +73,6 @@ public class InternalCartesianBoundsTests extends InternalAggregationTestCase<In
         assertValueClose(sampled.bottom, reduced.bottom);
         assertValueClose(sampled.left, reduced.left);
         assertValueClose(sampled.right, reduced.right);
-    }
-
-    @Override
-    protected void assertFromXContent(InternalCartesianBounds aggregation, ParsedAggregation parsedAggregation) {
-        assertTrue(parsedAggregation instanceof ParsedCartesianBounds);
-        ParsedCartesianBounds parsed = (ParsedCartesianBounds) parsedAggregation;
-
-        assertEquals(aggregation.topLeft(), parsed.topLeft());
-        assertEquals(aggregation.bottomRight(), parsed.bottomRight());
     }
 
     @Override

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/InternalCartesianCentroidTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/InternalCartesianCentroidTests.java
@@ -8,18 +8,13 @@
 package org.elasticsearch.xpack.spatial.search.aggregations.metrics;
 
 import org.elasticsearch.common.geo.SpatialPoint;
-import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.geo.ShapeTestUtils;
 import org.elasticsearch.geometry.Point;
 import org.elasticsearch.plugins.SearchPlugin;
-import org.elasticsearch.search.aggregations.Aggregation;
-import org.elasticsearch.search.aggregations.ParsedAggregation;
 import org.elasticsearch.search.aggregations.metrics.InternalCentroid;
 import org.elasticsearch.search.aggregations.support.SamplingContext;
 import org.elasticsearch.test.InternalAggregationTestCase;
-import org.elasticsearch.xcontent.NamedXContentRegistry;
-import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xpack.spatial.LocalStateSpatialPlugin;
 import org.elasticsearch.xpack.spatial.common.CartesianPoint;
 
@@ -38,18 +33,6 @@ public class InternalCartesianCentroidTests extends InternalAggregationTestCase<
     @Override
     protected SearchPlugin registerPlugin() {
         return new LocalStateSpatialPlugin();
-    }
-
-    @Override
-    protected List<NamedXContentRegistry.Entry> getNamedXContents() {
-        return CollectionUtils.appendToCopy(
-            super.getNamedXContents(),
-            new NamedXContentRegistry.Entry(
-                Aggregation.class,
-                new ParseField(CartesianCentroidAggregationBuilder.NAME),
-                (p, c) -> ParsedCartesianCentroid.fromXContent(p, (String) c)
-            )
-        );
     }
 
     @Override
@@ -105,15 +88,6 @@ public class InternalCartesianCentroidTests extends InternalAggregationTestCase<
         );
         InternalCentroid reducedCentroid = maxValueCentroid.reduce(Collections.singletonList(maxValueCentroid), null);
         assertThat(reducedCentroid.count(), equalTo(Long.MAX_VALUE));
-    }
-
-    @Override
-    protected void assertFromXContent(InternalCartesianCentroid aggregation, ParsedAggregation parsedAggregation) {
-        assertTrue(parsedAggregation instanceof ParsedCartesianCentroid);
-        ParsedCartesianCentroid parsed = (ParsedCartesianCentroid) parsedAggregation;
-
-        assertEquals(aggregation.centroid(), parsed.centroid());
-        assertEquals(aggregation.count(), parsed.count());
     }
 
     @Override


### PR DESCRIPTION
This Pr removes any reference to ParsedAggregation from the test framework to facilitate removing the actual implementations and make sure we are not removing coverage.

relates https://github.com/elastic/elasticsearch/issues/104789