### PR TITLE
[Connectors API] Fix bug when creating a sync job via API

### DIFF
--- a/docs/changelog/104802.yaml
+++ b/docs/changelog/104802.yaml
@@ -1,0 +1,5 @@
+pr: 104802
+summary: "[Connectors API] Fix bug when triggering a sync job via API"
+area: Application
+type: bug
+issues: []

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/400_connector_sync_job_post.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/400_connector_sync_job_post.yml
@@ -29,7 +29,7 @@ setup:
       connector_sync_job.get:
         connector_sync_job_id: $id
 
-  - match: { connector.id: test-connector}
+  - match: { connector.id: test-connector }
   - match: { job_type: full }
   - match: { trigger_method: on_demand }
   - match: { status: pending }
@@ -40,6 +40,106 @@ setup:
   - match: { id: $id }
   - exists: created_at
   - exists: last_seen
+
+---
+'Create connector sync job with filtering':
+  - do:
+      connector.update_filtering:
+        connector_id: test-connector
+        body:
+          filtering:
+            - active:
+                advanced_snippet:
+                  created_at: "2023-05-25T12:30:00.000Z"
+                  updated_at: "2023-05-25T12:30:00.000Z"
+                  value: { }
+                rules:
+                  - created_at: "2023-05-25T12:30:00.000Z"
+                    field: _
+                    id: RULE-ACTIVE-SYNC-JOB-TEST
+                    order: 0
+                    policy: include
+                    rule: regex
+                    updated_at: "2023-05-25T12:30:00.000Z"
+                    value: ".*"
+                validation:
+                  errors: [ ]
+                  state: valid
+              domain: DEFAULT
+              draft:
+                advanced_snippet:
+                  created_at: "2023-05-25T12:30:00.000Z"
+                  updated_at: "2023-05-25T12:30:00.000Z"
+                  value: { }
+                rules:
+                  - created_at: "2023-05-25T12:30:00.000Z"
+                    field: _
+                    id: RULE-DRAFT-0
+                    order: 0
+                    policy: include
+                    rule: regex
+                    updated_at: "2023-05-25T12:30:00.000Z"
+                    value: ".*"
+                validation:
+                  errors: [ ]
+                  state: valid
+            - active:
+                advanced_snippet:
+                  created_at: "2021-05-25T12:30:00.000Z"
+                  updated_at: "2021-05-25T12:30:00.000Z"
+                  value: { }
+                rules:
+                  - created_at: "2021-05-25T12:30:00.000Z"
+                    field: _
+                    id: RULE-ACTIVE-1
+                    order: 0
+                    policy: include
+                    rule: regex
+                    updated_at: "2021-05-25T12:30:00.000Z"
+                    value: ".*"
+                validation:
+                  errors: [ ]
+                  state: valid
+              domain: TEST
+              draft:
+                advanced_snippet:
+                  created_at: "2021-05-25T12:30:00.000Z"
+                  updated_at: "2021-05-25T12:30:00.000Z"
+                  value: { }
+                rules:
+                  - created_at: "2021-05-25T12:30:00.000Z"
+                    field: _
+                    id: RULE-DRAFT-1
+                    order: 0
+                    policy: exclude
+                    rule: regex
+                    updated_at: "2021-05-25T12:30:00.000Z"
+                    value: ".*"
+                validation:
+                  errors: [ ]
+                  state: valid
+
+  - match: { result: updated }
+
+  - do:
+      connector_sync_job.post:
+        body:
+          id: test-connector
+          job_type: full
+          trigger_method: on_demand
+
+  - set:  { id: id }
+
+  - match: { id: $id }
+
+  - do:
+      connector_sync_job.get:
+        connector_sync_job_id: $id
+
+  - match: { connector.filtering.rules.0.id: RULE-ACTIVE-SYNC-JOB-TEST }
+  - match: { connector.filtering.rules.0.rule: regex }
+  - match: { connector.filtering.validation.state: valid }
+  - match: { connector.filtering.advanced_snippet.created_at: "2023-05-25T12:30:00.000Z" }
 
 ---
 'Create connector sync job with complex connector document':

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/Connector.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/Connector.java
@@ -22,6 +22,7 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.application.connector.filtering.FilteringRules;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -47,6 +48,7 @@ import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstr
  *     <li>An error string capturing the latest error encountered during the connector's operation, if any.</li>
  *     <li>A {@link ConnectorFeatures} object encapsulating the set of features enabled for this connector.</li>
  *     <li>A list of {@link ConnectorFiltering} objects for applying filtering rules to the data processed by the connector.</li>
+ *     <li>An optional {@link FilteringRules} object that represents active filtering rules applied to a sync job.</li>
  *     <li>The name of the Elasticsearch index where the synchronized data is stored or managed.</li>
  *     <li>A boolean flag 'isNative' indicating whether the connector is a native Elasticsearch connector.</li>
  *     <li>The language associated with the connector.</li>
@@ -79,6 +81,8 @@ public class Connector implements NamedWriteable, ToXContentObject {
     private final ConnectorFeatures features;
     private final List<ConnectorFiltering> filtering;
     @Nullable
+    private final FilteringRules syncJobFiltering;
+    @Nullable
     private final String indexName;
     private final boolean isNative;
     @Nullable
@@ -110,6 +114,7 @@ public class Connector implements NamedWriteable, ToXContentObject {
      * @param error              Information about the last error encountered by the connector, if any.
      * @param features           Features enabled for the connector.
      * @param filtering          Filtering settings applied by the connector.
+     * @param syncJobFiltering   Filtering settings used by a sync job, it contains subset of data from 'filtering'.
      * @param indexName          Name of the index associated with the connector.
      * @param isNative           Flag indicating whether the connector is a native type.
      * @param language           The language supported by the connector.
@@ -132,6 +137,7 @@ public class Connector implements NamedWriteable, ToXContentObject {
         String error,
         ConnectorFeatures features,
         List<ConnectorFiltering> filtering,
+        FilteringRules syncJobFiltering,
         String indexName,
         boolean isNative,
         String language,
@@ -153,6 +159,7 @@ public class Connector implements NamedWriteable, ToXContentObject {
         this.error = error;
         this.features = features;
         this.filtering = filtering;
+        this.syncJobFiltering = syncJobFiltering;
         this.indexName = indexName;
         this.isNative = isNative;
         this.language = language;
@@ -176,6 +183,7 @@ public class Connector implements NamedWriteable, ToXContentObject {
         this.error = in.readOptionalString();
         this.features = in.readOptionalWriteable(ConnectorFeatures::new);
         this.filtering = in.readOptionalCollectionAsList(ConnectorFiltering::new);
+        this.syncJobFiltering = in.readOptionalWriteable(FilteringRules::new);
         this.indexName = in.readOptionalString();
         this.isNative = in.readBoolean();
         this.language = in.readOptionalString();
@@ -391,6 +399,7 @@ public class Connector implements NamedWriteable, ToXContentObject {
         out.writeOptionalString(error);
         out.writeOptionalWriteable(features);
         out.writeOptionalCollection(filtering);
+        out.writeOptionalWriteable(syncJobFiltering);
         out.writeOptionalString(indexName);
         out.writeBoolean(isNative);
         out.writeOptionalString(language);
@@ -435,6 +444,10 @@ public class Connector implements NamedWriteable, ToXContentObject {
 
     public List<ConnectorFiltering> getFiltering() {
         return filtering;
+    }
+
+    public FilteringRules getSyncJobFiltering() {
+        return syncJobFiltering;
     }
 
     public String getIndexName() {
@@ -500,6 +513,7 @@ public class Connector implements NamedWriteable, ToXContentObject {
             && Objects.equals(error, connector.error)
             && Objects.equals(features, connector.features)
             && Objects.equals(filtering, connector.filtering)
+            && Objects.equals(syncJobFiltering, connector.syncJobFiltering)
             && Objects.equals(indexName, connector.indexName)
             && Objects.equals(language, connector.language)
             && Objects.equals(lastSeen, connector.lastSeen)
@@ -523,6 +537,7 @@ public class Connector implements NamedWriteable, ToXContentObject {
             error,
             features,
             filtering,
+            syncJobFiltering,
             indexName,
             isNative,
             language,
@@ -553,6 +568,7 @@ public class Connector implements NamedWriteable, ToXContentObject {
         private String error;
         private ConnectorFeatures features;
         private List<ConnectorFiltering> filtering;
+        private FilteringRules syncJobFiltering;
         private String indexName;
         private boolean isNative;
         private String language;
@@ -603,6 +619,11 @@ public class Connector implements NamedWriteable, ToXContentObject {
 
         public Builder setFiltering(List<ConnectorFiltering> filtering) {
             this.filtering = filtering;
+            return this;
+        }
+
+        public Builder setSyncJobFiltering(FilteringRules syncJobFiltering) {
+            this.syncJobFiltering = syncJobFiltering;
             return this;
         }
 
@@ -676,6 +697,7 @@ public class Connector implements NamedWriteable, ToXContentObject {
                 error,
                 features,
                 filtering,
+                syncJobFiltering,
                 indexName,
                 isNative,
                 language,

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorFiltering.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorFiltering.java
@@ -66,6 +66,18 @@ public class ConnectorFiltering implements Writeable, ToXContentObject {
         this.draft = new FilteringRules(in);
     }
 
+    public FilteringRules getActive() {
+        return active;
+    }
+
+    public String getDomain() {
+        return domain;
+    }
+
+    public FilteringRules getDraft() {
+        return draft;
+    }
+
     private static final ParseField ACTIVE_FIELD = new ParseField("active");
     private static final ParseField DOMAIN_FIELD = new ParseField("domain");
     private static final ParseField DRAFT_FIELD = new ParseField("draft");

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/filtering/FilteringRules.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/filtering/FilteringRules.java
@@ -57,6 +57,18 @@ public class FilteringRules implements Writeable, ToXContentObject {
         this.filteringValidationInfo = new FilteringValidationInfo(in);
     }
 
+    public FilteringAdvancedSnippet getAdvancedSnippet() {
+        return advancedSnippet;
+    }
+
+    public List<FilteringRule> getRules() {
+        return rules;
+    }
+
+    public FilteringValidationInfo getFilteringValidationInfo() {
+        return filteringValidationInfo;
+    }
+
     private static final ParseField ADVANCED_SNIPPET_FIELD = new ParseField("advanced_snippet");
     private static final ParseField RULES_FIELD = new ParseField("rules");
     private static final ParseField VALIDATION_FIELD = new ParseField("validation");

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJob.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJob.java
@@ -25,16 +25,15 @@ import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.application.connector.Connector;
 import org.elasticsearch.xpack.application.connector.ConnectorConfiguration;
-import org.elasticsearch.xpack.application.connector.ConnectorFiltering;
 import org.elasticsearch.xpack.application.connector.ConnectorIngestPipeline;
 import org.elasticsearch.xpack.application.connector.ConnectorSyncStatus;
 import org.elasticsearch.xpack.application.connector.ConnectorUtils;
+import org.elasticsearch.xpack.application.connector.filtering.FilteringRules;
 
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -350,7 +349,7 @@ public class ConnectorSyncJob implements Writeable, ToXContentObject {
             String syncJobConnectorId = Strings.isNullOrEmpty(connectorId) ? parsedConnectorId : connectorId;
 
             return new Connector.Builder().setConnectorId(syncJobConnectorId)
-                .setFiltering((List<ConnectorFiltering>) args[i++])
+                .setSyncJobFiltering((FilteringRules) args[i++])
                 .setIndexName((String) args[i++])
                 .setLanguage((String) args[i++])
                 .setPipeline((ConnectorIngestPipeline) args[i++])
@@ -362,9 +361,10 @@ public class ConnectorSyncJob implements Writeable, ToXContentObject {
 
     static {
         SYNC_JOB_CONNECTOR_PARSER.declareString(optionalConstructorArg(), Connector.ID_FIELD);
-        SYNC_JOB_CONNECTOR_PARSER.declareObjectArray(
+        SYNC_JOB_CONNECTOR_PARSER.declareObjectOrNull(
             optionalConstructorArg(),
-            (p, c) -> ConnectorFiltering.fromXContent(p),
+            (p, c) -> FilteringRules.fromXContent(p),
+            null,
             Connector.FILTERING_FIELD
         );
         SYNC_JOB_CONNECTOR_PARSER.declareStringOrNull(optionalConstructorArg(), Connector.INDEX_NAME_FIELD);
@@ -498,8 +498,8 @@ public class ConnectorSyncJob implements Writeable, ToXContentObject {
                 if (connector.getConnectorId() != null) {
                     builder.field(Connector.ID_FIELD.getPreferredName(), connector.getConnectorId());
                 }
-                if (connector.getFiltering() != null) {
-                    builder.field(Connector.FILTERING_FIELD.getPreferredName(), connector.getFiltering());
+                if (connector.getSyncJobFiltering() != null) {
+                    builder.field(Connector.FILTERING_FIELD.getPreferredName(), connector.getSyncJobFiltering());
                 }
                 if (connector.getIndexName() != null) {
                     builder.field(Connector.INDEX_NAME_FIELD.getPreferredName(), connector.getIndexName());

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobIndexService.java
@@ -38,9 +38,11 @@ import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.application.connector.Connector;
+import org.elasticsearch.xpack.application.connector.ConnectorFiltering;
 import org.elasticsearch.xpack.application.connector.ConnectorIndexService;
 import org.elasticsearch.xpack.application.connector.ConnectorSyncStatus;
 import org.elasticsearch.xpack.application.connector.ConnectorTemplateRegistry;
+import org.elasticsearch.xpack.application.connector.filtering.FilteringRules;
 import org.elasticsearch.xpack.application.connector.syncjob.action.PostConnectorSyncJobAction;
 import org.elasticsearch.xpack.application.connector.syncjob.action.UpdateConnectorSyncJobIngestionStatsAction;
 
@@ -52,6 +54,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.stream.Stream;
 
@@ -427,12 +430,23 @@ public class ConnectorSyncJobIndexService {
                         return;
                     }
                     try {
-                        final Connector syncJobConnectorInfo = ConnectorSyncJob.syncJobConnectorFromXContentBytes(
+                        final Connector connector = Connector.fromXContentBytes(
                             response.getSourceAsBytesRef(),
                             connectorId,
                             XContentType.JSON
                         );
-                        listener.onResponse(syncJobConnectorInfo);
+
+                        // Build the connector representation for sync job
+                        final Connector syncJobConnector = new Connector.Builder().setConnectorId(connector.getConnectorId())
+                            .setSyncJobFiltering(transformConnectorFilteringToSyncJobRepresentation(connector.getFiltering()))
+                            .setIndexName(connector.getIndexName())
+                            .setLanguage(connector.getLanguage())
+                            .setPipeline(connector.getPipeline())
+                            .setServiceType(connector.getServiceType())
+                            .setConfiguration(connector.getConfiguration())
+                            .build();
+
+                        listener.onResponse(syncJobConnector);
                     } catch (Exception e) {
                         listener.onFailure(e);
                     }
@@ -446,6 +460,20 @@ public class ConnectorSyncJobIndexService {
         } catch (Exception e) {
             listener.onFailure(e);
         }
+    }
+
+    /**
+     * Transforms the first {@link ConnectorFiltering} object from a list into a {@link FilteringRules} representation for a sync job.
+     * This method specifically extracts the 'active' filtering rules from the first {@link ConnectorFiltering} object in the list,
+     * if the list is neither null nor empty.
+     *
+     * @param connectorFiltering The list of {@link ConnectorFiltering} objects to be transformed. Can be null or empty.
+     */
+    FilteringRules transformConnectorFilteringToSyncJobRepresentation(List<ConnectorFiltering> connectorFiltering) {
+        return Optional.ofNullable(connectorFiltering)
+            .filter(list -> list.isEmpty() == false)
+            .map(list -> list.get(0).getActive())
+            .orElse(null);
     }
 
     /**

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorTestUtils.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorTestUtils.java
@@ -187,8 +187,10 @@ public final class ConnectorTestUtils {
     }
 
     public static Connector getRandomSyncJobConnectorInfo() {
+        ConnectorFiltering randomFiltering = getRandomConnectorFiltering();
         return new Connector.Builder().setConnectorId(randomAlphaOfLength(10))
-            .setFiltering(List.of(getRandomConnectorFiltering()))
+            .setSyncJobFiltering(randomFiltering.getActive())
+            .setFiltering(List.of(randomFiltering))
             .setIndexName(randomAlphaOfLength(10))
             .setLanguage(randomAlphaOfLength(10))
             .setServiceType(randomAlphaOfLength(10))

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobIndexServiceTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobIndexServiceTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xpack.application.connector.Connector;
+import org.elasticsearch.xpack.application.connector.ConnectorFiltering;
 import org.elasticsearch.xpack.application.connector.ConnectorIndexService;
 import org.elasticsearch.xpack.application.connector.ConnectorSyncStatus;
 import org.elasticsearch.xpack.application.connector.ConnectorTestUtils;
@@ -35,6 +36,7 @@ import java.io.IOException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -62,34 +64,35 @@ public class ConnectorSyncJobIndexServiceTests extends ESSingleNodeTestCase {
     private static final int ONE_SECOND_IN_MILLIS = 1000;
 
     private ConnectorSyncJobIndexService connectorSyncJobIndexService;
-    private Connector connectorOne;
-    private Connector connectorTwo;
+
+    private String connectorOneId;
+    private String connectorTwoId;
 
     @Before
     public void setup() throws Exception {
-        connectorOne = ConnectorTestUtils.getRandomSyncJobConnectorInfo();
-        connectorTwo = ConnectorTestUtils.getRandomSyncJobConnectorInfo();
 
-        createConnector(connectorOne);
-        createConnector(connectorTwo);
+        connectorOneId = createConnector();
+        connectorTwoId = createConnector();
 
         this.connectorSyncJobIndexService = new ConnectorSyncJobIndexService(client());
     }
 
-    private void createConnector(Connector connector) throws IOException, InterruptedException, ExecutionException, TimeoutException {
+    private String createConnector() throws IOException, InterruptedException, ExecutionException, TimeoutException {
+
+        Connector connector = ConnectorTestUtils.getRandomConnector();
+
         final IndexRequest indexRequest = new IndexRequest(ConnectorIndexService.CONNECTOR_INDEX_NAME).opType(DocWriteRequest.OpType.INDEX)
-            .id(connector.getConnectorId())
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
             .source(connector.toXContent(jsonBuilder(), ToXContent.EMPTY_PARAMS));
         ActionFuture<DocWriteResponse> index = client().index(indexRequest);
 
         // wait 10 seconds for connector creation
-        index.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        return index.get(TIMEOUT_SECONDS, TimeUnit.SECONDS).getId();
     }
 
     public void testCreateConnectorSyncJob() throws Exception {
         PostConnectorSyncJobAction.Request syncJobRequest = ConnectorSyncJobTestUtils.getRandomPostConnectorSyncJobActionRequest(
-            connectorOne.getConnectorId()
+            connectorOneId
         );
         ConnectorSyncJobType requestJobType = syncJobRequest.getJobType();
         ConnectorSyncJobTriggerMethod requestTriggerMethod = syncJobRequest.getTriggerMethod();
@@ -110,7 +113,7 @@ public class ConnectorSyncJobIndexServiceTests extends ESSingleNodeTestCase {
 
     public void testCreateConnectorSyncJob_WithMissingJobType_ExpectDefaultJobTypeToBeSet() throws Exception {
         PostConnectorSyncJobAction.Request syncJobRequest = new PostConnectorSyncJobAction.Request(
-            connectorOne.getConnectorId(),
+            connectorOneId,
             null,
             ConnectorSyncJobTriggerMethod.ON_DEMAND
         );
@@ -123,7 +126,7 @@ public class ConnectorSyncJobIndexServiceTests extends ESSingleNodeTestCase {
 
     public void testCreateConnectorSyncJob_WithMissingTriggerMethod_ExpectDefaultTriggerMethodToBeSet() throws Exception {
         PostConnectorSyncJobAction.Request syncJobRequest = new PostConnectorSyncJobAction.Request(
-            connectorOne.getConnectorId(),
+            connectorOneId,
             ConnectorSyncJobType.FULL,
             null
         );
@@ -148,7 +151,7 @@ public class ConnectorSyncJobIndexServiceTests extends ESSingleNodeTestCase {
 
     public void testDeleteConnectorSyncJob() throws Exception {
         PostConnectorSyncJobAction.Request syncJobRequest = ConnectorSyncJobTestUtils.getRandomPostConnectorSyncJobActionRequest(
-            connectorOne.getConnectorId()
+            connectorOneId
         );
         PostConnectorSyncJobAction.Response response = awaitPutConnectorSyncJob(syncJobRequest);
         String syncJobId = response.getId();
@@ -166,7 +169,7 @@ public class ConnectorSyncJobIndexServiceTests extends ESSingleNodeTestCase {
 
     public void testGetConnectorSyncJob() throws Exception {
         PostConnectorSyncJobAction.Request syncJobRequest = ConnectorSyncJobTestUtils.getRandomPostConnectorSyncJobActionRequest(
-            connectorOne.getConnectorId()
+            connectorOneId
         );
         ConnectorSyncJobType jobType = syncJobRequest.getJobType();
         ConnectorSyncJobTriggerMethod triggerMethod = syncJobRequest.getTriggerMethod();
@@ -179,7 +182,7 @@ public class ConnectorSyncJobIndexServiceTests extends ESSingleNodeTestCase {
         assertThat(syncJob.getId(), equalTo(syncJobId));
         assertThat(syncJob.getJobType(), equalTo(jobType));
         assertThat(syncJob.getTriggerMethod(), equalTo(triggerMethod));
-        assertThat(syncJob.getConnector().getConnectorId(), equalTo(connectorOne.getConnectorId()));
+        assertThat(syncJob.getConnector().getConnectorId(), equalTo(connectorOneId));
     }
 
     public void testGetConnectorSyncJob_WithMissingSyncJobId_ExpectException() {
@@ -188,7 +191,7 @@ public class ConnectorSyncJobIndexServiceTests extends ESSingleNodeTestCase {
 
     public void testCheckInConnectorSyncJob() throws Exception {
         PostConnectorSyncJobAction.Request syncJobRequest = ConnectorSyncJobTestUtils.getRandomPostConnectorSyncJobActionRequest(
-            connectorOne.getConnectorId()
+            connectorOneId
         );
         PostConnectorSyncJobAction.Response response = awaitPutConnectorSyncJob(syncJobRequest);
         String syncJobId = response.getId();
@@ -227,7 +230,7 @@ public class ConnectorSyncJobIndexServiceTests extends ESSingleNodeTestCase {
 
     public void testCancelConnectorSyncJob() throws Exception {
         PostConnectorSyncJobAction.Request syncJobRequest = ConnectorSyncJobTestUtils.getRandomPostConnectorSyncJobActionRequest(
-            connectorOne.getConnectorId()
+            connectorOneId
         );
         PostConnectorSyncJobAction.Response response = awaitPutConnectorSyncJob(syncJobRequest);
         String syncJobId = response.getId();
@@ -269,7 +272,7 @@ public class ConnectorSyncJobIndexServiceTests extends ESSingleNodeTestCase {
 
         for (int i = 0; i < numberOfSyncJobs; i++) {
             PostConnectorSyncJobAction.Request request = ConnectorSyncJobTestUtils.getRandomPostConnectorSyncJobActionRequest(
-                connectorOne.getConnectorId()
+                connectorOneId
             );
             PostConnectorSyncJobAction.Response response = awaitPutConnectorSyncJob(request);
             ConnectorSyncJob syncJob = awaitGetConnectorSyncJob(response.getId());
@@ -309,7 +312,7 @@ public class ConnectorSyncJobIndexServiceTests extends ESSingleNodeTestCase {
     }
 
     public void testListConnectorSyncJobs_WithStatusPending_GivenOnePendingTwoCancelled_ExpectOnePending() throws Exception {
-        String connectorId = connectorOne.getConnectorId();
+        String connectorId = connectorOneId;
 
         PostConnectorSyncJobAction.Request requestOne = ConnectorSyncJobTestUtils.getRandomPostConnectorSyncJobActionRequest(connectorId);
         PostConnectorSyncJobAction.Request requestTwo = ConnectorSyncJobTestUtils.getRandomPostConnectorSyncJobActionRequest(connectorId);
@@ -342,9 +345,6 @@ public class ConnectorSyncJobIndexServiceTests extends ESSingleNodeTestCase {
 
     @AwaitsFix(bugUrl = "https://github.com/elastic/enterprise-search-team/issues/6351")
     public void testListConnectorSyncJobs_WithConnectorOneId_GivenTwoOverallOneFromConnectorOne_ExpectOne() throws Exception {
-        String connectorOneId = connectorOne.getConnectorId();
-        String connectorTwoId = connectorTwo.getConnectorId();
-
         PostConnectorSyncJobAction.Request requestOne = ConnectorSyncJobTestUtils.getRandomPostConnectorSyncJobActionRequest(
             connectorOneId
         );
@@ -378,7 +378,7 @@ public class ConnectorSyncJobIndexServiceTests extends ESSingleNodeTestCase {
 
     public void testUpdateConnectorSyncJobError() throws Exception {
         PostConnectorSyncJobAction.Request syncJobRequest = ConnectorSyncJobTestUtils.getRandomPostConnectorSyncJobActionRequest(
-            connectorOne.getConnectorId()
+            connectorOneId
         );
         PostConnectorSyncJobAction.Response response = awaitPutConnectorSyncJob(syncJobRequest);
         String syncJobId = response.getId();
@@ -407,7 +407,7 @@ public class ConnectorSyncJobIndexServiceTests extends ESSingleNodeTestCase {
 
     public void testUpdateConnectorSyncJobIngestionStats() throws Exception {
         PostConnectorSyncJobAction.Request syncJobRequest = ConnectorSyncJobTestUtils.getRandomPostConnectorSyncJobActionRequest(
-            connectorOne.getConnectorId()
+            connectorOneId
         );
         PostConnectorSyncJobAction.Response response = awaitPutConnectorSyncJob(syncJobRequest);
         String syncJobId = response.getId();
@@ -451,7 +451,7 @@ public class ConnectorSyncJobIndexServiceTests extends ESSingleNodeTestCase {
 
     public void testUpdateConnectorSyncJobIngestionStats_WithoutLastSeen_ExpectUpdateOfLastSeen() throws Exception {
         PostConnectorSyncJobAction.Request syncJobRequest = ConnectorSyncJobTestUtils.getRandomPostConnectorSyncJobActionRequest(
-            connectorOne.getConnectorId()
+            connectorOneId
         );
         PostConnectorSyncJobAction.Response response = awaitPutConnectorSyncJob(syncJobRequest);
         String syncJobId = response.getId();
@@ -490,6 +490,23 @@ public class ConnectorSyncJobIndexServiceTests extends ESSingleNodeTestCase {
                 new UpdateConnectorSyncJobIngestionStatsAction.Request(NON_EXISTING_SYNC_JOB_ID, 0L, 0L, 0L, 0L, Instant.now())
             )
         );
+    }
+
+    public void testTransformConnectorFilteringToSyncJobRepresentation_WithFilteringEqualNull() {
+        List<ConnectorFiltering> filtering = null;
+        assertNull(connectorSyncJobIndexService.transformConnectorFilteringToSyncJobRepresentation(filtering));
+    }
+
+    public void testTransformConnectorFilteringToSyncJobRepresentation_WithFilteringEmpty() {
+        List<ConnectorFiltering> filtering = Collections.emptyList();
+        assertNull(connectorSyncJobIndexService.transformConnectorFilteringToSyncJobRepresentation(filtering));
+    }
+
+    public void testTransformConnectorFilteringToSyncJobRepresentation_WithFilteringRules() {
+        ConnectorFiltering filtering1 = ConnectorTestUtils.getRandomConnectorFiltering();
+
+        List<ConnectorFiltering> filtering = List.of(filtering1, ConnectorTestUtils.getRandomConnectorFiltering());
+        assertEquals(connectorSyncJobIndexService.transformConnectorFilteringToSyncJobRepresentation(filtering), filtering1.getActive());
     }
 
     private UpdateResponse awaitUpdateConnectorSyncJobIngestionStats(UpdateConnectorSyncJobIngestionStatsAction.Request request)

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobTests.java
@@ -21,7 +21,6 @@ import java.time.Instant;
 import java.util.List;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 
@@ -46,88 +45,60 @@ public class ConnectorSyncJobTests extends ESTestCase {
     public void testFromXContent_WithAllFields_AllSet() throws IOException {
         String content = XContentHelper.stripWhitespace("""
             {
-            "cancelation_requested_at": "2023-12-01T14:19:39.394194Z",
-                                "canceled_at": "2023-12-01T14:19:39.394194Z",
-                                "completed_at": "2023-12-01T14:19:39.394194Z",
-                                "connector": {
-                                    "id": "connector-id",
-                                    "filtering": [
-                                        {
-                                            "active": {
-                                                "advanced_snippet": {
-                                                    "created_at": "2023-12-01T14:18:37.397819Z",
-                                                    "updated_at": "2023-12-01T14:18:37.397819Z",
-                                                    "value": {}
-                                                },
-                                                "rules": [
-                                                    {
-                                                        "created_at": "2023-12-01T14:18:37.397819Z",
-                                                        "field": "_",
-                                                        "id": "DEFAULT",
-                                                        "order": 0,
-                                                        "policy": "include",
-                                                        "rule": "regex",
-                                                        "updated_at": "2023-12-01T14:18:37.397819Z",
-                                                        "value": ".*"
-                                                    }
-                                                ],
-                                                "validation": {
-                                                    "errors": [],
-                                                    "state": "valid"
-                                                }
-                                            },
-                                            "domain": "DEFAULT",
-                                            "draft": {
-                                                "advanced_snippet": {
-                                                    "created_at": "2023-12-01T14:18:37.397819Z",
-                                                    "updated_at": "2023-12-01T14:18:37.397819Z",
-                                                    "value": {}
-                                                },
-                                                "rules": [
-                                                    {
-                                                        "created_at": "2023-12-01T14:18:37.397819Z",
-                                                        "field": "_",
-                                                        "id": "DEFAULT",
-                                                        "order": 0,
-                                                        "policy": "include",
-                                                        "rule": "regex",
-                                                        "updated_at": "2023-12-01T14:18:37.397819Z",
-                                                        "value": ".*"
-                                                    }
-                                                ],
-                                                "validation": {
-                                                    "errors": [],
-                                                    "state": "valid"
-                                                }
-                                            }
-                                        }
-                                    ],
-                                    "index_name": "search-connector",
-                                    "language": "english",
-                                    "pipeline": {
-                                        "extract_binary_content": true,
-                                        "name": "ent-search-generic-ingestion",
-                                        "reduce_whitespace": true,
-                                        "run_ml_inference": false
-                                    },
-                                    "service_type": "service type",
-                                    "configuration": {}
-                                },
-                                "created_at": "2023-12-01T14:18:43.07693Z",
-                                "deleted_document_count": 10,
-                                "error": "some-error",
-                                "id": "HIC-JYwB9RqKhB7x_hIE",
-                                "indexed_document_count": 10,
-                                "indexed_document_volume": 10,
-                                "job_type": "full",
-                                "last_seen": "2023-12-01T14:18:43.07693Z",
-                                "metadata": {},
-                                "started_at": "2023-12-01T14:18:43.07693Z",
-                                "status": "canceling",
-                                "total_document_count": 0,
-                                "trigger_method": "scheduled",
-                                "worker_hostname": "worker-hostname"
-                                }
+                "cancelation_requested_at": "2023-12-01T14:19:39.394194Z",
+                "canceled_at": "2023-12-01T14:19:39.394194Z",
+                "completed_at": "2023-12-01T14:19:39.394194Z",
+                "connector": {
+                    "id": "connector-id",
+                    "filtering": {
+                        "advanced_snippet": {
+                            "created_at": "2023-12-01T14:18:37.397819Z",
+                            "updated_at": "2023-12-01T14:18:37.397819Z",
+                            "value": {}
+                        },
+                        "rules": [
+                            {
+                                "created_at": "2023-12-01T14:18:37.397819Z",
+                                "field": "_",
+                                "id": "DEFAULT",
+                                "order": 0,
+                                "policy": "include",
+                                "rule": "regex",
+                                "updated_at": "2023-12-01T14:18:37.397819Z",
+                                "value": ".*"
+                            }
+                        ],
+                        "validation": {
+                            "errors": [],
+                            "state": "valid"
+                        }
+                    },
+                    "index_name": "search-connector",
+                    "language": "english",
+                    "pipeline": {
+                        "extract_binary_content": true,
+                        "name": "ent-search-generic-ingestion",
+                        "reduce_whitespace": true,
+                        "run_ml_inference": false
+                    },
+                    "service_type": "service type",
+                    "configuration": {}
+                },
+                "created_at": "2023-12-01T14:18:43.07693Z",
+                "deleted_document_count": 10,
+                "error": "some-error",
+                "id": "HIC-JYwB9RqKhB7x_hIE",
+                "indexed_document_count": 10,
+                "indexed_document_volume": 10,
+                "job_type": "full",
+                "last_seen": "2023-12-01T14:18:43.07693Z",
+                "metadata": {},
+                "started_at": "2023-12-01T14:18:43.07693Z",
+                "status": "canceling",
+                "total_document_count": 0,
+                "trigger_method": "scheduled",
+                "worker_hostname": "worker-hostname"
+            }
             """);
 
         ConnectorSyncJob syncJob = ConnectorSyncJob.fromXContentBytes(new BytesArray(content), XContentType.JSON);
@@ -137,7 +108,7 @@ public class ConnectorSyncJobTests extends ESTestCase {
         assertThat(syncJob.getCompletedAt(), equalTo(Instant.parse("2023-12-01T14:19:39.394194Z")));
 
         assertThat(syncJob.getConnector().getConnectorId(), equalTo("connector-id"));
-        assertThat(syncJob.getConnector().getFiltering(), hasSize(greaterThan(0)));
+        assertThat(syncJob.getConnector().getSyncJobFiltering().getRules(), hasSize(1));
         assertThat(syncJob.getConnector().getIndexName(), equalTo("search-connector"));
         assertThat(syncJob.getConnector().getLanguage(), equalTo("english"));
         assertThat(syncJob.getConnector().getPipeline(), notNullValue());
@@ -161,82 +132,54 @@ public class ConnectorSyncJobTests extends ESTestCase {
     public void testFromXContent_WithOnlyNonNullableFieldsSet_DoesNotThrow() throws IOException {
         String content = XContentHelper.stripWhitespace("""
             {
-                                "connector": {
-                                    "id": "connector-id",
-                                    "filtering": [
-                                        {
-                                            "active": {
-                                                "advanced_snippet": {
-                                                    "created_at": "2023-12-01T14:18:37.397819Z",
-                                                    "updated_at": "2023-12-01T14:18:37.397819Z",
-                                                    "value": {}
-                                                },
-                                                "rules": [
-                                                    {
-                                                        "created_at": "2023-12-01T14:18:37.397819Z",
-                                                        "field": "_",
-                                                        "id": "DEFAULT",
-                                                        "order": 0,
-                                                        "policy": "include",
-                                                        "rule": "regex",
-                                                        "updated_at": "2023-12-01T14:18:37.397819Z",
-                                                        "value": ".*"
-                                                    }
-                                                ],
-                                                "validation": {
-                                                    "errors": [],
-                                                    "state": "valid"
-                                                }
-                                            },
-                                            "domain": "DEFAULT",
-                                            "draft": {
-                                                "advanced_snippet": {
-                                                    "created_at": "2023-12-01T14:18:37.397819Z",
-                                                    "updated_at": "2023-12-01T14:18:37.397819Z",
-                                                    "value": {}
-                                                },
-                                                "rules": [
-                                                    {
-                                                        "created_at": "2023-12-01T14:18:37.397819Z",
-                                                        "field": "_",
-                                                        "id": "DEFAULT",
-                                                        "order": 0,
-                                                        "policy": "include",
-                                                        "rule": "regex",
-                                                        "updated_at": "2023-12-01T14:18:37.397819Z",
-                                                        "value": ".*"
-                                                    }
-                                                ],
-                                                "validation": {
-                                                    "errors": [],
-                                                    "state": "valid"
-                                                }
-                                            }
-                                        }
-                                    ],
-                                    "index_name": "search-connector",
-                                    "language": "english",
-                                    "pipeline": {
-                                        "extract_binary_content": true,
-                                        "name": "ent-search-generic-ingestion",
-                                        "reduce_whitespace": true,
-                                        "run_ml_inference": false
-                                    },
-                                    "service_type": "service type",
-                                    "configuration": {}
-                                },
-                                "created_at": "2023-12-01T14:18:43.07693Z",
-                                "deleted_document_count": 10,
-                                "id": "HIC-JYwB9RqKhB7x_hIE",
-                                "indexed_document_count": 10,
-                                "indexed_document_volume": 10,
-                                "job_type": "full",
-                                "last_seen": "2023-12-01T14:18:43.07693Z",
-                                "metadata": {},
-                                "status": "canceling",
-                                "total_document_count": 0,
-                                "trigger_method": "scheduled"
-                                }
+                "connector": {
+                    "id": "connector-id",
+                    "filtering": {
+                        "advanced_snippet": {
+                            "created_at": "2023-12-01T14:18:37.397819Z",
+                            "updated_at": "2023-12-01T14:18:37.397819Z",
+                            "value": {}
+                        },
+                        "rules": [
+                            {
+                                "created_at": "2023-12-01T14:18:37.397819Z",
+                                "field": "_",
+                                "id": "DEFAULT",
+                                "order": 0,
+                                "policy": "include",
+                                "rule": "regex",
+                                "updated_at": "2023-12-01T14:18:37.397819Z",
+                                "value": ".*"
+                            }
+                        ],
+                        "validation": {
+                            "errors": [],
+                            "state": "valid"
+                        }
+                    },
+                    "index_name": "search-connector",
+                    "language": "english",
+                    "pipeline": {
+                        "extract_binary_content": true,
+                        "name": "ent-search-generic-ingestion",
+                        "reduce_whitespace": true,
+                        "run_ml_inference": false
+                    },
+                    "service_type": "service type",
+                    "configuration": {}
+                },
+                "created_at": "2023-12-01T14:18:43.07693Z",
+                "deleted_document_count": 10,
+                "id": "HIC-JYwB9RqKhB7x_hIE",
+                "indexed_document_count": 10,
+                "indexed_document_volume": 10,
+                "job_type": "full",
+                "last_seen": "2023-12-01T14:18:43.07693Z",
+                "metadata": {},
+                "status": "canceling",
+                "total_document_count": 0,
+                "trigger_method": "scheduled"
+            }
             """);
 
         ConnectorSyncJob.fromXContentBytes(new BytesArray(content), XContentType.JSON);
@@ -245,88 +188,60 @@ public class ConnectorSyncJobTests extends ESTestCase {
     public void testFromXContent_WithAllNullableFieldsSetToNull_DoesNotThrow() throws IOException {
         String content = XContentHelper.stripWhitespace("""
             {
-            "cancelation_requested_at": null,
-                                "canceled_at": null,
-                                "completed_at": null,
-                                "connector": {
-                                    "id": "connector-id",
-                                    "filtering": [
-                                        {
-                                            "active": {
-                                                "advanced_snippet": {
-                                                    "created_at": "2023-12-01T14:18:37.397819Z",
-                                                    "updated_at": "2023-12-01T14:18:37.397819Z",
-                                                    "value": {}
-                                                },
-                                                "rules": [
-                                                    {
-                                                        "created_at": "2023-12-01T14:18:37.397819Z",
-                                                        "field": "_",
-                                                        "id": "DEFAULT",
-                                                        "order": 0,
-                                                        "policy": "include",
-                                                        "rule": "regex",
-                                                        "updated_at": "2023-12-01T14:18:37.397819Z",
-                                                        "value": ".*"
-                                                    }
-                                                ],
-                                                "validation": {
-                                                    "errors": [],
-                                                    "state": "valid"
-                                                }
-                                            },
-                                            "domain": "DEFAULT",
-                                            "draft": {
-                                                "advanced_snippet": {
-                                                    "created_at": "2023-12-01T14:18:37.397819Z",
-                                                    "updated_at": "2023-12-01T14:18:37.397819Z",
-                                                    "value": {}
-                                                },
-                                                "rules": [
-                                                    {
-                                                        "created_at": "2023-12-01T14:18:37.397819Z",
-                                                        "field": "_",
-                                                        "id": "DEFAULT",
-                                                        "order": 0,
-                                                        "policy": "include",
-                                                        "rule": "regex",
-                                                        "updated_at": "2023-12-01T14:18:37.397819Z",
-                                                        "value": ".*"
-                                                    }
-                                                ],
-                                                "validation": {
-                                                    "errors": [],
-                                                    "state": "valid"
-                                                }
-                                            }
-                                        }
-                                    ],
-                                    "index_name": "search-connector",
-                                    "language": "english",
-                                    "pipeline": {
-                                        "extract_binary_content": true,
-                                        "name": "ent-search-generic-ingestion",
-                                        "reduce_whitespace": true,
-                                        "run_ml_inference": false
-                                    },
-                                    "service_type": "service type",
-                                    "configuration": {}
-                                },
-                                "created_at": "2023-12-01T14:18:43.07693Z",
-                                "deleted_document_count": 10,
-                                "error": null,
-                                "id": "HIC-JYwB9RqKhB7x_hIE",
-                                "indexed_document_count": 10,
-                                "indexed_document_volume": 10,
-                                "job_type": "full",
-                                "last_seen": null,
-                                "metadata": {},
-                                "started_at": null,
-                                "status": "canceling",
-                                "total_document_count": 0,
-                                "trigger_method": "scheduled",
-                                "worker_hostname": null
-                                }
+                "cancelation_requested_at": null,
+                "canceled_at": null,
+                "completed_at": null,
+                "connector": {
+                    "id": "connector-id",
+                    "filtering": {
+                        "advanced_snippet": {
+                            "created_at": "2023-12-01T14:18:37.397819Z",
+                            "updated_at": "2023-12-01T14:18:37.397819Z",
+                            "value": {}
+                        },
+                        "rules": [
+                            {
+                                "created_at": "2023-12-01T14:18:37.397819Z",
+                                "field": "_",
+                                "id": "DEFAULT",
+                                "order": 0,
+                                "policy": "include",
+                                "rule": "regex",
+                                "updated_at": "2023-12-01T14:18:37.397819Z",
+                                "value": ".*"
+                            }
+                        ],
+                        "validation": {
+                            "errors": [],
+                            "state": "valid"
+                        }
+                    },
+                    "index_name": "search-connector",
+                    "language": "english",
+                    "pipeline": {
+                        "extract_binary_content": true,
+                        "name": "ent-search-generic-ingestion",
+                        "reduce_whitespace": true,
+                        "run_ml_inference": false
+                    },
+                    "service_type": "service type",
+                    "configuration": {}
+                },
+                "created_at": "2023-12-01T14:18:43.07693Z",
+                "deleted_document_count": 10,
+                "error": null,
+                "id": "HIC-JYwB9RqKhB7x_hIE",
+                "indexed_document_count": 10,
+                "indexed_document_volume": 10,
+                "job_type": "full",
+                "last_seen": null,
+                "metadata": {},
+                "started_at": null,
+                "status": "canceling",
+                "total_document_count": 0,
+                "trigger_method": "scheduled",
+                "worker_hostname": null
+            }
             """);
 
         ConnectorSyncJob.fromXContentBytes(new BytesArray(content), XContentType.JSON);
@@ -336,57 +251,29 @@ public class ConnectorSyncJobTests extends ESTestCase {
         String content = XContentHelper.stripWhitespace("""
             {
                 "id": "connector-id",
-                "filtering": [
-                    {
-                        "active": {
-                            "advanced_snippet": {
-                                "created_at": "2023-12-01T14:18:37.397819Z",
-                                "updated_at": "2023-12-01T14:18:37.397819Z",
-                                "value": {}
-                            },
-                            "rules": [
-                                {
-                                    "created_at": "2023-12-01T14:18:37.397819Z",
-                                    "field": "_",
-                                    "id": "DEFAULT",
-                                    "order": 0,
-                                    "policy": "include",
-                                    "rule": "regex",
-                                    "updated_at": "2023-12-01T14:18:37.397819Z",
-                                    "value": ".*"
-                                }
-                            ],
-                            "validation": {
-                                "errors": [],
-                                "state": "valid"
-                            }
-                        },
-                        "domain": "DEFAULT",
-                        "draft": {
-                            "advanced_snippet": {
-                                "created_at": "2023-12-01T14:18:37.397819Z",
-                                "updated_at": "2023-12-01T14:18:37.397819Z",
-                                "value": {}
-                            },
-                            "rules": [
-                                {
-                                    "created_at": "2023-12-01T14:18:37.397819Z",
-                                    "field": "_",
-                                    "id": "DEFAULT",
-                                    "order": 0,
-                                    "policy": "include",
-                                    "rule": "regex",
-                                    "updated_at": "2023-12-01T14:18:37.397819Z",
-                                    "value": ".*"
-                                }
-                            ],
-                            "validation": {
-                                "errors": [],
-                                "state": "valid"
-                            }
+                "filtering": {
+                    "advanced_snippet": {
+                        "created_at": "2023-12-01T14:18:37.397819Z",
+                        "updated_at": "2023-12-01T14:18:37.397819Z",
+                        "value": {}
+                    },
+                    "rules": [
+                        {
+                            "created_at": "2023-12-01T14:18:37.397819Z",
+                            "field": "_",
+                            "id": "DEFAULT",
+                            "order": 0,
+                            "policy": "include",
+                            "rule": "regex",
+                            "updated_at": "2023-12-01T14:18:37.397819Z",
+                            "value": ".*"
                         }
+                    ],
+                    "validation": {
+                        "errors": [],
+                        "state": "valid"
                     }
-                ],
+                },
                 "index_name": "search-connector",
                 "language": "english",
                 "pipeline": {
@@ -403,7 +290,7 @@ public class ConnectorSyncJobTests extends ESTestCase {
         Connector connector = ConnectorSyncJob.syncJobConnectorFromXContentBytes(new BytesArray(content), null, XContentType.JSON);
 
         assertThat(connector.getConnectorId(), equalTo("connector-id"));
-        assertThat(connector.getFiltering().size(), equalTo(1));
+        assertThat(connector.getSyncJobFiltering().getRules(), hasSize(1));
         assertThat(connector.getIndexName(), equalTo("search-connector"));
         assertThat(connector.getLanguage(), equalTo("english"));
         assertThat(connector.getPipeline(), notNullValue());
@@ -415,57 +302,29 @@ public class ConnectorSyncJobTests extends ESTestCase {
         String content = XContentHelper.stripWhitespace("""
             {
                 "id": "connector-id",
-                "filtering": [
-                    {
-                        "active": {
-                            "advanced_snippet": {
-                                "created_at": "2023-12-01T14:18:37.397819Z",
-                                "updated_at": "2023-12-01T14:18:37.397819Z",
-                                "value": {}
-                            },
-                            "rules": [
-                                {
-                                    "created_at": "2023-12-01T14:18:37.397819Z",
-                                    "field": "_",
-                                    "id": "DEFAULT",
-                                    "order": 0,
-                                    "policy": "include",
-                                    "rule": "regex",
-                                    "updated_at": "2023-12-01T14:18:37.397819Z",
-                                    "value": ".*"
-                                }
-                            ],
-                            "validation": {
-                                "errors": [],
-                                "state": "valid"
-                            }
-                        },
-                        "domain": "DEFAULT",
-                        "draft": {
-                            "advanced_snippet": {
-                                "created_at": "2023-12-01T14:18:37.397819Z",
-                                "updated_at": "2023-12-01T14:18:37.397819Z",
-                                "value": {}
-                            },
-                            "rules": [
-                                {
-                                    "created_at": "2023-12-01T14:18:37.397819Z",
-                                    "field": "_",
-                                    "id": "DEFAULT",
-                                    "order": 0,
-                                    "policy": "include",
-                                    "rule": "regex",
-                                    "updated_at": "2023-12-01T14:18:37.397819Z",
-                                    "value": ".*"
-                                }
-                            ],
-                            "validation": {
-                                "errors": [],
-                                "state": "valid"
-                            }
+                "filtering":  {
+                    "advanced_snippet": {
+                        "created_at": "2023-12-01T14:18:37.397819Z",
+                        "updated_at": "2023-12-01T14:18:37.397819Z",
+                        "value": {}
+                    },
+                    "rules": [
+                        {
+                            "created_at": "2023-12-01T14:18:37.397819Z",
+                            "field": "_",
+                            "id": "DEFAULT",
+                            "order": 0,
+                            "policy": "include",
+                            "rule": "regex",
+                            "updated_at": "2023-12-01T14:18:37.397819Z",
+                            "value": ".*"
                         }
+                    ],
+                    "validation": {
+                        "errors": [],
+                        "state": "valid"
                     }
-                ],
+                },
                 "index_name": null,
                 "language": null,
                 "pipeline": null,


### PR DESCRIPTION
### Changes
- Fix `Connector` representation in `ConnectorSyncJob` class, the `filtering` field should only represent the active rules applied for a given sync job, otherwise it will cause a sync job to fail
- This should be backported to 8.12 as a bugfix
- Adapt tests
- Tested manually


### Reproduction
- Create a connector
- Get its ID
- Trigger a on demand [sync job via API](https://www.elastic.co/guide/en/elasticsearch/reference/master/create-connector-sync-job-api.html) , I could reproduce getting an error
```
[FMWK][15:49:32][ERROR] [Connector id: HUeGQI0BpfSJQu5aFEpG, index name: search-gdrive, Sync job id: KkcYQY0BpfSJQu5a9krZ] dictionary update sequence element #0 has length 3; 2 is required
Traceback (most recent call last):
  File "/Users/jedr/connectors-python/connectors/sync_job_runner.py", line 139, in execute
    await self._execute_content_sync_job(job_type, bulk_options)
  File "/Users/jedr/connectors-python/connectors/sync_job_runner.py", line 195, in _execute_content_sync_job
    await self.sync_job.validate_filtering(validator=self.data_provider)
  File "/Users/jedr/connectors-python/connectors/protocol/connectors.py", line 290, in validate_filtering
    validation_result = await validator.validate_filtering(self.filtering)
  File "/Users/jedr/connectors-python/connectors/protocol/connectors.py", line 252, in filtering
    return Filter(self.get("connector", "filtering", default={}))
  File "/Users/jedr/connectors-python/connectors/protocol/connectors.py", line 413, in __init__
    super().__init__(filter_)
ValueError: dictionary update sequence element #0 has length 3; 2 is required
```
- Kibana selects only active filtering property before writing the sync job in the index, see https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/lib/start_sync.ts#L65
-  We don't do it in connectors api and it's causing issues


