### PR TITLE
[8.12] [DOCS] Rephrases sentence in data_description param of PUT job API docs (#104792)

### DIFF
--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -430,16 +430,17 @@ end::daily-model-snapshot-retention-after-days[]
 
 tag::data-description[]
 The data description defines the format of the input data when you send data to
-the job by using the <<ml-post-data,post data>> API. Note that when configure
-a {dfeed}, these properties are automatically set. When data is received via
-the <<ml-post-data,post data>> API, it is not stored in {es}. Only the results
-for {anomaly-detect} are retained.
+the job by using the <<ml-post-data,post data>> API. Note that when using a 
+{dfeed}, only the `time_field` needs to be set, the rest of the properties are 
+automatically set. When data is received via the <<ml-post-data,post data>> API, 
+it is not stored in {es}. Only the results for {anomaly-detect} are retained.
 +
 .Properties of `data_description`
 [%collapsible%open]
 ====
 `format`:::
-  (string) Only `JSON` format is supported at this time.
+  (string) Only `xcontent` format is supported at this time, and this is the 
+  default value.
 
 `time_field`:::
   (string) The name of the field that contains the timestamp.


### PR DESCRIPTION
Backports the following commits to 8.12:
 - [DOCS] Rephrases sentence in data_description param of PUT job API docs (#104792)