### PR TITLE
[Connector Secrets] Fix flaky spec

### DIFF
--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/secrets/ConnectorSecretsTestUtils.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/secrets/ConnectorSecretsTestUtils.java
@@ -28,7 +28,7 @@ public class ConnectorSecretsTestUtils {
     }
 
     public static PostConnectorSecretRequest getRandomPostConnectorSecretRequest() {
-        return new PostConnectorSecretRequest(randomAlphaOfLengthBetween(0, 20));
+        return new PostConnectorSecretRequest(randomAlphaOfLengthBetween(1, 20));
     }
 
     public static PostConnectorSecretResponse getRandomPostConnectorSecretResponse() {


### PR DESCRIPTION
Fix a flaky spec that was introduced in https://github.com/elastic/elasticsearch/pull/104766

The `value` field in a `.connector-secrets` doc can't be empty, so for this test the lower limit for the generated string should be `1`.