### PR TITLE
[Connector Secrets] Add delete API endpoint

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector_secret.delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector_secret.delete.json
@@ -1,0 +1,28 @@
+{
+  "connector_secret.delete": {
+    "documentation": {
+      "url": null,
+      "description": "Deletes a connector secret."
+    },
+    "stability": "experimental",
+    "visibility":"private",
+    "headers":{
+      "accept": [ "application/json"]
+    },
+    "url":{
+      "paths":[
+        {
+          "path":"/_connector/_secret/{id}",
+          "methods":[ "DELETE" ],
+          "parts":{
+            "id":{
+              "type":"string",
+              "description":"The ID of the secret"
+            }
+          }
+        }
+      ]
+    },
+    "params":{}
+  }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ClusterPrivilegeResolver.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ClusterPrivilegeResolver.java
@@ -333,7 +333,7 @@ public class ClusterPrivilegeResolver {
 
     public static final NamedClusterPrivilege WRITE_CONNECTOR_SECRETS = new ActionClusterPrivilege(
         "write_connector_secrets",
-        Set.of("cluster:admin/xpack/connector/secret/post")
+        Set.of("cluster:admin/xpack/connector/secret/post", "cluster:admin/xpack/connector/secret/delete")
     );
 
     private static final Map<String, NamedClusterPrivilege> VALUES = sortByAccessLevel(

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/510_connector_secret_get.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/510_connector_secret_get.yml
@@ -53,7 +53,7 @@ setup:
       catch: unauthorized
 
 ---
-'Get connector secret - Missing secret id':
+'Get connector secret - Secret does not exist':
   - do:
       connector_secret.get:
         id: non-existing-secret-id

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/520_connector_secret_delete.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/520_connector_secret_delete.yml
@@ -1,0 +1,71 @@
+setup:
+  - skip:
+      version: " - 8.12.99"
+      reason: Introduced in 8.13.0
+
+---
+'Delete connector secret - admin':
+  - do:
+      connector_secret.post:
+        body:
+          value: my-secret
+  - set: { id: id }
+  - match: { id: $id }
+
+  - do:
+      connector_secret.delete:
+        id: $id
+  - match: { deleted: true }
+
+  - do:
+      connector_secret.get:
+        id: $id
+      catch: missing
+
+---
+'Delete connector secret - user with privileges':
+  - skip:
+      features: headers
+
+  - do:
+      headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
+      connector_secret.post:
+        body:
+          value: my-secret
+  - set: { id: id }
+  - match: { id: $id }
+  - do:
+      headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
+      connector_secret.delete:
+        id: $id
+  - match: { deleted: true }
+  - do:
+      headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
+      connector_secret.get:
+        id: $id
+      catch: missing
+
+---
+'Delete connector secret - user without privileges':
+  - skip:
+      features: headers
+
+  - do:
+      headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
+      connector_secret.post:
+        body:
+          value: my-secret
+  - set: { id: id }
+  - match: { id: $id }
+  - do:
+      headers: { Authorization: "Basic ZW50c2VhcmNoLXVucHJpdmlsZWdlZDplbnRzZWFyY2gtdW5wcml2aWxlZ2VkLXVzZXI=" }  # unprivileged
+      connector_secret.get:
+        id: $id
+      catch: unauthorized
+
+---
+'Get connector secret - Missing secret id':
+  - do:
+      connector_secret.delete:
+        id: non-existing-secret-id
+      catch: missing

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/520_connector_secret_delete.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/520_connector_secret_delete.yml
@@ -59,12 +59,12 @@ setup:
   - match: { id: $id }
   - do:
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVucHJpdmlsZWdlZDplbnRzZWFyY2gtdW5wcml2aWxlZ2VkLXVzZXI=" }  # unprivileged
-      connector_secret.get:
+      connector_secret.delete:
         id: $id
       catch: unauthorized
 
 ---
-'Get connector secret - Missing secret id':
+'Delete connector secret - Secret does not exist':
   - do:
       connector_secret.delete:
         id: non-existing-secret-id

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearch.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearch.java
@@ -274,9 +274,9 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
         if (ConnectorSecretsFeature.isEnabled()) {
             actionHandlers.addAll(
                 List.of(
+                    new ActionHandler<>(DeleteConnectorSecretAction.INSTANCE, TransportDeleteConnectorSecretAction.class),
                     new ActionHandler<>(GetConnectorSecretAction.INSTANCE, TransportGetConnectorSecretAction.class),
-                    new ActionHandler<>(PostConnectorSecretAction.INSTANCE, TransportPostConnectorSecretAction.class),
-                    new ActionHandler<>(DeleteConnectorSecretAction.INSTANCE, TransportDeleteConnectorSecretAction.class)
+                    new ActionHandler<>(PostConnectorSecretAction.INSTANCE, TransportPostConnectorSecretAction.class)
                 )
             );
         }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearch.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearch.java
@@ -90,10 +90,13 @@ import org.elasticsearch.xpack.application.connector.action.UpdateConnectorSched
 import org.elasticsearch.xpack.application.connector.action.UpdateConnectorServiceTypeAction;
 import org.elasticsearch.xpack.application.connector.secrets.ConnectorSecretsFeature;
 import org.elasticsearch.xpack.application.connector.secrets.ConnectorSecretsIndexService;
+import org.elasticsearch.xpack.application.connector.secrets.action.DeleteConnectorSecretAction;
 import org.elasticsearch.xpack.application.connector.secrets.action.GetConnectorSecretAction;
 import org.elasticsearch.xpack.application.connector.secrets.action.PostConnectorSecretAction;
+import org.elasticsearch.xpack.application.connector.secrets.action.RestDeleteConnectorSecretAction;
 import org.elasticsearch.xpack.application.connector.secrets.action.RestGetConnectorSecretAction;
 import org.elasticsearch.xpack.application.connector.secrets.action.RestPostConnectorSecretAction;
+import org.elasticsearch.xpack.application.connector.secrets.action.TransportDeleteConnectorSecretAction;
 import org.elasticsearch.xpack.application.connector.secrets.action.TransportGetConnectorSecretAction;
 import org.elasticsearch.xpack.application.connector.secrets.action.TransportPostConnectorSecretAction;
 import org.elasticsearch.xpack.application.connector.syncjob.action.CancelConnectorSyncJobAction;
@@ -272,7 +275,8 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
             actionHandlers.addAll(
                 List.of(
                     new ActionHandler<>(GetConnectorSecretAction.INSTANCE, TransportGetConnectorSecretAction.class),
-                    new ActionHandler<>(PostConnectorSecretAction.INSTANCE, TransportPostConnectorSecretAction.class)
+                    new ActionHandler<>(PostConnectorSecretAction.INSTANCE, TransportPostConnectorSecretAction.class),
+                    new ActionHandler<>(DeleteConnectorSecretAction.INSTANCE, TransportDeleteConnectorSecretAction.class)
                 )
             );
         }
@@ -355,7 +359,9 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
         }
 
         if (ConnectorSecretsFeature.isEnabled()) {
-            restHandlers.addAll(List.of(new RestGetConnectorSecretAction(), new RestPostConnectorSecretAction()));
+            restHandlers.addAll(
+                List.of(new RestGetConnectorSecretAction(), new RestPostConnectorSecretAction(), new RestDeleteConnectorSecretAction())
+            );
         }
 
         return Collections.unmodifiableList(restHandlers);

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/secrets/ConnectorSecretsIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/secrets/ConnectorSecretsIndexService.java
@@ -97,7 +97,8 @@ public class ConnectorSecretsIndexService {
     }
 
     public void deleteSecret(String id, ActionListener<DeleteConnectorSecretResponse> listener) {
-        clientWithOrigin.prepareDelete(CONNECTOR_SECRETS_INDEX_NAME, id)
+        try {
+            clientWithOrigin.prepareDelete(CONNECTOR_SECRETS_INDEX_NAME, id)
             .execute(listener.delegateFailureAndWrap((delegate, deleteResponse) -> {
                 if (deleteResponse.getResult() == DocWriteResponse.Result.NOT_FOUND) {
                     delegate.onFailure(new ResourceNotFoundException("No secret with id [" + id + "]"));
@@ -105,5 +106,8 @@ public class ConnectorSecretsIndexService {
                 }
                 delegate.onResponse(new DeleteConnectorSecretResponse(deleteResponse.getResult() == DocWriteResponse.Result.DELETED));
             }));
+        } catch (Exception e) {
+            listener.onFailure(e);
+        }
     }
 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/secrets/ConnectorSecretsIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/secrets/ConnectorSecretsIndexService.java
@@ -97,11 +97,11 @@ public class ConnectorSecretsIndexService {
         }
     }
 
-    public void deleteSecret(DeleteConnectorSecretRequest request, ActionListener<DeleteConnectorSecretResponse> listener) {
-        clientWithOrigin.prepareDelete(CONNECTOR_SECRETS_INDEX_NAME, request.id())
+    public void deleteSecret(String id, ActionListener<DeleteConnectorSecretResponse> listener) {
+        clientWithOrigin.prepareDelete(CONNECTOR_SECRETS_INDEX_NAME, id)
             .execute(listener.delegateFailureAndWrap((delegate, deleteResponse) -> {
                 if (deleteResponse.getResult() == DocWriteResponse.Result.NOT_FOUND) {
-                    delegate.onFailure(new ResourceNotFoundException("No secret with id [" + request.id() + "]"));
+                    delegate.onFailure(new ResourceNotFoundException("No secret with id [" + id + "]"));
                     return;
                 }
                 delegate.onResponse(new DeleteConnectorSecretResponse(deleteResponse.getResult() == DocWriteResponse.Result.DELETED));

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/secrets/ConnectorSecretsIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/secrets/ConnectorSecretsIndexService.java
@@ -16,7 +16,6 @@ import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.OriginSettingClient;
 import org.elasticsearch.indices.SystemIndexDescriptor;
 import org.elasticsearch.xcontent.XContentType;
-import org.elasticsearch.xpack.application.connector.secrets.action.DeleteConnectorSecretRequest;
 import org.elasticsearch.xpack.application.connector.secrets.action.DeleteConnectorSecretResponse;
 import org.elasticsearch.xpack.application.connector.secrets.action.GetConnectorSecretResponse;
 import org.elasticsearch.xpack.application.connector.secrets.action.PostConnectorSecretRequest;

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/secrets/ConnectorSecretsIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/secrets/ConnectorSecretsIndexService.java
@@ -99,13 +99,13 @@ public class ConnectorSecretsIndexService {
     public void deleteSecret(String id, ActionListener<DeleteConnectorSecretResponse> listener) {
         try {
             clientWithOrigin.prepareDelete(CONNECTOR_SECRETS_INDEX_NAME, id)
-            .execute(listener.delegateFailureAndWrap((delegate, deleteResponse) -> {
-                if (deleteResponse.getResult() == DocWriteResponse.Result.NOT_FOUND) {
-                    delegate.onFailure(new ResourceNotFoundException("No secret with id [" + id + "]"));
-                    return;
-                }
-                delegate.onResponse(new DeleteConnectorSecretResponse(deleteResponse.getResult() == DocWriteResponse.Result.DELETED));
-            }));
+                .execute(listener.delegateFailureAndWrap((delegate, deleteResponse) -> {
+                    if (deleteResponse.getResult() == DocWriteResponse.Result.NOT_FOUND) {
+                        delegate.onFailure(new ResourceNotFoundException("No secret with id [" + id + "]"));
+                        return;
+                    }
+                    delegate.onResponse(new DeleteConnectorSecretResponse(deleteResponse.getResult() == DocWriteResponse.Result.DELETED));
+                }));
         } catch (Exception e) {
             listener.onFailure(e);
         }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/secrets/action/DeleteConnectorSecretAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/secrets/action/DeleteConnectorSecretAction.java
@@ -9,13 +9,11 @@ package org.elasticsearch.xpack.application.connector.secrets.action;
 
 import org.elasticsearch.action.ActionType;
 
-public class DeleteConnectorSecretAction extends ActionType<DeleteConnectorSecretResponse> {
+public class DeleteConnectorSecretAction {
 
     public static final String NAME = "cluster:admin/xpack/connector/secret/delete";
 
-    public static final DeleteConnectorSecretAction INSTANCE = new DeleteConnectorSecretAction();
+    public static final ActionType<DeleteConnectorSecretResponse> INSTANCE = new ActionType<>(NAME);
 
-    private DeleteConnectorSecretAction() {
-        super(NAME);
-    }
+    private DeleteConnectorSecretAction() {/* no instances */}
 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/secrets/action/DeleteConnectorSecretAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/secrets/action/DeleteConnectorSecretAction.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.connector.secrets.action;
+
+import org.elasticsearch.action.ActionType;
+
+public class DeleteConnectorSecretAction extends ActionType<DeleteConnectorSecretResponse> {
+
+    public static final String NAME = "cluster:admin/xpack/connector/secret/delete";
+
+    public static final DeleteConnectorSecretAction INSTANCE = new DeleteConnectorSecretAction();
+
+    private DeleteConnectorSecretAction() {
+        super(NAME);
+    }
+}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/secrets/action/DeleteConnectorSecretRequest.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/secrets/action/DeleteConnectorSecretRequest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.connector.secrets.action;
+
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+import java.util.Objects;
+
+public class DeleteConnectorSecretRequest extends ActionRequest {
+
+    private final String id;
+
+    public DeleteConnectorSecretRequest(String id) {
+        this.id = Objects.requireNonNull(id);
+    }
+
+    public DeleteConnectorSecretRequest(StreamInput in) throws IOException {
+        super(in);
+        this.id = in.readString();
+    }
+
+    public String id() {
+        return id;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(id);
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        return null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DeleteConnectorSecretRequest that = (DeleteConnectorSecretRequest) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/secrets/action/DeleteConnectorSecretRequest.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/secrets/action/DeleteConnectorSecretRequest.java
@@ -9,11 +9,14 @@ package org.elasticsearch.xpack.application.connector.secrets.action;
 
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 import java.util.Objects;
+
+import static org.elasticsearch.action.ValidateActions.addValidationError;
 
 public class DeleteConnectorSecretRequest extends ActionRequest {
 
@@ -40,7 +43,13 @@ public class DeleteConnectorSecretRequest extends ActionRequest {
 
     @Override
     public ActionRequestValidationException validate() {
-        return null;
+        ActionRequestValidationException validationException = null;
+
+        if (Strings.isNullOrEmpty(id)) {
+            validationException = addValidationError("id missing", validationException);
+        }
+
+        return validationException;
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/secrets/action/DeleteConnectorSecretResponse.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/secrets/action/DeleteConnectorSecretResponse.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.connector.secrets.action;
+
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.xcontent.ToXContentObject;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Objects;
+
+public class DeleteConnectorSecretResponse extends ActionResponse implements ToXContentObject {
+
+    private final boolean deleted;
+
+    public DeleteConnectorSecretResponse(boolean deleted) {
+        this.deleted = deleted;
+    }
+
+    public DeleteConnectorSecretResponse(StreamInput in) throws IOException {
+        super(in);
+        this.deleted = in.readBoolean();
+    }
+
+    public boolean isDeleted() {
+        return deleted;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeBoolean(deleted);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field("deleted", deleted);
+        return builder.endObject();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DeleteConnectorSecretResponse that = (DeleteConnectorSecretResponse) o;
+        return deleted == that.deleted;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(deleted);
+    }
+}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/secrets/action/RestDeleteConnectorSecretAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/secrets/action/RestDeleteConnectorSecretAction.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.connector.secrets.action;
+
+import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.Scope;
+import org.elasticsearch.rest.ServerlessScope;
+import org.elasticsearch.rest.action.RestToXContentListener;
+
+import java.io.IOException;
+import java.util.List;
+
+@ServerlessScope(Scope.INTERNAL)
+public class RestDeleteConnectorSecretAction extends BaseRestHandler {
+
+    @Override
+    public String getName() {
+        return "connector_delete_secret";
+    }
+
+    @Override
+    public List<Route> routes() {
+        return List.of(new Route(RestRequest.Method.DELETE, "/_connector/_secret/{id}"));
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        final String id = request.param("id");
+        return restChannel -> client.execute(
+            DeleteConnectorSecretAction.INSTANCE,
+            new DeleteConnectorSecretRequest(id),
+            new RestToXContentListener<>(restChannel)
+        );
+    }
+}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/secrets/action/TransportDeleteConnectorSecretAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/secrets/action/TransportDeleteConnectorSecretAction.java
@@ -36,6 +36,6 @@ public class TransportDeleteConnectorSecretAction extends HandledTransportAction
     }
 
     protected void doExecute(Task task, DeleteConnectorSecretRequest request, ActionListener<DeleteConnectorSecretResponse> listener) {
-        connectorSecretsIndexService.deleteSecret(request, listener);
+        connectorSecretsIndexService.deleteSecret(request.id(), listener);
     }
 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/secrets/action/TransportDeleteConnectorSecretAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/secrets/action/TransportDeleteConnectorSecretAction.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.connector.secrets.action;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.application.connector.secrets.ConnectorSecretsIndexService;
+
+public class TransportDeleteConnectorSecretAction extends HandledTransportAction<
+    DeleteConnectorSecretRequest,
+    DeleteConnectorSecretResponse> {
+
+    private final ConnectorSecretsIndexService connectorSecretsIndexService;
+
+    @Inject
+    public TransportDeleteConnectorSecretAction(TransportService transportService, ActionFilters actionFilters, Client client) {
+        super(
+            DeleteConnectorSecretAction.NAME,
+            transportService,
+            actionFilters,
+            DeleteConnectorSecretRequest::new,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE
+        );
+        this.connectorSecretsIndexService = new ConnectorSecretsIndexService(client);
+    }
+
+    protected void doExecute(Task task, DeleteConnectorSecretRequest request, ActionListener<DeleteConnectorSecretResponse> listener) {
+        connectorSecretsIndexService.deleteSecret(request, listener);
+    }
+}

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/secrets/ConnectorSecretsTestUtils.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/secrets/ConnectorSecretsTestUtils.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.application.connector.secrets;
 
 import org.elasticsearch.xpack.application.connector.secrets.action.DeleteConnectorSecretRequest;
+import org.elasticsearch.xpack.application.connector.secrets.action.DeleteConnectorSecretResponse;
 import org.elasticsearch.xpack.application.connector.secrets.action.GetConnectorSecretRequest;
 import org.elasticsearch.xpack.application.connector.secrets.action.GetConnectorSecretResponse;
 import org.elasticsearch.xpack.application.connector.secrets.action.PostConnectorSecretRequest;
@@ -15,6 +16,7 @@ import org.elasticsearch.xpack.application.connector.secrets.action.PostConnecto
 
 import static org.elasticsearch.test.ESTestCase.randomAlphaOfLength;
 import static org.elasticsearch.test.ESTestCase.randomAlphaOfLengthBetween;
+import static org.elasticsearch.test.ESTestCase.randomBoolean;
 
 public class ConnectorSecretsTestUtils {
 
@@ -28,15 +30,19 @@ public class ConnectorSecretsTestUtils {
         return new GetConnectorSecretResponse(id, value);
     }
 
-    public static DeleteConnectorSecretRequest getRandomDeleteConnectorSecretRequest() {
-        return new DeleteConnectorSecretRequest(randomAlphaOfLengthBetween(0, 20));
-    }
-
     public static PostConnectorSecretRequest getRandomPostConnectorSecretRequest() {
         return new PostConnectorSecretRequest(randomAlphaOfLengthBetween(1, 20));
     }
 
     public static PostConnectorSecretResponse getRandomPostConnectorSecretResponse() {
         return new PostConnectorSecretResponse(randomAlphaOfLength(10));
+    }
+
+    public static DeleteConnectorSecretRequest getRandomDeleteConnectorSecretRequest() {
+        return new DeleteConnectorSecretRequest(randomAlphaOfLengthBetween(1, 20));
+    }
+
+    public static DeleteConnectorSecretResponse getRandomDeleteConnectorSecretResponse() {
+        return new DeleteConnectorSecretResponse(randomBoolean());
     }
 }

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/secrets/ConnectorSecretsTestUtils.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/secrets/ConnectorSecretsTestUtils.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.application.connector.secrets;
 
+import org.elasticsearch.xpack.application.connector.secrets.action.DeleteConnectorSecretRequest;
 import org.elasticsearch.xpack.application.connector.secrets.action.GetConnectorSecretRequest;
 import org.elasticsearch.xpack.application.connector.secrets.action.GetConnectorSecretResponse;
 import org.elasticsearch.xpack.application.connector.secrets.action.PostConnectorSecretRequest;
@@ -25,6 +26,10 @@ public class ConnectorSecretsTestUtils {
         final String id = randomAlphaOfLength(10);
         final String value = randomAlphaOfLength(10);
         return new GetConnectorSecretResponse(id, value);
+    }
+
+    public static DeleteConnectorSecretRequest getRandomDeleteConnectorSecretRequest() {
+        return new DeleteConnectorSecretRequest(randomAlphaOfLengthBetween(0, 20));
     }
 
     public static PostConnectorSecretRequest getRandomPostConnectorSecretRequest() {

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/secrets/action/DeleteConnectorSecretActionTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/secrets/action/DeleteConnectorSecretActionTests.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.connector.secrets.action;
+
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.application.connector.secrets.ConnectorSecretsTestUtils;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+
+public class DeleteConnectorSecretActionTests extends ESTestCase {
+
+    public void testValidate_WhenConnectorSecretIdIsPresent_ExpectNoValidationError() {
+        DeleteConnectorSecretRequest request = ConnectorSecretsTestUtils.getRandomDeleteConnectorSecretRequest();
+        ActionRequestValidationException exception = request.validate();
+
+        assertThat(exception, nullValue());
+    }
+
+    public void testValidate_WhenConnectorSecretIdIsEmpty_ExpectValidationError() {
+        DeleteConnectorSecretRequest requestWithMissingConnectorId = new DeleteConnectorSecretRequest("");
+        ActionRequestValidationException exception = requestWithMissingConnectorId.validate();
+
+        assertThat(exception, notNullValue());
+        assertThat(exception.getMessage(), containsString("id missing"));
+    }
+}

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/secrets/action/DeleteConnectorSecretActionTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/secrets/action/DeleteConnectorSecretActionTests.java
@@ -15,7 +15,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
-
 public class DeleteConnectorSecretActionTests extends ESTestCase {
 
     public void testValidate_WhenConnectorSecretIdIsPresent_ExpectNoValidationError() {

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/secrets/action/DeleteConnectorSecretRequestBWCSerializingTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/secrets/action/DeleteConnectorSecretRequestBWCSerializingTests.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.connector.secrets.action;
+
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.xpack.core.ml.AbstractBWCWireSerializationTestCase;
+
+import java.io.IOException;
+
+public class DeleteConnectorSecretRequestBWCSerializingTests extends AbstractBWCWireSerializationTestCase<DeleteConnectorSecretRequest> {
+
+    @Override
+    protected Writeable.Reader<DeleteConnectorSecretRequest> instanceReader() {
+        return DeleteConnectorSecretRequest::new;
+    }
+
+    @Override
+    protected DeleteConnectorSecretRequest createTestInstance() {
+        return new DeleteConnectorSecretRequest(randomAlphaOfLengthBetween(1, 10));
+    }
+
+    @Override
+    protected DeleteConnectorSecretRequest mutateInstance(DeleteConnectorSecretRequest instance) throws IOException {
+        return randomValueOtherThan(instance, this::createTestInstance);
+    }
+
+    @Override
+    protected DeleteConnectorSecretRequest mutateInstanceForVersion(DeleteConnectorSecretRequest instance, TransportVersion version) {
+        return new DeleteConnectorSecretRequest(instance.id());
+    }
+}

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/secrets/action/DeleteConnectorSecretResponseBWCSerializingTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/secrets/action/DeleteConnectorSecretResponseBWCSerializingTests.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.connector.secrets.action;
+
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.xpack.application.connector.Connector;
+import org.elasticsearch.xpack.application.connector.secrets.ConnectorSecretsTestUtils;
+import org.elasticsearch.xpack.core.ml.AbstractBWCWireSerializationTestCase;
+
+import java.io.IOException;
+import java.util.List;
+
+public class DeleteConnectorSecretResponseBWCSerializingTests extends AbstractBWCWireSerializationTestCase<DeleteConnectorSecretResponse> {
+
+    @Override
+    public NamedWriteableRegistry getNamedWriteableRegistry() {
+        return new NamedWriteableRegistry(List.of(new NamedWriteableRegistry.Entry(Connector.class, Connector.NAME, Connector::new)));
+    }
+
+    @Override
+    protected Writeable.Reader<DeleteConnectorSecretResponse> instanceReader() {
+        return DeleteConnectorSecretResponse::new;
+    }
+
+    @Override
+    protected DeleteConnectorSecretResponse createTestInstance() {
+        return ConnectorSecretsTestUtils.getRandomDeleteConnectorSecretResponse();
+    }
+
+    @Override
+    protected DeleteConnectorSecretResponse mutateInstance(DeleteConnectorSecretResponse instance) throws IOException {
+        return randomValueOtherThan(instance, this::createTestInstance);
+    }
+
+    @Override
+    protected DeleteConnectorSecretResponse mutateInstanceForVersion(DeleteConnectorSecretResponse instance, TransportVersion version) {
+        return instance;
+    }
+}

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/secrets/action/TransportDeleteConnectorSecretActionTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/secrets/action/TransportDeleteConnectorSecretActionTests.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.connector.secrets.action;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.Transport;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.application.connector.secrets.ConnectorSecretsTestUtils;
+import org.junit.Before;
+
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.Mockito.mock;
+
+public class TransportDeleteConnectorSecretActionTests extends ESSingleNodeTestCase {
+
+    private static final Long TIMEOUT_SECONDS = 10L;
+
+    private final ThreadPool threadPool = new TestThreadPool(getClass().getName());
+    private TransportDeleteConnectorSecretAction action;
+
+    @Before
+    public void setup() {
+        TransportService transportService = new TransportService(
+            Settings.EMPTY,
+            mock(Transport.class),
+            threadPool,
+            TransportService.NOOP_TRANSPORT_INTERCEPTOR,
+            x -> null,
+            null,
+            Collections.emptySet()
+        );
+
+        action = new TransportDeleteConnectorSecretAction(transportService, mock(ActionFilters.class), client());
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        ThreadPool.terminate(threadPool, TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    }
+
+    public void testDeleteConnectorSecret_ExpectNoWarnings() throws InterruptedException {
+        DeleteConnectorSecretRequest request = ConnectorSecretsTestUtils.getRandomDeleteConnectorSecretRequest();
+
+        executeRequest(request);
+
+        ensureNoWarnings();
+    }
+
+    private void executeRequest(DeleteConnectorSecretRequest request) throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(1);
+        action.doExecute(mock(Task.class), request, ActionListener.wrap(response -> latch.countDown(), exception -> latch.countDown()));
+
+        boolean requestTimedOut = latch.await(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+        assertTrue("Timeout waiting for delete request", requestTimedOut);
+    }
+}

--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
@@ -138,6 +138,7 @@ public class Constants {
         "cluster:admin/xpack/connector/update_pipeline",
         "cluster:admin/xpack/connector/update_scheduling",
         "cluster:admin/xpack/connector/update_service_type",
+        "cluster:admin/xpack/connector/secret/delete",
         "cluster:admin/xpack/connector/secret/get",
         "cluster:admin/xpack/connector/secret/post",
         "cluster:admin/xpack/connector/sync_job/cancel",

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccountsTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccountsTests.java
@@ -345,6 +345,7 @@ public class ElasticServiceAccountsTests extends ESTestCase {
         assertThat(role.cluster().check(ILMActions.PUT.name(), request, authentication), is(true));
 
         // Connector secrets. Enterprise Search has read and write access.
+        assertThat(role.cluster().check("cluster:admin/xpack/connector/secret/delete", request, authentication), is(true));
         assertThat(role.cluster().check("cluster:admin/xpack/connector/secret/get", request, authentication), is(true));
         assertThat(role.cluster().check("cluster:admin/xpack/connector/secret/post", request, authentication), is(true));
 


### PR DESCRIPTION
## Changes

- Add DELETE endpoint for `/_connector/_secret/{id}`
- Add endpoint to `write_connector_secrets` cluster privilege